### PR TITLE
Update links to app.pulumi.com

### DIFF
--- a/_includes/toolbar.html
+++ b/_includes/toolbar.html
@@ -9,7 +9,7 @@
             <img src="/images/logo/logo-white-white.svg" class="toolbar-logo" alt="Pulumi">
         </a>
         <div class="mdl-layout-spacer"></div>
-        <a href="https://pulumi.com/home">
+        <a href="https://app.pulumi.com/home">
             <button class="mdl-button mdl-js-button mdl-button-primary toolbar-button">
                 DASHBOARD
             </button>

--- a/quickstart/aws-ec2.md
+++ b/quickstart/aws-ec2.md
@@ -84,7 +84,7 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver EC2 instance
         + 3 resources created
     Update duration: 32.938640858s
 
-    Permalink: https://pulumi.com/lindydonna/ec2-quickstart-dev/updates/3
+    Permalink: https://app.pulumi.com/lindydonna/ec2-quickstart-dev/updates/3
     ```
 
     To see the full details of the deployment and the resources that are now part of the stack, open the update link in a browser. The **Resources** tab on pulumi.com has a link to the AWS console for the provisioned EC2 instance.
@@ -171,7 +171,7 @@ Pulumi program to define the new state we want our infrastructure to be in, then
           1 resource unchanged
     Update duration: 1m44.50461533s
 
-    Permalink: https://pulumi.com/lindydonna/ec2-quickstart-dev/updates/6
+    Permalink: https://app.pulumi.com/lindydonna/ec2-quickstart-dev/updates/6
     ```
 
 1.  We can use `pulumi stack output` to get the value of stack outputs from the CLI.  So we can `curl` the EC2 instance to see the HTTP server running there. Stack outputs can also be viewed on the Pulumi Console.

--- a/tour/basics-stacks.md
+++ b/tour/basics-stacks.md
@@ -23,8 +23,8 @@ The [`pulumi stack`](/reference/cli/pulumi_stack) command manages all things sta
 ```bash
 $ pulumi stack ls
 NAME                   RESOURCE COUNT     URL
-broomllc/prod          73                 https://pulumi.com/broomllc/prod
-broomllc/staging*      88                 https://pulumi.com/broomllc/staging
+broomllc/prod          73                 https://app.pulumi.com/broomllc/prod
+broomllc/staging*      88                 https://app.pulumi.com/broomllc/staging
 ```
 
 The `*` next to `staging` indicates that's the stack we're on.  Most CLI commands are contextual depending on the

--- a/welcome.html
+++ b/welcome.html
@@ -34,7 +34,7 @@ layout: welcome
     <p class="text heading2">experience awaits.</p>
     <p class="text fineprint">Welcome to our private beta! Sign in with your GitHub account to get started.</p>
 
-    <form method="post" action="https://pulumi.com/login">
+    <form method="post" action="https://app.pulumi.com/login">
         <input id="redirect-url-form-input" type="hidden" name="redirectUrl" value="" /> 
         <button class="welcome-button">
             SIGN IN WITH GITHUB


### PR DESCRIPTION
With today's DNS changes to the Pulumi Service, we'll start using https://app.pulumi.com as the canonical location for the console. This PR updates what appear to be all the places where we the text "pulumi.com" is in reference to the console.

I didn't change the way we refer to the console in prose. e.g. I left the text alone that said "Removing the stack will remove all stack history from pulumi.com and ...". Changing it to "app.pulumi.com" means that users would need to internalize the difference between the two domains, when all we are really trying to say is that "when you go to the website". (Feel free to push back if you disagree!)