### PR TITLE
Enable serving gzip-compressed content

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -88,6 +88,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
 
     defaultCacheBehavior: {
         targetOriginId: contentBucket.arn,
+        compress: true,
 
         viewerProtocolPolicy: "redirect-to-https",
         allowedMethods: ["GET", "HEAD", "OPTIONS"],


### PR DESCRIPTION
Flip a bit to enable CloudFront to serve content as gzip-compressed if the client specifies it will accept it.

Fixes #421 
