### PR TITLE
Update Travis CI configuration to allow forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,9 @@ branches:
   - master
   - production
 before_install:
-# travisqueue, to limit practical concurrency per branch. We
-# cannot run `go get` to install it because the Go runtime on
-# the ruby VM is too old. So instead we get it from
-# get.pulumi.com (which is definitely not recommended or
-# supported).
-- mkdir -p ~/.bin/
-- curl https://get.pulumi.com/internal/travisqueue > ~/.bin/travisqueue
-- chmod +x ~/.bin/travisqueue
-- export PATH=$PATH:$HOME/.bin
-# Proceed or kill this current build.
-- travisqueue start
+# Use travisqueue to manage build concurrency.
+- ./scripts/travisqueue.sh install
+- ./scripts/travisqueue.sh start
 # Install required tools.
 # pulumi
 - curl -L https://get.pulumi.com/ | bash -s -- --version 0.15.0
@@ -31,8 +23,6 @@ script:
 - echo "TRAVIS_EVENT_TYPE=${TRAVIS_EVENT_TYPE}"
 - make travis_${TRAVIS_EVENT_TYPE}
 after_script:
-# Start another build to restart any builds that were cancelled while
-# this one was being processed.
-- travisqueue finish
+- ./scripts/travisqueue.sh finish
 notifications:
   webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -21,8 +21,8 @@ export AWS_ACCESS_KEY_ID="${!ACCESS_KEY_ENV_VAR}"
 export AWS_SECRET_ACCESS_KEY="${!SECRET_KEY_ENV_VAR}"
 
 if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
-    echo "Error: No AWS credentials found."
-    exit 1
+    echo "Skipping preview, no AWS credentials found."
+    exit 0
 fi
 echo "Using AWS Access KEY ID ${AWS_ACCESS_KEY_ID}"
 

--- a/scripts/travisqueue.sh
+++ b/scripts/travisqueue.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Runs travisqueue to ensure that only one `push` job is running
+# concurrently for a given branch. This is how we can avoid conflicts
+# when running `pulumi update` in response to any push.
+
+# Travis doesn't make secret config available on forks, so we skip
+# it when TRAVIS_TOKEN is not set.
+if [ -z ${TRAVIS_TOKEN:-} ]; then
+    echo "Skipping travisqueue, TRAVIS_TOKEN is not set."
+fi
+
+case ${1:-} in
+    install)
+        # We cannot run `go get` to install it because the Go runtime on
+        # the ruby VM is too old. So instead we get it from get.pulumi.com.
+        # (Which is neither recommended nor supported).
+        mkdir -p ~/.bin/
+        curl https://get.pulumi.com/internal/travisqueue > ~/.bin/travisqueue
+        chmod +x ~/.bin/travisqueue
+        ;;
+    start)
+        ~/.bin/travisqueue start
+        ;;
+    finish)
+        ~/.bin/travisqueue finish
+        ;;
+    *)
+        echo "Unknown command '${1:-}'."
+        ;;
+esac

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -21,8 +21,8 @@ export AWS_ACCESS_KEY_ID="${!ACCESS_KEY_ENV_VAR}"
 export AWS_SECRET_ACCESS_KEY="${!SECRET_KEY_ENV_VAR}"
 
 if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
-    echo "Error: No AWS credentials found."
-    exit 1
+    echo "Skipping update, no AWS credentials found."
+    exit 0
 fi
 echo "Using AWS Access KEY ID ${AWS_ACCESS_KEY_ID}"
 


### PR DESCRIPTION
We cannot assume encrypted Travis env vars are available, so just skip those steps rather than failing.