### PR TITLE
Make the left nav collapsable

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -19,7 +19,7 @@ include.tree is the actual set of sections to render. It is an array with shape:
             {% assign path  = found_page.url %}
         {% endif %}
     {% endcapture %}
-    <div class="sidenav-section {% if forloop.last == false %}separator{% endif %}">
+    <div class="sidenav-section toggleVisible {% if forloop.last == false %}separator{% endif %}">
         {% assign sidenav_expanded = false %}
         {% assign filename = path | replace: '/', ' ' | strip | replace: ' ', '/' | append: '.md' %}
         {% if page.path == filename %}
@@ -45,15 +45,27 @@ include.tree is the actual set of sections to render. It is an array with shape:
         `toplevel` is for items that don't have a `section` but should be rendered as a top-level item (with an href that includes the .html).
         {% endcomment %}
         {% if item.section or item.toplevel %}
-            <div data-title="{{ item.title }}">
-                <div class="sidenav-topic {{ sidenav_selected }}">
-                    <a data-title="{{ item.title }}" href="{{ path }}.html">{{ item.title }}</a>
+            {% if sidenav_expanded %}
+                {% assign toggle_state = "toggleVisible" %}
+            {% else %}
+                {% assign toggle_state = "toggle" %}
+            {% endif %}
+            <div class="{{ toggle_state }}" data-title="{{ item.title }}">
+                <div class="collapsed">
+                    <div class="sidenav-topic {{ sidenav_selected }}">
+                        <a data-title="{{ item.title }}" href="{{ path }}.html">{{ item.title }}</a>
+                        <span class="toggleButton">▹</span>
+                    </div>
                 </div>
-                {% if item.section and sidenav_expanded %}
+                <div class="expanded">
+                    <div class="sidenav-topic {{ sidenav_selected }}">
+                        <a data-title="{{ item.title }}" href="{{ path }}.html">{{ item.title }}</a>
+                        <span class="toggleButton">▾</span>
+                    </div>
                     <div class="sidenav-subsection">
                         {% include toc_sub.html tree=item.section %}
                     </div>
-                {% endif %}
+                </div>
             </div>
         {% else %}
             {% if path %}

--- a/_sass/_pulumi.scss
+++ b/_sass/_pulumi.scss
@@ -406,6 +406,9 @@ h4 { font-size: 22px; font-weight: 500; }
 }
 
 .toc {
+    border: 1px solid rgba(0,0,0,.12);
+    background-color: #f0f0f0;
+    padding: 8px;
     margin-right: 16px;
 
     // Render links like headings.
@@ -423,7 +426,7 @@ h4 { font-size: 22px; font-weight: 500; }
     }
 
     .sidenav-section {
-        font-size: 13px;
+        font-size: 16px;
         line-height: 20px;
         padding: 8px 0;
     }
@@ -444,11 +447,12 @@ h4 { font-size: 22px; font-weight: 500; }
         a {
             font-weight: bold !important;
         }
-        background-color: $accent4;
+        color: $primary;
     }
 
     .sidenav-subsection {
-        padding: 8px 0 0 16px;
+        font-size: 14px;
+        padding: 16px;
     }
 
     .sidenav-subsection a {


### PR DESCRIPTION
This change spiffs up the left nav a little bit. This includes a little
bit nicer styling (bigger fonts, light grey background with a border,
etc), but more notably, the ability to collapse sections. This makes
leaping around between sections a lot smoother.

Part of pulumi/docs#744.