### PR TITLE
Deny s3:ListBucket for s3://pulumi.io

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -37,6 +37,25 @@ const contentBucket = new aws.s3.Bucket(
         protect: false,
     });
 
+// contentBucket needs to have the "public-read" ACL so its contents can be ready by CloudFront and
+// served. But we deny the s3:ListBucket permission to prevent unintended disclosure of the bucket's
+// contents.
+const denyListPolicyState: aws.s3.BucketPolicyArgs = {
+    bucket: contentBucket.bucket,
+    policy: contentBucket.arn.apply(arn => JSON.stringify({
+        Version: "2008-10-17",
+        Statement: [
+            {
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:ListBucket",
+                Resource: arn,
+            },
+        ],
+    })),
+};
+const denyListPolicy = new aws.s3.BucketPolicy("deny-list", denyListPolicyState);
+
 // logsBucket stores the request logs for incomming requests.
 const logsBucket = new aws.s3.Bucket(
     "requestLogs",


### PR DESCRIPTION
The Pulumi program we use to standup a website using S3 and CloudFront makes the S3 bucket's contents world-readable, via the "public-read" ACL. This is required for CloudFront to read data from S3, however, it doesn't follow best practices with regard to security.

The "public-read" ACL includes the s3:ListBucket permission, which can be used to enumerate the bucket's contents. For https://pulumi.io that isn't a problem, since the whole point of the website is to make the data available. But it doesn't follow best practices.

This PR simply adds a new some bucket policy to deny all users the s3:ListBucket permission. (Which also includes people who have read/write access to the bucket; if this becomes a burden we can use a more specific principle.) https://pulumi.io should work just like it has before, but if you are using the AWS CLI you won't be able to run `aws s3 ls s3://pulumi.io` anymore.

Same change as https://github.com/pulumi/get.pulumi.com/pull/33