### PR TITLE
Begin improving onboarding flow

### DIFF
--- a/_data/quickstart.yaml
+++ b/_data/quickstart.yaml
@@ -1,11 +1,12 @@
-nav_section: "Tutorials"
+nav_section: "Getting Started"
 toc: 
-- title: Tutorials
+- title: Getting Started
   path: /quickstart/index
+- title: AWS Tutorials
+  path: /quickstart/aws-hello-world
   section:
-  - quickstart/aws-hello-world.md
-  - quickstart/aws-containers.md
-  - quickstart/aws-rest-api.md
-  - quickstart/aws-ec2.md
-  - quickstart/aws-extract-thumbnail.md
-  - quickstart/aws-s3-website.md
+   - quickstart/aws-containers.md
+   - quickstart/aws-rest-api.md
+   - quickstart/aws-ec2.md
+   - quickstart/aws-extract-thumbnail.md
+   - quickstart/aws-s3-website.md

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -47,7 +47,7 @@
                                         <a href="/install/">Install</a>
                                     </li>
                                     <li>
-                                        <a href="/quickstart/">Tutorials</a>
+                                        <a href="/quickstart/">Getting Started</a>
                                     </li>
                                     <li>
                                         <a href="/reference/">Reference</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -34,7 +34,7 @@
 
                             <ul class="main-nav">
                                 <li class="{% if toc.nav_section == "Install" %}current-page{% endif %}"><a href="/install">Install</a></li>
-                                <li class="{% if toc.nav_section == "Tutorials" %}current-page{% endif %}"><a href="/quickstart">Tutorials</a></li>
+                                <li class="{% if toc.nav_section == "Getting Started" %}current-page{% endif %}"><a href="/quickstart">Getting Started</a></li>
                                 <li class="{% if toc.nav_section == "Tour" %}current-page{% endif %}"><a href="/tour">Tour</a></li>
                                 <li class="{% if toc.nav_section == "Reference" and page.url != "/search.html" %}current-page{% endif %}"><a href="/reference">Reference</a></li>
                                 <li><a href="https://github.com/pulumi/examples" target=_blank>Examples</a></li>

