### PR TITLE
Replace Google Analytics with Segment (pulumi.io)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,13 +1,4 @@
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-116166038-2"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'UA-116166038-2');
-    </script>
-
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Pulumi Documentation</title>
@@ -25,4 +16,5 @@
             crossorigin="anonymous"></script>
     <script src="/js/langchoose.js"></script>
     <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    <script> !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0"; analytics.load("mNROzbfcr6gi80tV37QuBcL0tK1DWvte"); analytics.page(); }}();</script>
 </head>


### PR DESCRIPTION
Replace GoogleAnalytics with Segment in the docs site. This `<head>` element should be evaluated on every page, which will send the page view event.

The Segment ID baked into the JavaScript snippet is `mNROzbfcr6gi80tV37QuBcL0tK1DWvte`.

Fixes #366 