### PR TITLE
Improve the landing page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,4 @@
 <header class="main-header">
-    <a href="https://github.com/pulumi/pulumi"><img style="position: absolute; top: 45px; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
-
     <div class="utility-bar hidden-xs hidden-sm">
         <div class="container-fluid">
             <div class="row">

--- a/_includes/utility-links.html
+++ b/_includes/utility-links.html
@@ -3,3 +3,8 @@
 <li><a href="https://slack.pulumi.io/" target="_blank">Slack</a></li>
 <li><a href="https://github.com/pulumi" target="_blank">GitHub</a></li>
 <li><a href="https://app.pulumi.com/" target="_blank">Console</a></li>
+<li class="gh-widget">
+    <a class="github-button"
+       href="https://github.com/pulumi/pulumi"
+       data-size="small" data-show-count="true" aria-label="Star pulumi/pulumi on GitHub">Star</a>
+</li>

--- a/_sass/_pulumi.scss
+++ b/_sass/_pulumi.scss
@@ -170,9 +170,15 @@ svg {
 }
 
 .get-to-the-cloud {
-    color: #4a5960;
+    color: #333;
     font-size: 36px;
-    margin: 48px 0 !important;
+    margin: 48px 0 32px 0 !important;
+}
+
+.get-to-the-cloud-sub {
+    color: #4a5960;
+    font-size: 28px;
+    margin: 32px 0 48px 0 !important;
 }
 
 .what-is-pulumi {
@@ -533,7 +539,6 @@ h4 { font-size: 22px; font-weight: 500; }
         display: table;
         width: 100%;
         border-spacing: 10px;
-        margin-bottom: 24px;
     }
     .mdl-card {
         display: table-cell;

--- a/_sass/partials/_header.scss
+++ b/_sass/partials/_header.scss
@@ -100,6 +100,13 @@ body{
 	}
 }
 
