### PR TITLE
Fix a couple more broken links

### DIFF
--- a/quickstart/cloudfx/index.md
+++ b/quickstart/cloudfx/index.md
@@ -47,7 +47,7 @@ The Cloud framework is open source and available in the [pulumi/pulumi-cloud](ht
 
 ## Authentication
 
-Authentication options must be set for the target cloud provider. See the [AWS installation page](/install/aws.html) for details (more providers for the Cloud framework coming soon).
+Authentication options must be set for the target cloud provider. See the [AWS setup page](/quickstart/aws/setup.html) for details (more providers for the Cloud framework coming soon).
 
 ## Configuration
 

--- a/quickstart/kubernetes/tutorial-guestbook.md
+++ b/quickstart/kubernetes/tutorial-guestbook.md
@@ -27,8 +27,8 @@ The code for this tutorial is
 You need to have the Pulumi CLI and a working Kubernetes cluster.
 [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) is an easy way to get started.
 
-1. [Install Pulumi](../install)
-2. [Connect Pulumi to a Kubernetes Cluster](../install/kubernetes.html)
+1. [Install Pulumi](../install.html)
+2. [Connect Pulumi to a Kubernaetes Cluster](./setup.html)
 
 ## Running the Guestbook
 


### PR DESCRIPTION
This slipped through due to the differences between Jekyll
and our actual hosted cloud websites.