### PR TITLE
Clean up `make docker` target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM ruby
-COPY Gemfile /src/Gemfile
-COPY Gemfile.lock /src/Gemfile.lock
+FROM ruby AS builder
+
+COPY Gemfile* /src/
+COPY Makefile /src/
 WORKDIR /src
-RUN apt-get update 
-RUN apt-get -y install curl
+RUN bundle install
+
+RUN apt-get update && apt-get -y install \
+  curl
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash 
-RUN apt-get install -y nodejs
-COPY Makefile /src/Makefile
-RUN make ensure
-COPY . /src
+RUN apt-get install -y \
+  nodejs
+RUN npm install broken-link-checker typedoc
 CMD make serve

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ banner:
 .PHONY: docker
 docker:
 	docker build . -t docs
-	docker run -it -p 4000:4000 docs
+	docker run -it --rm -v $(PWD):/src -p 4000:4000 docs
 
 .PHONY: configure
 configure:


### PR DESCRIPTION
- Allow live-reloading of content in the docker container
- Remove container after exit
- Fix the image build so that most steps are cached