### PR TITLE
Rework StackReferences documentation

### DIFF
--- a/shortlinks/stack-reference.md
+++ b/shortlinks/stack-reference.md
@@ -1,0 +1,4 @@
+---
+redirect_to: reference/organizing-stacks-projects.html#inter-stack-dependencies
+permalink: help/stack-reference
+---


### PR DESCRIPTION
When constructing a stack reference the string must now be of the form
`<organization>/<project>/<stack>`. I have rewritten the content here
to use this new form, as well as simplified the example so it exploits
the fact that stack names may now be duplicated across projects to
remove some of the extra logic that was not core to the example.