### PR TITLE
Use a slimmed down layout for manual redirects

### DIFF
--- a/packages/pulumi-aws/index.md
+++ b/packages/pulumi-aws/index.md
@@ -1,1 +1,5 @@
-<meta http-equiv="refresh" content="0; url=/reference/pkg/nodejs/@pulumi/aws">
+---
+layout: redirect
+redirect:
+  to: /reference/pkg/nodejs/@pulumi/aws
+---

--- a/packages/pulumi-azure/index.md
+++ b/packages/pulumi-azure/index.md
@@ -1,1 +1,5 @@
-<meta http-equiv="refresh" content="0; url=/reference/pkg/nodejs/@pulumi/azure">
+---
+layout: redirect
+redirect:
+  to: /reference/pkg/nodejs/@pulumi/azure
+---

--- a/packages/pulumi-cloud/index.md
+++ b/packages/pulumi-cloud/index.md
@@ -1,1 +1,5 @@
-<meta http-equiv="refresh" content="0; url=/reference/pkg/nodejs/@pulumi/cloud">
+---
+layout: redirect
+redirect:
+  to: /reference/pkg/nodejs/@pulumi/cloud
+---

--- a/packages/pulumi-kubernetes/index.md
+++ b/packages/pulumi-kubernetes/index.md
@@ -1,1 +1,5 @@
-<meta http-equiv="refresh" content="0; url=/reference/pkg/nodejs/@pulumi/kubernetes">
+---
+layout: redirect
+redirect:
+  to: /reference/pkg/nodejs/@pulumi/kubernetes
+---

--- a/packages/pulumi/index.md
+++ b/packages/pulumi/index.md
@@ -1,1 +1,5 @@
-<meta http-equiv="refresh" content="0; url=/reference/pkg/nodejs/@pulumi/pulumi">
+---
+layout: redirect
+redirect:
+  to: /reference/pkg/nodejs/@pulumi/pulumi
+---


### PR DESCRIPTION
Minor cleanup while I was looking at redirects...

We use the `jekyll-redirect-from` plugin that lets us specify `redirect_from:` in front matter when a page has been renamed. However, there are cases where we don't want to specify `redirect_from:` in the front matter and need to create redirects manually, such as for the generated API documentation.

Instead of using the default layout for such manual redirects (which includes lots of superfluous HTML), use the slimmer [built-in layout](https://github.com/jekyll/jekyll-redirect-from/blob/master/lib/jekyll-redirect-from/redirect.html) from the `jekyll-redirect-from` plugin. This way, all our redirects will have the same resulting redirect HTML.

The output looks like:

```html
<!DOCTYPE html>
<html lang="en-US">
  <meta charset="utf-8">
  <title>Redirecting&hellip;</title>
  <link rel="canonical" href="/reference/pkg/nodejs/@pulumi/pulumi">
  <meta http-equiv="refresh" content="0; url=/reference/pkg/nodejs/@pulumi/pulumi">
  <meta name="robots" content="noindex">
  <h1>Redirecting&hellip;</h1>
  <a href="/reference/pkg/nodejs/@pulumi/pulumi">Click here if you are not redirected.</a>
  <script>location="/reference/pkg/nodejs/@pulumi/pulumi"</script>
</html>
```