### PR TITLE
Improve responsive layout

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -18,7 +18,7 @@ comment3: prototypical Jekyll/Liquid template file.
 $CENTER-WIDTH: 1200px;
 $TOOLBAR-HEIGHT: 70px;
 $TAB-GROUP-HEIGHT: 60px;
-$MOBILE-WIDTH: 830px;
+$MOBILE-WIDTH: 768px;
 
 /**
  * Fonts
@@ -245,7 +245,6 @@ a.btn > svg {
 }
 
 .docsContent {
-    max-width: 960px;
     margin-right: auto;
 }
 
@@ -253,12 +252,14 @@ a.btn > svg {
     /* On mobile, add a bit of padding at the top due to the current weirdness of wrapping the TOC. */
     .docsContent {
         padding-top: 24px;
+        max-width: calc(100% - 32px);
     }
 }
 @media (min-width: $MOBILE-WIDTH) {
     /* On non-mobile, add some padding between the TOC and content. */
     .docsContent {
         padding-left: 24px;
+        max-width: calc(100% - 290px);
     }
 }
 


### PR DESCRIPTION
Until we have implemented pulumi/docs#150, we have some issues with
layouts on small screens, due to the left-nav taking up too much
space.  This change improves the situation in two ways:

1) First, use a more sophisticated max-width on the content, using
   calc(100% - px), to ensure we don't wrap prematurely.

2) Switch to a lower min-width/max-width setting for @media before
   going into the overflowed mobile mode.  I've chosen the original
   iPad ressolution of 768px so that for most laptops and tablets
   we will still show the left-nav on the left and content on the
   right.  For phones, we still wrap completely wherein the content
   comes immediately after the left-nav.

Again, until we have a proper floating left-nav, we're probably
reaching a local maxima on how good we can make this experience...