### PR TITLE
Fix broken link in TOC

### DIFF
--- a/_data/reference.yaml
+++ b/_data/reference.yaml
@@ -78,7 +78,7 @@ toc:
   - title: Travis CI
     path: /reference/cd-travis.html
 - title: Supported Clouds
-  path: /reference/clouds
+  path: /reference/clouds.html
 - title: Supported Languages
   path: /reference/languages
   section:


### PR DESCRIPTION
Honestly can't explain why this one has to be `.html` but other top-level nav paths can leave it off (and apparently get re-written to `.html`).  But this appears to fix the problem.