### PR TITLE
Add docs for CircleCI

### DIFF
--- a/_data/reference.yaml
+++ b/_data/reference.yaml
@@ -95,16 +95,18 @@ toc:
   section:
   - title: Pulumi GitHub App
     path: /reference/cd-github.html
-  - title: Pulumi GitHub Actions
-    path: /reference/cd-github-actions.html
   - title: AWS Code Services
     path: /reference/cd-aws-code-services.html
-  - title: Travis CI
-    path: /reference/cd-travis.html
-  - title: GitLab CI
-    path: /reference/cd-gitlab-ci.html
   - title: Azure DevOps
     path: /reference/cd-azure-devops.html
+  - title: CircleCI
+    path: /reference/cd-circleci.html
+  - title: GitHub Actions
+    path: /reference/cd-github-actions.html
+  - title: GitLab CI
+    path: /reference/cd-gitlab-ci.html
+  - title: Travis CI
+    path: /reference/cd-travis.html
 - title: Pulumi Vs. Others
   path: /reference/vs/index
   section:

--- a/reference/cd-circleci.md
+++ b/reference/cd-circleci.md
@@ -1,0 +1,59 @@
+---
+title: CircleCI
+---
+
+This page details how to use [CircleCI](https://circleci.com/) to deploy Pulumi stacks.
+
+You can refer to [CircleCI's documentation](https://circleci.com/docs/2.0/config-intro/#section=configuration)
+for information on how to configure your CircleCI jobs and workflows.
+
+When it comes to integrating Pulumi, just like Like other CI/CD services, it is generally a matter
+of downloading the Pulumi command-line tool and running `pulumi update` from within the CircleCI
+environment. However, [Pulumi Orbs for CircleCI](https://circleci.com/orbs/registry/orb/pulumi/pulumi)
+enable a standard way to do this integration, without needing any custom scripting.
+
+## Pulumi Orbs
+
+The Pulumi orbs for CircleCI takes care of the mechanics of downloading and installing the Pulumi
+command-line tool, so that you can just focus on the specific steps to deploy your stacks within
+your CircleCI configuration.
+
+> For the most up-to-date information about Pulumi orbs, refer to the Pulumi page within the CircleCI
+> orb registry at https://circleci.com/orbs/registry/orb/pulumi/pulumi.
+
+The following CircleCI `config.yaml` shows the Pulumi orbs in-action. It references the
+`pulumi/pulumi@1.0.0` orb package, and then downloads starts Pulumi using the  `pulumi/login` orb,
+and finally updates a stack using the `pulumi/update` orb.
+
+```yaml
+version: 2.1
+orbs:
+  pulumi: pulumi/pulumi@1.0.0
+jobs:
+  build:
+    docker:
+      - image: circleci/node:7.10
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - pulumi/login
+      - run:
+          command: |
+            npm install
+            npm run build
+      - pulumi/update:
+          stack: website-prod
+```
+
+Integrating Pulumi into CircleCI starts with the `pulumi/login` orb, which will take care of
+downloading the Pulumi command-line tool if it is not on the current `$PATH`. It will then run
+`pulumi login` using available credentials.
+
+You can either specify the Pulumi access token with the `access-token` parameter, or default to using
+the `$PULUMI_ACCESS_TOKEN` environment variable. Using the environment variable is preferred, as you
+can secure store that using secure [project-level configuration](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project) within CircleCI.
+
+### Reference
+
+The full [reference documentation](https://github.com/pulumi/circleci#orb-reference) for the Pulumi
+orbs can be found along side their source code [on Github](https://github.com/pulumi/circleci).

--- a/reference/cd.md
+++ b/reference/cd.md
@@ -5,29 +5,24 @@ title: Continuous Deployment
 Pulumi is great for continuous deployment and supports a range of workflows.  In fact, our team uses Pulumi
 itself to deploy and manage [https://pulumi.com/](https://pulumi.com) and follows many of the practices described below.
 
-## Continuous integration
+## CI / CD
 
 Continuous integration (CI) encompasses the system you use for automatically testing your source code, usually upon
 commits to a particular branch.  This relates to, but is independent from, continuous deployment (CD), which deploys
 a subset of these code changes after specific gates have been passed (certain tests passing, approval, and so on).
 
-Pulumi can be used with any CI provider - including:
-
-- AWS Code Services (CodePipeline, CodeBuild)
-- CircleCI
-- Travis
-- Jenkins
-- etc.
-
-Pulumi can also bridge results from your CI system with GitHub, for example surfacing the results of stack
-updates on GitHub pull requests. See [Pulumi GitHub App](./cd-github.html) for more information.
-
 ### Provider-specific examples
 
 * [AWS Code Services](./cd-aws-code-services.html)
 * [Azure DevOps](./cd-azure-devops.html)
+* [CircleCI](./cd-circleci.html)
+* [GitHub Actions](./cd-github-actions.html)
 * [GitLab CI](./cd-gitlab-ci.html)
 * [Travis](./cd-travis.html)
+
+
+Pulumi can also bridge results from your CI/CD system with GitHub, for example surfacing the results of stack
+updates on GitHub pull requests. See [Pulumi GitHub App](./cd-github.html) for more information.
 
 ## Branching strategy for deployments
 


### PR DESCRIPTION
Adds some documentation for how to use Pulumi with CircleCI, which is made trivial by the use of CircleCI orbs.

I also did some slight tweaking of the base Continuous Delivery page, as we now have enough provider-specific examples we can just let them stand on their own.

While poking around I did try to move all of our `/reference/ci-*` docs into a separate `/reference/continuous-deliver/` folder for better SEO, but that was a thorny enough change it should be left for a separate PR.

Fixes https://github.com/pulumi/docs/issues/631.