### PR TITLE
Force Powershell to use TLS1.2

### DIFF
--- a/quickstart/install.md
+++ b/quickstart/install.md
@@ -133,7 +133,7 @@ If you prefer to download and manually install the tarball, please select "Manua
 To install on Windows, run our installation script from a `cmd.exe` window:
 
 ```batch
-@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))" && SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"
+@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))" && SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"
 ```
 
 This will install the `pulumi.exe` CLI to `%USERPROFILE%\.pulumi\bin` and add it to your path.


### PR DESCRIPTION
We will be moving get.pulumi.com over to requring TLS 1.2 in a short
while. When we do so, some versions of PowerShell will not establish a
secure connection to this host by default.

We must force PowerShell to use TLS 1.2 in this case, otherwise our
call to download the install.ps1 script and then run it would fail.