### PR TITLE
Document the 'pulumi state' command

### DIFF
--- a/_data/reference.yaml
+++ b/_data/reference.yaml
@@ -77,6 +77,8 @@ toc:
     path: /reference/cli/pulumi_refresh.html
   - title: Stack
     path: /reference/cli/pulumi_stack.html
+  - title: State
+    path: /reference/cli/pulumi_state.html
   - title: Update
     path: /reference/cli/pulumi_up.html
 - title: Cloud Console

--- a/reference/troubleshooting.md
+++ b/reference/troubleshooting.md
@@ -158,6 +158,10 @@ to manually edit the stack's existing state to fix the corruption.
 
 Note that this is an advanced operation and should be an absolute last resort.
 
+If you intend to unprotect or delete a resource, consider using the [`pulumi state`](./cli/pulumi_state.html) command to
+do so instead of editing your state directly. `pulumi state` also makes surgical fixes to your state but without
+requiring you to edit the JSON representation of your stack's current state.
+
 To get a JSON representation of your stack's current state, you can export your current stack
 to a file:
 


### PR DESCRIPTION
The docs website already has autogenerated documentation for 'pulumi
state' thanks to Cobra, so this commit links to it from the
troubleshooting doc and inserts it into the sidebar for easy navigation.

Fixes https://github.com/pulumi/docs/issues/608