### PR TITLE
Don't select `Reference` toolbar button on search.html

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -34,7 +34,7 @@
                                 <li class="{% if toc.nav_section == "Install" %}current-page{% endif %}"><a href="/install">Install</a></li>
                                 <li class="{% if toc.nav_section == "Tutorials" %}current-page{% endif %}"><a href="/quickstart">Tutorials</a></li>
                                 <li class="{% if toc.nav_section == "Tour" %}current-page{% endif %}"><a href="/tour">Tour</a></li>
-                                <li class="{% if toc.nav_section == "Reference" %}current-page{% endif %}"><a href="/reference">Reference</a></li>
+                                <li class="{% if toc.nav_section == "Reference" and page.url != "/search.html" %}current-page{% endif %}"><a href="/reference">Reference</a></li>
                                 <li><a href="https://github.com/pulumi/examples" target=_blank>Examples</a></li>
                             </ul>
 


### PR DESCRIPTION
I wasn't able to figure out why `toc.nav_section` is `"Reference"` on `search.html`, so this is kind of a hack. Open to ideas.

Before:

<img width="1314" alt="screen shot 2018-06-25 at 12 37 04 pm" src="https://user-images.githubusercontent.com/710598/41871700-814c0d80-7874-11e8-8c26-c6fedaa4bcaf.png">

After:

<img width="1335" alt="screen shot 2018-06-25 at 12 33 04 pm" src="https://user-images.githubusercontent.com/710598/41871580-38ee7f46-7874-11e8-9486-d47c1dc80a4e.png">

Fixes #437