--- a/_sass/_pulumi.scss
+++ b/_sass/_pulumi.scss
@@ -156,7 +156,7 @@ svg {
 
 .get-to-the-cloud {
     color: #4a5960;
-    font-size: 24px;
+    font-size: 36px;
     margin-top: 48px !important;
 }
 

--- a/index.md
+++ b/index.md
@@ -14,9 +14,9 @@ searchindex: false
 </span>
 
 <div class="card-table">
-    <a href="https://www.pulumi.com"><img src="/images/logo/logo.svg" alt="Pulumi" width="350" style="margin-top: 32px"></a>
+    <a href="https://www.pulumi.com"><img src="/images/logo/logo.svg" alt="Pulumi" width="350"></a>
     <h2 class="get-to-the-cloud no-anchor">
-        Get Code to the Cloud. Faster. Together.
+        Program the Cloud.
     </h2>
     <div>
         <p class="curl-install">

--- a/quickstart/aws-extract-thumbnail.md
+++ b/quickstart/aws-extract-thumbnail.md
@@ -1,10 +1,14 @@
 ---
-title: "Serverless and Containers on AWS"
+title: "Everything Together (Colada) on AWS"
 ---
 
-In this tutorial, we'll use JavaScript to combine serverless, containers and cloud infrastructure together in a single application. We use serverless functions as event triggers and containers for longer-running tasks. 
+In this tutorial, we'll use JavaScript to combine serverless, containers and cloud infrastructure together into a
+"Colada" application. We use serverless functions as event triggers and containers for longer-running tasks.
 
-We'll build an application that extracts a thumbnail from a video using AWS Lambda and [Fargate](https://aws.amazon.com/fargate/). Below is the architecture of the Pulumi application. The [code for this tutorial](https://github.com/pulumi/examples/tree/master/cloud-js-thumbnailer) is available on GitHub. 
+We'll build an application that extracts a thumbnail from a video using AWS Lambda and
+[Fargate](https://aws.amazon.com/fargate/). Below is the architecture of the Pulumi application. The
+code for this tutorial is [available on GitHub](https://github.com/pulumi/examples/tree/master/cloud-js-thumbnailer),
+and a video walkthrough of this example is [available on YouTube](https://www.youtube.com/watch?v=Bofmh1qnNSE).
 
 ![Video thumbnail diagram](../images/quickstart/video-thumbnail-diagram.png){:width="600px"}
 

--- a/quickstart/aws-hello-world.md
+++ b/quickstart/aws-hello-world.md
@@ -1,13 +1,16 @@
 ---
-title: Hello, World on AWS
+title: Hello World on AWS
 ---
 
-In this tutorial, we'll use Pulumi to create a serverless single-page app that uses a AWS Lambda to change the content that is served. We'll do this with 5 lines of JavaScript, a few lines of configuration, and whatever static content we wish to serve (in this case, a simple HTML page and a favicon).
+In this tutorial, we'll use Pulumi to create a serverless app that serves static content, in addition to dynamic routes
+in AWS Lambda. We'll do this with 5 lines of JavaScript, a few lines of configuration, and whatever static content we
+wish to serve (in this case, a simple HTML page and a favicon). After seeing this in action, we'll build on these basic
+concepts to explore additional containers, serverless, and infrastructure tutorials.
 
 ## What we'll do
 
 - **Initialize** a new Pulumi project
-- **Define** our stack in JavaScript
+- **Define** our program in JavaScript
 - **Deploy** our stack to AWS
 - **Manage** our stack in the Pulumi dashboard
 - Tear it down
@@ -115,8 +118,10 @@ In this example we've seen:
 
 From here, you can dive deeper:
 
+- Try out additional AWS tutorials:
+  - [Containers](./aws-rest-api.html): Create a load-balanced, hosted NGINX container service
+  - [Serverless](./aws-rest-api.html): Create a REST API that uses serverless functions and DynamoDB
+  - [Infrastructure](./aws-ec2.html): Create an EC2-based WebServer and associated infrastructure
+  - [Everything Together (Colada)](./aws-extract-thumbnail.html): Create a video thumbnail app that uses containers,
+      serverless, and infrastructure together
 - Take [a tour of Pulumi](../tour/index.html).
-- Try out these tutorials:
-  - [Create a serverless REST API](./aws-rest-api.html)
-  - [Host a static site on S3](./aws-s3-website.html)
-  - [Create EC2 instances on AWS](./aws-ec2.html)

--- a/quickstart/aws-rest-api.md
+++ b/quickstart/aws-rest-api.md
@@ -1,5 +1,5 @@
 ---
-title: "Serverless REST API on AWS"
+title: "Serverless on AWS"
 ---
 
 With Pulumi, you can combine infrastructure definitions and application code in one program. The [@pulumi/cloud] library is a set of Pulumi [components](../reference/programming-model.html#components) that provide a higher-level abstraction over AWS. So, instead of provisioning an API Gateway instance, Lambda functions, and setting up IAM roles, you can use [cloud.API] and define application code at the same time as the infrastructure it depends on.

--- a/quickstart/aws-s3-website.md
+++ b/quickstart/aws-s3-website.md
@@ -1,5 +1,5 @@
 ---
-title: "Static Website on AWS S3"
+title: "Bonus! Static Website using AWS S3"
 redirect_from: "/quickstart/part2.html"
 ---
 

--- a/quickstart/index.md
+++ b/quickstart/index.md
@@ -1,56 +1,45 @@
 ---
-title: Tutorials
+title: Getting Started
 ---
 
-To get started with Pulumi, [configure AWS](../install/aws.html). Then, run the following commands: 
+To get started with Pulumi, [install it](../install) and choose from one of the following next steps:
 
-```bash
-# Step 1. Install Pulumi
-curl -fsSL https://get.pulumi.com | sh
+* [Take a Tour](../tour): Take a Tour of Pulumi, learning key programming model concepts, one at a time
+* [Hello World](aws-hello-world.html): Create a simple HTTP app that uses serverless functions (currently AWS-only)
+* [Tutorials](#tutorials): Take 5-minute tutorials for containers, serverless, or infrastructure (currently AWS-only)
+* [Examples](#examples): Explore examples across many clouds, languages, and scenarios (including AWS, Azure, GCP, and Kubernetes)
 
-# Step 2. Create a new project
-pulumi new hello-aws-javascript
+## <a name="tutorials"></a>Tutorials
 
-# Step 3. Deploy to the cloud
-pulumi update
-```
+Each tutorial walks through an end-to-end scenario in 5 minutes:
 
-## Featured tutorials
+* [Containers](aws-containers.html): Create a load-balanced, hosted NGINX container service
+* [Serverless](aws-rest-api.html): Create a REST API that uses serverless functions and Dynamo DB
+* [Infrastructure](aws-ec2.html): Create an EC2-based WebServer and associated infrastructure
+* [Everything Together (Colada)](aws-extract-thumbnail.html): Create a video thumbnail app that uses containers, serverless, and infrastructure together
 
-- [Hello World](aws-hello-world.html). A simple single-page app that uses serverless functions.
-- [Containers](aws-containers.html). Deploy an NGINX container to production in 5 minutes.
-- [Serverless REST API](aws-rest-api.html). In just 20 lines of code, create a REST API that uses serverless functions and Dynamo DB.
-- [Provision virtual machines on AWS](aws-ec2.html). Use JavaScript to create repeatable deployments of cloud infrastructure.
-- [Create an application with serverless functions and containers](aws-extract-thumbnail.html). Create a full application that extracts a thumbnail from a video, using AWS Lambda and FFmpeg running in a Docker container.
+> **Note:** Although Pulumi supports Azure, GCP, Kubernetes, and other cloud providers, these tutorials use AWS. If you
+> don't have an AWS account, [create one now](https://aws.amazon.com/free/). Tutorials for other clouds are on their way.
 
-## Featured examples
+## <a name="examples"></a>Examples
 
-Check out these examples in the [Pulumi examples repo](https://github.com/pulumi/examples) on GitHub. 
+Our [examples repo](https://github.com/pulumi/examples) on GitHub contains examples across many clouds -- AWS, Azure,
+GCP, and Kubernetes -- languages -- JavaScript, TypeScript, Python, and Go -- and scenarios -- containers, serverless,
+and infrastructure. Each example is self-contained and easily deployable with instructions in its README.
 
-### Containers
+These are good starting points for basic introductions across each cloud provider/scenario:
 
-- [Voting app with two containers (TypeScript)](https://github.com/pulumi/examples/tree/master/cloud-ts-voting-app). 
-A simple voting app that uses Redis for a data store and a Python Flask app for the frontend. 
+* **Containers**:
+    - [AWS ECS/Fargate](https://github.com/pulumi/examples/tree/master/cloud-js-containers)
+    - [Kubernetes Guestbook](https://github.com/pulumi/examples/tree/master/kubernetes-ts-guestbook)
+* **Serverless**:
+    - [AWS Lambdas](https://github.com/pulumi/examples/tree/master/cloud-js-api)
+    - [Google Cloud Functions](https://github.com/pulumi/examples/tree/master/gcp-ts-functions)
+    - [Azure Functions](https://github.com/pulumi/examples/tree/master/azure-ts-functions)
+* **Infrastructure**:
+    - [AWS VM WebServer](https://github.com/pulumi/examples/tree/master/aws-js-webserver)
+    - [Azure VM WebServer](https://github.com/pulumi/examples/tree/master/azure-js-webserver)
+    - [GCP VM WebServer](https://github.com/pulumi/examples/tree/master/gcp-js-webserver)
 
-### Serverless functions
-
-- [URL Shortener (TypeScript)](https://github.com/pulumi/examples/tree/master/cloud-ts-url-shortener/). A complete URL shortener web application using high-level `cloud.Table` and `cloud.API` components.
-- [Video Thumbnailer (JavaScript)](https://github.com/pulumi/examples/tree/master/cloud-js-thumbnailer/). An end-to-end pipeline for generating keyframe thumbnails from videos uploaded to a bucket using containerized [FFmpeg](https://www.ffmpeg.org/).  
-- [Raw AWS Serverless (TypeScript)](https://github.com/pulumi/examples/tree/master/aws-ts-serverless-raw). A complete serverless application using raw `aws.apigateway.RestAPI`, `aws.lambda.Function` and `aws.dynamodb.Table` resources from `@pulumi/aws`. 
-
-### Infrastructure
-
-- [AWS EC2 instance (Python)](https://github.com/pulumi/examples/tree/master/aws-py-webserver)
-- [Azure Virtual Machine (JavaScript)](https://github.com/pulumi/examples/tree/master/azure-js-webserver)
-- [Static website on AWS S3 (JavaScript)](https://github.com/pulumi/examples/tree/master/aws-js-s3-folder)
-
-### Kubernetes 
-
-- [Kubernetes Guestbook (TypeScript)](https://github.com/pulumi/examples/tree/master/kubernetes-ts-guestbook). A version of the Kubernetes Guestbook app using Pulumi and `@pulumi/kubernetes`.
-
-
-
-<!-- LINKS: -->
-[Pulumi examples repo]: https://github.com/pulumi/examples
-<!-- END LINKS: -->
-
+For more compete examples, please check out the index in
+[the example repo's README](https://github.com/pulumi/examples/blob/master/README.md).

--- a/tour/basics-destroying.md
+++ b/tour/basics-destroying.md
@@ -60,6 +60,8 @@ Stack 'ahoy-pulumi-dev' has been removed!
 That concludes our first lesson.  Please proceed to learn a bit more about the concepts we've just encountered and
 how to extend this basic knowledge to build even more powerful cloud programs using Pulumi.
 
+If you're ready to start programming the cloud, check out the [tutorials](../quickstart/index.html#tutorials) next!
+
 <div class="tour-nav">
     <a class="tour-button enabled" href="basics-previewing.html" title="Performing updates">◀</a>
     <span class="tour-index"><strong>8</strong>/8</span>

--- a/tour/programs-exports.md
+++ b/tour/programs-exports.md
@@ -89,6 +89,8 @@ This concludes the second lesson of the tour.  If there are topics you'd like to
 get in touch.  Feel free to file suggestions as issues directly in our
 [pulumi/docs repo](https://github.com/pulumi/docs/issues).
 
+If you're ready to start programming the cloud, check out the [tutorials](../quickstart/index.html#tutorials) next!
+
 <div class="tour-nav">
     <a class="tour-button enabled" href="programs-configuration.html" title="Custom configuration">◀</a>
     <span class="tour-index"><strong>8</strong>/8</span>


### PR DESCRIPTION
This changes a few things to do with onboarding, as part of
pulumi/docs#500 and generally preparing to support Azure, GCP, and
Kubernetes-based onboarding flows. This includes

* Rename Tutorials to Getting Started. This is where we want everybody
  to go to first, which will then direct them to Install, Tutorials,
  Examples, and/or taking the Tour. We can and will merge more of this.

* Change the phrasing of Tutorials to simply: Hello World, Containers,
  Serverless, Infrastructure, and Colada, to reinforce our overall
  taxonomy. The old examples appeared to have semi-arbitrary components
  to the titles, like mentioning EC2, S3, REST, etc., which are fine for
  people who want to go deep on something specific, but not so great if
  all you want to know is how to do e.g. Serverless using Pulumi.

* Decrease the spacing above the logo to get stuff above the fold.

* Change "Get Code to the Cloud. Faster. Together" to simply
  "Program the Cloud." This is particularly catchy for the OSS project.

* Redo the Examples index on the Getting Started page. It was missing a
  bunch, and now that we have a real index in the Examples repo, there's
  no sense in duplicating it (especially as it will drift out of date).
  So, instead, try to nudge people looking for a specific scenario in
  our taxonomy, on a specific cloud, to the right example. I am thinking
  this probably ought to become a matrix of sorts.

* Add backlinks to Tutorials after completing the Tour.

* Wordsmith a bunch of content...