### PR TITLE
Address review feedback to changelog and quickstart

### DIFF
--- a/install/changelog.md
+++ b/install/changelog.md
@@ -51,23 +51,23 @@ Released on April 26, 2018
 
 ### Added
 
--  Add a `pulumi cancel` command ([pulumi/pulumi#1230](https://github.com/pulumi/pulumi/pull/1230)). This command cancels any in-progress operation for the current stack. Note that the target stack may need to be manually repaired via `stack export` and `import`.
+-  Add a `pulumi cancel` command ([pulumi/pulumi#1230](https://github.com/pulumi/pulumi/pull/1230)). This command cancels any in-progress operation for the current stack. 
 
 ### Changed 
 -  (**Breaking**) Eliminate `pulumi init` requirement ([pulumi/pulumi#1226](https://github.com/pulumi/pulumi/pull/1226)). The `pulumi init` command is no longer required and should not be used for new stacks. For stacks created prior to the v0.12.0 SDK, `pulumi init` should still be run in the project directory if you are connecting to an existing stack. For new projects, stacks will be created under the currently logged in account. After upgrading the CLI, it is necessary to run `pulumi stack select`, as the location of bookkeeping files has been changed. For more information, see [Creating Stacks](../reference/stack.html#create-stack).
 
--  (**Breaking**) Remove the explicit 'pulumi preview' command ([pulumi/pulumi#1170](https://github.com/pulumi/pulumi/pull/1170)). The `pulumi preview` output has now been merged in to the `pulumi update` command. Before an update is run, the preview is shown you can choose whether to proceed or see more update details. To see just the preview operation, run `pulumi update --preview`.
+-  (**Breaking**) Remove the explicit 'pulumi preview' command ([pulumi/pulumi#1170](https://github.com/pulumi/pulumi/pull/1170)). The `pulumi preview` output has now been merged in to the `pulumi update` command. Before an update is run, the preview is shown and you can choose whether to proceed or see more update details. To see just the preview operation, run `pulumi update --preview`.
 
--  (**Breaking**) Add support for Node 8.10 for Lambda implementations ([pulumi/pulumi-aws#195](https://github.com/pulumi/pulumi-aws/pull/195)). When provisioning an AWS Lambda, the target runtime is Node.js version 8.10, rather than 6.10.2.
+-  (**Breaking**) Add support for Node 8.10 for AWS Lambda ([pulumi/pulumi-aws#195](https://github.com/pulumi/pulumi-aws/pull/195)). Lambdas created with `aws.serverless.Function` and via JavaScript callbacks in `@pulumi/cloud` now default to Node.js 8.10.
 
--  Switch to a more streamlined view for property diffs in `pulumi update` ([pulumi/pulumi#1212](https://github.com/pulumi/pulumi/pull/1212)). When just part of a property has changed, only the changed part is displayed.
+-  Switch to a more streamlined view for property diffs in `pulumi update` ([pulumi/pulumi#1212](https://github.com/pulumi/pulumi/pull/1212)). 
 
--  Allow multiple versions of the `@pulumi/pulumi` package to be loaded ([pulumi/pulumi#1209](https://github.com/pulumi/pulumi/pull/1209)). This change allows a program to use more than one version of `@pulumi/pulumi`. 
+-  Allow multiple versions of the `@pulumi/pulumi` package to be loaded ([pulumi/pulumi#1209](https://github.com/pulumi/pulumi/pull/1209)). This allows packages and dependencies to be versioned independently.
 
 ### Fixed
--  When running a `pulumi update` or `destroy` operation, a single ctrl-c will cancel the current operation. A second ctrl-c will terminate the operation, possibly leaving resources in an untracked state. ([pulumi/pulumi#1231](https://github.com/pulumi/pulumi/pull/1231)).
+-  When running a `pulumi update` or `destroy` operation, a single ctrl-c will cancel the current operation, waiting for it to complete. A second ctrl-c will terminate the operation immediately. ([pulumi/pulumi#1231](https://github.com/pulumi/pulumi/pull/1231)).
 
--  When getting update logs, get all results ([pulumi/pulumi#1220](https://github.com/pulumi/pulumi/pull/1220)). Fixes a bug where logs could sometimes be truncated.
+-  When getting update logs, get all results ([pulumi/pulumi#1220](https://github.com/pulumi/pulumi/pull/1220)). Fixes a bug where logs could sometimes be truncated in the pulumi.com console.
 
 ## v0.11.3 {#v113}
 
@@ -92,9 +92,6 @@ Released on April 13, 2018
 ## v0.11.2 {#v112}
 
 Released on April 6, 2018
-
-- Default organization is the user. To target a different one, use `<owner-name>/<stack-name>`.
-- Removed the preview command, which is now `pulumi update --preview`.
 
 ### Added
 

--- a/quickstart/part1.md
+++ b/quickstart/part1.md
@@ -93,7 +93,7 @@ virtual machine in the cloud.
     ```
 
 1.  Pulumi programs are deployed to a [stack](../reference/stack.html), which is an isolated and independently
-   configurable instance of a Pulumi program.  We'll create a new stack for our program. 
+   configurable instance of a Pulumi program.  We'll create a new stack for our program.
 
     ```bash
     $ pulumi stack init webserver-testing
@@ -108,7 +108,7 @@ virtual machine in the cloud.
     webserver-testing*                               n/a                      n/a
     ```
 
-    The new stack is marked with an asterisk to indicate that it is the currently active stack. All deployment operations target this stack. Stack names must be unique within an account, so you should include a unique project name as a prefix.
+    The new stack is marked with an asterisk to indicate that it is the currently active stack. All deployment operations target this stack.
 
 1.  Pulumi programs also support [configuration](../reference/config.html) which is defined per-stack to decide how that
    instance of the program should be parameterized.  We need to configure the AWS region we'll deploy to, such as 
@@ -148,29 +148,6 @@ virtual machine in the cloud.
     ```
 
     The update shows that it will create 3 resources, rather than 2, as the stack is itself counted as a [Component](../reference/programming-model.html#components) which owns all resources being created. Components are covered in more details in [part 2](./part2.html).
-
-1.  To see the exact resource that will be created, choose the "details" option:
-
-    ```
-    Do you want to proceed? details
-    + pulumi:pulumi:Stack: (create)
-        [urn=urn:pulumi:webserver-testing::webserver::pulumi:pulumi:Stack::webserver-webserver-testing]
-        + aws:ec2/securityGroup:SecurityGroup: (create)
-          [... details omitted ...]
-        + aws:ec2/instance:Instance: (create)
-          [... details omitted ...]
-        ---outputs:---
-        publicHostName: computed<string>
-        publicIp      : computed<string>
-
-    info: 3 changes previewed:
-        + 3 resources to create
-
-    Do you want to proceed?
-      yes
-    > no
-      details
-    ```
 
 1.  Now, deploy the program and provision resources with the "yes" option, which takes about 30 seconds to complete. While resources are being created, you will see a `creating...` progress indicator for the stack component. 
     
@@ -324,17 +301,8 @@ Before moving on, let's tear down the resources that are part of our stack.
     Please confirm that this is what you'd like to do by typing ("webserver-testing"): webserver-testing
     Previewing stack 'webserver-testing'
     Previewing changes:
+    ...
 
-    #: Resource Type          Name                         Plan      Extra Info
-    1: aws:ec2:Instance       webserver-www                - delete
-    2: aws:ec2:SecurityGroup  webserver-secgrp             - delete
-    3: pulumi:pulumi:Stack    webserver-webserver-testing  - delete
-
-    info: 3 changes previewed:
-        - 3 resources to delete
-
-    Do you want to proceed? yes
-    Destroying stack 'webserver-testing'
     Performing changes:
 
     #: Resource Type          Name                         Status     Extra Info

--- a/quickstart/part2.md
+++ b/quickstart/part2.md
@@ -104,38 +104,7 @@ First, we'll create a Pulumi program that uploads files from the `www` directory
     $ pulumi config set aws:region us-west-2
     ```
 
-1.  Run `pulumi update` preview and deploy AWS resources. As expected, a stack component is creataed, along with a new Bucket and two S3 Objects --- one for each file in the `www` folder.
-
-    ```bash
-    $ pulumi update
-    Previewing stack 'website-testing'
-    Previewing changes:
-
-    #: Resource Type        Name                       Plan      Extra Info
-    1: pulumi:pulumi:Stack  s3website-website-testing  + create
-    2: aws:s3:Bucket        s3-website-bucket          + create
-    3: aws:s3:BucketObject  favicon.png                + create
-    4: aws:s3:BucketObject  index.html                 + create
-
-    info: 4 changes previewed:
-        + 4 resources to create
-
-    Do you want to proceed? yes
-    Updating stack 'website-testing'
-    Performing changes:
-
-    #: Resource Type        Name                       Status     Extra Info
-    1: pulumi:pulumi:Stack  s3website-website-testing  + created
-    2: aws:s3:Bucket        s3-website-bucket          + created
-    3: aws:s3:BucketObject  favicon.png                + created
-    4: aws:s3:BucketObject  index.html                 + created
-
-    info: 4 changes performed:
-        + 4 resources created
-    Update duration: 5.792898385s
-
-    Permalink: https://pulumi.com/lindydonna/-/-/website-testing/updates/1
-    ```
+1.  Run `pulumi update` to preview and deploy AWS resources. This creates a stack component, a Bucket and two S3 Objects (one for each file in the `www` folder).
 
 1.  To see the name of the bucket that was created, run `pulumi stack output`. Note that an extra 7-digit identifier is appended to the name. All Pulumi resources add this identifier automatically, so that you don't have to manually create unique names.
 
@@ -214,35 +183,14 @@ In this section, we configure the S3 bucket to serve the files to a browser. To 
 
     ```bash
     $ pulumi update
-    Previewing stack 'website-testing'
-    Previewing changes:
-
-    #: Resource Type        Name                       Plan         Extra Info
-    1: pulumi:pulumi:Stack  s3website-website-testing  * no change
-    2: aws:s3:Bucket        s3-website-bucket          ~ update     changes: + websites
-    3: aws:s3:BucketPolicy  bucketPolicy               + create
-
-    info: 2 changes previewed:
-        + 1 resource to create
-        ~ 1 resource to update
-          3 resources unchanged
-
-    Do you want to proceed? yes
-    Updating stack 'website-testing'
-    Performing changes:
+    ...
 
     #: Resource Type        Name                       Status     Extra Info
     1: pulumi:pulumi:Stack  s3website-website-testing  done
     2: aws:s3:Bucket        s3-website-bucket          ~ updated  changes: + websites
     3: aws:s3:BucketPolicy  bucketPolicy               + created
 
-    info: 2 changes performed:
-        + 1 resource created
-        ~ 1 resource updated
-          3 resources unchanged
-    Update duration: 4.882755297s
-
-    Permalink: https://pulumi.com/lindydonna/-/-/website-testing/updates/2    
+    ...
     ```
 
 1.  Open the site URL in a browser to see both the rendered HTML and the favicon:
@@ -315,39 +263,7 @@ In this section, we'll create a simplified version of the example above, that ju
 
     Since we still want a stack output for `bucketName`, we create a stack output of the component output property `folder.bucketName`.
 
-1.  Run `pulumi update`. Because the program no longer creates S3 objects and does not apply a bucket policy, those resources will be deleted. The bucket Bucket will also be re-created: the parent of a resource is part of its identity and the parent of `s3-website-bucket` has changed from the stack to an instance of `S3Folder`. Note that the output of `console.log` is printed in the "Diagnostics" section below.
-
-    ```bash
-    $ pulumi update
-    Previewing stack 'website-testing'
-    Previewing changes:
-    [... details omitted ...]
-
-    Do you want to proceed? yes
-    Updating stack 'website-testing'
-    Performing changes:
-
-    #: Resource Type        Name                       Status     Extra Info
-    1: pulumi:pulumi:Stack  s3website-website-testing  done       1 info message
-    2: examples:S3Folder    s3-website-bucket          + created
-    3: aws:s3:Bucket        s3-website-bucket          + created
-    4: aws:s3:BucketObject  index.html                 - deleted
-    5: aws:s3:BucketObject  favicon.png                - deleted
-    6: aws:s3:BucketPolicy  bucketPolicy               - deleted
-    7: aws:s3:Bucket        s3-website-bucket          - deleted
-
-    Diagnostics:
-      pulumi:pulumi:Stack: s3website-website-testing
-        info: Path where files would be uploaded: ./www
-
-    info: 6 changes performed:
-        + 2 resources created
-        - 4 resources deleted
-          1 resource unchanged
-    Update duration: 7.047243828s
-
-    Permalink: https://pulumi.com/lindydonna/-/-/website-testing/updates/3
-    ```
+1.  Run `pulumi update`. Because the program no longer creates S3 objects and does not apply a bucket policy, those resources will be deleted. The bucket Bucket will also be re-created: the parent of a resource is part of its identity and the parent of `s3-website-bucket` has changed from the stack to an instance of `S3Folder`. Note that the output of `console.log` is printed in the "Diagnostics" section.
 
 1.  Verify the bucket exists by using the AWS Console or CLI:
 
@@ -360,31 +276,7 @@ In this section, we'll create a simplified version of the example above, that ju
 
 Let's remove the cloud resources that have been provisioned.
 
-1.  Run `pulumi destroy` to tear down all resources:
-
-    ```
-    $ pulumi destroy
-    This will permanently destroy all resources in the 'website-testing' stack!
-    Please confirm that this is what you'd like to do by typing ("website-testing"): website-testing
-    Previewing stack 'website-testing'
-    Previewing changes:
-    [... details omitted ...]
-
-    Do you want to proceed? yes
-    Destroying stack 'website-testing'
-    Performing changes:
-
-    #: Resource Type        Name                       Status     Extra Info
-    1: aws:s3:Bucket        s3-website-bucket          - deleted
-    2: examples:S3Folder    s3-website-bucket          - deleted
-    3: pulumi:pulumi:Stack  s3website-website-testing  - deleted
-
-    info: 3 changes performed:
-        - 3 resources deleted
-    Update duration: 1.021430968s
-
-    Permalink: https://pulumi.com/lindydonna/-/-/website-testing/updates/4
-    ```
+1.  Run `pulumi destroy` to tear down all resources.
 
 1.  To delete the stack itself, run `pulumi stack rm`. Note that this command deletes all deployment history from the Pulumi Console.
 

--- a/reference/cd.md
+++ b/reference/cd.md
@@ -38,7 +38,7 @@ your source code is effectively everything Pulumi needs to perform a deployment,
 The easiest way to achieve a Pulumi-based CD flow is to simply integrate it into your existing CI process.
 
 The basic idea here is that, after running your usual CI processes upon merging a commit into a release branch, you can
-proceed to doing a Pulumi deployment.  This usually entails running `pulumi update --preview` followed by a `pulumi update`.
+proceed to doing a Pulumi deployment.  This usually entails running `pulumi update --preview` followed by a `pulumi update --force`.
 After the deployment completes, of course, you may want to perform additional post-deployment verification.
 
 There are many variants of this, of course.  For instance, Pulumi makes it so easy to stand up new developer stacks, you

--- a/reference/deploy.md
+++ b/reference/deploy.md
@@ -22,7 +22,7 @@ info: 3 changes previewed:
     + 3 resources to create
 ```
 
-Because the changes are not actually applied during the preview phase, it is not possible for `pulumi update` to know for sure whether a change will occur or not when it is dependent on the output of some resource being created or replaced.  Because of this, `pulumi update --preview` always presents a conservative summary of the changes that will be applied.  This means that when changes are actually applied, it may observe fewer changes being needed, but will never observe more than what was shown during preview.
+Because the changes are not actually applied during the preview phase, the preview doesn't always know whether a change will occur, as it may be dependent on whether another resource is created on replaced. So, the preview always presents a conservative summary of the changes that will be applied.  When changes are actually applied, there may be fewer changes than the preview, but there will never be additional changes.
 
 For more information, see [the Pulumi programming model](./programming-model.html).
 


### PR DESCRIPTION
@lukehoban This addresses your feedback from the last PR. Please take a look at the quickstart updates. For part 2, I cut out most of the output, and I started using ellipses to highlight just part of the output. I also cut off some things at the end, like the update duration and the permalink.

I prefer the ellipses if there are two parts being elided, so I changed Part 1 to be consistent.