### PR TITLE
Build the search index ahead of time during site generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ build:
 	@echo -e "\033[0;32mBUILD:\033[0m"
 	bundle install --path=./vendor
 	bundler exec jekyll build
+	node ./scripts/build-search-index.js < ./_site/search-data.json > ./_site/search-index.json
+	rm ./_site/search-data.json
 
 .PHONY: test
 test:

--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,12 @@ exclude:
   - vendor
   - yarn.lock
 
+# search-index.json is generated as part of `make build`. However, running `make serve` will delete
+# all files under /_site that aren't specified here. We specify it here to avoid deleting a previously
+# generated index when using `make serve`.
+keep_files:
+  - search-index.json
+
 # Tables of contents, stored in the _data folder, that control the sidebar nav
 # To add a new entry to the table of contents, create a new doc in the appropriate folder,
 # then add an entry in _data/<toc>.yaml. 

--- a/js/search-worker.js
+++ b/js/search-worker.js
@@ -6,8 +6,7 @@ var index;
 
 // Download the search index synchronously.
 var req = new XMLHttpRequest();
-var async = false;
-req.open("GET", "/search-index.json", async);
+req.open("GET", "/search-index.json", false /* async */);
 req.send();
 if (req.readyState === req.DONE && req.status === 200) {
     var data = JSON.parse(req.responseText);
@@ -24,6 +23,9 @@ function search(query) {
             return results.map(function(result) {
                 // Extract the url and title from the ref string (they're separated by "|").
                 var i = result.ref.indexOf("|");
+                if (i === -1) {
+                    throw new Error("'|' not found in ref: " + result.ref);
+                }
                 var url = result.ref.substring(0, i);
                 var title = result.ref.substring(i + 1);
                 return { url: url, title: title };

--- a/js/search.js
+++ b/js/search.js
@@ -6,7 +6,7 @@
     var spinner = document.getElementById("spinner");
     var searchResultsContainer = document.getElementById("search-results-container");
 
-    // Use a worker to create the index in the background.
+    // Use a worker to download and setup the index in the background.
     var worker = new Worker("/js/search-worker.js");
     worker.onmessage = function (message) {
         var payload = message.data.payload;

--- a/js/search.js
+++ b/js/search.js
@@ -1,7 +1,6 @@
 "use strict";
 
 (function () {
-    var searchForm = document.getElementById("search-form");
     var searchBox = document.getElementById("search-box");
     var spinner = document.getElementById("spinner");
     var searchResultsContainer = document.getElementById("search-results-container");
@@ -13,48 +12,16 @@
         displaySearchResults(payload.results);
     };
 
-    // Extract the query from the browser's URL, set the search-box to the query,
-    // and kick-off the search by sending a message to the worker.
+    // Extract the query from the browser's URL.
     var query = getQueryVariable("q");
     if (query) {
+        // Set the search-box's value to the query.
         searchBox.value = query;
-        sendSearchMessage(query);
+        // Kick-off the search by sending a message to the worker.
+        worker.postMessage({ type: "search", payload: query });
     } else {
+        // If no query, display empty results.
         displaySearchResults([]);
-    }
-
-    // To speed up subsequent searches on this page, if the browser supports pushState,
-    // add a listener to the search form's submit event that prevents the browser from
-    // doing an actual GET request navigation on searches. Instead, we just proceed with
-    // the new search without navigating and update the browser location with the new
-    // query string programmatically.
-    if (history.pushState) {
-        searchForm.addEventListener("submit", function (e) {
-            e.preventDefault();
-
-            var query = searchBox.value;
-            if (query) {
-                // Update the browser's location with the new query string.
-                var newurl = window.location.protocol + "//" + window.location.host +
-                    window.location.pathname + "?q=" + encodeURIComponent(query);
-                history.pushState({ path: newurl }, "", newurl);
-
-                // Kick-off the new search.
-                sendSearchMessage(query);
-            }
-
-            return false;
-        });
-    }
-
-    // If we're navigating back/forward from a history.pushState,
-    // then intercept and search for the term again.
-    window.onpopstate = function (event) {
-        var query = getQueryVariable("q");
-        if (query) {
-            searchBox.value = query;
-            sendSearchMessage(query);
-        }
     }
 
     // Extracts a query string variable from the browser's location.
@@ -69,11 +36,6 @@
                 return decodeURIComponent(pair[1].replace(/\+/g, "%20"));
             }
         }
-    }
-
-    // Sends a message to the worker to kick-off a search.
-    function sendSearchMessage(query) {
-        worker.postMessage({ type: "search", payload: query });
     }
 
     // Display the results of the search.

--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -1,0 +1,42 @@
+// Adapted from https://lunrjs.com/guides/index_prebuilding.html
+
+const lunr = require("../js/lunr.min.js");
+const stdin = process.stdin;
+const stdout = process.stdout;
+
+let buffer = [];
+
+stdin.resume();
+stdin.setEncoding("utf8");
+
+stdin.on("data", data => buffer.push(data));
+
+stdin.on("end", () => {
+    const data = JSON.parse(buffer.join(""));
+
+    const index = lunr(function () {
+        this.ref("ref");
+        this.field("title", { boost: 10 });
+        this.field("content");
+
+        for (var url in data) {
+            const page = data[url];
+            if (page.title || page.content) {
+                // We use '|' to separate the url and title in the ref, so
+                // ensure we haven't inadvertently introduced a page that
+                // contains a '|' in its url.
+                if (url.indexOf("|") !== -1) {
+                    throw new Error(`unexpected '|' in url: ${url}`);
+                }
+
+                this.add({
+                    ref: url + "|" + page.title,
+                    title: page.title,
+                    content: page.content
+                });
+            }
+        }
+    })
+
+    stdout.write(JSON.stringify(index));
+});

--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -22,9 +22,9 @@ stdin.on("end", () => {
         for (var url in data) {
             const page = data[url];
             if (page.title || page.content) {
-                // We use '|' to separate the url and title in the ref, so
+                // We use '|' to separate the URL and title in the ref, so
                 // ensure we haven't inadvertently introduced a page that
-                // contains a '|' in its url.
+                // contains a '|' in its URL.
                 if (url.indexOf("|") !== -1) {
                     throw new Error(`unexpected '|' in url: ${url}`);
                 }


### PR DESCRIPTION
Follow-up from #419: Build the search index ahead of time during site generation.

Also, stop intercepting the form submit event when on `/search.html` (to avoid subsequent GET requests). It's simpler to just always make a new GET request to `/search.html` each time a search is done. This addresses https://github.com/pulumi/home/issues/309.