### PR TITLE
Record engine events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ before_install:
 - ./scripts/travisqueue.sh start
 # Install required tools.
 # pulumi
-- curl -L https://get.pulumi.com/ | bash -s -- --version 0.16.2-dev-1540331970-gb14d2593
+- curl -L https://get.pulumi.com/ | bash -s -- --version 0.16.6-dev.1543332884
 - export PATH=$PATH:$HOME/.pulumi/bin
+# Remove after pulumi/pulumi/issues/2203 is resolved.
+- export PULUMI_RECORD_ENGINE_EVENTS=1
 # yarn
 - npm i -g yarn
 # Work around a current issue in bundler. See:

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -33,8 +33,5 @@ yarn install
 yarn build
 
 # Login, select the stack, and update.
-export PULUMI_STACK_NAME="pulumi/pulumi.io-${ENVIRONMENT}"
-# Remove once pulumi/pulumi/issues/1715 is fixed.
-export PULUMI_PERSIST_PREVIEWS="1"
-pulumi stack select ${PULUMI_STACK_NAME}
+pulumi stack select "pulumi/pulumi.io-${ENVIRONMENT}"
 pulumi preview

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -33,6 +33,5 @@ yarn install
 yarn build
 
 # Login, select the stack, and update.
-export PULUMI_STACK_NAME="pulumi/pulumi.io-${ENVIRONMENT}"
-pulumi stack select ${PULUMI_STACK_NAME}
+pulumi stack select "pulumi/pulumi.io-${ENVIRONMENT}"
 pulumi update --yes --skip-preview


### PR DESCRIPTION
Bump the version of `pulumi` used to deploy https://pulumi.io and enable a feature behind a flag. Everything should "just work"™️ 🤞 .