### PR TITLE
Add dashboard.json

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -1,0 +1,35 @@
+{
+    "gettingStarted": {
+        "title": "Getting Started",
+        "icon": "school",
+        "items": [
+            { "title": "Installation and Setup", "url": "https://docs.pulumi.com/install/" },
+            { "title": "Quick Start", "url": "https://docs.pulumi.com/quickstart/" },
+            { "title": "Examples", "url": "https://github.com/pulumi/examples" },
+            { "title": "Pulumi Slack", "url": "https://pulumi.slack.com/" }
+        ]
+    },
+    "documentation": {
+        "title": "Documentation",
+        "icon": "library_books",
+        "items": [
+            { "title": "Introduction", "url": "https://docs.pulumi.com/reference/" },
+            { "title": "Concepts", "url": "https://docs.pulumi.com/reference/concepts.html" },
+            { "title": "Programming Model", "url": "https://docs.pulumi.com/reference/programming-model.html" },
+            { "title": "Learn about AWS", "url": "https://docs.pulumi.com/reference/aws.html" },
+            { "title": "Learn about Kubernetes", "url": "https://docs.pulumi.com/reference/kubernetes.html" }
+        ]
+    },
+    "news": {
+        "title": "News",
+        "icon": "radio",
+        "items": [
+            {
+                "title": "Pulumi 0.11.3 now available",
+                "url": "https://docs.pulumi.com/install/changelog.html#v113",
+                "date": "2018-04-13"
+            }
+        ],
+        "actionItem": { "title": "Read all news", "url": "https://docs.pulumi.com/install/changelog.html" }
+    }
+}


### PR DESCRIPTION
To allow updating the Pulumi Console's Getting Started, Documentation, and News Dashboard cards faster than going through the normal testing->staging->production deployment of the service, and since these particular cards are docs-focused, we'll host this JSON file on the docs site and have the Console request it from the browser.

For now, News will mostly be a list of recent releases with links to the changelog, but eventually we'll want to change it so it's sourced from the Pulumi blog (via [JSON Feed](https://jsonfeed.org/) or RSS).

Related: https://github.com/pulumi/pulumi-service/pull/1271