### PR TITLE
Fix nav bar scrolling on iOS

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -425,15 +425,8 @@ a.btn > svg {
     padding: 0 12px;
 }
 
-.mdl-layout__obfuscator {
-    // Makes the darkened view (shown when the drawer is visible)
-    // take up the whole screen.
-    position: fixed;
-}
-
 .mdl-layout__drawer {
-    margin-top: $TOOLBAR-HEIGHT;
-    padding: 0 8px 8px 8px;
+    padding: $TOOLBAR-HEIGHT 8px 8px 8px;
 }
 
 // Always hide the default drawer toggle button.


### PR DESCRIPTION
Scrolling the nav bar wasn't working when the content was longer than the height of the screen on iOS (it worked correctly in Chrome's mobile views on desktop). This fixes it.

Before:

![ios_scroll_before](https://user-images.githubusercontent.com/710598/38704705-05797604-3e5c-11e8-95f6-0d36fcf59040.gif)

After:

![ios_scroll](https://user-images.githubusercontent.com/710598/38704553-936715da-3e5b-11e8-9b00-26f91abb0474.gif)