### PR TITLE
Fix broken left-nav links

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -14,7 +14,7 @@
         {% if item.section %}
             <div data-title="{{ item.title }}">
                 <div>
-                    <a data-title="{{ item.title }}" href="{{ path }}">{{ item.title}}</a>
+                    <a data-title="{{ item.title }}" href="{{ path }}.html">{{ item.title}}</a>
                 </div>
                 <div class="sidenav-subsection">
                     {% include_cached toc_sub.html tree=item.section %}

--- a/_includes/toc_sub.html
+++ b/_includes/toc_sub.html
@@ -13,7 +13,7 @@
     {% if item.section %}
         <div data-title="{{ item.title }}">
             <div>
-                <a data-title="{{ item.title }}" href="{{ path }}">{{ item.title}}</a>
+                <a data-title="{{ item.title }}" href="{{ path }}.html">{{ item.title}}</a>
             </div>
             <div class="sidenav-subsection">
                 {% include_cached toc_sub.html tree=item.section %}


### PR DESCRIPTION
I vaguely recall that Jekyll permits `.html`-less links, while our
custom Go web server does not.  I believe that's the reason the broken
link detector happily succeeds even though we have broken links.

In this case, the new left-nav emitted broken links for the section
links.  The fix is simple: manually append `.html`.

We will want to be on the lookout for more instances of this ...