### PR TITLE
Add CORS rules for accessing data

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -33,7 +33,16 @@ const contentBucket = new aws.s3.Bucket(
         website: {
             indexDocument: "index.html",
             errorDocument: "404.html",
-        }
+        },
+        // The docs website serves a file dashboard.json, which is read by a few services
+        // to surface recent updates. We need to set CORS headers for that file.
+        corsRules: [
+            {
+                allowedHeaders: [ "*" ],
+                allowedOrigins: [ "*" ],
+                allowedMethods: [ "GET" ],
+            },
+        ],
     },
     protectResource);
 


### PR DESCRIPTION
Set some (perhaps overly liberal) CORS rules to allow downloading `dashboard.json` from any other domain. We could narrow this down to the set of known stacks of the Pulumi service. But keeping it broad seems reasonable for the time being.

With this requests to content from [staging.]pulumi.io will be allowed from another host domain. This is something we explicitly set in the `docs` binary that powers docs.pulumi.com.
https://github.com/pulumi/pulumi-service/blob/master/cmd/docs/main.go#L136