### PR TITLE
Fix title directive in faq.md

### DIFF
--- a/reference/faq.md
+++ b/reference/faq.md
@@ -1,5 +1,5 @@
 ---
-Title: "FAQ"
+title: "FAQ"
 ---
 
 ## How does Pulumi depend on pulumi.com?


### PR DESCRIPTION
In #467, the title directive in faq was changed from "title: " to
"Title: " which unfortuantely does not do the right thing, leading to
a blank section on the reference page.