### PR TITLE
Merge from master to production, add redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,6 @@ gem "jekyll", "3.6.2"
 gem "jekyll-octicons"
 gem "kramdown"
 gem "jekyll-include-cache", "~> 0.1"
+gem "jekyll-redirect-from"
+
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,8 @@ GEM
     jekyll-octicons (4.0.1)
       jekyll (~> 3.1)
       octicons (~> 4.0)
+    jekyll-redirect-from (0.13.0)
+      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.1)
       sass (~> 3.4)
     jekyll-watch (1.5.1)
@@ -60,6 +62,7 @@ DEPENDENCIES
   jekyll (= 3.6.2)
   jekyll-include-cache (~> 0.1)
   jekyll-octicons
+  jekyll-redirect-from
   kramdown
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ plugins:
   - jekyll-octicons
   - kramdown
   - jekyll-include-cache # used for recursive loop in _includes/tree.html
+  - jekyll-redirect-from # for 301 redirects
 
 markdown: kramdown
 kramdown:

--- a/reference/javascript.md
+++ b/reference/javascript.md
@@ -1,5 +1,6 @@
 ---
 title: "▶ JavaScript and TypeScript"
+redirect_from: "/concepts/npm-packages.html"
 ---
 
 ## Using Pulumi NPM Packages {#npm-packages}


### PR DESCRIPTION
Ideally, the production docs deployment should get the redirect support, so as to not break existing links.