### PR TITLE
Make a smattering of mobile fixes

### DIFF
--- a/_includes/toolbar.html
+++ b/_includes/toolbar.html
@@ -23,7 +23,7 @@
 <!-- Tabs -->
 <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
     <div class="mdl-tabs__tab-dir toolbar-tabs">
-        <a href="/" class="mdl-tabs__tab {% if toc.nav_section == "Welcome" %}is-active{% endif %}">WELCOME</a>
+        <a href="/" class="mdl-tabs__tab welcome-tab {% if toc.nav_section == "Welcome" %}is-active{% endif %}">WELCOME</a>
         <a href="/install" class="mdl-tabs__tab {% if toc.nav_section == "Install" %}is-active{% endif %}">INSTALL</a>
         <a href="/quickstart" class="mdl-tabs__tab {% if toc.nav_section == "Quickstart" %}is-active{% endif %}">QUICKSTART</a>
         <a href="/reference" class="mdl-tabs__tab {% if toc.nav_section == "Reference" %}is-active{% endif %}">REFERENCE</a>

--- a/css/style.scss
+++ b/css/style.scss
@@ -18,6 +18,7 @@ comment3: prototypical Jekyll/Liquid template file.
 $CENTER-WIDTH: 1200px;
 $TOOLBAR-HEIGHT: 70px;
 $TAB-GROUP-HEIGHT: 60px;
