### PR TITLE
Add anchor tags to our headers

### DIFF
--- a/404.html
+++ b/404.html
@@ -32,7 +32,7 @@ layout: 404
 </div>
 
 <div id="clouds-and-beams">
-    <h1>404</h1>
-    <h2>Sorry, the page you're looking for could not be found.</h2>
+    <h1 class="no-anchor">404</h1>
+    <h2 class="no-anchor">Sorry, the page you're looking for could not be found.</h2>
     <p>Please try visiting our <a class="link" href="/">homepage</a> instead.</p>
 </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,4 +19,10 @@
         <script async defer src="https://buttons.github.io/buttons.js"></script>
     {% endif %}
     <script> !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0"; analytics.load("mNROzbfcr6gi80tV37QuBcL0tK1DWvte"); analytics.page(); }}();</script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function(event) {
+         anchors.add('h1:not(.no-anchor), h2:not(.no-anchor), h3:not(.no-anchor), h4:not(.no-anchor), h5:not(.no-anchor), h6:not(.no-anchor)');
+      });
+    </script>
 </head>

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ layout: default_index
 
 <div class="card-table">
     <a href="https://www.pulumi.com"><img src="/images/logo/logo.svg" alt="Pulumi" width="350" style="margin-top: 32px"></a>
-    <h2 class="get-to-the-cloud">
+    <h2 class="get-to-the-cloud no-anchor">
         Get Code to the Cloud. Faster. Together.
     </h2>
     <div>
@@ -34,7 +34,7 @@ layout: default_index
         <img src="/images/icon-feature-containers.svg"
             style="margin-bottom: 30px" width="125">
         <div class="mdl-card__title">
-            <h2 class="mdl-card__title-text">
+            <h2 class="mdl-card__title-text no-anchor">
                 <a href="/quickstart/aws-containers.html">Containers</a>
             </h2>
         </div>
@@ -53,7 +53,7 @@ layout: default_index
         <img src="/images/icon-feature-serverless.svg"
             style="margin-bottom: 30px" width="125">
         <div class="mdl-card__title">
-            <h2 class="mdl-card__title-text">
+            <h2 class="mdl-card__title-text no-anchor">
                 <a href="/quickstart/aws-rest-api.html">Serverless</a>
             </h2>
         </div>
@@ -72,7 +72,7 @@ layout: default_index
         <img src="/images/icon-feature-data.svg"
             style="margin-bottom: 30px" width="125">
         <div class="mdl-card__title">
-            <h2 class="mdl-card__title-text">
+            <h2 class="mdl-card__title-text no-anchor">
                 <a href="/quickstart/aws-ec2.html">Infrastructure</a>
             </h2>
         </div>
@@ -91,7 +91,7 @@ layout: default_index
         <img src="/images/icon-feature-colada.svg"
             style="margin-bottom: 30px" width="125">
         <div class="mdl-card__title">
-            <h2 class="mdl-card__title-text">
+            <h2 class="mdl-card__title-text no-anchor">
                 <a href="/quickstart/aws-extract-thumbnail.html">CoLaDa</a>
             </h2>
         </div>


### PR DESCRIPTION
This uses anchorjs to include anchor tags on all of our header
elements.  You get the nice hover behavior where if you hover over a
header, a little anchor link pops up and you can right click it and
copy the link and then share it.

There were a handfull of places where we explicity used header
elements and we didn't actually want links. In these places, I've
applied the `no-anchor` class and instructed anchorjs not to decorate
headers with this class.

It's possible that there are few other places we'll want to do this,
but from my grepping it looked like this would be sufficent. If we
find more places, we can just assign this class by hand.

Fixes #454