### PR TITLE
update project.md, re resusable components

### DIFF
--- a/reference/project.md
+++ b/reference/project.md
@@ -4,8 +4,6 @@ title: "Projects"
 
 A Pulumi project is any folder which contains a `Pulumi.yaml` file.  When in a subfolder, the closest enclosing folder with a `Pulumi.yaml` file determines the current project.  A new project can be created with `pulumi new`.  A project specifies which runtime to use, which determines where to look for the program that should be executed during deployments.  Currently, `nodejs` and `python` are supported runtimes.
 
-Packages that contain [reusable components](./programming-model.html#components) do not need a project file and can simply use the package manager's standard metadata format.
-
 ## Project file {#pulumi-yaml}
 
 The `Pulumi.yaml` project file specifies metadata about your project.


### PR DESCRIPTION
Remove the claim that reusable components do not need a projects file.  This statement is confusing and unnecessary.