### PR TITLE
Fix broken links, run in PR

### DIFF
--- a/_data/reference.yaml
+++ b/_data/reference.yaml
@@ -107,6 +107,3 @@ toc:
 - title: Change Log
   path: /reference/changelog
   toplevel: true
-- title: Known issues
-  path: /reference/known-issues
-  toplevel: true

--- a/quickstart/aws/tutorial-containers-ecs-fargate.md
+++ b/quickstart/aws/tutorial-containers-ecs-fargate.md
@@ -38,7 +38,7 @@ In this tutorial, we'll use JavaScript to build and deploy a simple container to
     exports.url = service.defaultEndpoint.apply(e => `http://${e.hostname}`);
     ```    
 
-    This example uses [cloud.Service](../reference/pkg/nodejs/@pulumi/cloud/index.html#Service), which is a high-level, convenient interface for building containers and provisioning an AWS container service.
+    This example uses [cloud.Service](/reference/pkg/nodejs/@pulumi/cloud/index.html#Service), which is a high-level, convenient interface for building containers and provisioning an AWS container service.
 
 1.  Create a subfolder `app` with the following files:
 

--- a/quickstart/cloudfx/tutorial-rest-api.md
+++ b/quickstart/cloudfx/tutorial-rest-api.md
@@ -107,6 +107,6 @@ For an end-to-end application with a frontend, see the [URL shortener sample](ht
 
 <!-- LINKS -->
 [@pulumi/cloud]: ../cloudfx/index.html
-[cloud.API]: ../reference/pkg/nodejs/@pulumi/cloud-aws/index.html#API
-[cloud.Table]: ../reference/pkg/nodejs/@pulumi/cloud-aws/index.html#Table
+[cloud.API]: /reference/pkg/nodejs/@pulumi/cloud-aws/index.html#API
+[cloud.Table]: /reference/pkg/nodejs/@pulumi/cloud-aws/index.html#Table
 <!-- END LINKS -->

--- a/reference/changelog.md
+++ b/reference/changelog.md
@@ -4,12 +4,12 @@ redirect_from: /install/changelog.html
 ---
 
 <!-- Common links -->
-[`Output`]: https://docs.pulumi.com/packages/pulumi/classes/_resource_.output.html
-[Python documentation]: ../reference/python.html
-[Defining and setting stack settings]: ../reference/config.html#config-stack
-[Configuration]: ../reference/config.html
-[Pulumi npm packages]: ../reference/javascript.html#npm-packages
-[Programming Model]: ../reference/programming-model.html
+[`Output`]: /reference/pkg/nodejs/@pulumi/pulumi/index.html#Output
+[Python documentation]: ./python.html
+[Defining and setting stack settings]: ./config.html#config-stack
+[Configuration]: ./config.html
+[Pulumi npm packages]: ./javascript.html#npm-packages
+[Programming Model]: ./programming-model.html
 <!-- End common links -->
 
 ## Available versions {#all-versions}
@@ -740,10 +740,10 @@ Released on December 28, 2017
 
 #### Pulumi Console and managed stacks
 
-New in this release is the [Pulumi Console](https://beta.pulumi.com) and stacks that are managed by Pulumi. This is the recommended way to safely deploy cloud applications.
+New in this release is the [Pulumi Console](https://app.pulumi.com) and stacks that are managed by Pulumi. This is the recommended way to safely deploy cloud applications.
 - `pulumi stack init` now creates a Pulumi managed stack. For a local stack, use `--local`.
 - All Pulumi CLI commands now work with managed stacks. Login to Pulumi via `pulumi login`.
-- The [Pulumi Console](https://beta.pulumi.com) provides a management experience for stacks. You can view the currently deployed resources (along with the AWS ARNs) and see logs from the last update operation.
+- The [Pulumi Console](https://app.pulumi.com) provides a management experience for stacks. You can view the currently deployed resources (along with the AWS ARNs) and see logs from the last update operation.
 
 #### Components and output properties
 

--- a/reference/component-tutorial.md
+++ b/reference/component-tutorial.md
@@ -71,7 +71,7 @@ In this tutorial, we'll create a simplified version of the example above, that j
     ```  
 
 <!-- LINKS -->
-[pulumi.ComponentResource]: pkg/nodejs/@pulumi/index.html#ComponentResource
+[pulumi.ComponentResource]: pkg/nodejs/@pulumi/pulumi/index.html#ComponentResource
 [Component]: ./programming-model.html#components
 [s3-folder]: https://github.com/pulumi/examples/tree/master/aws-js-s3-folder
 [s3-folder-component]: https://github.com/pulumi/examples/tree/master/aws-js-s3-folder-component

--- a/reference/javascript.md
+++ b/reference/javascript.md
@@ -136,6 +136,6 @@ runtime:
 ```
 
 <!-- LINKS -->
-[`pulumi.Config`]: pkg/nodejs/@pulumi/index.html#Config
+[`pulumi.Config`]: pkg/nodejs/@pulumi/pulumi/index.html#Config
 [Using configuration values in JavaScript]: ./config.html#javascript
 <!-- END LINKS -->

--- a/reference/known-issues.md
+++ b/reference/known-issues.md
@@ -1,5 +1,0 @@
----
-title: "Known issues"
----
-
-For known issues and workarounds, see [issues labeled **known-issue** on GitHub](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+label%3Aknown-issue++user%3Apulumi). If you encounter an problem that's not already logged, please file a [GitHub issue](https://github.com/pulumi/pulumi/issues/new). 


### PR DESCRIPTION
This change fixes a handful of broken links. I wasn't sure why a
few slipped through recently, when the `make test` target was actually
running clean, and it turns out we had been aggressively filtering out
many links we shouldn't be. This change fixes that, and pulumi/docs#568
tracks fixing the last two remaining categories of known issues.

This also half-fixes pulumi/docs#298, by running the broken link
checker in PR. It isn't a complete fix, because to do that, we'd need
to run the checker against the actual pulumi.io websites after doing
a deployment. In principle, not hard, but will require a bit of plumbing
of stack outputs for the URL into the Makefile `test` target. In
practice, this PR checking should catch most errors, and finds them
sooner during PR when a developer still has an opportunity to fix them.