### PR TITLE
Fix rendering issues around the langchooser

### DIFF
--- a/_includes/langchoose.html
+++ b/_includes/langchoose.html
@@ -6,3 +6,9 @@
         <a class="mdl-tabs__tab langtab">Go</a>
     </div>
 </div>
+
+{% comment %}
+.mdl-tabs__tab uses floats, so we need to use clearfix to avoid
+wrapping/indenting the subsequent element containing the code snippet.
+{% endcomment %}
+<div class="clearfix"></div>

--- a/js/langchoose.js
+++ b/js/langchoose.js
@@ -43,21 +43,16 @@ function selectLanguage(lang) {
             });
 
             // Any explicit prologue elements:
-            $("span").each(function (i, e) { 
+            $("div").each(function (i, e) {
                 var classes = getElemClasses(e);
                 for (var i = 0; i < classes.length; i++) {
                     if (classes[i].startsWith("language-prologue-")) {
-                        // A prologue, when used correctly, ends up in a <p/> block.  So, head up to that, and then
-                        // take the immediately following sibling, and either hide or show it.
-                        var p = $(e).parent();
-                        if (p) {
-                            var next = p.next();
-                            if (next) {
-                                if (classes[i] === "language-prologue-"+lang) {
-                                    $(next).show();
-                                } else {
-                                    $(next).hide();
-                                }
+                        var next = $(e).next();
+                        if (next) {
+                            if (classes[i] === "language-prologue-"+lang) {
+                                $(next).show();
+                            } else {
+                                $(next).hide();
                             }
                         }
                         break;
@@ -73,7 +68,7 @@ function selectLanguage(lang) {
 $(function() {
     // For every language tab, inject a handler and make the correct one hidden.
     $("a").each(function (i, e) {
-        var classes = ($(e).attr("class") || "").split(/\s+/);
+        var classes = getElemClasses(e);
         for (var i = 0; i < classes.length; i++) {
             if (classes[i] === "langtab") {
                 var lang = e.innerText.toLowerCase();

--- a/tour/basics-projects.md
+++ b/tour/basics-projects.md
@@ -11,7 +11,7 @@ Use [`pulumi new <template-name>`](/reference/cli/pulumi_new.html) to quickly sc
 
 {% include langchoose.html %}
 
-<span class="language-prologue-javascript"></span>
+<div class="language-prologue-javascript"></div>
 ```bash
 $ pulumi new aws-javascript --dir ahoy-pulumi
 This command will walk you through creating a new Pulumi project.
@@ -26,7 +26,7 @@ aws:region: (us-east-1)
 New project is configured and ready to deploy with 'pulumi update'.
 ```
 
-<span class="language-prologue-typescript"></span>
+<div class="language-prologue-typescript"></div>
 ```bash
 $ pulumi new aws-typescript --dir ahoy-pulumi
 This command will walk you through creating a new Pulumi project.
@@ -41,7 +41,7 @@ aws:region: (us-east-1)
 New project is configured and ready to deploy with 'pulumi update'.
 ```
 
-<span class="language-prologue-python"></span>
+<div class="language-prologue-python"></div>
 ```bash
 $ pulumi new aws-python --dir ahoy-pulumi
 This command will walk you through creating a new Pulumi project.
@@ -56,7 +56,7 @@ aws:region: (us-east-1)
 New project is configured and ready to deploy with 'pulumi update'.
 ```
 
-<span class="language-prologue-go"></span>
+<div class="language-prologue-go"></div>
 ```bash
 $ pulumi new aws-go --dir ahoy-pulumi
 This command will walk you through creating a new Pulumi project.

--- a/tour/programs-packages.md
+++ b/tour/programs-packages.md
@@ -16,22 +16,22 @@ These packages are installed as any ordinary package would be:
 
 {% include langchoose.html %}
 
-<span class="language-prologue-javascript"></span>
+<div class="language-prologue-javascript"></div>
 ```bash
 $ npm install @pulumi/aws --save
 ```
 
-<span class="language-prologue-typescript"></span>
+<div class="language-prologue-typescript"></div>
 ```bash
 $ npm install @pulumi/aws --save
 ```
 
-<span class="language-prologue-python"></span>
+<div class="language-prologue-python"></div>
 ```bash
 $ pip install pulumi_aws
 ```
 
-<span class="language-prologue-go"></span>
+<div class="language-prologue-go"></div>
 ```bash
 $ go get -u github.com/pulumi/pulumi-aws/sdk/go/aws/...
 ```


### PR DESCRIPTION
- The material tabs use float, so we need to use clearfix to avoid wrapping/indenting the subsequent element containing the code snippet.

Before:

<img width="388" alt="screen shot 2018-06-18 at 2 49 34 pm" src="https://user-images.githubusercontent.com/710598/41564380-75973658-7307-11e8-8b95-8bd3f30006a8.png">

After:

<img width="389" alt="screen shot 2018-06-18 at 2 49 43 pm" src="https://user-images.githubusercontent.com/710598/41564388-7bfbe5d4-7307-11e8-88cc-2e9f19b184e8.png">

- Use `<div>` instead of `<span>` for the `language-prologue-*`, as `<span>` will be wrapped in `<p>` by Jekyll, causing a gap to appear between the tabs and the code (since we have some margin below paragraphs). Using `<div>` avoids Jekyll from adding a `<p>`.

Before:

<img width="711" alt="screen shot 2018-06-18 at 2 50 04 pm" src="https://user-images.githubusercontent.com/710598/41564400-844d7658-7307-11e8-952f-db483b27d8c9.png">

After:

<img width="713" alt="screen shot 2018-06-18 at 2 50 13 pm" src="https://user-images.githubusercontent.com/710598/41564406-8a007532-7307-11e8-94d8-8e2c8293fa1d.png">

Part of #148