### PR TITLE
Use Jekyll front matter variable for latest Pulumi version. Fixes #53

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -1,7 +1,10 @@
 ---
 layout: default
 nav_section: "install"
+installer_version: "0.9.8"
 ---
+
+<!-- To update this page with a new binary release, update `installer_version` in the YAML front matter above. -->
 
 # Installation and Setup
 
@@ -18,7 +21,7 @@ The first step is to download a binary release suitable for your system.
 
 **NOTE**: if you don't have access to the downloads below, you should have received a link to the binaries. If not, please [contact us](/contact).
 
-The current version of Pulumi's SDK is <b>v0.9.8</b> and is
+The current version of Pulumi's SDK is **{{ page.installer_version }}** and is
 available for these systems:
 
 <div class="little-jumbotron">
@@ -29,21 +32,21 @@ available for these systems:
                     id="macos-download-link"
                     class="[ btn btn-lg ] [ white hover-white bg-brand hover-bg-accent2 no-underline ]"
                     style="padding-left: 12px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px"
-                    href="/releases/pulumi-v0.9.8-darwin.x64.tar.gz" role="button">
+                    href="/releases/pulumi-v{{page.installer_version}}-darwin.x64.tar.gz" role="button">
                 {% octicon cloud-download height:24 %} macOS x64
             </a>
             <a
                     id="windows-download-link"
                     class="[ btn btn-lg ] [ white hover-white bg-brand hover-bg-accent2 no-underline ]"
                     style="padding-left: 12px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px"
-                    href="/releases/pulumi-v0.9.8-windows.x64.zip" role="button">
+                    href="/releases/pulumi-v{{page.installer_version}}-windows.x64.zip" role="button">
                 {% octicon cloud-download height:24 %} Windows x64
             </a>
             <a
                     id="linux-download-link"
                     class="[ btn btn-lg ] [ white hover-white bg-brand hover-bg-accent2 no-underline ]"
                     style="padding-left: 12px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px"
-                    href="/releases/pulumi-v0.9.8-linux.x64.tar.gz" role="button">
+                    href="/releases/pulumi-v{{page.installer_version}}-linux.x64.tar.gz" role="button">
                 {% octicon cloud-download height:24 %} Linux x64
             </a>
         </p>
@@ -116,18 +119,18 @@ First download the Pulumi SDK release for your operating system per the above in
 
 Now run the installer, the process depends on if you are on macOS/Linux vs Windows:
 
-* On macOS and Linux, extract the `pulumi-v0.9.8-darwin.x64.tar.gz` or `pulumi-v0.9.8-linux.x64.tar.gz` tarball to any
+* On macOS and Linux, extract the `pulumi-v{{page.installer_version}}-darwin.x64.tar.gz` or `pulumi-v{{page.installer_version}}-linux.x64.tar.gz` tarball to any
   directory, then run the `install.sh` script inside the pulumi folder that was extracted.
 
 On macOS run:
 ```bash
-$ tar -xzf pulumi-v0.9.8-darwin.x64.tar.gz
+$ tar -xzf pulumi-v{{page.installer_version}}-darwin.x64.tar.gz
 $ ./pulumi/install.sh
 ```
 
 On Linux run:
 ```bash
-$ tar -xzf pulumi-v0.9.8-linux.x64.tar.gz
+$ tar -xzf pulumi-v{{page.installer_version}}-linux.x64.tar.gz
 $ ./pulumi/install.sh
 ```
 
@@ -135,7 +138,7 @@ This script will install Pulumi into `/usr/local/pulumi`. Depending on your syst
 so it can create a subfolder of `/usr/local` and so it can run `npm link`. The script will tell you if this is going to
 happen.  After the installer has run, you may delete the `pulumi` folder that was created by untaring the tarball.
 
-* On Windows, extract `pulumi-v0.9.8-windows.x64.zip` to the installation target and run  `install.cmd` from either a
+* On Windows, extract `pulumi-v{{page.installer_version}}-windows.x64.zip` to the installation target and run  `install.cmd` from either a
   CMD or PowerShell shell.  We recommend `%SystemRoot%\Program Files`.
 
 Afterwards, you'll need to add the installation's `bin` directory to you `PATH`.  This makes running `pulumi` CLI easy
@@ -149,7 +152,7 @@ you have the tools installed and available on your `PATH`, try running `pulumi v
 
 ```bash
 $ pulumi version
-v0.9.8
+v{{page.installer_version}}
 ```
 
 We're almost done, but not quite: Pulumi still needs to be told exactly how to talk with your favorite cloud provider.


### PR DESCRIPTION
I verified that the generated HTML is identical to the previous commit (with the exception of `<b>` vs `<strong>`, since I changed `<b>` in the text to markdown `**`).

Once this is merged in, I'll update the wiki https://github.com/pulumi/home/wiki/Producing-an-SDK to document the front matter variable.