### PR TITLE
Add basic documentation for stack tags

### DIFF
--- a/reference/organizing-stacks-projects.md
+++ b/reference/organizing-stacks-projects.md
@@ -128,3 +128,7 @@ structure enables seamless continuous deployment.
 
 In this model, there is a rough correspondence between a Git repo and a Pulumi project, and a Git branch and
 its associated Pulumi stack. Please read more about [how these mapping are maintained here](./cd.html).
+
+## Tagging Stacks
+
+Stacks have associated metadata in the form of name/value tags. You can assign custom tags to stacks to customize how stacks are listed in the [Pulumi Cloud Console](https://app.pulumi.com). For example, if you have many projects with separate stacks for production, staging, and testing environments, it may be useful to group stacks by environment instead of by project. To do this, you could assign a custom `environment` tag to each stack, assigning a value of `production` to each production stack, `staging` to each staging stack, etc. Then in the Pulumi Cloud Console, you'll be able to group stacks by `Tag: environment`. Please read more about [how to manage stack tags here](stack.md#stack-tags).

--- a/reference/stack.md
+++ b/reference/stack.md
@@ -124,3 +124,13 @@ To delete a stack with no resources, run `pulumi stack rm`. Removing the stack w
 If a stack still has resources associated with it, they must first be deleted via `pulumi destroy`. This command uses the latest configuration values, rather than the ones that were last used when the program was deployed. 
 
 To force the deletion of a stack that still contains resources --- potentially orphaning them --- use `pulumi stack rm --force`.  
+
+## Stack tags
+
+Stacks have associated metadata in the form of tags, with each tag consisting of a name and value. A set of built-in tags are automatically assigned and updated each time a stack is updated (such as `pulumi:project`, `pulumi:runtime`, `pulumi:description`, `gitHub:owner`, `gitHub:repo`, `vcs:owner`, `vcs:repo`, and `vcs:kind`). To view a stack's tags, run [`pulumi stack tag ls`](/reference/cli/pulumi_stack_tag_ls.html).
+
+Custom tags can be assigned to a stack by running [`pulumi stack tag set <name> <value>`](/reference/cli/pulumi_stack_tag_set.html) and can be used to customize the grouping of stacks in the [Pulumi Cloud Console](https://app.pulumi.com). For example, if you have many projects with separate stacks for production, staging, and testing environments, it may be useful to group stacks by environment instead of by project. To do this, you could assign a custom tag named `environment` to each stack. For example, running `pulumi stack tag set environment production` assigns a custom `environment` tag with a value of `production` to the active stack. Once you've assigned an `environment` tag to each stack, you'll be able to group by `Tag: environment` in the Pulumi Cloud Console.
+
+> **Note:** As a best practice, custom tags should not be prefixed with `pulumi:`, `gitHub:`, or `vcs:` to avoid conflicting with built-in tags that are assigned and updated with fresh values each time a stack is updated.
+
+Tags can be deleted by running [`pulumi stack tag rm <name>`](/reference/cli/pulumi_stack_tag_rm.html).


### PR DESCRIPTION
I was originally planning a separate page, but there isn't much more to write about, so the main info is at `reference/stack.md#stack-tags` (which I'll link to from the service).

As a follow-up, it might be nice to include a screenshot of the service showing the grouping.

Fixes #766