### PR TITLE
Reword the Quickstart links slightly

### DIFF
--- a/_data/quickstart.yaml
+++ b/_data/quickstart.yaml
@@ -3,10 +3,10 @@ toc:
 - title: Quickstart
   path: /quickstart/index
   section:
-  - quickstart/step1.md
-  - quickstart/step2.md
-  - quickstart/step3.md
-  - quickstart/step4.md
-  - quickstart/step5.md
+  - quickstart/part1.md
+  - quickstart/part2.md
+  - quickstart/part3.md
+  - quickstart/part4.md
+  - quickstart/part5.md
   - quickstart/aws.md
   - quickstart/cloud.md

--- a/quickstart/index.md
+++ b/quickstart/index.md
@@ -2,18 +2,17 @@
 title: Getting Started
 ---
 
-> **Note:** The 5-step Quickstart is still under development.  In the meantime, please see the
+> **Note:** The 5-part Quickstart is still under development.  In the meantime, please see the
 > [AWS Tutorial](./aws.html), the [Cloud-Agnostic Serverless and Containers Tutorial](./cloud.html), or the detailed
 > [Reference](/reference), which includes details about Pulumi concepts, programming model, and APIs.
 
-Get started with Pulumi by taking this 5 part tour (🚧 coming soon): 
-* [Step 1: Your First Pulumi Program](./step1.html)
-* Step 2: Infrastructure as Software
-* Step 3: Containers and Functions
-* Step 4: Application and Infrastructure as One
-* Step 5: Next Steps
+Welcome!  We are excited that you want to learn Pulumi.  The Pulumi Quickstart teaches you how to:
 
-To learn more about Pulumi, check out the [Introduction](../reference) and [Concepts](../reference/concepts.html).
+1. [Set up your environment and build your first Pulumi program](./part1.html)
+2. [Manage your infrastructure using Pulumi](./part2.html)
+3. [Create programs that use containers and serverless functions](./part3.html)
+4. [Deploy application and infrastructure code together using the same tools and workflows](./part4.html)
+5. [Navigate our examples and reference documentation to learn more](./part5.html)
 
 ## Tutorials
 
@@ -22,9 +21,21 @@ For an introductory walkthrough of Pulumi, see the following tutorials:
 * [Using Pulumi with AWS Infrastructure](./aws.html)
 * [Using Pulumi for Cloud-Agnostic Serverless + Containers](./cloud.html)
 
+## Additional Documentation
+
+In addition to the tutorial, you can check out the reference documentation for information:
+
+* [An overall introduction to Pulumi](../reference/index.html)
+* [Learn the core concepts used by Pulumi programs](../reference/concepts.html)
+* [Use JavaScript or TypeScript to program the cloud](../reference/javascript.html)
+* [Use Python to program the cloud](../reference/python.html)
+
+Much more is available in the table of contents available in [the reference section index](../reference/index.html).
+
 ## Code Examples
 
 For code samples, see the following folders in the [Pulumi examples zipfile](/examples/pulumi-examples.zip):
+
 - **webserver**. Create EC2 VMs using JavaScript. Companion to the [AWS infrastructure tutorial](./aws.html). 
 - **url-shortener**. A complete URL shortener SPA that uses Pulumi's high-level cloud programming model.
 - **serverless-raw**. Deploy a complete serverless C# application using lower-level AWS resources.

--- a/quickstart/part1.md
+++ b/quickstart/part1.md
@@ -1,5 +1,5 @@
 ---
-title: Step 1 - Your First Pulumi Program
+title: Part 1: Your First Pulumi Program
 ---
 
 <!-- Common links -->
@@ -194,8 +194,8 @@ virtual machine in the cloud.
 
     Note the output values `publicDns` and `publicIp` are not yet available, as they depend on the properties of a
     provisioned resource. The update shows that it will create 3 resources, rather than 2, as the stack is itself counted
-    as a component which owns all resources being created.  Components are covered in more details in [step
-    2](./step2.html).
+    as a component which owns all resources being created.  Components are covered in more details in [part
+    2](./part2.html).
 
 1.  Now, let's deploy the program and provision resources, via `pulumi update`. It takes about 30 seconds to
     provision the EC2 instance.
@@ -400,16 +400,16 @@ In this first tutorial, we saw how to use Pulumi programs to create and manage c
 plain JavaScript and NPM packages, and that Pulumi programs are executed during `preview` and `update` to determine that
 state we want our infrastructure to be in.  We also saw the core lifecycle of a Pulumi stack.
 
-In the [next section](./step2.html), we'll look at ways we can use programming languages to make defining infrastructure
+In the [next section](./part2.html), we'll look at ways we can use programming languages to make defining infrastructure
 even easier by using loops, conditionals, functions and classes.  And we'll see how these can be combined to build
 reusable abstractions, libraries and new packages.
 
-After that, in [step 3](./step3.html) and [step 4](./step4.html), we'll see examples of some powerful libraries that can be built
+After that, in [part 3](./part3.html) and [part 4](./part4.html), we'll see examples of some powerful libraries that can be built
 from these abstractions for serverless application development and for highly-productive cloud-agnostic app development.
 We'll see that the foundational principles of Pulumi programs and stacks covered in this tutorial apply in all of these
 other cases as well.
 
-And finally, in [step 5](./step5.html), we'll see how we can mix and match the kind of raw cloud infrastructure we defined in
+And finally, in [part 5](./part5.html), we'll see how we can mix and match the kind of raw cloud infrastructure we defined in
 this tutorial with the higher level libraries in later sections.
 
-[Continue with step 2 of the quickstart.](./step2.html)
+[Continue with part 2 of the quickstart.](./part2.html)

--- a/quickstart/part2.md
+++ b/quickstart/part2.md
@@ -1,5 +1,5 @@
 ---
-title: Step 2 🚧
+title: Part 2: Infrastructure as Software 🚧
 ---
 
 # Infrastructure as Software

--- a/quickstart/part3.md
+++ b/quickstart/part3.md
@@ -1,5 +1,5 @@
 ---
-title: Step 3 🚧
+title: Part 3: Containers and Functions 🚧
 ---
 
 # Containers and Functions

--- a/quickstart/part4.md
+++ b/quickstart/part4.md
@@ -1,5 +1,5 @@
 ---
-title: Step 4 🚧
+title: Part 4: Application and Infrastructure as One 🚧
 ---
 
 # Application and Infrastructure as One

--- a/quickstart/part5.md
+++ b/quickstart/part5.md
@@ -1,5 +1,5 @@
 ---
-title: Step 5 🚧
+title: Part 5: Next Steps 🚧
 ---
 
 # Next Steps
@@ -7,4 +7,3 @@ title: Step 5 🚧
 * Ideas for extensions on the tutorial to try to learn more about Pulumi.
 * Pointers to examples/tutorials for additional scenarios
 * Pointers to conceptual docs for deep dives
-


### PR DESCRIPTION
The current jumping off point into the Quickstart was confusing for me,
and made it sound like the Quickstart isn't available at all -- despite
having a very good part 1 already written!  We also used the terms
"step" versus "part" inconsistently.  I personally prefer part,
particularly because we already tell people to take "steps" (like
installation, etc) within the sections, and the dual meaning can be
confusing.