### PR TITLE
Add the ability to have "mini" ToCs

### DIFF
--- a/_includes/mini-toc.html
+++ b/_includes/mini-toc.html
@@ -1,0 +1,6 @@
+<div class="mini-toc">
+    <p>Table of Contents</p>
+    <ul>
+        <!-- this will be populated dynamically with all H2s on the page; see js/main.js -->
+    </ul>
+</div>

--- a/_sass/_pulumi.scss
+++ b/_sass/_pulumi.scss
@@ -705,6 +705,43 @@ h4 { font-size: 22px; font-weight: 500; }
 .toggleVisible > .collapsed { display: none; }
 .toggleVisible > .expanded { display: block; }
 
+// Mini table of contents styling.
+.mini-toc p {
+    font-size: 18px;
+    color: #707070;
+    font-weight: 700;
+    margin: 0px;
+}
+.mini-toc ul {
+    padding: 16px;
+    margin: 0;
+}
+.mini-toc ul li {
+    list-style: none;
+    margin: 0 0 .7em;
+    padding: 0 0 0 17px;
+}
+.mini-toc ul li::before {
+    content: "";
+    position: absolute;
+    top: 8px;
+    left: -4px;
+    width: 10px;
+    height: 10px;
+    z-index: 1;
+    border-radius: 50%;
+    background: $primary2;
+}
+.mini-toc ul li:not(:first-child)::after {
+    content: "";
+    position: absolute;
+    height: 28px;
+    width: 1px;
+    left: 0;
+    bottom: 18px;
+    border-left: 1px solid #bbecff; /*lightened primary2 blue*/
+}
+
 //  Widget showing the downloads for Pulumi.
 .downloads-container {
     display: flex;

--- a/js/main.js
+++ b/js/main.js
@@ -19,6 +19,21 @@ function bindToggles(selector) {
     });
 }
 
+function generateMiniToc() {
+    var toc = $(".mini-toc > ul");
+    if (toc) {
+        $("h2").each(function () {
+            var id = $(this).attr("id");
+            var text = $(this).text();
+            if (id && text) {
+                toc.append($("<li/>", {
+                    html: "<a href='#" + id + "'>" + text + "</a>"
+                }));
+            }
+        });
+    }
+}
+
 (function ($) {
     //----------------------------------------
     // Essentials
@@ -28,6 +43,9 @@ function bindToggles(selector) {
     // Set up toggle functionality.
     bindToggles(".toggle");
     bindToggles(".toggleVisible");
+
+    // Create a mini TOC if desired.
+    generateMiniToc();
 
     // breakpoints
     var $screen_xxs = 320;

--- a/reference/programming-model.md
+++ b/reference/programming-model.md
@@ -2,6 +2,8 @@
 title: "Programming Model"
 ---
 
+{% include mini-toc.html %}
+
 In Pulumi, [resources](#resources) are defined by allocating resource objects in a program, such as `new aws.ec2.Instance(...)`.  The first argument passed to the resource constructor is its `name`, which must be unique within the Pulumi program. To create dependencies between resources, just reference the [output properties](#outputs) of a resource. For example, this definition of an EC2 instance creates a dependency on a `SecurityGroup`:
 
 {% include langchoose.html %}


### PR DESCRIPTION
This change introduces the notion of a "mini" ToC, which simply
helps navigate within the H2s in a given page. This is useful for
sections like our Programming Model topic which contains lots of
goodies, but which aren't obvious at a glance. I've only added it
here but will undoubtedly add it in more places as appropriate
throughout the course of tackling pulumi/docs#744.