### PR TITLE
Add quickstart notes on how to install AWS plugin

### DIFF
--- a/quickstart/aws/tutorial-containers-ecs-fargate.md
+++ b/quickstart/aws/tutorial-containers-ecs-fargate.md
@@ -102,6 +102,10 @@ In this tutorial, we'll use JavaScript to build and deploy a simple container to
     Update duration: 3m53.44141303s
     ```
 
+> ***Note***: If you see an error message like `no resource plugin 'aws' found in the workspace or on your $PATH`, you
+> can manually install the Pulumi AWS plugin with `pulumi plugin install resource aws v$(npm info @pulumi/aws
+> version)`.
+
 1.  View the endpoint URL and run curl:
 
     ```bash

--- a/quickstart/aws/tutorial-ec2-webserver.md
+++ b/quickstart/aws/tutorial-ec2-webserver.md
@@ -65,6 +65,10 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver EC2 instance
         + 3 resources to create
     ```
 
+> ***Note***: If you see an error message like `no resource plugin 'aws' found in the workspace or on your $PATH`, you
+> can manually install the Pulumi AWS plugin with `pulumi plugin install resource aws v$(npm info @pulumi/aws
+> version)`.
+
 1.  Now, proceed with the deployment, which takes about 30 seconds to complete. 
 
     ```

--- a/quickstart/aws/tutorial-rest-api.md
+++ b/quickstart/aws/tutorial-rest-api.md
@@ -89,6 +89,10 @@ The stack is ready to deploy, which is done as follows:
 pulumi up
 ```
 
+> ***Note***: If you see an error message like `no resource plugin 'aws' found in the workspace or on your $PATH`, you
+> can manually install the Pulumi AWS plugin with `pulumi plugin install resource aws v$(npm info @pulumi/aws
+> version)`.
+
 This command instructs Pulumi to determine the resources needed to create the stack. First, a preview is shown of the changes that will be made:
 
 ![Stack preview](https://user-images.githubusercontent.com/4564579/46554998-da6c9980-c896-11e8-8530-6ca4c8db8123.png){:width="700px"}

--- a/quickstart/aws/tutorial-s3-website.md
+++ b/quickstart/aws/tutorial-s3-website.md
@@ -75,6 +75,10 @@ In this tutorial, we'll show how you can use [@pulumi/aws] to provision raw reso
 
 1.  Run `pulumi update` to preview and deploy AWS resources. This creates a stack component, a Bucket and two S3 Objects (one for each file in the `www` folder).
 
+> ***Note***: If you see an error message like `no resource plugin 'aws' found in the workspace or on your $PATH`, you
+> can manually install the Pulumi AWS plugin with `pulumi plugin install resource aws v$(npm info @pulumi/aws
+> version)`.
+
 1.  To see the name of the bucket that was created, run `pulumi stack output`. Note that an extra 7-digit identifier is appended to the name. All Pulumi resources add this identifier automatically, so that you don't have to manually create unique names.
 
     ```bash

--- a/quickstart/cloudfx/tutorial-rest-api.md
+++ b/quickstart/cloudfx/tutorial-rest-api.md
@@ -71,6 +71,10 @@ In this tutorial, we'll show how to create a simple REST API that counts the num
         + 14 resources created
     ```
 
+> ***Note***: If you see an error message like `no resource plugin 'aws' found in the workspace or on your $PATH`, you
+> can manually install the Pulumi AWS plugin with `pulumi plugin install resource aws v$(npm info @pulumi/aws/
+> version)`.
+
 1.  View the endpoint URL and curl a few routes:
 
     ```bash

--- a/quickstart/cloudfx/tutorial-thumbnailer.md
+++ b/quickstart/cloudfx/tutorial-thumbnailer.md
@@ -139,6 +139,10 @@ and a video walkthrough of this example is [available on YouTube](https://www.yo
     Update duration: 1m48.486679173s
     ```
 
+> ***Note***: If you see an error message like `no resource plugin 'aws' found in the workspace or on your $PATH`, you
+> can manually install the Pulumi AWS plugin with `pulumi plugin install resource aws v$(npm info @pulumi/aws
+> version)`.
+
 ## Test the application
 
 To test the application, we'll upload a video to S3, view the running application logs, then download the thumbnail from S3.


### PR DESCRIPTION
Customers sometimes run into issues with the AWS quickstart when their
AWS plugin did not automatically install as part of their package
installation. In the event that NPM did not correctly install their
plugin, this commit adds notes to the relevant areas that instruct users
on how to install the plugin manually.

Fixes https://github.com/pulumi/pulumi/issues/2097