### PR TITLE
Remove scrollbars from code snippets

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -95,7 +95,7 @@ code {
 
 pre {
     @extend code;
-    overflow: scroll;
+    overflow: auto;
     padding: 8px;
     border-radius: 2px;
     border: 1px solid #ddd;


### PR DESCRIPTION
Use `auto` so that scrollbars only appear when needed (`scroll` means always show the scrollbars).

Note: The default settings on macOS is to hide scrollbars by default, so you need to [disable that](http://osxdaily.com/2011/08/03/show-scroll-bars-mac-os-x-lion/) to repro the issue on macOS.

Fixes #344 

/cc @ericrudder 