### PR TITLE
Fix relative CLI links

### DIFF
--- a/_plugins/replace_regex.rb
+++ b/_plugins/replace_regex.rb
@@ -1,0 +1,6 @@
+module ReplaceRegexFilter
+  def replace_regex(input, regex, replacement = '')
+    input.gsub(Regexp.new(regex), replacement.to_s)
+  end
+end
+Liquid::Template.register_filter(ReplaceRegexFilter)

--- a/reference/cli/README.txt
+++ b/reference/cli/README.txt
@@ -1,0 +1,1 @@
+This directory is auto-generated.  Please do not hand edit.

--- a/reference/commands.md
+++ b/reference/commands.md
@@ -21,7 +21,8 @@ The most common commands in the CLI that you'll be using are as follows:
 
 Below is the complete documentation for all available commands:
 
-{% include_relative cli/pulumi.md %}
+{% capture pulumi_cli %}{% include_relative cli/pulumi.md %}{% endcapture %}
+{{ pulumi_cli | markdownify | replace_regex: 'pulumi_(.*)\.md', './cli/pulumi_\1.html' }}
 
 ## Command-line Completion
 


### PR DESCRIPTION
This fixes the relative CLI links caused by the relative_import of
reference/cli/pulumi.md from reference/commands.md.  The simplest fix
would have obviously been to just edit the reference/commands.md file,
but then it wouldn't be pure generated code.  Instead, I've done
something I'm not proud of, but it seems to be the quickest path to
fixing this given our current situation with Jekyll/Liquid: use a custom
regex to rewrite the specific links that we're targeting on import.