### PR TITLE
Make more onboarding tweaks

### DIFF
--- a/_sass/_pulumi.scss
+++ b/_sass/_pulumi.scss
@@ -142,11 +142,26 @@ $accent4: #fbe5d7; // light orange
     min-width: 120px;
     font-size: 14px;
     font-weight: bold;
+    color: $primary2;
+    background-color: #fff;
+    border: 1px solid $primary2;
+}
+.button:hover {
+    background-color: $primary2;
 }
 
 .button.small {
     font-size: 12px;
     padding: 10px 12px;
+}
+
+.button.primary {
+    color: #fff;
+    background-color: $primary2;
+}
+.button.primary:hover {
+    border: 1px solid $primary;
+    background-color: $primary;
 }
 
 // Don't have SVG icons default to black. Just use current text color.
@@ -158,6 +173,18 @@ svg {
     color: #4a5960;
     font-size: 36px;
     margin-top: 48px !important;
+}
+
+.what-is-pulumi {
+    color: #333;
+    font-size: 18px;
+    margin: 48px auto 0px auto;
+    max-width: 960px;
+}
+
+.what-is-pulumi-cta {
+    font-weight: 600;
+    text-transform: uppercase;
 }
 
 .learn {

--- a/index.md
+++ b/index.md
@@ -3,15 +3,17 @@ layout: default_index
 searchindex: false
 ---
 
-<span class="github-stars-widget">
-    <a
-            href="https://github.com/pulumi/pulumi"
-            class="github-button"
-            data-size="large"
-            data-show-count="true"
-            aria-label="Star pulumi/pulumi on GitHub">
-        Star</a>
-</span>
+<p style="margin-bottom: 0">
+    <span class="github-stars-widget">
+        <a
+                href="https://github.com/pulumi/pulumi"
+                class="github-button"
+                data-size="large"
+                data-show-count="true"
+                aria-label="Star pulumi/pulumi on GitHub">
+            Star</a>
+    </span>
+</p>
 
 <div class="card-table">
     <a href="https://www.pulumi.com"><img src="/images/logo/logo.svg" alt="Pulumi" width="350"></a>
@@ -25,8 +27,14 @@ searchindex: false
     </div>
     <p style="text-align: center; margin-bottom: 0">
         <a href="/install"><button class="button small">INSTALL</button></a>
+        <a href="/quickstart"><button class="button small primary">GET STARTED</button></a>
         <a href="/tour"><button class="button small">TAKE A TOUR</button></a>
         <a href="https://github.com/pulumi/examples"><button class="button small">EXAMPLES</button></a>
+    </p>
+    <p class="what-is-pulumi">
+        <span class="what-is-pulumi-cta">Define cloud applications and infrastructure</span>
+        in your favorite language, using an open source platform that enables sharing, reuse,
+        and safe and predictable changes in a team environment.
     </p>
 </div>
 
@@ -48,7 +56,7 @@ searchindex: false
         </div>
         <div class="mdl-card__actions">
             <a href="/quickstart/aws-containers.html">
-                <button class="button">GET STARTED</button>
+                <button class="button">START NOW</button>
             </a>
         </div>
     </div>
@@ -69,7 +77,7 @@ searchindex: false
         </div>
         <div class="mdl-card__actions">
             <a href="/quickstart/aws-rest-api.html">
-                <button class="button">GET STARTED</button>
+                <button class="button">START NOW</button>
             </a>
         </div>
     </div>
@@ -90,7 +98,7 @@ searchindex: false
         </div>
         <div class="mdl-card__actions">
             <a href="/quickstart/aws-ec2.html">
-                <button class="button">GET STARTED</button>
+                <button class="button">START NOW</button>
             </a>
         </div>
     </div>
@@ -111,7 +119,7 @@ searchindex: false
         </div>
         <div class="mdl-card__actions">
             <a href="/quickstart/aws-extract-thumbnail.html">
-                <button class="button">GET STARTED</button>
+                <button class="button">START NOW</button>
             </a>
         </div>
     </div>

--- a/install/index.md
+++ b/install/index.md
@@ -9,30 +9,25 @@ NOTE: To update this page with a new binary release, do the following:
 - Update changelog.md with the latest fixes in the release
 -->
 
-The current Pulumi SDK version is <a href="./changelog.html#{{ page.installer_version }}">{{ page.installer_version }}</a>.
-For older SDK versions, please see <a href="./changelog.html#all-versions">Previous SDK Versions</a>.
+To install Pulumi, run the following command from a terminal:
 
-The installer script downloads and installs Pulumi, or upgrades to the latest version if you've already installed it.
-
-## macOS and Linux
-
-Run the following command to install the latest version of Pulumi:
+**On macOS or Linux**:
 
 ```bash
-curl -fsSL https://get.pulumi.com | sh
+$ curl -fsSL https://get.pulumi.com | sh
 ```
 
 This will install the `pulumi` CLI to `~/.pulumi/bin` and add it to your path.
 
-## Windows
-
-Run the following command (in `cmd.exe`) to install the latest version of Pulumi:
+**On Windows** (in a cmd.exe shell):
 
 ```batch
 @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))" && SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"
 ```
 
 This will install the `pulumi.exe` CLI to `%USERPROFILE%\.pulumi\bin` and add it to your path.
+
+The installer script downloads and installs Pulumi, or upgrades to the latest version if you've already installed it.
 
 ## Cloud Configuration
 
@@ -43,103 +38,76 @@ After installation, you will want to configure Pulumi for your cloud provider:
 * [GCP](./gcp.html)
 * [Kubernetes](./kubernetes.html)
 
-## Manual Installation {#instructions}
+## Verifying the Installation
 
-If you prefer, you can download and install Pulumi manually:
-
-<div class="downloads-container">
-    <div class="download-card">
-        <h2>macOS x64</h2>
-        <p>macOS Sierra 10.12 or later is required. More information is <a href="#mac">below</a>.</p>
-        <a
-                id="macos-download-link"
-                class="download-button"
-                role="button"
-                href="https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-darwin-x64.tar.gz">
-            <button class="button">DOWNLOAD</button>
-        </a>
-    </div>
-    <div class="download-card">
-        <h2>Linux x64</h2>
-        <p>Pre-built binaries for most Linux distros. More information is <a href="#linux">below</a>.</p>
-        <a
-                id="linux-download-link"
-                class="download-button"
-                role="button"
-                href="https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-linux-x64.tar.gz">
-            <button class="button">DOWNLOAD</button>
-        </a>
-    </div>
-    <div class="download-card">
-        <h2>Windows x64</h2>
-        <p>Windows 8 or 10 are supported. More information is <a href="#windows">below</a>.</p>
-        <a
-                id="windows-download-link"
-                class="download-button"
-                role="button"
-                href="https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-windows-x64.zip">
-            <button class="button">DOWNLOAD</button>
-        </a>
-    </div>
-</div>
-
-### Windows install {#windows}
-
-Windows 8 and 10 are supported.
-
-1.  Download [Pulumi {{page.installer_version}} for Windows x64](https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-windows-x64.zip).
-
-1.  Copy the extracted zipfile contents to a folder such as `C:\pulumi`.
-
-1. Add `C:\pulumi\bin` to your path via **System Properties** -> **Advanced** -> **Environment Variables** -> **User Variables** -> **Path** -> **Edit**.
-
-### macOS install {#mac}
-
-macOS Sierra (10.12) or later is required. 
-
-1.  Download [Pulumi {{page.installer_version}} for macOS](https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-darwin-x64.tar.gz).
-
-1.  Unzip the tarball and run the install script. After installation, you may delete the extracted folder. 
-
-    ```bash
-    $ tar -xzf pulumi-v{{page.installer_version}}-darwin-x64.tar.gz
-    $ ./pulumi/install.sh 
-    ```
-
-1.  Add `/usr/local/pulumi/bin` to your path:
-
-    ```
-    echo "export PATH=\$PATH:/usr/local/pulumi/bin" >> ~/.profile
-    ```
-
-### Linux install {#linux}
-
-We provide a pre-built binary for Linux.
-
-1.  Download [Pulumi {{page.installer_version}} for Linux x64](https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-linux-x64.tar.gz).
-
-1.  Unzip the tarball and run the install script. After installation, you may delete the extracted folder. 
-
-    ```bash
-    $ tar -xzf pulumi-v{{page.installer_version}}-linux-x64.tar.gz
-    $ ./pulumi/install.sh
-    ```
-
-1.  Add `/usr/local/pulumi/bin` to your path:
-
-    ```
-    echo "export PATH=\$PATH:/usr/local/pulumi/bin" >> ~/.profile
-    ```
-
-## Verify the install
-
-After installing Pulumi, verify the tool is on your path: 
+After installing, verify everything is in working order by running the `pulumi` CLI:
 
 ```bash
 $ pulumi version
 v{{page.installer_version}}
 ```
 
+If you get an error that `pulumi` could not be found, it means your `PATH` environment variable has not been configured
+correctly. Please go back and ensure your `PATH` contains the directory containing the `pulumi` CLI installed earlier.
+
+## Older Versions
+
+The current Pulumi SDK version is {{ page.installer_version }}. For a full history of past SDK versions, including
+release notes, please visit <a href="./changelog.html">the Change Log</a>.
+
+## Manual Installation {#instructions}
+
+Packages are available for all major operating systems if you prefer to install them manually.
+
+### Manual macOS Install {#mac}
+
+macOS Sierra (10.12) or later is required.
+
+1. Download [Pulumi {{page.installer_version}} for macOS](https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-darwin-x64.tar.gz).
+
+2. Unzip the tarball and run the install script. After installation, you may delete the extracted folder.
+
+    ```bash
+    $ tar -xzf pulumi-v{{page.installer_version}}-darwin-x64.tar.gz
+    $ ./pulumi/install.sh 
+    ```
+
+3. Add `/usr/local/pulumi/bin` to your path:
+
+    ```
+    echo "export PATH=\$PATH:/usr/local/pulumi/bin" >> ~/.profile
+    ```
+
+### Manual Linux Install {#linux}
+
+We provide a pre-built binary for Linux.
+
+1. Download [Pulumi {{page.installer_version}} for Linux x64](https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-linux-x64.tar.gz).
+
+2. Unzip the tarball and run the install script. After installation, you may delete the extracted folder. 
+
+    ```bash
+    $ tar -xzf pulumi-v{{page.installer_version}}-linux-x64.tar.gz
+    $ ./pulumi/install.sh
+    ```
+
+3. Add `/usr/local/pulumi/bin` to your path:
+
+    ```
+    echo "export PATH=\$PATH:/usr/local/pulumi/bin" >> ~/.profile
+    ```
+
+### Manual Windows Install {#windows}
+
+Windows 8 and 10 are supported.
+
+1. Download [Pulumi {{page.installer_version}} for Windows x64](https://get.pulumi.com/releases/sdk/pulumi-v{{page.installer_version}}-windows-x64.zip).
+
+2. Copy the extracted zipfile contents to a folder such as `C:\pulumi`.
+
+3. Add `C:\pulumi\bin` to your path via **System Properties** -> **Advanced** -> **Environment Variables** -> **User Variables** -> **Path** -> **Edit**.
+
 ## Uninstalling Pulumi
 
-To uninstall Pulumi, delete the `.pulumi` folder in your home directory. If you used the manual installer, you should also delete the `pulumi` folder that was created.
+To uninstall Pulumi, delete the `.pulumi` folder in your home directory. If you used the manual installer, you should
+also delete the `pulumi` folder that was created.

--- a/quickstart/index.md
+++ b/quickstart/index.md
@@ -2,7 +2,11 @@
 title: Getting Started
 ---
 
-To get started with Pulumi, [install it](../install) and choose from one of the following next steps:
+Welcome to the intro guide to Pulumi. This is the best place to get started using Pulumi to create cloud applications
+and infrastructure. Pulumi supports many languages and clouds, leverages package management for easy sharing and reuse,
+and is built atop an open source platform for creating and versioning your cloud software safely and in a team setting.
+
+[Install Pulumi](../install) and then choose from one of the following next steps:
 
 * [Take a Tour](../tour): Take a Tour of Pulumi, learning key programming model concepts, one at a time
 * [Hello World](aws-hello-world.html): Create a simple HTTP app that uses serverless functions (currently AWS-only)


### PR DESCRIPTION
* Add a GET STARTED button to the landing page.

* Change the default button to white, with a blue outline. For primary
  buttons -- like GET STARTED, which we wish to draw attention to, color
  them with the blue background instead of just the outline.

* Add a one sentence overview of Pulumi to the landing page. As is
  stands, there's no clue about what Pulumi is... Similarly, add a
  little paragraph intro to the Quickstart page.

* Streamline the Install page so that it jumps straight to the action.