### PR TITLE
Fix documentation for packages mixing __all__ and top-level resources 

### DIFF
--- a/reference/pkg/python/pulumi/index.md
+++ b/reference/pkg/python/pulumi/index.md
@@ -99,7 +99,7 @@ provider for the given module member.</p>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The <a class="reference internal" href="#pulumi.ProviderResource" title="pulumi.ProviderResource"><code class="xref py py-class docutils literal notranslate"><span class="pre">ProviderResource</span></code></a> associated with the given module member, or None if one does not exist.</td>
 </tr>
-<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">Optional[ProviderReference]</td>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">Optional[<a class="reference internal" href="#pulumi.ProviderResource" title="pulumi.ProviderResource">ProviderResource</a>]</td>
 </tr>
 </tbody>
 </table>
@@ -199,7 +199,7 @@ resource.</li>
 
 <dl class="class">
 <dt id="pulumi.ResourceOptions">
-<em class="property">class </em><code class="descclassname">pulumi.</code><code class="descname">ResourceOptions</code><span class="sig-paren">(</span><em>parent: Optional[Resource] = None</em>, <em>depends_on: Optional[List[Resource]] = None</em>, <em>protect: Optional[bool] = None</em>, <em>provider: Optional[ProviderResource] = None</em>, <em>providers: Optional[Mapping[str</em>, <em>ProviderResource]] = None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi.ResourceOptions" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">pulumi.</code><code class="descname">ResourceOptions</code><span class="sig-paren">(</span><em>parent: Optional[Resource] = None</em>, <em>depends_on: Optional[List[Resource]] = None</em>, <em>protect: Optional[bool] = None</em>, <em>provider: Optional[ProviderResource] = None</em>, <em>providers: Optional[Mapping[str</em>, <em>ProviderResource]] = None</em>, <em>delete_before_replace: Optional[bool] = None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi.ResourceOptions" title="Permalink to this definition">¶</a></dt>
 <dd><p>ResourceOptions is a bag of optional settings that control a resource’s behavior.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -216,6 +216,7 @@ If no provider is supplied, the default provider for the resource’s package wi
 provider is pulled from the parent’s provider bag.</li>
 <li><strong>providers</strong> (<em>Optional</em><em>[</em><em>Mapping</em><em>[</em><em>str</em><em>,</em><a class="reference internal" href="#pulumi.ProviderResource" title="pulumi.ProviderResource"><em>ProviderResource</em></a><em>]</em><em>]</em>) – An optional set of providers to use for child resources. Keyed
 by package name (e.g. “aws”)</li>
+<li><strong>delete_before_replace</strong> (<em>Optional</em><em>[</em><em>bool</em><em>]</em>) – If provided and True, this resource must be deleted before it is replaced.</li>
 </ul>
 </td>
 </tr>
@@ -251,6 +252,12 @@ provider bag (see also ResourceOptions.providers).</p>
 <dt id="pulumi.ResourceOptions.providers">
 <code class="descname">providers</code><em class="property"> = None</em><a class="headerlink" href="#pulumi.ResourceOptions.providers" title="Permalink to this definition">¶</a></dt>
 <dd><p>An optional set of providers to use for child resources. Keyed by package name (e.g. “aws”)</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi.ResourceOptions.delete_before_replace">
+<code class="descname">delete_before_replace</code><em class="property"> = None</em><a class="headerlink" href="#pulumi.ResourceOptions.delete_before_replace" title="Permalink to this definition">¶</a></dt>
+<dd><p>If provided and True, this resource must be deleted before it is replaced.</p>
 </dd></dl>
 
 </dd></dl>

--- a/reference/pkg/python/pulumi_aws/index.md
+++ b/reference/pkg/python/pulumi_aws/index.md
@@ -25,7 +25,6 @@
 <li class="toctree-l1"><a class="reference internal" href="codedeploy/">codedeploy</a></li>
 <li class="toctree-l1"><a class="reference internal" href="codepipeline/">codepipeline</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cognito/">cognito</a></li>
-<li class="toctree-l1"><a class="reference internal" href="config/">config</a></li>
 <li class="toctree-l1"><a class="reference internal" href="datasync/">datasync</a></li>
 <li class="toctree-l1"><a class="reference internal" href="dax/">dax</a></li>
 <li class="toctree-l1"><a class="reference internal" href="devicefarm/">devicefarm</a></li>

--- a/reference/pkg/python/pulumi_azure/index.md
+++ b/reference/pkg/python/pulumi_azure/index.md
@@ -12,7 +12,6 @@
 <li class="toctree-l1"><a class="reference internal" href="cdn/">cdn</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cognitive/">cognitive</a></li>
 <li class="toctree-l1"><a class="reference internal" href="compute/">compute</a></li>
-<li class="toctree-l1"><a class="reference internal" href="config/">config</a></li>
 <li class="toctree-l1"><a class="reference internal" href="containerservice/">containerservice</a></li>
 <li class="toctree-l1"><a class="reference internal" href="core/">core</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cosmosdb/">cosmosdb</a></li>

--- a/reference/pkg/python/pulumi_gcp/index.md
+++ b/reference/pkg/python/pulumi_gcp/index.md
@@ -11,7 +11,6 @@
 <li class="toctree-l1"><a class="reference internal" href="cloudfunctions/">cloudfunctions</a></li>
 <li class="toctree-l1"><a class="reference internal" href="composer/">composer</a></li>
 <li class="toctree-l1"><a class="reference internal" href="compute/">compute</a></li>
-<li class="toctree-l1"><a class="reference internal" href="config/">config</a></li>
 <li class="toctree-l1"><a class="reference internal" href="container/">container</a></li>
 <li class="toctree-l1"><a class="reference internal" href="containeranalysis/">containeranalysis</a></li>
 <li class="toctree-l1"><a class="reference internal" href="dataflow/">dataflow</a></li>

--- a/tools/pydocgen/pydocgen/__init__.py
+++ b/tools/pydocgen/pydocgen/__init__.py
@@ -254,6 +254,5 @@ def main():
         if path.exists(tempdir):
             shutil.rmtree(tempdir)
         if path.exists(outdir):
-            pass
             shutil.rmtree(outdir)
 

--- a/tools/pydocgen/pydocgen/__init__.py
+++ b/tools/pydocgen/pydocgen/__init__.py
@@ -152,7 +152,7 @@ def generate_sphinx_files(ctx: Context):
 def should_generate_multimodule(module):
     """
     Returns whether or not we should generate a multi-page page tree for this particular module or if we should fit
-    evernthing on a single page.
+    everything on a single page.
 
     :param Any module: A module object to inspect.
     :return True if we should generate a multi-page page tree for this module.

--- a/tools/pydocgen/pydocgen/__init__.py
+++ b/tools/pydocgen/pydocgen/__init__.py
@@ -134,18 +134,37 @@ def generate_sphinx_files(ctx: Context):
         # that this module has.
         #
         # TFGen explicitly populates this array.
-        if not hasattr(module, "__all__"):
+        if not should_generate_multimodule(module):
             # No submodules? Render the without_module_template and be done.
             render_template_to(ctx, doc_path, without_module_template, provider=provider)
         else:
             # If there are submodules, run through each one and render module templates for each one.
             all_modules = getattr(module, "__all__")
+            # Skip the "config" submodule - it can't be imported.
+            all_modules = list(filter(lambda mod: mod != "config", all_modules))
             render_template_to(ctx, doc_path, with_module_template, provider=provider, submodules=all_modules)
             create_dir(ctx.tempdir, "providers", provider.package_name)
             for module in all_modules:
                 dest = path.join("providers", provider.package_name, f"{module}.rst")
                 module_meta = {"name": module, "full_name": f"{provider.package_name}.{module}"}
                 render_template_to(ctx, dest, module_template, module=module_meta)
+
+def should_generate_multimodule(module):
+    """
+    Returns whether or not we should generate a multi-page page tree for this particular module or if we should fit
+    evernthing on a single page.
+
+    :param Any module: A module object to inspect.
+    :return True if we should generate a multi-page page tree for this module.
+    :rtype bool
+    """
+    if not hasattr(module, "__all__"):
+        return False
+
+    # Even if this module does define __all__, if its only submodule is config, treat it as a single-page module.
+    # Config is not a "real" submodule - Sphinx can't import it and there are no docs to generate for it.
+    all_modules = getattr(module, "__all__")
+    return all_modules != ["config"]
 
 
 def build_sphinx(ctx: Context):
@@ -235,5 +254,6 @@ def main():
         if path.exists(tempdir):
             shutil.rmtree(tempdir)
         if path.exists(outdir):
+            pass
             shutil.rmtree(outdir)
 

--- a/tools/pydocgen/pydocgen/templates/providers/provider_without_module.rst
+++ b/tools/pydocgen/pydocgen/templates/providers/provider_without_module.rst
@@ -2,5 +2,6 @@
 ===================
 
 .. automodule:: {{ provider.package_name }}
+    :ignore-module-all:
     :members:
     :imported-members:


### PR DESCRIPTION
This PR contains a few fixes to the documentation generator tool:

1. The `config` module in `tfgen`-generated packages can't be safely imported outside of a Pulumi program. Because of this, Sphinx also can't import it and is unable to generate documentation for it. It's better for us in this case to simply skip it, which this PR now does.
2. When rendering single-package modules (e.g. `pulumi_random`, `pulumi_vsphere`, etc, any module that doesn't have any submodules other than `config`), we must pass `ignore-module-all` to Sphinx, since Sphinx uses `__all__` to determine the public surface area of a module and we are lying a little bit about what our public surface area is.

There are a few diffs in existing docs with these changes, but more importantly this unblocks the addition of docs for a few other packages that weren't working before (in a followup PR).