### PR TITLE
Fix dangling footer

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -135,6 +135,7 @@ a.btn > svg {
 
 .center-container {
     padding: 0 24px;
+    overflow: hidden;
     min-height: calc(100vh - 250px);
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
Due to the float style on the content divs, the center column wasn't
getting the full height applied.  We need to use overflow to ensure
that it does, which pushes the footer back down to the bottom where it
belongs.