### PR TITLE
Fix rogue <hr> tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ configure:
 	gem install jekyll bundler
 	yarn install
 
+.PHONY: ensure
+configure:
+	bundle install
+
 .PHONY: serve
 serve: 
 	@echo -e "\033[0;32mSERVE:\033[0m"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,5 @@
 <footer class="tc mw8 center">
+    <div class="cb"></div>
     <div class="container">
         <hr />
         <small class="[ ttu pa3 ] [ gray ]">Copyright &copy; 2018 Pulumi Corporation</small>


### PR DESCRIPTION
This PR fixes #79, the rogue `<hr>` that was at the top of the page.

@lindydonna  The root problem was in the new table of contents. Using the chrome dev tools I noticed that the `<footer>` element was trying to be displayed near the very top of the page. This doesn't make sense, but since I new we were using the `float` CSS property on the table of contents, it was something related to that. The `<footer>` thought it was at the top of the page because ... _this is where if CSS made sense I could explain some logical reason for how this works, but I do not. I do remember enough from reading [this book](https://www.wiley.com/en-us/HTML+and+CSS%3A+Design+and+Build+Websites-p-9781118008188) that the answer has to do with `clear`_ ... A Google search with "floated divs take no space" later lead me to [this blog post](https://css-tricks.com/the-how-and-why-of-clearing-floats/) which explained the deal. And, because Tachyons is annoying like this, the class name to add `clear: both;` is `cb`.

Anyways, the rogue `<hr>` is back inline. The PR also adds a `make ensure` build task to install dependencies, like the required Ruby gems.