+$MOBILE-WIDTH: 830px;
 
 /**
  * Fonts
@@ -129,8 +130,11 @@ a.btn > svg {
     padding-top: 8px;
 }
 
-.column {
-    float: left; 
+@media (min-width: $MOBILE-WIDTH) {
+    /* Don't float left otherwise the text expands to consume too much horizontal space. */
+    .column {
+        float: left;
+    }
 }
 
 .center-container {
@@ -147,7 +151,6 @@ a.btn > svg {
     color: #212121;
 
     p, li {
-        font-size: 16px;
         -webkit-font-smoothing: antialiased;
     }
     h1 {
@@ -212,6 +215,22 @@ a.btn > svg {
     }
 }
 
+@media (max-width: $MOBILE-WIDTH) {
+    /* Smaller fonts on mobile. */
+    .content-container {
+        p, li {
+            font-size: 14px;
+        }
+    }
+}
+@media (min-width: $MOBILE-WIDTH) {
+    .content-container {
+        p, li {
+            font-size: 16px;
+        }
+    }
+}
+
 .docsToc {
     background: rgb(247,247,247);
     width: 200px;
@@ -227,8 +246,20 @@ a.btn > svg {
 
 .docsContent {
     max-width: 960px;
-    padding-left: 24px;
     margin-right: auto;
+}
+
+@media (max-width: $MOBILE-WIDTH) {
+    /* On mobile, add a bit of padding at the top due to the current weirdness of wrapping the TOC. */
+    .docsContent {
+        padding-top: 24px;
+    }
+}
+@media (min-width: $MOBILE-WIDTH) {
+    /* On non-mobile, add some padding between the TOC and content. */
+    .docsContent {
+        padding-left: 24px;
+    }
 }
 
 .toolbar {
@@ -322,20 +353,33 @@ a.btn > svg {
 }
 
 .section {
-    padding-top: 24px;
-}
-
-.card-table {
-    margin: 24px 0;
-    td {
-        padding: 8px;
-    }
+    padding: 24px 0 8px 0;
 }
 
 .mdl-card {
+    margin: 24px 0;
     background-color: $accent3;
     min-height: 128px;
-    width: 100%;
+}
+
+@media (max-width: $MOBILE-WIDTH) {
+    /* On mobile, cards show up vertically stacked, and expanded to 100% width. */
+    .mdl-card {
+        width: 100%;
+    }
+}
+@media (min-width: $MOBILE-WIDTH) {
+    /* On regular browsers, cards are horizontally aligned, like a table, and are evenly spaced. */
+    .card-table {
+        display: table;
+        width: 100%;
+        table-layout: fixed;
+        border-spacing: 10px;
+        margin-bottom: 24px;
+    }
+    .mdl-card {
+        display: table-cell;
+    }
 }
 
 .mdl-card__title {
@@ -361,4 +405,11 @@ a.btn > svg {
     line-height: 20px;
     display: inline-block;
     vertical-align: middle;
+}
+
+@media (max-width: $MOBILE-WIDTH) {
+    /* Hide the WELCOME tab on mobile (there isn't enough space for it, and the Pulumi logo suffices). */
+    .welcome-tab {
+        display: none;
+    }
 }

--- a/index.md
+++ b/index.md
@@ -8,58 +8,50 @@ layout: default
     Pulumi is a programming platform for the cloud.  To get started, choose from one of the following:
 </p>
 
-<table class="card-table" width="100%">
-    <tr>
-        <td align="center" valign="center" width="33%">
-            <div class="mdl-card mdl-shadow--2dp">
-                <div class="mdl-card__title">
-                    <h2 class="mdl-card__title-text">
-                        <i class="material-icons">get_app</i>
-                        &nbsp;
-                        <a href="/install">Install</a>
-                    </h2>
-                </div>
-                <div class="mdl-card__supporting-text">
-                    <span class="card-text">
-                        Install the Pulumi SDK for JavaScript, TypeScript, or Python
-                    </span>
-                </div>
-            </div>
-        </td>
-        <td align="center" valign="center" width="33%">
-            <div class="mdl-card mdl-shadow--2dp">
-                <div class="mdl-card__title">
-                    <h2 class="mdl-card__title-text">
-                        <i class="material-icons">schedule</i>
-                        &nbsp;
-                        <a href="/quickstart">Quickstart</a>
-                    </h2>
-                </div>
-                <div class="mdl-card__supporting-text">
-                    <span class="card-text">
-                        Learn how to use Pulumi in just a few minutes
-                    </span>
-                </div>
-            </div>
-        </td>
-        <td align="center" valign="center" width="33%">
-            <div class="mdl-card mdl-shadow--2dp">
-                <div class="mdl-card__title">
-                    <h2 class="mdl-card__title-text">
-                        <i class="material-icons">description</i>
-                        &nbsp;
-                        <a href="/reference">Reference</a>
-                    </h2>
-                </div>
-                <div class="mdl-card__supporting-text">
-                    <span class="card-text">
-                        Read all about Pulumi concepts, CLI, and APIs
-                    </span>
-                </div>
-            </div>
-        </td>
-    </tr>
-</table>
+<div class="card-table">
+    <div class="mdl-card mdl-shadow--2dp">
+        <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text">
+                <i class="material-icons">get_app</i>
+                &nbsp;
+                <a href="/install">Install</a>
+            </h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                Install the Pulumi SDK for JavaScript, TypeScript, or Python
+            </span>
+        </div>
+    </div>
+    <div class="mdl-card mdl-shadow--2dp">
+        <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text">
+                <i class="material-icons">schedule</i>
+                &nbsp;
+                <a href="/quickstart">Quickstart</a>
+            </h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                Learn how to use Pulumi in just a few minutes
+            </span>
+        </div>
+    </div>
+    <div class="mdl-card mdl-shadow--2dp">
+        <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text">
+                <i class="material-icons">description</i>
+                &nbsp;
+                <a href="/reference">Reference</a>
+            </h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                Read all about Pulumi concepts, CLI, and APIs
+            </span>
+        </div>
+    </div>
+</div>
 
 For questions or feedback, reach us at [support@pulumi.com](mailto:support@pulumi.com), or [on GitHub](
 https://github.com/pulumi).

--- a/install/index.md
+++ b/install/index.md
@@ -13,88 +13,80 @@ NOTE: To update this page with a new binary release, do the following:
 
 The current version is **{{ page.installer_version }}**.
 
-<table class="card-table" width="100%">
-    <tr>
-        <td align="center" valign="center" width="33%">
-            <div class="mdl-card mdl-shadow--2dp">
-                <div class="mdl-card__title">
-                    <h2 class="mdl-card__title-text">
-                        <i class="material-icons">get_app</i>
-                        &nbsp;
-                        <a href="/install">macOS x64</a>
-                    </h2>
-                </div>
-                <div class="mdl-card__supporting-text">
-                    <span class="card-text">
-                        macOS Sierra 10.12 or later is required.
-                        See <a href="#mac">below</a> for detailed installation instructions.
-                    </span>
-                </div>
-                <div class="mdl-card__actions mdl-card--border">
-                    <a
-                            id="macos-download-link"
-                            href="/releases/pulumi-v{{page.installer_version}}-darwin.x64.tar.gz" role="button">
-                        <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
-                            {% octicon cloud-download height:24 %} DOWNLOAD
-                        </button>
-                    </a>
-                </div>
-            </div>
-        </td>
-        <td align="center" valign="center" width="33%">
-            <div class="mdl-card mdl-shadow--2dp">
-                <div class="mdl-card__title">
-                    <h2 class="mdl-card__title-text">
-                        <i class="material-icons">get_app</i>
-                        &nbsp;
-                        <a href="/install">Linux x64</a>
-                    </h2>
-                </div>
-                <div class="mdl-card__supporting-text">
-                    <span class="card-text">
-                        Ubuntu Trusty 14.04 LTS builds are available.
-                        See <a href="#linux">below</a> for detailed installation instructions.
-                    </span>
-                </div>
-                <div class="mdl-card__actions mdl-card--border">
-                    <a
-                            id="linux-download-link"
-                            href="/releases/pulumi-v{{page.installer_version}}-linux.x64.tar.gz" role="button">
-                        <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
-                            {% octicon cloud-download height:24 %} DOWNLOAD
-                        </button>
-                    </a>
-                </div>
-            </div>
-        </td>
-        <td align="center" valign="center" width="33%">
-            <div class="mdl-card mdl-shadow--2dp">
-                <div class="mdl-card__title">
-                    <h2 class="mdl-card__title-text">
-                        <i class="material-icons">get_app</i>
-                        &nbsp;
-                        <a href="/install">Windows x64</a>
-                    </h2>
-                </div>
-                <div class="mdl-card__supporting-text">
-                    <span class="card-text">
-                        Windows 8 or 10 are supported.
-                        See <a href="#windows">below</a> for detailed installation instructions.
-                    </span>
-                </div>
-                <div class="mdl-card__actions mdl-card--border">
-                    <a
-                            id="windows-download-link"
-                            href="/releases/pulumi-v{{page.installer_version}}-windows.x64.zip" role="button">
-                        <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
-                            {% octicon cloud-download height:24 %} DOWNLOAD
-                        </button>
-                    </a>
-                </div>
-            </div>
-        </td>
-    </tr>
-</table>
+<div class="card-table">
+    <div class="mdl-card mdl-shadow--2dp">
+        <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text">
+                <i class="material-icons">get_app</i>
+                &nbsp;
+                <a href="/install">macOS x64</a>
+            </h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                macOS Sierra 10.12 or later is required.
+                See <a href="#mac">below</a> for detailed installation instructions.
+            </span>
+        </div>
+        <div class="mdl-card__actions mdl-card--border">
+            <a
+                    id="macos-download-link"
+                    href="/releases/pulumi-v{{page.installer_version}}-darwin.x64.tar.gz" role="button">
+                <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
+                    {% octicon cloud-download height:24 %} DOWNLOAD
+                </button>
+            </a>
+        </div>
+    </div>
+    <div class="mdl-card mdl-shadow--2dp">
+        <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text">
+                <i class="material-icons">get_app</i>
+                &nbsp;
+                <a href="/install">Linux x64</a>
+            </h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                Ubuntu Trusty 14.04 LTS builds are available.
+                See <a href="#linux">below</a> for detailed installation instructions.
+            </span>
+        </div>
+        <div class="mdl-card__actions mdl-card--border">
+            <a
+                    id="linux-download-link"
+                    href="/releases/pulumi-v{{page.installer_version}}-linux.x64.tar.gz" role="button">
+                <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
+                    {% octicon cloud-download height:24 %} DOWNLOAD
+                </button>
+            </a>
+        </div>
+    </div>
+    <div class="mdl-card mdl-shadow--2dp">
+        <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text">
+                <i class="material-icons">get_app</i>
+                &nbsp;
+                <a href="/install">Windows x64</a>
+            </h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                Windows 8 or 10 are supported.
+                See <a href="#windows">below</a> for detailed installation instructions.
+            </span>
+        </div>
+        <div class="mdl-card__actions mdl-card--border">
+            <a
+                    id="windows-download-link"
+                    href="/releases/pulumi-v{{page.installer_version}}-windows.x64.zip" role="button">
+                <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
+                    {% octicon cloud-download height:24 %} DOWNLOAD
+                </button>
+            </a>
+        </div>
+    </div>
+</div>
 
 For older SDK versions, please see <a href="./changelog.html#all-versions">Previous SDK Versions</a>.
 


### PR DESCRIPTION
This fixes a bunch of minor formatting issues so the site renders
"reasonably" on mobile.  This includes

* Hide the WELCOME tab on mobile, since we don't have enough horizontal
  space for the four materially-styled tabs otherwise.

* Lay out cards as a table on regular browsers, and as a vertically
  stacked list of cards on mobile.

* Reduce the font size from 16px to 14px so that more text fits easily.

* Ensure that when the navigation bar forces the main content to wrap,
  we do something sane.  Note that it still isn't great, however as
  explained in pulumi/docs#150, I believe the right answer is to create
  a hamburger left-nav, rather than continuing down this rabbit hole.