### PR TITLE
Simplify install page, group instructions by OS, add 0.11 SDK

### DIFF
--- a/_data/install.yaml
+++ b/_data/install.yaml
@@ -5,5 +5,5 @@ toc:  # No landing page
 - title: Install
   section:
   - install/index.md
-  - install/changelog.md
   - install/aws-config.md
+  - install/changelog.md

--- a/css/style.scss
+++ b/css/style.scss
@@ -173,6 +173,9 @@ blockquote {
 
 .docsToc {
   width: 25%;
+  font-size: 15px;
+  padding-left: 0px;
+  padding-right: 0px;
 }
 
 .docsToc:after {

--- a/install/aws-config.md
+++ b/install/aws-config.md
@@ -1,32 +1,24 @@
 ---
-title: "Configure AWS credentials"
+title: "▶ Configure Pulumi for AWS"
 ---
 
-To target AWS in a Pulumi program, you will need to configure your system
-so that Pulumi can communicate with AWS.  Pulumi does not store this information anywhere, and these credentials
-must include sufficient IAM rights to deploy and manage resources in your AWS account.
+<!-- LINKS -->
+[Pulumi AWS provider]: ../reference/aws.html
+[iam-user-console]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_console
+[configure-aws-cli]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
 
-The easiest way to configure your AWS credentials is to simply set the `AWS_ACCESS_KEY_ID` and
-`AWS_SECRET_ACCESS_KEY` environment variables to the values given to you in the IAM console.  For example,
-on macOS or Linux:
+The [Pulumi AWS provider] uses the AWS SDK to manage and provision resources. 
 
-```bash
-$ export AWS_ACCESS_KEY_ID=AK**************WORA
-$ export AWS_SECRET_ACCESS_KEY=7n******************************6eLEKd8G
-```
+1.  If you haven't already, [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html). If you're using [Homebrew](https://brew.sh/) on macOS, you can use the community-managed [awscli](http://formulae.brew.sh/formula/awscli) via `brew install awscli`.
 
-Of course the `**` strings should be replaced with your own credentials.
+2.  If necessary, [create an IAM user in the AWS console][iam-user-console] with type  **Programmatic access**. The IAM user should have sufficient rights to deploy and manage your program's resources. If you know the precise kinds of resources you wish to create and delete, you can restrict the IAM user accordingly.
 
-Alternatively, you can install the [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) and use
-it to configure your IAM credentials locally on your machine.  These will be stored and cached in your home directory:
+3.  Configure the AWS CLI with the IAM credentials, such as with the `aws configure` command. For other configuration options, see the AWS article [Configuring the AWS CLI](configure-aws-cli).
 
-```bash
-$ aws configure
-AWS Access Key ID [AK**************WORA]:
-AWS Secret Access Key [7n******************************6eLEKd8G]:
-Default region name [us-west-2]:
-Default output format [None]:
-```
-
-In general, you can use any of the other configuration options documented on the [AWS SDK website](
-http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html).
+    ```bash
+    $ aws configure --profile user2
+    AWS Access Key ID [None]: AKIAI44QH8DHBEXAMPLE
+    AWS Secret Access Key [None]: je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
+    Default region name [None]: us-west-2
+    Default output format [None]: text
+    ```

--- a/install/changelog.md
+++ b/install/changelog.md
@@ -14,9 +14,43 @@ title: "Change log"
 [Using the Pulumi Console]: ../managed-cloud/console.html
 <!-- End common links -->
 
-See [known issues](../reference/known-issues.html) for currently known issues and workarounds.
+## Available versions {#all-versions}
 
-## v0.11.0 {#v11}
+<table class="table table-sm table-bordered">
+  <thead>
+    <tr>
+      <th scope="col">Version</th>
+      <th scope="col">Date</th>
+      <th scope="col">Downloads</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row"><a href="#v11">0.11.0</a></th>
+      <td>2018/03/20</td>
+      <td>{% include sdk-links.html version='0.11.0' %}</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="#v10">0.10.0</a></th>
+      <td>2018/02/27</td>
+      <td>{% include sdk-links.html version='0.10.0' %}</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="#v913">0.9.13</a></th>
+      <td>2018/02/07</td>
+      <td>{% include sdk-links.html version='0.9.13' %}</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="#v911">0.9.11</a></th>
+      <td>2018/01/22</td>
+      <td>{% include sdk-links.html version='0.9.11' %}</td>
+    </tr>
+  </tbody>
+</table>
+
+> See [known issues](../reference/known-issues.html) for currently known issues and workarounds.
+
+## SDK version 0.11.0 {#v11}
 Released 2018/03/20 
 
 ### Added
@@ -66,7 +100,7 @@ Released 2018/03/20
 
 -  Produce better error messages when the main module is not found ([pulumi/pulumi#976](https://github.com/pulumi/pulumi/pull/976)). If you're running TypeScript but have not run `tsc` or your main JavaScript file does not exist, the CLI will print a helpful `info:` message that points to the possible source of the error. 
 
-## 0.10 {#v10}
+## SDK version 0.10.0 {#v10}
 Released on 2018/02/27 
 
 ### Added
@@ -117,7 +151,7 @@ Released on 2018/02/27
 -  Error when using `float64` attributes using SDK v0.9.9 ([pulumi-terraform#95](https://github.com/pulumi/pulumi-terraform/issues/95))
 -  `pulumi logs` entries only return first line ([pulumi#857](https://github.com/pulumi/pulumi/issues/857))
 
-## 0.9.13 {#v913}
+## SDK version 0.9.13 {#v913}
 Released on 2018/02/07 
 
 ### Added
@@ -126,7 +160,7 @@ Released on 2018/02/07
 
 - Added additional configuration for docker builds for a container. The `build` property of a container may now either be a string (which is treated as a path to the folder to do a `docker build` in) or an object with properties `context`, `dockerfile` and `args`, which are passed to `docker build`. If unset, `context` defaults to the current working directory, `dockerfile` defaults to `Dockerfile` and `args` default to no arguments.
 
-## 0.9.11 {#v911}
+## SDK version 0.9.11 {#v911}
 Released on 2018/01/22
 
 ### Added
@@ -169,7 +203,7 @@ Released on 2018/01/22
 
 - When a stack is removed, `pulumi` now deletes any configuration it had saved in either the `Pulumi.yaml` file or the workspace.
 
-## 0.9.8 
+## SDK version 0.9.8 
 
 ### Added 
 

--- a/install/index.md
+++ b/install/index.md
@@ -1,28 +1,19 @@
 ---
 title: "Installation and Setup"
-installer_version: "0.10.0"
+installer_version: "0.11.0"
 ---
 
 <!-- 
 NOTE: To update this page with a new binary release, do the following:
 - Update `installer_version` in the YAML front matter above. 
-- Update release-notes.md with the latest fixes in the release
+- Update changelog.md with the latest fixes in the release
 -->
 
-Follow these instructions to install the Pulumi SDK on your development or build machine.
-
-The latest version of the Pulumi SDK is **{{ page.installer_version }}**. See the [change log](./changelog.html) to learn what's new.
-
-## Download the SDK
-
-### Featured downloads
-
-The current version of Pulumi's SDK is **{{ page.installer_version }}** and is
-available for these systems:
+## Pulumi SDK 
 
 <div class="little-jumbotron">
     <div class="container">
-        <h4 class="f4 title">Pulumi Cloud SDK</h4>
+        <h4 class="f4 title">Version {{ page.installer_version }}</h4>
         <p>
             <a
                     id="macos-download-link"
@@ -46,128 +37,73 @@ available for these systems:
                 {% octicon cloud-download height:24 %} Linux x64
             </a>
         </p>
+        <p>For all available SDKs, see <a href="./changelog.html#all-versions">Previous SDK Versions</a></p>
     </div>
 </div>
 
-### All available versions
+## Installation instructions
 
-We provide pre-built binaries for x64 architectures on the following OS versions:
--  macOS: Sierra or later
--  Windows: 8 and 10
--  Linux: Ubuntu Trusty 14.04 LTS
+- [macOS](#mac)
+- [Windows](#windows)
+- [Linux](#linux)
 
-<table class="table table-sm table-bordered">
-  <thead>
-    <tr>
-      <th scope="col">Version</th>
-      <th scope="col">Date</th>
-      <th scope="col">Downloads</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row"><a href="./changelog.html#v10">0.10.0</a></th>
-      <td>2018/02/27</td>
-      <td>{% include sdk-links.html version='0.10.0' %}</td>
-    </tr>
-    <tr>
-      <th scope="row"><a href="./changelog.html#v913">0.9.13</a></th>
-      <td>2018/02/07</td>
-      <td>{% include sdk-links.html version='0.9.13' %}</td>
-    </tr>
-    <tr>
-      <th scope="row"><a href="./changelog.html#v911">0.9.11</a></th>
-      <td>2018/01/22</td>
-      <td>{% include sdk-links.html version='0.9.11' %}</td>
-    </tr>
-  </tbody>
-</table>
+### macOS install {#mac}
 
-## Installation and setup
+macOS Siera (10.12) or later is required. 
 
-### Prerequisites
+1.  Install [Node.js 6.10.2 (LTS)](https://nodejs.org/dist/v6.10.2/node-v6.10.2.pkg). This exact version is required, to match the version supported by AWS Lambda and other public cloud implementations. You can use [Node Version Manager (nvm)](https://github.com/creationix/nvm) to manage multiple Node versions.
 
-Before installing and using Pulumi's SDK, you'll need Node.js and an NPM package management client.
+2.  Download [Pulumi {{page.installer_version}} for macOS](/releases/pulumi-v{{page.installer_version}}-darwin.x64.tar.gz).
 
-#### Node.js 6.10.2 (LTS)
+3.  Unzip the tarball and run the install script. After installation, you may delete the extracted folder. 
 
-First, install Node.js 6.10.2 (LTS).  This can be done by downloading and installing a package from the
-[Node.js release page](https://nodejs.org/download/release/v6.10.2/), or by using the [Node Version Manager (nvm)](
-https://github.com/creationix/nvm).  Links are included below for convenience.
+    ```bash
+    $ tar -xzf pulumi-v{{page.installer_version}}-darwin.x64.tar.gz
+    $ ./pulumi/install.sh 
+    ```
 
-<div class="little-jumbotron">
-    <div class="container">
-        <h4 class="f4 title">Node.js 6.10.2 (LTS)</h4>
-        <p>
-            <a class="[ btn btn-lg ] [ white hover-white bg-brand hover-bg-accent2 no-underline ]"
-                    style="padding-left: 12px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px"
-                    href="https://nodejs.org/dist/v6.10.2/node-v6.10.2.pkg" role="button">
-                {% octicon cloud-download height:24 %} macOS x64
-            </a>
-            <a class="[ btn btn-lg ] [ white hover-white bg-brand hover-bg-accent2 no-underline ]"
-                    style="padding-left: 12px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px"
-                    href="https://nodejs.org/dist/v6.10.2/node-v6.10.2-x64.msi" role="button">
-                {% octicon cloud-download height:24 %} Windows x64
-            </a>
-            <a class="[ btn btn-lg ] [ white hover-white bg-brand hover-bg-accent2 no-underline ]"
-                    style="padding-left: 12px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px"
-                    href="https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-x64.tar.gz" role="button">
-                {% octicon cloud-download height:24 %} Linux x64
-            </a>
-        </p>
-    </div>
-</div>
+4.  Add `/usr/local/pulumi/bin` to your path:
 
-**Please note**: Pulumi *requires* Node.js 6.10.2 (LTS).  This ensures the environment that you are using locally
-matches the version of the Node.js runtime used by AWS Lambda.  In the future, Pulumi intends to support additional
-Node.js versions.  
+    ```
+    echo "export PATH=\$PATH:/usr/local/pulumi/bin" >> ~/.profile
+    ```
 
-#### NPM or Yarn
+### Windows install {#windows}
 
-Next, install an NPM client.  Either NPM itself or Yarn are fine choices, and you only need one:
+Windows 8 and 10 are supported.
 
-* NPM comes with Node.js, so if this is your client of choice, you're done!  If you need to update or check your
-  installation, please follow the [instructions](https://docs.npmjs.com/getting-started/installing-node) to do so.
+1.  Install [Node.js 6.10.2 (LTS)](https://nodejs.org/dist/v6.10.2/node-v6.10.2-x64.msi). This exact version is required, to match the version supported by AWS Lambda and other public cloud implementations. You can use [Node Version Manager (nvm)](https://github.com/creationix/nvm) to manage multiple Node versions.
 
-* To install Yarn, a slightly faster client thanks to improved caching, follow the [installation instructions](
-  https://yarnpkg.com/lang/en/docs/install/) and run `yarn --version` afterwards to ensure that it worked.
+2.  Download [Pulumi {{page.installer_version}} for Windows x64](/releases/pulumi-v{{page.installer_version}}-windows.x64.zip).
 
-### Install the Pulumi tools
+3.  Extract the zipfile to `%SystemRoot%\Program Files` or another directory and run `install.cmd` from either the command prompt or PowerShell.
 
-First download the Pulumi SDK release for your operating system per the above instructions.
+4. Add `%SystemRoot%\Program Files\Pulumi` to your path via **System Properties** -> **Advanced** -> **Environment Variables** -> **User Variables** -> **Path** -> **Edit**.
 
-Now run the installer, the process depends on if you are on macOS/Linux vs Windows:
+### Linux install {#linux}
 
-* On macOS and Linux, extract the `pulumi-v{{page.installer_version}}-darwin.x64.tar.gz` or `pulumi-v{{page.installer_version}}-linux.x64.tar.gz` tarball to any
-  directory, then run the `install.sh` script inside the pulumi folder that was extracted.
+We provide a pre-built binary for Ubuntu Trusty 14.04 LTS.
 
-On macOS run:
-```bash
-$ tar -xzf pulumi-v{{page.installer_version}}-darwin.x64.tar.gz
-$ ./pulumi/install.sh
-```
+1.  Install [Node.js 6.10.2 (LTS)](https://nodejs.org/dist/v6.10.2/node-v6.10.2-linux-x64.tar.gz). This exact version is required, to match the version supported by AWS Lambda and other public cloud implementations. You can use [Node Version Manager (nvm)](https://github.com/creationix/nvm) to manage multiple Node versions.
 
-On Linux run:
-```bash
-$ tar -xzf pulumi-v{{page.installer_version}}-linux.x64.tar.gz
-$ ./pulumi/install.sh
-```
+2.  Download [Pulumi {{page.installer_version}} for Linux x64](/releases/pulumi-v{{page.installer_version}}-linux.x64.tar.gz).
 
-This script will install Pulumi into `/usr/local/pulumi`. Depending on your system, the process may ask for your password
-so it can create a subfolder of `/usr/local` and so it can run `npm link`. The script will tell you if this is going to
-happen.  After the installer has run, you may delete the `pulumi` folder that was created by untaring the tarball.
+3.  Unzip the tarball and run the install script. After installation, you may delete the extracted folder. 
 
-* On Windows, extract `pulumi-v{{page.installer_version}}-windows.x64.zip` to the installation target and run  `install.cmd` from either a
-  CMD or PowerShell shell.  We recommend `%SystemRoot%\Program Files`.
+    ```bash
+    $ tar -xzf pulumi-v{{page.installer_version}}-linux.x64.tar.gz
+    $ ./pulumi/install.sh
+    ```
 
-Afterwards, you'll need to add the installation's `bin` directory to you `PATH`.  This makes running `pulumi` CLI easy
-and also ensures that dynamically loaded language and resource providers can be found:
+4.  Add `/usr/local/pulumi/bin` to your path:
 
-* On macOS and Linux, add a line to your profile: `echo "export PATH=\$PATH:/usr/local/pulumi/bin" >> ~/.profile`.
-* On Windows, add `%SystemRoot%\Program Files\Pulumi` to your `PATH` environment variable underneath system settings.
+    ```
+    echo "export PATH=\$PATH:/usr/local/pulumi/bin" >> ~/.profile
+    ```
 
-After doing this, the `pulumi` CLI will be available for creating, configuring, and deploying applications.  To verify
-you have the tools installed and available on your `PATH`, try running `pulumi version`.  You should see:
+## Verify the install
+
+After installing Pulumi, verify the tool is on your path: 
 
 ```bash
 $ pulumi version
@@ -176,5 +112,7 @@ v{{page.installer_version}}
 
 ## Configure provider credentials
 
-Next, configure the AWS CLI and set up your credentials. See [Configuring Pulumi for AWS](./aws-config.html).
-
+Configure the credentials for your cloud provider of choice:
+-   [Configure Pulumi for AWS](./aws-config.html)
+-   Configure Pulumi for Azure
+-   Configure Pulumi for Kubernetes


### PR DESCRIPTION
The page still isn't great, but that's partly because of the large heading sizes and styling of the install box. But, it should be an overall improvement.

I thought about putting the full downloads list at the bottom, but it felt out of place after the link to the AWS setup instructions. Also, I want to make sure our current customers can find the previous SDK links. That said, I can probably just remove the 0.9.11 SDK links.

Rather than looking at the diff, it's probably more useful to look at the rendered markdown file in GItHub. 

Here's a screenshot of what it looks like on the docs site:
![image](https://user-images.githubusercontent.com/4260261/37698135-5719ba66-2c9e-11e8-94a7-0cf286495978.png)
