### PR TITLE
Relax Linux requirments

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -140,7 +140,7 @@ The below known issue is tracked by https://github.com/pulumi/home/issues/156. N
 
 ### Linux install {#linux}
 
-We provide a pre-built binary for Ubuntu Trusty 14.04 LTS.
+We provide a pre-built binary for Linux.
 
 2.  Download [Pulumi {{page.installer_version}} for Linux x64](/releases/pulumi-v{{page.installer_version}}-linux.x64.tar.gz).
 


### PR DESCRIPTION
While CI runs on Ubuntu 14.04, we have local developers that use
Fedora and newer versions of Ubuntu. GGo should give us a binary that
works across multiple Linux distributions, so call out explicitly that
we expect this to work most places.