### PR TITLE
Flesh out programming model docs

### DIFF
--- a/reference/programming-model.md
+++ b/reference/programming-model.md
@@ -83,11 +83,15 @@ All resource constructors also accept a third argument which can provide the fol
 
 ## Resource outputs {#outputs}
 
-Outputs are a key part of how Pulumi tracks dependencies between resources.  Because the values of Outputs are not available until resources are created, these are represented using a special [Output] type which internally represents two things:
+Outputs are a key part of how Pulumi tracks dependencies between resources.  Because the values of Outputs are not available until resources are created, these are represented using a special [`Output`][pulumi.Output] type which internally represents two things:
 1. An eventually available value of the output
 2. The depdency on the source(s) of the output value
 
-The output properties of all resource objects in Pulumi have type [`Output`][pulumi.Output]. Resource inputs have type [`Input`][pulumi.Input], which accepts either a raw value or an output from another resource. This allows dependencies to be inferred, including ensuring that resources are not created or updatred until all their dependencies are availabe and up to date.  
+In fact, `Output`s are similar to promises/futures that you may be familiar with from other programming models but also carry along dependency information.
+
+The output properties of all resource objects in Pulumi have type [`Output`][pulumi.Output]. Resource inputs have type [`Input`][pulumi.Input], which accepts either a raw value, a `Promise`, or an output from another resource. This allows dependencies to be inferred, including ensuring that resources are not created or updatred until all their dependencies are availabe and up to date.  
+
+### Apply {#apply}
 
 To transform an output into a new value, use the [`apply` method](pkg/nodejs/@pulumi/pulumi/#property-apply). For example, use the following to create an HTTPS URL from the DNS name of a virtual machine: 
 
@@ -117,6 +121,8 @@ The `apply` method accepts a callback which will be passed the value of the `Out
 
 > Note: The `Output` itself cannot be used directly in string concatenation or other operations, as it is not itself the value of the output.  To transform the value of the output (when it becomes available), the `apply` method should be used instead.
 
+### All {#all}
+
 To combine multiple `Output`s into a transformed value, use [pulumi.all].  This allows a new value to be constructed from several inputs, such as concatenating outputs from two different resources together, or constructing a policy document using information from several other resources.
 
 {% include langchoose.html %}
@@ -133,11 +139,17 @@ let connectionString = pulumi.all([sqlServer.name, database.name])
 
 ```python
 # `all` is not yet available in Python
+#
+# See https://github.com/pulumi/pulumi/issues/2284.
 ```
 
 ```go
-// `all` is not yet available in Go
+// `all` is not yet available in Go.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
+
+### Convert Input to Output {#frominput}
 
 To turn an `Input` into an `Output`, use [pulumi.output].  This can be useful when you want to transform an input value that could either be a raw value or an `Output`:
 
@@ -165,7 +177,9 @@ def split(input):
 ```
 
 ```go
-// Helpers for converting Inputs to Outputs are not yet available in Go
+// Helpers for converting Inputs to Outputs are not yet available in Go.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 ## Stack output {#stack-outputs}
@@ -295,11 +309,15 @@ console.log(`Active: ${data.active}`);
 ```
 
 ```python
-# JSON parsing helpers for config are not built-in for Python currently
+# JSON parsing helpers for config are not built-in for Python currently.
+#
+# See https://github.com/pulumi/pulumi/issues/1535.
 ```
 
 ```go
-// JSON parsing helpers for config are not built-in for Go currently
+// JSON parsing helpers for config are not built-in for Go currently.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 ## Components {#components}
@@ -335,7 +353,9 @@ class MyResource(ComponentResource):
 ```
 
 ```go
-// ComponentResources are not directly supported in Go currently
+// ComponentResources are not directly supported in Go currently.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 The call to `super` registers the component instance with the Pulumi engine. This records the resource in the checkpoint and tracks it across program deployments. Since all resources must have a name, a component constructor should accept a name and pass it to `super`.
@@ -386,7 +406,9 @@ self.register_outputs({
 ```
 
 ```go
-// ComponentResources are not directly supported in Go currently
+// ComponentResources are not directly supported in Go currently.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 In addition to the usual resource options, components accept a set of [providers](#providers) to use for their child resources. If a component is itself a child of another component, its set of providers is inherited from its parent by default.
@@ -402,11 +424,15 @@ let component = new MyResource("component", { providers: { aws: useast1, kuberne
 ```
 
 ```python
-# Providers are not supported in Python currently
+# Providers are not supported in Python currently.
+#
+# See https://github.com/pulumi/pulumi/issues/1535.
 ```
 
 ```go
-// ComponentResources are not directly supported in Go currently
+// ComponentResources are not directly supported in Go currently.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 For more information about components, see the [Pulumi Components](component-tutorial.html) tutorial.
@@ -436,11 +462,15 @@ let instance = new aws.ec2.Instance("myInstance", {
 ```
 
 ```python
-# Providers are not supported in Python currently
+# Providers are not supported in Python currently.
+#
+# See https://github.com/pulumi/pulumi/issues/1535.
 ```
 
 ```go
-// Providers are not supported in Go currently
+// Providers are not supported in Go currently.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 
@@ -507,11 +537,15 @@ let listener = new aws.elasticloadbalancingv2.Listener("listener", {
 ```
 
 ```python
-# Providers are not supported in Python currently
+# Providers are not supported in Python currently.
+#
+# See https://github.com/pulumi/pulumi/issues/1535.
 ```
 
 ```go
-// Providers are not supported in Go currently
+// Providers are not supported in Go currently.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 ```bash
@@ -549,11 +583,15 @@ let myResource = new MyResource("myResource", { providers: { aws: useast1, kuber
 ```
 
 ```python
-# Providers are not supported in Python currently
+# Providers are not supported in Python currently.
+#
+# See https://github.com/pulumi/pulumi/issues/1535.
 ```
 
 ```go
-// Providers are not supported in Go currently
+// Providers are not supported in Go currently.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 ## Packages {#packages}
@@ -585,11 +623,15 @@ bucket.onObjectCreated("onObject", async (ev: aws.s3.BucketEvent) => {
 ```
 
 ```python
-# Runtime code provided via callbacks are not supported in Python currently
+# Runtime code provided via callbacks are not supported in Python currently.
+#
+# See https://github.com/pulumi/pulumi/issues/1535.
 ```
 
 ```go
-// Runtime code provided via callbacks are not supported in Go currently
+// Runtime code provided via callbacks are not supported in Go currently.
+// 
+// See https://github.com/pulumi/pulumi/issues/1614.
 ```
 
 Libraries which use JavaScript callbacks as inputs to be provided as source text to resource construction (like the Lambda that is created by the `onObjectCreated` function in the example above) are built on top of the [pulumi.runtime.serializeFunction] API, which takes as input a JavaScript `Function` object, and returns a `Promise` that contains the serialized form of that function. 

--- a/reference/programming-model.md
+++ b/reference/programming-model.md
@@ -4,14 +4,45 @@ title: "Programming Model"
 
 In Pulumi, [resources](#resources) are defined by allocating resource objects in a program, such as `new aws.ec2.Instance(...)`.  The first argument passed to the resource constructor is its `name`, which must be unique within the Pulumi program. To create dependencies between resources, just reference the [output properties](#outputs) of a resource. For example, this definition of an EC2 instance creates a dependency on a `SecurityGroup`:
 
+{% include langchoose.html %}
 
-```js
+```javascript
 let group = new aws.ec2.SecurityGroup(...);
-
 let server = new aws.ec2.Instance("webserver-www", {
     ...
     securityGroups: [ group.name ], // reference the security group resource above
 });
+```
+
+```typescript
+let group = new aws.ec2.SecurityGroup(...);
+let server = new aws.ec2.Instance("webserver-www", {
+    ...
+    securityGroups: [ group.name ], // reference the security group resource above
+});
+```
+
+```python
+group = aws.ec2.SecurityGroup(...)
+server = aws.ec2.Instance('webserver-www',
+    ...
+    security_groups=[group.name]) # reference the security group resource above
+```
+
+```go
+group, err := ec2.NewSecurityGroup(ctx, "webserver-securitygroup", &ec2.SecurityGroupArgs{
+    ...
+})
+if err != nil {
+    return err
+}
+server, err := ec2.NewInstance(ctx, "webserver-www", &ec2.InstanceArgs{
+    ...
+    SecurityGroups: []interface{}{group}, // reference the security group resource above
+})
+if err != nil {
+    return err
+}
 ```
 
 To publish values that you wish to access outside your application, create a [stack output](#stack-outputs) via module exports. 
@@ -56,51 +87,107 @@ Outputs are a key part of how Pulumi tracks dependencies between resources.  Bec
 1. An eventually available value of the output
 2. The depdency on the source(s) of the output value
 
-The output properties of all resource objects in Pulumi have type [Output][pulumi.Output]. Resource inputs have type [`Input`](pulumi.Input), which accepts either a raw value or an output from another resource. This allows dependencies to be inferred, including ensuring that resources are not created or updatred until all their dependencies are availabe and up to date.  
+The output properties of all resource objects in Pulumi have type [`Output`][pulumi.Output]. Resource inputs have type [`Input`](pulumi.Input), which accepts either a raw value or an output from another resource. This allows dependencies to be inferred, including ensuring that resources are not created or updatred until all their dependencies are availabe and up to date.  
 
 To transform an output into a new value, use the [`apply` method](pkg/nodejs/@pulumi/pulumi/#property-apply). For example, use the following to create an HTTPS URL from the DNS name of a virtual machine: 
 
-```js
+{% include langchoose.html %}
+
+```javascript
 let url = virtualmachine.dnsName.apply(dnsName => "https://" + dnsName)
+```
+
+```typescript
+let url = virtualmachine.dnsName.apply(dnsName => "https://" + dnsName)
+```
+
+```python
+url = virtual_machine.dns_name.apply(
+    lambda dns_name: "https://" + dns_name
+)
+```
+
+```go
+url := virtualmachine.DnsName().Apply(func(dnsName string) (interface{}, error) { 
+    return "https://" + dnsName, nil 
+})
 ```
 
 The `apply` method accepts a callback which will be passed the value of the `Output` when it is availabe, and which returns the new value.  The result of the call to `apply` is new `Output` whose value is the value returned from the callback, and which includes the dependencies of the original `Output`.  If the callback itself returns an `Output`, the dependencies of that output are unioned into the dependencies of the returned `Output`.
 
->>> Note: The `Output` itself cannot be used directly in string concatenation or other operations, as it is not itself the value of the output.  To transform the value of the output (when it becomes available), the `apply` method should be used instead.
+> Note: The `Output` itself cannot be used directly in string concatenation or other operations, as it is not itself the value of the output.  To transform the value of the output (when it becomes available), the `apply` method should be used instead.
 
 To combine multiple `Output`s into a transformed value, use [pulumi.all].  This allows a new value to be constructed from several inputs, such as concatenating outputs from two different resources together, or constructing a policy document using information from several other resources.
 
-```ts
+{% include langchoose.html %}
+
+```javascript
 let connectionString = pulumi.all([sqlServer.name, database.name])
-                             .apply(([server, db]) => `Server=tcp:${server}.database.windows.net;initial catalog=${db}...`),
+                             .apply(([server, db]) => `Server=tcp:${server}.database.windows.net;initial catalog=${db}...`);
+```
+
+```typescript
+let connectionString = pulumi.all([sqlServer.name, database.name])
+                             .apply(([server, db]) => `Server=tcp:${server}.database.windows.net;initial catalog=${db}...`);
+```
+
+```python
+# `all` is not yet available in Python
+```
+
+```go
+// `all` is not yet available in Go
 ```
 
 To turn an `Input` into an `Output`, use [pulumi.output].  This can be useful when you want to transform an input value that could either be a raw value or an `Output`:
 
-```ts
+{% include langchoose.html %}
+
+```javascript
+function split(input) {
+    let output = pulumi.output(input);
+    return output.apply(v => v.split());
+}
+```
+
+```typescript
 function split(input: pulumi.Input<string>): pulumi.Output<string[]> {
     let output = pulumi.output(input);
     return output.apply(v => v.split());
 }
 ```
 
+```python
+def split(input):
+    output = Output.from_input(input);
+    output.apply(lambda v: v.split());
+}
+```
+
+```go
+// Helpers for converting Inputs to Outputs are not yet available in Go
+```
+
 ## Stack output {#stack-outputs}
 
 A [stack output](stack.html#outputs) is a value that can be easily retrieved from the Pulumi CLI and is displayed on pulumi.com. To export values from a stack, use the following definition in the top-level of the entry point for your project:
 
-**JavaScript**
-```js
-exports.url = ...
+{% include langchoose.html %}
+
+```javascript
+exports.url = resource.url;
 ```
 
-**TypeScript**
-```ts
-export let url = ...
+```typescript
+export let url = resource.url;
 ```
 
-**Python**
 ```python
-pulumi.output(url, ...)
+pulumi.export("url", resource.url)
+```
+
+```go
+ctx.Export("url", resource.Url())
 ```
 
 From the CLI, you can then use `pulumi stack output url` to get the value and incorporate into other scripts or tools. 
@@ -109,19 +196,40 @@ The right-hand side of a stack export can be a regular JavaScript value, an [Out
 
 Stack exports are JSON serialized, though quotes are removed when exporting just a string value. For example:
 
-```js
-exports.x = "hello" 
-// result of `pulumi stack output x`:
-// hello
+{% include langchoose.html %}
 
+```javascript
+exports.x = "hello" 
 exports.o = {num: 42}
-// result of `pulumi stack output o`:
-// {"num": 42}
+```
+
+```typescript
+export let x = "hello";
+export let o = {num: 42};
+```
+
+```python
+pulumi.export("x", "hello")
+pulumi.export("o", {'num': 42})
+```
+
+```go
+ctx.Export("x", "hello")
+ctx.Export("o", map[string]interface{}{
+    "num": 42,
+})
+```
+
+```bash
+$ pulumi stack output x
+hello
+$ pulumi stack output o
+{"num": 42}
 ```
 
 The full set of outputs can be rendered as JSON using `pulumi stack output --json`:
 
-```
+```bash
 $ pulumi stack output --json
 {
   "x": "hello",
@@ -135,10 +243,30 @@ $ pulumi stack output --json
 
 To access configuration values that have been set with `pulumi config set`, use the following:
 
-```js
+{% include langchoose.html %}
+
+```javascript
 let config = new pulumi.Config();
 let name = config.require("name");
 console.log(`Hello, ${name}!`);
+```
+
+```typescript
+let config = new pulumi.Config();
+let name = config.require("name");
+console.log(`Hello, ${name}!`);
+```
+
+```python
+config = pulumi.Config("project");
+name = config.require("name");
+print(f"Hello, {name}!")
+```
+
+```go
+conf = config.New(ctx, "project");
+name = conf.Require("name");
+fmt.Printf("Hello, %s!", name);
 ```
 
 Config values can be retrieved using [config.get] or [config.require].  Using `get` will return `undefined` if the configuration value was not provided, and `require` will raise an exception with a helpful error message to prevent the deployment from continuing.
@@ -147,7 +275,15 @@ Configuration values are always stored as strings, but can be parsed as richly t
 
 For richer structured data, the [config.getObject] method can be used to parse JSON values.  For example, following `pulumi config set data '{"active": true, "nums": [1,2,3]}'`, a program can read the `data` config into a rich object with:
 
-```ts
+{% include langchoose.html %}
+
+```javascript
+let config = new pulumi.Config();
+let data = config.requireObject("data");
+console.log(`Active: ${data.active}`); 
+```
+
+```typescript
 interface Data {
     active: boolean;
     nums: number[];
@@ -158,6 +294,14 @@ let data = config.requireObject<Data>("data");
 console.log(`Active: ${data.active}`); 
 ```
 
+```python
+# JSON parsing helpers for config are not built-in for Python currently
+```
+
+```go
+// JSON parsing helpers for config are not built-in for Go currently
+```
+
 ## Components {#components}
 
 A Pulumi **component** is a logical group of resources which contains other components and physical cloud resources. A Pulumi stack is itself a component that contains all top-level components and resources in a program. 
@@ -166,12 +310,32 @@ To create a new component, either in a top-level program or in a library, create
 
 Here's a simple component definition:
 
-```js
+{% include langchoose.html %}
+
+```javascript
 class MyResource extends pulumi.ComponentResource {
     constructor(name, opts) {
         super("pkg:MyResource", name, {}, opts);
     }
 }
+```
+
+```typescript
+class MyResource extends pulumi.ComponentResource {
+    constructor(name, opts) {
+        super("pkg:MyResource", name, {}, opts);
+    }
+}
+```
+
+```python
+class MyResource(ComponentResource):
+    def __init__(self, name, opts = None):
+        super(MyResource, self).__init__('pkg:MyResource', name, None, opts)
+```
+
+```go
+// ComponentResources are not directly supported in Go currently
 ```
 
 The call to `super` registers the component instance with the Pulumi engine. This records the resource in the checkpoint and tracks it across program deployments. Since all resources must have a name, a component constructor should accept a name and pass it to `super`.
@@ -180,22 +344,69 @@ A component must register a namespace, such as `pkg:MyResource` in the example a
 
 Components will often contain child resources. To track this relationship, pass the component instance as the parent when constructing a resource:
 
-```js
+{% include langchoose.html %}
+
+```javascript
 let bucket = new aws.s3.Bucket(`${name}-bucket`, {}, { parent: this });
+```
+
+```typescript
+let bucket = new aws.s3.Bucket(`${name}-bucket`, {}, { parent: this });
+```
+
+```python
+bucket = s3.Bucket(f"{name}-bucket", __opts__=ResourceOptions(parent=self))
+```
+
+```go
+bucket := s3.Bucket(ctx, fmt.Sprintf("%s-bucket", name), &s3.BucketArgs{}, pulumi.ResourceOpt{Parent: parent});
 ```
 
 Components can define their own properties using [registerOutputs]. The Pulumi engine uses this information to display the logical outputs of the component.  The call to `registerOutputs` also tells Pulumi that the resource is done registering children and should be considered fully constructed, so it is recommended that this method be called in all components even if no outputs need to be registered.
 
-```js
+
+{% include langchoose.html %}
+
+```javascript
 this.registerOutputs({
     bucketDnsName: bucket.bucketDomainName,
 })
 ```
 
+```typescript
+this.registerOutputs({
+    bucketDnsName: bucket.bucketDomainName,
+})
+```
+
+```python
+self.register_outputs({
+    bucketDnsName: bucket.bucketDomainName
+})
+```
+
+```go
+// ComponentResources are not directly supported in Go currently
+```
+
 In addition to the usual resource options, components accept a set of [providers](#providers) to use for their child resources. If a component is itself a child of another component, its set of providers is inherited from its parent by default.
 
-```js
+{% include langchoose.html %}
+
+```javascript
 let component = new MyResource("component", { providers: { aws: useast1, kubernetes: myk8s } });
+```
+
+```typescript
+let component = new MyResource("component", { providers: { aws: useast1, kubernetes: myk8s } });
+```
+
+```python
+# Providers are not supported in Python currently
+```
+
+```go
+// ComponentResources are not directly supported in Go currently
 ```
 
 For more information about components, see the [Pulumi Components](component-tutorial.html) tutorial.
@@ -204,7 +415,9 @@ For more information about components, see the [Pulumi Components](component-tut
 
 A [CustomResource][pulumi.CustomResource] needs an associated resource provider to manage its Create, Read, Update, and Delete (_CRUD_) operations. This is in contrast to a [ComponentResource][pulumi.ComponentResource], whose logic is authored entirely in a Pulumi program's source language (e.g. Javascript or Python). By default, a `CustomResource`'s provider is determined based on its [package](#packages). This default provider is automatically created by Pulumi, and is configured using its package's [config values](#config). For example, the configuration and program below will create a single EC2 instance in the `us-west-2` region.
 
-```js
+{% include langchoose.html %}
+
+```javascript
 let aws = require("@pulumi/aws");
 
 let instance = new aws.ec2.Instance("myInstance", {
@@ -213,13 +426,33 @@ let instance = new aws.ec2.Instance("myInstance", {
 });
 ```
 
+```typescript
+let aws = require("@pulumi/aws");
+
+let instance = new aws.ec2.Instance("myInstance", {
+    instanceType: "t2.micro",
+    ami: "myAMI",
+});
+```
+
+```python
+# Providers are not supported in Python currently
+```
+
+```go
+// Providers are not supported in Go currently
+```
+
+
 ```bash
 $ pulumi config set aws:region us-west-2
 ```
 
 While this works for the majority of Pulumi programs, some programs may have special requirements (e.g. the ability to deploy into multiple AWS regions simultaneously or to deploy into a Kubernetes cluster created earlier in the program) that require explicitly creating, configuring, and referencing providers. This is typically done by instantiating the relevant package's `Provider` type and passing it in the options for each `CustomResource` or `ComponentResource` that needs to use it. For example, the configuration and program below will create an ACM certificate in the `us-east-1` region and a load balancer listener in the `us-west-2` region.
 
-```js
+{% include langchoose.html %}
+
+```javascript
 let pulumi = require("@pulumi/pulumi");
 let aws = require("@pulumi/aws");
 
@@ -246,13 +479,50 @@ let listener = new aws.elasticloadbalancingv2.Listener("listener", {
 });
 ```
 
+```typescript
+let pulumi = require("@pulumi/pulumi");
+let aws = require("@pulumi/aws");
+
+// Create an AWS provider for the us-east-1 region.
+let useast1 = new aws.Provider("useast1", { region: "us-east-1" });
+
+// Create an ACM certificate in us-east-1.
+let cert = new aws.acm.Certificate("cert", {
+    domainName: "foo.com",
+    validationMethod: "EMAIL",
+}, { provider: useast1 });
+
+// Create an ALB listener in the default region that references the ACM certificate created above.
+let listener = new aws.elasticloadbalancingv2.Listener("listener", {
+    loadBalancerArn: loadBalancerArn,
+    port: 443,
+    protocol: "HTTPS",
+    sslPolicy: "ELBSecurityPolicy-2016-08",
+    certificateArn: cert.arn,
+    defaultAction: {
+        targetGroupArn: targetGroupArn,
+        type: "forward",
+    },
+});
 ```
+
+```python
+# Providers are not supported in Python currently
+```
+
+```go
+// Providers are not supported in Go currently
+```
+
+```bash
 $ pulumi config set aws:region us-west-2
 ```
 
 Component resources also accept a set of providers to use with their child resources. For example, the EC2 instance parented to `myResource` in the program below will be created in `us-east-1`, and the Kubernetes pod parented to `myResource` will be created in the cluster targeted by the "test-ci" context.
 
-```js
+{% include langchoose.html %}
+
+```javascript
 class MyResource extends pulumi.ComponentResource {
     constructor(name, opts) {
         let instance = new aws.ec2.Instance("instance", { ... }, { parent: this });
@@ -265,6 +535,27 @@ let myk8s = new kubernetes.Provider("myk8s", { context: "test-ci" });
 let myResource = new MyResource("myResource", { providers: { aws: useast1, kubernetes: myk8s } });
 ```
 
+```typescript
+class MyResource extends pulumi.ComponentResource {
+    constructor(name, opts) {
+        let instance = new aws.ec2.Instance("instance", { ... }, { parent: this });
+        let pod = new kubernetes.core.v1.Pod("pod", { ... }, { parent: this });
+    }
+}
+
+let useast1 = new aws.Provider("useast1", { region: "us-east-1" });
+let myk8s = new kubernetes.Provider("myk8s", { context: "test-ci" });
+let myResource = new MyResource("myResource", { providers: { aws: useast1, kubernetes: myk8s } });
+```
+
+```python
+# Providers are not supported in Python currently
+```
+
+```go
+// Providers are not supported in Go currently
+```
+
 ## Packages {#packages}
 
 Pulumi packages are normal NPM or Python packages. They transitively depend on `@pulumi/pulumi` which defines how resources created by a Pulumi program will be communicated to the Pulumi engine.  This ability to register resources with the Pulumi engine is the only difference between a Pulumi package and any other NPM package.
@@ -275,12 +566,29 @@ Some Pulumi packages have a dependency on a [Resource Provider plugin](/referenc
 
 You can create libraries and components that allow the caller to pass in JavaScript callbacks to invoke at runtime. For example, a JavaScript callback could be used as the implementation of an AWS Lambda function. 
 
-```ts
+```javascript
 let bucket = new aws.s3.Bucket("mybucket");
 bucket.onObjectCreated("onObject", async (ev) => {
     // This callback will be invoked at runtime any time an object is added to the bucket.
     console.log(JSON.stringify(ev));
 });
+```
+
+
+```typescript
+let bucket = new aws.s3.Bucket("mybucket");
+bucket.onObjectCreated("onObject", async (ev: aws.s3.BucketEvent) => {
+    // This callback will be invoked at runtime any time an object is added to the bucket.
+    console.log(JSON.stringify(ev));
+});
+```
+
+```python
+# Runtime code provided via callbacks are not supported in Python currently
+```
+
+```go
+// Runtime code provided via callbacks are not supported in Go currently
 ```
 
 Libraries which use JavaScript callbacks as inputs to be provided as source text to resource construction (like the Lambda that is created by the `onObjectCreated` function in the example above) are built on top of the [pulumi.runtime.serializeFunction] API, which takes as input a JavaScript `Function` object, and returns a `Promise` that contains the serialized form of that function. 
@@ -298,6 +606,7 @@ For more details see the docs on [serializing functions](serializing-functions.h
 [pulumi.ComponentResource]: pkg/nodejs/@pulumi/pulumi/#ComponentResource
 [pulumi.CustomResource]: pkg/nodejs/@pulumi/pulumi/#CustomResource
 [pulumi.Output]: pkg/nodejs/@pulumi/pulumi/#Output
+[pulumi.Input]: pkg/nodejs/@pulumi/pulumi/#Input
 [@pulumi/pulumi]: pkg/nodejs/@pulumi/pulumi
 [@pulumi/aws]: pkg/nodejs/@pulumi/aws
 [@pulumi/kubernetes]: pkg/nodejs/@pulumi/kubernetes/

--- a/reference/programming-model.md
+++ b/reference/programming-model.md
@@ -76,7 +76,7 @@ This package also provides the following helpers:
 A resource is created via `new Resource(name, args)` in JavaScript. All resources must have a name, which must be unique in the Pulumi program.
 
 All resource constructors also accept a third argument which can provide the following additional properties. 
-- `dependencies` - a list of explicit resource dependencies
+- `dependsOn` - a list of explicit resource dependencies
 - `protect` - whether to mark a resource as protected. A protected resource cannot be deleted directly: first you must set `protect: false` and run `pulumi update`. Then, the resource can be deleted, either by removing the line of code or by running `pulumi destroy`.
 - `parent` - optional parent for the resource. See [Components](#components).
 - `provider` - optional provider for the resource. See [Providers](#providers).
@@ -87,7 +87,7 @@ Outputs are a key part of how Pulumi tracks dependencies between resources.  Bec
 1. An eventually available value of the output
 2. The depdency on the source(s) of the output value
 
-The output properties of all resource objects in Pulumi have type [`Output`][pulumi.Output]. Resource inputs have type [`Input`](pulumi.Input), which accepts either a raw value or an output from another resource. This allows dependencies to be inferred, including ensuring that resources are not created or updatred until all their dependencies are availabe and up to date.  
+The output properties of all resource objects in Pulumi have type [`Output`][pulumi.Output]. Resource inputs have type [`Input`][pulumi.Input], which accepts either a raw value or an output from another resource. This allows dependencies to be inferred, including ensuring that resources are not created or updatred until all their dependencies are availabe and up to date.  
 
 To transform an output into a new value, use the [`apply` method](pkg/nodejs/@pulumi/pulumi/#property-apply). For example, use the following to create an HTTPS URL from the DNS name of a virtual machine: 
 
@@ -566,6 +566,8 @@ Some Pulumi packages have a dependency on a [Resource Provider plugin](/referenc
 
 You can create libraries and components that allow the caller to pass in JavaScript callbacks to invoke at runtime. For example, a JavaScript callback could be used as the implementation of an AWS Lambda function. 
 
+{% include langchoose.html %}
+
 ```javascript
 let bucket = new aws.s3.Bucket("mybucket");
 bucket.onObjectCreated("onObject", async (ev) => {
@@ -573,7 +575,6 @@ bucket.onObjectCreated("onObject", async (ev) => {
     console.log(JSON.stringify(ev));
 });
 ```
-
 
 ```typescript
 let bucket = new aws.s3.Bucket("mybucket");

--- a/shortlinks/outputs.md
+++ b/shortlinks/outputs.md
@@ -1,0 +1,4 @@
+---
+redirect_to: /references/programming-model#outputs
+permalink: help/outputs/
+---


### PR DESCRIPTION
Also add shortlink for outputs for use in error messages.

Also adds language chooser to all code examples in the programming model docs. This helps ensure these docs are useful across languages.  There are many places where topics covered in these docs are not yet supported, and that is called out more explicitly now.