### PR TITLE
README and script fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 *.swp
 .jekyll-metadata
+vendor
+.bundle
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ configure:
 
 .PHONY: ensure
 ensure:
-	bundle install
-	npm install -g broken-link-checker
+	bundle install --path=./vendor
+	npm install broken-link-checker typedoc
 
 .PHONY: serve
 serve: 
@@ -34,12 +34,12 @@ generate:
 .PHONY: build
 build: 
 	@echo -e "\033[0;32mBUILD:\033[0m"
-	bundle install
+	bundle install --path=./vendor
 	bundler exec jekyll build
 
 .PHONY: test
 test:
-	blc http://localhost:4000 -r --exclude-external  --exclude '*/releases/pulumi*' --exclude '*/examples/*' --exclude '*/reference/pkg/*'
+	./node_modules/.bin/blc http://localhost:4000 -r --exclude-external  --exclude '*/releases/pulumi*' --exclude '*/examples/*' --exclude '*/reference/pkg/*'
 
 .PHONY: deploy
 deploy:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ just check the resulting files directly into the repo under `./packages/`.
 
 ## Development
 
+### Prerequisites
+- Install a recent version of Ruby
+- Install the necessary Ruby Gems:
+  ```gem install jekyll bundler```
+- Install a recent version of Go
+- Install mustache:
+  ```go get -u github.com/cbroglie/mustache```
+
 Run `make configure` to get the required Gem dependencies. (Assuming you have a recent Ruby
 installation on your system.
 
@@ -31,15 +39,13 @@ installation on your system.
 
 `make generate` will regenerate the TypeScript documentation if needed, as well as the CLI documentation in [references/cli](reference/cli). The generated API documentation is placed in the [packages](packages/) folder. This is extremely hacky.
 
-   Prerequisites:
-  - Ensure that repos `pulumi`, `pulumi-aws`, and `pulumi-cloud` are peers to `docs`, and have been checked out to the right release branch.
-  - Run `make only_build` in each of these repos
-  - Install typedoc globally:
-    ```npm install -g typedoc@0.8```
-  - Patch typedoc so it doesn't bring its own version of TypeScript. For more information, see [this issue comment in typedoc](https://github.com/TypeStrong/typedoc/issues/624#issuecomment-352897218). On a Mac:
-    ```rm -rf /usr/local/lib/node_modules/typedoc/node_modules/typescript/```
-  - Install TypeScript globally:
-    ```npm install -g typescript@2.6.2```
+The following repos must be peers of `docs`, should be checked out to an appropriate branch, and should be built before running `make generate`:
+- `pulumi`
+- `pulumi-aws`
+- `pulumi-azure`
+- `pulumi-cloud`
+- `pulumi-gcp`
+- `pulumi-kubernetes`
 
 ## Generating a change log
 

--- a/scripts/run_typedoc.sh
+++ b/scripts/run_typedoc.sh
@@ -10,77 +10,62 @@
 
 set -o nounset -o errexit -o pipefail
 
-PULUMI_AWS_DOCS=`mktemp -d`
-PULUMI_DOCS=`mktemp -d`
-PULUMI_CLOUD_DOCS=`mktemp -d`
-PULUMI_AZURE_DOCS=`mktemp -d`
-PULUMI_K8S_DOCS=`mktemp -d`
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TYPEDOC="$SCRIPT_DIR/../node_modules/.bin/typedoc"
 
-TYPEDOC_OPTS="--mode modules --readme none --gitRevision master --excludePrivate"
+PULUMI_DOCS=`mktemp -d`
 
 # pulumi
 echo -e "\033[0;95mrunning typedoc on pulumi\033[0m"
 pushd .
 cd ../pulumi/sdk/nodejs
-typedoc . $TYPEDOC_OPTS --out $PULUMI_DOCS
+$TYPEDOC --json $PULUMI_DOCS/pulumi.docs.json --mode modules --includeDeclarations --excludeExternals
 popd
 
 # pulumi-aws
 echo -e "\033[0;95mrunning typedoc on pulumi-aws\033[0m"
 pushd .
-cd ../pulumi-aws/pack/nodejs
-typedoc . $TYPEDOC_OPTS --out $PULUMI_AWS_DOCS
+cd ../pulumi-aws/sdk/nodejs
+$TYPEDOC --json $PULUMI_DOCS/pulumi-aws.docs.json --mode modules --includeDeclarations --excludeExternals
 popd
 
 # pulumi-cloud
 echo -e "\033[0;95mrunning typedoc on pulumi-cloud\033[0m"
 pushd .
 cd ../pulumi-cloud/api
-typedoc . $TYPEDOC_OPTS --out $PULUMI_CLOUD_DOCS
+$TYPEDOC --json $PULUMI_DOCS/pulumi-cloud.docs.json --mode modules --includeDeclarations --excludeExternals
 popd
 
 # pulumi-azure
 echo -e "\033[0;95mrunning typedoc on pulumi-azure\033[0m"
 pushd .
-cd ../pulumi-azure/pack/nodejs
-typedoc . $TYPEDOC_OPTS --out $PULUMI_AZURE_DOCS
+cd ../pulumi-azure/sdk/nodejs
+$TYPEDOC --json $PULUMI_DOCS/pulumi-azure.docs.json --mode modules --includeDeclarations --excludeExternals
 popd
 
 # pulumi-kubernetes
 echo -e "\033[0;95mrunning typedoc on pulumi-kubernetes\033[0m"
 pushd .
 cd ../pulumi-kubernetes/pack/nodejs
-typedoc . $TYPEDOC_OPTS --out $PULUMI_K8S_DOCS
+$TYPEDOC --json $PULUMI_DOCS/pulumi-kubernetes.docs.json --mode modules --includeDeclarations --excludeExternals
 popd
 
-echo "Finished running typedoc. Copying into /packages."
-mkdir -p ./packages/
+# pulumi-gcp
+echo -e "\033[0;95mrunning typedoc on pulumi-gcp\033[0m"
+pushd .
+cd ../pulumi-gcp/sdk/nodejs
+$TYPEDOC --json $PULUMI_DOCS/pulumi-gcp.docs.json --mode modules --includeDeclarations --excludeExternals
+popd
 
-# Purge existing
-rm -rf ./packages/pulumi-aws/
-rm -rf ./packages/pulumi/
-rm -rf ./packages/pulumi-cloud/
-rm -rf ./packages/pulumi-azure/
-rm -rf ./packages/pulumi-kubernetes/
+echo "Finished running typedoc. Generating update docs..."
+TSC_DOCGEN="go run ./tools/tscdocgen/*.go"
+PKG_DOCS=./reference/pkg/nodejs/@pulumi
 
-mkdir ./packages/pulumi-aws/
-mkdir ./packages/pulumi/
-mkdir ./packages/pulumi-cloud/
-mkdir ./packages/pulumi-azure/
-mkdir ./packages/pulumi-kubernetes/
-
-# Copy updated
-cp -R $PULUMI_AWS_DOCS/   ./packages/pulumi-aws/
-cp -R $PULUMI_DOCS/       ./packages/pulumi/
-cp -R $PULUMI_CLOUD_DOCS/ ./packages/pulumi-cloud/
-cp -R $PULUMI_AZURE_DOCS/   ./packages/pulumi-azure/
-cp -R $PULUMI_K8S_DOCS/   ./packages/pulumi-kubernetes/
-
-# Cleanup
-rm -rf $PULUMI_AWS_DOCS
-rm -rf $PULUMI_DOCS
-rm -rf $PULUMI_CLOUD_DOCS
-rm -rf $PULUMI_AZURE_DOCS
-rm -rf $PULUMI_K8S_DOCS
+$TSC_DOCGEN $PULUMI_DOCS/pulumi.docs.json $PKG_DOCS/pulumi
+$TSC_DOCGEN $PULUMI_DOCS/pulumi-aws.docs.json $PKG_DOCS/aws
+$TSC_DOCGEN $PULUMI_DOCS/pulumi-cloud.docs.json $PKG_DOCS/cloud
+$TSC_DOCGEN $PULUMI_DOCS/pulumi-azure.docs.json $PKG_DOCS/azure
+$TSC_DOCGEN $PULUMI_DOCS/pulumi-kubernetes.docs.json $PKG_DOCS/kubernetes
+$TSC_DOCGEN $PULUMI_DOCS/pulumi-gcp.docs.json $PKG_DOCS/gcp
 
 echo "Done"

--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -497,6 +497,7 @@ const (
 	typeDocInterfaceNode      typeDocNodeKind = "Interface"
 	typeDocMethodNode         typeDocNodeKind = "Method"
 	typeDocModuleNode         typeDocNodeKind = "Module"
+	typeDocObjectLiteral      typeDocNodeKind = "Object literal"
 	typeDocParameterNode      typeDocNodeKind = "Parameter"
 	typeDocPropertyNode       typeDocNodeKind = "Property"
 	typeDocTypeAliasNode      typeDocNodeKind = "Type alias"
@@ -529,7 +530,9 @@ func createLabel(node *typeDocNode, parent *typeDocNode) string {
 		return fmt.Sprintf("property %s", node.Name)
 	case typeDocTypeAliasNode:
 		return fmt.Sprintf("type %s", node.Name)
-	case typeDocVariableNode:
+	case typeDocEnumMemberNode:
+		return fmt.Sprintf("enum member %s", node.Name)
+	case typeDocVariableNode, typeDocObjectLiteral:
 		if node.Flags.IsConst {
 			return fmt.Sprintf("const %s", node.Name)
 		} else {


### PR DESCRIPTION
- Stop requiring/performing global tools installs
- Update `scripts/run_typedoc` to use tscdocgen and a local typedoc
- Fix paths in `scripts/run_typedoc` and add the GCP repo
- Update the README to describe the new steps

Note that these changes do not include freshly-generated docs; that will
be done as a follow-up.