### PR TITLE
Fix copy-paste error in Azure tutorial

### DIFF
--- a/quickstart/azure/tutorial-container-webserver.md
+++ b/quickstart/azure/tutorial-container-webserver.md
@@ -142,4 +142,4 @@ Before moving on, let's tear down the resources that are part of our stack.
 
 ## Summary
 
-In this tutorial, we saw how to use Pulumi programs to create and manage cloud resources in Google Cloud, using regular JavaScript and NPM packages. To preview and update infrastructure, use `pulumi update`. To clean up resources, run `pulumi destroy`.
+In this tutorial, we saw how to use Pulumi programs to create and manage cloud resources in Microsoft Azure, using regular JavaScript and NPM packages. To preview and update infrastructure, use `pulumi update`. To clean up resources, run `pulumi destroy`.


### PR DESCRIPTION
Looks like this last paragraph was copied over from the GCP version (including the reference to GCP). This commit fixes the copy-paste error.