### PR TITLE
Update quickstart to match 0.9.3

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -8,13 +8,15 @@ nav_section: "install"
 Follow these instructions to install the Pulumi Cloud SDK on your development or build machine.
 
 For detailed instructions on using Pulumi, please refer to the <a href="/quickstart">Quickstart</a>.  For any
-feedback or questions, please do not hesitate to [contact us](/contact) -- we'd love to hear from you!
+feedback or questions, please do not hesitate to [contact us](/contact)---we'd love to hear from you!
 
 ## Download the SDK
 
 The first step is to download a binary release suitable for your system.
 
 ### Featured Downloads
+
+**NOTE**: if you don't have access to the downloads below, you should have received a link to the binaries. If not, please [contact us](/contact).
 
 The current version of Pulumi's SDK is <b>v0.9.2</b> and is
 available for these systems:

--- a/quickstart/aws.md
+++ b/quickstart/aws.md
@@ -25,60 +25,63 @@ and associated [Security Group](/packages/pulumi-aws/classes/_ec2_securitygroup_
 
 1. Create a folder `webserver`:
 
-    ```bash
-    $ mkdir webserver
-    $ cd webserver
-    ```
+   ```bash
+   $ mkdir webserver
+   $ cd webserver
+   ```
 
 1. Since this example uses TypeScript, create `package.json` in the project folder:
 
-    ```json
-    {
-        "name": "url-shortener",
-        "version": "1.0.0",
-        "license": "MIT",
-        "main": "bin/index.js",
-        "typings": "bin/index.d.ts",
-        "scripts": {
-            "build": "tsc"
-        },
-        "devDependencies": {
-            "typescript": "^2.1.4"
-        },
-        "peerDependencies": {
-            "@pulumi/cloud": "*"
-        },
-        "dependencies": {
-            "@types/node": "^8.0.26"
-        }  
-    }
-    ```
+   ```json
+   {
+      "name": "url-shortener",
+      "version": "1.0.0",
+      "license": "MIT",
+      "main": "bin/index.js",
+      "typings": "bin/index.d.ts",
+      "scripts": {
+         "build": "tsc"
+      },
+      "devDependencies": {
+         "typescript": "^2.1.4"
+      },
+      "peerDependencies": {
+         "@pulumi/cloud": "*"
+      },
+      "dependencies": {
+         "@types/node": "^8.0.26"
+      }  
+   }
+   ```
 
 1. Create a `tsconfig.json` file with the TypeScript compiler settings and a list of your program files:
 
-    ```json
-    {
-        "compilerOptions": {
-            "outDir": "bin",
-            "target": "es6",
-            "module": "commonjs",
-            "moduleResolution": "node",
-            "declaration": true,
-            "sourceMap": true,
-            "stripInternal": true,
-            "experimentalDecorators": true,
-            "pretty": true,
-            "noFallthroughCasesInSwitch": true,
-            "noImplicitAny": true,
-            "noImplicitReturns": true,
-            "forceConsistentCasingInFileNames": true,
-            "strictNullChecks": true
-        },
-        "files": [
-            "index.ts"
-        ]
-    }
-    ```
+   ```json
+   {
+      "compilerOptions": {
+         "outDir": "bin",
+         "target": "es6",
+         "lib": [
+               "es6"
+         ],
+         "module": "commonjs",
+         "moduleResolution": "node",
+         "declaration": true,
+         "sourceMap": true,
+         "stripInternal": true,
+         "experimentalDecorators": true,
+         "pretty": true,
+         "noFallthroughCasesInSwitch": true,
+         "noImplicitAny": true,
+         "noImplicitReturns": true,
+         "forceConsistentCasingInFileNames": true,
+         "strictNullChecks": true
+      },
+      "files": [
+         "index.ts"
+      ]
+   }
+   ```
 
 1. Create `Pulumi.yaml` with the following contents:
 
@@ -92,9 +95,9 @@ and associated [Security Group](/packages/pulumi-aws/classes/_ec2_securitygroup_
 
 1. Link with the Pulumi SDK packages so that your `require`s will find the right thing, using either `yarn` or `npm`:
 
-    ```bash
-    $ yarn link pulumi @pulumi/aws
-    ```
+   ```bash
+   $ yarn link pulumi @pulumi/aws
+   ```
 
 ### Add code to provision an EC2 instance
 
@@ -104,7 +107,7 @@ Create a new file `index.ts` with the following contents:
 import * as aws from "@pulumi/aws";
 
 // the type InstanceType contains friendly names for AWS instance sizes
-export let size: aws.ec2.InstanceType = "t2.micro"; 
+let size: aws.ec2.InstanceType = "t2.micro"; 
 
 // create a new security group for port 80
 let group = new aws.ec2.SecurityGroup("web-secgrp", { 
@@ -114,17 +117,8 @@ let group = new aws.ec2.SecurityGroup("web-secgrp", {
     ],
 });
 
-// a function to find the Amazon Linux AMI for the current region
-async function getLinuxAmi() {
-    let result = await aws.getAmi({
-        owners: ["amazon"],
-        filter: [{ name: "name", values: ["amzn-ami-hvm-2017.09.0.20170930-x86_64-gp2"] }]
-    });
-    return result.imageId;
-}
-
-// Create a simple web server using the startup script for the instance
-// Use the AWS metadata service to get the availability zone for the instance
+// (optional) create a simple web server using the startup script for the instance
+// use the AWS metadata service to get the availability zone for the instance
 let userData = 
     `#!/bin/bash
     echo "Hello, World!\nInstance metadata:" > index.html
@@ -132,14 +126,14 @@ let userData =
     nohup python -m SimpleHTTPServer 80 &`;
 
 let server = new aws.ec2.Instance("web-server-www", {
+    tags: { "Name": "web-server-www" },
     instanceType: size,
     securityGroups: [ group.name ],     // reference the group object above
-    ami: getLinuxAmi(),                 // call custom function
-    tags: { "Name": "web-server-www" },
+    ami: aws.ec2.getLinuxAMI(size),     // call built-in function (can also be custom)
     userData: userData                  // set up a simple web server    
 });
 
-server.publicDns.then(url => console.log(`Server URL: http://${url}`));
+server.publicDns.then(dns => console.log(`Server URL: http://${dns}`));
 ```
 
 This example uses the [`@pulumi/aws`](/packages/pulumi-aws/index.html) package to create and manage AWS resources.  It creates two resources: an [`aws.ec2.SecurityGroup`](/packages/pulumi-aws/classes/_ec2_securitygroup_.securitygroup.html), which allows access for incoming HTTP requests, and an [`aws.ec2.Instance`](/packages/pulumi-aws/classes/_ec2_instance_.instance.html), which will be created in that security group using the appropriate Amazon Machine Image (AMI) for the region where you deploy the program.
@@ -165,132 +159,121 @@ production.
 
 1. Create a Pulumi repository. A repository is a collection of Pulumi projects:
 
-    ```bash
-    $ pulumi init
-    Initialized Pulumi repository in /Users/donnam/src/hello-world/.pulumi
+   ```bash
+   $ pulumi init
+   Initialized Pulumi repository in /Users/donnam/src/hello-world/.pulumi
+   ```
+
+1. Create a new Pulumi stack called "testing". (Be sure to pass the `--local` flag, as otherwise the command will attempt to create a stack in the Pulumi hosted service.)
+
+   ```bash
+   $ pulumi stack init testing --local
+   ```
+
+1. We can get a preview of what will happen during a deployment by running `pulumi preview`. If you run it now, you'll see an error, because the AWS region has not yet been selected:
+
+   ```
+   Previewing changes:
+    error: Missing required configuration variable 'aws:config:region'
+           please set a value using the command `pulumi config set aws:config:region <value>`
+    error: An error occurred while advancing the preview: an unhandled error occurred: Program exited with non-zero exit code: 1
     ```
+   
+   To configure the region, use the `config set` command. For example, to choose `us-west-2`:
 
-1. Create a new Pulumi stack called "testing":
+   ```bash
+   $ pulumi config set aws:config:region us-west-2
+   warning: saved config key 'aws:config:region' value 'us-west-2' as plaintext; re-run with --secret to encrypt the value instead
+   ```
 
-    ```bash
-    $ pulumi stack init testing
-    ```
+   You can view config values for the current stack via `pulumi config`:
 
-1. We can get a preview of what will happen during a deployment by running `pulumi preview`. 
+   ```bash
+   $ pulumi config
+   KEY                              VALUE
+   aws:config:region                us-west-2
+   ```
 
-   You'll see an error:  `Error: Missing required configuration variable 'aws:config:region'`.  As the error states, before we can preview or update our application, we need to configure the AWS region we will be targeting. For example, to choose `us-west-2`:
+1. We can now successfully run `pulumi preview` to see the complete set of resources that will be created. This does not actually provision anything.
 
-    ```bash
-    $ pulumi config set aws:config:region us-west-2
-    ```
+   ```bash
+   $ pulumi preview --summary
+   Previewing changes:
+   + pulumi:pulumi:Stack: (create)
+      [urn=urn:pulumi:testing::webserver::pulumi:pulumi:Stack::webserver-testing]
+      + aws:ec2/securityGroup:SecurityGroup: (create)
+         [urn=urn:pulumi:testing::webserver::aws:ec2/securityGroup:SecurityGroup::web-secgrp]
+      + aws:ec2/instance:Instance: (create)
+         [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www]
+   info: Server URL: http://undefined
+   info: 3 changes previewed:
+      + 3 resources to create
+   ```
 
-1. We can now successfully run `pulumi preview` to see the complete set of resources that will be created:
+   Note that the server URL is `http://undefined`. This is expected, as Pulumi won't know the resource name until it has been provisioned at least once.
+   
+   Note that the update shows that it will create 3 resources, rather than 2. The stack itself is counted as a resource, even though it does not correspond to physical infrastructure. 
 
-    ```bash
-    $ pulumi preview
-    Previewing changes:
-    info: Server URL: http://undefined
-    + aws:ec2/securityGroup:SecurityGroup: (create)
-        [urn=urn:lumi:testing::webserver::aws:ec2/securityGroup:SecurityGroup::web-secgrp]
-        description: "Enable HTTP access"
-        ingress    : [
-            [0]: {
-                    cidrBlocks: [
-                        [0]: "0.0.0.0/0"
-                    ]
-                    fromPort  : 80
-                    protocol  : "tcp"
-                    toPort    : 80
-                }
-        ]
-        name       : "web-secgrp-f552bbcd376c5f94"
-    + aws:ec2/instance:Instance: (create)
-        [urn=urn:lumi:testing::webserver::aws:ec2/instance:Instance::web-server-www]
-        ami            : "ami-7172b611"
-        instanceType   : "t2.micro"
-        securityGroups : [
-            [0]: computed<string>
-        ]
-        sourceDestCheck: true
-        tags           : {
-            name: "pulumi"
-        }
-    info: 2 changes previewed:
-        + 2 resources to create
-    ```
-
-    Note that the server URL is `http://undefined`. This is expected, as Pulumi won't know the resource name until it has been provisioned at least once.
-    
-    As expected, we see that updating this program will create two resources.
+   To see full details of what will be deployed, leave off the `--summary` flag.
 
 1. Let's go ahead and deploy the update. This will take about 30 seconds as it waits for the actual EC2 instance to finish spinning up:
 
-    ```bash
-    $ pulumi update
-    Performing changes:
-    + aws:ec2/securityGroup:SecurityGroup: (create)
-        [urn=urn:lumi:testing::webserver::aws:ec2/securityGroup:SecurityGroup::web-secgrp]
-        description: "Enable HTTP access"
-        ingress    : [
-            [0]: {
-                    cidrBlocks: [
-                        [0]: "0.0.0.0/0"
-                    ]
-                    fromPort  : 80
-                    protocol  : "tcp"
-                    toPort    : 80
-                }
-        ]
-        name       : "web-secgrp-cea08d71378cb4fe"
-        ---outputs:---
-        <snip>
-    + aws:ec2/instance:Instance: (create)
-        [urn=urn:lumi:testing::webserver::aws:ec2/instance:Instance::web-server-www]
-        ami            : "ami-7172b611"
-        instanceType   : "t2.micro"
-        securityGroups : [
-            [0]: "web-secgrp-cea08d71378cb4fe"
-        ]
-        sourceDestCheck: true
-        tags           : {
-            name: "pulumi"
-        }
-        ---outputs:---
-        <snip>
-    info: Server URL: http://ec2-52-43-64-227.us-west-2.compute.amazonaws.com                
-    info: 2 changes performed:
-        + 2 resources created
-    Update duration: 25.518253662s
-    ```
+   ```bash
+   $ pulumi update
+   Performing changes:
+   + pulumi:pulumi:Stack: (create)
+      [urn=urn:pulumi:testing::webserver::pulumi:pulumi:Stack::webserver-testing]
+      + aws:ec2/securityGroup:SecurityGroup: (create)
+         [urn=urn:pulumi:testing::webserver::aws:ec2/securityGroup:SecurityGroup::web-secgrp]
+         <snip>
+      + aws:ec2/instance:Instance: (create)
+         [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www]
+         ami            : "ami-7172b611"
+         instanceType   : "t2.micro"
+         securityGroups : [
+               [0]: "web-secgrp-1522198"
+         ]
+         <snip>
+   info: Server URL: http://ec2-52-26-240-166.us-west-2.compute.amazonaws.com
+   info: 3 changes performed:
+      + 3 resources created
+   Update duration: 29.867075499s
+   ```
 
-    This time, there is a real URL for the server.
-
-1. We now have a running EC2 instance.  We can run `aws ec2 describe-instances --filter Name=tag:name,Values=pulumi`, or open the AWS Console, to see that this new instance is now running.
-
-1. View the provisioned resources via `pulumi stack`:
-
-    ```bash
-    Current stack is testing
-        (use `pulumi stack select` to change stack; `pulumi stack ls` lists known ones)
-    Last update at 2017-10-30 13:59:23.606056356 -0700 PDT
-    Additional update info:
-    <snip>
-
-    2 resources currently in this stack:
-
-    TYPE                                             NAME
-    aws:ec2/securityGroup:SecurityGroup              web-secgrp
-    aws:ec2/instance:Instance                        web-server-www
-    ```    
+   This time, there is a real URL for the server.
 
 1. Give the instance a few minutes to initialize, then verify that the server is running:
 
-    ```bash
-    $ curl http://your-url.us-west-2.compute.amazonaws.com
-    Hello, World!
-    Instance metadata:
-    us-west-2a    
-    ```
+   ```bash
+   $ curl http://your-url.us-west-2.compute.amazonaws.com
+   Hello, World!
+   Instance metadata:
+   us-west-2a    
+   ```
+
+1. Since this is an instance running in your own AWS account, you can run `aws ec2 describe-instances --filter Name=tag:name,Values=pulumi`, or open the AWS Console, to view the instance properties.
+
+1. You can always view your provisioned resources via `pulumi stack`. To see full details, use the `--show-ids` or `-i` flag:
+
+   ```bash
+   Current stack is testing:
+      Managed by Donnas-MacBook-Pro.local
+      Last updated at 2017-12-14 17:33:27.40281 -0800 PST
+      Pulumi version v0.9.3
+      Plugin pulumi-provider-aws [resource] version v0.9.3
+      Plugin pulumi-langhost-nodejs [language] version v0.9.3
+
+   Current stack resources (3):
+      TYPE                                             NAME
+      pulumi:pulumi:Stack                              webserver-testing
+      aws:ec2/securityGroup:SecurityGroup              web-secgrp
+      aws:ec2/instance:Instance                        web-server-www
+
+   Current stack outputs (0):
+      No output values currently in this stack
+
+   Use `pulumi stack select` to change stack; `pulumi stack ls` lists known ones
+   ```    
 
 ## Leverage a reusable component
 
@@ -300,79 +283,83 @@ Now, let's create a function that creates instances. We can then use it to creat
 
 1. Remove the last line of code:
 
-    ```typescript
-    // delete this:
-    server.publicDns.then(url => console.log(`Server URL: http://${url}`));
-    ```
+   ```typescript
+   // remove this line:
+   server.publicDns.then(url => console.log(`Server URL: http://${url}`));
+   ```
 
 1. Remove the definition of `server` and replace with the following:
 
-    ```typescript
-    export function createInstance(name: string, size: aws.ec2.InstanceType): aws.ec2.Instance {
-        let result = new aws.ec2.Instance(name, {
-            instanceType: size,                 // use function argument for size
-            securityGroups: [ group.name ],     // reference the group object above
-            ami: getLinuxAmi(),                 // call custom function
-            tags: { "Name": name },
-            userData: userData                  // set up a simple web server    
-        });
+   ```typescript
+   export function createInstance(name: string, size: aws.ec2.InstanceType): aws.ec2.Instance {
+      let result = new aws.ec2.Instance(name, {
+         tags: { "Name": name },             // use the `name` parameter
+         instanceType: size,                 // use function argument for size
+         securityGroups: [ group.name ],     // reference the group object above
+         ami: getLinuxAmi(),                 // call custom function
+         userData: userData                  // set up a simple web server    
+      });
 
-        result.publicDns.then(url => console.log(`Server URL: http://${url}`));
+      result.publicDns.then(url => console.log(`Server URL: http://${url}`));
 
-        return result;
-    }
-    ```
+      return result;
+   }
+   ```
 
 1. Create a new file `index.ts` with the following contents. This will provision two EC2 instances with different sizes.
 
-    ```typescript
-    import * as aws from "@pulumi/aws";
-    import * as webserver from "./webserver"; // use our custom component
+   ```typescript
+   import * as aws from "@pulumi/aws";
+   import * as webserver from "./webserver"; // use the new custom component
 
-    let webInstance = webserver.createInstance("web-server-www", "t2.micro");
-    let appInstance = webserver.createInstance("web-server-app", "t2.nano");
-    ```
+   let webInstance = webserver.createInstance("web-server-www", "t2.micro");
+   let appInstance = webserver.createInstance("web-server-app", "t2.nano");
+   ```
 
-1. Compile via `yarn build`.
+1. Compile via `yarn build` or `tsc`.
 
-1. We can run `pulumi preview` to see what changes this will make to our infrastructure. Note that only one new resource is created: since the security group and `web-server-www` instance are unchanged, they do not need to be updated or replaced.
+1. Run `pulumi preview` to see what changes this will make to your infrastructure. Note that only one new resource is created: since the security group and `web-server-www` instance are unchanged, they do not need to be updated or replaced. So, only the new server has a undefined URL.
 
-    ```bash
-    $ pulumi preview
-    Previewing changes:
-    info: www address: http://ec2-52-24-173-163.us-west-2.compute.amazonaws.com
-    info: app address: http://undefined
-    + aws:ec2/instance:Instance: (create)
-        [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-app]
-        ami            : "ami-29f80351"
-        instanceType   : "t2.nano"
-        securityGroups : [
-            [0]: "web-secgrp-241e97032e20c4c1"
-        ]
-        sourceDestCheck: true
-        tags           : {
-            Name: "web-server-app"
-        }
-        userData       : "#!/bin/bash\n  echo \"Hello, World!\nInstance metadata:\" > index.html\n  curl http://169.254.169.254/latest/meta-data/placement/availability-zone >> index.html\n  nohup python -m SimpleHTTPServer 80 &"
-    info: 1 change previewed:
-        + 1 resource to create
-        2 resources unchanged
-    ```
+   ```bash
+   $ pulumi preview
+   Previewing changes:
+   * pulumi:pulumi:Stack: (same)
+      [urn=urn:pulumi:testing::webserver::pulumi:pulumi:Stack::webserver-testing]
+   info: Server URL: http://ec2-34-216-29-77.us-west-2.compute.amazonaws.com
+      + aws:ec2/instance:Instance: (create)
+         [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-app]
+         ami            : "ami-7172b611"
+         instanceType   : "t2.nano"
+         securityGroups : [
+               [0]: "web-secgrp-f8391fc"
+         ]
+         sourceDestCheck: true
+         tags           : {
+               Name: "web-server-app"
+         }
+         userData       : "#!/bin/bash\n    echo \"Hello, World!\nInstance metadata:\" > index.html\n    curl http://169.254.169.254/latest/meta-data/placement/availability-zone >> index.html\n    nohup python -m SimpleHTTPServer 80 &"
+   info: Server URL: http://undefined
+   info: 1 change previewed:
+      + 1 resource to create
+      3 resources unchanged
+   ```
 
 1. Run `pulumi update` to make the resource changes:
 
-    ```bash
-    $ pulumi update
-    Performing changes:
-    info: www address: http://ec2-52-24-173-163.us-west-2.compute.amazonaws.com
-    + aws:ec2/instance:Instance: (create)
-        <snip>
-    info: app address: http://ec2-35-165-221-166.us-west-2.compute.amazonaws.com
-    info: 1 change performed:
-        + 1 resource created
-        2 resources unchanged
-    Update duration: 28.341593905s
-    ```
+   ```bash
+   $ pulumi update
+   Performing changes:
+   * pulumi:pulumi:Stack: (same)
+      [urn=urn:pulumi:testing::webserver::pulumi:pulumi:Stack::webserver-testing]
+   info: Server URL: http://ec2-34-216-29-77.us-west-2.compute.amazonaws.com
+      + aws:ec2/instance:Instance: (create)
+      <snip>
+   info: Server URL: http://ec2-52-89-84-84.us-west-2.compute.amazonaws.com
+   info: 1 change performed:
+      + 1 resource created
+      3 resources unchanged
+   Update duration: 16.105927027s
+   ```
 
 With a simple and natural extension the the original code, we've created a true cloud component. Anyone who uses the `webserver` package can automatically leverage the logic we've defined.
 
@@ -386,141 +373,129 @@ Make the following changes to the code:
 
 1. In `webserver.ts`, add a new string function argument for availability zone in `createInstance`, and pass the property `availabilityZone: zone` to the `aws.ec2.Instance` constructor. 
 
+   ```typescript
+   export function createInstance(name: string, size: aws.ec2.InstanceType, zone: string): aws.ec2.Instance {
+      let result = new aws.ec2.Instance(name, {
+         availabilityZone: zone,
+      // ...
+   ```    
+
 1. In `index.ts`, remove the definitions of `webInstance` and `appInstance`. Add the following code to create an EC2 instance in each availability zone in the region:
 
-    ```typescript
-    (async () => {
-        let zones: string[] = (await aws.getAvailabilityZones()).names;
-        for (let i = 0; i < zones.length; i++) {
-            let server = webserver.createInstance("web-server-www-" + i, "t2.micro", zones[i]);
-        }
-    })();    
-    ```
+   ```typescript
+   // the async block is currently required, due to the use of `await` 
+   // this will be improved in the future
+   (async () => {
+      let zones: string[] = (await aws.getAvailabilityZones()).names;
+      for (let i = 0; i < zones.length; i++) {
+         let server = webserver.createInstance("web-server-www-" + i, "t2.micro", zones[i]);
+      }
+   })();    
+   ```
 
 1. Run `yarn build`.
 
-1. Run `pulumi preview`. Since we changed the instance name, two resources will be deleted and 3 resources will be created (since there are 3 availability zones in west-us-2).
+1. Run `pulumi preview`. Since we changed the instance name, two resources will be deleted and 3 resources will be created, as there are 3 availability zones in west-us-2:
 
-    ```bash
-    $ pulumi preview
-    Previewing changes:
-    info: Server URL: http://undefined
-    info: Server URL: http://undefined
-    info: Server URL: http://undefined
-    + aws:ec2/instance:Instance: (create)
-        <snip>
-    + aws:ec2/instance:Instance: (create)
-        <snip>
-    + aws:ec2/instance:Instance: (create)
-        <snip>
-    - aws:ec2/instance:Instance: (delete)
-        <snip>
-        tags           : {
-            Name: "web-server-app"
-        }
-        <snip>
-    - aws:ec2/instance:Instance: (delete)
-        <snip>
-        tags           : {
-            Name: "web-server-www"
-        }
-        <snip>
-    info: 5 changes previewed:
-        + 3 resources to create
-        - 2 resources to delete
-        1 resource unchanged
-    ```    
+   ```bash
+   $ pulumi preview --summary
+   Previewing changes:
+   * pulumi:pulumi:Stack: (same)
+      [urn=urn:pulumi:testing::webserver::pulumi:pulumi:Stack::webserver-testing]
+   + aws:ec2/instance:Instance: (create)
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-0]
+   info: Server URL: http://undefined
+   + aws:ec2/instance:Instance: (create)
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-1]
+   info: Server URL: http://undefined
+   + aws:ec2/instance:Instance: (create)
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-2]
+   info: Server URL: http://undefined
+      - aws:ec2/instance:Instance: (delete)
+         [id=i-0411117ebe29fa49e]
+         [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-app]
+      - aws:ec2/instance:Instance: (delete)
+         [id=i-0057df76ac1324fce]
+         [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www]
+   info: 5 changes previewed:
+      + 3 resources to create
+      - 2 resources to delete
+      2 resources unchanged
+   ```    
 
 1. Run `pulumi update`.
 
-    ```bash
-    $ pulumi update
-    Performing changes:
-    + aws:ec2/instance:Instance: (create)
-        <snip>
-    info: Server URL: http://ec2-34-208-122-55.us-west-2.compute.amazonaws.com
-    + aws:ec2/instance:Instance: (create)
-        <snip>
-    info: Server URL: http://ec2-35-160-70-200.us-west-2.compute.amazonaws.com
-    + aws:ec2/instance:Instance: (create)
-        <snip>
-    info: Server URL: http://ec2-34-215-88-48.us-west-2.compute.amazonaws.com
-    - aws:ec2/instance:Instance: (delete)
-        <snip>
-    - aws:ec2/instance:Instance: (delete)
-        <snip>
-    info: 5 changes performed:
-        + 3 resources created
-        - 2 resources deleted
-        1 resource unchanged
-    Update duration: 2m59.419848955s
-    ```
+   ```bash
+   $ pulumi update --summary
+   Performing changes:
+   * pulumi:pulumi:Stack: (same)
+      [urn=urn:pulumi:testing::webserver::pulumi:pulumi:Stack::webserver-testing]
+   + aws:ec2/instance:Instance: (create)
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-0]
+   info: Server URL: http://ec2-34-208-200-113.us-west-2.compute.amazonaws.com
+   + aws:ec2/instance:Instance: (create)
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-1]
+   info: Server URL: http://ec2-35-161-236-236.us-west-2.compute.amazonaws.com
+   + aws:ec2/instance:Instance: (create)
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-2]
+   info: Server URL: http://ec2-34-215-170-73.us-west-2.compute.amazonaws.com
+      - aws:ec2/instance:Instance: (delete)
+         [id=i-0411117ebe29fa49e]
+         [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-app]
+      - aws:ec2/instance:Instance: (delete)
+         [id=i-0057df76ac1324fce]
+         [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www]
+   info: 5 changes performed:
+      + 3 resources created
+      - 2 resources deleted
+      2 resources unchanged
+   Update duration: 2m14.896208211s
+   ```
 
 1. Give the instances a few minutes to initialize, then `curl` each URL that was printed out. You will see that each instance is in a different availability zone. 
 
-    Tip: to see just the instance URLs, run `pulumi update` again. Since there will be no changes, it will print just the `console.log` statements.
+   Tip: to see just the instance URLs, run `pulumi update` again. Since there will be no changes, it will print just the `console.log` statements.
 
-    ```bash
-    $ curl http://your-url.us-west-2.compute.amazonaws.com
-    Hello, World!
-    Instance metadata:
-    us-west-2a
-    ```
+   ```bash
+   $ curl http://your-url.us-west-2.compute.amazonaws.com
+   Hello, World!
+   Instance metadata:
+   us-west-2a
+   ```
 
-This example shows the power of using real programming language constructs to define infrastructure. Markup languages simply aren't expressive enough to describe these common patterns.
+This example shows the power of using real programming language constructs to define infrastructure. Markup languages simply aren't expressive enough to describe these common patterns. 
 
 ## Clean up
 
 1. To clean up after ourselves, just run `pulumi destroy` and answer the confirmation question at the prompt:
 
-    ```bash
-    $ pulumi destroy
-    This will permanently destroy all resources in the 'testing' stack!
-    Please confirm that this is what you'd like to do by typing ("testing"): testing
-    Performing changes:
-    - aws:ec2/instance:Instance: (delete)
-        [id=i-01ea9554bb9d44ca8]
-        [urn=urn:lumi:testing::webserver::aws:ec2/instance:Instance::web-server-api]
-        ami            : "ami-7172b611"
-        instanceType   : "t2.nano"
-        securityGroups : [
-            [0]: "web-secgrp-cea08d71378cb4fe"
-        ]
-        sourceDestCheck: true
-        tags           : {
-            name: "pulumi"
-        }
-    - aws:ec2/instance:Instance: (delete)
-        [id=i-0b12d17d90b9d343e]
-        [urn=urn:lumi:testing::webserver::aws:ec2/instance:Instance::web-server-www]
-        ami            : "ami-7172b611"
-        instanceType   : "t2.micro"
-        securityGroups : [
-            [0]: "web-secgrp-cea08d71378cb4fe"
-        ]
-        sourceDestCheck: true
-        tags           : {
-            name: "pulumi"
-        }
-    - aws:ec2/securityGroup:SecurityGroup: (delete)
-        [id=sg-4bfe3a36]
-        [urn=urn:lumi:testing::webserver::aws:ec2/securityGroup:SecurityGroup::web-secgrp]
-        description: "Enable HTTP access"
-        ingress    : [
-            [0]: {
-                    cidrBlocks: [
-                        [0]: "0.0.0.0/0"
-                    ]
-                    fromPort  : 80
-                    protocol  : "tcp"
-                    toPort    : 80
-                }
-        ]
-        name       : "web-secgrp-cea08d71378cb4fe"
-    info: 3 changes deployed:
-        - 3 resources deleted
-    Update duration: 2m13.232697769s
-    ```
+   ```bash
+   $ pulumi destroy
+   This will permanently destroy all resources in the 'testing' stack!
+   Please confirm that this is what you'd like to do by typing ("testing"): testing
+   Performing changes:
+   - aws:ec2/instance:Instance: (delete)
+      [id=i-0de2b82c7cedbc0dc]
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-2]
+      <snip>
+   - aws:ec2/instance:Instance: (delete)
+      [id=i-0f442c1c4b7326fb4]
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-1]
+      <snip>
+   - aws:ec2/instance:Instance: (delete)
+      [id=i-00b2217ec6726d66d]
+      [urn=urn:pulumi:testing::webserver::aws:ec2/instance:Instance::web-server-www-0]
+      <snip>
+   - aws:ec2/securityGroup:SecurityGroup: (delete)
+      [id=sg-14f97668]
+      [urn=urn:pulumi:testing::webserver::aws:ec2/securityGroup:SecurityGroup::web-secgrp]
+      <snip>
+   - pulumi:pulumi:Stack: (delete)
+      [urn=urn:pulumi:testing::webserver::pulumi:pulumi:Stack::webserver-testing]
+   info: 5 changes performed:
+      - 5 resources deleted
+   Update duration: 3m4.947625452s
+   ```
 
 > _Note_: Pulumi currently runs all infrastructure updates sequentially to provide the greatest assurance of repeatable
 > results.  Parallel execution of infrastructure updates is available with an experimental `--parallel N` flag, and this will likely become the default in the future.

--- a/quickstart/cloud.md
+++ b/quickstart/cloud.md
@@ -39,62 +39,65 @@ Since this example builds a custom container, you should first have [Docker](htt
 1. In the `voting-app` folder, add the following file as `index.ts`:
 
    ```typescript
-    import * as cloud from "@pulumi/cloud";
+   import * as cloud from "@pulumi/cloud";
 
-    // To simplify this example, we have defined the password directly in code
-    // In a real app, would add the secret via `pulumi config secret <key> <value>` and
-    // access via pulumi.Config APIs
-    let redisPassword = "SECRETPASSWORD"; 
+   // To simplify this example, we have defined the password directly in code
+   // In a real app, would add the secret via `pulumi config secret <key> <value>` and
+   // access via pulumi.Config APIs
+   let redisPassword = "SECRETPASSWORD"; 
 
-    let redisPort = 6379;
+   // The data layer for the application
+   // Use the 'image' property to point to a pre-built Docker image.
+   let redisCache = new cloud.Service("voting-app-cache", {
+      containers: {
+         redis: {
+               image: "redis:alpine",
+               memory: 128,
+               ports: [{ port: 6379 }],
+               command: ["redis-server", "--requirepass", redisPassword],
+         },
+      },
+   });
 
-    let redisCache = new cloud.Service("voting-app-cache", {
-        containers: {
-            redis: {
-                image: "redis:alpine",
-                memory: 128,
-                ports: [{ port: redisPort }],
-                command: ["redis-server", "--requirepass", redisPassword],
-            },
-        },
-    });
+   // A custom container for the frontend, which is a Python Flask app
+   // Use the 'build' property to specify a folder that contains a Dockerfile.
+   // Pulumi builds the container for you and pushes to an ECR registry
+   let frontend = new cloud.Service("voting-app-frontend", {
+      containers: {
+         votingAppFrontend: {
+               build: "./frontend",   // path to the folder containing the Dockerfile
+               memory: 128,
+               ports: [{ port: 80 }],            
+               environment: { 
+                  // pass the Redis container info in environment variables
+                  // (the use of promises will be improved in the future)
+                  "REDIS": redisCache.getEndpoint().then(e => e.hostname),
+                  "REDIS_PORT": redisCache.getEndpoint().then(e => e.port.toString()),
+                  "REDIS_PWD": redisPassword
+               }
+         },
+      },
+   });
 
-    let frontend = new cloud.Service("voting-app-frontend", {
-        containers: {
-            votingAppFrontend: {
-                build: "./frontend",
-                memory: 128,
-                ports: [{ port: 80 }],            
-                environment: { 
-                    // pass in the created container info in environment variables
-                    // the awkward nested promises will be improved soon; see pulumi/pulumi #331
-                    "REDIS": redisCache.getEndpoint("redis", redisPort).then(e => e.hostname),
-                    "REDIS_PORT": redisCache.getEndpoint("redis", redisPort).then(e => e.port).then(port => port.toString()),
-                    "REDIS_PWD": redisPassword
-                }
-            },
-        },
-    });
-
-    frontend.getEndpoint().then(e => console.log(`http://${e.hostname}:${e.port}`));
+   // Export a variable that will be displayed during 'pulumi update'
+   export let frontendURL = frontend.getEndpoint().then(e => `http://${e.hostname}:${e.port}`);
    ```
 
 #### Understanding the code
 
 Even though this Pulumi program is just over 36 lines long, it does quite a bit:
 
-- It creates two containers, a Redis cache with container port 6379 and a custom Docker container for the app frontend.
-- Stores the port in the variable `redisPort`, since the frontend app needs to connect to the Redis container.
-- Creates a container `redisCache`. This is a Redis cache that uses the `redis` image with tag `alpine` from DockerHub. Since it's a built image, you just have to specify the port and startup command.
-- Creates a second container `frontend`, which is more interesting. If you look at `frontend/app/main.py` in the `voting-app` folder, you'll see that the app expects the Redis connection information to be provided in environment variables:
+- Creates a container `redisCache`. This is a Redis cache that just uses the `redis` image with tag `alpine` from Docker Hub. Since it's a built image, you just have to specify the port and startup command.
+- Creates a custom container `frontend`:
+  - Uses the `build` property to point to a folder with a Dockerfile. Pulumi automatically invokes `docker build` for you and pushes the container to ECR.
+  - Exports the output `frontendURL`, via the line `export let frontEndUrl = ...`. This creates an output property that can be used by other parts of your program and is displayed during `pulumi update`.
+  - Uses Pulumi APIs to statically lookup the server name and port for the container `redisCache` and set environment variables. This makes it easy to connect containers to each other. The Flask app uses these environment variables to connect to the Redis cache container. See these definitions in `frontend/app/main.py` in the `voting-app` folder:
 
-   ```python
-   redis_server =   os.environ['REDIS']
-   redis_port =     os.environ['REDIS_PORT']
-   redis_password = os.environ['REDIS_PWD']
-   ```
-
-   We can use Pulumi APIs to statically lookup the server name and port for the container `redisCache`. So, it is very easy to connect containers to each other.
+    ```python
+    redis_server =   os.environ['REDIS']
+    redis_port =     os.environ['REDIS_PORT']
+    redis_password = os.environ['REDIS_PWD']
+    ```
 
 ### Build, preview, and update
 
@@ -104,18 +107,18 @@ Now, lets deploy this elegant program to AWS.
 
 1. Link with the Pulumi SDK packages so that your `require`s will find the right thing, using either `yarn` or `npm`:
 
-    ```bash
-    $ yarn link pulumi @pulumi/cloud
-    ```
+   ```bash
+   $ yarn link pulumi @pulumi/cloud
+   ```
 
 1. Compile the code via `yarn build`.
 
 1. Create a new Pulumi repository and stack:
 
-    ```bash
-    $ pulumi init
-    $ pulumi stack init testing
-    ```
+   ```bash
+   $ pulumi init
+   $ pulumi stack init votingapp-testing --local
+   ```
 
 1. Set your AWS region via `pulumi config set aws:config:region us-west-2` (or whichever region you prefer).
 
@@ -125,17 +128,131 @@ Now, lets deploy this elegant program to AWS.
    $ pulumi config set cloud-aws:config:ecsAutoCluster true
    ```
 
-1. Preview changes via `pulumi preview`. This step will create the Docker container but will not provision resources.
+1. Ensure the Docker daemon is running on your machine, then preview changes via `pulumi preview`. This step will create the Docker container but will not provision resources.
 
-1. Deploy the changes with `pulumi update`. This is when the resources are provisioned and will take 20-30 minutes. In the future, Pulumi will parallelize resource creations so that the experience is smoother.
-   
-   The frontend URL can get lost amid the output (this will be improved, see [\#454](https://github.com/pulumi/pulumi/issues/454)). As a workaround, once the deployment is complete, run `pulumi update` again. 
+   There are a number of resources that are automatically created for you, such as the ECS cluster, EFS instance, networking resources, log group, and so on. This is all implemented using the patterns specified in AWS reference architectures, freeing you to think in terms of high-level concepts.
 
-1. In a browser, navigate to the URL. You should see the voting app webpage. 
+   ```bash
+   $ pulumi preview --summary
+   Previewing changes:
+   + pulumi:pulumi:Stack: (create)
+      [urn=urn:pulumi:votingapp-testing::voting-app::pulumi:pulumi:Stack::voting-app-votingapp-testing]
+      + aws:ec2/vpc:Vpc: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/vpc:Vpc::pulumi-votingapp--global]
+      + aws:ec2/internetGateway:InternetGateway: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/internetGateway:InternetGateway::pulumi-votingapp--global]
+      + aws:ec2/routeTable:RouteTable: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/routeTable:RouteTable::pulumi-votingapp--global]
+      + aws:ec2/subnet:Subnet: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/subnet:Subnet::pulumi-votingapp--global-0]
+      + aws:ec2/routeTableAssociation:RouteTableAssociation: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/routeTableAssociation:RouteTableAssociation::pulumi-votingapp--global-0]
+      + aws:ec2/subnet:Subnet: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/subnet:Subnet::pulumi-votingapp--global-1]
+      + aws:ec2/routeTableAssociation:RouteTableAssociation: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/routeTableAssociation:RouteTableAssociation::pulumi-votingapp--global-1]
+      + aws:ecs/cluster:Cluster: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ecs/cluster:Cluster::pulumi-votingapp--global]
+      + aws:iam/role:Role: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:iam/role:Role::pulumi-votingapp--global]
+      + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-votingapp--global-5e4162cd]
+      + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-votingapp--global-efc8f10d]
+      + aws:iam/instanceProfile:InstanceProfile: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:iam/instanceProfile:InstanceProfile::pulumi-votingapp--global]
+      + aws:ec2/securityGroup:SecurityGroup: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/securityGroup:SecurityGroup::pulumi-votingapp--global]
+      + aws:efs/fileSystem:FileSystem: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:efs/fileSystem:FileSystem::pulumi-votingapp--global]
+      + aws:ec2/securityGroup:SecurityGroup: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/securityGroup:SecurityGroup::pulumi-votingapp--global-fs]
+      + aws:efs/mountTarget:MountTarget: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:efs/mountTarget:MountTarget::pulumi-votingapp--global-0]
+      + aws:efs/mountTarget:MountTarget: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:efs/mountTarget:MountTarget::pulumi-votingapp--global-1]
+      + aws:ec2/launchConfiguration:LaunchConfiguration: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ec2/launchConfiguration:LaunchConfiguration::pulumi-votingapp--global]
+      + aws:cloudformation/stack:Stack: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:cloudformation/stack:Stack::pulumi-votingapp--global]
+      + cloud:service:Service: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service::voting-app-cache]
+      + aws:elasticloadbalancingv2/loadBalancer:LoadBalancer: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:elasticloadbalancingv2/loadBalancer:LoadBalancer::pulumi-vo-ne1]
+         + aws:elasticloadbalancingv2/targetGroup:TargetGroup: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:elasticloadbalancingv2/targetGroup:TargetGroup::pulumi-vo-ne0]
+         + aws:elasticloadbalancingv2/listener:Listener: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:elasticloadbalancingv2/listener:Listener::pulumi-vo-ne0]
+      + cloud:global:infrastructure: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::cloud:global:infrastructure::global-infrastructure]
+         + aws:iam/role:Role: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:global:infrastructure$aws:iam/role:Role::pulumi-vot-load-balancer]
+         + aws:iam/rolePolicy:RolePolicy: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:global:infrastructure$aws:iam/rolePolicy:RolePolicy::pulumi-vot-load-balancer]
+         + aws:cloudwatch/logGroup:LogGroup: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:cloudwatch/logGroup:LogGroup::voting-app-cache]
+      + cloud:logCollector:LogCollector: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::cloud:logCollector:LogCollector::pulumi-votingapp-testing]
+         + aws:serverless:Function: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:logCollector:LogCollector$aws:serverless:Function::pulumi-votingapp-testing]
+               + aws:iam/role:Role: (create)
+                  [urn=urn:pulumi:votingapp-testing::voting-app::cloud:logCollector:LogCollector$aws:serverless:Function$aws:iam/role:Role::pulumi-votingapp-testing]
+               + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+                  [urn=urn:pulumi:votingapp-testing::voting-app::cloud:logCollector:LogCollector$aws:serverless:Function$aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-votingapp-testing-32be53a2]
+               + aws:lambda/function:Function: (create)
+                  [urn=urn:pulumi:votingapp-testing::voting-app::cloud:logCollector:LogCollector$aws:serverless:Function$aws:lambda/function:Function::pulumi-votingapp-testing]
+         + aws:lambda/permission:Permission: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:logCollector:LogCollector$aws:lambda/permission:Permission::pulumi-votingapp-testing]
+         + aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::voting-app-cache]
+         + aws:iam/role:Role: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:global:infrastructure$aws:iam/role:Role::pulumi-votingapp-te-task]
+         + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:global:infrastructure$aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-vot-task-32be53a2]
+         + aws:iam/rolePolicyAttachment:RolePolicyAttachment: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:global:infrastructure$aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-vot-task-fd1a00e5]
+         + aws:ecs/taskDefinition:TaskDefinition: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:ecs/taskDefinition:TaskDefinition::voting-app-cache]
+         + aws:ecs/service:Service: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:ecs/service:Service::voting-app-cache]
+      + cloud:service:Service: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service::voting-app-frontend]
+      + aws:elasticloadbalancingv2/loadBalancer:LoadBalancer: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:elasticloadbalancingv2/loadBalancer:LoadBalancer::pulumi-vo-ne2]
+         + aws:elasticloadbalancingv2/targetGroup:TargetGroup: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:elasticloadbalancingv2/targetGroup:TargetGroup::pulumi-vo-ne1]
+   info: Building container image 'pulum-df6d90cb-container' from ./frontend
+         + aws:elasticloadbalancingv2/listener:Listener: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:elasticloadbalancingv2/listener:Listener::pulumi-vo-ne1]
+         + aws:cloudwatch/logGroup:LogGroup: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:cloudwatch/logGroup:LogGroup::voting-app-frontend]
+         + aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::voting-app-frontend]
+      + aws:ecr/repository:Repository: (create)
+         [urn=urn:pulumi:votingapp-testing::voting-app::aws:ecr/repository:Repository::pulum-df6d90cb-container]
+   info: Sending build context to Docker daemon  12.29kB
+   <snip>
+   info: Skipping image publish during preview: pulum-df6d90cb-container
+         + aws:ecs/taskDefinition:TaskDefinition: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:ecs/taskDefinition:TaskDefinition::voting-app-frontend]
+         + aws:ecs/service:Service: (create)
+               [urn=urn:pulumi:votingapp-testing::voting-app::cloud:service:Service$aws:ecs/service:Service::voting-app-frontend]
+   info: 49 changes previewed:
+       + 49 resources to create
+   ```
+
+1. Deploy the changes with `pulumi update`. This is when the resources are provisioned and will take 20-30 minutes. (In the future, Pulumi will parallelize resource creations so that the experience is smoother.) You'll see that there is a stack output `frontendUrl`:
+
+   ```bash
+   ---outputs:---
+   frontendURL: "http://pulumi-vo-ne2-d7f97ef-7c5e2c22a22ec44a.elb.us-west-2.amazonaws.com:34567"
+   ```
+
+1. In a browser, navigate to the URL specified for `frontendURL`. You should see the voting app webpage. 
 
    ![Voting app screenshot](./voting-app-webpage.png)
 
-### Cleanup resources
+### Clean up resources
 
 Clean up your resources with `pulumi destroy`. This will take a few minutes, as deletes for some AWS resources can take some time.
 

--- a/quickstart/overview.md
+++ b/quickstart/overview.md
@@ -113,7 +113,7 @@ additional methods for managing infrastructure state across updates, including a
 
 Since this is a simple example, it might seem that using AWS CloudFormation would not be too onerous. Unfortunately, because CloudFormation lacks high-level programming language constructs, even a simple infrastructure definition is very verbose. And, because CloudFormation uses embedded formulas and strings to reference objects, it's quite error-prone. With Pulumi, you don't need special tools to analyze your infrastructure definition, you just use regular code.
 
-In particular, it takes *90 lines* of CloudFormation to define the infrastructure for this simple example. Pulumi programs tend to be 10x smaller than the CloudFormation they replace. 
+In particular, it takes *90 lines* of CloudFormation JSON to define the infrastructure for this simple example. (YAML is more verbose but easier to read). Pulumi programs tend to be 10x smaller than the CloudFormation JSON they replace. 
 
 The elided CloudFormation definition is below. Notice the use of strings to connect objects and the custom syntax of `Fn::` and `Ref`. Wouldn't you rather just use JavaScript?
 
@@ -122,17 +122,17 @@ The elided CloudFormation definition is below. Notice the use of strings to conn
   "AWSTemplateFormatVersion" : "2010-09-09",
   "Parameters" : {
     "InstanceType" : {
-        "7 lines elided": ""
+        // 7 lines elided
     }
   },
   "Mappings" : {
     "AWSInstanceType2Arch" : {
-      "t1.micro"    : { "Arch" : "PV64"   },
-      "35 additional lines elided": ""
+      "t1.micro"    : { "Arch" : "PV64"   }
+      // 35 additional lines elided
     },
     "AWSRegionArch2AMI" : {
-      "us-east-1"      : { "PV64" : "ami-50842d38", "HVM64" : "ami-08842d60", "HVMG2" : "ami-3a329952"  },
-      "9 additional line elided": ""
+      "us-east-1"      : { "PV64" : "ami-50842d38", "HVM64" : "ami-08842d60", "HVMG2" : "ami-3a329952"  }
+      // 9 additional lines elided
     }
   },
   "Resources" : {


### PR DESCRIPTION
NOTE: there are a lot of diffs in the source code, because I realized that the number of spaces in code blocks was causing weird formatting issues in the rendered output.

@ellismg I'm not going to push an update to the site; I'll wait for you to update docs with the 0.9.3 drop (assuming that was your plan)