### PR TITLE
Avoid whitespace wrapping in the SIGN IN button

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -65,7 +65,7 @@
                                 <input type="search" id="search-box" name="q" placeholder="Search..." autocomplete="off">
                                 <button type="submit"><i class="fas fa-search"></i></button>
                             </form>
-                            <a href="https://app.pulumi.com" id="sign-in-button"><button class="button primary">SIGN IN</button></a>
+                            <a href="https://app.pulumi.com" id="sign-in-button"><button class="button primary no-wrap">SIGN IN</button></a>
                         </span>
                     </div>
                 </div>

--- a/_sass/_pulumi.scss
+++ b/_sass/_pulumi.scss
@@ -183,6 +183,10 @@ $accent4: #fbe5d7; // light orange
     background-color: #66deff;
 }
 
+.no-wrap {
+    white-space: nowrap !important;
+}
+
 // Don't have SVG icons default to black. Just use current text color.
 svg {
     fill: currentColor;


### PR DESCRIPTION
Minor thing that's been bugging me. The SIGN IN button was wrapping to a new line in Safari; this change prevents that.

Before:

<img width="482" alt="screen shot 2019-01-24 at 1 44 35 pm" src="https://user-images.githubusercontent.com/710598/51710590-76551900-1fde-11e9-9cca-bed1cff7a4de.png">

After:

<img width="494" alt="screen shot 2019-01-24 at 1 44 43 pm" src="https://user-images.githubusercontent.com/710598/51710598-7ce39080-1fde-11e9-8f99-2c58631b976f.png">
