### PR TITLE
Unset the body background color

### DIFF
--- a/_sass/partials/_container.scss
+++ b/_sass/partials/_container.scss
@@ -1,6 +1,5 @@
 body {
     position: relative;
-    background-color: $purple;
 }
 
 .row {


### PR DESCRIPTION
Applying a dark background color to the body tag causes some browsers (Chrome, Firefox, Safari) to paint the scroll thumb in a light color in order to provide suitable contrast, but since we’re setting the background color of page _content_ back to white, the scroll thumb gets lost, which makes it difficult to visualize the size of a page and one’s scroll position within it.

Before & after:

![](http://nunciato-dropshare.s3.amazonaws.com/Screen-Recording-2018-12-26-11-29-33.gif)