+.gh-widget {
+	> span {
+		position: relative;
+		top: 3px;
+    }
+}
+
 .main-nav-block {
 	background-color: $purple-mid;
 		

--- a/index.md
+++ b/index.md
@@ -3,38 +3,82 @@ layout: default_index
 searchindex: false
 ---
 
-<p style="margin-bottom: 0">
-    <span class="github-stars-widget">
-        <a
-                href="https://github.com/pulumi/pulumi"
-                class="github-button"
-                data-size="large"
-                data-show-count="true"
-                aria-label="Star pulumi/pulumi on GitHub">
-            Star</a>
-    </span>
-</p>
-
-<div class="card-table">
-    <a href="https://www.pulumi.com"><img src="/images/logo/logo.svg" alt="Pulumi" width="350"></a>
+<div class="card-table" style="margin-top: 24px">
+    <a href="https://www.pulumi.com"><img src="/images/logo/logo.svg" alt="Pulumi" width="300"></a>
     <h2 class="get-to-the-cloud no-anchor">
         Cloud Native Infrastructure as Code
     </h2>
+    <h3 class="get-to-the-cloud-sub no-anchor">
+        Build software for any cloud using your favorite language.
+    </h3>
     <p style="text-align: center; margin-bottom: 0">
+        <a href="/quickstart/install.html"><button class="button primary">INSTALL</button></a>
         <a href="/quickstart"><button class="button primary">GET STARTED</button></a>
-        <a href="/tour"><button class="button">TAKE A TOUR</button></a>
-        <a href="https://github.com/pulumi/examples"><button class="button">EXAMPLES</button></a>
-    </p>
-    <p class="what-is-pulumi">
-        <span class="what-is-pulumi-cta">
-            Create, deploy, and manage cloud native applications and infrastructure
-        </span>
-        in your favorite language, using an open source platform that enables sharing, reuse,
-        and safe and predictable changes in a team environment.
+        <a href="https://github.com/pulumi/examples" target="_blank"><button class="button primary">EXAMPLES</button></a>
     </p>
 </div>
 
-<div class="card-table">
+<div class="card-table" style="background: #fafafa; margin: 32px 0 0 0; border-top: 1px solid #eee">
+    <div class="mdl-card mdl-shadow--2dp get-started-card">
+        <a href="/quickstart/aws/index.html"><img src="/images/quickstart/aws-purple.png" style="width: 250px"></a>
+        <a href="/quickstart/azure/index.html"><img src="/images/quickstart/azure-purple.png" style="width: 250px"></a>
+        <a href="/quickstart/gcp/index.html"><img src="/images/quickstart/gcp-purple.png" style="width: 250px"></a>
+        <a href="/quickstart/kubernetes/index.html"><img src="/images/quickstart/k8s-purple.png" style="width: 250px"></a>
+    </div>
+</div>
+
+<div class="card-table" style="border-top: 1px solid #eee">
+    <div class="mdl-card mdl-shadow--2dp get-started-card">
+        <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text no-anchor" style="color: #999">Why Pulumi?</h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                <div class="content" style="text-align: left; display: inline-block; margin: auto">
+                    By using general purpose languages for infrastructure as code,
+                    you get all the benefits of real languages -- IDEs, abstractions and
+                    reuse thanks to functions, classes, and packages, debugging, testability,
+                    and more. The result is far less copy and paste and greater productivity,
+                    and it works the same way no matter which cloud you're targeting.
+                </div>
+            </span>
+        </div>
+    </div>
+    <div class="mdl-card mdl-shadow--2dp get-started-card">
+        <div class="mdl-card__title">
+           <h2 class="mdl-card__title-text no-anchor" style="color: #999">Alternatives</h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                <div class="content" style="text-align: left; display: inline-block; margin: auto">
+                    Other approaches use YAML, JSON, or bespoke DSLs that you need to
+                    master -- and convince your team to use. These "languages" fall short of
+                    general purpose languages, lacking abstractions and reuse, and reinvent
+                    familiar concepts like package managers. Worse, these solutions are usually
+                    unique to every given cloud that you need to target.
+                </div>
+            </span>
+        </div>
+    </div>
+    <div class="mdl-card mdl-shadow--2dp get-started-card">
+        <div class="mdl-card__title">
+           <h2 class="mdl-card__title-text no-anchor" style="color: #999">Community</h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+            <span class="card-text">
+                <div class="content" style="text-align: left; display: inline-block; margin: auto">
+                    Pulumi's SDK is fully open source and extensible, enabling you to
+                    participate in a rich ecosystem of libraries that ease common tasks,
+                    ranging from containers to serverless to infrastructure, and everything
+                    in between. Languages and clouds are supported using an extensible
+                    plugin model, enabling public, private, and even hybrid cloud support.
+                </div>
+            </span>
+        </div>
+    </div>
+</div>
+
+<div class="card-table" style="background: #fafafa; border-top: 1px solid #eee; margin-bottom: 64px">
     <div class="mdl-card mdl-shadow--2dp get-started-card">
         <a href="/quickstart/aws/tutorial-containers-ecs-fargate.html">
           <img src="/images/icon-feature-containers.svg"
@@ -117,43 +161,6 @@ searchindex: false
             <a href="/quickstart/kubernetes/index.html">
                 <button class="button">START NOW</button>
             </a>
-        </div>
-    </div>
-</div>
-
-<div class="card-table" style="margin: 64px 0;">
-    <div class="col-sm-10 col-sm-offset-1">
-        <div class="row cols-are-spaced-md">
-            <div class="col col-md-4">
-                <div class="content" style="text-align: center; display: inline-block; margin: auto">
-                    <ul class="logo-roll text-center-xs text-center-sm" style="margin-left: 15px">
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-js.png" alt="js"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-python.png" alt="python"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-golang.png" alt="golang"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-ts.png" alt="typescript"></li>
-                    </ul>
-                </div>
-            </div>
-            <div class="col col-md-4">
-                <div class="content" style="text-align: center; display: inline-block; margin: auto">
-                    <ul class="logo-roll text-center-xs text-center-sm" style="margin-left: 15px">
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-aws.png" alt="aws"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-azure.png" alt="azure"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-gd.png" alt="gd"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-kubernetes.png" alt="kubernetes"></li>
-                    </ul>
-                </div>
-            </div>
-            <div class="col col-md-4">
-                <div class="content" style="text-align: center; display: inline-block; margin: auto">
-                    <ul class="logo-roll text-center-xs text-center-sm" style="margin-left: 15px">
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-github.png" alt="github"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-vs.png" alt="vs"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-npm.png" alt="npm"></li>
-                        <li><img src="https://www.pulumi.com/assets/logos/tech/logo-travisci.png" alt="travisci"></li>
-                    </ul>
-                </div>
-            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This change improves the landing page slightly:

* Shrink the Pulumi logo on the landing page a little bit.

* Improve the sub-heading to just "Build software for any cloud
  using your favorite language," from the previous wordy blurb.

* Drop the "Tour" button, and add an "Install" button in its place.

* Colorize all buttons the same. The prior approach of making
  "Get Started" being a different color had the confusing effect of
  making it seem like you were actively in the Getting Started section.

* Move the GitHub star button from just the homepage to the upper right
  corner of the nav bar, similar to what we do on www.pulumi.com.

* Add a band of cloud logos just beneath the buttons. This only
  includes AWS, Azure, GCP, and Kubernetes -- I've dropped OpenStack
  and the Pulumi Cloud Framework, asthey are lesser known/used.

* Add a band with "Why Pulumi?", "Alternatives", and "Community,"
  with little blurbs to tell people what Pulumi *is* and why you
  might be interested in using it.

This is part of the recurring task, pulumi/docs#500, improves
pulumi/docs#572, and fixes pulumi/docs#601.

There is more to do here -- notably, I'd like some code snippets
and perhaps a CLI screenshot somewhere on this page, perhaps as a
distinct band above or beneath the "Why Pulumi?", etc. table.