### PR TITLE
Remove extra hyphen from string when getting env from stack name

### DIFF
--- a/reference/organizing-stacks-projects.md
+++ b/reference/organizing-stacks-projects.md
@@ -104,7 +104,7 @@ The Pulumi programming model offers a way to do this with its `StackReference` r
 ```typescript
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-const env = pulumi.getStack().substring(pulumi.getStack().lastIndexOf("-"));
+const env = pulumi.getStack().substring(pulumi.getStack().lastIndexOf("-")).replace("-", "");
 const infra = new pulumi.StackReference(`acmecorp-infra-${env}`);
 const provider = new k8s.Provider("k8s", { kubeConfig: infra.getOutput("kubeConfig") });
 const service = new k8s.v1.core.Service(..., { provider: provider });


### PR DESCRIPTION
Basically `env` here ends up with a preceding hyphen when inferring environment from the stack name (i.e. `lumo-infra-staging` results in env being `-staging`). 

I'm no typescript whiz so there is probably a better way of doing this. Overall, maybe it would be better to recommend using a variable in the stack config instead of parsing the stack name? So do a `pulumi config set lumo-infra:environment staging` and:

```
export const config = new pulumi.Config("lumo-infra");
export const env = config.require("environment");
```