### PR TITLE
Hide expand/collapse buttons for empty sections

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -50,21 +50,31 @@ include.tree is the actual set of sections to render. It is an array with shape:
             {% else %}
                 {% assign toggle_state = "toggle" %}
             {% endif %}
+            {% assign has_subtree = false %}
+            {% for subitem in item.section %}
+                {% assign has_subtree = true %}
+            {% endfor %}
             <div class="{{ toggle_state }}" data-title="{{ item.title }}">
                 <div class="collapsed">
                     <div class="sidenav-topic {{ sidenav_selected }}">
                         <a data-title="{{ item.title }}" href="{{ path }}.html">{{ item.title }}</a>
-                        <span class="toggleButton">▹</span>
+                        {% if has_subtree %}
+                            <span class="toggleButton">▹</span>
+                        {% endif %}
                     </div>
                 </div>
                 <div class="expanded">
                     <div class="sidenav-topic {{ sidenav_selected }}">
                         <a data-title="{{ item.title }}" href="{{ path }}.html">{{ item.title }}</a>
-                        <span class="toggleButton">▾</span>
+                        {% if has_subtree %}
+                            <span class="toggleButton">▾</span>
+                        {% endif %}
                     </div>
-                    <div class="sidenav-subsection">
-                        {% include toc_sub.html tree=item.section %}
-                    </div>
+                    {% if has_subtree %}
+                        <div class="sidenav-subsection">
+                            {% include toc_sub.html tree=item.section %}
+                        </div>
+                    {% endif %}
                 </div>
             </div>
         {% else %}


### PR DESCRIPTION
This change hides the expand/collapse buttons for sections that
don't have any sub-navigation within them.