### PR TITLE
Add basic OpenStack docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ banner:
 	@echo -e "\033[1;37mPulumi Documentation Site\033[0m"
 	@echo -e "\033[1;37m=========================\033[0m"
 
+.PHONY: docker
+docker:
+	docker build . -t docs
+	docker run -it -p 4000:4000 docs
+
 .PHONY: configure
 configure:
 	@echo -e "\033[0;32mCONFIGURE:\033[0m"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ installation on your system.
 
 `make serve` will build the website and serve it to http://localhost:4000.
 
+`make docker` will run `build` and `serve` in a docker container with all prerequisites installed.
+
 `make test` runs a broken link checker tool against http://localhost:4000.
 
 `make generate` will regenerate the TypeScript documentation if needed, as well as the CLI documentation in [references/cli](reference/cli). The generated API documentation is placed in the [packages](packages/) folder. This is extremely hacky.

--- a/_data/install.yaml
+++ b/_data/install.yaml
@@ -6,5 +6,6 @@ toc:
   - install/aws.md
   - install/azure.md
   - install/gcp.md
+  - install/openstack.md
   - install/kubernetes.md
   - install/changelog.md

--- a/install/index.md
+++ b/install/index.md
@@ -36,6 +36,7 @@ After installation, you will want to configure Pulumi for your cloud provider:
 * [AWS](./aws.html)
 * [Azure](./azure.html)
 * [GCP](./gcp.html)
+* [OpenStack](./openstack.html)
 * [Kubernetes](./kubernetes.html)
 
 ## Verifying the Installation

--- a/install/openstack.md
+++ b/install/openstack.md
@@ -1,0 +1,19 @@
+---
+title: "Configure Pulumi for OpenStack"
+---
+
+[Pulumi OpenStack Provider]: ../reference/openstack.html
+[Download your OpenStack credentials]: https://docs.openstack.org/newton/user-guide/common/cli-set-environment-variables-using-openstack-rc.html
+
+The [Pulumi OpenStack Provider] needs to be configured with OpenStack credentials
+before it can be used to create resources.
+
+You will need to provide the OpenStack Provider with your OpenStack account details. You can [Download your OpenStack credentials] as a sourceable rc file from the OpenStack dashboard.
+
+> Your credentials are only used to authenticate with OpenStack APIs on your behalf. Your credentials are never sent to pulumi.com.
+
+To communicate your credentials to the Pulumi OpenStack Provider, source the rc file downloaded from OpenStack.
+
+```bash
+source openrc.sh
+```

--- a/reference/index.md
+++ b/reference/index.md
@@ -8,6 +8,7 @@ Pulumi supports many cloud providers.  Please see below for additional informati
 * [Microsoft Azure](./azure.html)
 * [Google Cloud Platform](./gcp.html)
 * [Kubernetes](./kubernetes.html) for any cloud vendor
+* [OpenStack](./openstack.html)
 
 Pulumi also supports some high level libraries to enable productivity and multi-cloud scenarios:
 

--- a/reference/openstack.md
+++ b/reference/openstack.md
@@ -1,0 +1,31 @@
+---
+title: "OpenStack"
+---
+
+The OpenStack provider for Pulumi can be used to provision any of the cloud resources available in [OpenStack](https://www.openstack.org/).  The OpenStack provider must be configured with credentials to deploy and update resources in an OpenStack cloud.
+
+See the [full API documentation](./pkg/nodejs/@pulumi/openstack/index.html) for complete details of the available OpenStack provider APIs.
+
+## Example
+
+```javascript
+const openstack = require("@pulumi/openstack")
+
+const instance = new os.compute.Instance("test", {
+	flavorName: "s1-2",
+	imageName: "Ubuntu 16.04",
+});
+```
+
+## Libraries
+
+The following packages are available in packager managers:
+* JavaScript/TypeScript: https://www.npmjs.com/package/@pulumi/openstack
+* Python: https://pypi.org/project/pulumi-openstack/
+* Go: `github.com/pulumi/pulumi-aws/sdk/go/openstack`
+
+The OpenStack provider is open source and available in the [pulumi/pulumi-openstack](https://github.com/pulumi/pulumi-openstack) repo. 
+
+## Authentication
+
+The OpenStack provider supports several options for providing access to OpenStack credentials.  See [OpenStack installation page](/install/openstack.html) for details.

--- a/tour/basics-deploying.md
+++ b/tour/basics-deploying.md
@@ -14,7 +14,7 @@ From that point onward, any edits to your program result in the minimal incremen
 
 > Before deploying, you will need to configure your machine to access your cloud provider of choice.  In general, Pulumi
 > just uses standard client configuration.  Please see the following instructions for details: [AWS](/install/aws.html),
-> [Azure](/install/azure.html), [Google Cloud](/install/gcp.html), or [Kubernetes](/install/kubernetes.html).
+> [Azure](/install/azure.html), [Google Cloud](/install/gcp.html), [OpenStack](/install/openstack.html), or [Kubernetes](/install/kubernetes.html).
 
 ***
 

--- a/tour/programs-packages.md
+++ b/tour/programs-packages.md
@@ -9,8 +9,8 @@ in the usual means.
 
 Packages let you share and reuse your Pulumi creations with your team and/or the community.
 
-Packages are also how we distribute the foundational cloud resource definitions for AWS, Azure, Google Cloud, and
-Kubernetes, in addition to our frameworks that aggregate these resources into higher level abstractions.
+Packages are also how we distribute the foundational cloud resource definitions for AWS, Azure, Google Cloud, OpenStack,
+and Kubernetes, in addition to our frameworks that aggregate these resources into higher level abstractions.
 
 These packages are installed as any ordinary package would be:
 

--- a/tour/programs-resources.md
+++ b/tour/programs-resources.md
@@ -50,7 +50,7 @@ More complex resource types require additional properties, as will soon see.  Re
 * `id` is the cloud provider allocated unique identifier, usually just its name or ID
 
 Although resources can be allocated by hand using the SDK directly, you will almost always create them using an
-appropriate language package, such as the AWS, Azure, GCP, or Kubernetes packages.
+appropriate language package, such as the AWS, Azure, GCP, OpenStack, or Kubernetes packages.
 
 A resource may be created with one of the following three properties:
 


### PR DESCRIPTION
Adds basic OpenStack docs for install and reference sections to match the other providers.
Also added OpenStack to the places where lists of all providers were mentioned (i.e. "AWS, Azure, GCP, and Kubernetes" -> "AWS, Azure, GCP, OpenStack, and Kubernetes"

Also added a "make docker" to more easily use the Dockerfile present.