### PR TITLE
Fix logo jiggles

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -299,6 +299,11 @@ a.btn > svg {
 .toolbar-logo {
     height: 20px;
     margin: 0 40px 0 12px;
+
+    // Workaround for Chrome rendering issue related to SVG while other CSS transition
+    // effects are occurring at the same time. See:
+    // https://github.com/pulumi/pulumi-service/issues/1160#issuecomment-382611311
+    transform: translateZ(0);
 }
 
 .toolbar-spacer {


### PR DESCRIPTION
Apply workaround for Chrome issue to the `docs` repo as well. See:
https://github.com/pulumi/pulumi-service/pull/1219