### PR TITLE
Generate Python Kubernetes documentation

### DIFF
--- a/_data/reference.yaml
+++ b/_data/reference.yaml
@@ -159,6 +159,8 @@ toc:
         path: /reference/pkg/python/pulumi_azure/index.html
       - title: pulumi_gcp
         path: /reference/pkg/python/pulumi_gcp/index.html
+      - title: pulumi_kubernetes
+        path: /reference/pkg/python/pulumi_kubernetes/index.html
       - title: pulumi_random
         path: /reference/pkg/python/pulumi_random/index.html 
       - title: pulumi_openstack

--- a/reference/pkg/python/index.md
+++ b/reference/pkg/python/index.md
@@ -14,6 +14,7 @@ Each cloud vendor has a dedicated package for deploying resources to it:
 * [Amazon Web Services (`pulumi_aws`)](pulumi_aws)
 * [Microsoft Azure (`pulumi_azure`)](pulumi_azure)
 * [Google Cloud Platform (`pulumi_gcp`)](pulumi_gcp)
+* [Kubernetes (`pulumi_kubernetes`)](pulumi_kubernetes)
 
 ### Helper Libraries
 

--- a/reference/pkg/python/pulumi/index.md
+++ b/reference/pkg/python/pulumi/index.md
@@ -619,7 +619,7 @@ value as well as the Resource the value came from.  This allows for a precise �
 dependency graph’ to be created, which properly tracks the relationship between resources.</p>
 <dl class="method">
 <dt id="pulumi.Output.__getitem__">
-<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>key: Any</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[typing.Any][Any]<a class="headerlink" href="#pulumi.Output.__getitem__" title="Permalink to this definition">¶</a></dt>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>key: Any</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[Any]<a class="headerlink" href="#pulumi.Output.__getitem__" title="Permalink to this definition">¶</a></dt>
 <dd><p>Syntax sugar for looking up attributes dynamically off of outputs.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -637,7 +637,7 @@ dependency graph’ to be created, which properly tracks the relationship betwee
 
 <dl class="method">
 <dt id="pulumi.Output.__getattr__">
-<code class="descname">__getattr__</code><span class="sig-paren">(</span><em>item: str</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[typing.Any][Any]<a class="headerlink" href="#pulumi.Output.__getattr__" title="Permalink to this definition">¶</a></dt>
+<code class="descname">__getattr__</code><span class="sig-paren">(</span><em>item: str</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[Any]<a class="headerlink" href="#pulumi.Output.__getattr__" title="Permalink to this definition">¶</a></dt>
 <dd><p>Syntax sugar for retrieving attributes off of outputs.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -655,7 +655,7 @@ dependency graph’ to be created, which properly tracks the relationship betwee
 
 <dl class="method">
 <dt id="pulumi.Output.apply">
-<code class="descname">apply</code><span class="sig-paren">(</span><em>func: Callable[[T], Union[U, Awaitable[U], Output[T]]]</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[~U][U]<a class="headerlink" href="#pulumi.Output.apply" title="Permalink to this definition">¶</a></dt>
+<code class="descname">apply</code><span class="sig-paren">(</span><em>func: Callable[T, Union[T, Awaitable[T], Output[T]]]</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[U]<a class="headerlink" href="#pulumi.Output.apply" title="Permalink to this definition">¶</a></dt>
 <dd><p>Transforms the data of the output with the provided func.  The result remains a
 Output so that dependent resources can be properly tracked.</p>
 <p>‘func’ is not allowed to make resources.</p>
@@ -681,7 +681,7 @@ type.</td>
 
 <dl class="staticmethod">
 <dt id="pulumi.Output.from_input">
-<em class="property">static </em><code class="descname">from_input</code><span class="sig-paren">(</span><em>val: Union[T, Awaitable[T], Output[T]]</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[~T][T]<a class="headerlink" href="#pulumi.Output.from_input" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">from_input</code><span class="sig-paren">(</span><em>val: Union[T, Awaitable[T], Output[T]]</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[T]<a class="headerlink" href="#pulumi.Output.from_input" title="Permalink to this definition">¶</a></dt>
 <dd><p>Takes an Input value and produces an Output value from it, deeply unwrapping nested Input values as necessary
 given the type.</p>
 <table class="docutils field-list" frame="void" rules="none">
@@ -700,7 +700,7 @@ given the type.</p>
 
 <dl class="staticmethod">
 <dt id="pulumi.Output.all">
-<em class="property">static </em><code class="descname">all</code><span class="sig-paren">(</span><em>*args</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[typing.List[~T]][List[T]]<a class="headerlink" href="#pulumi.Output.all" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">all</code><span class="sig-paren">(</span><em>*args</em><span class="sig-paren">)</span> &#x2192; pulumi.output.Output[List[T]]<a class="headerlink" href="#pulumi.Output.all" title="Permalink to this definition">¶</a></dt>
 <dd><p>Produces an Output of Lists from a List of Inputs.</p>
 <p>This function can be used to combine multiple, separate Inputs into a single
 Output which can then be used as the target of <cite>apply</cite>. Resource dependencies

--- a/reference/pkg/python/pulumi_aws/index.md
+++ b/reference/pkg/python/pulumi_aws/index.md
@@ -58,7 +58,6 @@
 <li class="toctree-l1"><a class="reference internal" href="iot/">iot</a></li>
 <li class="toctree-l1"><a class="reference internal" href="kinesis/">kinesis</a></li>
 <li class="toctree-l1"><a class="reference internal" href="kms/">kms</a></li>
-<li class="toctree-l1"><a class="reference internal" href="lambda/">lambda</a></li>
 <li class="toctree-l1"><a class="reference internal" href="licensemanager/">licensemanager</a></li>
 <li class="toctree-l1"><a class="reference internal" href="lightsail/">lightsail</a></li>
 <li class="toctree-l1"><a class="reference internal" href="macie/">macie</a></li>

--- a/reference/pkg/python/pulumi_aws/lambda_/index.md
+++ b/reference/pkg/python/pulumi_aws/lambda_/index.md
@@ -1,0 +1,937 @@
+<div class="section" id="module-pulumi_aws.lambda_">
+<span id="lambda"></span><h1><a class="reference internal" href="#lambda">lambda</a><a class="headerlink" href="#module-pulumi_aws.lambda_" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_aws.lambda_.Alias">
+<em class="property">class </em><code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">Alias</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>description=None</em>, <em>function_name=None</em>, <em>function_version=None</em>, <em>name=None</em>, <em>routing_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Alias" title="Permalink to this definition">¶</a></dt>
+<dd><p>Creates a Lambda function alias. Creates an alias that points to the specified Lambda function version.</p>
+<p>For information about Lambda and how to use it, see [What is AWS Lambda?][1]
+For information about function aliases, see [CreateAlias][2] and [AliasRoutingConfiguration][3] in the API docs.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Description of the alias.</li>
+<li><strong>function_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The function ARN of the Lambda function for which you want to create an alias.</li>
+<li><strong>function_version</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Lambda function version for which you are creating the alias. Pattern: <cite>($LATEST|[0-9]+)</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Name for the alias you are creating. Pattern: <cite>(?!^[0-9]+$)([a-zA-Z0-9-_]+)</cite></li>
+<li><strong>routing_config</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – The Lambda alias’ route configuration settings. Fields documented below</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Alias.arn">
+<code class="descname">arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Alias.arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Amazon Resource Name (ARN) identifying your Lambda function alias.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Alias.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Alias.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>Description of the alias.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Alias.function_name">
+<code class="descname">function_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Alias.function_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The function ARN of the Lambda function for which you want to create an alias.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Alias.function_version">
+<code class="descname">function_version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Alias.function_version" title="Permalink to this definition">¶</a></dt>
+<dd><p>Lambda function version for which you are creating the alias. Pattern: <cite>($LATEST|[0-9]+)</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Alias.invoke_arn">
+<code class="descname">invoke_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Alias.invoke_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ARN to be used for invoking Lambda Function from API Gateway - to be used in [<cite>aws_api_gateway_integration</cite>](<a class="reference external" href="https://www.terraform.io/docs/providers/aws/r/api_gateway_integration.html)'s">https://www.terraform.io/docs/providers/aws/r/api_gateway_integration.html)’s</a> <cite>uri</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Alias.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Alias.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>Name for the alias you are creating. Pattern: <cite>(?!^[0-9]+$)([a-zA-Z0-9-_]+)</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Alias.routing_config">
+<code class="descname">routing_config</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Alias.routing_config" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Lambda alias’ route configuration settings. Fields documented below</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.Alias.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Alias.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.Alias.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Alias.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_aws.lambda_.EventSourceMapping">
+<em class="property">class </em><code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">EventSourceMapping</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>batch_size=None</em>, <em>enabled=None</em>, <em>event_source_arn=None</em>, <em>function_name=None</em>, <em>starting_position=None</em>, <em>starting_position_timestamp=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB and SQS</p>
+<p>For information about Lambda and how to use it, see [What is AWS Lambda?][1]
+For information about event source mappings, see [CreateEventSourceMapping][2] in the API docs.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>batch_size</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The largest number of records that Lambda will retrieve from your event source at the time of invocation. Defaults to <cite>100</cite> for DynamoDB and Kinesis, <cite>10</cite> for SQS.</li>
+<li><strong>enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Determines if the mapping will be enabled on creation. Defaults to <cite>true</cite>.</li>
+<li><strong>event_source_arn</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The event source ARN - can either be a Kinesis or DynamoDB stream.</li>
+<li><strong>function_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name or the ARN of the Lambda function that will be subscribing to events.</li>
+<li><strong>starting_position</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The position in the stream where AWS Lambda should start reading. Must be one of <cite>AT_TIMESTAMP</cite> (Kinesis only), <cite>LATEST</cite> or <cite>TRIM_HORIZON</cite> if getting events from Kinesis or DynamoDB. Must not be provided if getting events from SQS. More information about these positions can be found in the [AWS DynamoDB Streams API Reference](<a class="reference external" href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html">https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html</a>) and [AWS Kinesis API Reference](<a class="reference external" href="https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#Kinesis-GetShardIterator-request-ShardIteratorType">https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#Kinesis-GetShardIterator-request-ShardIteratorType</a>).</li>
+<li><strong>starting_position_timestamp</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A timestamp in [RFC3339 format](<a class="reference external" href="https://tools.ietf.org/html/rfc3339#section-5.8">https://tools.ietf.org/html/rfc3339#section-5.8</a>) of the data record which to start reading when using <cite>starting_position</cite> set to <cite>AT_TIMESTAMP</cite>. If a record with this exact timestamp does not exist, the next later record is chosen. If the timestamp is older than the current trim horizon, the oldest available record is chosen.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.batch_size">
+<code class="descname">batch_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.batch_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>The largest number of records that Lambda will retrieve from your event source at the time of invocation. Defaults to <cite>100</cite> for DynamoDB and Kinesis, <cite>10</cite> for SQS.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.enabled">
+<code class="descname">enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Determines if the mapping will be enabled on creation. Defaults to <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.event_source_arn">
+<code class="descname">event_source_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.event_source_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The event source ARN - can either be a Kinesis or DynamoDB stream.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.function_arn">
+<code class="descname">function_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.function_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The the ARN of the Lambda function the event source mapping is sending events to. (Note: this is a computed value that differs from <cite>function_name</cite> above.)</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.function_name">
+<code class="descname">function_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.function_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name or the ARN of the Lambda function that will be subscribing to events.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.last_modified">
+<code class="descname">last_modified</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.last_modified" title="Permalink to this definition">¶</a></dt>
+<dd><p>The date this resource was last modified.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.last_processing_result">
+<code class="descname">last_processing_result</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.last_processing_result" title="Permalink to this definition">¶</a></dt>
+<dd><p>The result of the last AWS Lambda invocation of your Lambda function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.starting_position">
+<code class="descname">starting_position</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.starting_position" title="Permalink to this definition">¶</a></dt>
+<dd><p>The position in the stream where AWS Lambda should start reading. Must be one of <cite>AT_TIMESTAMP</cite> (Kinesis only), <cite>LATEST</cite> or <cite>TRIM_HORIZON</cite> if getting events from Kinesis or DynamoDB. Must not be provided if getting events from SQS. More information about these positions can be found in the [AWS DynamoDB Streams API Reference](<a class="reference external" href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html">https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html</a>) and [AWS Kinesis API Reference](<a class="reference external" href="https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#Kinesis-GetShardIterator-request-ShardIteratorType">https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#Kinesis-GetShardIterator-request-ShardIteratorType</a>).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.starting_position_timestamp">
+<code class="descname">starting_position_timestamp</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.starting_position_timestamp" title="Permalink to this definition">¶</a></dt>
+<dd><p>A timestamp in [RFC3339 format](<a class="reference external" href="https://tools.ietf.org/html/rfc3339#section-5.8">https://tools.ietf.org/html/rfc3339#section-5.8</a>) of the data record which to start reading when using <cite>starting_position</cite> set to <cite>AT_TIMESTAMP</cite>. If a record with this exact timestamp does not exist, the next later record is chosen. If the timestamp is older than the current trim horizon, the oldest available record is chosen.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.state">
+<code class="descname">state</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.state" title="Permalink to this definition">¶</a></dt>
+<dd><p>The state of the event source mapping.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.state_transition_reason">
+<code class="descname">state_transition_reason</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.state_transition_reason" title="Permalink to this definition">¶</a></dt>
+<dd><p>The reason the event source mapping is in its current state.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.uuid">
+<code class="descname">uuid</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.uuid" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUID of the created event source mapping.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.EventSourceMapping.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.EventSourceMapping.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_aws.lambda_.Function">
+<em class="property">class </em><code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">Function</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>dead_letter_config=None</em>, <em>description=None</em>, <em>environment=None</em>, <em>code=None</em>, <em>name=None</em>, <em>handler=None</em>, <em>kms_key_arn=None</em>, <em>layers=None</em>, <em>memory_size=None</em>, <em>publish=None</em>, <em>reserved_concurrent_executions=None</em>, <em>role=None</em>, <em>runtime=None</em>, <em>s3_bucket=None</em>, <em>s3_key=None</em>, <em>s3_object_version=None</em>, <em>source_code_hash=None</em>, <em>tags=None</em>, <em>timeout=None</em>, <em>tracing_config=None</em>, <em>vpc_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Function" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS. The Lambda Function itself includes source code and runtime configuration.</p>
+<p>For information about Lambda and how to use it, see [What is AWS Lambda?][1]</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>dead_letter_config</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Nested block to configure the function’s <em>dead letter queue</em>. See details below.</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Description of what your Lambda Function does.</li>
+<li><strong>environment</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – The Lambda environment’s configuration settings. Fields documented below.</li>
+<li><strong>code</strong> (<em>pulumi.Input</em><em>[</em><em>pulumi.Archive</em><em>]</em>) – The path to the function’s deployment package within the local filesystem. If defined, The <cite>s3_</cite>-prefixed options cannot be used.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A unique name for your Lambda Function.</li>
+<li><strong>handler</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The function [entrypoint][3] in your code.</li>
+<li><strong>kms_key_arn</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The ARN for the KMS encryption key.</li>
+<li><strong>layers</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers][10]</li>
+<li><strong>memory_size</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Amount of memory in MB your Lambda Function can use at runtime. Defaults to <cite>128</cite>. See [Limits][5]</li>
+<li><strong>publish</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Whether to publish creation/change as new Lambda Function Version. Defaults to <cite>false</cite>.</li>
+<li><strong>reserved_concurrent_executions</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The amount of reserved concurrent executions for this lambda function. Defaults to Unreserved Concurrency Limits. See [Managing Concurrency][9]</li>
+<li><strong>role</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – IAM role attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See [Lambda Permission Model][4] for more details.</li>
+<li><strong>runtime</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – See [Runtimes][6] for valid values.</li>
+<li><strong>s3_bucket</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The S3 bucket location containing the function’s deployment package. Conflicts with <cite>filename</cite>. This bucket must reside in the same AWS region where you are creating the Lambda function.</li>
+<li><strong>s3_key</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The S3 key of an object containing the function’s deployment package. Conflicts with <cite>filename</cite>.</li>
+<li><strong>s3_object_version</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The object version containing the function’s deployment package. Conflicts with <cite>filename</cite>.</li>
+<li><strong>source_code_hash</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either <cite>filename</cite> or <cite>s3_key</cite>. The usual way to set this is <cite>${base64sha256(file(“file.zip”))}</cite>, where “file.zip” is the local filename of the lambda function source archive.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – A mapping of tags to assign to the object.</li>
+<li><strong>timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The amount of time your Lambda Function has to run in seconds. Defaults to <cite>3</cite>. See [Limits][5]</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[dict] tracing_config
+:param pulumi.Input[dict] vpc_config: Provide this to allow your function to access your VPC. Fields documented below. See [Lambda in VPC][7]</p>
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.arn">
+<code class="descname">arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Amazon Resource Name (ARN) identifying your Lambda Function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.dead_letter_config">
+<code class="descname">dead_letter_config</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.dead_letter_config" title="Permalink to this definition">¶</a></dt>
+<dd><p>Nested block to configure the function’s <em>dead letter queue</em>. See details below.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>Description of what your Lambda Function does.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.environment">
+<code class="descname">environment</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.environment" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Lambda environment’s configuration settings. Fields documented below.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.code">
+<code class="descname">code</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.code" title="Permalink to this definition">¶</a></dt>
+<dd><p>The path to the function’s deployment package within the local filesystem. If defined, The <cite>s3_</cite>-prefixed options cannot be used.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>A unique name for your Lambda Function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.handler">
+<code class="descname">handler</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.handler" title="Permalink to this definition">¶</a></dt>
+<dd><p>The function [entrypoint][3] in your code.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.invoke_arn">
+<code class="descname">invoke_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.invoke_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ARN to be used for invoking Lambda Function from API Gateway - to be used in [<cite>aws_api_gateway_integration</cite>](<a class="reference external" href="https://www.terraform.io/docs/providers/aws/r/api_gateway_integration.html)'s">https://www.terraform.io/docs/providers/aws/r/api_gateway_integration.html)’s</a> <cite>uri</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.kms_key_arn">
+<code class="descname">kms_key_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.kms_key_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ARN for the KMS encryption key.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.last_modified">
+<code class="descname">last_modified</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.last_modified" title="Permalink to this definition">¶</a></dt>
+<dd><p>The date this resource was last modified.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.layers">
+<code class="descname">layers</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.layers" title="Permalink to this definition">¶</a></dt>
+<dd><p>List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers][10]</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.memory_size">
+<code class="descname">memory_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.memory_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>Amount of memory in MB your Lambda Function can use at runtime. Defaults to <cite>128</cite>. See [Limits][5]</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.publish">
+<code class="descname">publish</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.publish" title="Permalink to this definition">¶</a></dt>
+<dd><p>Whether to publish creation/change as new Lambda Function Version. Defaults to <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.qualified_arn">
+<code class="descname">qualified_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.qualified_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Amazon Resource Name (ARN) identifying your Lambda Function Version
+(if versioning is enabled via <cite>publish = true</cite>).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.reserved_concurrent_executions">
+<code class="descname">reserved_concurrent_executions</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.reserved_concurrent_executions" title="Permalink to this definition">¶</a></dt>
+<dd><p>The amount of reserved concurrent executions for this lambda function. Defaults to Unreserved Concurrency Limits. See [Managing Concurrency][9]</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.role">
+<code class="descname">role</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.role" title="Permalink to this definition">¶</a></dt>
+<dd><p>IAM role attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See [Lambda Permission Model][4] for more details.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.runtime">
+<code class="descname">runtime</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.runtime" title="Permalink to this definition">¶</a></dt>
+<dd><p>See [Runtimes][6] for valid values.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.s3_bucket">
+<code class="descname">s3_bucket</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.s3_bucket" title="Permalink to this definition">¶</a></dt>
+<dd><p>The S3 bucket location containing the function’s deployment package. Conflicts with <cite>filename</cite>. This bucket must reside in the same AWS region where you are creating the Lambda function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.s3_key">
+<code class="descname">s3_key</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.s3_key" title="Permalink to this definition">¶</a></dt>
+<dd><p>The S3 key of an object containing the function’s deployment package. Conflicts with <cite>filename</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.s3_object_version">
+<code class="descname">s3_object_version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.s3_object_version" title="Permalink to this definition">¶</a></dt>
+<dd><p>The object version containing the function’s deployment package. Conflicts with <cite>filename</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.source_code_hash">
+<code class="descname">source_code_hash</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.source_code_hash" title="Permalink to this definition">¶</a></dt>
+<dd><p>Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either <cite>filename</cite> or <cite>s3_key</cite>. The usual way to set this is <cite>${base64sha256(file(“file.zip”))}</cite>, where “file.zip” is the local filename of the lambda function source archive.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.source_code_size">
+<code class="descname">source_code_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.source_code_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>The size in bytes of the function .zip file.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>A mapping of tags to assign to the object.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.timeout">
+<code class="descname">timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The amount of time your Lambda Function has to run in seconds. Defaults to <cite>3</cite>. See [Limits][5]</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.version">
+<code class="descname">version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.version" title="Permalink to this definition">¶</a></dt>
+<dd><p>Latest published version of your Lambda Function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Function.vpc_config">
+<code class="descname">vpc_config</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Function.vpc_config" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provide this to allow your function to access your VPC. Fields documented below. See [Lambda in VPC][7]</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.Function.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Function.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.Function.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Function.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_aws.lambda_.GetFunctionResult">
+<em class="property">class </em><code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">GetFunctionResult</code><span class="sig-paren">(</span><em>arn=None</em>, <em>dead_letter_config=None</em>, <em>description=None</em>, <em>environment=None</em>, <em>handler=None</em>, <em>invoke_arn=None</em>, <em>kms_key_arn=None</em>, <em>last_modified=None</em>, <em>layers=None</em>, <em>memory_size=None</em>, <em>qualified_arn=None</em>, <em>reserved_concurrent_executions=None</em>, <em>role=None</em>, <em>runtime=None</em>, <em>source_code_hash=None</em>, <em>source_code_size=None</em>, <em>timeout=None</em>, <em>tracing_config=None</em>, <em>version=None</em>, <em>vpc_config=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getFunction.</p>
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.arn">
+<code class="descname">arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Amazon Resource Name (ARN) identifying your Lambda Function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.dead_letter_config">
+<code class="descname">dead_letter_config</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.dead_letter_config" title="Permalink to this definition">¶</a></dt>
+<dd><p>Configure the function’s <em>dead letter queue</em>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>Description of what your Lambda Function does.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.environment">
+<code class="descname">environment</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.environment" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Lambda environment’s configuration settings.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.handler">
+<code class="descname">handler</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.handler" title="Permalink to this definition">¶</a></dt>
+<dd><p>The function entrypoint in your code.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.invoke_arn">
+<code class="descname">invoke_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.invoke_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ARN to be used for invoking Lambda Function from API Gateway.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.kms_key_arn">
+<code class="descname">kms_key_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.kms_key_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ARN for the KMS encryption key.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.last_modified">
+<code class="descname">last_modified</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.last_modified" title="Permalink to this definition">¶</a></dt>
+<dd><p>The date this resource was last modified.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.layers">
+<code class="descname">layers</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.layers" title="Permalink to this definition">¶</a></dt>
+<dd><p>A list of Lambda Layer ARNs attached to your Lambda Function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.memory_size">
+<code class="descname">memory_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.memory_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>Amount of memory in MB your Lambda Function can use at runtime.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.qualified_arn">
+<code class="descname">qualified_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.qualified_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Amazon Resource Name (ARN) identifying your Lambda Function Version</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.reserved_concurrent_executions">
+<code class="descname">reserved_concurrent_executions</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.reserved_concurrent_executions" title="Permalink to this definition">¶</a></dt>
+<dd><p>The amount of reserved concurrent executions for this lambda function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.role">
+<code class="descname">role</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.role" title="Permalink to this definition">¶</a></dt>
+<dd><p>IAM role attached to the Lambda Function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.runtime">
+<code class="descname">runtime</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.runtime" title="Permalink to this definition">¶</a></dt>
+<dd><p>The runtime environment for the Lambda function..</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.source_code_hash">
+<code class="descname">source_code_hash</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.source_code_hash" title="Permalink to this definition">¶</a></dt>
+<dd><p>Base64-encoded representation of raw SHA-256 sum of the zip file.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.source_code_size">
+<code class="descname">source_code_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.source_code_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>The size in bytes of the function .zip file.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.timeout">
+<code class="descname">timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The function execution time at which Lambda should terminate the function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.tracing_config">
+<code class="descname">tracing_config</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.tracing_config" title="Permalink to this definition">¶</a></dt>
+<dd><p>Tracing settings of the function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.version">
+<code class="descname">version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.version" title="Permalink to this definition">¶</a></dt>
+<dd><p>The version of the Lambda function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.vpc_config">
+<code class="descname">vpc_config</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.vpc_config" title="Permalink to this definition">¶</a></dt>
+<dd><p>VPC configuration associated with your Lambda function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetFunctionResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetFunctionResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_aws.lambda_.GetInvocationResult">
+<em class="property">class </em><code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">GetInvocationResult</code><span class="sig-paren">(</span><em>result=None</em>, <em>result_map=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.GetInvocationResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getInvocation.</p>
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetInvocationResult.result">
+<code class="descname">result</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetInvocationResult.result" title="Permalink to this definition">¶</a></dt>
+<dd><p>A result of the lambda function invocation.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetInvocationResult.result_map">
+<code class="descname">result_map</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetInvocationResult.result_map" title="Permalink to this definition">¶</a></dt>
+<dd><p>This field is set only if result is a map of primitive types.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.GetInvocationResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.GetInvocationResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_aws.lambda_.LayerVersion">
+<em class="property">class </em><code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">LayerVersion</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compatible_runtimes=None</em>, <em>description=None</em>, <em>filename=None</em>, <em>layer_name=None</em>, <em>license_info=None</em>, <em>s3_bucket=None</em>, <em>s3_key=None</em>, <em>s3_object_version=None</em>, <em>source_code_hash=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a Lambda Layer Version resource. Lambda Layers allow you to reuse shared bits of code across multiple lambda functions.</p>
+<p>For information about Lambda Layers and how to use them, see [AWS Lambda Layers][1]</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compatible_runtimes</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – A list of [Runtimes][2] this layer is compatible with. Up to 5 runtimes can be specified.</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Description of what your Lambda Layer does.</li>
+<li><strong>filename</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The path to the function’s deployment package within the local filesystem. If defined, The <cite>s3_</cite>-prefixed options cannot be used.</li>
+<li><strong>layer_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A unique name for your Lambda Layer</li>
+<li><strong>license_info</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – License info for your Lambda Layer. See [License Info][3].</li>
+<li><strong>s3_bucket</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The S3 bucket location containing the function’s deployment package. Conflicts with <cite>filename</cite>. This bucket must reside in the same AWS region where you are creating the Lambda function.</li>
+<li><strong>s3_key</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The S3 key of an object containing the function’s deployment package. Conflicts with <cite>filename</cite>.</li>
+<li><strong>s3_object_version</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The object version containing the function’s deployment package. Conflicts with <cite>filename</cite>.</li>
+<li><strong>source_code_hash</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either <cite>filename</cite> or <cite>s3_key</cite>. The usual way to set this is <cite>${base64sha256(file(“file.zip”))}</cite>, where “file.zip” is the local filename of the lambda layer source archive.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.arn">
+<code class="descname">arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Amazon Resource Name (ARN) identifying your Lambda Layer.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.compatible_runtimes">
+<code class="descname">compatible_runtimes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.compatible_runtimes" title="Permalink to this definition">¶</a></dt>
+<dd><p>A list of [Runtimes][2] this layer is compatible with. Up to 5 runtimes can be specified.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.created_date">
+<code class="descname">created_date</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.created_date" title="Permalink to this definition">¶</a></dt>
+<dd><p>The date this resource was created.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>Description of what your Lambda Layer does.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.filename">
+<code class="descname">filename</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.filename" title="Permalink to this definition">¶</a></dt>
+<dd><p>The path to the function’s deployment package within the local filesystem. If defined, The <cite>s3_</cite>-prefixed options cannot be used.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.layer_arn">
+<code class="descname">layer_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.layer_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Amazon Resource Name (ARN) identifying your specific Lambda Layer version.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.layer_name">
+<code class="descname">layer_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.layer_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>A unique name for your Lambda Layer</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.license_info">
+<code class="descname">license_info</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.license_info" title="Permalink to this definition">¶</a></dt>
+<dd><p>License info for your Lambda Layer. See [License Info][3].</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.s3_bucket">
+<code class="descname">s3_bucket</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.s3_bucket" title="Permalink to this definition">¶</a></dt>
+<dd><p>The S3 bucket location containing the function’s deployment package. Conflicts with <cite>filename</cite>. This bucket must reside in the same AWS region where you are creating the Lambda function.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.s3_key">
+<code class="descname">s3_key</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.s3_key" title="Permalink to this definition">¶</a></dt>
+<dd><p>The S3 key of an object containing the function’s deployment package. Conflicts with <cite>filename</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.s3_object_version">
+<code class="descname">s3_object_version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.s3_object_version" title="Permalink to this definition">¶</a></dt>
+<dd><p>The object version containing the function’s deployment package. Conflicts with <cite>filename</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.source_code_hash">
+<code class="descname">source_code_hash</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.source_code_hash" title="Permalink to this definition">¶</a></dt>
+<dd><p>Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either <cite>filename</cite> or <cite>s3_key</cite>. The usual way to set this is <cite>${base64sha256(file(“file.zip”))}</cite>, where “file.zip” is the local filename of the lambda layer source archive.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.source_code_size">
+<code class="descname">source_code_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.source_code_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>The size in bytes of the function .zip file.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.LayerVersion.version">
+<code class="descname">version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.version" title="Permalink to this definition">¶</a></dt>
+<dd><p>This Lamba Layer version.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.LayerVersion.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.LayerVersion.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.LayerVersion.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_aws.lambda_.Permission">
+<em class="property">class </em><code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">Permission</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>action=None</em>, <em>event_source_token=None</em>, <em>function=None</em>, <em>principal=None</em>, <em>qualifier=None</em>, <em>source_account=None</em>, <em>source_arn=None</em>, <em>statement_id=None</em>, <em>statement_id_prefix=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Permission" title="Permalink to this definition">¶</a></dt>
+<dd><p>Creates a Lambda permission to allow external sources invoking the Lambda function
+(e.g. CloudWatch Event Rule, SNS or S3).</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>action</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The AWS Lambda action you want to allow in this statement. (e.g. <cite>lambda:InvokeFunction</cite>)</li>
+<li><strong>event_source_token</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The Event Source Token to validate.  Used with [Alexa Skills][1].</li>
+<li><strong>function</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Name of the Lambda function whose resource policy you are updating</li>
+<li><strong>principal</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The principal who is getting this permission.
+e.g. <cite>s3.amazonaws.com</cite>, an AWS account ID, or any valid AWS service principal
+such as <cite>events.amazonaws.com</cite> or <cite>sns.amazonaws.com</cite>.</li>
+<li><strong>qualifier</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Query parameter to specify function version or alias name.
+The permission will then apply to the specific qualified ARN.
+e.g. <cite>arn:aws:lambda:aws-region:acct-id:function:function-name:2</cite></li>
+<li><strong>source_account</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – This parameter is used for S3 and SES. The AWS account ID (without a hyphen) of the source owner.</li>
+<li><strong>source_arn</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – When granting Amazon S3 or CloudWatch Events permission to
+invoke your function, you should specify this field with the Amazon Resource Name (ARN)
+for the S3 Bucket or CloudWatch Events Rule as its value.  This ensures that only events
+generated from the specified bucket or rule can invoke the function.
+API Gateway ARNs have a unique structure described
+[here](<a class="reference external" href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html">http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html</a>).</li>
+<li><strong>statement_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A unique statement identifier. By default generated by Terraform.</li>
+<li><strong>statement_id_prefix</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A statement identifier prefix. Terraform will generate a unique suffix. Conflicts with <cite>statement_id</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.action">
+<code class="descname">action</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.action" title="Permalink to this definition">¶</a></dt>
+<dd><p>The AWS Lambda action you want to allow in this statement. (e.g. <cite>lambda:InvokeFunction</cite>)</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.event_source_token">
+<code class="descname">event_source_token</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.event_source_token" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Event Source Token to validate.  Used with [Alexa Skills][1].</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.function">
+<code class="descname">function</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.function" title="Permalink to this definition">¶</a></dt>
+<dd><p>Name of the Lambda function whose resource policy you are updating</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.principal">
+<code class="descname">principal</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.principal" title="Permalink to this definition">¶</a></dt>
+<dd><p>The principal who is getting this permission.
+e.g. <cite>s3.amazonaws.com</cite>, an AWS account ID, or any valid AWS service principal
+such as <cite>events.amazonaws.com</cite> or <cite>sns.amazonaws.com</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.qualifier">
+<code class="descname">qualifier</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.qualifier" title="Permalink to this definition">¶</a></dt>
+<dd><p>Query parameter to specify function version or alias name.
+The permission will then apply to the specific qualified ARN.
+e.g. <cite>arn:aws:lambda:aws-region:acct-id:function:function-name:2</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.source_account">
+<code class="descname">source_account</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.source_account" title="Permalink to this definition">¶</a></dt>
+<dd><p>This parameter is used for S3 and SES. The AWS account ID (without a hyphen) of the source owner.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.source_arn">
+<code class="descname">source_arn</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.source_arn" title="Permalink to this definition">¶</a></dt>
+<dd><p>When granting Amazon S3 or CloudWatch Events permission to
+invoke your function, you should specify this field with the Amazon Resource Name (ARN)
+for the S3 Bucket or CloudWatch Events Rule as its value.  This ensures that only events
+generated from the specified bucket or rule can invoke the function.
+API Gateway ARNs have a unique structure described
+[here](<a class="reference external" href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html">http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html</a>).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.statement_id">
+<code class="descname">statement_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.statement_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>A unique statement identifier. By default generated by Terraform.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_aws.lambda_.Permission.statement_id_prefix">
+<code class="descname">statement_id_prefix</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_aws.lambda_.Permission.statement_id_prefix" title="Permalink to this definition">¶</a></dt>
+<dd><p>A statement identifier prefix. Terraform will generate a unique suffix. Conflicts with <cite>statement_id</cite>.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.Permission.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Permission.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_aws.lambda_.Permission.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.Permission.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_aws.lambda_.get_function">
+<code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">get_function</code><span class="sig-paren">(</span><em>function_name=None</em>, <em>qualifier=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.get_function" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides information about a Lambda Function.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_aws.lambda_.get_invocation">
+<code class="descclassname">pulumi_aws.lambda_.</code><code class="descname">get_invocation</code><span class="sig-paren">(</span><em>function_name=None</em>, <em>input=None</em>, <em>qualifier=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_aws.lambda_.get_invocation" title="Permalink to this definition">¶</a></dt>
+<dd><p>Use this data source to invoke custom lambda functions as data source.
+The lambda function is invoked with [RequestResponse](<a class="reference external" href="https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax">https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax</a>)
+invocation type.</p>
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_f5bigip/index.md
+++ b/reference/pkg/python/pulumi_f5bigip/index.md
@@ -3,7 +3,6 @@
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="cm/">cm</a></li>
-<li class="toctree-l1"><a class="reference internal" href="config/">config</a></li>
 <li class="toctree-l1"><a class="reference internal" href="ltm/">ltm</a></li>
 <li class="toctree-l1"><a class="reference internal" href="net/">net</a></li>
 <li class="toctree-l1"><a class="reference internal" href="sys/">sys</a></li>

--- a/reference/pkg/python/pulumi_gcp/index.md
+++ b/reference/pkg/python/pulumi_gcp/index.md
@@ -29,7 +29,6 @@
 <li class="toctree-l1"><a class="reference internal" href="redis/">redis</a></li>
 <li class="toctree-l1"><a class="reference internal" href="resourcemanager/">resourcemanager</a></li>
 <li class="toctree-l1"><a class="reference internal" href="runtimeconfig/">runtimeconfig</a></li>
-<li class="toctree-l1"><a class="reference internal" href="serviceAccount/">serviceAccount</a></li>
 <li class="toctree-l1"><a class="reference internal" href="sourcerepo/">sourcerepo</a></li>
 <li class="toctree-l1"><a class="reference internal" href="spanner/">spanner</a></li>
 <li class="toctree-l1"><a class="reference internal" href="sql/">sql</a></li>

--- a/reference/pkg/python/pulumi_kubernetes/admissionregistration/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/admissionregistration/index.md
@@ -1,0 +1,9 @@
+<div class="section" id="admissionregistration">
+<h1>admissionregistration<a class="headerlink" href="#admissionregistration" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1alpha1/">v1alpha1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/admissionregistration/v1alpha1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/admissionregistration/v1alpha1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.admissionregistration.v1alpha1">
+<span id="v1alpha1"></span><h1>v1alpha1<a class="headerlink" href="#module-pulumi_kubernetes.admissionregistration.v1alpha1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfiguration">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.admissionregistration.v1alpha1.</code><code class="descname">InitializerConfiguration</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>initializers=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfiguration" title="Permalink to this definition">¶</a></dt>
+<dd><p>InitializerConfiguration describes the configuration of initializers.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfiguration.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfiguration.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfiguration.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfiguration.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfigurationList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.admissionregistration.v1alpha1.</code><code class="descname">InitializerConfigurationList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfigurationList" title="Permalink to this definition">¶</a></dt>
+<dd><p>InitializerConfigurationList is a list of InitializerConfiguration.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfigurationList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfigurationList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfigurationList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1alpha1.InitializerConfigurationList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/admissionregistration/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/admissionregistration/v1beta1/index.md
@@ -1,0 +1,181 @@
+<div class="section" id="module-pulumi_kubernetes.admissionregistration.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.admissionregistration.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfiguration">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.admissionregistration.v1beta1.</code><code class="descname">MutatingWebhookConfiguration</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>webhooks=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfiguration" title="Permalink to this definition">¶</a></dt>
+<dd><p>MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or
+reject and may change the object.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfiguration.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfiguration.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfiguration.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfiguration.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfigurationList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.admissionregistration.v1beta1.</code><code class="descname">MutatingWebhookConfigurationList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfigurationList" title="Permalink to this definition">¶</a></dt>
+<dd><p>MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfigurationList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfigurationList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfigurationList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.MutatingWebhookConfigurationList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfiguration">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.admissionregistration.v1beta1.</code><code class="descname">ValidatingWebhookConfiguration</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>webhooks=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfiguration" title="Permalink to this definition">¶</a></dt>
+<dd><p>ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept
+or reject and object without changing it.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfiguration.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfiguration.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfiguration.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfiguration.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfigurationList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.admissionregistration.v1beta1.</code><code class="descname">ValidatingWebhookConfigurationList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfigurationList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfigurationList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfigurationList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfigurationList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.admissionregistration.v1beta1.ValidatingWebhookConfigurationList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apiextensions/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apiextensions/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="apiextensions">
+<h1>apiextensions<a class="headerlink" href="#apiextensions" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apiextensions/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apiextensions/v1beta1/index.md
@@ -1,0 +1,92 @@
+<div class="section" id="module-pulumi_kubernetes.apiextensions.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.apiextensions.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinition">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apiextensions.v1beta1.</code><code class="descname">CustomResourceDefinition</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinition" title="Permalink to this definition">¶</a></dt>
+<dd><p>CustomResourceDefinition represents a resource that should be exposed on the API server.  Its
+name MUST be in the format &lt;.spec.name&gt;.&lt;.spec.group&gt;.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinition.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinition.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinition.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinition.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinitionList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apiextensions.v1beta1.</code><code class="descname">CustomResourceDefinitionList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinitionList" title="Permalink to this definition">¶</a></dt>
+<dd><p>CustomResourceDefinitionList is a list of CustomResourceDefinition objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinitionList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinitionList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinitionList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiextensions.v1beta1.CustomResourceDefinitionList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apiregistration/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apiregistration/index.md
@@ -1,0 +1,9 @@
+<div class="section" id="apiregistration">
+<h1>apiregistration<a class="headerlink" href="#apiregistration" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apiregistration/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apiregistration/v1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.apiregistration.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.apiregistration.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.apiregistration.v1.APIService">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apiregistration.v1.</code><code class="descname">APIService</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1.APIService" title="Permalink to this definition">¶</a></dt>
+<dd><p>APIService represents a server for a particular GroupVersion. Name must be “version.group”.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apiregistration.v1.APIService.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1.APIService.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apiregistration.v1.APIService.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1.APIService.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apiregistration.v1.APIServiceList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apiregistration.v1.</code><code class="descname">APIServiceList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1.APIServiceList" title="Permalink to this definition">¶</a></dt>
+<dd><p>APIServiceList is a list of APIService objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apiregistration.v1.APIServiceList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1.APIServiceList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apiregistration.v1.APIServiceList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1.APIServiceList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apiregistration/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apiregistration/v1beta1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.apiregistration.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.apiregistration.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.apiregistration.v1beta1.APIService">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apiregistration.v1beta1.</code><code class="descname">APIService</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1beta1.APIService" title="Permalink to this definition">¶</a></dt>
+<dd><p>APIService represents a server for a particular GroupVersion. Name must be “version.group”.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apiregistration.v1beta1.APIService.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1beta1.APIService.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apiregistration.v1beta1.APIService.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1beta1.APIService.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apiregistration.v1beta1.APIServiceList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apiregistration.v1beta1.</code><code class="descname">APIServiceList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1beta1.APIServiceList" title="Permalink to this definition">¶</a></dt>
+<dd><p>APIServiceList is a list of APIService objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apiregistration.v1beta1.APIServiceList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1beta1.APIServiceList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apiregistration.v1beta1.APIServiceList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apiregistration.v1beta1.APIServiceList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apps/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apps/index.md
@@ -1,0 +1,10 @@
+<div class="section" id="apps">
+<h1>apps<a class="headerlink" href="#apps" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta2/">v1beta2</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apps/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apps/v1/index.md
@@ -1,0 +1,459 @@
+<div class="section" id="module-pulumi_kubernetes.apps.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.apps.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.ControllerRevision">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">ControllerRevision</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>data=None</em>, <em>metadata=None</em>, <em>revision=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.ControllerRevision" title="Permalink to this definition">¶</a></dt>
+<dd><p>ControllerRevision implements an immutable snapshot of state data. Clients are responsible for
+serializing and deserializing the objects that contain their internal state. Once a
+ControllerRevision has been successfully created, it can not be updated. The API Server will
+fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may,
+however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers
+for update and rollback, this object is beta. However, it may be subject to name and
+representation changes in future releases, and clients should not depend on its stability. It is
+primarily for internal use by controllers.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.ControllerRevision.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.ControllerRevision.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.ControllerRevision.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.ControllerRevision.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.ControllerRevisionList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">ControllerRevisionList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.ControllerRevisionList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ControllerRevisionList is a resource containing a list of ControllerRevision objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.ControllerRevisionList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.ControllerRevisionList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.ControllerRevisionList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.ControllerRevisionList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.DaemonSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">DaemonSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.DaemonSet" title="Permalink to this definition">¶</a></dt>
+<dd><p>DaemonSet represents the configuration of a daemon set.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.DaemonSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.DaemonSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.DaemonSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.DaemonSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.DaemonSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">DaemonSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.DaemonSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>DaemonSetList is a collection of daemon sets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.DaemonSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.DaemonSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.DaemonSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.DaemonSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.Deployment">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">Deployment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.Deployment" title="Permalink to this definition">¶</a></dt>
+<dd><p>Deployment enables declarative updates for Pods and ReplicaSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.Deployment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.Deployment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.Deployment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.Deployment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.DeploymentList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">DeploymentList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.DeploymentList" title="Permalink to this definition">¶</a></dt>
+<dd><p>DeploymentList is a list of Deployments.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.DeploymentList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.DeploymentList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.DeploymentList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.DeploymentList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.ReplicaSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">ReplicaSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.ReplicaSet" title="Permalink to this definition">¶</a></dt>
+<dd><p>ReplicaSet ensures that a specified number of pod replicas are running at any given time.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.ReplicaSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.ReplicaSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.ReplicaSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.ReplicaSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.ReplicaSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">ReplicaSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.ReplicaSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ReplicaSetList is a collection of ReplicaSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.ReplicaSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.ReplicaSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.ReplicaSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.ReplicaSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.StatefulSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">StatefulSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.StatefulSet" title="Permalink to this definition">¶</a></dt>
+<dd><dl class="docutils">
+<dt>StatefulSet represents a set of pods with consistent identities. Identities are defined as:</dt>
+<dd><ul class="first last simple">
+<li>Network: A single stable DNS and hostname.</li>
+<li>Storage: As many VolumeClaims as requested.</li>
+</ul>
+</dd>
+</dl>
+<p>The StatefulSet guarantees that a given network identity will always map to the same storage
+identity.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.StatefulSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.StatefulSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.StatefulSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.StatefulSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1.StatefulSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1.</code><code class="descname">StatefulSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1.StatefulSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>StatefulSetList is a collection of StatefulSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.StatefulSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.StatefulSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1.StatefulSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1.StatefulSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apps/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apps/v1beta1/index.md
@@ -1,0 +1,288 @@
+<div class="section" id="module-pulumi_kubernetes.apps.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.apps.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta1.ControllerRevision">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta1.</code><code class="descname">ControllerRevision</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>data=None</em>, <em>metadata=None</em>, <em>revision=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.ControllerRevision" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of ControllerRevision is deprecated by
+apps/v1beta2/ControllerRevision. See the release notes for more information. ControllerRevision
+implements an immutable snapshot of state data. Clients are responsible for serializing and
+deserializing the objects that contain their internal state. Once a ControllerRevision has been
+successfully created, it can not be updated. The API Server will fail validation of all requests
+that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that,
+due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this
+object is beta. However, it may be subject to name and representation changes in future
+releases, and clients should not depend on its stability. It is primarily for internal use by
+controllers.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.ControllerRevision.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.ControllerRevision.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.ControllerRevision.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.ControllerRevision.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta1.ControllerRevisionList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta1.</code><code class="descname">ControllerRevisionList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.ControllerRevisionList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ControllerRevisionList is a resource containing a list of ControllerRevision objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.ControllerRevisionList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.ControllerRevisionList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.ControllerRevisionList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.ControllerRevisionList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta1.Deployment">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta1.</code><code class="descname">Deployment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.Deployment" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the
+release notes for more information. Deployment enables declarative updates for Pods and
+ReplicaSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.Deployment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.Deployment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.Deployment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.Deployment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta1.DeploymentList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta1.</code><code class="descname">DeploymentList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.DeploymentList" title="Permalink to this definition">¶</a></dt>
+<dd><p>DeploymentList is a list of Deployments.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.DeploymentList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.DeploymentList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.DeploymentList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.DeploymentList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta1.StatefulSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta1.</code><code class="descname">StatefulSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.StatefulSet" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of StatefulSet is deprecated by apps/v1beta2/StatefulSet. See
+the release notes for more information. StatefulSet represents a set of pods with consistent
+identities. Identities are defined as:</p>
+<blockquote>
+<div><ul class="simple">
+<li>Network: A single stable DNS and hostname.</li>
+<li>Storage: As many VolumeClaims as requested.</li>
+</ul>
+</div></blockquote>
+<p>The StatefulSet guarantees that a given network identity will always map to the same storage
+identity.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.StatefulSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.StatefulSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.StatefulSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.StatefulSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta1.StatefulSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta1.</code><code class="descname">StatefulSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.StatefulSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>StatefulSetList is a collection of StatefulSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.StatefulSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.StatefulSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta1.StatefulSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta1.StatefulSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/apps/v1beta2/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/apps/v1beta2/index.md
@@ -1,0 +1,467 @@
+<div class="section" id="module-pulumi_kubernetes.apps.v1beta2">
+<span id="v1beta2"></span><h1>v1beta2<a class="headerlink" href="#module-pulumi_kubernetes.apps.v1beta2" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.ControllerRevision">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">ControllerRevision</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>data=None</em>, <em>metadata=None</em>, <em>revision=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ControllerRevision" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of ControllerRevision is deprecated by
+apps/v1/ControllerRevision. See the release notes for more information. ControllerRevision
+implements an immutable snapshot of state data. Clients are responsible for serializing and
+deserializing the objects that contain their internal state. Once a ControllerRevision has been
+successfully created, it can not be updated. The API Server will fail validation of all requests
+that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that,
+due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this
+object is beta. However, it may be subject to name and representation changes in future
+releases, and clients should not depend on its stability. It is primarily for internal use by
+controllers.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.ControllerRevision.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ControllerRevision.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.ControllerRevision.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ControllerRevision.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.ControllerRevisionList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">ControllerRevisionList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ControllerRevisionList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ControllerRevisionList is a resource containing a list of ControllerRevision objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.ControllerRevisionList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ControllerRevisionList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.ControllerRevisionList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ControllerRevisionList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.DaemonSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">DaemonSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DaemonSet" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of DaemonSet is deprecated by apps/v1/DaemonSet. See the release
+notes for more information. DaemonSet represents the configuration of a daemon set.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.DaemonSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DaemonSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.DaemonSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DaemonSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.DaemonSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">DaemonSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DaemonSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>DaemonSetList is a collection of daemon sets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.DaemonSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DaemonSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.DaemonSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DaemonSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.Deployment">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">Deployment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.Deployment" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of Deployment is deprecated by apps/v1/Deployment. See the
+release notes for more information. Deployment enables declarative updates for Pods and
+ReplicaSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.Deployment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.Deployment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.Deployment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.Deployment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.DeploymentList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">DeploymentList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DeploymentList" title="Permalink to this definition">¶</a></dt>
+<dd><p>DeploymentList is a list of Deployments.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.DeploymentList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DeploymentList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.DeploymentList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.DeploymentList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.ReplicaSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">ReplicaSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ReplicaSet" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1/ReplicaSet. See the
+release notes for more information. ReplicaSet ensures that a specified number of pod replicas
+are running at any given time.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.ReplicaSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ReplicaSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.ReplicaSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ReplicaSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.ReplicaSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">ReplicaSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ReplicaSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ReplicaSetList is a collection of ReplicaSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.ReplicaSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ReplicaSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.ReplicaSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.ReplicaSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.StatefulSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">StatefulSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.StatefulSet" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of StatefulSet is deprecated by apps/v1/StatefulSet. See the
+release notes for more information. StatefulSet represents a set of pods with consistent
+identities. Identities are defined as:</p>
+<blockquote>
+<div><ul class="simple">
+<li>Network: A single stable DNS and hostname.</li>
+<li>Storage: As many VolumeClaims as requested.</li>
+</ul>
+</div></blockquote>
+<p>The StatefulSet guarantees that a given network identity will always map to the same storage
+identity.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.StatefulSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.StatefulSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.StatefulSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.StatefulSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.apps.v1beta2.StatefulSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.apps.v1beta2.</code><code class="descname">StatefulSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.StatefulSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>StatefulSetList is a collection of StatefulSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.StatefulSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.StatefulSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.apps.v1beta2.StatefulSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.apps.v1beta2.StatefulSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/auditregistration/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/auditregistration/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="auditregistration">
+<h1>auditregistration<a class="headerlink" href="#auditregistration" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1alpha1/">v1alpha1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/auditregistration/v1alpha1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/auditregistration/v1alpha1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.auditregistration.v1alpha1">
+<span id="v1alpha1"></span><h1>v1alpha1<a class="headerlink" href="#module-pulumi_kubernetes.auditregistration.v1alpha1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.auditregistration.v1alpha1.AuditSink">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.auditregistration.v1alpha1.</code><code class="descname">AuditSink</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.auditregistration.v1alpha1.AuditSink" title="Permalink to this definition">¶</a></dt>
+<dd><p>AuditSink represents a cluster level audit sink</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.auditregistration.v1alpha1.AuditSink.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.auditregistration.v1alpha1.AuditSink.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.auditregistration.v1alpha1.AuditSink.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.auditregistration.v1alpha1.AuditSink.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.auditregistration.v1alpha1.AuditSinkList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.auditregistration.v1alpha1.</code><code class="descname">AuditSinkList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.auditregistration.v1alpha1.AuditSinkList" title="Permalink to this definition">¶</a></dt>
+<dd><p>AuditSinkList is a list of AuditSink items.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.auditregistration.v1alpha1.AuditSinkList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.auditregistration.v1alpha1.AuditSinkList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.auditregistration.v1alpha1.AuditSinkList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.auditregistration.v1alpha1.AuditSinkList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/authentication/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/authentication/index.md
@@ -1,0 +1,9 @@
+<div class="section" id="authentication">
+<h1>authentication<a class="headerlink" href="#authentication" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/authentication/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/authentication/v1/index.md
@@ -1,0 +1,48 @@
+<div class="section" id="module-pulumi_kubernetes.authentication.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.authentication.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.authentication.v1.TokenReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authentication.v1.</code><code class="descname">TokenReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authentication.v1.TokenReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be
+cached by the webhook token authenticator plugin in the kube-apiserver.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authentication.v1.TokenReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authentication.v1.TokenReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authentication.v1.TokenReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authentication.v1.TokenReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/authentication/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/authentication/v1beta1/index.md
@@ -1,0 +1,48 @@
+<div class="section" id="module-pulumi_kubernetes.authentication.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.authentication.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.authentication.v1beta1.TokenReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authentication.v1beta1.</code><code class="descname">TokenReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authentication.v1beta1.TokenReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be
+cached by the webhook token authenticator plugin in the kube-apiserver.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authentication.v1beta1.TokenReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authentication.v1beta1.TokenReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authentication.v1beta1.TokenReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authentication.v1beta1.TokenReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/authorization/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/authorization/index.md
@@ -1,0 +1,9 @@
+<div class="section" id="authorization">
+<h1>authorization<a class="headerlink" href="#authorization" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/authorization/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/authorization/v1/index.md
@@ -1,0 +1,190 @@
+<div class="section" id="module-pulumi_kubernetes.authorization.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.authorization.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.authorization.v1.LocalSubjectAccessReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authorization.v1.</code><code class="descname">LocalSubjectAccessReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authorization.v1.LocalSubjectAccessReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given
+namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped
+policy that includes permissions checking.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1.LocalSubjectAccessReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1.LocalSubjectAccessReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1.LocalSubjectAccessReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1.LocalSubjectAccessReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.authorization.v1.SelfSubjectAccessReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authorization.v1.</code><code class="descname">SelfSubjectAccessReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SelfSubjectAccessReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling
+in a spec.namespace means “in all namespaces”.  Self is a special case, because users should
+always be able to check whether they can perform an action</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1.SelfSubjectAccessReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SelfSubjectAccessReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1.SelfSubjectAccessReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SelfSubjectAccessReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.authorization.v1.SelfSubjectRulesReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authorization.v1.</code><code class="descname">SelfSubjectRulesReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SelfSubjectRulesReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>SelfSubjectRulesReview enumerates the set of actions the current user can perform within a
+namespace. The returned list of actions may be incomplete depending on the server’s
+authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview
+should be used by UIs to show/hide actions, or to quickly let an end user reason about their
+permissions. It should NOT Be used by external systems to drive authorization decisions as this
+raises confused deputy, cache lifetime/revocation, and correctness concerns.
+SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions
+to the API server.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1.SelfSubjectRulesReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SelfSubjectRulesReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1.SelfSubjectRulesReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SelfSubjectRulesReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.authorization.v1.SubjectAccessReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authorization.v1.</code><code class="descname">SubjectAccessReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SubjectAccessReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>SubjectAccessReview checks whether or not a user or group can perform an action.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1.SubjectAccessReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SubjectAccessReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1.SubjectAccessReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1.SubjectAccessReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/authorization/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/authorization/v1beta1/index.md
@@ -1,0 +1,190 @@
+<div class="section" id="module-pulumi_kubernetes.authorization.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.authorization.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.authorization.v1beta1.LocalSubjectAccessReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authorization.v1beta1.</code><code class="descname">LocalSubjectAccessReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.LocalSubjectAccessReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given
+namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped
+policy that includes permissions checking.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1beta1.LocalSubjectAccessReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.LocalSubjectAccessReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1beta1.LocalSubjectAccessReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.LocalSubjectAccessReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SelfSubjectAccessReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authorization.v1beta1.</code><code class="descname">SelfSubjectAccessReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SelfSubjectAccessReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling
+in a spec.namespace means “in all namespaces”.  Self is a special case, because users should
+always be able to check whether they can perform an action</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SelfSubjectAccessReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SelfSubjectAccessReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SelfSubjectAccessReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SelfSubjectAccessReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SelfSubjectRulesReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authorization.v1beta1.</code><code class="descname">SelfSubjectRulesReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SelfSubjectRulesReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>SelfSubjectRulesReview enumerates the set of actions the current user can perform within a
+namespace. The returned list of actions may be incomplete depending on the server’s
+authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview
+should be used by UIs to show/hide actions, or to quickly let an end user reason about their
+permissions. It should NOT Be used by external systems to drive authorization decisions as this
+raises confused deputy, cache lifetime/revocation, and correctness concerns.
+SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions
+to the API server.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SelfSubjectRulesReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SelfSubjectRulesReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SelfSubjectRulesReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SelfSubjectRulesReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SubjectAccessReview">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.authorization.v1beta1.</code><code class="descname">SubjectAccessReview</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SubjectAccessReview" title="Permalink to this definition">¶</a></dt>
+<dd><p>SubjectAccessReview checks whether or not a user or group can perform an action.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SubjectAccessReview.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SubjectAccessReview.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.authorization.v1beta1.SubjectAccessReview.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.authorization.v1beta1.SubjectAccessReview.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/autoscaling/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/autoscaling/index.md
@@ -1,0 +1,10 @@
+<div class="section" id="autoscaling">
+<h1>autoscaling<a class="headerlink" href="#autoscaling" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v2beta1/">v2beta1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v2beta2/">v2beta2</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/autoscaling/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/autoscaling/v1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.autoscaling.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.autoscaling.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscaler">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.autoscaling.v1.</code><code class="descname">HorizontalPodAutoscaler</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscaler" title="Permalink to this definition">¶</a></dt>
+<dd><p>configuration of a horizontal pod autoscaler.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscaler.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscaler.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscaler.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscaler.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscalerList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.autoscaling.v1.</code><code class="descname">HorizontalPodAutoscalerList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscalerList" title="Permalink to this definition">¶</a></dt>
+<dd><p>list of horizontal pod autoscaler objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscalerList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscalerList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscalerList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v1.HorizontalPodAutoscalerList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/autoscaling/v2beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/autoscaling/v2beta1/index.md
@@ -1,0 +1,93 @@
+<div class="section" id="module-pulumi_kubernetes.autoscaling.v2beta1">
+<span id="v2beta1"></span><h1>v2beta1<a class="headerlink" href="#module-pulumi_kubernetes.autoscaling.v2beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscaler">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.autoscaling.v2beta1.</code><code class="descname">HorizontalPodAutoscaler</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscaler" title="Permalink to this definition">¶</a></dt>
+<dd><p>HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which
+automatically manages the replica count of any resource implementing the scale subresource based
+on the metrics specified.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscaler.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscaler.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscaler.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscaler.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscalerList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.autoscaling.v2beta1.</code><code class="descname">HorizontalPodAutoscalerList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscalerList" title="Permalink to this definition">¶</a></dt>
+<dd><p>HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscalerList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscalerList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscalerList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta1.HorizontalPodAutoscalerList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/autoscaling/v2beta2/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/autoscaling/v2beta2/index.md
@@ -1,0 +1,93 @@
+<div class="section" id="module-pulumi_kubernetes.autoscaling.v2beta2">
+<span id="v2beta2"></span><h1>v2beta2<a class="headerlink" href="#module-pulumi_kubernetes.autoscaling.v2beta2" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscaler">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.autoscaling.v2beta2.</code><code class="descname">HorizontalPodAutoscaler</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscaler" title="Permalink to this definition">¶</a></dt>
+<dd><p>HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which
+automatically manages the replica count of any resource implementing the scale subresource based
+on the metrics specified.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscaler.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscaler.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscaler.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscaler.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscalerList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.autoscaling.v2beta2.</code><code class="descname">HorizontalPodAutoscalerList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscalerList" title="Permalink to this definition">¶</a></dt>
+<dd><p>HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscalerList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscalerList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscalerList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.autoscaling.v2beta2.HorizontalPodAutoscalerList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/batch/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/batch/index.md
@@ -1,0 +1,10 @@
+<div class="section" id="batch">
+<h1>batch<a class="headerlink" href="#batch" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v2alpha1/">v2alpha1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/batch/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/batch/v1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.batch.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.batch.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.batch.v1.Job">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.batch.v1.</code><code class="descname">Job</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.batch.v1.Job" title="Permalink to this definition">¶</a></dt>
+<dd><p>Job represents the configuration of a single job.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v1.Job.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v1.Job.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v1.Job.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v1.Job.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.batch.v1.JobList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.batch.v1.</code><code class="descname">JobList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.batch.v1.JobList" title="Permalink to this definition">¶</a></dt>
+<dd><p>JobList is a collection of jobs.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v1.JobList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v1.JobList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v1.JobList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v1.JobList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/batch/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/batch/v1beta1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.batch.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.batch.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.batch.v1beta1.CronJob">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.batch.v1beta1.</code><code class="descname">CronJob</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.batch.v1beta1.CronJob" title="Permalink to this definition">¶</a></dt>
+<dd><p>CronJob represents the configuration of a single cron job.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v1beta1.CronJob.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v1beta1.CronJob.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v1beta1.CronJob.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v1beta1.CronJob.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.batch.v1beta1.CronJobList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.batch.v1beta1.</code><code class="descname">CronJobList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.batch.v1beta1.CronJobList" title="Permalink to this definition">¶</a></dt>
+<dd><p>CronJobList is a collection of cron jobs.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v1beta1.CronJobList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v1beta1.CronJobList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v1beta1.CronJobList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v1beta1.CronJobList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/batch/v2alpha1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/batch/v2alpha1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.batch.v2alpha1">
+<span id="v2alpha1"></span><h1>v2alpha1<a class="headerlink" href="#module-pulumi_kubernetes.batch.v2alpha1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.batch.v2alpha1.CronJob">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.batch.v2alpha1.</code><code class="descname">CronJob</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.batch.v2alpha1.CronJob" title="Permalink to this definition">¶</a></dt>
+<dd><p>CronJob represents the configuration of a single cron job.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v2alpha1.CronJob.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v2alpha1.CronJob.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v2alpha1.CronJob.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v2alpha1.CronJob.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.batch.v2alpha1.CronJobList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.batch.v2alpha1.</code><code class="descname">CronJobList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.batch.v2alpha1.CronJobList" title="Permalink to this definition">¶</a></dt>
+<dd><p>CronJobList is a collection of cron jobs.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v2alpha1.CronJobList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v2alpha1.CronJobList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.batch.v2alpha1.CronJobList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.batch.v2alpha1.CronJobList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/certificates/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/certificates/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="certificates">
+<h1>certificates<a class="headerlink" href="#certificates" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/certificates/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/certificates/v1beta1/index.md
@@ -1,0 +1,90 @@
+<div class="section" id="module-pulumi_kubernetes.certificates.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.certificates.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequest">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.certificates.v1beta1.</code><code class="descname">CertificateSigningRequest</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequest" title="Permalink to this definition">¶</a></dt>
+<dd><p>Describes a certificate signing request</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequest.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequest.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequest.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequest.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequestList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.certificates.v1beta1.</code><code class="descname">CertificateSigningRequestList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequestList" title="Permalink to this definition">¶</a></dt>
+<dd><dl class="method">
+<dt id="pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequestList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequestList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequestList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.certificates.v1beta1.CertificateSigningRequestList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/coordination/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/coordination/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="coordination">
+<h1>coordination<a class="headerlink" href="#coordination" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/coordination/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/coordination/v1beta1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.coordination.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.coordination.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.coordination.v1beta1.Lease">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.coordination.v1beta1.</code><code class="descname">Lease</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.coordination.v1beta1.Lease" title="Permalink to this definition">¶</a></dt>
+<dd><p>Lease defines a lease concept.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.coordination.v1beta1.Lease.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.coordination.v1beta1.Lease.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.coordination.v1beta1.Lease.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.coordination.v1beta1.Lease.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.coordination.v1beta1.LeaseList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.coordination.v1beta1.</code><code class="descname">LeaseList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.coordination.v1beta1.LeaseList" title="Permalink to this definition">¶</a></dt>
+<dd><p>LeaseList is a list of Lease objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.coordination.v1beta1.LeaseList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.coordination.v1beta1.LeaseList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.coordination.v1beta1.LeaseList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.coordination.v1beta1.LeaseList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/core/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/core/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="core">
+<h1>core<a class="headerlink" href="#core" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/core/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/core/v1/index.md
@@ -1,0 +1,1484 @@
+<div class="section" id="module-pulumi_kubernetes.core.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.core.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.Binding">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">Binding</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>target=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.Binding" title="Permalink to this definition">¶</a></dt>
+<dd><p>Binding ties one object to another; for example, a pod is bound to a node by a scheduler.
+Deprecated in 1.7, please use the bindings subresource of pods instead.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Binding.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Binding.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Binding.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Binding.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ComponentStatus">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ComponentStatus</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>conditions=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ComponentStatus" title="Permalink to this definition">¶</a></dt>
+<dd><p>ComponentStatus (and ComponentStatusList) holds the cluster validation info.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ComponentStatus.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ComponentStatus.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ComponentStatus.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ComponentStatus.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ComponentStatusList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ComponentStatusList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ComponentStatusList" title="Permalink to this definition">¶</a></dt>
+<dd><p>Status of all the conditions for the component as a list of ComponentStatus objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ComponentStatusList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ComponentStatusList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ComponentStatusList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ComponentStatusList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ConfigMap">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ConfigMap</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>binary_data=None</em>, <em>data=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ConfigMap" title="Permalink to this definition">¶</a></dt>
+<dd><p>ConfigMap holds configuration data for pods to consume.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ConfigMap.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ConfigMap.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ConfigMap.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ConfigMap.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ConfigMapList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ConfigMapList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ConfigMapList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ConfigMapList is a resource containing a list of ConfigMap objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ConfigMapList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ConfigMapList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ConfigMapList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ConfigMapList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.Endpoints">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">Endpoints</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>subsets=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.Endpoints" title="Permalink to this definition">¶</a></dt>
+<dd><dl class="docutils">
+<dt>Endpoints is a collection of endpoints that implement the actual service. Example:</dt>
+<dd><blockquote class="first">
+<div><p>Name: “mysvc”,
+Subsets: [</p>
+<blockquote>
+<div><dl class="docutils">
+<dt>{</dt>
+<dd>Addresses: [{“ip”: “10.10.1.1”}, {“ip”: “10.10.2.2”}],
+Ports: [{“name”: “a”, “port”: 8675}, {“name”: “b”, “port”: 309}]</dd>
+</dl>
+<p>},
+{</p>
+<blockquote>
+<div>Addresses: [{“ip”: “10.10.3.3”}],
+Ports: [{“name”: “a”, “port”: 93}, {“name”: “b”, “port”: 76}]</div></blockquote>
+<p>},</p>
+</div></blockquote>
+</div></blockquote>
+<p class="last">]</p>
+</dd>
+</dl>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Endpoints.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Endpoints.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Endpoints.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Endpoints.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.EndpointsList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">EndpointsList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.EndpointsList" title="Permalink to this definition">¶</a></dt>
+<dd><p>EndpointsList is a list of endpoints.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.EndpointsList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.EndpointsList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.EndpointsList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.EndpointsList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.Event">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">Event</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>action=None</em>, <em>count=None</em>, <em>event_time=None</em>, <em>first_timestamp=None</em>, <em>involved_object=None</em>, <em>last_timestamp=None</em>, <em>message=None</em>, <em>metadata=None</em>, <em>reason=None</em>, <em>related=None</em>, <em>reporting_component=None</em>, <em>reporting_instance=None</em>, <em>series=None</em>, <em>source=None</em>, <em>type=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.Event" title="Permalink to this definition">¶</a></dt>
+<dd><p>Event is a report of an event somewhere in the cluster.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Event.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Event.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Event.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Event.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.EventList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">EventList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.EventList" title="Permalink to this definition">¶</a></dt>
+<dd><p>EventList is a list of events.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.EventList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.EventList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.EventList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.EventList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.LimitRange">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">LimitRange</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.LimitRange" title="Permalink to this definition">¶</a></dt>
+<dd><p>LimitRange sets resource usage limits for each kind of resource in a Namespace.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.LimitRange.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.LimitRange.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.LimitRange.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.LimitRange.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.LimitRangeList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">LimitRangeList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.LimitRangeList" title="Permalink to this definition">¶</a></dt>
+<dd><p>LimitRangeList is a list of LimitRange items.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.LimitRangeList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.LimitRangeList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.LimitRangeList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.LimitRangeList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.Namespace">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">Namespace</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.Namespace" title="Permalink to this definition">¶</a></dt>
+<dd><p>Namespace provides a scope for Names. Use of multiple namespaces is optional.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Namespace.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Namespace.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Namespace.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Namespace.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.NamespaceList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">NamespaceList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.NamespaceList" title="Permalink to this definition">¶</a></dt>
+<dd><p>NamespaceList is a list of Namespaces.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.NamespaceList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.NamespaceList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.NamespaceList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.NamespaceList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.Node">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">Node</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.Node" title="Permalink to this definition">¶</a></dt>
+<dd><p>Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e.
+in etcd).</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Node.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Node.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Node.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Node.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.NodeList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">NodeList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.NodeList" title="Permalink to this definition">¶</a></dt>
+<dd><p>NodeList is the whole list of all Nodes which have been registered with master.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.NodeList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.NodeList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.NodeList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.NodeList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolume">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">PersistentVolume</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolume" title="Permalink to this definition">¶</a></dt>
+<dd><p>PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to
+a node. More info: <a class="reference external" href="https://kubernetes.io/docs/concepts/storage/persistent-volumes">https://kubernetes.io/docs/concepts/storage/persistent-volumes</a></p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolume.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolume.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolume.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolume.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeClaim">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">PersistentVolumeClaim</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeClaim" title="Permalink to this definition">¶</a></dt>
+<dd><p>PersistentVolumeClaim is a user’s request for and claim to a persistent volume</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeClaim.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeClaim.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeClaim.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeClaim.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeClaimList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">PersistentVolumeClaimList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeClaimList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PersistentVolumeClaimList is a list of PersistentVolumeClaim items.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeClaimList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeClaimList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeClaimList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeClaimList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">PersistentVolumeList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PersistentVolumeList is a list of PersistentVolume items.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PersistentVolumeList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PersistentVolumeList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.Pod">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">Pod</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.Pod" title="Permalink to this definition">¶</a></dt>
+<dd><p>Pod is a collection of containers that can run on a host. This resource is created by clients
+and scheduled onto hosts.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Pod.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Pod.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Pod.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Pod.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.PodList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">PodList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.PodList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodList is a list of Pods.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PodList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PodList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PodList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PodList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.PodTemplate">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">PodTemplate</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>template=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.PodTemplate" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodTemplate describes a template for creating copies of a predefined pod.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PodTemplate.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PodTemplate.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PodTemplate.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PodTemplate.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.PodTemplateList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">PodTemplateList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.PodTemplateList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodTemplateList is a list of PodTemplates.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PodTemplateList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PodTemplateList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.PodTemplateList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.PodTemplateList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ReplicationController">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ReplicationController</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ReplicationController" title="Permalink to this definition">¶</a></dt>
+<dd><p>ReplicationController represents the configuration of a replication controller.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ReplicationController.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ReplicationController.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ReplicationController.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ReplicationController.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ReplicationControllerList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ReplicationControllerList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ReplicationControllerList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ReplicationControllerList is a collection of replication controllers.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ReplicationControllerList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ReplicationControllerList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ReplicationControllerList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ReplicationControllerList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ResourceQuota">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ResourceQuota</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ResourceQuota" title="Permalink to this definition">¶</a></dt>
+<dd><p>ResourceQuota sets aggregate quota restrictions enforced per namespace</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ResourceQuota.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ResourceQuota.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ResourceQuota.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ResourceQuota.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ResourceQuotaList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ResourceQuotaList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ResourceQuotaList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ResourceQuotaList is a list of ResourceQuota items.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ResourceQuotaList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ResourceQuotaList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ResourceQuotaList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ResourceQuotaList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.Secret">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">Secret</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>data=None</em>, <em>metadata=None</em>, <em>string_data=None</em>, <em>type=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.Secret" title="Permalink to this definition">¶</a></dt>
+<dd><p>Secret holds secret data of a certain type. The total bytes of the values in the Data field must
+be less than MaxSecretSize bytes.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Secret.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Secret.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Secret.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Secret.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.SecretList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">SecretList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.SecretList" title="Permalink to this definition">¶</a></dt>
+<dd><p>SecretList is a list of Secret.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.SecretList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.SecretList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.SecretList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.SecretList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.Service">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">Service</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.Service" title="Permalink to this definition">¶</a></dt>
+<dd><p>Service is a named abstraction of software service (for example, mysql) consisting of local port
+(for example 3306) that the proxy listens on, and the selector that determines which pods will
+answer requests sent through the proxy.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Service.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Service.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.Service.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.Service.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ServiceAccount">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ServiceAccount</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>automount_service_account_token=None</em>, <em>image_pull_secrets=None</em>, <em>metadata=None</em>, <em>secrets=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceAccount" title="Permalink to this definition">¶</a></dt>
+<dd><p>ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems,
+for an identity * a principal that can be authenticated and authorized * a set of secrets</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ServiceAccount.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceAccount.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ServiceAccount.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceAccount.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ServiceAccountList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ServiceAccountList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceAccountList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ServiceAccountList is a list of ServiceAccount objects</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ServiceAccountList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceAccountList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ServiceAccountList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceAccountList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.core.v1.ServiceList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.core.v1.</code><code class="descname">ServiceList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ServiceList holds a list of services.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ServiceList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.core.v1.ServiceList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.core.v1.ServiceList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/events/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/events/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="events">
+<h1>events<a class="headerlink" href="#events" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/events/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/events/v1beta1/index.md
@@ -1,0 +1,92 @@
+<div class="section" id="module-pulumi_kubernetes.events.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.events.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.events.v1beta1.Event">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.events.v1beta1.</code><code class="descname">Event</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>action=None</em>, <em>deprecated_count=None</em>, <em>deprecated_first_timestamp=None</em>, <em>deprecated_last_timestamp=None</em>, <em>deprecated_source=None</em>, <em>event_time=None</em>, <em>metadata=None</em>, <em>note=None</em>, <em>reason=None</em>, <em>regarding=None</em>, <em>related=None</em>, <em>reporting_controller=None</em>, <em>reporting_instance=None</em>, <em>series=None</em>, <em>type=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.events.v1beta1.Event" title="Permalink to this definition">¶</a></dt>
+<dd><p>Event is a report of an event somewhere in the cluster. It generally denotes some state change
+in the system.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.events.v1beta1.Event.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.events.v1beta1.Event.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.events.v1beta1.Event.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.events.v1beta1.Event.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.events.v1beta1.EventList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.events.v1beta1.</code><code class="descname">EventList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.events.v1beta1.EventList" title="Permalink to this definition">¶</a></dt>
+<dd><p>EventList is a list of Event objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.events.v1beta1.EventList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.events.v1beta1.EventList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.events.v1beta1.EventList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.events.v1beta1.EventList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/extensions/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/extensions/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="extensions">
+<h1>extensions<a class="headerlink" href="#extensions" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/extensions/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/extensions/v1beta1/index.md
@@ -1,0 +1,544 @@
+<div class="section" id="module-pulumi_kubernetes.extensions.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.extensions.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DaemonSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">DaemonSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DaemonSet" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the
+release notes for more information. DaemonSet represents the configuration of a daemon set.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DaemonSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DaemonSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DaemonSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DaemonSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DaemonSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">DaemonSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DaemonSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>DaemonSetList is a collection of daemon sets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DaemonSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DaemonSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DaemonSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DaemonSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.Deployment">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">Deployment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.Deployment" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the
+release notes for more information. Deployment enables declarative updates for Pods and
+ReplicaSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.Deployment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.Deployment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.Deployment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.Deployment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DeploymentList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">DeploymentList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DeploymentList" title="Permalink to this definition">¶</a></dt>
+<dd><p>DeploymentList is a list of Deployments.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DeploymentList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DeploymentList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.DeploymentList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.DeploymentList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.Ingress">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">Ingress</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.Ingress" title="Permalink to this definition">¶</a></dt>
+<dd><p>Ingress is a collection of rules that allow inbound connections to reach the endpoints defined
+by a backend. An Ingress can be configured to give services externally-reachable urls, load
+balance traffic, terminate SSL, offer name based virtual hosting etc.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.Ingress.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.Ingress.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.Ingress.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.Ingress.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.IngressList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">IngressList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.IngressList" title="Permalink to this definition">¶</a></dt>
+<dd><p>IngressList is a collection of Ingress.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.IngressList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.IngressList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.IngressList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.IngressList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.NetworkPolicy">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">NetworkPolicy</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.NetworkPolicy" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by
+networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set
+of Pods</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.NetworkPolicy.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.NetworkPolicy.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.NetworkPolicy.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.NetworkPolicy.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.NetworkPolicyList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">NetworkPolicyList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.NetworkPolicyList" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED 1.9 - This group version of NetworkPolicyList is deprecated by
+networking/v1/NetworkPolicyList. Network Policy List is a list of NetworkPolicy objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.NetworkPolicyList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.NetworkPolicyList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.NetworkPolicyList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.NetworkPolicyList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicy">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">PodSecurityPolicy</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicy" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodSecurityPolicy governs the ability to make requests that affect the Security Context that
+will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group
+instead.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicy.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicy.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicy.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicy.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicyList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">PodSecurityPolicyList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicyList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use
+PodSecurityPolicyList from policy API Group instead.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicyList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicyList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicyList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.PodSecurityPolicyList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.ReplicaSet">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">ReplicaSet</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.ReplicaSet" title="Permalink to this definition">¶</a></dt>
+<dd><p>DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the
+release notes for more information. ReplicaSet ensures that a specified number of pod replicas
+are running at any given time.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.ReplicaSet.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.ReplicaSet.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.ReplicaSet.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.ReplicaSet.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.extensions.v1beta1.ReplicaSetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.extensions.v1beta1.</code><code class="descname">ReplicaSetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.ReplicaSetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ReplicaSetList is a collection of ReplicaSets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.ReplicaSetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.ReplicaSetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.extensions.v1beta1.ReplicaSetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.extensions.v1beta1.ReplicaSetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/index.md
@@ -1,0 +1,106 @@
+<div class="section" id="pulumi-kubernetes">
+<h1>Pulumi Kubernetes<a class="headerlink" href="#pulumi-kubernetes" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="admissionregistration/">admissionregistration</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="admissionregistration/v1alpha1/">v1alpha1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="admissionregistration/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="apiextensions/">apiextensions</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="apiextensions/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="apiregistration/">apiregistration</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="apiregistration/v1/">v1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="apiregistration/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="apps/">apps</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="apps/v1/">v1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="apps/v1beta1/">v1beta1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="apps/v1beta2/">v1beta2</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="auditregistration/">auditregistration</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="auditregistration/v1alpha1/">v1alpha1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="authentication/">authentication</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="authentication/v1/">v1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="authentication/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="authorization/">authorization</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="authorization/v1/">v1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="authorization/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="autoscaling/">autoscaling</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="autoscaling/v1/">v1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="autoscaling/v2beta1/">v2beta1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="autoscaling/v2beta2/">v2beta2</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="batch/">batch</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="batch/v1/">v1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="batch/v1beta1/">v1beta1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="batch/v2alpha1/">v2alpha1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="certificates/">certificates</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="certificates/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="coordination/">coordination</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="coordination/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="core/">core</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="core/v1/">v1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="events/">events</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="events/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="extensions/">extensions</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="extensions/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="meta/">meta</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="meta/v1/">v1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="networking/">networking</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="networking/v1/">v1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="policy/">policy</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="policy/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="rbac/">rbac</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="rbac/v1/">v1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="rbac/v1alpha1/">v1alpha1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="rbac/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="scheduling/">scheduling</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="scheduling/v1alpha1/">v1alpha1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="scheduling/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="settings/">settings</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="settings/v1alpha1/">v1alpha1</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="storage/">storage</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="storage/v1/">v1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="storage/v1alpha1/">v1alpha1</a></li>
+<li class="toctree-l2"><a class="reference internal" href="storage/v1beta1/">v1beta1</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/meta/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/meta/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="meta">
+<h1>meta<a class="headerlink" href="#meta" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/meta/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/meta/v1/index.md
@@ -1,0 +1,47 @@
+<div class="section" id="module-pulumi_kubernetes.meta.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.meta.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.meta.v1.Status">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.meta.v1.</code><code class="descname">Status</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>code=None</em>, <em>details=None</em>, <em>message=None</em>, <em>metadata=None</em>, <em>reason=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.meta.v1.Status" title="Permalink to this definition">¶</a></dt>
+<dd><p>Status is a return value for calls that don’t return other objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.meta.v1.Status.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.meta.v1.Status.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.meta.v1.Status.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.meta.v1.Status.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/networking/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/networking/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="networking">
+<h1>networking<a class="headerlink" href="#networking" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/networking/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/networking/v1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.networking.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.networking.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.networking.v1.NetworkPolicy">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.networking.v1.</code><code class="descname">NetworkPolicy</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.networking.v1.NetworkPolicy" title="Permalink to this definition">¶</a></dt>
+<dd><p>NetworkPolicy describes what network traffic is allowed for a set of Pods</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.networking.v1.NetworkPolicy.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.networking.v1.NetworkPolicy.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.networking.v1.NetworkPolicy.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.networking.v1.NetworkPolicy.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.networking.v1.NetworkPolicyList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.networking.v1.</code><code class="descname">NetworkPolicyList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.networking.v1.NetworkPolicyList" title="Permalink to this definition">¶</a></dt>
+<dd><p>NetworkPolicyList is a list of NetworkPolicy objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.networking.v1.NetworkPolicyList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.networking.v1.NetworkPolicyList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.networking.v1.NetworkPolicyList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.networking.v1.NetworkPolicyList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/policy/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/policy/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="policy">
+<h1>policy<a class="headerlink" href="#policy" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/policy/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/policy/v1beta1/index.md
@@ -1,0 +1,181 @@
+<div class="section" id="module-pulumi_kubernetes.policy.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.policy.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodDisruptionBudget">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.policy.v1beta1.</code><code class="descname">PodDisruptionBudget</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodDisruptionBudget" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodDisruptionBudget is an object to define the max disruption that can be caused to a collection
+of pods</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodDisruptionBudget.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodDisruptionBudget.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodDisruptionBudget.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodDisruptionBudget.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodDisruptionBudgetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.policy.v1beta1.</code><code class="descname">PodDisruptionBudgetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodDisruptionBudgetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodDisruptionBudgetList is a collection of PodDisruptionBudgets.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodDisruptionBudgetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodDisruptionBudgetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodDisruptionBudgetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodDisruptionBudgetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodSecurityPolicy">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.policy.v1beta1.</code><code class="descname">PodSecurityPolicy</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodSecurityPolicy" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodSecurityPolicy governs the ability to make requests that affect the Security Context that
+will be applied to a pod and container.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodSecurityPolicy.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodSecurityPolicy.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodSecurityPolicy.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodSecurityPolicy.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodSecurityPolicyList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.policy.v1beta1.</code><code class="descname">PodSecurityPolicyList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodSecurityPolicyList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodSecurityPolicyList is a list of PodSecurityPolicy objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodSecurityPolicyList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodSecurityPolicyList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.policy.v1beta1.PodSecurityPolicyList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.policy.v1beta1.PodSecurityPolicyList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/rbac/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/rbac/index.md
@@ -1,0 +1,10 @@
+<div class="section" id="rbac">
+<h1>rbac<a class="headerlink" href="#rbac" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1alpha1/">v1alpha1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/rbac/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/rbac/v1/index.md
@@ -1,0 +1,361 @@
+<div class="section" id="module-pulumi_kubernetes.rbac.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.rbac.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRole">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1.</code><code class="descname">ClusterRole</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>aggregation_rule=None</em>, <em>metadata=None</em>, <em>rules=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRole" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit
+by a RoleBinding or ClusterRoleBinding.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRole.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRole.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRole.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRole.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleBinding">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1.</code><code class="descname">ClusterRoleBinding</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>role_ref=None</em>, <em>subjects=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleBinding" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole
+in the global namespace, and adds who information via Subject.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleBinding.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleBinding.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleBinding.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleBinding.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleBindingList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1.</code><code class="descname">ClusterRoleBindingList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleBindingList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleBindingList is a collection of ClusterRoleBindings</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleBindingList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleBindingList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleBindingList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleBindingList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1.</code><code class="descname">ClusterRoleList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleList is a collection of ClusterRoles</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.ClusterRoleList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.ClusterRoleList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1.Role">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1.</code><code class="descname">Role</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>rules=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1.Role" title="Permalink to this definition">¶</a></dt>
+<dd><p>Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a
+RoleBinding.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.Role.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.Role.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.Role.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.Role.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1.RoleBinding">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1.</code><code class="descname">RoleBinding</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>role_ref=None</em>, <em>subjects=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleBinding" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleBinding references a role, but does not contain it.  It can reference a Role in the same
+namespace or a ClusterRole in the global namespace. It adds who information via Subjects and
+namespace information by which namespace it exists in.  RoleBindings in a given namespace only
+have effect in that namespace.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.RoleBinding.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleBinding.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.RoleBinding.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleBinding.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1.RoleBindingList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1.</code><code class="descname">RoleBindingList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleBindingList" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleBindingList is a collection of RoleBindings</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.RoleBindingList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleBindingList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.RoleBindingList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleBindingList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1.RoleList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1.</code><code class="descname">RoleList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleList" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleList is a collection of Roles</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.RoleList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1.RoleList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1.RoleList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/rbac/v1alpha1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/rbac/v1alpha1/index.md
@@ -1,0 +1,361 @@
+<div class="section" id="module-pulumi_kubernetes.rbac.v1alpha1">
+<span id="v1alpha1"></span><h1>v1alpha1<a class="headerlink" href="#module-pulumi_kubernetes.rbac.v1alpha1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRole">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1alpha1.</code><code class="descname">ClusterRole</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>aggregation_rule=None</em>, <em>metadata=None</em>, <em>rules=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRole" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit
+by a RoleBinding or ClusterRoleBinding.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRole.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRole.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRole.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRole.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBinding">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1alpha1.</code><code class="descname">ClusterRoleBinding</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>role_ref=None</em>, <em>subjects=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBinding" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole
+in the global namespace, and adds who information via Subject.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBinding.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBinding.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBinding.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBinding.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBindingList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1alpha1.</code><code class="descname">ClusterRoleBindingList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBindingList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleBindingList is a collection of ClusterRoleBindings</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBindingList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBindingList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBindingList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleBindingList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1alpha1.</code><code class="descname">ClusterRoleList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleList is a collection of ClusterRoles</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.ClusterRoleList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.ClusterRoleList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.Role">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1alpha1.</code><code class="descname">Role</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>rules=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.Role" title="Permalink to this definition">¶</a></dt>
+<dd><p>Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a
+RoleBinding.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.Role.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.Role.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.Role.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.Role.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleBinding">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1alpha1.</code><code class="descname">RoleBinding</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>role_ref=None</em>, <em>subjects=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleBinding" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleBinding references a role, but does not contain it.  It can reference a Role in the same
+namespace or a ClusterRole in the global namespace. It adds who information via Subjects and
+namespace information by which namespace it exists in.  RoleBindings in a given namespace only
+have effect in that namespace.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleBinding.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleBinding.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleBinding.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleBinding.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleBindingList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1alpha1.</code><code class="descname">RoleBindingList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleBindingList" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleBindingList is a collection of RoleBindings</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleBindingList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleBindingList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleBindingList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleBindingList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1alpha1.</code><code class="descname">RoleList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleList" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleList is a collection of Roles</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1alpha1.RoleList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1alpha1.RoleList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/rbac/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/rbac/v1beta1/index.md
@@ -1,0 +1,361 @@
+<div class="section" id="module-pulumi_kubernetes.rbac.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.rbac.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRole">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1beta1.</code><code class="descname">ClusterRole</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>aggregation_rule=None</em>, <em>metadata=None</em>, <em>rules=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRole" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit
+by a RoleBinding or ClusterRoleBinding.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRole.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRole.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRole.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRole.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleBinding">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1beta1.</code><code class="descname">ClusterRoleBinding</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>role_ref=None</em>, <em>subjects=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleBinding" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole
+in the global namespace, and adds who information via Subject.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleBinding.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleBinding.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleBinding.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleBinding.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleBindingList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1beta1.</code><code class="descname">ClusterRoleBindingList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleBindingList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleBindingList is a collection of ClusterRoleBindings</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleBindingList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleBindingList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleBindingList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleBindingList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1beta1.</code><code class="descname">ClusterRoleList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleList" title="Permalink to this definition">¶</a></dt>
+<dd><p>ClusterRoleList is a collection of ClusterRoles</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.ClusterRoleList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.ClusterRoleList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1beta1.Role">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1beta1.</code><code class="descname">Role</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>rules=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.Role" title="Permalink to this definition">¶</a></dt>
+<dd><p>Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a
+RoleBinding.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.Role.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.Role.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.Role.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.Role.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleBinding">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1beta1.</code><code class="descname">RoleBinding</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>role_ref=None</em>, <em>subjects=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleBinding" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleBinding references a role, but does not contain it.  It can reference a Role in the same
+namespace or a ClusterRole in the global namespace. It adds who information via Subjects and
+namespace information by which namespace it exists in.  RoleBindings in a given namespace only
+have effect in that namespace.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleBinding.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleBinding.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleBinding.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleBinding.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleBindingList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1beta1.</code><code class="descname">RoleBindingList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleBindingList" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleBindingList is a collection of RoleBindings</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleBindingList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleBindingList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleBindingList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleBindingList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.rbac.v1beta1.</code><code class="descname">RoleList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleList" title="Permalink to this definition">¶</a></dt>
+<dd><p>RoleList is a collection of Roles</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.rbac.v1beta1.RoleList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.rbac.v1beta1.RoleList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/scheduling/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/scheduling/index.md
@@ -1,0 +1,9 @@
+<div class="section" id="scheduling">
+<h1>scheduling<a class="headerlink" href="#scheduling" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1alpha1/">v1alpha1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/scheduling/v1alpha1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/scheduling/v1alpha1/index.md
@@ -1,0 +1,92 @@
+<div class="section" id="module-pulumi_kubernetes.scheduling.v1alpha1">
+<span id="v1alpha1"></span><h1>v1alpha1<a class="headerlink" href="#module-pulumi_kubernetes.scheduling.v1alpha1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.scheduling.v1alpha1.PriorityClass">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.scheduling.v1alpha1.</code><code class="descname">PriorityClass</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>description=None</em>, <em>global_default=None</em>, <em>metadata=None</em>, <em>value=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.scheduling.v1alpha1.PriorityClass" title="Permalink to this definition">¶</a></dt>
+<dd><p>PriorityClass defines mapping from a priority class name to the priority integer value. The
+value can be any valid integer.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.scheduling.v1alpha1.PriorityClass.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.scheduling.v1alpha1.PriorityClass.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.scheduling.v1alpha1.PriorityClass.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.scheduling.v1alpha1.PriorityClass.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.scheduling.v1alpha1.PriorityClassList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.scheduling.v1alpha1.</code><code class="descname">PriorityClassList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.scheduling.v1alpha1.PriorityClassList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PriorityClassList is a collection of priority classes.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.scheduling.v1alpha1.PriorityClassList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.scheduling.v1alpha1.PriorityClassList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.scheduling.v1alpha1.PriorityClassList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.scheduling.v1alpha1.PriorityClassList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/scheduling/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/scheduling/v1beta1/index.md
@@ -1,0 +1,92 @@
+<div class="section" id="module-pulumi_kubernetes.scheduling.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.scheduling.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.scheduling.v1beta1.PriorityClass">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.scheduling.v1beta1.</code><code class="descname">PriorityClass</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>description=None</em>, <em>global_default=None</em>, <em>metadata=None</em>, <em>value=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.scheduling.v1beta1.PriorityClass" title="Permalink to this definition">¶</a></dt>
+<dd><p>PriorityClass defines mapping from a priority class name to the priority integer value. The
+value can be any valid integer.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.scheduling.v1beta1.PriorityClass.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.scheduling.v1beta1.PriorityClass.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.scheduling.v1beta1.PriorityClass.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.scheduling.v1beta1.PriorityClass.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.scheduling.v1beta1.PriorityClassList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.scheduling.v1beta1.</code><code class="descname">PriorityClassList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.scheduling.v1beta1.PriorityClassList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PriorityClassList is a collection of priority classes.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.scheduling.v1beta1.PriorityClassList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.scheduling.v1beta1.PriorityClassList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.scheduling.v1beta1.PriorityClassList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.scheduling.v1beta1.PriorityClassList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/settings/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/settings/index.md
@@ -1,0 +1,8 @@
+<div class="section" id="settings">
+<h1>settings<a class="headerlink" href="#settings" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1alpha1/">v1alpha1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/settings/v1alpha1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/settings/v1alpha1/index.md
@@ -1,0 +1,91 @@
+<div class="section" id="module-pulumi_kubernetes.settings.v1alpha1">
+<span id="v1alpha1"></span><h1>v1alpha1<a class="headerlink" href="#module-pulumi_kubernetes.settings.v1alpha1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.settings.v1alpha1.PodPreset">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.settings.v1alpha1.</code><code class="descname">PodPreset</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.settings.v1alpha1.PodPreset" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodPreset is a policy resource that defines additional runtime requirements for a Pod.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.settings.v1alpha1.PodPreset.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.settings.v1alpha1.PodPreset.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.settings.v1alpha1.PodPreset.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.settings.v1alpha1.PodPreset.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.settings.v1alpha1.PodPresetList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.settings.v1alpha1.</code><code class="descname">PodPresetList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.settings.v1alpha1.PodPresetList" title="Permalink to this definition">¶</a></dt>
+<dd><p>PodPresetList is a list of PodPreset objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.settings.v1alpha1.PodPresetList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.settings.v1alpha1.PodPresetList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.settings.v1alpha1.PodPresetList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.settings.v1alpha1.PodPresetList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/storage/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/storage/index.md
@@ -1,0 +1,10 @@
+<div class="section" id="storage">
+<h1>storage<a class="headerlink" href="#storage" title="Permalink to this headline">¶</a></h1>
+<div class="toctree-wrapper compound">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="v1/">v1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1alpha1/">v1alpha1</a></li>
+<li class="toctree-l1"><a class="reference internal" href="v1beta1/">v1beta1</a></li>
+</ul>
+</div>
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/storage/v1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/storage/v1/index.md
@@ -1,0 +1,184 @@
+<div class="section" id="module-pulumi_kubernetes.storage.v1">
+<span id="v1"></span><h1>v1<a class="headerlink" href="#module-pulumi_kubernetes.storage.v1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1.StorageClass">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1.</code><code class="descname">StorageClass</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>allow_volume_expansion=None</em>, <em>allowed_topologies=None</em>, <em>metadata=None</em>, <em>mount_options=None</em>, <em>parameters=None</em>, <em>provisioner=None</em>, <em>reclaim_policy=None</em>, <em>volume_binding_mode=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1.StorageClass" title="Permalink to this definition">¶</a></dt>
+<dd><p>StorageClass describes the parameters for a class of storage for which PersistentVolumes can be
+dynamically provisioned.</p>
+<p>StorageClasses are non-namespaced; the name of the storage class according to etcd is in
+ObjectMeta.Name.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1.StorageClass.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1.StorageClass.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1.StorageClass.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1.StorageClass.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1.StorageClassList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1.</code><code class="descname">StorageClassList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1.StorageClassList" title="Permalink to this definition">¶</a></dt>
+<dd><p>StorageClassList is a collection of storage classes.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1.StorageClassList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1.StorageClassList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1.StorageClassList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1.StorageClassList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1.VolumeAttachment">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1.</code><code class="descname">VolumeAttachment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1.VolumeAttachment" title="Permalink to this definition">¶</a></dt>
+<dd><p>VolumeAttachment captures the intent to attach or detach the specified volume to/from the
+specified node.</p>
+<p>VolumeAttachment objects are non-namespaced.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1.VolumeAttachment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1.VolumeAttachment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1.VolumeAttachment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1.VolumeAttachment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1.VolumeAttachmentList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1.</code><code class="descname">VolumeAttachmentList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1.VolumeAttachmentList" title="Permalink to this definition">¶</a></dt>
+<dd><p>VolumeAttachmentList is a collection of VolumeAttachment objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1.VolumeAttachmentList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1.VolumeAttachmentList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1.VolumeAttachmentList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1.VolumeAttachmentList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/storage/v1alpha1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/storage/v1alpha1/index.md
@@ -1,0 +1,93 @@
+<div class="section" id="module-pulumi_kubernetes.storage.v1alpha1">
+<span id="v1alpha1"></span><h1>v1alpha1<a class="headerlink" href="#module-pulumi_kubernetes.storage.v1alpha1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1alpha1.VolumeAttachment">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1alpha1.</code><code class="descname">VolumeAttachment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1alpha1.VolumeAttachment" title="Permalink to this definition">¶</a></dt>
+<dd><p>VolumeAttachment captures the intent to attach or detach the specified volume to/from the
+specified node.</p>
+<p>VolumeAttachment objects are non-namespaced.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1alpha1.VolumeAttachment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1alpha1.VolumeAttachment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1alpha1.VolumeAttachment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1alpha1.VolumeAttachment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1alpha1.VolumeAttachmentList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1alpha1.</code><code class="descname">VolumeAttachmentList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1alpha1.VolumeAttachmentList" title="Permalink to this definition">¶</a></dt>
+<dd><p>VolumeAttachmentList is a collection of VolumeAttachment objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1alpha1.VolumeAttachmentList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1alpha1.VolumeAttachmentList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1alpha1.VolumeAttachmentList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1alpha1.VolumeAttachmentList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_kubernetes/storage/v1beta1/index.md
+++ b/reference/pkg/python/pulumi_kubernetes/storage/v1beta1/index.md
@@ -1,0 +1,184 @@
+<div class="section" id="module-pulumi_kubernetes.storage.v1beta1">
+<span id="v1beta1"></span><h1>v1beta1<a class="headerlink" href="#module-pulumi_kubernetes.storage.v1beta1" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1beta1.StorageClass">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1beta1.</code><code class="descname">StorageClass</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>allow_volume_expansion=None</em>, <em>allowed_topologies=None</em>, <em>metadata=None</em>, <em>mount_options=None</em>, <em>parameters=None</em>, <em>provisioner=None</em>, <em>reclaim_policy=None</em>, <em>volume_binding_mode=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.StorageClass" title="Permalink to this definition">¶</a></dt>
+<dd><p>StorageClass describes the parameters for a class of storage for which PersistentVolumes can be
+dynamically provisioned.</p>
+<p>StorageClasses are non-namespaced; the name of the storage class according to etcd is in
+ObjectMeta.Name.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1beta1.StorageClass.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.StorageClass.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1beta1.StorageClass.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.StorageClass.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1beta1.StorageClassList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1beta1.</code><code class="descname">StorageClassList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.StorageClassList" title="Permalink to this definition">¶</a></dt>
+<dd><p>StorageClassList is a collection of storage classes.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1beta1.StorageClassList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.StorageClassList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1beta1.StorageClassList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.StorageClassList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1beta1.VolumeAttachment">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1beta1.</code><code class="descname">VolumeAttachment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>metadata=None</em>, <em>spec=None</em>, <em>status=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.VolumeAttachment" title="Permalink to this definition">¶</a></dt>
+<dd><p>VolumeAttachment captures the intent to attach or detach the specified volume to/from the
+specified node.</p>
+<p>VolumeAttachment objects are non-namespaced.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1beta1.VolumeAttachment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.VolumeAttachment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1beta1.VolumeAttachment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.VolumeAttachment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_kubernetes.storage.v1beta1.VolumeAttachmentList">
+<em class="property">class </em><code class="descclassname">pulumi_kubernetes.storage.v1beta1.</code><code class="descname">VolumeAttachmentList</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>items=None</em>, <em>metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.VolumeAttachmentList" title="Permalink to this definition">¶</a></dt>
+<dd><p>VolumeAttachmentList is a collection of VolumeAttachment objects.</p>
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1beta1.VolumeAttachmentList.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.VolumeAttachmentList.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_kubernetes.storage.v1beta1.VolumeAttachmentList.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop: str</em><span class="sig-paren">)</span> &#x2192; str<a class="headerlink" href="#pulumi_kubernetes.storage.v1beta1.VolumeAttachmentList.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+</div>

--- a/reference/pkg/python/pulumi_openstack/index.md
+++ b/reference/pkg/python/pulumi_openstack/index.md
@@ -4,7 +4,6 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="blockstorage/">blockstorage</a></li>
 <li class="toctree-l1"><a class="reference internal" href="compute/">compute</a></li>
-<li class="toctree-l1"><a class="reference internal" href="config/">config</a></li>
 <li class="toctree-l1"><a class="reference internal" href="containerinfra/">containerinfra</a></li>
 <li class="toctree-l1"><a class="reference internal" href="database/">database</a></li>
 <li class="toctree-l1"><a class="reference internal" href="dns/">dns</a></li>

--- a/reference/pkg/python/pulumi_packet/index.md
+++ b/reference/pkg/python/pulumi_packet/index.md
@@ -1,8 +1,1188 @@
-<div class="section" id="pulumi-packet">
-<h1>Pulumi Packet<a class="headerlink" href="#pulumi-packet" title="Permalink to this headline">¶</a></h1>
-<div class="toctree-wrapper compound">
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="config/">config</a></li>
+<div class="section" id="module-pulumi_packet">
+<span id="pulumi-packet"></span><h1>Pulumi Packet<a class="headerlink" href="#module-pulumi_packet" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_packet.Device">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">Device</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>always_pxe=None</em>, <em>billing_cycle=None</em>, <em>description=None</em>, <em>facility=None</em>, <em>hardware_reservation_id=None</em>, <em>hostname=None</em>, <em>ipxe_script_url=None</em>, <em>operating_system=None</em>, <em>plan=None</em>, <em>project_id=None</em>, <em>public_ipv4_subnet_size=None</em>, <em>storage=None</em>, <em>tags=None</em>, <em>user_data=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Device" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a Packet device resource. This can be used to create,
+modify, and delete devices.</p>
+<dl class="docutils">
+<dt>&gt; <strong>Note:</strong> All arguments including the root_password and user_data will be stored in</dt>
+<dd>the raw state as plain-text.</dd>
+</dl>
+<p>[Read more about sensitive data in state](<a class="reference external" href="https://www.terraform.io/docs/state/sensitive-data.html">https://www.terraform.io/docs/state/sensitive-data.html</a>).</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>always_pxe</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If true, a device with OS <cite>custom_ipxe</cite> will
+continue to boot via iPXE on reboots.</li>
+<li><strong>billing_cycle</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – monthly or hourly</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Description string for the device</li>
+<li><strong>facility</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The facility in which to create the device. To find the facility code, visit [Facilities API docs](<a class="reference external" href="https://www.packet.net/developers/api/#facilities">https://www.packet.net/developers/api/#facilities</a>), set your API auth token in the top of the page and see JSON from the API response.</li>
+<li><strong>hardware_reservation_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The id of hardware reservation where you want this device deployed, or <cite>next-available</cite> if you want to pick your next available reservation automatically.</li>
+<li><strong>hostname</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The device name</li>
+<li><strong>ipxe_script_url</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – URL pointing to a hosted iPXE script. More
+information is in the
+[Custom iPXE](<a class="reference external" href="https://help.packet.net/article/26-custom-ipxe">https://help.packet.net/article/26-custom-ipxe</a>)
+doc.</li>
+<li><strong>operating_system</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The operating system slug. To find the slug, or visit [Operating Systems API docs](<a class="reference external" href="https://www.packet.net/developers/api/#operatingsystems">https://www.packet.net/developers/api/#operatingsystems</a>), set your API auth token in the top of the page and see JSON from the API response.</li>
+<li><strong>plan</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The device plan slug. To find the plan slug, visit [Device plans API docs](<a class="reference external" href="https://www.packet.net/developers/api/#plans">https://www.packet.net/developers/api/#plans</a>), set your auth token in the top of the page and see JSON from the API response.</li>
+<li><strong>project_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The id of the project in which to create the device</li>
+<li><strong>public_ipv4_subnet_size</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Size of allocated subnet, more
+information is in the
+[Custom Subnet Size](<a class="reference external" href="https://help.packet.net/article/55-custom-subnet-size">https://help.packet.net/article/55-custom-subnet-size</a>) doc.</li>
+<li><strong>storage</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](<a class="reference external" href="https://help.packet.net/article/61-custom-partitioning-raid">https://help.packet.net/article/61-custom-partitioning-raid</a>) doc.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – Tags attached to the device</li>
+<li><strong>user_data</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A string of the desired User Data for the device.</li>
 </ul>
-</div>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.Device.access_private_ipv4">
+<code class="descname">access_private_ipv4</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.access_private_ipv4" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ipv4 private IP assigned to the device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.access_public_ipv4">
+<code class="descname">access_public_ipv4</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.access_public_ipv4" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ipv4 maintenance IP assigned to the device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.access_public_ipv6">
+<code class="descname">access_public_ipv6</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.access_public_ipv6" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ipv6 maintenance IP assigned to the device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.always_pxe">
+<code class="descname">always_pxe</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.always_pxe" title="Permalink to this definition">¶</a></dt>
+<dd><p>If true, a device with OS <cite>custom_ipxe</cite> will
+continue to boot via iPXE on reboots.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.billing_cycle">
+<code class="descname">billing_cycle</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.billing_cycle" title="Permalink to this definition">¶</a></dt>
+<dd><p>monthly or hourly</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.created">
+<code class="descname">created</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.created" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timestamp for when the device was created</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>Description string for the device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.facility">
+<code class="descname">facility</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.facility" title="Permalink to this definition">¶</a></dt>
+<dd><p>The facility in which to create the device. To find the facility code, visit [Facilities API docs](<a class="reference external" href="https://www.packet.net/developers/api/#facilities">https://www.packet.net/developers/api/#facilities</a>), set your API auth token in the top of the page and see JSON from the API response.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.hardware_reservation_id">
+<code class="descname">hardware_reservation_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.hardware_reservation_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The id of hardware reservation where you want this device deployed, or <cite>next-available</cite> if you want to pick your next available reservation automatically.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.hostname">
+<code class="descname">hostname</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.hostname" title="Permalink to this definition">¶</a></dt>
+<dd><p>The device name</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.ipxe_script_url">
+<code class="descname">ipxe_script_url</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.ipxe_script_url" title="Permalink to this definition">¶</a></dt>
+<dd><p>URL pointing to a hosted iPXE script. More
+information is in the
+[Custom iPXE](<a class="reference external" href="https://help.packet.net/article/26-custom-ipxe">https://help.packet.net/article/26-custom-ipxe</a>)
+doc.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.locked">
+<code class="descname">locked</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.locked" title="Permalink to this definition">¶</a></dt>
+<dd><p>Whether the device is locked</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.networks">
+<code class="descname">networks</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.networks" title="Permalink to this definition">¶</a></dt>
+<dd><p>The device’s private and public IP (v4 and v6) network details</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.operating_system">
+<code class="descname">operating_system</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.operating_system" title="Permalink to this definition">¶</a></dt>
+<dd><p>The operating system slug. To find the slug, or visit [Operating Systems API docs](<a class="reference external" href="https://www.packet.net/developers/api/#operatingsystems">https://www.packet.net/developers/api/#operatingsystems</a>), set your API auth token in the top of the page and see JSON from the API response.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.plan">
+<code class="descname">plan</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.plan" title="Permalink to this definition">¶</a></dt>
+<dd><p>The device plan slug. To find the plan slug, visit [Device plans API docs](<a class="reference external" href="https://www.packet.net/developers/api/#plans">https://www.packet.net/developers/api/#plans</a>), set your auth token in the top of the page and see JSON from the API response.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.project_id">
+<code class="descname">project_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.project_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The id of the project in which to create the device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.public_ipv4_subnet_size">
+<code class="descname">public_ipv4_subnet_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.public_ipv4_subnet_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>Size of allocated subnet, more
+information is in the
+[Custom Subnet Size](<a class="reference external" href="https://help.packet.net/article/55-custom-subnet-size">https://help.packet.net/article/55-custom-subnet-size</a>) doc.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.root_password">
+<code class="descname">root_password</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.root_password" title="Permalink to this definition">¶</a></dt>
+<dd><p>Root password to the server (disabled after 24 hours)</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.state">
+<code class="descname">state</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.state" title="Permalink to this definition">¶</a></dt>
+<dd><p>The status of the device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.storage">
+<code class="descname">storage</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.storage" title="Permalink to this definition">¶</a></dt>
+<dd><p>JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](<a class="reference external" href="https://help.packet.net/article/61-custom-partitioning-raid">https://help.packet.net/article/61-custom-partitioning-raid</a>) doc.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>Tags attached to the device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.updated">
+<code class="descname">updated</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.updated" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timestamp for the last time the device was updated</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Device.user_data">
+<code class="descname">user_data</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Device.user_data" title="Permalink to this definition">¶</a></dt>
+<dd><p>A string of the desired User Data for the device.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Device.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Device.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Device.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Device.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.GetOperatingSystemResult">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">GetOperatingSystemResult</code><span class="sig-paren">(</span><em>slug=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.GetOperatingSystemResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getOperatingSystem.</p>
+<dl class="attribute">
+<dt id="pulumi_packet.GetOperatingSystemResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.GetOperatingSystemResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.GetPrecreatedIpBlockResult">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">GetPrecreatedIpBlockResult</code><span class="sig-paren">(</span><em>address=None</em>, <em>cidr=None</em>, <em>cidr_notation=None</em>, <em>gateway=None</em>, <em>manageable=None</em>, <em>management=None</em>, <em>netmask=None</em>, <em>network=None</em>, <em>quantity=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.GetPrecreatedIpBlockResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getPrecreatedIpBlock.</p>
+<dl class="attribute">
+<dt id="pulumi_packet.GetPrecreatedIpBlockResult.cidr_notation">
+<code class="descname">cidr_notation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.GetPrecreatedIpBlockResult.cidr_notation" title="Permalink to this definition">¶</a></dt>
+<dd><p>CIDR notation of the looked up block.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.GetPrecreatedIpBlockResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.GetPrecreatedIpBlockResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.GetSpotMarketPriceResult">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">GetSpotMarketPriceResult</code><span class="sig-paren">(</span><em>price=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.GetSpotMarketPriceResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getSpotMarketPrice.</p>
+<dl class="attribute">
+<dt id="pulumi_packet.GetSpotMarketPriceResult.price">
+<code class="descname">price</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.GetSpotMarketPriceResult.price" title="Permalink to this definition">¶</a></dt>
+<dd><p>Current spot market price for given plan in given facility.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.GetSpotMarketPriceResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.GetSpotMarketPriceResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.IpAttachment">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">IpAttachment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>cidr_notation=None</em>, <em>device_id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.IpAttachment" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a resource to attach elastic IP subnets to devices.</p>
+<p>To attach an IP subnet from a reserved block to a provisioned device, you must derive a subnet CIDR belonging to
+one of your reserved blocks in the same project and facility as the target device.</p>
+<p>For example, you have reserved IPv4 address block 147.229.10.152/30, you can choose to assign either the whole
+block as one subnet to a device; or 2 subnets with CIDRs 147.229.10.152/31’ and 147.229.10.154/31; or 4 subnets
+with mask prefix length 32. More about the elastic IP subnets is [here](<a class="reference external" href="https://help.packet.net/article/54-elastic-ips">https://help.packet.net/article/54-elastic-ips</a>).</p>
+<p>Device and reserved block must be in the same facility.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>cidr_notation</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – CIDR notation of subnet from block reserved in the same
+project and facility as the device</li>
+<li><strong>device_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – ID of device to which to assign the subnet</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.IpAttachment.address_family">
+<code class="descname">address_family</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.IpAttachment.address_family" title="Permalink to this definition">¶</a></dt>
+<dd><p>Address family as integer (4 or 6)</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.IpAttachment.cidr">
+<code class="descname">cidr</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.IpAttachment.cidr" title="Permalink to this definition">¶</a></dt>
+<dd><p>length of CIDR prefix of the subnet as integer</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.IpAttachment.cidr_notation">
+<code class="descname">cidr_notation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.IpAttachment.cidr_notation" title="Permalink to this definition">¶</a></dt>
+<dd><p>CIDR notation of subnet from block reserved in the same
+project and facility as the device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.IpAttachment.device_id">
+<code class="descname">device_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.IpAttachment.device_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>ID of device to which to assign the subnet</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.IpAttachment.gateway">
+<code class="descname">gateway</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.IpAttachment.gateway" title="Permalink to this definition">¶</a></dt>
+<dd><p>IP address of gateway for the subnet</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.IpAttachment.netmask">
+<code class="descname">netmask</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.IpAttachment.netmask" title="Permalink to this definition">¶</a></dt>
+<dd><p>Subnet mask in decimal notation, e.g. “255.255.255.0”</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.IpAttachment.network">
+<code class="descname">network</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.IpAttachment.network" title="Permalink to this definition">¶</a></dt>
+<dd><p>Subnet network address</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.IpAttachment.public">
+<code class="descname">public</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.IpAttachment.public" title="Permalink to this definition">¶</a></dt>
+<dd><p>boolean flag whether subnet is reachable from the Internet</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.IpAttachment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.IpAttachment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.IpAttachment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.IpAttachment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.Organization">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">Organization</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>description=None</em>, <em>logo=None</em>, <em>name=None</em>, <em>twitter=None</em>, <em>website=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Organization" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a resource to manage organization resource in Packet.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Description string.</li>
+<li><strong>logo</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Logo URL.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the Organization.</li>
+<li><strong>twitter</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Twitter handle.</li>
+<li><strong>website</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Website link.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.Organization.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Organization.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>Description string.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Organization.logo">
+<code class="descname">logo</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Organization.logo" title="Permalink to this definition">¶</a></dt>
+<dd><p>Logo URL.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Organization.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Organization.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the Organization.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Organization.twitter">
+<code class="descname">twitter</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Organization.twitter" title="Permalink to this definition">¶</a></dt>
+<dd><p>Twitter handle.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Organization.website">
+<code class="descname">website</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Organization.website" title="Permalink to this definition">¶</a></dt>
+<dd><p>Website link.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Organization.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Organization.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Organization.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Organization.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.Project">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">Project</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>name=None</em>, <em>organization_id=None</em>, <em>payment_method_id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Project" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a Packet Project resource to allow you manage devices
+in your projects.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the Project on Packet.net</li>
+<li><strong>organization_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The UUID of Organization under which you want to create the project. If you leave it out, the project will be create under your the default Organization of your account.</li>
+<li><strong>payment_method_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The UUID of payment method for this project. If you keep it empty, Packet API will pick your default Payment Method.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.Project.created">
+<code class="descname">created</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Project.created" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timestamp for when the Project was created</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Project.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Project.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the Project on Packet.net</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Project.organization_id">
+<code class="descname">organization_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Project.organization_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUID of Organization under which you want to create the project. If you leave it out, the project will be create under your the default Organization of your account.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Project.payment_method_id">
+<code class="descname">payment_method_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Project.payment_method_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUID of payment method for this project. If you keep it empty, Packet API will pick your default Payment Method.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Project.updated">
+<code class="descname">updated</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Project.updated" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timestamp for the last time the Project was updated</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Project.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Project.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Project.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Project.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.Provider">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">Provider</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>auth_token=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Provider" title="Permalink to this definition">¶</a></dt>
+<dd><p>The provider type for the packet package. By default, resources use package-wide configuration
+settings, however an explicit <cite>Provider</cite> instance may be created and passed during resource
+construction to achieve fine-grained programmatic control over provider settings. See the
+[documentation](<a class="reference external" href="https://pulumi.io/reference/programming-model.html#providers">https://pulumi.io/reference/programming-model.html#providers</a>) for more information.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[str] auth_token</p>
+<dl class="method">
+<dt id="pulumi_packet.Provider.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Provider.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Provider.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Provider.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.ReservedIpBlock">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">ReservedIpBlock</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>facility=None</em>, <em>project_id=None</em>, <em>quantity=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.ReservedIpBlock" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a resource to create and manage blocks of reserved IP addresses in a project.</p>
+<p>When user provision first device in a facility, Packet automatically allocates IPv6/56 and private IPv4/25 blocks.
+The new device then gets IPv6 and private IPv4 addresses from those block. It also gets a public IPv4/31 address.
+Every new device in the project and facility will automatically get IPv6 and private IPv4 addresses from pre-allocated i
+blocks.
+The IPv6 and private IPv4 blocks can’t be created, only imported.</p>
+<p>It is only possible to create public IPv4 blocks, with masks from /24 (256 addresses) to /32 (1 address).</p>
+<p>Once IP block is allocated or imported, an address from it can be assigned to device with the <cite>packet_ip_attachment</cite> resource.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>facility</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The facility where to allocate the address block</li>
+<li><strong>project_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The packet project ID where to allocate the address block</li>
+<li><strong>quantity</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of allocated /32 addresses, a power of 2</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.address_family">
+<code class="descname">address_family</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.address_family" title="Permalink to this definition">¶</a></dt>
+<dd><p>Address family as integer (4 or 6)</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.cidr">
+<code class="descname">cidr</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.cidr" title="Permalink to this definition">¶</a></dt>
+<dd><p>length of CIDR prefix of the block as integer</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.cidr_notation">
+<code class="descname">cidr_notation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.cidr_notation" title="Permalink to this definition">¶</a></dt>
+<dd><p>Address and mask in CIDR notation, e.g. “147.229.15.30/31”</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.facility">
+<code class="descname">facility</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.facility" title="Permalink to this definition">¶</a></dt>
+<dd><p>The facility where to allocate the address block</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.netmask">
+<code class="descname">netmask</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.netmask" title="Permalink to this definition">¶</a></dt>
+<dd><p>Mask in decimal notation, e.g. “255.255.255.0”</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.network">
+<code class="descname">network</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.network" title="Permalink to this definition">¶</a></dt>
+<dd><p>Network IP address portion of the block specification</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.project_id">
+<code class="descname">project_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.project_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The packet project ID where to allocate the address block</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.public">
+<code class="descname">public</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.public" title="Permalink to this definition">¶</a></dt>
+<dd><p>boolean flag whether addresses from a block are public</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.ReservedIpBlock.quantity">
+<code class="descname">quantity</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.quantity" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of allocated /32 addresses, a power of 2</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.ReservedIpBlock.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.ReservedIpBlock.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.ReservedIpBlock.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.SSHKey">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">SSHKey</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>name=None</em>, <em>public_key=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.SSHKey" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a Packet SSH key resource to allow you manage SSH
+keys on your account. All SSH keys on your account are loaded on
+all new devices, they do not have to be explicitly declared on
+device creation.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the SSH key for identification</li>
+<li><strong>public_key</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The public key. If this is a file, it
+can be read using the file interpolation function</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.SSHKey.created">
+<code class="descname">created</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SSHKey.created" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timestamp for when the SSH key was created</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SSHKey.fingerprint">
+<code class="descname">fingerprint</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SSHKey.fingerprint" title="Permalink to this definition">¶</a></dt>
+<dd><p>The fingerprint of the SSH key</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SSHKey.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SSHKey.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the SSH key for identification</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SSHKey.public_key">
+<code class="descname">public_key</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SSHKey.public_key" title="Permalink to this definition">¶</a></dt>
+<dd><p>The public key. If this is a file, it
+can be read using the file interpolation function</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SSHKey.updated">
+<code class="descname">updated</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SSHKey.updated" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timestamp for the last time the SSH key was updated</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.SSHKey.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.SSHKey.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.SSHKey.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.SSHKey.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.SpotMarketRequest">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">SpotMarketRequest</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>devices_max=None</em>, <em>devices_min=None</em>, <em>facilities=None</em>, <em>instance_parameters=None</em>, <em>max_bid_price=None</em>, <em>project_id=None</em>, <em>wait_for_devices=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.SpotMarketRequest" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a Packet Spot Market Request resource to allow you to
+manage spot market requests on your account. <a class="reference external" href="https://help.packet.net/en-us/article/20-spot-market">https://help.packet.net/en-us/article/20-spot-market</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>devices_max</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Maximum number devices to be created</li>
+<li><strong>devices_min</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Miniumum number devices to be created</li>
+<li><strong>facilities</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – Facility IDs where devices should be created</li>
+<li><strong>instance_parameters</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Device parameters. See device resource for details</li>
+<li><strong>max_bid_price</strong> (<em>pulumi.Input</em><em>[</em><em>float</em><em>]</em>) – Maximum price user is willing to pay per hour per device</li>
+<li><strong>project_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Project ID</li>
+<li><strong>wait_for_devices</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – On resource creation - wait until all desired devices are active, on resource destruction - wait until devices are removed</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.SpotMarketRequest.devices_max">
+<code class="descname">devices_max</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.devices_max" title="Permalink to this definition">¶</a></dt>
+<dd><p>Maximum number devices to be created</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SpotMarketRequest.devices_min">
+<code class="descname">devices_min</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.devices_min" title="Permalink to this definition">¶</a></dt>
+<dd><p>Miniumum number devices to be created</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SpotMarketRequest.facilities">
+<code class="descname">facilities</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.facilities" title="Permalink to this definition">¶</a></dt>
+<dd><p>Facility IDs where devices should be created</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SpotMarketRequest.instance_parameters">
+<code class="descname">instance_parameters</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.instance_parameters" title="Permalink to this definition">¶</a></dt>
+<dd><p>Device parameters. See device resource for details</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SpotMarketRequest.max_bid_price">
+<code class="descname">max_bid_price</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.max_bid_price" title="Permalink to this definition">¶</a></dt>
+<dd><p>Maximum price user is willing to pay per hour per device</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SpotMarketRequest.project_id">
+<code class="descname">project_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.project_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>Project ID</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.SpotMarketRequest.wait_for_devices">
+<code class="descname">wait_for_devices</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.wait_for_devices" title="Permalink to this definition">¶</a></dt>
+<dd><p>On resource creation - wait until all desired devices are active, on resource destruction - wait until devices are removed</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.SpotMarketRequest.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.SpotMarketRequest.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.SpotMarketRequest.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.Volume">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">Volume</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>billing_cycle=None</em>, <em>description=None</em>, <em>facility=None</em>, <em>locked=None</em>, <em>plan=None</em>, <em>project_id=None</em>, <em>size=None</em>, <em>snapshot_policies=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Volume" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a Packet Block Storage Volume resource to allow you to
+manage block volumes on your account.
+Once created by Terraform, they must then be attached and mounted
+using the api and <cite>packet_block_attach</cite> and <cite>packet_block_detach</cite>
+scripts.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>billing_cycle</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The billing cycle, defaults to “hourly”</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Optional description for the volume</li>
+<li><strong>facility</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The facility to create the volume in</li>
+<li><strong>locked</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Lock or unlock the volume</li>
+<li><strong>plan</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The service plan slug of the volume</li>
+<li><strong>project_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The packet project ID to deploy the volume in</li>
+<li><strong>size</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The size in GB to make the volume</li>
+<li><strong>snapshot_policies</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – Optional list of snapshot policies</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.attachments">
+<code class="descname">attachments</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.attachments" title="Permalink to this definition">¶</a></dt>
+<dd><p>A list of attachments, each with it’s own <cite>href</cite> attribute</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.billing_cycle">
+<code class="descname">billing_cycle</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.billing_cycle" title="Permalink to this definition">¶</a></dt>
+<dd><p>The billing cycle, defaults to “hourly”</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.created">
+<code class="descname">created</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.created" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timestamp for when the volume was created</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>Optional description for the volume</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.facility">
+<code class="descname">facility</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.facility" title="Permalink to this definition">¶</a></dt>
+<dd><p>The facility to create the volume in</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.locked">
+<code class="descname">locked</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.locked" title="Permalink to this definition">¶</a></dt>
+<dd><p>Lock or unlock the volume</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the volume</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.plan">
+<code class="descname">plan</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.plan" title="Permalink to this definition">¶</a></dt>
+<dd><p>The service plan slug of the volume</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.project_id">
+<code class="descname">project_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.project_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The packet project ID to deploy the volume in</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.size">
+<code class="descname">size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.size" title="Permalink to this definition">¶</a></dt>
+<dd><p>The size in GB to make the volume</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.snapshot_policies">
+<code class="descname">snapshot_policies</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.snapshot_policies" title="Permalink to this definition">¶</a></dt>
+<dd><p>Optional list of snapshot policies</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.state">
+<code class="descname">state</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.state" title="Permalink to this definition">¶</a></dt>
+<dd><p>The state of the volume</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.Volume.updated">
+<code class="descname">updated</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.Volume.updated" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timestamp for the last time the volume was updated</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Volume.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Volume.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.Volume.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.Volume.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_packet.VolumeAttachment">
+<em class="property">class </em><code class="descclassname">pulumi_packet.</code><code class="descname">VolumeAttachment</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>device_id=None</em>, <em>volume_id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.VolumeAttachment" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides attachment of Packet Block Storage Volume to Devices.</p>
+<p>Device and volume must be in the same location (facility).</p>
+<p>Once attached by Terraform, they must then be mounted using the <cite>packet_block_attach</cite> and <cite>packet_block_detach</cite> scripts.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>device_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The ID of the device to which the volume should be attached</li>
+<li><strong>volume_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The ID of the volume to attach</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_packet.VolumeAttachment.device_id">
+<code class="descname">device_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.VolumeAttachment.device_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ID of the device to which the volume should be attached</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_packet.VolumeAttachment.volume_id">
+<code class="descname">volume_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_packet.VolumeAttachment.volume_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ID of the volume to attach</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.VolumeAttachment.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.VolumeAttachment.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_packet.VolumeAttachment.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.VolumeAttachment.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_packet.get_operating_system">
+<code class="descclassname">pulumi_packet.</code><code class="descname">get_operating_system</code><span class="sig-paren">(</span><em>distro=None</em>, <em>name=None</em>, <em>provisionable_on=None</em>, <em>version=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.get_operating_system" title="Permalink to this definition">¶</a></dt>
+<dd><p>Use this data source to get Packet Operating System image.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_packet.get_precreated_ip_block">
+<code class="descclassname">pulumi_packet.</code><code class="descname">get_precreated_ip_block</code><span class="sig-paren">(</span><em>address_family=None</em>, <em>facility=None</em>, <em>project_id=None</em>, <em>public=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.get_precreated_ip_block" title="Permalink to this definition">¶</a></dt>
+<dd><p>Use this data source to get CIDR expression for precreated IPv6 and IPv4 blocks in Packet.
+You can then use the cidrsubnet TF builtin function to derive subnets.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_packet.get_spot_market_price">
+<code class="descclassname">pulumi_packet.</code><code class="descname">get_spot_market_price</code><span class="sig-paren">(</span><em>facility=None</em>, <em>plan=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_packet.get_spot_market_price" title="Permalink to this definition">¶</a></dt>
+<dd><p>Use this data source to get Packet Spot Market Price.</p>
+</dd></dl>
+
 </div>

--- a/reference/pkg/python/pulumi_vsphere/index.md
+++ b/reference/pkg/python/pulumi_vsphere/index.md
@@ -1,8 +1,7094 @@
-<div class="section" id="pulumi-vsphere">
-<h1>Pulumi vSphere<a class="headerlink" href="#pulumi-vsphere" title="Permalink to this headline">¶</a></h1>
-<div class="toctree-wrapper compound">
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="config/">config</a></li>
+<div class="section" id="module-pulumi_vsphere">
+<span id="pulumi-vsphere"></span><h1>Pulumi vSphere<a class="headerlink" href="#module-pulumi_vsphere" title="Permalink to this headline">¶</a></h1>
+<dl class="class">
+<dt id="pulumi_vsphere.ComputeCluster">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">ComputeCluster</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>custom_attributes=None</em>, <em>datacenter_id=None</em>, <em>dpm_automation_level=None</em>, <em>dpm_enabled=None</em>, <em>dpm_threshold=None</em>, <em>drs_advanced_options=None</em>, <em>drs_automation_level=None</em>, <em>drs_enable_predictive_drs=None</em>, <em>drs_enable_vm_overrides=None</em>, <em>drs_enabled=None</em>, <em>drs_migration_threshold=None</em>, <em>folder=None</em>, <em>force_evacuate_on_destroy=None</em>, <em>ha_admission_control_failover_host_system_ids=None</em>, <em>ha_admission_control_host_failure_tolerance=None</em>, <em>ha_admission_control_performance_tolerance=None</em>, <em>ha_admission_control_policy=None</em>, <em>ha_admission_control_resource_percentage_auto_compute=None</em>, <em>ha_admission_control_resource_percentage_cpu=None</em>, <em>ha_admission_control_resource_percentage_memory=None</em>, <em>ha_admission_control_slot_policy_explicit_cpu=None</em>, <em>ha_admission_control_slot_policy_explicit_memory=None</em>, <em>ha_admission_control_slot_policy_use_explicit_size=None</em>, <em>ha_advanced_options=None</em>, <em>ha_datastore_apd_recovery_action=None</em>, <em>ha_datastore_apd_response=None</em>, <em>ha_datastore_apd_response_delay=None</em>, <em>ha_datastore_pdl_response=None</em>, <em>ha_enabled=None</em>, <em>ha_heartbeat_datastore_ids=None</em>, <em>ha_heartbeat_datastore_policy=None</em>, <em>ha_host_isolation_response=None</em>, <em>ha_host_monitoring=None</em>, <em>ha_vm_component_protection=None</em>, <em>ha_vm_dependency_restart_condition=None</em>, <em>ha_vm_failure_interval=None</em>, <em>ha_vm_maximum_failure_window=None</em>, <em>ha_vm_maximum_resets=None</em>, <em>ha_vm_minimum_uptime=None</em>, <em>ha_vm_monitoring=None</em>, <em>ha_vm_restart_additional_delay=None</em>, <em>ha_vm_restart_priority=None</em>, <em>ha_vm_restart_timeout=None</em>, <em>host_cluster_exit_timeout=None</em>, <em>host_system_ids=None</em>, <em>name=None</em>, <em>proactive_ha_automation_level=None</em>, <em>proactive_ha_enabled=None</em>, <em>proactive_ha_moderate_remediation=None</em>, <em>proactive_ha_provider_ids=None</em>, <em>proactive_ha_severe_remediation=None</em>, <em>tags=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeCluster" title="Permalink to this definition">¶</a></dt>
+<dd><p>-&gt; <strong>A note on the naming of this resource:</strong> VMware refers to clusters of
+hosts in the UI and documentation as _clusters_, _HA <a href="#id1"><span class="problematic" id="id2">clusters_</span></a>, or _DRS
+<a href="#id3"><span class="problematic" id="id4">clusters_</span></a>. All of these refer to the same kind of resource (with the latter two
+referring to specific features of clustering). In Terraform, we use
+<cite>vsphere_compute_cluster</cite> to differentiate host clusters from _datastore
+<a href="#id5"><span class="problematic" id="id6">clusters_</span></a>, which are clusters of datastores that can be used to distribute load
+and ensure fault tolerance via distribution of virtual machines. Datastore
+clusters can also be managed through Terraform, via the
+[<cite>vsphere_datastore_cluster</cite> resource][docs-r-vsphere-datastore-cluster].</p>
+<p>[docs-r-vsphere-datastore-cluster]: /docs/providers/vsphere/r/datastore_cluster.html</p>
+<p>The <cite>vsphere_compute_cluster</cite> resource can be used to create and manage
+clusters of hosts allowing for resource control of compute resources, load
+balancing through DRS, and high availability through vSphere HA.</p>
+<p>For more information on vSphere clusters and DRS, see [this
+page][ref-vsphere-drs-clusters]. For more information on vSphere HA, see [this
+page][ref-vsphere-ha-clusters].</p>
+<p>[ref-vsphere-drs-clusters]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-8ACF3502-5314-469F-8CC9-4A9BD5925BC2.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-8ACF3502-5314-469F-8CC9-4A9BD5925BC2.html</a>
+[ref-vsphere-ha-clusters]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.avail.doc/GUID-5432CA24-14F1-44E3-87FB-61D937831CF6.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.avail.doc/GUID-5432CA24-14F1-44E3-87FB-61D937831CF6.html</a></p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> vSphere DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>custom_attributes</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – A map of custom attribute ids to attribute
+value strings to set for the datastore cluster. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</li>
+<li><strong>datacenter_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object ID][docs-about-morefs] of
+the datacenter to create the cluster in. Forces a new resource if changed.</li>
+<li><strong>dpm_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The automation level for host power
+operations in this cluster. Can be one of <cite>manual</cite> or <cite>automated</cite>. Default:
+<cite>manual</cite>.</li>
+<li><strong>dpm_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable DPM support for DRS in this cluster.
+Requires <cite>drs_enabled</cite> to be <cite>true</cite> in order to be effective.
+Default: <cite>false</cite>.</li>
+<li><strong>dpm_threshold</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – A value between <cite>1</cite> and <cite>5</cite> indicating the
+threshold of load within the cluster that influences host power operations.
+This affects both power on and power off operations - a lower setting will
+tolerate more of a surplus/deficit than a higher setting. Default: <cite>3</cite>.</li>
+<li><strong>drs_advanced_options</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – A key/value map that specifies advanced
+options for DRS and DPM.</li>
+<li><strong>drs_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The default automation level for all
+virtual machines in this cluster. Can be one of <cite>manual</cite>,
+<cite>partiallyAutomated</cite>, or <cite>fullyAutomated</cite>. Default: <cite>manual</cite>.</li>
+<li><strong>drs_enable_predictive_drs</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When <cite>true</cite>, enables DRS to use data
+from [vRealize Operations Manager][ref-vsphere-vro] to make proactive DRS
+recommendations. &lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>drs_enable_vm_overrides</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Allow individual DRS overrides to be
+set for virtual machines in the cluster. Default: <cite>true</cite>.</li>
+<li><strong>drs_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable DRS for this cluster. Default: <cite>false</cite>.</li>
+<li><strong>drs_migration_threshold</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – A value between <cite>1</cite> and <cite>5</cite> indicating
+the threshold of imbalance tolerated between hosts. A lower setting will
+tolerate more imbalance while a higher setting will tolerate less. Default:
+<cite>3</cite>.</li>
+<li><strong>folder</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The relative path to a folder to put this cluster in.
+This is a path relative to the datacenter you are deploying the cluster to.
+Example: for the <cite>dc1</cite> datacenter, and a provided <cite>folder</cite> of <cite>foo/bar</cite>,
+Terraform will place a cluster named <cite>terraform-compute-cluster-test</cite> in a
+host folder located at <cite>/dc1/host/foo/bar</cite>, with the final inventory path
+being <cite>/dc1/host/foo/bar/terraform-datastore-cluster-test</cite>.</li>
+<li><strong>force_evacuate_on_destroy</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When destroying the resource, setting this to
+<cite>true</cite> will auto-remove any hosts that are currently a member of the cluster,
+as if they were removed by taking their entry out of <cite>host_system_ids</cite> (see
+below). This is an advanced
+option and should only be used for testing. Default: <cite>false</cite>.</li>
+<li><strong>ha_admission_control_failover_host_system_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – Defines the
+[managed object IDs][docs-about-morefs] of hosts to use as dedicated failover
+hosts. These hosts are kept as available as possible - admission control will
+block access to the host, and DRS will ignore the host when making
+recommendations.</li>
+<li><strong>ha_admission_control_host_failure_tolerance</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum number
+of failed hosts that admission control tolerates when making decisions on
+whether to permit virtual machine operations. The maximum is one less than
+the number of hosts in the cluster. Default: <cite>1</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_admission_control_performance_tolerance</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The percentage of
+resource reduction that a cluster of virtual machines can tolerate in case of
+a failover. A value of 0 produces warnings only, whereas a value of 100
+disables the setting. Default: <cite>100</cite> (disabled).</li>
+<li><strong>ha_admission_control_policy</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The type of admission control
+policy to use with vSphere HA. Can be one of <cite>resourcePercentage</cite>,
+<cite>slotPolicy</cite>, <cite>failoverHosts</cite>, or <cite>disabled</cite>. Default: <cite>resourcePercentage</cite>.</li>
+<li><strong>ha_admission_control_resource_percentage_auto_compute</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Automatically determine available resource percentages by subtracting the
+average number of host resources represented by the
+<cite>ha_admission_control_host_failure_tolerance</cite>
+setting from the total amount of resources in the cluster. Disable to supply
+user-defined values. Default: <cite>true</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_admission_control_resource_percentage_cpu</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Controls the
+user-defined percentage of CPU resources in the cluster to reserve for
+failover. Default: <cite>100</cite>.</li>
+<li><strong>ha_admission_control_resource_percentage_memory</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Controls the
+user-defined percentage of memory resources in the cluster to reserve for
+failover. Default: <cite>100</cite>.</li>
+<li><strong>ha_admission_control_slot_policy_explicit_cpu</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Controls the
+user-defined CPU slot size, in MHz. Default: <cite>32</cite>.</li>
+<li><strong>ha_admission_control_slot_policy_explicit_memory</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Controls the
+user-defined memory slot size, in MB. Default: <cite>100</cite>.</li>
+<li><strong>ha_admission_control_slot_policy_use_explicit_size</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Controls
+whether or not you wish to supply explicit values to CPU and memory slot
+sizes. The default is <cite>false</cite>, which tells vSphere to gather a automatic
+average based on all powered-on virtual machines currently in the cluster.</li>
+<li><strong>ha_advanced_options</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – A key/value map that specifies advanced
+options for vSphere HA.</li>
+<li><strong>ha_datastore_apd_recovery_action</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Controls the action to take
+on virtual machines if an APD status on an affected datastore clears in the
+middle of an APD event. Can be one of <cite>none</cite> or <cite>reset</cite>. Default: <cite>none</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_datastore_apd_response</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Controls the action to take on
+virtual machines when the cluster has detected loss to all paths to a
+relevant datastore. Can be one of <cite>disabled</cite>, <cite>warning</cite>,
+<cite>restartConservative</cite>, or <cite>restartAggressive</cite>.  Default: <cite>disabled</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_datastore_apd_response_delay</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Controls the delay in minutes
+to wait after an APD timeout event to execute the response action defined in
+<cite>ha_datastore_apd_response</cite>. Default: <cite>3</cite>
+minutes. &lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_datastore_pdl_response</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Controls the action to take on
+virtual machines when the cluster has detected a permanent device loss to a
+relevant datastore. Can be one of <cite>disabled</cite>, <cite>warning</cite>, or
+<cite>restartAggressive</cite>. Default: <cite>disabled</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable vSphere HA for this cluster. Default:
+<cite>false</cite>.</li>
+<li><strong>ha_heartbeat_datastore_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The list of managed object IDs for
+preferred datastores to use for HA heartbeating. This setting is only useful
+when <cite>ha_heartbeat_datastore_policy</cite> is set
+to either <cite>userSelectedDs</cite> or <cite>allFeasibleDsWithUserPreference</cite>.</li>
+<li><strong>ha_heartbeat_datastore_policy</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The selection policy for HA
+heartbeat datastores. Can be one of <cite>allFeasibleDs</cite>, <cite>userSelectedDs</cite>, or
+<cite>allFeasibleDsWithUserPreference</cite>. Default:
+<cite>allFeasibleDsWithUserPreference</cite>.</li>
+<li><strong>ha_host_isolation_response</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The action to take on virtual
+machines when a host has detected that it has been isolated from the rest of
+the cluster. Can be one of <cite>none</cite>, <cite>powerOff</cite>, or <cite>shutdown</cite>. Default:
+<cite>none</cite>.</li>
+<li><strong>ha_host_monitoring</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Global setting that controls whether
+vSphere HA remediates virtual machines on host failure. Can be one of <cite>enabled</cite>
+or <cite>disabled</cite>. Default: <cite>enabled</cite>.</li>
+<li><strong>ha_vm_component_protection</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Controls vSphere VM component
+protection for virtual machines in this cluster. Can be one of <cite>enabled</cite> or
+<cite>disabled</cite>. Default: <cite>enabled</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_vm_dependency_restart_condition</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The condition used to
+determine whether or not virtual machines in a certain restart priority class
+are online, allowing HA to move on to restarting virtual machines on the next
+priority. Can be one of <cite>none</cite>, <cite>poweredOn</cite>, <cite>guestHbStatusGreen</cite>, or
+<cite>appHbStatusGreen</cite>. The default is <cite>none</cite>, which means that a virtual machine
+is considered ready immediately after a host is found to start it on.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_vm_failure_interval</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – If a heartbeat from a virtual machine
+is not received within this configured interval, the virtual machine is
+marked as failed. The value is in seconds. Default: <cite>30</cite>.</li>
+<li><strong>ha_vm_maximum_failure_window</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The length of the reset window in
+which <cite>ha_vm_maximum_resets</cite> can operate. When this
+window expires, no more resets are attempted regardless of the setting
+configured in <cite>ha_vm_maximum_resets</cite>. <cite>-1</cite> means no window, meaning an
+unlimited reset time is allotted. The value is specified in seconds. Default:
+<cite>-1</cite> (no window).</li>
+<li><strong>ha_vm_maximum_resets</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum number of resets that HA will
+perform to a virtual machine when responding to a failure event. Default: <cite>3</cite></li>
+<li><strong>ha_vm_minimum_uptime</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The time, in seconds, that HA waits after
+powering on a virtual machine before monitoring for heartbeats. Default:
+<cite>120</cite> (2 minutes).</li>
+<li><strong>ha_vm_monitoring</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The type of virtual machine monitoring to use
+when HA is enabled in the cluster. Can be one of <cite>vmMonitoringDisabled</cite>,
+<cite>vmMonitoringOnly</cite>, or <cite>vmAndAppMonitoring</cite>. Default: <cite>vmMonitoringDisabled</cite>.</li>
+<li><strong>ha_vm_restart_additional_delay</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Additional delay in seconds
+after ready condition is met. A VM is considered ready at this point.
+Default: <cite>0</cite> (no delay). &lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>ha_vm_restart_priority</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The default restart priority
+for affected virtual machines when vSphere detects a host failure. Can be one
+of <cite>lowest</cite>, <cite>low</cite>, <cite>medium</cite>, <cite>high</cite>, or <cite>highest</cite>. Default: <cite>medium</cite>.</li>
+<li><strong>ha_vm_restart_timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum time, in seconds,
+that vSphere HA will wait for virtual machines in one priority to be ready
+before proceeding with the next priority. Default: <cite>600</cite> (10 minutes).
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>host_cluster_exit_timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The timeout for each host maintenance mode
+operation when removing hosts from a cluster. The value is specified in
+seconds. Default: <cite>3600</cite> (1 hour).</li>
+<li><strong>host_system_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The [managed object IDs][docs-about-morefs] of
+the hosts to put in the cluster.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the cluster.</li>
+<li><strong>proactive_ha_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Determines how the host
+quarantine, maintenance mode, or virtual machine migration recommendations
+made by proactive HA are to be handled. Can be one of <cite>Automated</cite> or
+<cite>Manual</cite>. Default: <cite>Manual</cite>. &lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>proactive_ha_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enables Proactive HA. Default: <cite>false</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>proactive_ha_moderate_remediation</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The configured remediation
+for moderately degraded hosts. Can be one of <cite>MaintenanceMode</cite> or
+<cite>QuarantineMode</cite>. Note that this cannot be set to <cite>MaintenanceMode</cite> when
+<cite>proactive_ha_severe_remediation</cite> is set
+to <cite>QuarantineMode</cite>. Default: <cite>QuarantineMode</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>proactive_ha_provider_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The list of IDs for health update
+providers configured for this cluster.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>proactive_ha_severe_remediation</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The configured remediation for
+severely degraded hosts. Can be one of <cite>MaintenanceMode</cite> or <cite>QuarantineMode</cite>.
+Note that this cannot be set to <cite>QuarantineMode</cite> when
+<cite>proactive_ha_moderate_remediation</cite> is
+set to <cite>MaintenanceMode</cite>. Default: <cite>QuarantineMode</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
 </ul>
-</div>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>A map of custom attribute ids to attribute
+value strings to set for the datastore cluster. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.datacenter_id">
+<code class="descname">datacenter_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.datacenter_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs] of
+the datacenter to create the cluster in. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.dpm_automation_level">
+<code class="descname">dpm_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.dpm_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The automation level for host power
+operations in this cluster. Can be one of <cite>manual</cite> or <cite>automated</cite>. Default:
+<cite>manual</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.dpm_enabled">
+<code class="descname">dpm_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.dpm_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable DPM support for DRS in this cluster.
+Requires <cite>drs_enabled</cite> to be <cite>true</cite> in order to be effective.
+Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.dpm_threshold">
+<code class="descname">dpm_threshold</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.dpm_threshold" title="Permalink to this definition">¶</a></dt>
+<dd><p>A value between <cite>1</cite> and <cite>5</cite> indicating the
+threshold of load within the cluster that influences host power operations.
+This affects both power on and power off operations - a lower setting will
+tolerate more of a surplus/deficit than a higher setting. Default: <cite>3</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.drs_advanced_options">
+<code class="descname">drs_advanced_options</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.drs_advanced_options" title="Permalink to this definition">¶</a></dt>
+<dd><p>A key/value map that specifies advanced
+options for DRS and DPM.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.drs_automation_level">
+<code class="descname">drs_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.drs_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The default automation level for all
+virtual machines in this cluster. Can be one of <cite>manual</cite>,
+<cite>partiallyAutomated</cite>, or <cite>fullyAutomated</cite>. Default: <cite>manual</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.drs_enable_predictive_drs">
+<code class="descname">drs_enable_predictive_drs</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.drs_enable_predictive_drs" title="Permalink to this definition">¶</a></dt>
+<dd><p>When <cite>true</cite>, enables DRS to use data
+from [vRealize Operations Manager][ref-vsphere-vro] to make proactive DRS
+recommendations. &lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.drs_enable_vm_overrides">
+<code class="descname">drs_enable_vm_overrides</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.drs_enable_vm_overrides" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow individual DRS overrides to be
+set for virtual machines in the cluster. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.drs_enabled">
+<code class="descname">drs_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.drs_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable DRS for this cluster. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.drs_migration_threshold">
+<code class="descname">drs_migration_threshold</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.drs_migration_threshold" title="Permalink to this definition">¶</a></dt>
+<dd><p>A value between <cite>1</cite> and <cite>5</cite> indicating
+the threshold of imbalance tolerated between hosts. A lower setting will
+tolerate more imbalance while a higher setting will tolerate less. Default:
+<cite>3</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.folder">
+<code class="descname">folder</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.folder" title="Permalink to this definition">¶</a></dt>
+<dd><p>The relative path to a folder to put this cluster in.
+This is a path relative to the datacenter you are deploying the cluster to.
+Example: for the <cite>dc1</cite> datacenter, and a provided <cite>folder</cite> of <cite>foo/bar</cite>,
+Terraform will place a cluster named <cite>terraform-compute-cluster-test</cite> in a
+host folder located at <cite>/dc1/host/foo/bar</cite>, with the final inventory path
+being <cite>/dc1/host/foo/bar/terraform-datastore-cluster-test</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.force_evacuate_on_destroy">
+<code class="descname">force_evacuate_on_destroy</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.force_evacuate_on_destroy" title="Permalink to this definition">¶</a></dt>
+<dd><p>When destroying the resource, setting this to
+<cite>true</cite> will auto-remove any hosts that are currently a member of the cluster,
+as if they were removed by taking their entry out of <cite>host_system_ids</cite> (see
+below). This is an advanced
+option and should only be used for testing. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_failover_host_system_ids">
+<code class="descname">ha_admission_control_failover_host_system_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_failover_host_system_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>Defines the
+[managed object IDs][docs-about-morefs] of hosts to use as dedicated failover
+hosts. These hosts are kept as available as possible - admission control will
+block access to the host, and DRS will ignore the host when making
+recommendations.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_host_failure_tolerance">
+<code class="descname">ha_admission_control_host_failure_tolerance</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_host_failure_tolerance" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum number
+of failed hosts that admission control tolerates when making decisions on
+whether to permit virtual machine operations. The maximum is one less than
+the number of hosts in the cluster. Default: <cite>1</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_performance_tolerance">
+<code class="descname">ha_admission_control_performance_tolerance</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_performance_tolerance" title="Permalink to this definition">¶</a></dt>
+<dd><p>The percentage of
+resource reduction that a cluster of virtual machines can tolerate in case of
+a failover. A value of 0 produces warnings only, whereas a value of 100
+disables the setting. Default: <cite>100</cite> (disabled).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_policy">
+<code class="descname">ha_admission_control_policy</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_policy" title="Permalink to this definition">¶</a></dt>
+<dd><p>The type of admission control
+policy to use with vSphere HA. Can be one of <cite>resourcePercentage</cite>,
+<cite>slotPolicy</cite>, <cite>failoverHosts</cite>, or <cite>disabled</cite>. Default: <cite>resourcePercentage</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_resource_percentage_auto_compute">
+<code class="descname">ha_admission_control_resource_percentage_auto_compute</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_resource_percentage_auto_compute" title="Permalink to this definition">¶</a></dt>
+<dd><p>Automatically determine available resource percentages by subtracting the
+average number of host resources represented by the
+<cite>ha_admission_control_host_failure_tolerance</cite>
+setting from the total amount of resources in the cluster. Disable to supply
+user-defined values. Default: <cite>true</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_resource_percentage_cpu">
+<code class="descname">ha_admission_control_resource_percentage_cpu</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_resource_percentage_cpu" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the
+user-defined percentage of CPU resources in the cluster to reserve for
+failover. Default: <cite>100</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_resource_percentage_memory">
+<code class="descname">ha_admission_control_resource_percentage_memory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_resource_percentage_memory" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the
+user-defined percentage of memory resources in the cluster to reserve for
+failover. Default: <cite>100</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_slot_policy_explicit_cpu">
+<code class="descname">ha_admission_control_slot_policy_explicit_cpu</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_slot_policy_explicit_cpu" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the
+user-defined CPU slot size, in MHz. Default: <cite>32</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_slot_policy_explicit_memory">
+<code class="descname">ha_admission_control_slot_policy_explicit_memory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_slot_policy_explicit_memory" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the
+user-defined memory slot size, in MB. Default: <cite>100</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_admission_control_slot_policy_use_explicit_size">
+<code class="descname">ha_admission_control_slot_policy_use_explicit_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_admission_control_slot_policy_use_explicit_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls
+whether or not you wish to supply explicit values to CPU and memory slot
+sizes. The default is <cite>false</cite>, which tells vSphere to gather a automatic
+average based on all powered-on virtual machines currently in the cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_advanced_options">
+<code class="descname">ha_advanced_options</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_advanced_options" title="Permalink to this definition">¶</a></dt>
+<dd><p>A key/value map that specifies advanced
+options for vSphere HA.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_datastore_apd_recovery_action">
+<code class="descname">ha_datastore_apd_recovery_action</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_datastore_apd_recovery_action" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the action to take
+on virtual machines if an APD status on an affected datastore clears in the
+middle of an APD event. Can be one of <cite>none</cite> or <cite>reset</cite>. Default: <cite>none</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_datastore_apd_response">
+<code class="descname">ha_datastore_apd_response</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_datastore_apd_response" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the action to take on
+virtual machines when the cluster has detected loss to all paths to a
+relevant datastore. Can be one of <cite>disabled</cite>, <cite>warning</cite>,
+<cite>restartConservative</cite>, or <cite>restartAggressive</cite>.  Default: <cite>disabled</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_datastore_apd_response_delay">
+<code class="descname">ha_datastore_apd_response_delay</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_datastore_apd_response_delay" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the delay in minutes
+to wait after an APD timeout event to execute the response action defined in
+<cite>ha_datastore_apd_response</cite>. Default: <cite>3</cite>
+minutes. &lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_datastore_pdl_response">
+<code class="descname">ha_datastore_pdl_response</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_datastore_pdl_response" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the action to take on
+virtual machines when the cluster has detected a permanent device loss to a
+relevant datastore. Can be one of <cite>disabled</cite>, <cite>warning</cite>, or
+<cite>restartAggressive</cite>. Default: <cite>disabled</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_enabled">
+<code class="descname">ha_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable vSphere HA for this cluster. Default:
+<cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_heartbeat_datastore_ids">
+<code class="descname">ha_heartbeat_datastore_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_heartbeat_datastore_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The list of managed object IDs for
+preferred datastores to use for HA heartbeating. This setting is only useful
+when <cite>ha_heartbeat_datastore_policy</cite> is set
+to either <cite>userSelectedDs</cite> or <cite>allFeasibleDsWithUserPreference</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_heartbeat_datastore_policy">
+<code class="descname">ha_heartbeat_datastore_policy</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_heartbeat_datastore_policy" title="Permalink to this definition">¶</a></dt>
+<dd><p>The selection policy for HA
+heartbeat datastores. Can be one of <cite>allFeasibleDs</cite>, <cite>userSelectedDs</cite>, or
+<cite>allFeasibleDsWithUserPreference</cite>. Default:
+<cite>allFeasibleDsWithUserPreference</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_host_isolation_response">
+<code class="descname">ha_host_isolation_response</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_host_isolation_response" title="Permalink to this definition">¶</a></dt>
+<dd><p>The action to take on virtual
+machines when a host has detected that it has been isolated from the rest of
+the cluster. Can be one of <cite>none</cite>, <cite>powerOff</cite>, or <cite>shutdown</cite>. Default:
+<cite>none</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_host_monitoring">
+<code class="descname">ha_host_monitoring</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_host_monitoring" title="Permalink to this definition">¶</a></dt>
+<dd><p>Global setting that controls whether
+vSphere HA remediates virtual machines on host failure. Can be one of <cite>enabled</cite>
+or <cite>disabled</cite>. Default: <cite>enabled</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_component_protection">
+<code class="descname">ha_vm_component_protection</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_component_protection" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls vSphere VM component
+protection for virtual machines in this cluster. Can be one of <cite>enabled</cite> or
+<cite>disabled</cite>. Default: <cite>enabled</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_dependency_restart_condition">
+<code class="descname">ha_vm_dependency_restart_condition</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_dependency_restart_condition" title="Permalink to this definition">¶</a></dt>
+<dd><p>The condition used to
+determine whether or not virtual machines in a certain restart priority class
+are online, allowing HA to move on to restarting virtual machines on the next
+priority. Can be one of <cite>none</cite>, <cite>poweredOn</cite>, <cite>guestHbStatusGreen</cite>, or
+<cite>appHbStatusGreen</cite>. The default is <cite>none</cite>, which means that a virtual machine
+is considered ready immediately after a host is found to start it on.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_failure_interval">
+<code class="descname">ha_vm_failure_interval</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_failure_interval" title="Permalink to this definition">¶</a></dt>
+<dd><p>If a heartbeat from a virtual machine
+is not received within this configured interval, the virtual machine is
+marked as failed. The value is in seconds. Default: <cite>30</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_maximum_failure_window">
+<code class="descname">ha_vm_maximum_failure_window</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_maximum_failure_window" title="Permalink to this definition">¶</a></dt>
+<dd><p>The length of the reset window in
+which <cite>ha_vm_maximum_resets</cite> can operate. When this
+window expires, no more resets are attempted regardless of the setting
+configured in <cite>ha_vm_maximum_resets</cite>. <cite>-1</cite> means no window, meaning an
+unlimited reset time is allotted. The value is specified in seconds. Default:
+<cite>-1</cite> (no window).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_maximum_resets">
+<code class="descname">ha_vm_maximum_resets</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_maximum_resets" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum number of resets that HA will
+perform to a virtual machine when responding to a failure event. Default: <cite>3</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_minimum_uptime">
+<code class="descname">ha_vm_minimum_uptime</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_minimum_uptime" title="Permalink to this definition">¶</a></dt>
+<dd><p>The time, in seconds, that HA waits after
+powering on a virtual machine before monitoring for heartbeats. Default:
+<cite>120</cite> (2 minutes).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_monitoring">
+<code class="descname">ha_vm_monitoring</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_monitoring" title="Permalink to this definition">¶</a></dt>
+<dd><p>The type of virtual machine monitoring to use
+when HA is enabled in the cluster. Can be one of <cite>vmMonitoringDisabled</cite>,
+<cite>vmMonitoringOnly</cite>, or <cite>vmAndAppMonitoring</cite>. Default: <cite>vmMonitoringDisabled</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_restart_additional_delay">
+<code class="descname">ha_vm_restart_additional_delay</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_restart_additional_delay" title="Permalink to this definition">¶</a></dt>
+<dd><p>Additional delay in seconds
+after ready condition is met. A VM is considered ready at this point.
+Default: <cite>0</cite> (no delay). &lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_restart_priority">
+<code class="descname">ha_vm_restart_priority</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_restart_priority" title="Permalink to this definition">¶</a></dt>
+<dd><p>The default restart priority
+for affected virtual machines when vSphere detects a host failure. Can be one
+of <cite>lowest</cite>, <cite>low</cite>, <cite>medium</cite>, <cite>high</cite>, or <cite>highest</cite>. Default: <cite>medium</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.ha_vm_restart_timeout">
+<code class="descname">ha_vm_restart_timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.ha_vm_restart_timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum time, in seconds,
+that vSphere HA will wait for virtual machines in one priority to be ready
+before proceeding with the next priority. Default: <cite>600</cite> (10 minutes).
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.host_cluster_exit_timeout">
+<code class="descname">host_cluster_exit_timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.host_cluster_exit_timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The timeout for each host maintenance mode
+operation when removing hosts from a cluster. The value is specified in
+seconds. Default: <cite>3600</cite> (1 hour).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.host_system_ids">
+<code class="descname">host_system_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.host_system_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object IDs][docs-about-morefs] of
+the hosts to put in the cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.proactive_ha_automation_level">
+<code class="descname">proactive_ha_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.proactive_ha_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>Determines how the host
+quarantine, maintenance mode, or virtual machine migration recommendations
+made by proactive HA are to be handled. Can be one of <cite>Automated</cite> or
+<cite>Manual</cite>. Default: <cite>Manual</cite>. &lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.proactive_ha_enabled">
+<code class="descname">proactive_ha_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.proactive_ha_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enables Proactive HA. Default: <cite>false</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.proactive_ha_moderate_remediation">
+<code class="descname">proactive_ha_moderate_remediation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.proactive_ha_moderate_remediation" title="Permalink to this definition">¶</a></dt>
+<dd><p>The configured remediation
+for moderately degraded hosts. Can be one of <cite>MaintenanceMode</cite> or
+<cite>QuarantineMode</cite>. Note that this cannot be set to <cite>MaintenanceMode</cite> when
+<cite>proactive_ha_severe_remediation</cite> is set
+to <cite>QuarantineMode</cite>. Default: <cite>QuarantineMode</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.proactive_ha_provider_ids">
+<code class="descname">proactive_ha_provider_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.proactive_ha_provider_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The list of IDs for health update
+providers configured for this cluster.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.proactive_ha_severe_remediation">
+<code class="descname">proactive_ha_severe_remediation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.proactive_ha_severe_remediation" title="Permalink to this definition">¶</a></dt>
+<dd><p>The configured remediation for
+severely degraded hosts. Can be one of <cite>MaintenanceMode</cite> or <cite>QuarantineMode</cite>.
+Note that this cannot be set to <cite>QuarantineMode</cite> when
+<cite>proactive_ha_moderate_remediation</cite> is
+set to <cite>MaintenanceMode</cite>. Default: <cite>QuarantineMode</cite>.
+&lt;sup&gt;*&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeCluster.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeCluster.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeCluster.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeCluster.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.ComputeClusterHostGroup">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">ComputeClusterHostGroup</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compute_cluster_id=None</em>, <em>host_system_ids=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterHostGroup" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_compute_cluster_host_group</cite> resource can be used to manage groups
+of hosts in a cluster, either created by the
+[<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-resource] resource or looked up
+by the [<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-data-source] data source.</p>
+<p>[tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
+[tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html</p>
+<p>This resource mainly serves as an input to the
+[<cite>vsphere_compute_cluster_vm_host_rule</cite>][tf-vsphere-cluster-vm-host-rule-resource]
+resource - see the documentation for that resource for further details on how
+to use host groups.</p>
+<p>[tf-vsphere-cluster-vm-host-rule-resource]: /docs/providers/vsphere/r/compute_cluster_vm_host_rule.html</p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> vSphere DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</li>
+<li><strong>host_system_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The [managed object IDs][docs-about-morefs] of
+the hosts to put in the cluster.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the host group. This must be unique in the
+cluster. Forces a new resource if changed.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterHostGroup.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterHostGroup.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterHostGroup.host_system_ids">
+<code class="descname">host_system_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterHostGroup.host_system_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object IDs][docs-about-morefs] of
+the hosts to put in the cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterHostGroup.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterHostGroup.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the host group. This must be unique in the
+cluster. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterHostGroup.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterHostGroup.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterHostGroup.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterHostGroup.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.ComputeClusterVmAffinityRule">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">ComputeClusterVmAffinityRule</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compute_cluster_id=None</em>, <em>enabled=None</em>, <em>mandatory=None</em>, <em>name=None</em>, <em>virtual_machine_ids=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAffinityRule" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_compute_cluster_vm_affinity_rule</cite> resource can be used to manage
+VM affinity rules in a cluster, either created by the
+[<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-resource] resource or looked up
+by the [<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-data-source] data source.</p>
+<p>[tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
+[tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html</p>
+<p>This rule can be used to tell a set to virtual machines to run together on a
+single host within a cluster. When configured, DRS will make a best effort to
+ensure that the virtual machines run on the same host, or prevent any operation
+that would keep that from happening, depending on the value of the
+<cite>mandatory</cite> flag.</p>
+<p>-&gt; Keep in mind that this rule can only be used to tell VMs to run together on
+a _non-<a href="#id7"><span class="problematic" id="id8">specific_</span></a> host - it can’t be used to pin VMs to a host. For that, see
+the
+[<cite>vsphere_compute_cluster_vm_host_rule</cite>][tf-vsphere-cluster-vm-host-rule-resource]
+resource.</p>
+<p>[tf-vsphere-cluster-vm-host-rule-resource]: /docs/providers/vsphere/r/compute_cluster_vm_host_rule.html</p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> vSphere DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</li>
+<li><strong>enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable this rule in the cluster. Default: <cite>true</cite>.</li>
+<li><strong>mandatory</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the rule. This must be unique in the cluster.</li>
+<li><strong>virtual_machine_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The UUIDs of the virtual machines to run
+on the same host together.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAffinityRule.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAffinityRule.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAffinityRule.enabled">
+<code class="descname">enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAffinityRule.enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable this rule in the cluster. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAffinityRule.mandatory">
+<code class="descname">mandatory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAffinityRule.mandatory" title="Permalink to this definition">¶</a></dt>
+<dd><p>When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAffinityRule.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAffinityRule.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the rule. This must be unique in the cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAffinityRule.virtual_machine_ids">
+<code class="descname">virtual_machine_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAffinityRule.virtual_machine_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUIDs of the virtual machines to run
+on the same host together.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmAffinityRule.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAffinityRule.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmAffinityRule.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAffinityRule.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.ComputeClusterVmAntiAffinityRule">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">ComputeClusterVmAntiAffinityRule</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compute_cluster_id=None</em>, <em>enabled=None</em>, <em>mandatory=None</em>, <em>name=None</em>, <em>virtual_machine_ids=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAntiAffinityRule" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_compute_cluster_vm_anti_affinity_rule</cite> resource can be used to
+manage VM anti-affinity rules in a cluster, either created by the
+[<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-resource] resource or looked up
+by the [<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-data-source] data source.</p>
+<p>[tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
+[tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html</p>
+<p>This rule can be used to tell a set to virtual machines to run on different
+hosts within a cluster, useful for preventing single points of failure in
+application cluster scenarios. When configured, DRS will make a best effort to
+ensure that the virtual machines run on different hosts, or prevent any
+operation that would keep that from happening, depending on the value of the
+<cite>mandatory</cite> flag.</p>
+<p>-&gt; Keep in mind that this rule can only be used to tell VMs to run separately
+on _non-<a href="#id9"><span class="problematic" id="id10">specific_</span></a> hosts - specific hosts cannot be specified with this rule.
+For that, see the
+[<cite>vsphere_compute_cluster_vm_host_rule</cite>][tf-vsphere-cluster-vm-host-rule-resource]
+resource.</p>
+<p>[tf-vsphere-cluster-vm-host-rule-resource]: /docs/providers/vsphere/r/compute_cluster_vm_host_rule.html</p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> vSphere DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</li>
+<li><strong>enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable this rule in the cluster. Default: <cite>true</cite>.</li>
+<li><strong>mandatory</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the rule. This must be unique in the cluster.</li>
+<li><strong>virtual_machine_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The UUIDs of the virtual machines to run
+on hosts different from each other.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAntiAffinityRule.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAntiAffinityRule.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAntiAffinityRule.enabled">
+<code class="descname">enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAntiAffinityRule.enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable this rule in the cluster. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAntiAffinityRule.mandatory">
+<code class="descname">mandatory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAntiAffinityRule.mandatory" title="Permalink to this definition">¶</a></dt>
+<dd><p>When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAntiAffinityRule.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAntiAffinityRule.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the rule. This must be unique in the cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmAntiAffinityRule.virtual_machine_ids">
+<code class="descname">virtual_machine_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAntiAffinityRule.virtual_machine_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUIDs of the virtual machines to run
+on hosts different from each other.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmAntiAffinityRule.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAntiAffinityRule.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmAntiAffinityRule.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmAntiAffinityRule.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">ComputeClusterVmDependencyRule</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compute_cluster_id=None</em>, <em>dependency_vm_group_name=None</em>, <em>enabled=None</em>, <em>mandatory=None</em>, <em>name=None</em>, <em>vm_group_name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_compute_cluster_vm_dependency_rule</cite> resource can be used to manage
+VM dependency rules in a cluster, either created by the
+[<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-resource] resource or looked up
+by the [<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-data-source] data source.</p>
+<p>[tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
+[tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html</p>
+<p>A virtual machine dependency rule applies to vSphere HA, and allows
+user-defined startup orders for virtual machines in the case of host failure.
+Virtual machines are supplied via groups, which can be managed via the
+[<cite>vsphere_compute_cluster_vm_group</cite>][tf-vsphere-cluster-vm-group-resource]
+resource.</p>
+<p>[tf-vsphere-cluster-vm-group-resource]: /docs/providers/vsphere/r/compute_cluster_vm_group.html</p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</li>
+<li><strong>dependency_vm_group_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the VM group that this
+rule depends on. The VMs defined in the group specified by
+<cite>vm_group_name</cite> will not be started until the VMs in this
+group are started.</li>
+<li><strong>enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable this rule in the cluster. Default: <cite>true</cite>.</li>
+<li><strong>mandatory</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the rule. This must be unique in the
+cluster.</li>
+<li><strong>vm_group_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the VM group that is the subject of
+this rule. The VMs defined in this group will not be started until the VMs in
+the group specified by
+<cite>dependency_vm_group_name</cite> are started.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule.dependency_vm_group_name">
+<code class="descname">dependency_vm_group_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule.dependency_vm_group_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the VM group that this
+rule depends on. The VMs defined in the group specified by
+<cite>vm_group_name</cite> will not be started until the VMs in this
+group are started.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule.enabled">
+<code class="descname">enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule.enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable this rule in the cluster. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule.mandatory">
+<code class="descname">mandatory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule.mandatory" title="Permalink to this definition">¶</a></dt>
+<dd><p>When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the rule. This must be unique in the
+cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule.vm_group_name">
+<code class="descname">vm_group_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule.vm_group_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the VM group that is the subject of
+this rule. The VMs defined in this group will not be started until the VMs in
+the group specified by
+<cite>dependency_vm_group_name</cite> are started.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmDependencyRule.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmDependencyRule.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.ComputeClusterVmGroup">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">ComputeClusterVmGroup</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compute_cluster_id=None</em>, <em>name=None</em>, <em>virtual_machine_ids=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmGroup" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_compute_cluster_vm_group</cite> resource can be used to manage groups of
+virtual machines in a cluster, either created by the
+[<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-resource] resource or looked up
+by the [<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-data-source] data source.</p>
+<p>[tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
+[tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html</p>
+<p>This resource mainly serves as an input to the
+[<cite>vsphere_compute_cluster_vm_dependency_rule</cite>][tf-vsphere-cluster-vm-dependency-rule-resource]
+and
+[<cite>vsphere_compute_cluster_vm_host_rule</cite>][tf-vsphere-cluster-vm-host-rule-resource]
+resources. See the individual resource documentation pages for more information.</p>
+<p>[tf-vsphere-cluster-vm-dependency-rule-resource]: /docs/providers/vsphere/r/compute_cluster_vm_dependency_rule.html
+[tf-vsphere-cluster-vm-host-rule-resource]: /docs/providers/vsphere/r/compute_cluster_vm_host_rule.html</p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> vSphere DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the VM group. This must be unique in the
+cluster. Forces a new resource if changed.</li>
+<li><strong>virtual_machine_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The UUIDs of the virtual machines in this
+group.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmGroup.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmGroup.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmGroup.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmGroup.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the VM group. This must be unique in the
+cluster. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmGroup.virtual_machine_ids">
+<code class="descname">virtual_machine_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmGroup.virtual_machine_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUIDs of the virtual machines in this
+group.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmGroup.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmGroup.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmGroup.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmGroup.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">ComputeClusterVmHostRule</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>affinity_host_group_name=None</em>, <em>anti_affinity_host_group_name=None</em>, <em>compute_cluster_id=None</em>, <em>enabled=None</em>, <em>mandatory=None</em>, <em>name=None</em>, <em>vm_group_name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_compute_cluster_vm_host_rule</cite> resource can be used to manage
+VM-to-host rules in a cluster, either created by the
+[<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-resource] resource or looked up
+by the [<cite>vsphere_compute_cluster</cite>][tf-vsphere-cluster-data-source] data source.</p>
+<p>[tf-vsphere-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
+[tf-vsphere-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html</p>
+<p>This resource can create both _affinity <a href="#id11"><span class="problematic" id="id12">rules_</span></a>, where virtual machines run on
+specified hosts, or _anti-<a href="#id13"><span class="problematic" id="id14">affinity_</span></a> rules, where virtual machines run on hosts
+outside of the ones specified in the rule. Virtual machines and hosts are
+supplied via groups, which can be managed via the
+[<cite>vsphere_compute_cluster_vm_group</cite>][tf-vsphere-cluster-vm-group-resource] and
+[<cite>vsphere_compute_cluster_host_group</cite>][tf-vsphere-cluster-host-group-resource]
+resources.</p>
+<p>[tf-vsphere-cluster-vm-group-resource]: /docs/providers/vsphere/r/compute_cluster_vm_group.html
+[tf-vsphere-cluster-host-group-resource]: /docs/providers/vsphere/r/compute_cluster_host_group.html</p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> vSphere DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>affinity_host_group_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – When this field is used, the virtual
+machines defined in <cite>vm_group_name</cite> will be run on the
+hosts defined in this host group.</li>
+<li><strong>anti_affinity_host_group_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – When this field is used, the
+virtual machines defined in <cite>vm_group_name</cite> will _not_ be
+run on the hosts defined in this host group.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</li>
+<li><strong>enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable this rule in the cluster. Default: <cite>true</cite>.</li>
+<li><strong>mandatory</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the rule. This must be unique in the
+cluster.</li>
+<li><strong>vm_group_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the virtual machine group to use
+with this rule.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.affinity_host_group_name">
+<code class="descname">affinity_host_group_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.affinity_host_group_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>When this field is used, the virtual
+machines defined in <cite>vm_group_name</cite> will be run on the
+hosts defined in this host group.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.anti_affinity_host_group_name">
+<code class="descname">anti_affinity_host_group_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.anti_affinity_host_group_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>When this field is used, the
+virtual machines defined in <cite>vm_group_name</cite> will _not_ be
+run on the hosts defined in this host group.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the group in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.enabled">
+<code class="descname">enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable this rule in the cluster. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.mandatory">
+<code class="descname">mandatory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.mandatory" title="Permalink to this definition">¶</a></dt>
+<dd><p>When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the rule. This must be unique in the
+cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.vm_group_name">
+<code class="descname">vm_group_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.vm_group_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the virtual machine group to use
+with this rule.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ComputeClusterVmHostRule.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ComputeClusterVmHostRule.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.CustomAttribute">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">CustomAttribute</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>managed_object_type=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.CustomAttribute" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_custom_attribute</cite> resource can be used to create and manage custom
+attributes, which allow users to associate user-specific meta-information with 
+vSphere managed objects. Custom attribute values must be strings and are stored 
+on the vCenter Server and not the managed object.</p>
+<p>For more information about custom attributes, click [here][ext-custom-attributes].</p>
+<p>[ext-custom-attributes]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-73606C4C-763C-4E27-A1DA-032E4C46219D.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-73606C4C-763C-4E27-A1DA-032E4C46219D.html</a></p>
+<p>&gt; <strong>NOTE:</strong> Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>managed_object_type</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The object type that this attribute may be
+applied to. If not set, the custom attribute may be applied to any object
+type. For a full list, click here. Forces a new
+resource if changed.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the custom attribute.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.CustomAttribute.managed_object_type">
+<code class="descname">managed_object_type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.CustomAttribute.managed_object_type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The object type that this attribute may be
+applied to. If not set, the custom attribute may be applied to any object
+type. For a full list, click here. Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.CustomAttribute.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.CustomAttribute.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the custom attribute.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.CustomAttribute.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.CustomAttribute.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.CustomAttribute.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.CustomAttribute.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.Datacenter">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">Datacenter</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>custom_attributes=None</em>, <em>folder=None</em>, <em>name=None</em>, <em>tags=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Datacenter" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a VMware vSphere datacenter resource. This can be used as the primary
+container of inventory objects such as hosts and virtual machines.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>custom_attributes</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Map of custom attribute ids to value 
+strings to set for datacenter resource. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</li>
+<li><strong>folder</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The folder where the datacenter should be created.
+Forces a new resource if changed.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the datacenter. This name needs to be unique
+within the folder. Forces a new resource if changed.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.Datacenter.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Datacenter.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Map of custom attribute ids to value 
+strings to set for datacenter resource. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Datacenter.folder">
+<code class="descname">folder</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Datacenter.folder" title="Permalink to this definition">¶</a></dt>
+<dd><p>The folder where the datacenter should be created.
+Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Datacenter.moid">
+<code class="descname">moid</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Datacenter.moid" title="Permalink to this definition">¶</a></dt>
+<dd><p>[Managed object ID][docs-about-morefs] of this datacenter.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Datacenter.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Datacenter.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the datacenter. This name needs to be unique
+within the folder. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Datacenter.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Datacenter.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.Datacenter.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Datacenter.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.Datacenter.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Datacenter.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.DatastoreCluster">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">DatastoreCluster</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>custom_attributes=None</em>, <em>datacenter_id=None</em>, <em>folder=None</em>, <em>name=None</em>, <em>sdrs_advanced_options=None</em>, <em>sdrs_automation_level=None</em>, <em>sdrs_default_intra_vm_affinity=None</em>, <em>sdrs_enabled=None</em>, <em>sdrs_free_space_threshold=None</em>, <em>sdrs_free_space_threshold_mode=None</em>, <em>sdrs_free_space_utilization_difference=None</em>, <em>sdrs_io_balance_automation_level=None</em>, <em>sdrs_io_latency_threshold=None</em>, <em>sdrs_io_load_balance_enabled=None</em>, <em>sdrs_io_load_imbalance_threshold=None</em>, <em>sdrs_io_reservable_iops_threshold=None</em>, <em>sdrs_io_reservable_percent_threshold=None</em>, <em>sdrs_io_reservable_threshold_mode=None</em>, <em>sdrs_load_balance_interval=None</em>, <em>sdrs_policy_enforcement_automation_level=None</em>, <em>sdrs_rule_enforcement_automation_level=None</em>, <em>sdrs_space_balance_automation_level=None</em>, <em>sdrs_space_utilization_threshold=None</em>, <em>sdrs_vm_evacuation_automation_level=None</em>, <em>tags=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_datastore_cluster</cite> resource can be used to create and manage
+datastore clusters. This can be used to create groups of datastores with a
+shared management interface, allowing for resource control and load balancing
+through Storage DRS.</p>
+<p>For more information on vSphere datastore clusters and Storage DRS, see [this
+page][ref-vsphere-datastore-clusters].</p>
+<p>[ref-vsphere-datastore-clusters]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html</a></p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> Storage DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>custom_attributes</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – A map of custom attribute ids to attribute
+value strings to set for the datastore cluster. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</li>
+<li><strong>datacenter_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object ID][docs-about-morefs] of
+the datacenter to create the datastore cluster in. Forces a new resource if
+changed.</li>
+<li><strong>folder</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The relative path to a folder to put this datastore
+cluster in.  This is a path relative to the datacenter you are deploying the
+datastore to.  Example: for the <cite>dc1</cite> datacenter, and a provided <cite>folder</cite> of
+<cite>foo/bar</cite>, Terraform will place a datastore cluster named
+<cite>terraform-datastore-cluster-test</cite> in a datastore folder located at
+<cite>/dc1/datastore/foo/bar</cite>, with the final inventory path being
+<cite>/dc1/datastore/foo/bar/terraform-datastore-cluster-test</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the datastore cluster.</li>
+<li><strong>sdrs_advanced_options</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – A key/value map of advanced Storage DRS
+settings that are not exposed via Terraform or the vSphere client.</li>
+<li><strong>sdrs_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The global automation level for all
+virtual machines in this datastore cluster. Default: <cite>manual</cite>.</li>
+<li><strong>sdrs_default_intra_vm_affinity</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When <cite>true</cite>, all disks in a
+single virtual machine will be kept on the same datastore. Default: <cite>true</cite>.</li>
+<li><strong>sdrs_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable Storage DRS for this datastore cluster.
+Default: <cite>false</cite>.</li>
+<li><strong>sdrs_free_space_threshold</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The free space threshold to use.
+When set to <cite>utilization</cite>, <cite>drs_space_utilization_threshold</cite> is used, and
+when set to <cite>freeSpace</cite>, <cite>drs_free_space_threshold</cite> is used. Default:
+<cite>utilization</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[str] sdrs_free_space_threshold_mode
+:param pulumi.Input[int] sdrs_free_space_utilization_difference: The threshold, in</p>
+<blockquote>
+<div>percent, of difference between space utilization in datastores before storage
+DRS makes decisions to balance the space. Default: <cite>5</cite> percent.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>sdrs_io_balance_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Overrides the default
+automation settings when correcting I/O load imbalances.</li>
+<li><strong>sdrs_io_latency_threshold</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The I/O latency threshold, in
+milliseconds, that storage DRS uses to make recommendations to move disks
+from this datastore. Default: <cite>15</cite> seconds.</li>
+<li><strong>sdrs_io_load_balance_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable I/O load balancing for
+this datastore cluster. Default: <cite>true</cite>.</li>
+<li><strong>sdrs_io_load_imbalance_threshold</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The difference between load
+in datastores in the cluster before storage DRS makes recommendations to
+balance the load. Default: <cite>5</cite> percent.</li>
+<li><strong>sdrs_io_reservable_iops_threshold</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The threshold of reservable
+IOPS of all virtual machines on the datastore before storage DRS makes
+recommendations to move VMs off of a datastore. Note that this setting should
+only be set if <cite>sdrs_io_reservable_percent_threshold</cite> cannot make an accurate
+estimate of the capacity of the datastores in your cluster, and should be set
+to roughly 50-60% of the worst case peak performance of the backing LUNs.</li>
+<li><strong>sdrs_io_reservable_percent_threshold</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The threshold, in
+percent, of actual estimated performance of the datastore (in IOPS) that
+storage DRS uses to make recommendations to move VMs off of a datastore when
+the total reservable IOPS exceeds the threshold. Default: <cite>60</cite> percent.</li>
+<li><strong>sdrs_io_reservable_threshold_mode</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The reservable IOPS
+threshold setting to use, <cite>sdrs_io_reservable_percent_threshold</cite> in the event
+of <cite>automatic</cite>, or <cite>sdrs_io_reservable_iops_threshold</cite> in the event of
+<cite>manual</cite>. Default: <cite>automatic</cite>.</li>
+<li><strong>sdrs_load_balance_interval</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The storage DRS poll interval, in
+minutes. Default: <cite>480</cite> minutes.</li>
+<li><strong>sdrs_policy_enforcement_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Overrides the default
+automation settings when correcting storage and VM policy violations.</li>
+<li><strong>sdrs_rule_enforcement_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Overrides the default
+automation settings when correcting affinity rule violations.</li>
+<li><strong>sdrs_space_balance_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Overrides the default
+automation settings when correcting disk space imbalances.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[int] sdrs_space_utilization_threshold
+:param pulumi.Input[str] sdrs_vm_evacuation_automation_level: Overrides the default</p>
+<blockquote>
+<div>automation settings when generating recommendations for datastore evacuation.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>A map of custom attribute ids to attribute
+value strings to set for the datastore cluster. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.datacenter_id">
+<code class="descname">datacenter_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.datacenter_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs] of
+the datacenter to create the datastore cluster in. Forces a new resource if
+changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.folder">
+<code class="descname">folder</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.folder" title="Permalink to this definition">¶</a></dt>
+<dd><p>The relative path to a folder to put this datastore
+cluster in.  This is a path relative to the datacenter you are deploying the
+datastore to.  Example: for the <cite>dc1</cite> datacenter, and a provided <cite>folder</cite> of
+<cite>foo/bar</cite>, Terraform will place a datastore cluster named
+<cite>terraform-datastore-cluster-test</cite> in a datastore folder located at
+<cite>/dc1/datastore/foo/bar</cite>, with the final inventory path being
+<cite>/dc1/datastore/foo/bar/terraform-datastore-cluster-test</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the datastore cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_advanced_options">
+<code class="descname">sdrs_advanced_options</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_advanced_options" title="Permalink to this definition">¶</a></dt>
+<dd><p>A key/value map of advanced Storage DRS
+settings that are not exposed via Terraform or the vSphere client.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_automation_level">
+<code class="descname">sdrs_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The global automation level for all
+virtual machines in this datastore cluster. Default: <cite>manual</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_default_intra_vm_affinity">
+<code class="descname">sdrs_default_intra_vm_affinity</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_default_intra_vm_affinity" title="Permalink to this definition">¶</a></dt>
+<dd><p>When <cite>true</cite>, all disks in a
+single virtual machine will be kept on the same datastore. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_enabled">
+<code class="descname">sdrs_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable Storage DRS for this datastore cluster.
+Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_free_space_threshold">
+<code class="descname">sdrs_free_space_threshold</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_free_space_threshold" title="Permalink to this definition">¶</a></dt>
+<dd><p>The free space threshold to use.
+When set to <cite>utilization</cite>, <cite>drs_space_utilization_threshold</cite> is used, and
+when set to <cite>freeSpace</cite>, <cite>drs_free_space_threshold</cite> is used. Default:
+<cite>utilization</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_free_space_utilization_difference">
+<code class="descname">sdrs_free_space_utilization_difference</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_free_space_utilization_difference" title="Permalink to this definition">¶</a></dt>
+<dd><p>The threshold, in
+percent, of difference between space utilization in datastores before storage
+DRS makes decisions to balance the space. Default: <cite>5</cite> percent.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_io_balance_automation_level">
+<code class="descname">sdrs_io_balance_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_io_balance_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the default
+automation settings when correcting I/O load imbalances.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_io_latency_threshold">
+<code class="descname">sdrs_io_latency_threshold</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_io_latency_threshold" title="Permalink to this definition">¶</a></dt>
+<dd><p>The I/O latency threshold, in
+milliseconds, that storage DRS uses to make recommendations to move disks
+from this datastore. Default: <cite>15</cite> seconds.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_io_load_balance_enabled">
+<code class="descname">sdrs_io_load_balance_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_io_load_balance_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable I/O load balancing for
+this datastore cluster. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_io_load_imbalance_threshold">
+<code class="descname">sdrs_io_load_imbalance_threshold</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_io_load_imbalance_threshold" title="Permalink to this definition">¶</a></dt>
+<dd><p>The difference between load
+in datastores in the cluster before storage DRS makes recommendations to
+balance the load. Default: <cite>5</cite> percent.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_io_reservable_iops_threshold">
+<code class="descname">sdrs_io_reservable_iops_threshold</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_io_reservable_iops_threshold" title="Permalink to this definition">¶</a></dt>
+<dd><p>The threshold of reservable
+IOPS of all virtual machines on the datastore before storage DRS makes
+recommendations to move VMs off of a datastore. Note that this setting should
+only be set if <cite>sdrs_io_reservable_percent_threshold</cite> cannot make an accurate
+estimate of the capacity of the datastores in your cluster, and should be set
+to roughly 50-60% of the worst case peak performance of the backing LUNs.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_io_reservable_percent_threshold">
+<code class="descname">sdrs_io_reservable_percent_threshold</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_io_reservable_percent_threshold" title="Permalink to this definition">¶</a></dt>
+<dd><p>The threshold, in
+percent, of actual estimated performance of the datastore (in IOPS) that
+storage DRS uses to make recommendations to move VMs off of a datastore when
+the total reservable IOPS exceeds the threshold. Default: <cite>60</cite> percent.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_io_reservable_threshold_mode">
+<code class="descname">sdrs_io_reservable_threshold_mode</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_io_reservable_threshold_mode" title="Permalink to this definition">¶</a></dt>
+<dd><p>The reservable IOPS
+threshold setting to use, <cite>sdrs_io_reservable_percent_threshold</cite> in the event
+of <cite>automatic</cite>, or <cite>sdrs_io_reservable_iops_threshold</cite> in the event of
+<cite>manual</cite>. Default: <cite>automatic</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_load_balance_interval">
+<code class="descname">sdrs_load_balance_interval</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_load_balance_interval" title="Permalink to this definition">¶</a></dt>
+<dd><p>The storage DRS poll interval, in
+minutes. Default: <cite>480</cite> minutes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_policy_enforcement_automation_level">
+<code class="descname">sdrs_policy_enforcement_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_policy_enforcement_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the default
+automation settings when correcting storage and VM policy violations.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_rule_enforcement_automation_level">
+<code class="descname">sdrs_rule_enforcement_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_rule_enforcement_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the default
+automation settings when correcting affinity rule violations.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_space_balance_automation_level">
+<code class="descname">sdrs_space_balance_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_space_balance_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the default
+automation settings when correcting disk space imbalances.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.sdrs_vm_evacuation_automation_level">
+<code class="descname">sdrs_vm_evacuation_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.sdrs_vm_evacuation_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the default
+automation settings when generating recommendations for datastore evacuation.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreCluster.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DatastoreCluster.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DatastoreCluster.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DatastoreCluster.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.DatastoreClusterVmAntiAffinityRule">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">DatastoreClusterVmAntiAffinityRule</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>datastore_cluster_id=None</em>, <em>enabled=None</em>, <em>mandatory=None</em>, <em>name=None</em>, <em>virtual_machine_ids=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DatastoreClusterVmAntiAffinityRule" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_datastore_cluster_vm_anti_affinity_rule</cite> resource can be used to
+manage VM anti-affinity rules in a datastore cluster, either created by the
+[<cite>vsphere_datastore_cluster</cite>][tf-vsphere-datastore-cluster-resource] resource or looked up
+by the [<cite>vsphere_datastore_cluster</cite>][tf-vsphere-datastore-cluster-data-source] data source.</p>
+<p>[tf-vsphere-datastore-cluster-resource]: /docs/providers/vsphere/r/datastore_cluster.html
+[tf-vsphere-datastore-cluster-data-source]: /docs/providers/vsphere/d/datastore_cluster.html</p>
+<p>This rule can be used to tell a set to virtual machines to run on different
+datastores within a cluster, useful for preventing single points of failure in
+application cluster scenarios. When configured, Storage DRS will make a best effort to
+ensure that the virtual machines run on different datastores, or prevent any
+operation that would keep that from happening, depending on the value of the
+<cite>mandatory</cite> flag.</p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> Storage DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>datastore_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the datastore cluster to put the group in.  Forces
+a new resource if changed.</li>
+<li><strong>enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable this rule in the cluster. Default: <cite>true</cite>.</li>
+<li><strong>mandatory</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the rule. This must be unique in the cluster.</li>
+<li><strong>virtual_machine_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The UUIDs of the virtual machines to run
+on different datastores from each other.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.datastore_cluster_id">
+<code class="descname">datastore_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.datastore_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the datastore cluster to put the group in.  Forces
+a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.enabled">
+<code class="descname">enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable this rule in the cluster. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.mandatory">
+<code class="descname">mandatory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.mandatory" title="Permalink to this definition">¶</a></dt>
+<dd><p>When this value is <cite>true</cite>, prevents any virtual
+machine operations that may violate this rule. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the rule. This must be unique in the cluster.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.virtual_machine_ids">
+<code class="descname">virtual_machine_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.virtual_machine_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUIDs of the virtual machines to run
+on different datastores from each other.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DatastoreClusterVmAntiAffinityRule.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.DistributedPortGroup">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">DistributedPortGroup</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>active_uplinks=None</em>, <em>allow_forged_transmits=None</em>, <em>allow_mac_changes=None</em>, <em>allow_promiscuous=None</em>, <em>auto_expand=None</em>, <em>block_all_ports=None</em>, <em>block_override_allowed=None</em>, <em>check_beacon=None</em>, <em>custom_attributes=None</em>, <em>description=None</em>, <em>directpath_gen2_allowed=None</em>, <em>distributed_virtual_switch_uuid=None</em>, <em>egress_shaping_average_bandwidth=None</em>, <em>egress_shaping_burst_size=None</em>, <em>egress_shaping_enabled=None</em>, <em>egress_shaping_peak_bandwidth=None</em>, <em>failback=None</em>, <em>ingress_shaping_average_bandwidth=None</em>, <em>ingress_shaping_burst_size=None</em>, <em>ingress_shaping_enabled=None</em>, <em>ingress_shaping_peak_bandwidth=None</em>, <em>lacp_enabled=None</em>, <em>lacp_mode=None</em>, <em>live_port_moving_allowed=None</em>, <em>name=None</em>, <em>netflow_enabled=None</em>, <em>netflow_override_allowed=None</em>, <em>network_resource_pool_key=None</em>, <em>network_resource_pool_override_allowed=None</em>, <em>notify_switches=None</em>, <em>number_of_ports=None</em>, <em>port_config_reset_at_disconnect=None</em>, <em>port_name_format=None</em>, <em>port_private_secondary_vlan_id=None</em>, <em>security_policy_override_allowed=None</em>, <em>shaping_override_allowed=None</em>, <em>standby_uplinks=None</em>, <em>tags=None</em>, <em>teaming_policy=None</em>, <em>traffic_filter_override_allowed=None</em>, <em>tx_uplink=None</em>, <em>type=None</em>, <em>uplink_teaming_override_allowed=None</em>, <em>vlan_id=None</em>, <em>vlan_override_allowed=None</em>, <em>vlan_ranges=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_distributed_port_group</cite> resource can be used to manage vSphere
+distributed virtual port groups. These port groups are connected to distributed
+virtual switches, which can be managed by the
+[<cite>vsphere_distributed_virtual_switch</cite>][distributed-virtual-switch] resource.</p>
+<p>Distributed port groups can be used as networks for virtual machines, allowing
+VMs to use the networking supplied by a distributed virtual switch (DVS), with
+a set of policies that apply to that individual newtork, if desired.</p>
+<p>For an overview on vSphere networking concepts, see [this
+page][ref-vsphere-net-concepts]. For more information on vSphere DVS
+portgroups, see [this page][ref-vsphere-dvportgroup].</p>
+<p>[distributed-virtual-switch]: /docs/providers/vsphere/r/distributed_virtual_switch.html
+[ref-vsphere-net-concepts]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html</a>
+[ref-vsphere-dvportgroup]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-69933F6E-2442-46CF-AA17-1196CB9A0A09.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-69933F6E-2442-46CF-AA17-1196CB9A0A09.html</a></p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[list] active_uplinks
+:param pulumi.Input[bool] allow_forged_transmits
+:param pulumi.Input[bool] allow_mac_changes
+:param pulumi.Input[bool] allow_promiscuous
+:param pulumi.Input[bool] auto_expand: Allows the port group to create additional ports</p>
+<blockquote>
+<div>past the limit specified in <cite>number_of_ports</cite> if necessary. Default: <cite>true</cite>.</div></blockquote>
+<p>:param pulumi.Input[bool] block_all_ports
+:param pulumi.Input[bool] block_override_allowed: Allow the [port shutdown</p>
+<blockquote>
+<div>policy][port-shutdown-policy] to be overridden on an individual port.</div></blockquote>
+<p>:param pulumi.Input[bool] check_beacon
+:param pulumi.Input[dict] custom_attributes: Map of custom attribute ids to attribute</p>
+<blockquote>
+<div>value string to set for port group. See [here][docs-setting-custom-attributes]
+for a reference on how to set values for custom attributes.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – An optional description for the port group.</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[bool] directpath_gen2_allowed
+:param pulumi.Input[str] distributed_virtual_switch_uuid: The ID of the DVS to add the</p>
+<blockquote>
+<div>port group to. Forces a new resource if changed.</div></blockquote>
+<p>:param pulumi.Input[int] egress_shaping_average_bandwidth
+:param pulumi.Input[int] egress_shaping_burst_size
+:param pulumi.Input[bool] egress_shaping_enabled
+:param pulumi.Input[int] egress_shaping_peak_bandwidth
+:param pulumi.Input[bool] failback
+:param pulumi.Input[int] ingress_shaping_average_bandwidth
+:param pulumi.Input[int] ingress_shaping_burst_size
+:param pulumi.Input[bool] ingress_shaping_enabled
+:param pulumi.Input[int] ingress_shaping_peak_bandwidth
+:param pulumi.Input[bool] lacp_enabled
+:param pulumi.Input[str] lacp_mode
+:param pulumi.Input[bool] live_port_moving_allowed: Allow a port in this port group to be</p>
+<blockquote>
+<div>moved to another port group while it is connected.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the port group.</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[bool] netflow_enabled
+:param pulumi.Input[bool] netflow_override_allowed: Allow the [Netflow</p>
+<blockquote>
+<div>policy][netflow-policy] on this port group to be overridden on an individual
+port.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>network_resource_pool_key</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The key of a network resource pool
+to associate with this port group. The default is <cite>-1</cite>, which implies no
+association.</li>
+<li><strong>network_resource_pool_override_allowed</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Allow the network
+resource pool set on this port group to be overridden on an individual port.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[bool] notify_switches
+:param pulumi.Input[int] number_of_ports: The number of ports available on this port</p>
+<blockquote>
+<div>group. Cannot be decreased below the amount of used ports on the port group.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>port_config_reset_at_disconnect</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Reset a port’s settings to the
+settings defined on this port group policy when the port disconnects.</li>
+<li><strong>port_name_format</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – An optional formatting policy for naming of
+the ports in this port group. See the <cite>portNameFormat</cite> attribute listed
+[here][ext-vsphere-portname-format] for details on the format syntax.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[int] port_private_secondary_vlan_id
+:param pulumi.Input[bool] security_policy_override_allowed: Allow the [security policy</p>
+<blockquote>
+<div>settings][sec-policy-settings] defined in this port group policy to be
+overridden on an individual port.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>shaping_override_allowed</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Allow the [traffic shaping
+options][traffic-shaping-settings] on this port group policy to be overridden
+on an individual port.</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[list] standby_uplinks
+:param pulumi.Input[list] tags
+:param pulumi.Input[str] teaming_policy
+:param pulumi.Input[bool] traffic_filter_override_allowed: Allow any traffic filters on</p>
+<blockquote>
+<div>this port group to be overridden on an individual port.</div></blockquote>
+<p>:param pulumi.Input[bool] tx_uplink
+:param pulumi.Input[str] type: The port group type. Can be one of <cite>earlyBinding</cite> (static</p>
+<blockquote>
+<div>binding) or <cite>ephemeral</cite>. Default: <cite>earlyBinding</cite>.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>uplink_teaming_override_allowed</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Allow the [uplink teaming
+options][uplink-teaming-settings] on this port group to be overridden on an
+individual port.</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[int] vlan_id
+:param pulumi.Input[bool] vlan_override_allowed: Allow the [VLAN settings][vlan-settings]</p>
+<blockquote>
+<div>on this port group to be overridden on an individual port.</div></blockquote>
+<p>:param pulumi.Input[list] vlan_ranges</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.auto_expand">
+<code class="descname">auto_expand</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.auto_expand" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allows the port group to create additional ports
+past the limit specified in <cite>number_of_ports</cite> if necessary. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.block_override_allowed">
+<code class="descname">block_override_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.block_override_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow the [port shutdown
+policy][port-shutdown-policy] to be overridden on an individual port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Map of custom attribute ids to attribute
+value string to set for port group. See [here][docs-setting-custom-attributes]
+for a reference on how to set values for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>An optional description for the port group.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.distributed_virtual_switch_uuid">
+<code class="descname">distributed_virtual_switch_uuid</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.distributed_virtual_switch_uuid" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ID of the DVS to add the
+port group to. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.live_port_moving_allowed">
+<code class="descname">live_port_moving_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.live_port_moving_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow a port in this port group to be
+moved to another port group while it is connected.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the port group.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.netflow_override_allowed">
+<code class="descname">netflow_override_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.netflow_override_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow the [Netflow
+policy][netflow-policy] on this port group to be overridden on an individual
+port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.network_resource_pool_key">
+<code class="descname">network_resource_pool_key</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.network_resource_pool_key" title="Permalink to this definition">¶</a></dt>
+<dd><p>The key of a network resource pool
+to associate with this port group. The default is <cite>-1</cite>, which implies no
+association.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.network_resource_pool_override_allowed">
+<code class="descname">network_resource_pool_override_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.network_resource_pool_override_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow the network
+resource pool set on this port group to be overridden on an individual port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.number_of_ports">
+<code class="descname">number_of_ports</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.number_of_ports" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of ports available on this port
+group. Cannot be decreased below the amount of used ports on the port group.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.port_config_reset_at_disconnect">
+<code class="descname">port_config_reset_at_disconnect</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.port_config_reset_at_disconnect" title="Permalink to this definition">¶</a></dt>
+<dd><p>Reset a port’s settings to the
+settings defined on this port group policy when the port disconnects.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.port_name_format">
+<code class="descname">port_name_format</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.port_name_format" title="Permalink to this definition">¶</a></dt>
+<dd><p>An optional formatting policy for naming of
+the ports in this port group. See the <cite>portNameFormat</cite> attribute listed
+[here][ext-vsphere-portname-format] for details on the format syntax.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.security_policy_override_allowed">
+<code class="descname">security_policy_override_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.security_policy_override_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow the [security policy
+settings][sec-policy-settings] defined in this port group policy to be
+overridden on an individual port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.shaping_override_allowed">
+<code class="descname">shaping_override_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.shaping_override_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow the [traffic shaping
+options][traffic-shaping-settings] on this port group policy to be overridden
+on an individual port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.traffic_filter_override_allowed">
+<code class="descname">traffic_filter_override_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.traffic_filter_override_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow any traffic filters on
+this port group to be overridden on an individual port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.type">
+<code class="descname">type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The port group type. Can be one of <cite>earlyBinding</cite> (static
+binding) or <cite>ephemeral</cite>. Default: <cite>earlyBinding</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.uplink_teaming_override_allowed">
+<code class="descname">uplink_teaming_override_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.uplink_teaming_override_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow the [uplink teaming
+options][uplink-teaming-settings] on this port group to be overridden on an
+individual port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedPortGroup.vlan_override_allowed">
+<code class="descname">vlan_override_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.vlan_override_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow the [VLAN settings][vlan-settings]
+on this port group to be overridden on an individual port.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DistributedPortGroup.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DistributedPortGroup.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DistributedPortGroup.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">DistributedVirtualSwitch</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>active_uplinks=None</em>, <em>allow_forged_transmits=None</em>, <em>allow_mac_changes=None</em>, <em>allow_promiscuous=None</em>, <em>block_all_ports=None</em>, <em>check_beacon=None</em>, <em>contact_detail=None</em>, <em>contact_name=None</em>, <em>custom_attributes=None</em>, <em>datacenter_id=None</em>, <em>description=None</em>, <em>directpath_gen2_allowed=None</em>, <em>egress_shaping_average_bandwidth=None</em>, <em>egress_shaping_burst_size=None</em>, <em>egress_shaping_enabled=None</em>, <em>egress_shaping_peak_bandwidth=None</em>, <em>failback=None</em>, <em>faulttolerance_maximum_mbit=None</em>, <em>faulttolerance_reservation_mbit=None</em>, <em>faulttolerance_share_count=None</em>, <em>faulttolerance_share_level=None</em>, <em>folder=None</em>, <em>hbr_maximum_mbit=None</em>, <em>hbr_reservation_mbit=None</em>, <em>hbr_share_count=None</em>, <em>hbr_share_level=None</em>, <em>hosts=None</em>, <em>ingress_shaping_average_bandwidth=None</em>, <em>ingress_shaping_burst_size=None</em>, <em>ingress_shaping_enabled=None</em>, <em>ingress_shaping_peak_bandwidth=None</em>, <em>ipv4_address=None</em>, <em>iscsi_maximum_mbit=None</em>, <em>iscsi_reservation_mbit=None</em>, <em>iscsi_share_count=None</em>, <em>iscsi_share_level=None</em>, <em>lacp_api_version=None</em>, <em>lacp_enabled=None</em>, <em>lacp_mode=None</em>, <em>link_discovery_operation=None</em>, <em>link_discovery_protocol=None</em>, <em>management_maximum_mbit=None</em>, <em>management_reservation_mbit=None</em>, <em>management_share_count=None</em>, <em>management_share_level=None</em>, <em>max_mtu=None</em>, <em>multicast_filtering_mode=None</em>, <em>name=None</em>, <em>netflow_active_flow_timeout=None</em>, <em>netflow_collector_ip_address=None</em>, <em>netflow_collector_port=None</em>, <em>netflow_enabled=None</em>, <em>netflow_idle_flow_timeout=None</em>, <em>netflow_internal_flows_only=None</em>, <em>netflow_observation_domain_id=None</em>, <em>netflow_sampling_rate=None</em>, <em>network_resource_control_enabled=None</em>, <em>network_resource_control_version=None</em>, <em>nfs_maximum_mbit=None</em>, <em>nfs_reservation_mbit=None</em>, <em>nfs_share_count=None</em>, <em>nfs_share_level=None</em>, <em>notify_switches=None</em>, <em>port_private_secondary_vlan_id=None</em>, <em>standby_uplinks=None</em>, <em>tags=None</em>, <em>teaming_policy=None</em>, <em>tx_uplink=None</em>, <em>uplinks=None</em>, <em>vdp_maximum_mbit=None</em>, <em>vdp_reservation_mbit=None</em>, <em>vdp_share_count=None</em>, <em>vdp_share_level=None</em>, <em>version=None</em>, <em>virtualmachine_maximum_mbit=None</em>, <em>virtualmachine_reservation_mbit=None</em>, <em>virtualmachine_share_count=None</em>, <em>virtualmachine_share_level=None</em>, <em>vlan_id=None</em>, <em>vlan_ranges=None</em>, <em>vmotion_maximum_mbit=None</em>, <em>vmotion_reservation_mbit=None</em>, <em>vmotion_share_count=None</em>, <em>vmotion_share_level=None</em>, <em>vsan_maximum_mbit=None</em>, <em>vsan_reservation_mbit=None</em>, <em>vsan_share_count=None</em>, <em>vsan_share_level=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_distributed_virtual_switch</cite> resource can be used to manage VMware
+Distributed Virtual Switches.</p>
+<p>An essential component of a distributed, scalable VMware datacenter, the
+vSphere Distributed Virtual Switch (DVS) provides centralized management and
+monitoring of the networking configuration of all the hosts that are associated
+with the switch. In addition to adding port groups (see the
+[<cite>vsphere_distributed_port_group</cite>][distributed-port-group] resource) that can
+be used as networks for virtual machines, a DVS can be configured to perform
+advanced high availability, traffic shaping, network monitoring, and more.</p>
+<p>For an overview on vSphere networking concepts, see [this
+page][ref-vsphere-net-concepts]. For more information on vSphere DVS, see [this
+page][ref-vsphere-dvs].</p>
+<p>[distributed-port-group]: /docs/providers/vsphere/r/distributed_port_group.html
+[ref-vsphere-net-concepts]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html</a>
+[ref-vsphere-dvs]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-375B45C7-684C-4C51-BA3C-70E48DFABF04.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-375B45C7-684C-4C51-BA3C-70E48DFABF04.html</a></p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>active_uplinks</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – A list of active uplinks to be used in load
+balancing. These uplinks need to match the definitions in the
+<cite>uplinks</cite> DVS argument. See
+here for more details.</li>
+<li><strong>allow_forged_transmits</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Controls whether or not a virtual
+network adapter is allowed to send network traffic with a different MAC
+address than that of its own.</li>
+<li><strong>allow_mac_changes</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Controls whether or not the Media Access
+Control (MAC) address can be changed.</li>
+<li><strong>allow_promiscuous</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable promiscuous mode on the network. This
+flag indicates whether or not all traffic is seen on a given port.</li>
+<li><strong>block_all_ports</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Shuts down all ports in the port groups that
+this policy applies to, effectively blocking all network access to connected
+virtual devices.</li>
+<li><strong>check_beacon</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enables beacon probing as an additional measure
+to detect NIC failure.</li>
+<li><strong>contact_detail</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The detailed contact information for the person
+who is responsible for the DVS.</li>
+<li><strong>contact_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the person who is responsible for the
+DVS.</li>
+<li><strong>custom_attributes</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Map of custom attribute ids to attribute
+value strings to set for virtual switch. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</li>
+<li><strong>datacenter_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The ID of the datacenter where the distributed
+virtual switch will be created. Forces a new resource if changed.</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A detailed description for the DVS.</li>
+<li><strong>directpath_gen2_allowed</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Allow VMDirectPath Gen2 for the ports
+for which this policy applies to.</li>
+<li><strong>egress_shaping_average_bandwidth</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The average bandwidth in bits
+per second if egress traffic shaping is enabled on the port.</li>
+<li><strong>egress_shaping_burst_size</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum burst size allowed in
+bytes if egress traffic shaping is enabled on the port.</li>
+<li><strong>egress_shaping_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – <cite>true</cite> if the traffic shaper is enabled
+on the port for egress traffic.</li>
+<li><strong>egress_shaping_peak_bandwidth</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The peak bandwidth during bursts
+in bits per second if egress traffic shaping is enabled on the port.</li>
+<li><strong>failback</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If <cite>true</cite>, the teaming policy will re-activate failed
+uplinks higher in precedence when they come back up.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[int] faulttolerance_maximum_mbit
+:param pulumi.Input[int] faulttolerance_reservation_mbit
+:param pulumi.Input[int] faulttolerance_share_count
+:param pulumi.Input[str] faulttolerance_share_level
+:param pulumi.Input[str] folder: The folder to create the DVS in. Forces a new resource</p>
+<blockquote>
+<div>if changed.</div></blockquote>
+<p>:param pulumi.Input[int] hbr_maximum_mbit
+:param pulumi.Input[int] hbr_reservation_mbit
+:param pulumi.Input[int] hbr_share_count
+:param pulumi.Input[str] hbr_share_level
+:param pulumi.Input[list] hosts: Use the <cite>host</cite> block to declare a host specification. The</p>
+<blockquote>
+<div>options are:</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>ingress_shaping_average_bandwidth</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The average bandwidth in
+bits per second if ingress traffic shaping is enabled on the port.</li>
+<li><strong>ingress_shaping_burst_size</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum burst size allowed in
+bytes if ingress traffic shaping is enabled on the port.</li>
+<li><strong>ingress_shaping_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – <cite>true</cite> if the traffic shaper is
+enabled on the port for ingress traffic.</li>
+<li><strong>ingress_shaping_peak_bandwidth</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The peak bandwidth during
+bursts in bits per second if ingress traffic shaping is enabled on the port.</li>
+<li><strong>ipv4_address</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – An IPv4 address to identify the switch. This is
+mostly useful when used with the Netflow arguments found
+below.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[int] iscsi_maximum_mbit
+:param pulumi.Input[int] iscsi_reservation_mbit
+:param pulumi.Input[int] iscsi_share_count
+:param pulumi.Input[str] iscsi_share_level
+:param pulumi.Input[str] lacp_api_version: The Link Aggregation Control Protocol group</p>
+<blockquote>
+<div>version to use with the switch. Possible values are <cite>singleLag</cite> and
+<cite>multipleLag</cite>.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>lacp_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enables LACP for the ports that this policy
+applies to.</li>
+<li><strong>lacp_mode</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The LACP mode. Can be one of <cite>active</cite> or <cite>passive</cite>.</li>
+<li><strong>link_discovery_operation</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Whether to <cite>advertise</cite> or <cite>listen</cite>
+for link discovery traffic.</li>
+<li><strong>link_discovery_protocol</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The discovery protocol type. Valid
+types are <cite>cdp</cite> and <cite>lldp</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[int] management_maximum_mbit
+:param pulumi.Input[int] management_reservation_mbit
+:param pulumi.Input[int] management_share_count
+:param pulumi.Input[str] management_share_level
+:param pulumi.Input[int] max_mtu: The maximum transmission unit (MTU) for the virtual</p>
+<blockquote>
+<div>switch.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>multicast_filtering_mode</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The multicast filtering mode to use
+with the switch. Can be one of <cite>legacyFiltering</cite> or <cite>snooping</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the distributed virtual switch.</li>
+<li><strong>netflow_active_flow_timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of seconds after which
+active flows are forced to be exported to the collector. Allowed range is
+<cite>60</cite> to <cite>3600</cite>. Default: <cite>60</cite>.</li>
+<li><strong>netflow_collector_ip_address</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – IP address for the Netflow
+collector, using IPv4 or IPv6. IPv6 is supported in vSphere Distributed
+Switch Version 6.0 or later. Must be set before Netflow can be enabled.</li>
+<li><strong>netflow_collector_port</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Port for the Netflow collector. This
+must be set before Netflow can be enabled.</li>
+<li><strong>netflow_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enables Netflow on all ports that this policy
+applies to.</li>
+<li><strong>netflow_idle_flow_timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of seconds after which
+idle flows are forced to be exported to the collector. Allowed range is <cite>10</cite>
+to <cite>600</cite>. Default: <cite>15</cite>.</li>
+<li><strong>netflow_internal_flows_only</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Whether to limit analysis to
+traffic that has both source and destination served by the same host.
+Default: <cite>false</cite>.</li>
+<li><strong>netflow_observation_domain_id</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The observation domain ID for
+the Netflow collector.</li>
+<li><strong>netflow_sampling_rate</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The ratio of total number of packets to
+the number of packets analyzed. The default is <cite>0</cite>, which indicates that the
+switch should analyze all packets. The maximum value is <cite>1000</cite>, which
+indicates an analysis rate of 0.001%.</li>
+<li><strong>network_resource_control_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Set to <cite>true</cite> to enable
+network I/O control. Default: <cite>false</cite>.</li>
+<li><strong>network_resource_control_version</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The version of network I/O
+control to use. Can be one of <cite>version2</cite> or <cite>version3</cite>. Default: <cite>version2</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[int] nfs_maximum_mbit
+:param pulumi.Input[int] nfs_reservation_mbit
+:param pulumi.Input[int] nfs_share_count
+:param pulumi.Input[str] nfs_share_level
+:param pulumi.Input[bool] notify_switches: If <cite>true</cite>, the teaming policy will notify the</p>
+<blockquote>
+<div>broadcast network of an uplink failover, triggering cache updates.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>port_private_secondary_vlan_id</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Used to define a secondary VLAN
+ID when using private VLANs.</li>
+<li><strong>standby_uplinks</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – A list of standby uplinks to be used in
+failover. These uplinks need to match the definitions in the
+<cite>uplinks</cite> DVS argument. See
+here for more details.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
+<li><strong>teaming_policy</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The uplink teaming policy. Can be one of
+<cite>loadbalance_ip</cite>, <cite>loadbalance_srcmac</cite>, <cite>loadbalance_srcid</cite>, or
+<cite>failover_explicit</cite>.</li>
+<li><strong>tx_uplink</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Forward all traffic transmitted by ports for which
+this policy applies to its DVS uplinks.</li>
+<li><strong>uplinks</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – A list of strings that uniquely identifies the names
+of the uplinks on the DVS across hosts. The number of items in this list
+controls the number of uplinks that exist on the DVS, in addition to the
+names.  See here for an example on how to
+use this option.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[int] vdp_maximum_mbit
+:param pulumi.Input[int] vdp_reservation_mbit
+:param pulumi.Input[int] vdp_share_count
+:param pulumi.Input[str] vdp_share_level
+:param pulumi.Input[str] version: - The version of the DVS to create. The default is to</p>
+<blockquote>
+<div>create the DVS at the latest version supported by the version of vSphere
+being used. A DVS can be upgraded to another version, but cannot be
+downgraded.</div></blockquote>
+<p>:param pulumi.Input[int] virtualmachine_maximum_mbit
+:param pulumi.Input[int] virtualmachine_reservation_mbit
+:param pulumi.Input[int] virtualmachine_share_count
+:param pulumi.Input[str] virtualmachine_share_level
+:param pulumi.Input[int] vlan_id
+:param pulumi.Input[list] vlan_ranges: Used to denote VLAN trunking. Use the <cite>min_vlan</cite></p>
+<blockquote>
+<div>and <cite>max_vlan</cite> sub-arguments to define the tagged VLAN range. Multiple
+<cite>vlan_range</cite> definitions are allowed, but they must not overlap. Example
+below:</div></blockquote>
+<p>:param pulumi.Input[int] vmotion_maximum_mbit
+:param pulumi.Input[int] vmotion_reservation_mbit
+:param pulumi.Input[int] vmotion_share_count
+:param pulumi.Input[str] vmotion_share_level
+:param pulumi.Input[int] vsan_maximum_mbit
+:param pulumi.Input[int] vsan_reservation_mbit
+:param pulumi.Input[int] vsan_share_count
+:param pulumi.Input[str] vsan_share_level</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.active_uplinks">
+<code class="descname">active_uplinks</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.active_uplinks" title="Permalink to this definition">¶</a></dt>
+<dd><p>A list of active uplinks to be used in load
+balancing. These uplinks need to match the definitions in the
+<cite>uplinks</cite> DVS argument. See
+here for more details.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.allow_forged_transmits">
+<code class="descname">allow_forged_transmits</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.allow_forged_transmits" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls whether or not a virtual
+network adapter is allowed to send network traffic with a different MAC
+address than that of its own.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.allow_mac_changes">
+<code class="descname">allow_mac_changes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.allow_mac_changes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls whether or not the Media Access
+Control (MAC) address can be changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.allow_promiscuous">
+<code class="descname">allow_promiscuous</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.allow_promiscuous" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable promiscuous mode on the network. This
+flag indicates whether or not all traffic is seen on a given port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.block_all_ports">
+<code class="descname">block_all_ports</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.block_all_ports" title="Permalink to this definition">¶</a></dt>
+<dd><p>Shuts down all ports in the port groups that
+this policy applies to, effectively blocking all network access to connected
+virtual devices.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.check_beacon">
+<code class="descname">check_beacon</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.check_beacon" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enables beacon probing as an additional measure
+to detect NIC failure.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.contact_detail">
+<code class="descname">contact_detail</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.contact_detail" title="Permalink to this definition">¶</a></dt>
+<dd><p>The detailed contact information for the person
+who is responsible for the DVS.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.contact_name">
+<code class="descname">contact_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.contact_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the person who is responsible for the
+DVS.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Map of custom attribute ids to attribute
+value strings to set for virtual switch. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.datacenter_id">
+<code class="descname">datacenter_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.datacenter_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ID of the datacenter where the distributed
+virtual switch will be created. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>A detailed description for the DVS.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.directpath_gen2_allowed">
+<code class="descname">directpath_gen2_allowed</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.directpath_gen2_allowed" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow VMDirectPath Gen2 for the ports
+for which this policy applies to.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.egress_shaping_average_bandwidth">
+<code class="descname">egress_shaping_average_bandwidth</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.egress_shaping_average_bandwidth" title="Permalink to this definition">¶</a></dt>
+<dd><p>The average bandwidth in bits
+per second if egress traffic shaping is enabled on the port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.egress_shaping_burst_size">
+<code class="descname">egress_shaping_burst_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.egress_shaping_burst_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum burst size allowed in
+bytes if egress traffic shaping is enabled on the port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.egress_shaping_enabled">
+<code class="descname">egress_shaping_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.egress_shaping_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p><cite>true</cite> if the traffic shaper is enabled
+on the port for egress traffic.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.egress_shaping_peak_bandwidth">
+<code class="descname">egress_shaping_peak_bandwidth</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.egress_shaping_peak_bandwidth" title="Permalink to this definition">¶</a></dt>
+<dd><p>The peak bandwidth during bursts
+in bits per second if egress traffic shaping is enabled on the port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.failback">
+<code class="descname">failback</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.failback" title="Permalink to this definition">¶</a></dt>
+<dd><p>If <cite>true</cite>, the teaming policy will re-activate failed
+uplinks higher in precedence when they come back up.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.folder">
+<code class="descname">folder</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.folder" title="Permalink to this definition">¶</a></dt>
+<dd><p>The folder to create the DVS in. Forces a new resource
+if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.hosts">
+<code class="descname">hosts</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.hosts" title="Permalink to this definition">¶</a></dt>
+<dd><p>Use the <cite>host</cite> block to declare a host specification. The
+options are:</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.ingress_shaping_average_bandwidth">
+<code class="descname">ingress_shaping_average_bandwidth</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.ingress_shaping_average_bandwidth" title="Permalink to this definition">¶</a></dt>
+<dd><p>The average bandwidth in
+bits per second if ingress traffic shaping is enabled on the port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.ingress_shaping_burst_size">
+<code class="descname">ingress_shaping_burst_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.ingress_shaping_burst_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum burst size allowed in
+bytes if ingress traffic shaping is enabled on the port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.ingress_shaping_enabled">
+<code class="descname">ingress_shaping_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.ingress_shaping_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p><cite>true</cite> if the traffic shaper is
+enabled on the port for ingress traffic.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.ingress_shaping_peak_bandwidth">
+<code class="descname">ingress_shaping_peak_bandwidth</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.ingress_shaping_peak_bandwidth" title="Permalink to this definition">¶</a></dt>
+<dd><p>The peak bandwidth during
+bursts in bits per second if ingress traffic shaping is enabled on the port.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.ipv4_address">
+<code class="descname">ipv4_address</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.ipv4_address" title="Permalink to this definition">¶</a></dt>
+<dd><p>An IPv4 address to identify the switch. This is
+mostly useful when used with the Netflow arguments found
+below.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.lacp_api_version">
+<code class="descname">lacp_api_version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.lacp_api_version" title="Permalink to this definition">¶</a></dt>
+<dd><p>The Link Aggregation Control Protocol group
+version to use with the switch. Possible values are <cite>singleLag</cite> and
+<cite>multipleLag</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.lacp_enabled">
+<code class="descname">lacp_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.lacp_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enables LACP for the ports that this policy
+applies to.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.lacp_mode">
+<code class="descname">lacp_mode</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.lacp_mode" title="Permalink to this definition">¶</a></dt>
+<dd><p>The LACP mode. Can be one of <cite>active</cite> or <cite>passive</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.link_discovery_operation">
+<code class="descname">link_discovery_operation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.link_discovery_operation" title="Permalink to this definition">¶</a></dt>
+<dd><p>Whether to <cite>advertise</cite> or <cite>listen</cite>
+for link discovery traffic.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.link_discovery_protocol">
+<code class="descname">link_discovery_protocol</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.link_discovery_protocol" title="Permalink to this definition">¶</a></dt>
+<dd><p>The discovery protocol type. Valid
+types are <cite>cdp</cite> and <cite>lldp</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.max_mtu">
+<code class="descname">max_mtu</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.max_mtu" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum transmission unit (MTU) for the virtual
+switch.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.multicast_filtering_mode">
+<code class="descname">multicast_filtering_mode</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.multicast_filtering_mode" title="Permalink to this definition">¶</a></dt>
+<dd><p>The multicast filtering mode to use
+with the switch. Can be one of <cite>legacyFiltering</cite> or <cite>snooping</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the distributed virtual switch.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.netflow_active_flow_timeout">
+<code class="descname">netflow_active_flow_timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.netflow_active_flow_timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of seconds after which
+active flows are forced to be exported to the collector. Allowed range is
+<cite>60</cite> to <cite>3600</cite>. Default: <cite>60</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.netflow_collector_ip_address">
+<code class="descname">netflow_collector_ip_address</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.netflow_collector_ip_address" title="Permalink to this definition">¶</a></dt>
+<dd><p>IP address for the Netflow
+collector, using IPv4 or IPv6. IPv6 is supported in vSphere Distributed
+Switch Version 6.0 or later. Must be set before Netflow can be enabled.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.netflow_collector_port">
+<code class="descname">netflow_collector_port</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.netflow_collector_port" title="Permalink to this definition">¶</a></dt>
+<dd><p>Port for the Netflow collector. This
+must be set before Netflow can be enabled.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.netflow_enabled">
+<code class="descname">netflow_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.netflow_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enables Netflow on all ports that this policy
+applies to.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.netflow_idle_flow_timeout">
+<code class="descname">netflow_idle_flow_timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.netflow_idle_flow_timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of seconds after which
+idle flows are forced to be exported to the collector. Allowed range is <cite>10</cite>
+to <cite>600</cite>. Default: <cite>15</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.netflow_internal_flows_only">
+<code class="descname">netflow_internal_flows_only</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.netflow_internal_flows_only" title="Permalink to this definition">¶</a></dt>
+<dd><p>Whether to limit analysis to
+traffic that has both source and destination served by the same host.
+Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.netflow_observation_domain_id">
+<code class="descname">netflow_observation_domain_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.netflow_observation_domain_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The observation domain ID for
+the Netflow collector.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.netflow_sampling_rate">
+<code class="descname">netflow_sampling_rate</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.netflow_sampling_rate" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ratio of total number of packets to
+the number of packets analyzed. The default is <cite>0</cite>, which indicates that the
+switch should analyze all packets. The maximum value is <cite>1000</cite>, which
+indicates an analysis rate of 0.001%.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.network_resource_control_enabled">
+<code class="descname">network_resource_control_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.network_resource_control_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Set to <cite>true</cite> to enable
+network I/O control. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.network_resource_control_version">
+<code class="descname">network_resource_control_version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.network_resource_control_version" title="Permalink to this definition">¶</a></dt>
+<dd><p>The version of network I/O
+control to use. Can be one of <cite>version2</cite> or <cite>version3</cite>. Default: <cite>version2</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.notify_switches">
+<code class="descname">notify_switches</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.notify_switches" title="Permalink to this definition">¶</a></dt>
+<dd><p>If <cite>true</cite>, the teaming policy will notify the
+broadcast network of an uplink failover, triggering cache updates.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.port_private_secondary_vlan_id">
+<code class="descname">port_private_secondary_vlan_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.port_private_secondary_vlan_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>Used to define a secondary VLAN
+ID when using private VLANs.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.standby_uplinks">
+<code class="descname">standby_uplinks</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.standby_uplinks" title="Permalink to this definition">¶</a></dt>
+<dd><p>A list of standby uplinks to be used in
+failover. These uplinks need to match the definitions in the
+<cite>uplinks</cite> DVS argument. See
+here for more details.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.teaming_policy">
+<code class="descname">teaming_policy</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.teaming_policy" title="Permalink to this definition">¶</a></dt>
+<dd><p>The uplink teaming policy. Can be one of
+<cite>loadbalance_ip</cite>, <cite>loadbalance_srcmac</cite>, <cite>loadbalance_srcid</cite>, or
+<cite>failover_explicit</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.tx_uplink">
+<code class="descname">tx_uplink</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.tx_uplink" title="Permalink to this definition">¶</a></dt>
+<dd><p>Forward all traffic transmitted by ports for which
+this policy applies to its DVS uplinks.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.uplinks">
+<code class="descname">uplinks</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.uplinks" title="Permalink to this definition">¶</a></dt>
+<dd><p>A list of strings that uniquely identifies the names
+of the uplinks on the DVS across hosts. The number of items in this list
+controls the number of uplinks that exist on the DVS, in addition to the
+names.  See here for an example on how to
+use this option.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.version">
+<code class="descname">version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.version" title="Permalink to this definition">¶</a></dt>
+<dd><ul class="simple">
+<li>The version of the DVS to create. The default is to</li>
+</ul>
+<p>create the DVS at the latest version supported by the version of vSphere
+being used. A DVS can be upgraded to another version, but cannot be
+downgraded.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.vlan_ranges">
+<code class="descname">vlan_ranges</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.vlan_ranges" title="Permalink to this definition">¶</a></dt>
+<dd><p>Used to denote VLAN trunking. Use the <cite>min_vlan</cite>
+and <cite>max_vlan</cite> sub-arguments to define the tagged VLAN range. Multiple
+<cite>vlan_range</cite> definitions are allowed, but they must not overlap. Example
+below:</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DistributedVirtualSwitch.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DistributedVirtualSwitch.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.DpmHostOverride">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">DpmHostOverride</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compute_cluster_id=None</em>, <em>dpm_automation_level=None</em>, <em>dpm_enabled=None</em>, <em>host_system_id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DpmHostOverride" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_dpm_host_override</cite> resource can be used to add a DPM override to a
+cluster for a particular host. This allows you to control the power management
+settings for individual hosts in the cluster while leaving any unspecified ones
+at the default power management settings.</p>
+<p>For more information on DPM within vSphere clusters, see [this
+page][ref-vsphere-cluster-dpm].</p>
+<p>[ref-vsphere-cluster-dpm]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-5E5E349A-4644-4C9C-B434-1C0243EBDC80.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-5E5E349A-4644-4C9C-B434-1C0243EBDC80.html</a></p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> vSphere DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the override in.  Forces a new
+resource if changed.</li>
+<li><strong>dpm_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The automation level for host power
+operations on this host. Can be one of <cite>manual</cite> or <cite>automated</cite>. Default:
+<cite>manual</cite>.</li>
+<li><strong>dpm_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable DPM support for this host. Default:
+<cite>false</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[str] host_system_id</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.DpmHostOverride.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DpmHostOverride.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the override in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DpmHostOverride.dpm_automation_level">
+<code class="descname">dpm_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DpmHostOverride.dpm_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The automation level for host power
+operations on this host. Can be one of <cite>manual</cite> or <cite>automated</cite>. Default:
+<cite>manual</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DpmHostOverride.dpm_enabled">
+<code class="descname">dpm_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DpmHostOverride.dpm_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable DPM support for this host. Default:
+<cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DpmHostOverride.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DpmHostOverride.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DpmHostOverride.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DpmHostOverride.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.DrsVmOverride">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">DrsVmOverride</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compute_cluster_id=None</em>, <em>drs_automation_level=None</em>, <em>drs_enabled=None</em>, <em>virtual_machine_id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DrsVmOverride" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_drs_vm_override</cite> resource can be used to add a DRS override to a
+cluster for a specific virtual machine. With this resource, one can enable or
+disable DRS and control the automation level for a single virtual machine
+without affecting the rest of the cluster.</p>
+<p>For more information on vSphere clusters and DRS, see [this
+page][ref-vsphere-drs-clusters].</p>
+<p>[ref-vsphere-drs-clusters]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-8ACF3502-5314-469F-8CC9-4A9BD5925BC2.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-8ACF3502-5314-469F-8CC9-4A9BD5925BC2.html</a></p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<p>&gt; <strong>NOTE:</strong> vSphere DRS requires a vSphere Enterprise Plus license.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the override in.  Forces a new
+resource if changed.</li>
+<li><strong>drs_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Overrides the automation level for this virtual
+machine in the cluster. Can be one of <cite>manual</cite>, <cite>partiallyAutomated</cite>, or
+<cite>fullyAutomated</cite>. Default: <cite>manual</cite>.</li>
+<li><strong>drs_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Overrides the default DRS setting for this virtual
+machine. Can be either <cite>true</cite> or <cite>false</cite>. Default: <cite>false</cite>.</li>
+<li><strong>virtual_machine_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The UUID of the virtual machine to create
+the override for.  Forces a new resource if changed.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.DrsVmOverride.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DrsVmOverride.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the override in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DrsVmOverride.drs_automation_level">
+<code class="descname">drs_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DrsVmOverride.drs_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the automation level for this virtual
+machine in the cluster. Can be one of <cite>manual</cite>, <cite>partiallyAutomated</cite>, or
+<cite>fullyAutomated</cite>. Default: <cite>manual</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DrsVmOverride.drs_enabled">
+<code class="descname">drs_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DrsVmOverride.drs_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the default DRS setting for this virtual
+machine. Can be either <cite>true</cite> or <cite>false</cite>. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.DrsVmOverride.virtual_machine_id">
+<code class="descname">virtual_machine_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.DrsVmOverride.virtual_machine_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUID of the virtual machine to create
+the override for.  Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DrsVmOverride.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DrsVmOverride.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.DrsVmOverride.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.DrsVmOverride.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.File">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">File</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>create_directories=None</em>, <em>datacenter=None</em>, <em>datastore=None</em>, <em>destination_file=None</em>, <em>source_datacenter=None</em>, <em>source_datastore=None</em>, <em>source_file=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.File" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_file</cite> resource can be used to upload files (such as virtual disk
+files) from the host machine that Terraform is running on to a target
+datastore.  The resource can also be used to copy files between datastores, or
+from one location to another on the same datastore.</p>
+<p>Updates to destination parameters such as <cite>datacenter</cite>, <cite>datastore</cite>, or
+<cite>destination_file</cite> will move the managed file a new destination based on the
+values of the new settings.  If any source parameter is changed, such as
+<cite>source_datastore</cite>, <cite>source_datacenter</cite> or <cite>source_file</cite>), the resource will be
+re-created. Depending on if destination parameters are being changed as well,
+this may result in the destination file either being overwritten or deleted at
+the old location.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>create_directories</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Create directories in <cite>destination_file</cite>
+path parameter if any missing for copy operation.</li>
+<li><strong>datacenter</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of a datacenter in which the file will be
+uploaded to.</li>
+<li><strong>datastore</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the datastore in which to upload the
+file to.</li>
+<li><strong>destination_file</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The path to where the file should be uploaded
+or copied to on vSphere.</li>
+<li><strong>source_datacenter</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of a datacenter in which the file
+will be copied from. Forces a new resource if changed.</li>
+<li><strong>source_datastore</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the datastore in which file will
+be copied from. Forces a new resource if changed.</li>
+<li><strong>source_file</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The path to the file being uploaded from the
+Terraform host to vSphere or copied within vSphere. Forces a new resource if
+changed.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.File.create_directories">
+<code class="descname">create_directories</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.File.create_directories" title="Permalink to this definition">¶</a></dt>
+<dd><p>Create directories in <cite>destination_file</cite>
+path parameter if any missing for copy operation.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.File.datacenter">
+<code class="descname">datacenter</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.File.datacenter" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of a datacenter in which the file will be
+uploaded to.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.File.datastore">
+<code class="descname">datastore</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.File.datastore" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the datastore in which to upload the
+file to.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.File.destination_file">
+<code class="descname">destination_file</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.File.destination_file" title="Permalink to this definition">¶</a></dt>
+<dd><p>The path to where the file should be uploaded
+or copied to on vSphere.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.File.source_datacenter">
+<code class="descname">source_datacenter</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.File.source_datacenter" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of a datacenter in which the file
+will be copied from. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.File.source_datastore">
+<code class="descname">source_datastore</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.File.source_datastore" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the datastore in which file will
+be copied from. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.File.source_file">
+<code class="descname">source_file</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.File.source_file" title="Permalink to this definition">¶</a></dt>
+<dd><p>The path to the file being uploaded from the
+Terraform host to vSphere or copied within vSphere. Forces a new resource if
+changed.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.File.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.File.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.File.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.File.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.Folder">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">Folder</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>custom_attributes=None</em>, <em>datacenter_id=None</em>, <em>path=None</em>, <em>tags=None</em>, <em>type=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Folder" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_folder</cite> resource can be used to manage vSphere inventory folders.
+The resource supports creating folders of the 5 major types - datacenter
+folders, host and cluster folders, virtual machine folders, datastore folders,
+and network folders.</p>
+<p>Paths are always relative to the specific type of folder you are creating.
+Subfolders are discovered by parsing the relative path specified in <cite>path</cite>, so
+<cite>foo/bar</cite> will create a folder named <cite>bar</cite> in the parent folder <cite>foo</cite>, as long
+as that folder exists.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>custom_attributes</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Map of custom attribute ids to attribute 
+value strings to set for folder. See [here][docs-setting-custom-attributes]
+for a reference on how to set values for custom attributes.</li>
+<li><strong>datacenter_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The ID of the datacenter the folder will be created in.
+Required for all folder types except for datacenter folders. Forces a new
+resource if changed.</li>
+<li><strong>path</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The path of the folder to be created. This is relative to
+the root of the type of folder you are creating, and the supplied datacenter.
+For example, given a default datacenter of <cite>default-dc</cite>, a folder of type
+<cite>vm</cite> (denoting a virtual machine folder), and a supplied folder of
+<cite>terraform-test-folder</cite>, the resulting path would be
+<cite>/default-dc/vm/terraform-test-folder</cite>.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
+<li><strong>type</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The type of folder to create. Allowed options are
+<cite>datacenter</cite> for datacenter folders, <cite>host</cite> for host and cluster folders,
+<cite>vm</cite> for virtual machine folders, <cite>datastore</cite> for datastore folders, and
+<cite>network</cite> for network folders. Forces a new resource if changed.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.Folder.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Folder.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Map of custom attribute ids to attribute 
+value strings to set for folder. See [here][docs-setting-custom-attributes]
+for a reference on how to set values for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Folder.datacenter_id">
+<code class="descname">datacenter_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Folder.datacenter_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The ID of the datacenter the folder will be created in.
+Required for all folder types except for datacenter folders. Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Folder.path">
+<code class="descname">path</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Folder.path" title="Permalink to this definition">¶</a></dt>
+<dd><p>The path of the folder to be created. This is relative to
+the root of the type of folder you are creating, and the supplied datacenter.
+For example, given a default datacenter of <cite>default-dc</cite>, a folder of type
+<cite>vm</cite> (denoting a virtual machine folder), and a supplied folder of
+<cite>terraform-test-folder</cite>, the resulting path would be
+<cite>/default-dc/vm/terraform-test-folder</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Folder.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Folder.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Folder.type">
+<code class="descname">type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Folder.type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The type of folder to create. Allowed options are
+<cite>datacenter</cite> for datacenter folders, <cite>host</cite> for host and cluster folders,
+<cite>vm</cite> for virtual machine folders, <cite>datastore</cite> for datastore folders, and
+<cite>network</cite> for network folders. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.Folder.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Folder.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.Folder.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Folder.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetComputeClusterResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetComputeClusterResult</code><span class="sig-paren">(</span><em>resource_pool_id=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetComputeClusterResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getComputeCluster.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetComputeClusterResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetComputeClusterResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetCustomAttributeResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetCustomAttributeResult</code><span class="sig-paren">(</span><em>managed_object_type=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetCustomAttributeResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getCustomAttribute.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetCustomAttributeResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetCustomAttributeResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetDatacenterResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetDatacenterResult</code><span class="sig-paren">(</span><em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetDatacenterResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getDatacenter.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetDatacenterResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetDatacenterResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetDatastoreClusterResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetDatastoreClusterResult</code><span class="sig-paren">(</span><em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetDatastoreClusterResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getDatastoreCluster.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetDatastoreClusterResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetDatastoreClusterResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetDatastoreResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetDatastoreResult</code><span class="sig-paren">(</span><em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetDatastoreResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getDatastore.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetDatastoreResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetDatastoreResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetDistributedVirtualSwitchResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetDistributedVirtualSwitchResult</code><span class="sig-paren">(</span><em>uplinks=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetDistributedVirtualSwitchResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getDistributedVirtualSwitch.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetDistributedVirtualSwitchResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetDistributedVirtualSwitchResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetHostResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetHostResult</code><span class="sig-paren">(</span><em>resource_pool_id=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetHostResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getHost.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetHostResult.resource_pool_id">
+<code class="descname">resource_pool_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetHostResult.resource_pool_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs] of the host’s
+root resource pool.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetHostResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetHostResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetNetworkResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetNetworkResult</code><span class="sig-paren">(</span><em>type=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetNetworkResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getNetwork.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetNetworkResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetNetworkResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetResourcePoolResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetResourcePoolResult</code><span class="sig-paren">(</span><em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetResourcePoolResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getResourcePool.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetResourcePoolResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetResourcePoolResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetTagCategoryResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetTagCategoryResult</code><span class="sig-paren">(</span><em>associable_types=None</em>, <em>cardinality=None</em>, <em>description=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetTagCategoryResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getTagCategory.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetTagCategoryResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetTagCategoryResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetTagResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetTagResult</code><span class="sig-paren">(</span><em>description=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetTagResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getTag.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetTagResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetTagResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetVappContainerResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetVappContainerResult</code><span class="sig-paren">(</span><em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetVappContainerResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getVappContainer.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVappContainerResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVappContainerResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetVirtualMachineResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetVirtualMachineResult</code><span class="sig-paren">(</span><em>alternate_guest_name=None</em>, <em>disks=None</em>, <em>firmware=None</em>, <em>guest_id=None</em>, <em>network_interface_types=None</em>, <em>scsi_bus_sharing=None</em>, <em>scsi_type=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getVirtualMachine.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVirtualMachineResult.alternate_guest_name">
+<code class="descname">alternate_guest_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult.alternate_guest_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The alternate guest name of the virtual machine when
+guest_id is a non-specific operating system, like <cite>otherGuest</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVirtualMachineResult.disks">
+<code class="descname">disks</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult.disks" title="Permalink to this definition">¶</a></dt>
+<dd><p>Information about each of the disks on this virtual machine or
+template. These are sorted by bus and unit number so that they can be applied
+to a <cite>vsphere_virtual_machine</cite> resource in the order the resource expects
+while cloning. This is useful for discovering certain disk settings while
+performing a linked clone, as all settings that are output by this data
+source must be the same on the destination virtual machine as the source.
+Only the first number of controllers defined by <cite>scsi_controller_scan_count</cite>
+are scanned for disks. The sub-attributes are:</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVirtualMachineResult.firmware">
+<code class="descname">firmware</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult.firmware" title="Permalink to this definition">¶</a></dt>
+<dd><p>The firmware type for this virtual machine. Can be <cite>bios</cite> or <cite>efi</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVirtualMachineResult.guest_id">
+<code class="descname">guest_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult.guest_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The guest ID of the virtual machine or template.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVirtualMachineResult.network_interface_types">
+<code class="descname">network_interface_types</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult.network_interface_types" title="Permalink to this definition">¶</a></dt>
+<dd><p>The network interface types for each network
+interface found on the virtual machine, in device bus order. Will be one of
+<cite>e1000</cite>, <cite>e1000e</cite>, <cite>pcnet32</cite>, <cite>sriov</cite>, <cite>vmxnet2</cite>, or <cite>vmxnet3</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVirtualMachineResult.scsi_bus_sharing">
+<code class="descname">scsi_bus_sharing</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult.scsi_bus_sharing" title="Permalink to this definition">¶</a></dt>
+<dd><p>Mode for sharing the SCSI bus. The modes are
+physicalSharing, virtualSharing, and noSharing. Only the first number of
+controllers defined by <cite>scsi_controller_scan_count</cite> are scanned.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVirtualMachineResult.scsi_type">
+<code class="descname">scsi_type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult.scsi_type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The common type of all SCSI controllers on this virtual machine.
+Will be one of <cite>lsilogic</cite> (LSI Logic Parallel), <cite>lsilogic-sas</cite> (LSI Logic
+SAS), <cite>pvscsi</cite> (VMware Paravirtual), <cite>buslogic</cite> (BusLogic), or <cite>mixed</cite> when
+there are multiple controller types. Only the first number of controllers
+defined by <cite>scsi_controller_scan_count</cite> are scanned.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVirtualMachineResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVirtualMachineResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.GetVmfsDisksResult">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">GetVmfsDisksResult</code><span class="sig-paren">(</span><em>disks=None</em>, <em>id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.GetVmfsDisksResult" title="Permalink to this definition">¶</a></dt>
+<dd><p>A collection of values returned by getVmfsDisks.</p>
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVmfsDisksResult.disks">
+<code class="descname">disks</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVmfsDisksResult.disks" title="Permalink to this definition">¶</a></dt>
+<dd><p>A lexicographically sorted list of devices discovered by the
+operation, matching the supplied <cite>filter</cite>, if provided.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.GetVmfsDisksResult.id">
+<code class="descname">id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.GetVmfsDisksResult.id" title="Permalink to this definition">¶</a></dt>
+<dd><p>id is the provider-assigned unique ID for this managed resource.</p>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.HaVmOverride">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">HaVmOverride</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>compute_cluster_id=None</em>, <em>ha_datastore_apd_recovery_action=None</em>, <em>ha_datastore_apd_response=None</em>, <em>ha_datastore_apd_response_delay=None</em>, <em>ha_datastore_pdl_response=None</em>, <em>ha_host_isolation_response=None</em>, <em>ha_vm_failure_interval=None</em>, <em>ha_vm_maximum_failure_window=None</em>, <em>ha_vm_maximum_resets=None</em>, <em>ha_vm_minimum_uptime=None</em>, <em>ha_vm_monitoring=None</em>, <em>ha_vm_monitoring_use_cluster_defaults=None</em>, <em>ha_vm_restart_priority=None</em>, <em>ha_vm_restart_timeout=None</em>, <em>virtual_machine_id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HaVmOverride" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_ha_vm_override</cite> resource can be used to add an override for
+vSphere HA settings on a cluster for a specific virtual machine. With this
+resource, one can control specific HA settings so that they are different than
+the cluster default, accommodating the needs of that specific virtual machine,
+while not affecting the rest of the cluster.</p>
+<p>For more information on vSphere HA, see [this page][ref-vsphere-ha-clusters].</p>
+<p>[ref-vsphere-ha-clusters]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.avail.doc/GUID-5432CA24-14F1-44E3-87FB-61D937831CF6.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.avail.doc/GUID-5432CA24-14F1-44E3-87FB-61D937831CF6.html</a></p>
+<p>&gt; <strong>NOTE:</strong> This resource requires vCenter and is not available on direct ESXi
+connections.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>compute_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the cluster to put the override in.  Forces a new
+resource if changed.</li>
+<li><strong>ha_datastore_apd_recovery_action</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Controls the action to take
+on this virtual machine if an APD status on an affected datastore clears in
+the middle of an APD event. Can be one of <cite>useClusterDefault</cite>, <cite>none</cite> or
+<cite>reset</cite>.  Default: <cite>useClusterDefault</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</li>
+<li><strong>ha_datastore_apd_response</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Controls the action to take on this
+virtual machine when the cluster has detected loss to all paths to a relevant
+datastore. Can be one of <cite>clusterDefault</cite>, <cite>disabled</cite>, <cite>warning</cite>,
+<cite>restartConservative</cite>, or <cite>restartAggressive</cite>.  Default: <cite>clusterDefault</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</li>
+<li><strong>ha_datastore_apd_response_delay</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Controls the delay in minutes
+to wait after an APD timeout event to execute the response action defined in
+<cite>ha_datastore_apd_response</cite>. Use <cite>-1</cite> to use
+the cluster default. Default: <cite>-1</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</li>
+<li><strong>ha_datastore_pdl_response</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Controls the action to take on this
+virtual machine when the cluster has detected a permanent device loss to a
+relevant datastore. Can be one of <cite>clusterDefault</cite>, <cite>disabled</cite>, <cite>warning</cite>, or
+<cite>restartAggressive</cite>. Default: <cite>clusterDefault</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</li>
+<li><strong>ha_host_isolation_response</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The action to take on this virtual
+machine when a host has detected that it has been isolated from the rest of
+the cluster. Can be one of <cite>clusterIsolationResponse</cite>, <cite>none</cite>, <cite>powerOff</cite>, or
+<cite>shutdown</cite>. Default: <cite>clusterIsolationResponse</cite>.</li>
+<li><strong>ha_vm_failure_interval</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – If a heartbeat from this virtual
+machine is not received within this configured interval, the virtual machine
+is marked as failed. The value is in seconds. Default: <cite>30</cite>.</li>
+<li><strong>ha_vm_maximum_failure_window</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The length of the reset window in
+which <cite>ha_vm_maximum_resets</cite> can operate. When this
+window expires, no more resets are attempted regardless of the setting
+configured in <cite>ha_vm_maximum_resets</cite>. <cite>-1</cite> means no window, meaning an
+unlimited reset time is allotted. The value is specified in seconds. Default:
+<cite>-1</cite> (no window).</li>
+<li><strong>ha_vm_maximum_resets</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum number of resets that HA will
+perform to this virtual machine when responding to a failure event. Default:
+<cite>3</cite></li>
+<li><strong>ha_vm_minimum_uptime</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The time, in seconds, that HA waits after
+powering on this virtual machine before monitoring for heartbeats. Default:
+<cite>120</cite> (2 minutes).</li>
+<li><strong>ha_vm_monitoring</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The type of virtual machine monitoring to use
+when HA is enabled in the cluster. Can be one of <cite>vmMonitoringDisabled</cite>,
+<cite>vmMonitoringOnly</cite>, or <cite>vmAndAppMonitoring</cite>. Default: <cite>vmMonitoringDisabled</cite>.</li>
+<li><strong>ha_vm_monitoring_use_cluster_defaults</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Determines whether or
+not the cluster’s default settings or the VM override settings specified in
+this resource are used for virtual machine monitoring. The default is <cite>true</cite>
+(use cluster defaults) - set to <cite>false</cite> to have overrides take effect.</li>
+<li><strong>ha_vm_restart_priority</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The restart priority for the virtual
+machine when vSphere detects a host failure. Can be one of
+<cite>clusterRestartPriority</cite>, <cite>lowest</cite>, <cite>low</cite>, <cite>medium</cite>, <cite>high</cite>, or <cite>highest</cite>.
+Default: <cite>clusterRestartPriority</cite>.</li>
+<li><strong>ha_vm_restart_timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum time, in seconds, that
+vSphere HA will wait for this virtual machine to be ready. Use <cite>-1</cite> to
+specify the cluster default.  Default: <cite>-1</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</li>
+<li><strong>virtual_machine_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The UUID of the virtual machine to create
+the override for.  Forces a new resource if changed.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.compute_cluster_id">
+<code class="descname">compute_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.compute_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the cluster to put the override in.  Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_datastore_apd_recovery_action">
+<code class="descname">ha_datastore_apd_recovery_action</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_datastore_apd_recovery_action" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the action to take
+on this virtual machine if an APD status on an affected datastore clears in
+the middle of an APD event. Can be one of <cite>useClusterDefault</cite>, <cite>none</cite> or
+<cite>reset</cite>.  Default: <cite>useClusterDefault</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_datastore_apd_response">
+<code class="descname">ha_datastore_apd_response</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_datastore_apd_response" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the action to take on this
+virtual machine when the cluster has detected loss to all paths to a relevant
+datastore. Can be one of <cite>clusterDefault</cite>, <cite>disabled</cite>, <cite>warning</cite>,
+<cite>restartConservative</cite>, or <cite>restartAggressive</cite>.  Default: <cite>clusterDefault</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_datastore_apd_response_delay">
+<code class="descname">ha_datastore_apd_response_delay</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_datastore_apd_response_delay" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the delay in minutes
+to wait after an APD timeout event to execute the response action defined in
+<cite>ha_datastore_apd_response</cite>. Use <cite>-1</cite> to use
+the cluster default. Default: <cite>-1</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_datastore_pdl_response">
+<code class="descname">ha_datastore_pdl_response</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_datastore_pdl_response" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the action to take on this
+virtual machine when the cluster has detected a permanent device loss to a
+relevant datastore. Can be one of <cite>clusterDefault</cite>, <cite>disabled</cite>, <cite>warning</cite>, or
+<cite>restartAggressive</cite>. Default: <cite>clusterDefault</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_host_isolation_response">
+<code class="descname">ha_host_isolation_response</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_host_isolation_response" title="Permalink to this definition">¶</a></dt>
+<dd><p>The action to take on this virtual
+machine when a host has detected that it has been isolated from the rest of
+the cluster. Can be one of <cite>clusterIsolationResponse</cite>, <cite>none</cite>, <cite>powerOff</cite>, or
+<cite>shutdown</cite>. Default: <cite>clusterIsolationResponse</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_vm_failure_interval">
+<code class="descname">ha_vm_failure_interval</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_vm_failure_interval" title="Permalink to this definition">¶</a></dt>
+<dd><p>If a heartbeat from this virtual
+machine is not received within this configured interval, the virtual machine
+is marked as failed. The value is in seconds. Default: <cite>30</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_vm_maximum_failure_window">
+<code class="descname">ha_vm_maximum_failure_window</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_vm_maximum_failure_window" title="Permalink to this definition">¶</a></dt>
+<dd><p>The length of the reset window in
+which <cite>ha_vm_maximum_resets</cite> can operate. When this
+window expires, no more resets are attempted regardless of the setting
+configured in <cite>ha_vm_maximum_resets</cite>. <cite>-1</cite> means no window, meaning an
+unlimited reset time is allotted. The value is specified in seconds. Default:
+<cite>-1</cite> (no window).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_vm_maximum_resets">
+<code class="descname">ha_vm_maximum_resets</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_vm_maximum_resets" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum number of resets that HA will
+perform to this virtual machine when responding to a failure event. Default:
+<cite>3</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_vm_minimum_uptime">
+<code class="descname">ha_vm_minimum_uptime</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_vm_minimum_uptime" title="Permalink to this definition">¶</a></dt>
+<dd><p>The time, in seconds, that HA waits after
+powering on this virtual machine before monitoring for heartbeats. Default:
+<cite>120</cite> (2 minutes).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_vm_monitoring">
+<code class="descname">ha_vm_monitoring</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_vm_monitoring" title="Permalink to this definition">¶</a></dt>
+<dd><p>The type of virtual machine monitoring to use
+when HA is enabled in the cluster. Can be one of <cite>vmMonitoringDisabled</cite>,
+<cite>vmMonitoringOnly</cite>, or <cite>vmAndAppMonitoring</cite>. Default: <cite>vmMonitoringDisabled</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_vm_monitoring_use_cluster_defaults">
+<code class="descname">ha_vm_monitoring_use_cluster_defaults</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_vm_monitoring_use_cluster_defaults" title="Permalink to this definition">¶</a></dt>
+<dd><p>Determines whether or
+not the cluster’s default settings or the VM override settings specified in
+this resource are used for virtual machine monitoring. The default is <cite>true</cite>
+(use cluster defaults) - set to <cite>false</cite> to have overrides take effect.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_vm_restart_priority">
+<code class="descname">ha_vm_restart_priority</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_vm_restart_priority" title="Permalink to this definition">¶</a></dt>
+<dd><p>The restart priority for the virtual
+machine when vSphere detects a host failure. Can be one of
+<cite>clusterRestartPriority</cite>, <cite>lowest</cite>, <cite>low</cite>, <cite>medium</cite>, <cite>high</cite>, or <cite>highest</cite>.
+Default: <cite>clusterRestartPriority</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.ha_vm_restart_timeout">
+<code class="descname">ha_vm_restart_timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.ha_vm_restart_timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum time, in seconds, that
+vSphere HA will wait for this virtual machine to be ready. Use <cite>-1</cite> to
+specify the cluster default.  Default: <cite>-1</cite>.
+&lt;sup&gt;[*][tf-vsphere-cluster-resource-version-restrictions]&lt;/sup&gt;</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HaVmOverride.virtual_machine_id">
+<code class="descname">virtual_machine_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.virtual_machine_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUID of the virtual machine to create
+the override for.  Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.HaVmOverride.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.HaVmOverride.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HaVmOverride.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.HostPortGroup">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">HostPortGroup</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>active_nics=None</em>, <em>allow_forged_transmits=None</em>, <em>allow_mac_changes=None</em>, <em>allow_promiscuous=None</em>, <em>check_beacon=None</em>, <em>failback=None</em>, <em>host_system_id=None</em>, <em>name=None</em>, <em>notify_switches=None</em>, <em>shaping_average_bandwidth=None</em>, <em>shaping_burst_size=None</em>, <em>shaping_enabled=None</em>, <em>shaping_peak_bandwidth=None</em>, <em>standby_nics=None</em>, <em>teaming_policy=None</em>, <em>virtual_switch_name=None</em>, <em>vlan_id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HostPortGroup" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_host_port_group</cite> resource can be used to manage vSphere standard
+port groups on an ESXi host. These port groups are connected to standard
+virtual switches, which can be managed by the
+[<cite>vsphere_host_virtual_switch</cite>][host-virtual-switch] resource.</p>
+<p>For an overview on vSphere networking concepts, see [this page][ref-vsphere-net-concepts].</p>
+<p>[host-virtual-switch]: /docs/providers/vsphere/r/host_virtual_switch.html
+[ref-vsphere-net-concepts]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[list] active_nics
+:param pulumi.Input[bool] allow_forged_transmits
+:param pulumi.Input[bool] allow_mac_changes
+:param pulumi.Input[bool] allow_promiscuous
+:param pulumi.Input[bool] check_beacon
+:param pulumi.Input[bool] failback
+:param pulumi.Input[str] host_system_id: The [managed object ID][docs-about-morefs] of</p>
+<blockquote>
+<div>the host to set the port group up on. Forces a new resource if changed.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the port group.  Forces a new resource if
+changed.</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[bool] notify_switches
+:param pulumi.Input[int] shaping_average_bandwidth
+:param pulumi.Input[int] shaping_burst_size
+:param pulumi.Input[bool] shaping_enabled
+:param pulumi.Input[int] shaping_peak_bandwidth
+:param pulumi.Input[list] standby_nics
+:param pulumi.Input[str] teaming_policy
+:param pulumi.Input[str] virtual_switch_name: The name of the virtual switch to bind</p>
+<blockquote>
+<div>this port group to. Forces a new resource if changed.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>vlan_id</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The VLAN ID/trunk mode for this port group.  An ID of
+<cite>0</cite> denotes no tagging, an ID of <cite>1</cite>-<cite>4094</cite> tags with the specific ID, and an
+ID of <cite>4095</cite> enables trunk mode, allowing the guest to manage its own
+tagging. Default: <cite>0</cite>.</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostPortGroup.computed_policy">
+<code class="descname">computed_policy</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.computed_policy" title="Permalink to this definition">¶</a></dt>
+<dd><p>A map with a full set of the [policy
+options][host-vswitch-policy-options] computed from defaults and overrides,
+explaining the effective policy for this port group.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostPortGroup.host_system_id">
+<code class="descname">host_system_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.host_system_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs] of
+the host to set the port group up on. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostPortGroup.key">
+<code class="descname">key</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.key" title="Permalink to this definition">¶</a></dt>
+<dd><p>The key for this port group as returned from the vSphere API.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostPortGroup.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the port group.  Forces a new resource if
+changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostPortGroup.ports">
+<code class="descname">ports</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.ports" title="Permalink to this definition">¶</a></dt>
+<dd><p>A list of ports that currently exist and are used on this port group.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostPortGroup.virtual_switch_name">
+<code class="descname">virtual_switch_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.virtual_switch_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the virtual switch to bind
+this port group to. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostPortGroup.vlan_id">
+<code class="descname">vlan_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.vlan_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The VLAN ID/trunk mode for this port group.  An ID of
+<cite>0</cite> denotes no tagging, an ID of <cite>1</cite>-<cite>4094</cite> tags with the specific ID, and an
+ID of <cite>4095</cite> enables trunk mode, allowing the guest to manage its own
+tagging. Default: <cite>0</cite>.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.HostPortGroup.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.HostPortGroup.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HostPortGroup.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.HostVirtualSwitch">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">HostVirtualSwitch</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>active_nics=None</em>, <em>allow_forged_transmits=None</em>, <em>allow_mac_changes=None</em>, <em>allow_promiscuous=None</em>, <em>beacon_interval=None</em>, <em>check_beacon=None</em>, <em>failback=None</em>, <em>host_system_id=None</em>, <em>link_discovery_operation=None</em>, <em>link_discovery_protocol=None</em>, <em>mtu=None</em>, <em>name=None</em>, <em>network_adapters=None</em>, <em>notify_switches=None</em>, <em>number_of_ports=None</em>, <em>shaping_average_bandwidth=None</em>, <em>shaping_burst_size=None</em>, <em>shaping_enabled=None</em>, <em>shaping_peak_bandwidth=None</em>, <em>standby_nics=None</em>, <em>teaming_policy=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_host_virtual_switch</cite> resource can be used to manage vSphere
+standard switches on an ESXi host. These switches can be used as a backing for
+standard port groups, which can be managed by the
+[<cite>vsphere_host_port_group</cite>][host-port-group] resource.</p>
+<p>For an overview on vSphere networking concepts, see [this
+page][ref-vsphere-net-concepts].</p>
+<p>[host-port-group]: /docs/providers/vsphere/r/host_port_group.html
+[ref-vsphere-net-concepts]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-2B11DBB8-CB3C-4AFF-8885-EFEA0FC562F4.html</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>active_nics</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The list of active network adapters used for load
+balancing.</li>
+<li><strong>allow_forged_transmits</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Controls whether or not the virtual
+network adapter is allowed to send network traffic with a different MAC
+address than that of its own. Default: <cite>true</cite>.</li>
+<li><strong>allow_mac_changes</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Controls whether or not the Media Access
+Control (MAC) address can be changed. Default: <cite>true</cite>.</li>
+<li><strong>allow_promiscuous</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable promiscuous mode on the network. This
+flag indicates whether or not all traffic is seen on a given port. Default:
+<cite>false</cite>.</li>
+<li><strong>beacon_interval</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The interval, in seconds, that a NIC beacon
+packet is sent out. This can be used with <cite>check_beacon</cite> to
+offer link failure capability beyond link status only. Default: <cite>1</cite>.</li>
+<li><strong>check_beacon</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable beacon probing - this requires that the
+<cite>beacon_interval</cite> option has been set in the bridge
+options. If this is set to <cite>false</cite>, only link status is used to check for
+failed NICs.  Default: <cite>false</cite>.</li>
+<li><strong>failback</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If set to <cite>true</cite>, the teaming policy will re-activate
+failed interfaces higher in precedence when they come back up.  Default:
+<cite>true</cite>.</li>
+<li><strong>host_system_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object ID][docs-about-morefs] of
+the host to set the virtual switch up on. Forces a new resource if changed.</li>
+<li><strong>link_discovery_operation</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Whether to <cite>advertise</cite> or <cite>listen</cite>
+for link discovery traffic. Default: <cite>listen</cite>.</li>
+<li><strong>link_discovery_protocol</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The discovery protocol type.  Valid
+types are <cite>cpd</cite> and <cite>lldp</cite>. Default: <cite>cdp</cite>.</li>
+<li><strong>mtu</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum transmission unit (MTU) for the virtual
+switch. Default: <cite>1500</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the virtual switch. Forces a new resource if
+changed.</li>
+<li><strong>network_adapters</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The network interfaces to bind to the bridge.</li>
+<li><strong>notify_switches</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If set to <cite>true</cite>, the teaming policy will
+notify the broadcast network of a NIC failover, triggering cache updates.
+Default: <cite>true</cite>.</li>
+<li><strong>number_of_ports</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of ports to create with this
+virtual switch. Default: <cite>128</cite>.</li>
+<li><strong>shaping_average_bandwidth</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The average bandwidth in bits per
+second if traffic shaping is enabled. Default: <cite>0</cite></li>
+<li><strong>shaping_burst_size</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum burst size allowed in bytes if
+shaping is enabled. Default: <cite>0</cite></li>
+<li><strong>shaping_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Set to <cite>true</cite> to enable the traffic shaper for
+ports managed by this virtual switch. Default: <cite>false</cite>.</li>
+<li><strong>shaping_peak_bandwidth</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The peak bandwidth during bursts in
+bits per second if traffic shaping is enabled. Default: <cite>0</cite></li>
+<li><strong>standby_nics</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The list of standby network adapters used for
+failover.</li>
+<li><strong>teaming_policy</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The network adapter teaming policy. Can be one
+of <cite>loadbalance_ip</cite>, <cite>loadbalance_srcmac</cite>, <cite>loadbalance_srcid</cite>, or
+<cite>failover_explicit</cite>. Default: <cite>loadbalance_srcid</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.active_nics">
+<code class="descname">active_nics</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.active_nics" title="Permalink to this definition">¶</a></dt>
+<dd><p>The list of active network adapters used for load
+balancing.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.allow_forged_transmits">
+<code class="descname">allow_forged_transmits</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.allow_forged_transmits" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls whether or not the virtual
+network adapter is allowed to send network traffic with a different MAC
+address than that of its own. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.allow_mac_changes">
+<code class="descname">allow_mac_changes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.allow_mac_changes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls whether or not the Media Access
+Control (MAC) address can be changed. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.allow_promiscuous">
+<code class="descname">allow_promiscuous</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.allow_promiscuous" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable promiscuous mode on the network. This
+flag indicates whether or not all traffic is seen on a given port. Default:
+<cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.beacon_interval">
+<code class="descname">beacon_interval</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.beacon_interval" title="Permalink to this definition">¶</a></dt>
+<dd><p>The interval, in seconds, that a NIC beacon
+packet is sent out. This can be used with <cite>check_beacon</cite> to
+offer link failure capability beyond link status only. Default: <cite>1</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.check_beacon">
+<code class="descname">check_beacon</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.check_beacon" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable beacon probing - this requires that the
+<cite>beacon_interval</cite> option has been set in the bridge
+options. If this is set to <cite>false</cite>, only link status is used to check for
+failed NICs.  Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.failback">
+<code class="descname">failback</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.failback" title="Permalink to this definition">¶</a></dt>
+<dd><p>If set to <cite>true</cite>, the teaming policy will re-activate
+failed interfaces higher in precedence when they come back up.  Default:
+<cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.host_system_id">
+<code class="descname">host_system_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.host_system_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs] of
+the host to set the virtual switch up on. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.link_discovery_operation">
+<code class="descname">link_discovery_operation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.link_discovery_operation" title="Permalink to this definition">¶</a></dt>
+<dd><p>Whether to <cite>advertise</cite> or <cite>listen</cite>
+for link discovery traffic. Default: <cite>listen</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.link_discovery_protocol">
+<code class="descname">link_discovery_protocol</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.link_discovery_protocol" title="Permalink to this definition">¶</a></dt>
+<dd><p>The discovery protocol type.  Valid
+types are <cite>cpd</cite> and <cite>lldp</cite>. Default: <cite>cdp</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.mtu">
+<code class="descname">mtu</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.mtu" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum transmission unit (MTU) for the virtual
+switch. Default: <cite>1500</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the virtual switch. Forces a new resource if
+changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.network_adapters">
+<code class="descname">network_adapters</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.network_adapters" title="Permalink to this definition">¶</a></dt>
+<dd><p>The network interfaces to bind to the bridge.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.notify_switches">
+<code class="descname">notify_switches</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.notify_switches" title="Permalink to this definition">¶</a></dt>
+<dd><p>If set to <cite>true</cite>, the teaming policy will
+notify the broadcast network of a NIC failover, triggering cache updates.
+Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.number_of_ports">
+<code class="descname">number_of_ports</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.number_of_ports" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of ports to create with this
+virtual switch. Default: <cite>128</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.shaping_average_bandwidth">
+<code class="descname">shaping_average_bandwidth</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.shaping_average_bandwidth" title="Permalink to this definition">¶</a></dt>
+<dd><p>The average bandwidth in bits per
+second if traffic shaping is enabled. Default: <cite>0</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.shaping_burst_size">
+<code class="descname">shaping_burst_size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.shaping_burst_size" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum burst size allowed in bytes if
+shaping is enabled. Default: <cite>0</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.shaping_enabled">
+<code class="descname">shaping_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.shaping_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Set to <cite>true</cite> to enable the traffic shaper for
+ports managed by this virtual switch. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.shaping_peak_bandwidth">
+<code class="descname">shaping_peak_bandwidth</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.shaping_peak_bandwidth" title="Permalink to this definition">¶</a></dt>
+<dd><p>The peak bandwidth during bursts in
+bits per second if traffic shaping is enabled. Default: <cite>0</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.standby_nics">
+<code class="descname">standby_nics</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.standby_nics" title="Permalink to this definition">¶</a></dt>
+<dd><p>The list of standby network adapters used for
+failover.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.HostVirtualSwitch.teaming_policy">
+<code class="descname">teaming_policy</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.teaming_policy" title="Permalink to this definition">¶</a></dt>
+<dd><p>The network adapter teaming policy. Can be one
+of <cite>loadbalance_ip</cite>, <cite>loadbalance_srcmac</cite>, <cite>loadbalance_srcid</cite>, or
+<cite>failover_explicit</cite>. Default: <cite>loadbalance_srcid</cite>.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.HostVirtualSwitch.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.HostVirtualSwitch.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.HostVirtualSwitch.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.License">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">License</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>labels=None</em>, <em>license_key=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.License" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides a VMware vSphere license resource. This can be used to add and remove license keys.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>labels</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – A map of key/value pairs to be attached as labels (tags) to the license key.</li>
+<li><strong>license_key</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The license key to add.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.License.edition_key">
+<code class="descname">edition_key</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.License.edition_key" title="Permalink to this definition">¶</a></dt>
+<dd><p>The product edition of the license key.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.License.labels">
+<code class="descname">labels</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.License.labels" title="Permalink to this definition">¶</a></dt>
+<dd><p>A map of key/value pairs to be attached as labels (tags) to the license key.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.License.license_key">
+<code class="descname">license_key</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.License.license_key" title="Permalink to this definition">¶</a></dt>
+<dd><p>The license key to add.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.License.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.License.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The display name for the license.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.License.total">
+<code class="descname">total</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.License.total" title="Permalink to this definition">¶</a></dt>
+<dd><p>Total number of units (example: CPUs) contained in the license.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.License.used">
+<code class="descname">used</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.License.used" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of units (example: CPUs) assigned to this license.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.License.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.License.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.License.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.License.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.NasDatastore">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">NasDatastore</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>access_mode=None</em>, <em>custom_attributes=None</em>, <em>datastore_cluster_id=None</em>, <em>folder=None</em>, <em>host_system_ids=None</em>, <em>name=None</em>, <em>remote_hosts=None</em>, <em>remote_path=None</em>, <em>security_type=None</em>, <em>tags=None</em>, <em>type=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.NasDatastore" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_nas_datastore</cite> resource can be used to create and manage NAS
+datastores on an ESXi host or a set of hosts. The resource supports mounting
+NFS v3 and v4.1 shares to be used as datastores.</p>
+<p>&gt; <strong>NOTE:</strong> Unlike [<cite>vsphere_vmfs_datastore</cite>][resource-vmfs-datastore], a NAS
+datastore is only mounted on the hosts you choose to mount it on. To mount on
+multiple hosts, you must specify each host that you want to add in the
+<cite>host_system_ids</cite> argument.</p>
+<p>[resource-vmfs-datastore]: /docs/providers/vsphere/r/vmfs_datastore.html</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>access_mode</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Access mode for the mount point. Can be one of
+<cite>readOnly</cite> or <cite>readWrite</cite>. Note that <cite>readWrite</cite> does not necessarily mean
+that the datastore will be read-write depending on the permissions of the
+actual share. Default: <cite>readWrite</cite>. Forces a new resource if changed.</li>
+<li><strong>custom_attributes</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Map of custom attribute ids to attribute 
+value strings to set on datasource resource. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</li>
+<li><strong>datastore_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object
+ID][docs-about-morefs] of a datastore cluster to put this datastore in.
+Conflicts with <cite>folder</cite>.</li>
+<li><strong>folder</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The relative path to a folder to put this datastore in.
+This is a path relative to the datacenter you are deploying the datastore to.
+Example: for the <cite>dc1</cite> datacenter, and a provided <cite>folder</cite> of <cite>foo/bar</cite>,
+Terraform will place a datastore named <cite>terraform-test</cite> in a datastore folder
+located at <cite>/dc1/datastore/foo/bar</cite>, with the final inventory path being
+<cite>/dc1/datastore/foo/bar/terraform-test</cite>. Conflicts with
+<cite>datastore_cluster_id</cite>.</li>
+<li><strong>host_system_ids</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The [managed object IDs][docs-about-morefs] of
+the hosts to mount the datastore on.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the datastore. Forces a new resource if
+changed.</li>
+<li><strong>remote_hosts</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The hostnames or IP addresses of the remote
+server or servers. Only one element should be present for NFS v3 but multiple
+can be present for NFS v4.1. Forces a new resource if changed.</li>
+<li><strong>remote_path</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The remote path of the mount point. Forces a new
+resource if changed.</li>
+<li><strong>security_type</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The security type to use when using NFS v4.1.
+Can be one of <cite>AUTH_SYS</cite>, <cite>SEC_KRB5</cite>, or <cite>SEC_KRB5I</cite>. Forces a new resource
+if changed.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
+<li><strong>type</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The type of NAS volume. Can be one of <cite>NFS</cite> (to denote
+v3) or <cite>NFS41</cite> (to denote NFS v4.1). Default: <cite>NFS</cite>. Forces a new resource if
+changed.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.access_mode">
+<code class="descname">access_mode</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.access_mode" title="Permalink to this definition">¶</a></dt>
+<dd><p>Access mode for the mount point. Can be one of
+<cite>readOnly</cite> or <cite>readWrite</cite>. Note that <cite>readWrite</cite> does not necessarily mean
+that the datastore will be read-write depending on the permissions of the
+actual share. Default: <cite>readWrite</cite>. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.accessible">
+<code class="descname">accessible</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.accessible" title="Permalink to this definition">¶</a></dt>
+<dd><p>The connectivity status of the datastore. If this is <cite>false</cite>,
+some other computed attributes may be out of date.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.capacity">
+<code class="descname">capacity</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.capacity" title="Permalink to this definition">¶</a></dt>
+<dd><p>Maximum capacity of the datastore, in megabytes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Map of custom attribute ids to attribute 
+value strings to set on datasource resource. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.datastore_cluster_id">
+<code class="descname">datastore_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.datastore_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object
+ID][docs-about-morefs] of a datastore cluster to put this datastore in.
+Conflicts with <cite>folder</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.folder">
+<code class="descname">folder</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.folder" title="Permalink to this definition">¶</a></dt>
+<dd><p>The relative path to a folder to put this datastore in.
+This is a path relative to the datacenter you are deploying the datastore to.
+Example: for the <cite>dc1</cite> datacenter, and a provided <cite>folder</cite> of <cite>foo/bar</cite>,
+Terraform will place a datastore named <cite>terraform-test</cite> in a datastore folder
+located at <cite>/dc1/datastore/foo/bar</cite>, with the final inventory path being
+<cite>/dc1/datastore/foo/bar/terraform-test</cite>. Conflicts with
+<cite>datastore_cluster_id</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.free_space">
+<code class="descname">free_space</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.free_space" title="Permalink to this definition">¶</a></dt>
+<dd><p>Available space of this datastore, in megabytes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.host_system_ids">
+<code class="descname">host_system_ids</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.host_system_ids" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object IDs][docs-about-morefs] of
+the hosts to mount the datastore on.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.maintenance_mode">
+<code class="descname">maintenance_mode</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.maintenance_mode" title="Permalink to this definition">¶</a></dt>
+<dd><p>The current maintenance mode state of the datastore.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.multiple_host_access">
+<code class="descname">multiple_host_access</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.multiple_host_access" title="Permalink to this definition">¶</a></dt>
+<dd><p>If <cite>true</cite>, more than one host in the datacenter has
+been configured with access to the datastore.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the datastore. Forces a new resource if
+changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.protocol_endpoint">
+<code class="descname">protocol_endpoint</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.protocol_endpoint" title="Permalink to this definition">¶</a></dt>
+<dd><p>Indicates that this NAS volume is a protocol endpoint.
+This field is only populated if the host supports virtual datastores.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.remote_hosts">
+<code class="descname">remote_hosts</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.remote_hosts" title="Permalink to this definition">¶</a></dt>
+<dd><p>The hostnames or IP addresses of the remote
+server or servers. Only one element should be present for NFS v3 but multiple
+can be present for NFS v4.1. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.remote_path">
+<code class="descname">remote_path</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.remote_path" title="Permalink to this definition">¶</a></dt>
+<dd><p>The remote path of the mount point. Forces a new
+resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.security_type">
+<code class="descname">security_type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.security_type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The security type to use when using NFS v4.1.
+Can be one of <cite>AUTH_SYS</cite>, <cite>SEC_KRB5</cite>, or <cite>SEC_KRB5I</cite>. Forces a new resource
+if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.type">
+<code class="descname">type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The type of NAS volume. Can be one of <cite>NFS</cite> (to denote
+v3) or <cite>NFS41</cite> (to denote NFS v4.1). Default: <cite>NFS</cite>. Forces a new resource if
+changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.uncommitted_space">
+<code class="descname">uncommitted_space</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.uncommitted_space" title="Permalink to this definition">¶</a></dt>
+<dd><p>Total additional storage space, in megabytes,
+potentially used by all virtual machines on this datastore.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.NasDatastore.url">
+<code class="descname">url</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.NasDatastore.url" title="Permalink to this definition">¶</a></dt>
+<dd><p>The unique locator for the datastore.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.NasDatastore.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.NasDatastore.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.NasDatastore.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.NasDatastore.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.Provider">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">Provider</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>allow_unverified_ssl=None</em>, <em>client_debug=None</em>, <em>client_debug_path=None</em>, <em>client_debug_path_run=None</em>, <em>password=None</em>, <em>persist_session=None</em>, <em>rest_session_path=None</em>, <em>user=None</em>, <em>vcenter_server=None</em>, <em>vim_session_path=None</em>, <em>vsphere_server=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Provider" title="Permalink to this definition">¶</a></dt>
+<dd><p>The provider type for the vsphere package. By default, resources use package-wide configuration
+settings, however an explicit <cite>Provider</cite> instance may be created and passed during resource
+construction to achieve fine-grained programmatic control over provider settings. See the
+[documentation](<a class="reference external" href="https://pulumi.io/reference/programming-model.html#providers">https://pulumi.io/reference/programming-model.html#providers</a>) for more information.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[bool] allow_unverified_ssl
+:param pulumi.Input[bool] client_debug
+:param pulumi.Input[str] client_debug_path
+:param pulumi.Input[str] client_debug_path_run
+:param pulumi.Input[str] password
+:param pulumi.Input[bool] persist_session
+:param pulumi.Input[str] rest_session_path
+:param pulumi.Input[str] user
+:param pulumi.Input[str] vcenter_server
+:param pulumi.Input[str] vim_session_path
+:param pulumi.Input[str] vsphere_server</p>
+<dl class="method">
+<dt id="pulumi_vsphere.Provider.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Provider.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.Provider.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Provider.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.ResourcePool">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">ResourcePool</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>cpu_expandable=None</em>, <em>cpu_limit=None</em>, <em>cpu_reservation=None</em>, <em>cpu_share_level=None</em>, <em>cpu_shares=None</em>, <em>custom_attributes=None</em>, <em>memory_expandable=None</em>, <em>memory_limit=None</em>, <em>memory_reservation=None</em>, <em>memory_share_level=None</em>, <em>memory_shares=None</em>, <em>name=None</em>, <em>parent_resource_pool_id=None</em>, <em>tags=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ResourcePool" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_resource_pool</cite> resource can be used to create and manage
+resource pools in standalone hosts or on compute clusters.</p>
+<p>For more information on vSphere resource pools, see [this
+page][ref-vsphere-resource_pools].</p>
+<p>[ref-vsphere-resource_pools]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-60077B40-66FF-4625-934A-641703ED7601.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-60077B40-66FF-4625-934A-641703ED7601.html</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>cpu_expandable</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Determines if the reservation on a resource
+pool can grow beyond the specified value if the parent resource pool has
+unreserved resources. Default: <cite>true</cite></li>
+<li><strong>cpu_limit</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The CPU utilization of a resource pool will not exceed
+this limit, even if there are available resources. Set to <cite>-1</cite> for unlimited.
+Default: <cite>-1</cite></li>
+<li><strong>cpu_reservation</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Amount of CPU (MHz) that is guaranteed
+available to the resource pool. Default: <cite>0</cite></li>
+<li><strong>cpu_share_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The CPU allocation level. The level is a
+simplified view of shares. Levels map to a pre-determined set of numeric
+values for shares. Can be one of <cite>low</cite>, <cite>normal</cite>, <cite>high</cite>, or <cite>custom</cite>. When
+<cite>low</cite>, <cite>normal</cite>, or <cite>high</cite> are specified values in <cite>cpu_shares</cite> will be
+ignored.  Default: <cite>normal</cite></li>
+<li><strong>cpu_shares</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of shares allocated for CPU. Used to
+determine resource allocation in case of resource contention. If this is set,
+<cite>cpu_share_level</cite> must be <cite>custom</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[dict] custom_attributes
+:param pulumi.Input[bool] memory_expandable: Determines if the reservation on a resource</p>
+<blockquote>
+<div>pool can grow beyond the specified value if the parent resource pool has
+unreserved resources. Default: <cite>true</cite></div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>memory_limit</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The CPU utilization of a resource pool will not exceed
+this limit, even if there are available resources. Set to <cite>-1</cite> for unlimited.
+Default: <cite>-1</cite></li>
+<li><strong>memory_reservation</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Amount of CPU (MHz) that is guaranteed
+available to the resource pool. Default: <cite>0</cite></li>
+<li><strong>memory_share_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The CPU allocation level. The level is a
+simplified view of shares. Levels map to a pre-determined set of numeric
+values for shares. Can be one of <cite>low</cite>, <cite>normal</cite>, <cite>high</cite>, or <cite>custom</cite>. When
+<cite>low</cite>, <cite>normal</cite>, or <cite>high</cite> are specified values in <cite>memory_shares</cite> will be
+ignored.  Default: <cite>normal</cite></li>
+<li><strong>memory_shares</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of shares allocated for CPU. Used to
+determine resource allocation in case of resource contention. If this is set,
+<cite>memory_share_level</cite> must be <cite>custom</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the resource pool.</li>
+<li><strong>parent_resource_pool_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object ID][docs-about-morefs]
+of the parent resource pool. This can be the root resource pool for a cluster
+or standalone host, or a resource pool itself. When moving a resource pool
+from one parent resource pool to another, both must share a common root
+resource pool or the move will fail.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.cpu_expandable">
+<code class="descname">cpu_expandable</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.cpu_expandable" title="Permalink to this definition">¶</a></dt>
+<dd><p>Determines if the reservation on a resource
+pool can grow beyond the specified value if the parent resource pool has
+unreserved resources. Default: <cite>true</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.cpu_limit">
+<code class="descname">cpu_limit</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.cpu_limit" title="Permalink to this definition">¶</a></dt>
+<dd><p>The CPU utilization of a resource pool will not exceed
+this limit, even if there are available resources. Set to <cite>-1</cite> for unlimited.
+Default: <cite>-1</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.cpu_reservation">
+<code class="descname">cpu_reservation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.cpu_reservation" title="Permalink to this definition">¶</a></dt>
+<dd><p>Amount of CPU (MHz) that is guaranteed
+available to the resource pool. Default: <cite>0</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.cpu_share_level">
+<code class="descname">cpu_share_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.cpu_share_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The CPU allocation level. The level is a
+simplified view of shares. Levels map to a pre-determined set of numeric
+values for shares. Can be one of <cite>low</cite>, <cite>normal</cite>, <cite>high</cite>, or <cite>custom</cite>. When
+<cite>low</cite>, <cite>normal</cite>, or <cite>high</cite> are specified values in <cite>cpu_shares</cite> will be
+ignored.  Default: <cite>normal</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.cpu_shares">
+<code class="descname">cpu_shares</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.cpu_shares" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of shares allocated for CPU. Used to
+determine resource allocation in case of resource contention. If this is set,
+<cite>cpu_share_level</cite> must be <cite>custom</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.memory_expandable">
+<code class="descname">memory_expandable</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.memory_expandable" title="Permalink to this definition">¶</a></dt>
+<dd><p>Determines if the reservation on a resource
+pool can grow beyond the specified value if the parent resource pool has
+unreserved resources. Default: <cite>true</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.memory_limit">
+<code class="descname">memory_limit</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.memory_limit" title="Permalink to this definition">¶</a></dt>
+<dd><p>The CPU utilization of a resource pool will not exceed
+this limit, even if there are available resources. Set to <cite>-1</cite> for unlimited.
+Default: <cite>-1</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.memory_reservation">
+<code class="descname">memory_reservation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.memory_reservation" title="Permalink to this definition">¶</a></dt>
+<dd><p>Amount of CPU (MHz) that is guaranteed
+available to the resource pool. Default: <cite>0</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.memory_share_level">
+<code class="descname">memory_share_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.memory_share_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The CPU allocation level. The level is a
+simplified view of shares. Levels map to a pre-determined set of numeric
+values for shares. Can be one of <cite>low</cite>, <cite>normal</cite>, <cite>high</cite>, or <cite>custom</cite>. When
+<cite>low</cite>, <cite>normal</cite>, or <cite>high</cite> are specified values in <cite>memory_shares</cite> will be
+ignored.  Default: <cite>normal</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.memory_shares">
+<code class="descname">memory_shares</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.memory_shares" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of shares allocated for CPU. Used to
+determine resource allocation in case of resource contention. If this is set,
+<cite>memory_share_level</cite> must be <cite>custom</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the resource pool.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.parent_resource_pool_id">
+<code class="descname">parent_resource_pool_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.parent_resource_pool_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs]
+of the parent resource pool. This can be the root resource pool for a cluster
+or standalone host, or a resource pool itself. When moving a resource pool
+from one parent resource pool to another, both must share a common root
+resource pool or the move will fail.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.ResourcePool.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.ResourcePool.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ResourcePool.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ResourcePool.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.ResourcePool.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.ResourcePool.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.StorageDrsVmOverride">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">StorageDrsVmOverride</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>datastore_cluster_id=None</em>, <em>sdrs_automation_level=None</em>, <em>sdrs_enabled=None</em>, <em>sdrs_intra_vm_affinity=None</em>, <em>virtual_machine_id=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.StorageDrsVmOverride" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_storage_drs_vm_override</cite> resource can be used to add a Storage DRS
+override to a datastore cluster for a specific virtual machine. With this
+resource, one can enable or disable Storage DRS, and control the automation
+level and disk affinity for a single virtual machine without affecting the rest
+of the datastore cluster.</p>
+<p>For more information on vSphere datastore clusters and Storage DRS, see [this
+page][ref-vsphere-datastore-clusters].</p>
+<p>[ref-vsphere-datastore-clusters]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>datastore_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the datastore cluster to put the override in.
+Forces a new resource if changed.</li>
+<li><strong>sdrs_automation_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Overrides any Storage DRS automation
+levels for this virtual machine. Can be one of <cite>automated</cite> or <cite>manual</cite>. When
+not specified, the datastore cluster’s settings are used according to the
+[specific SDRS subsystem][tf-vsphere-datastore-cluster-sdrs-levels].</li>
+<li><strong>sdrs_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Overrides the default Storage DRS setting for
+this virtual machine. When not specified, the datastore cluster setting is
+used.</li>
+<li><strong>sdrs_intra_vm_affinity</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Overrides the intra-VM affinity setting
+for this virtual machine. When <cite>true</cite>, all disks for this virtual machine
+will be kept on the same datastore. When <cite>false</cite>, Storage DRS may locate
+individual disks on different datastores if it helps satisfy cluster
+requirements. When not specified, the datastore cluster’s settings are used.</li>
+<li><strong>virtual_machine_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The UUID of the virtual machine to create
+the override for.  Forces a new resource if changed.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.StorageDrsVmOverride.datastore_cluster_id">
+<code class="descname">datastore_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.StorageDrsVmOverride.datastore_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the datastore cluster to put the override in.
+Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.StorageDrsVmOverride.sdrs_automation_level">
+<code class="descname">sdrs_automation_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.StorageDrsVmOverride.sdrs_automation_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides any Storage DRS automation
+levels for this virtual machine. Can be one of <cite>automated</cite> or <cite>manual</cite>. When
+not specified, the datastore cluster’s settings are used according to the
+[specific SDRS subsystem][tf-vsphere-datastore-cluster-sdrs-levels].</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.StorageDrsVmOverride.sdrs_enabled">
+<code class="descname">sdrs_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.StorageDrsVmOverride.sdrs_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the default Storage DRS setting for
+this virtual machine. When not specified, the datastore cluster setting is
+used.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.StorageDrsVmOverride.sdrs_intra_vm_affinity">
+<code class="descname">sdrs_intra_vm_affinity</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.StorageDrsVmOverride.sdrs_intra_vm_affinity" title="Permalink to this definition">¶</a></dt>
+<dd><p>Overrides the intra-VM affinity setting
+for this virtual machine. When <cite>true</cite>, all disks for this virtual machine
+will be kept on the same datastore. When <cite>false</cite>, Storage DRS may locate
+individual disks on different datastores if it helps satisfy cluster
+requirements. When not specified, the datastore cluster’s settings are used.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.StorageDrsVmOverride.virtual_machine_id">
+<code class="descname">virtual_machine_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.StorageDrsVmOverride.virtual_machine_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUID of the virtual machine to create
+the override for.  Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.StorageDrsVmOverride.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.StorageDrsVmOverride.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.StorageDrsVmOverride.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.StorageDrsVmOverride.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.Tag">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">Tag</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>category_id=None</em>, <em>description=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Tag" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_tag</cite> resource can be used to create and manage tags, which allow
+you to attach metadata to objects in the vSphere inventory to make these
+objects more sortable and searchable.</p>
+<p>For more information about tags, click [here][ext-tags-general].</p>
+<p>[ext-tags-general]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html</a></p>
+<p>&gt; <strong>NOTE:</strong> Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>category_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The unique identifier of the parent category in
+which this tag will be created. Forces a new resource if changed.</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A description for the tag.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The display name of the tag. The name must be unique
+within its category.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.Tag.category_id">
+<code class="descname">category_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Tag.category_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The unique identifier of the parent category in
+which this tag will be created. Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Tag.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Tag.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>A description for the tag.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.Tag.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.Tag.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The display name of the tag. The name must be unique
+within its category.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.Tag.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Tag.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.Tag.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.Tag.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.TagCategory">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">TagCategory</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>associable_types=None</em>, <em>cardinality=None</em>, <em>description=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.TagCategory" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_tag_category</cite> resource can be used to create and manage tag
+categories, which determine how tags are grouped together and applied to
+specific objects.</p>
+<p>For more information about tags, click [here][ext-tags-general]. For more
+information about tag categories specifically, click
+[here][ext-tag-categories].</p>
+<p>[ext-tags-general]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html</a>
+[ext-tag-categories]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-BA3D1794-28F2-43F3-BCE9-3964CB207FB6.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-BA3D1794-28F2-43F3-BCE9-3964CB207FB6.html</a></p>
+<p>&gt; <strong>NOTE:</strong> Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>associable_types</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – A list object types that this category is
+valid to be assigned to. For a full list, click
+here.</li>
+<li><strong>cardinality</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The number of tags that can be assigned from this
+category to a single object at once. Can be one of <cite>SINGLE</cite> (object can only
+be assigned one tag in this category), to <cite>MULTIPLE</cite> (object can be assigned
+multiple tags in this category). Forces a new resource if changed.</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A description for the category.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the category.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.TagCategory.associable_types">
+<code class="descname">associable_types</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.TagCategory.associable_types" title="Permalink to this definition">¶</a></dt>
+<dd><p>A list object types that this category is
+valid to be assigned to. For a full list, click
+here.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.TagCategory.cardinality">
+<code class="descname">cardinality</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.TagCategory.cardinality" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of tags that can be assigned from this
+category to a single object at once. Can be one of <cite>SINGLE</cite> (object can only
+be assigned one tag in this category), to <cite>MULTIPLE</cite> (object can be assigned
+multiple tags in this category). Forces a new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.TagCategory.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.TagCategory.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>A description for the category.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.TagCategory.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.TagCategory.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the category.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.TagCategory.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.TagCategory.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.TagCategory.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.TagCategory.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.VappContainer">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">VappContainer</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>cpu_expandable=None</em>, <em>cpu_limit=None</em>, <em>cpu_reservation=None</em>, <em>cpu_share_level=None</em>, <em>cpu_shares=None</em>, <em>custom_attributes=None</em>, <em>memory_expandable=None</em>, <em>memory_limit=None</em>, <em>memory_reservation=None</em>, <em>memory_share_level=None</em>, <em>memory_shares=None</em>, <em>name=None</em>, <em>parent_folder_id=None</em>, <em>parent_resource_pool_id=None</em>, <em>tags=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VappContainer" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_vapp_container</cite> resource can be used to create and manage
+vApps.</p>
+<p>For more information on vSphere vApps, see [this
+page][ref-vsphere-vapp].</p>
+<p>[ref-vsphere-vapp]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-2A95EBB8-1779-40FA-B4FB-4D0845750879.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-2A95EBB8-1779-40FA-B4FB-4D0845750879.html</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>cpu_expandable</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Determines if the reservation on a vApp
+container can grow beyond the specified value if the parent resource pool has
+unreserved resources. Default: <cite>true</cite></li>
+<li><strong>cpu_limit</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The CPU utilization of a vApp container will not
+exceed this limit, even if there are available resources. Set to <cite>-1</cite> for
+unlimited.
+Default: <cite>-1</cite></li>
+<li><strong>cpu_reservation</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Amount of CPU (MHz) that is guaranteed
+available to the vApp container. Default: <cite>0</cite></li>
+<li><strong>cpu_share_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The CPU allocation level. The level is a
+simplified view of shares. Levels map to a pre-determined set of numeric
+values for shares. Can be one of <cite>low</cite>, <cite>normal</cite>, <cite>high</cite>, or <cite>custom</cite>. When
+<cite>low</cite>, <cite>normal</cite>, or <cite>high</cite> are specified values in <cite>cpu_shares</cite> will be
+ignored.  Default: <cite>normal</cite></li>
+<li><strong>cpu_shares</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of shares allocated for CPU. Used to
+determine resource allocation in case of resource contention. If this is set,
+<cite>cpu_share_level</cite> must be <cite>custom</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[dict] custom_attributes
+:param pulumi.Input[bool] memory_expandable: Determines if the reservation on a vApp</p>
+<blockquote>
+<div>container can grow beyond the specified value if the parent resource pool has
+unreserved resources. Default: <cite>true</cite></div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>memory_limit</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The CPU utilization of a vApp container will not
+exceed this limit, even if there are available resources. Set to <cite>-1</cite> for
+unlimited.
+Default: <cite>-1</cite></li>
+<li><strong>memory_reservation</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Amount of CPU (MHz) that is guaranteed
+available to the vApp container. Default: <cite>0</cite></li>
+<li><strong>memory_share_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The CPU allocation level. The level is a
+simplified view of shares. Levels map to a pre-determined set of numeric
+values for shares. Can be one of <cite>low</cite>, <cite>normal</cite>, <cite>high</cite>, or <cite>custom</cite>. When
+<cite>low</cite>, <cite>normal</cite>, or <cite>high</cite> are specified values in <cite>memory_shares</cite> will be
+ignored.  Default: <cite>normal</cite></li>
+<li><strong>memory_shares</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of shares allocated for CPU. Used to
+determine resource allocation in case of resource contention. If this is set,
+<cite>memory_share_level</cite> must be <cite>custom</cite>.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the vApp container.</li>
+<li><strong>parent_folder_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object ID][docs-about-morefs] of
+the vApp container’s parent folder.</li>
+<li><strong>parent_resource_pool_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object ID][docs-about-morefs]
+of the parent resource pool. This can be the root resource pool for a cluster
+or standalone host, or a resource pool itself. When moving a vApp container
+from one parent resource pool to another, both must share a common root
+resource pool or the move will fail.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.cpu_expandable">
+<code class="descname">cpu_expandable</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.cpu_expandable" title="Permalink to this definition">¶</a></dt>
+<dd><p>Determines if the reservation on a vApp
+container can grow beyond the specified value if the parent resource pool has
+unreserved resources. Default: <cite>true</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.cpu_limit">
+<code class="descname">cpu_limit</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.cpu_limit" title="Permalink to this definition">¶</a></dt>
+<dd><p>The CPU utilization of a vApp container will not
+exceed this limit, even if there are available resources. Set to <cite>-1</cite> for
+unlimited.
+Default: <cite>-1</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.cpu_reservation">
+<code class="descname">cpu_reservation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.cpu_reservation" title="Permalink to this definition">¶</a></dt>
+<dd><p>Amount of CPU (MHz) that is guaranteed
+available to the vApp container. Default: <cite>0</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.cpu_share_level">
+<code class="descname">cpu_share_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.cpu_share_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The CPU allocation level. The level is a
+simplified view of shares. Levels map to a pre-determined set of numeric
+values for shares. Can be one of <cite>low</cite>, <cite>normal</cite>, <cite>high</cite>, or <cite>custom</cite>. When
+<cite>low</cite>, <cite>normal</cite>, or <cite>high</cite> are specified values in <cite>cpu_shares</cite> will be
+ignored.  Default: <cite>normal</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.cpu_shares">
+<code class="descname">cpu_shares</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.cpu_shares" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of shares allocated for CPU. Used to
+determine resource allocation in case of resource contention. If this is set,
+<cite>cpu_share_level</cite> must be <cite>custom</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.memory_expandable">
+<code class="descname">memory_expandable</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.memory_expandable" title="Permalink to this definition">¶</a></dt>
+<dd><p>Determines if the reservation on a vApp
+container can grow beyond the specified value if the parent resource pool has
+unreserved resources. Default: <cite>true</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.memory_limit">
+<code class="descname">memory_limit</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.memory_limit" title="Permalink to this definition">¶</a></dt>
+<dd><p>The CPU utilization of a vApp container will not
+exceed this limit, even if there are available resources. Set to <cite>-1</cite> for
+unlimited.
+Default: <cite>-1</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.memory_reservation">
+<code class="descname">memory_reservation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.memory_reservation" title="Permalink to this definition">¶</a></dt>
+<dd><p>Amount of CPU (MHz) that is guaranteed
+available to the vApp container. Default: <cite>0</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.memory_share_level">
+<code class="descname">memory_share_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.memory_share_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The CPU allocation level. The level is a
+simplified view of shares. Levels map to a pre-determined set of numeric
+values for shares. Can be one of <cite>low</cite>, <cite>normal</cite>, <cite>high</cite>, or <cite>custom</cite>. When
+<cite>low</cite>, <cite>normal</cite>, or <cite>high</cite> are specified values in <cite>memory_shares</cite> will be
+ignored.  Default: <cite>normal</cite></p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.memory_shares">
+<code class="descname">memory_shares</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.memory_shares" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of shares allocated for CPU. Used to
+determine resource allocation in case of resource contention. If this is set,
+<cite>memory_share_level</cite> must be <cite>custom</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the vApp container.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.parent_folder_id">
+<code class="descname">parent_folder_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.parent_folder_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs] of
+the vApp container’s parent folder.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.parent_resource_pool_id">
+<code class="descname">parent_resource_pool_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.parent_resource_pool_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs]
+of the parent resource pool. This can be the root resource pool for a cluster
+or standalone host, or a resource pool itself. When moving a vApp container
+from one parent resource pool to another, both must share a common root
+resource pool or the move will fail.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappContainer.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappContainer.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VappContainer.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VappContainer.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VappContainer.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VappContainer.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.VappEntity">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">VappEntity</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>container_id=None</em>, <em>custom_attributes=None</em>, <em>start_action=None</em>, <em>start_delay=None</em>, <em>start_order=None</em>, <em>stop_action=None</em>, <em>stop_delay=None</em>, <em>tags=None</em>, <em>target_id=None</em>, <em>wait_for_guest=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VappEntity" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_vapp_entity</cite> resource can be used to describe the behavior of an
+entity (virtual machine or sub-vApp container) in a vApp container.</p>
+<p>For more information on vSphere vApps, see [this
+page][ref-vsphere-vapp].</p>
+<p>[ref-vsphere-vapp]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-2A95EBB8-1779-40FA-B4FB-4D0845750879.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-2A95EBB8-1779-40FA-B4FB-4D0845750879.html</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>container_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – [Managed object ID|docs-about-morefs] of the vApp
+container the entity is a member of.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[dict] custom_attributes
+:param pulumi.Input[str] start_action: How to start the entity. Valid settings are none</p>
+<blockquote>
+<div>or powerOn. If set to none, then the entity does not participate in auto-start.
+Default: powerOn</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>start_delay</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Delay in seconds before continuing with the next
+entity in the order of entities to be started. Default: 120</li>
+<li><strong>start_order</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Order to start and stop target in vApp. Default: 1</li>
+<li><strong>stop_action</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Defines the stop action for the entity. Can be set
+to none, powerOff, guestShutdown, or suspend. If set to none, then the entity
+does not participate in auto-stop. Default: powerOff</li>
+<li><strong>stop_delay</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Delay in seconds before continuing with the next
+entity in the order sequence. This is only used if the stopAction is
+guestShutdown. Default: 120</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<p>:param pulumi.Input[list] tags
+:param pulumi.Input[str] target_id: [Managed object ID|docs-about-morefs] of the entity</p>
+<blockquote>
+<div>to power on or power off. This can be a virtual machine or a vApp.</div></blockquote>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>wait_for_guest</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Determines if the VM should be marked as being
+started when VMware Tools are ready instead of waiting for <cite>start_delay</cite>. This
+property has no effect for vApps. Default: false</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappEntity.container_id">
+<code class="descname">container_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappEntity.container_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>[Managed object ID|docs-about-morefs] of the vApp
+container the entity is a member of.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappEntity.start_action">
+<code class="descname">start_action</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappEntity.start_action" title="Permalink to this definition">¶</a></dt>
+<dd><p>How to start the entity. Valid settings are none
+or powerOn. If set to none, then the entity does not participate in auto-start.
+Default: powerOn</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappEntity.start_delay">
+<code class="descname">start_delay</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappEntity.start_delay" title="Permalink to this definition">¶</a></dt>
+<dd><p>Delay in seconds before continuing with the next
+entity in the order of entities to be started. Default: 120</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappEntity.start_order">
+<code class="descname">start_order</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappEntity.start_order" title="Permalink to this definition">¶</a></dt>
+<dd><p>Order to start and stop target in vApp. Default: 1</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappEntity.stop_action">
+<code class="descname">stop_action</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappEntity.stop_action" title="Permalink to this definition">¶</a></dt>
+<dd><p>Defines the stop action for the entity. Can be set
+to none, powerOff, guestShutdown, or suspend. If set to none, then the entity
+does not participate in auto-stop. Default: powerOff</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappEntity.stop_delay">
+<code class="descname">stop_delay</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappEntity.stop_delay" title="Permalink to this definition">¶</a></dt>
+<dd><p>Delay in seconds before continuing with the next
+entity in the order sequence. This is only used if the stopAction is
+guestShutdown. Default: 120</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappEntity.target_id">
+<code class="descname">target_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappEntity.target_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>[Managed object ID|docs-about-morefs] of the entity
+to power on or power off. This can be a virtual machine or a vApp.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VappEntity.wait_for_guest">
+<code class="descname">wait_for_guest</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VappEntity.wait_for_guest" title="Permalink to this definition">¶</a></dt>
+<dd><p>Determines if the VM should be marked as being
+started when VMware Tools are ready instead of waiting for <cite>start_delay</cite>. This
+property has no effect for vApps. Default: false</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VappEntity.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VappEntity.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VappEntity.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VappEntity.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.VirtualDisk">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">VirtualDisk</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>adapter_type=None</em>, <em>create_directories=None</em>, <em>datacenter=None</em>, <em>datastore=None</em>, <em>size=None</em>, <em>type=None</em>, <em>vmdk_path=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualDisk" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_virtual_disk</cite> resource can be used to create virtual disks outside
+of any given [<cite>vsphere_virtual_machine</cite>][docs-vsphere-virtual-machine]
+resource. These disks can be attached to a virtual machine by creating a disk
+block with the [<cite>attach</cite>][docs-vsphere-virtual-machine-disk-attach] parameter.</p>
+<p>[docs-vsphere-virtual-machine]: /docs/providers/vsphere/r/virtual_machine.html
+[docs-vsphere-virtual-machine-disk-attach]: /docs/providers/vsphere/r/virtual_machine.html#attach</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>adapter_type</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The adapter type for this virtual disk. Can be
+one of <cite>ide</cite>, <cite>lsiLogic</cite>, or <cite>busLogic</cite>.  Default: <cite>lsiLogic</cite>.</li>
+<li><strong>create_directories</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Tells the resource to create any
+directories that are a part of the <cite>vmdk_path</cite> parameter if they are missing.
+Default: <cite>false</cite>.</li>
+<li><strong>datacenter</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the datacenter in which to create the
+disk. Can be omitted when when ESXi or if there is only one datacenter in
+your infrastructure.</li>
+<li><strong>datastore</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the datastore in which to create the
+disk.</li>
+<li><strong>size</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – Size of the disk (in GB).</li>
+<li><strong>type</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The type of disk to create. Can be one of
+<cite>eagerZeroedThick</cite>, <cite>lazy</cite>, or <cite>thin</cite>. Default: <cite>eagerZeroedThick</cite>. For
+information on what each kind of disk provisioning policy means, click
+[here][docs-vmware-vm-disk-provisioning].</li>
+<li><strong>vmdk_path</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The path, including filename, of the virtual disk to
+be created.  This needs to end in <cite>.vmdk</cite>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualDisk.adapter_type">
+<code class="descname">adapter_type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.adapter_type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The adapter type for this virtual disk. Can be
+one of <cite>ide</cite>, <cite>lsiLogic</cite>, or <cite>busLogic</cite>.  Default: <cite>lsiLogic</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualDisk.create_directories">
+<code class="descname">create_directories</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.create_directories" title="Permalink to this definition">¶</a></dt>
+<dd><p>Tells the resource to create any
+directories that are a part of the <cite>vmdk_path</cite> parameter if they are missing.
+Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualDisk.datacenter">
+<code class="descname">datacenter</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.datacenter" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the datacenter in which to create the
+disk. Can be omitted when when ESXi or if there is only one datacenter in
+your infrastructure.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualDisk.datastore">
+<code class="descname">datastore</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.datastore" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the datastore in which to create the
+disk.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualDisk.size">
+<code class="descname">size</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.size" title="Permalink to this definition">¶</a></dt>
+<dd><p>Size of the disk (in GB).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualDisk.type">
+<code class="descname">type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The type of disk to create. Can be one of
+<cite>eagerZeroedThick</cite>, <cite>lazy</cite>, or <cite>thin</cite>. Default: <cite>eagerZeroedThick</cite>. For
+information on what each kind of disk provisioning policy means, click
+[here][docs-vmware-vm-disk-provisioning].</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualDisk.vmdk_path">
+<code class="descname">vmdk_path</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.vmdk_path" title="Permalink to this definition">¶</a></dt>
+<dd><p>The path, including filename, of the virtual disk to
+be created.  This needs to end in <cite>.vmdk</cite>.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VirtualDisk.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VirtualDisk.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualDisk.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.VirtualMachine">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">VirtualMachine</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>alternate_guest_name=None</em>, <em>annotation=None</em>, <em>boot_delay=None</em>, <em>boot_retry_delay=None</em>, <em>boot_retry_enabled=None</em>, <em>cdrom=None</em>, <em>clone=None</em>, <em>cpu_hot_add_enabled=None</em>, <em>cpu_hot_remove_enabled=None</em>, <em>cpu_limit=None</em>, <em>cpu_performance_counters_enabled=None</em>, <em>cpu_reservation=None</em>, <em>cpu_share_count=None</em>, <em>cpu_share_level=None</em>, <em>custom_attributes=None</em>, <em>datastore_cluster_id=None</em>, <em>datastore_id=None</em>, <em>disks=None</em>, <em>efi_secure_boot_enabled=None</em>, <em>enable_disk_uuid=None</em>, <em>enable_logging=None</em>, <em>ept_rvi_mode=None</em>, <em>extra_config=None</em>, <em>firmware=None</em>, <em>folder=None</em>, <em>force_power_off=None</em>, <em>guest_id=None</em>, <em>host_system_id=None</em>, <em>hv_mode=None</em>, <em>latency_sensitivity=None</em>, <em>memory=None</em>, <em>memory_hot_add_enabled=None</em>, <em>memory_limit=None</em>, <em>memory_reservation=None</em>, <em>memory_share_count=None</em>, <em>memory_share_level=None</em>, <em>migrate_wait_timeout=None</em>, <em>name=None</em>, <em>nested_hv_enabled=None</em>, <em>network_interfaces=None</em>, <em>num_cores_per_socket=None</em>, <em>num_cpus=None</em>, <em>resource_pool_id=None</em>, <em>run_tools_scripts_after_power_on=None</em>, <em>run_tools_scripts_after_resume=None</em>, <em>run_tools_scripts_before_guest_reboot=None</em>, <em>run_tools_scripts_before_guest_shutdown=None</em>, <em>run_tools_scripts_before_guest_standby=None</em>, <em>scsi_bus_sharing=None</em>, <em>scsi_controller_count=None</em>, <em>scsi_type=None</em>, <em>shutdown_wait_timeout=None</em>, <em>swap_placement_policy=None</em>, <em>sync_time_with_host=None</em>, <em>tags=None</em>, <em>vapp=None</em>, <em>wait_for_guest_net_routable=None</em>, <em>wait_for_guest_net_timeout=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualMachine" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_virtual_machine</cite> resource can be used to manage the complex
+lifecycle of a virtual machine. It supports management of disk, network
+interface, and CDROM devices, creation from scratch or cloning from template,
+and migration through both host and storage vMotion.</p>
+<p>For more details on working with virtual machines in vSphere, see [this
+page][vmware-docs-vm-management].</p>
+<p>[vmware-docs-vm-management]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-55238059-912E-411F-A0E9-A7A536972A91.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-55238059-912E-411F-A0E9-A7A536972A91.html</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>alternate_guest_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The guest name for the operating system
+when <cite>guest_id</cite> is <cite>other</cite> or <cite>other-64</cite>.</li>
+<li><strong>annotation</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A user-provided description of the virtual machine.
+The default is no annotation.</li>
+<li><strong>boot_delay</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of milliseconds to wait before starting
+the boot sequence. The default is no delay.</li>
+<li><strong>boot_retry_delay</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of milliseconds to wait before
+retrying the boot sequence. This only valid if <cite>boot_retry_enabled</cite> is true.
+Default: <cite>10000</cite> (10 seconds).</li>
+<li><strong>boot_retry_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If set to true, a virtual machine that
+fails to boot will try again after the delay defined in <cite>boot_retry_delay</cite>.
+Default: <cite>false</cite>.</li>
+<li><strong>cdrom</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – A specification for a CDROM device on this virtual
+machine. See CDROM options below.</li>
+<li><strong>clone</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – When specified, the VM will be created as a clone of a
+specified template. Optional customization options can be submitted as well.
+See creating a virtual machine from a
+template for more details.</li>
+<li><strong>cpu_hot_add_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Allow CPUs to be added to this virtual
+machine while it is running.</li>
+<li><strong>cpu_hot_remove_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Allow CPUs to be removed to this
+virtual machine while it is running.</li>
+<li><strong>cpu_limit</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum amount of CPU (in MHz) that this virtual
+machine can consume, regardless of available resources. The default is no
+limit.</li>
+<li><strong>cpu_performance_counters_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable CPU performance
+counters on this virtual machine. Default: <cite>false</cite>.</li>
+<li><strong>cpu_reservation</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The amount of CPU (in MHz) that this virtual
+machine is guaranteed. The default is no reservation.</li>
+<li><strong>cpu_share_count</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of CPU shares allocated to the
+virtual machine when the <cite>cpu_share_level</cite> is <cite>custom</cite>.</li>
+<li><strong>cpu_share_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The allocation level for CPU resources. Can be
+one of <cite>high</cite>, <cite>low</cite>, <cite>normal</cite>, or <cite>custom</cite>. Default: <cite>custom</cite>.</li>
+<li><strong>custom_attributes</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Map of custom attribute ids to attribute
+value strings to set for virtual machine. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</li>
+<li><strong>datastore_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the datastore cluster ID to use. This setting
+applies to entire virtual machine and implies that you wish to use Storage
+DRS with this virtual machine. See the section on virtual machine
+migration for details on changing this value.</li>
+<li><strong>datastore_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The datastore ID that the ISO is located in.
+Requried for using a datastore ISO. Conflicts with <cite>client_device</cite>.</li>
+<li><strong>disks</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – A specification for a virtual disk device on this virtual
+machine. See disk options below.</li>
+<li><strong>efi_secure_boot_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – When the <cite>firmware</cite> type is set to is
+<cite>efi</cite>, this enables EFI secure boot. Default: <cite>false</cite>.</li>
+<li><strong>enable_disk_uuid</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Expose the UUIDs of attached virtual disks to
+the virtual machine, allowing access to them in the guest. Default: <cite>false</cite>.</li>
+<li><strong>enable_logging</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable logging of virtual machine events to a
+log file stored in the virtual machine directory. Default: <cite>false</cite>.</li>
+<li><strong>ept_rvi_mode</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The EPT/RVI (hardware memory virtualization)
+setting for this virtual machine. Can be one of <cite>automatic</cite>, <cite>on</cite>, or <cite>off</cite>.
+Default: <cite>automatic</cite>.</li>
+<li><strong>extra_config</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Extra configuration data for this virtual
+machine. Can be used to supply advanced parameters not normally in
+configuration, such as data for cloud-config (under the guestinfo namespace).</li>
+<li><strong>firmware</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The firmware interface to use on the virtual machine.
+Can be one of <cite>bios</cite> or <cite>EFI</cite>. Default: <cite>bios</cite>.</li>
+<li><strong>folder</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The path to the folder to put this virtual machine in,
+relative to the datacenter that the resource pool is in.</li>
+<li><strong>force_power_off</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If a guest shutdown failed or timed out while
+updating or destroying (see
+<cite>shutdown_wait_timeout</cite>), force the power-off of
+the virtual machine. Default: <cite>true</cite>.</li>
+<li><strong>guest_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The guest ID for the operating system type. For a
+full list of possible values, see [here][vmware-docs-guest-ids]. Default: <cite>other-64</cite>.</li>
+<li><strong>host_system_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – An optional [managed object reference
+ID][docs-about-morefs] of a host to put this virtual machine on. See the
+section on virtual machine migration for
+details on changing this value. If a <cite>host_system_id</cite> is not supplied,
+vSphere will select a host in the resource pool to place the virtual machine,
+according to any defaults or DRS policies in place.</li>
+<li><strong>hv_mode</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The (non-nested) hardware virtualization setting for
+this virtual machine. Can be one of <cite>hvAuto</cite>, <cite>hvOn</cite>, or <cite>hvOff</cite>. Default:
+<cite>hvAuto</cite>.</li>
+<li><strong>latency_sensitivity</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Controls the scheduling delay of the
+virtual machine. Use a higher sensitivity for applications that require lower
+latency, such as VOIP, media player applications, or applications that
+require frequent access to mouse or keyboard devices. Can be one of <cite>low</cite>,
+<cite>normal</cite>, <cite>medium</cite>, or <cite>high</cite>.</li>
+<li><strong>memory</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The size of the virtual machine’s memory, in MB.
+Default: <cite>1024</cite> (1 GB).</li>
+<li><strong>memory_hot_add_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Allow memory to be added to this
+virtual machine while it is running.</li>
+<li><strong>memory_limit</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The maximum amount of memory (in MB) that this
+virtual machine can consume, regardless of available resources. The default
+is no limit.</li>
+<li><strong>memory_reservation</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The amount of memory (in MB) that this
+virtual machine is guaranteed. The default is no reservation.</li>
+<li><strong>memory_share_count</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of memory shares allocated to
+the virtual machine when the <cite>memory_share_level</cite> is <cite>custom</cite>.</li>
+<li><strong>memory_share_level</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The allocation level for memory resources.
+Can be one of <cite>high</cite>, <cite>low</cite>, <cite>normal</cite>, or <cite>custom</cite>. Default: <cite>custom</cite>.</li>
+<li><strong>migrate_wait_timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The amount of time, in minutes, to wait
+for a virtual machine migration to complete before failing. Default: 10
+minutes. Also see the section on virtual machine
+migration.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – An alias for both <cite>label</cite> and <cite>path</cite>, the latter when
+using <cite>attach</cite>. Required if not using <cite>label</cite>.</li>
+<li><strong>nested_hv_enabled</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable nested hardware virtualization on
+this virtual machine, facilitating nested virtualization in the guest.
+Default: <cite>false</cite>.</li>
+<li><strong>network_interfaces</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – A specification for a virtual NIC on this
+virtual machine. See network interface options
+below.</li>
+<li><strong>num_cores_per_socket</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of cores to distribute among
+the CPUs in this virtual machine. If specified, the value supplied to
+<cite>num_cpus</cite> must be evenly divisible by this value. Default: <cite>1</cite>.</li>
+<li><strong>num_cpus</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of virtual processors to assign to this
+virtual machine. Default: <cite>1</cite>.</li>
+<li><strong>resource_pool_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object reference
+ID][docs-about-morefs] of the resource pool to put this virtual machine in.
+See the section on virtual machine migration
+for details on changing this value.</li>
+<li><strong>run_tools_scripts_after_power_on</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable the execution of
+post-power-on scripts when VMware tools is installed. Default: <cite>true</cite>.</li>
+<li><strong>run_tools_scripts_after_resume</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable the execution of
+post-resume scripts when VMware tools is installed. Default: <cite>true</cite>.</li>
+<li><strong>run_tools_scripts_before_guest_reboot</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable the execution of
+pre-reboot scripts when VMware tools is installed. Default: <cite>false</cite>.</li>
+<li><strong>run_tools_scripts_before_guest_shutdown</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable the execution
+of pre-shutdown scripts when VMware tools is installed. Default: <cite>true</cite>.</li>
+<li><strong>run_tools_scripts_before_guest_standby</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable the execution of
+pre-standby scripts when VMware tools is installed. Default: <cite>true</cite>.</li>
+<li><strong>scsi_bus_sharing</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – Mode for sharing the SCSI bus. The modes are
+physicalSharing, virtualSharing, and noSharing. Default: <cite>noSharing</cite>.</li>
+<li><strong>scsi_controller_count</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The number of SCSI controllers that
+Terraform manages on this virtual machine. This directly affects the amount
+of disks you can add to the virtual machine and the maximum disk unit number.
+Note that lowering this value does not remove controllers. Default: <cite>1</cite>.</li>
+<li><strong>scsi_type</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The type of SCSI bus this virtual machine will have.
+Can be one of lsilogic (LSI Logic Parallel), lsilogic-sas (LSI Logic SAS) or
+pvscsi (VMware Paravirtual). Defualt: <cite>pvscsi</cite>.</li>
+<li><strong>shutdown_wait_timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The amount of time, in minutes, to wait
+for a graceful guest shutdown when making necessary updates to the virtual
+machine. If <cite>force_power_off</cite> is set to true, the VM will be force powered-off
+after this timeout, otherwise an error is returned. Default: 3 minutes.</li>
+<li><strong>swap_placement_policy</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The swap file placement policy for this
+virtual machine. Can be one of <cite>inherit</cite>, <cite>hostLocal</cite>, or <cite>vmDirectory</cite>.
+Default: <cite>inherit</cite>.</li>
+<li><strong>sync_time_with_host</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Enable guest clock synchronization with
+the host. Requires VMware tools to be installed. Default: <cite>false</cite>.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
+<li><strong>vapp</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Optional vApp configuration. The only sub-key available
+is <cite>properties</cite>, which is a key/value map of properties for virtual machines
+imported from OVF or OVA files. See Using vApp properties to supply OVF/OVA
+configuration for
+more details.</li>
+<li><strong>wait_for_guest_net_routable</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – Controls whether or not the guest
+network waiter waits for a routable address. When <cite>false</cite>, the waiter does
+not wait for a default gateway, nor are IP addresses checked against any
+discovered default gateways as part of its success criteria. Default: <cite>true</cite>.</li>
+<li><strong>wait_for_guest_net_timeout</strong> (<em>pulumi.Input</em><em>[</em><em>int</em><em>]</em>) – The amount of time, in minutes, to
+wait for an available IP address on this virtual machine. A value less than 1
+disables the waiter. Default: 5 minutes.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.alternate_guest_name">
+<code class="descname">alternate_guest_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.alternate_guest_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The guest name for the operating system
+when <cite>guest_id</cite> is <cite>other</cite> or <cite>other-64</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.annotation">
+<code class="descname">annotation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.annotation" title="Permalink to this definition">¶</a></dt>
+<dd><p>A user-provided description of the virtual machine.
+The default is no annotation.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.boot_delay">
+<code class="descname">boot_delay</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.boot_delay" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of milliseconds to wait before starting
+the boot sequence. The default is no delay.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.boot_retry_delay">
+<code class="descname">boot_retry_delay</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.boot_retry_delay" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of milliseconds to wait before
+retrying the boot sequence. This only valid if <cite>boot_retry_enabled</cite> is true.
+Default: <cite>10000</cite> (10 seconds).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.boot_retry_enabled">
+<code class="descname">boot_retry_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.boot_retry_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>If set to true, a virtual machine that
+fails to boot will try again after the delay defined in <cite>boot_retry_delay</cite>.
+Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.cdrom">
+<code class="descname">cdrom</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.cdrom" title="Permalink to this definition">¶</a></dt>
+<dd><p>A specification for a CDROM device on this virtual
+machine. See CDROM options below.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.change_version">
+<code class="descname">change_version</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.change_version" title="Permalink to this definition">¶</a></dt>
+<dd><p>A unique identifier for a given version of the last
+configuration applied, such the timestamp of the last update to the
+configuration.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.clone">
+<code class="descname">clone</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.clone" title="Permalink to this definition">¶</a></dt>
+<dd><p>When specified, the VM will be created as a clone of a
+specified template. Optional customization options can be submitted as well.
+See creating a virtual machine from a
+template for more details.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.cpu_hot_add_enabled">
+<code class="descname">cpu_hot_add_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.cpu_hot_add_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow CPUs to be added to this virtual
+machine while it is running.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.cpu_hot_remove_enabled">
+<code class="descname">cpu_hot_remove_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.cpu_hot_remove_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow CPUs to be removed to this
+virtual machine while it is running.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.cpu_limit">
+<code class="descname">cpu_limit</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.cpu_limit" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum amount of CPU (in MHz) that this virtual
+machine can consume, regardless of available resources. The default is no
+limit.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.cpu_performance_counters_enabled">
+<code class="descname">cpu_performance_counters_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.cpu_performance_counters_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable CPU performance
+counters on this virtual machine. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.cpu_reservation">
+<code class="descname">cpu_reservation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.cpu_reservation" title="Permalink to this definition">¶</a></dt>
+<dd><p>The amount of CPU (in MHz) that this virtual
+machine is guaranteed. The default is no reservation.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.cpu_share_count">
+<code class="descname">cpu_share_count</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.cpu_share_count" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of CPU shares allocated to the
+virtual machine when the <cite>cpu_share_level</cite> is <cite>custom</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.cpu_share_level">
+<code class="descname">cpu_share_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.cpu_share_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The allocation level for CPU resources. Can be
+one of <cite>high</cite>, <cite>low</cite>, <cite>normal</cite>, or <cite>custom</cite>. Default: <cite>custom</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Map of custom attribute ids to attribute
+value strings to set for virtual machine. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.datastore_cluster_id">
+<code class="descname">datastore_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.datastore_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the datastore cluster ID to use. This setting
+applies to entire virtual machine and implies that you wish to use Storage
+DRS with this virtual machine. See the section on virtual machine
+migration for details on changing this value.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.datastore_id">
+<code class="descname">datastore_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.datastore_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The datastore ID that the ISO is located in.
+Requried for using a datastore ISO. Conflicts with <cite>client_device</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.default_ip_address">
+<code class="descname">default_ip_address</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.default_ip_address" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IP address selected by Terraform to be used with
+any [provisioners][tf-docs-provisioners] configured on this resource.
+Whenever possible, this is the first IPv4 address that is reachable through
+the default gateway configured on the machine, then the first reachable IPv6
+address, and then the first general discovered address if neither exist. If
+VMware tools is not running on the virtual machine, or if the VM is powered
+off, this value will be blank.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.disks">
+<code class="descname">disks</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.disks" title="Permalink to this definition">¶</a></dt>
+<dd><p>A specification for a virtual disk device on this virtual
+machine. See disk options below.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.efi_secure_boot_enabled">
+<code class="descname">efi_secure_boot_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.efi_secure_boot_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>When the <cite>firmware</cite> type is set to is
+<cite>efi</cite>, this enables EFI secure boot. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.enable_disk_uuid">
+<code class="descname">enable_disk_uuid</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.enable_disk_uuid" title="Permalink to this definition">¶</a></dt>
+<dd><p>Expose the UUIDs of attached virtual disks to
+the virtual machine, allowing access to them in the guest. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.enable_logging">
+<code class="descname">enable_logging</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.enable_logging" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable logging of virtual machine events to a
+log file stored in the virtual machine directory. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.ept_rvi_mode">
+<code class="descname">ept_rvi_mode</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.ept_rvi_mode" title="Permalink to this definition">¶</a></dt>
+<dd><p>The EPT/RVI (hardware memory virtualization)
+setting for this virtual machine. Can be one of <cite>automatic</cite>, <cite>on</cite>, or <cite>off</cite>.
+Default: <cite>automatic</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.extra_config">
+<code class="descname">extra_config</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.extra_config" title="Permalink to this definition">¶</a></dt>
+<dd><p>Extra configuration data for this virtual
+machine. Can be used to supply advanced parameters not normally in
+configuration, such as data for cloud-config (under the guestinfo namespace).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.firmware">
+<code class="descname">firmware</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.firmware" title="Permalink to this definition">¶</a></dt>
+<dd><p>The firmware interface to use on the virtual machine.
+Can be one of <cite>bios</cite> or <cite>EFI</cite>. Default: <cite>bios</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.folder">
+<code class="descname">folder</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.folder" title="Permalink to this definition">¶</a></dt>
+<dd><p>The path to the folder to put this virtual machine in,
+relative to the datacenter that the resource pool is in.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.force_power_off">
+<code class="descname">force_power_off</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.force_power_off" title="Permalink to this definition">¶</a></dt>
+<dd><p>If a guest shutdown failed or timed out while
+updating or destroying (see
+<cite>shutdown_wait_timeout</cite>), force the power-off of
+the virtual machine. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.guest_id">
+<code class="descname">guest_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.guest_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The guest ID for the operating system type. For a
+full list of possible values, see [here][vmware-docs-guest-ids]. Default: <cite>other-64</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.guest_ip_addresses">
+<code class="descname">guest_ip_addresses</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.guest_ip_addresses" title="Permalink to this definition">¶</a></dt>
+<dd><p>The current list of IP addresses on this machine,
+including the value of <cite>default_ip_address</cite>. If VMware tools is not running
+on the virtual machine, or if the VM is powered off, this list will be empty.
+* <cite>moid</cite>: The [managed object reference ID][docs-about-morefs] of the created
+virtual machine.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.host_system_id">
+<code class="descname">host_system_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.host_system_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>An optional [managed object reference
+ID][docs-about-morefs] of a host to put this virtual machine on. See the
+section on virtual machine migration for
+details on changing this value. If a <cite>host_system_id</cite> is not supplied,
+vSphere will select a host in the resource pool to place the virtual machine,
+according to any defaults or DRS policies in place.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.hv_mode">
+<code class="descname">hv_mode</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.hv_mode" title="Permalink to this definition">¶</a></dt>
+<dd><p>The (non-nested) hardware virtualization setting for
+this virtual machine. Can be one of <cite>hvAuto</cite>, <cite>hvOn</cite>, or <cite>hvOff</cite>. Default:
+<cite>hvAuto</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.imported">
+<code class="descname">imported</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.imported" title="Permalink to this definition">¶</a></dt>
+<dd><p>This is flagged if the virtual machine has been imported, or the
+state has been migrated from a previous version of the resource. It
+influences the behavior of the first post-import apply operation. See the
+section on importing below.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.latency_sensitivity">
+<code class="descname">latency_sensitivity</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.latency_sensitivity" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls the scheduling delay of the
+virtual machine. Use a higher sensitivity for applications that require lower
+latency, such as VOIP, media player applications, or applications that
+require frequent access to mouse or keyboard devices. Can be one of <cite>low</cite>,
+<cite>normal</cite>, <cite>medium</cite>, or <cite>high</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.memory">
+<code class="descname">memory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.memory" title="Permalink to this definition">¶</a></dt>
+<dd><p>The size of the virtual machine’s memory, in MB.
+Default: <cite>1024</cite> (1 GB).</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.memory_hot_add_enabled">
+<code class="descname">memory_hot_add_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.memory_hot_add_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Allow memory to be added to this
+virtual machine while it is running.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.memory_limit">
+<code class="descname">memory_limit</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.memory_limit" title="Permalink to this definition">¶</a></dt>
+<dd><p>The maximum amount of memory (in MB) that this
+virtual machine can consume, regardless of available resources. The default
+is no limit.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.memory_reservation">
+<code class="descname">memory_reservation</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.memory_reservation" title="Permalink to this definition">¶</a></dt>
+<dd><p>The amount of memory (in MB) that this
+virtual machine is guaranteed. The default is no reservation.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.memory_share_count">
+<code class="descname">memory_share_count</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.memory_share_count" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of memory shares allocated to
+the virtual machine when the <cite>memory_share_level</cite> is <cite>custom</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.memory_share_level">
+<code class="descname">memory_share_level</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.memory_share_level" title="Permalink to this definition">¶</a></dt>
+<dd><p>The allocation level for memory resources.
+Can be one of <cite>high</cite>, <cite>low</cite>, <cite>normal</cite>, or <cite>custom</cite>. Default: <cite>custom</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.migrate_wait_timeout">
+<code class="descname">migrate_wait_timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.migrate_wait_timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The amount of time, in minutes, to wait
+for a virtual machine migration to complete before failing. Default: 10
+minutes. Also see the section on virtual machine
+migration.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>An alias for both <cite>label</cite> and <cite>path</cite>, the latter when
+using <cite>attach</cite>. Required if not using <cite>label</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.nested_hv_enabled">
+<code class="descname">nested_hv_enabled</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.nested_hv_enabled" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable nested hardware virtualization on
+this virtual machine, facilitating nested virtualization in the guest.
+Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.network_interfaces">
+<code class="descname">network_interfaces</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.network_interfaces" title="Permalink to this definition">¶</a></dt>
+<dd><p>A specification for a virtual NIC on this
+virtual machine. See network interface options
+below.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.num_cores_per_socket">
+<code class="descname">num_cores_per_socket</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.num_cores_per_socket" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of cores to distribute among
+the CPUs in this virtual machine. If specified, the value supplied to
+<cite>num_cpus</cite> must be evenly divisible by this value. Default: <cite>1</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.num_cpus">
+<code class="descname">num_cpus</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.num_cpus" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of virtual processors to assign to this
+virtual machine. Default: <cite>1</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.reboot_required">
+<code class="descname">reboot_required</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.reboot_required" title="Permalink to this definition">¶</a></dt>
+<dd><p>Value internal to Terraform used to determine if a
+configuration set change requires a reboot. This value is only useful during
+an update process and gets reset on refresh.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.resource_pool_id">
+<code class="descname">resource_pool_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.resource_pool_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object reference
+ID][docs-about-morefs] of the resource pool to put this virtual machine in.
+See the section on virtual machine migration
+for details on changing this value.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.run_tools_scripts_after_power_on">
+<code class="descname">run_tools_scripts_after_power_on</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.run_tools_scripts_after_power_on" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable the execution of
+post-power-on scripts when VMware tools is installed. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.run_tools_scripts_after_resume">
+<code class="descname">run_tools_scripts_after_resume</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.run_tools_scripts_after_resume" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable the execution of
+post-resume scripts when VMware tools is installed. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.run_tools_scripts_before_guest_reboot">
+<code class="descname">run_tools_scripts_before_guest_reboot</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.run_tools_scripts_before_guest_reboot" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable the execution of
+pre-reboot scripts when VMware tools is installed. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.run_tools_scripts_before_guest_shutdown">
+<code class="descname">run_tools_scripts_before_guest_shutdown</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.run_tools_scripts_before_guest_shutdown" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable the execution
+of pre-shutdown scripts when VMware tools is installed. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.run_tools_scripts_before_guest_standby">
+<code class="descname">run_tools_scripts_before_guest_standby</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.run_tools_scripts_before_guest_standby" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable the execution of
+pre-standby scripts when VMware tools is installed. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.scsi_bus_sharing">
+<code class="descname">scsi_bus_sharing</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.scsi_bus_sharing" title="Permalink to this definition">¶</a></dt>
+<dd><p>Mode for sharing the SCSI bus. The modes are
+physicalSharing, virtualSharing, and noSharing. Default: <cite>noSharing</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.scsi_controller_count">
+<code class="descname">scsi_controller_count</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.scsi_controller_count" title="Permalink to this definition">¶</a></dt>
+<dd><p>The number of SCSI controllers that
+Terraform manages on this virtual machine. This directly affects the amount
+of disks you can add to the virtual machine and the maximum disk unit number.
+Note that lowering this value does not remove controllers. Default: <cite>1</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.scsi_type">
+<code class="descname">scsi_type</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.scsi_type" title="Permalink to this definition">¶</a></dt>
+<dd><p>The type of SCSI bus this virtual machine will have.
+Can be one of lsilogic (LSI Logic Parallel), lsilogic-sas (LSI Logic SAS) or
+pvscsi (VMware Paravirtual). Defualt: <cite>pvscsi</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.shutdown_wait_timeout">
+<code class="descname">shutdown_wait_timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.shutdown_wait_timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The amount of time, in minutes, to wait
+for a graceful guest shutdown when making necessary updates to the virtual
+machine. If <cite>force_power_off</cite> is set to true, the VM will be force powered-off
+after this timeout, otherwise an error is returned. Default: 3 minutes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.swap_placement_policy">
+<code class="descname">swap_placement_policy</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.swap_placement_policy" title="Permalink to this definition">¶</a></dt>
+<dd><p>The swap file placement policy for this
+virtual machine. Can be one of <cite>inherit</cite>, <cite>hostLocal</cite>, or <cite>vmDirectory</cite>.
+Default: <cite>inherit</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.sync_time_with_host">
+<code class="descname">sync_time_with_host</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.sync_time_with_host" title="Permalink to this definition">¶</a></dt>
+<dd><p>Enable guest clock synchronization with
+the host. Requires VMware tools to be installed. Default: <cite>false</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.uuid">
+<code class="descname">uuid</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.uuid" title="Permalink to this definition">¶</a></dt>
+<dd><p>The UUID of the virtual disk’s VMDK file. This is used to track the
+virtual disk on the virtual machine.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.vapp">
+<code class="descname">vapp</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.vapp" title="Permalink to this definition">¶</a></dt>
+<dd><p>Optional vApp configuration. The only sub-key available
+is <cite>properties</cite>, which is a key/value map of properties for virtual machines
+imported from OVF or OVA files. See Using vApp properties to supply OVF/OVA
+configuration for
+more details.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.vapp_transports">
+<code class="descname">vapp_transports</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.vapp_transports" title="Permalink to this definition">¶</a></dt>
+<dd><p>Computed value which is only valid for cloned virtual
+machines. A list of vApp transport methods supported by the source virtual
+machine or template.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.vmware_tools_status">
+<code class="descname">vmware_tools_status</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.vmware_tools_status" title="Permalink to this definition">¶</a></dt>
+<dd><p>The state of VMware tools in the guest. This will
+determine the proper course of action for some device operations.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.vmx_path">
+<code class="descname">vmx_path</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.vmx_path" title="Permalink to this definition">¶</a></dt>
+<dd><p>The path of the virtual machine’s configuration file in the VM’s
+datastore.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.wait_for_guest_net_routable">
+<code class="descname">wait_for_guest_net_routable</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.wait_for_guest_net_routable" title="Permalink to this definition">¶</a></dt>
+<dd><p>Controls whether or not the guest
+network waiter waits for a routable address. When <cite>false</cite>, the waiter does
+not wait for a default gateway, nor are IP addresses checked against any
+discovered default gateways as part of its success criteria. Default: <cite>true</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachine.wait_for_guest_net_timeout">
+<code class="descname">wait_for_guest_net_timeout</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.wait_for_guest_net_timeout" title="Permalink to this definition">¶</a></dt>
+<dd><p>The amount of time, in minutes, to
+wait for an available IP address on this virtual machine. A value less than 1
+disables the waiter. Default: 5 minutes.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VirtualMachine.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VirtualMachine.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualMachine.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">VirtualMachineSnapshot</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>consolidate=None</em>, <em>description=None</em>, <em>memory=None</em>, <em>quiesce=None</em>, <em>remove_children=None</em>, <em>snapshot_name=None</em>, <em>virtual_machine_uuid=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_virtual_machine_snapshot</cite> resource can be used to manage snapshots
+for a virtual machine.</p>
+<p>For more information on managing snapshots and how they work in VMware, see
+[here][ext-vm-snapshot-management].</p>
+<p>[ext-vm-snapshot-management]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-CA948C69-7F58-4519-AEB1-739545EA94E5.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-CA948C69-7F58-4519-AEB1-739545EA94E5.html</a></p>
+<p>&gt; <strong>NOTE:</strong> A snapshot in VMware differs from traditional disk snapshots, and
+can contain the actual running state of the virtual machine, data for all disks
+that have not been set to be independent from the snapshot (including ones that
+have been attached via the [attach][docs-vsphere-virtual-machine-disk-attach]
+parameter to the <cite>vsphere_virtual_machine</cite> <cite>disk</cite> block), and even the
+configuration of the virtual machine at the time of the snapshot. Virtual
+machine, disk activity, and configuration changes post-snapshot are not
+included in the original state. Use this resource with care! Neither VMware nor
+HashiCorp recommends retaining snapshots for a extended period of time and does
+NOT recommend using them as as backup feature. For more information on the
+limitation of virtual machine snapshots, see [here][ext-vm-snap-limitations].</p>
+<p>[docs-vsphere-virtual-machine-disk-attach]: /docs/providers/vsphere/r/virtual_machine.html#attach
+[ext-vm-snap-limitations]: <a class="reference external" href="https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-53F65726-A23B-4CF0-A7D5-48E584B88613.html">https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-53F65726-A23B-4CF0-A7D5-48E584B88613.html</a></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>consolidate</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If set to <cite>true</cite>, the delta disks involved in this
+snapshot will be consolidated into the parent when this resource is
+destroyed.</li>
+<li><strong>description</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – A description for the snapshot.</li>
+<li><strong>memory</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If set to <cite>true</cite>, a dump of the internal state of the
+virtual machine is included in the snapshot.</li>
+<li><strong>quiesce</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If set to <cite>true</cite>, and the virtual machine is powered
+on when the snapshot is taken, VMware Tools is used to quiesce the file
+system in the virtual machine.</li>
+<li><strong>remove_children</strong> (<em>pulumi.Input</em><em>[</em><em>bool</em><em>]</em>) – If set to <cite>true</cite>, the entire snapshot subtree
+is removed when this resource is destroyed.</li>
+<li><strong>snapshot_name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the snapshot.</li>
+<li><strong>virtual_machine_uuid</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The virtual machine UUID.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.consolidate">
+<code class="descname">consolidate</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.consolidate" title="Permalink to this definition">¶</a></dt>
+<dd><p>If set to <cite>true</cite>, the delta disks involved in this
+snapshot will be consolidated into the parent when this resource is
+destroyed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.description">
+<code class="descname">description</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.description" title="Permalink to this definition">¶</a></dt>
+<dd><p>A description for the snapshot.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.memory">
+<code class="descname">memory</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.memory" title="Permalink to this definition">¶</a></dt>
+<dd><p>If set to <cite>true</cite>, a dump of the internal state of the
+virtual machine is included in the snapshot.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.quiesce">
+<code class="descname">quiesce</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.quiesce" title="Permalink to this definition">¶</a></dt>
+<dd><p>If set to <cite>true</cite>, and the virtual machine is powered
+on when the snapshot is taken, VMware Tools is used to quiesce the file
+system in the virtual machine.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.remove_children">
+<code class="descname">remove_children</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.remove_children" title="Permalink to this definition">¶</a></dt>
+<dd><p>If set to <cite>true</cite>, the entire snapshot subtree
+is removed when this resource is destroyed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.snapshot_name">
+<code class="descname">snapshot_name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.snapshot_name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the snapshot.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.virtual_machine_uuid">
+<code class="descname">virtual_machine_uuid</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.virtual_machine_uuid" title="Permalink to this definition">¶</a></dt>
+<dd><p>The virtual machine UUID.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VirtualMachineSnapshot.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VirtualMachineSnapshot.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="class">
+<dt id="pulumi_vsphere.VmfsDatastore">
+<em class="property">class </em><code class="descclassname">pulumi_vsphere.</code><code class="descname">VmfsDatastore</code><span class="sig-paren">(</span><em>__name__</em>, <em>__opts__=None</em>, <em>custom_attributes=None</em>, <em>datastore_cluster_id=None</em>, <em>disks=None</em>, <em>folder=None</em>, <em>host_system_id=None</em>, <em>name=None</em>, <em>tags=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_vmfs_datastore</cite> resource can be used to create and manage VMFS
+datastores on an ESXi host or a set of hosts. The resource supports using any
+SCSI device that can generally be used in a datastore, such as local disks, or
+disks presented to a host or multiple hosts over Fibre Channel or iSCSI.
+Devices can be specified manually, or discovered using the
+[<cite>vsphere_vmfs_disks</cite>][data-source-vmfs-disks] data source.</p>
+<p>[data-source-vmfs-disks]: /docs/providers/vsphere/d/vmfs_disks.html</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>__name__</strong> (<em>str</em>) – The name of the resource.</li>
+<li><strong>__opts__</strong> (<a class="reference internal" href="../pulumi/#pulumi.ResourceOptions" title="pulumi.ResourceOptions"><em>pulumi.ResourceOptions</em></a>) – Options for the resource.</li>
+<li><strong>custom_attributes</strong> (<em>pulumi.Input</em><em>[</em><em>dict</em><em>]</em>) – Map of custom attribute ids to attribute 
+value string to set on datastore resource. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</li>
+<li><strong>datastore_cluster_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object
+ID][docs-about-morefs] of a datastore cluster to put this datastore in.
+Conflicts with <cite>folder</cite>.</li>
+<li><strong>disks</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The disks to use with the datastore.</li>
+<li><strong>folder</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The relative path to a folder to put this datastore in.
+This is a path relative to the datacenter you are deploying the datastore to.
+Example: for the <cite>dc1</cite> datacenter, and a provided <cite>folder</cite> of <cite>foo/bar</cite>,
+Terraform will place a datastore named <cite>terraform-test</cite> in a datastore folder
+located at <cite>/dc1/datastore/foo/bar</cite>, with the final inventory path being
+<cite>/dc1/datastore/foo/bar/terraform-test</cite>. Conflicts with
+<cite>datastore_cluster_id</cite>.</li>
+<li><strong>host_system_id</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The [managed object ID][docs-about-morefs] of
+the host to set the datastore up on. Note that this is not necessarily the
+only host that the datastore will be set up on - see
+here for more info. Forces a
+new resource if changed.</li>
+<li><strong>name</strong> (<em>pulumi.Input</em><em>[</em><em>str</em><em>]</em>) – The name of the datastore. Forces a new resource if
+changed.</li>
+<li><strong>tags</strong> (<em>pulumi.Input</em><em>[</em><em>list</em><em>]</em>) – The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.accessible">
+<code class="descname">accessible</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.accessible" title="Permalink to this definition">¶</a></dt>
+<dd><p>The connectivity status of the datastore. If this is <cite>false</cite>,
+some other computed attributes may be out of date.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.capacity">
+<code class="descname">capacity</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.capacity" title="Permalink to this definition">¶</a></dt>
+<dd><p>Maximum capacity of the datastore, in megabytes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.custom_attributes">
+<code class="descname">custom_attributes</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.custom_attributes" title="Permalink to this definition">¶</a></dt>
+<dd><p>Map of custom attribute ids to attribute 
+value string to set on datastore resource. See
+[here][docs-setting-custom-attributes] for a reference on how to set values
+for custom attributes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.datastore_cluster_id">
+<code class="descname">datastore_cluster_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.datastore_cluster_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object
+ID][docs-about-morefs] of a datastore cluster to put this datastore in.
+Conflicts with <cite>folder</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.disks">
+<code class="descname">disks</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.disks" title="Permalink to this definition">¶</a></dt>
+<dd><p>The disks to use with the datastore.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.folder">
+<code class="descname">folder</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.folder" title="Permalink to this definition">¶</a></dt>
+<dd><p>The relative path to a folder to put this datastore in.
+This is a path relative to the datacenter you are deploying the datastore to.
+Example: for the <cite>dc1</cite> datacenter, and a provided <cite>folder</cite> of <cite>foo/bar</cite>,
+Terraform will place a datastore named <cite>terraform-test</cite> in a datastore folder
+located at <cite>/dc1/datastore/foo/bar</cite>, with the final inventory path being
+<cite>/dc1/datastore/foo/bar/terraform-test</cite>. Conflicts with
+<cite>datastore_cluster_id</cite>.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.free_space">
+<code class="descname">free_space</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.free_space" title="Permalink to this definition">¶</a></dt>
+<dd><p>Available space of this datastore, in megabytes.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.host_system_id">
+<code class="descname">host_system_id</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.host_system_id" title="Permalink to this definition">¶</a></dt>
+<dd><p>The [managed object ID][docs-about-morefs] of
+the host to set the datastore up on. Note that this is not necessarily the
+only host that the datastore will be set up on - see
+here for more info. Forces a
+new resource if changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.maintenance_mode">
+<code class="descname">maintenance_mode</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.maintenance_mode" title="Permalink to this definition">¶</a></dt>
+<dd><p>The current maintenance mode state of the datastore.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.multiple_host_access">
+<code class="descname">multiple_host_access</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.multiple_host_access" title="Permalink to this definition">¶</a></dt>
+<dd><p>If <cite>true</cite>, more than one host in the datacenter has
+been configured with access to the datastore.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.name">
+<code class="descname">name</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.name" title="Permalink to this definition">¶</a></dt>
+<dd><p>The name of the datastore. Forces a new resource if
+changed.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.tags">
+<code class="descname">tags</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.tags" title="Permalink to this definition">¶</a></dt>
+<dd><p>The IDs of any tags to attach to this resource. See
+[here][docs-applying-tags] for a reference on how to apply tags.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.uncommitted_space">
+<code class="descname">uncommitted_space</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.uncommitted_space" title="Permalink to this definition">¶</a></dt>
+<dd><p>Total additional storage space, in megabytes,
+potentially used by all virtual machines on this datastore.</p>
+</dd></dl>
+
+<dl class="attribute">
+<dt id="pulumi_vsphere.VmfsDatastore.url">
+<code class="descname">url</code><em class="property"> = None</em><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.url" title="Permalink to this definition">¶</a></dt>
+<dd><p>The unique locator for the datastore.</p>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VmfsDatastore.translate_output_property">
+<code class="descname">translate_output_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.translate_output_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of output properties
+into a format of their choosing before writing those properties to the resource object.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="method">
+<dt id="pulumi_vsphere.VmfsDatastore.translate_input_property">
+<code class="descname">translate_input_property</code><span class="sig-paren">(</span><em>prop</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.VmfsDatastore.translate_input_property" title="Permalink to this definition">¶</a></dt>
+<dd><p>Provides subclasses of Resource an opportunity to translate names of input properties into
+a format of their choosing before sending those properties to the Pulumi engine.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>prop</strong> (<em>str</em>) – A property name.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">A potentially transformed property name.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">str</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_compute_cluster">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_compute_cluster</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_compute_cluster" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_compute_cluster</cite> data source can be used to discover the ID of a
+cluster in vSphere. This is useful to fetch the ID of a cluster that you want
+to use for virtual machine placement via the
+[<cite>vsphere_virtual_machine</cite>][docs-virtual-machine-resource] resource, allowing
+you to specify the cluster’s root resource pool directly versus using the alias
+available through the [<cite>vsphere_resource_pool</cite>][docs-resource-pool-data-source]
+data source.</p>
+<p>[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html
+[docs-resource-pool-data-source]: /docs/providers/vsphere/d/resource_pool.html</p>
+<p>-&gt; You may also wish to see the
+[<cite>vsphere_compute_cluster</cite>][docs-compute-cluster-resource] resource for further
+details about clusters or how to work with them in Terraform.</p>
+<p>[docs-compute-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_custom_attribute">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_custom_attribute</code><span class="sig-paren">(</span><em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_custom_attribute" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_custom_attribute</cite> data source can be used to reference custom 
+attributes that are not managed by Terraform. Its attributes are exactly the 
+same as the [<cite>vsphere_custom_attribute</cite> resource][resource-custom-attribute], 
+and, like importing, the data source takes a name to search on. The <cite>id</cite> and 
+other attributes are then populated with the data found by the search.</p>
+<p>[resource-custom-attribute]: /docs/providers/vsphere/r/custom_attribute.html</p>
+<p>&gt; <strong>NOTE:</strong> Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_datacenter">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_datacenter</code><span class="sig-paren">(</span><em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_datacenter" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_datacenter</cite> data source can be used to discover the ID of a
+vSphere datacenter. This can then be used with resources or data sources that
+require a datacenter, such as the [<cite>vsphere_host</cite>][data-source-vsphere-host]
+data source.</p>
+<p>[data-source-vsphere-host]: /docs/providers/vsphere/d/host.html</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_datastore">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_datastore</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_datastore" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_datastore</cite> data source can be used to discover the ID of a
+datastore in vSphere. This is useful to fetch the ID of a datastore that you
+want to use to create virtual machines in using the
+[<cite>vsphere_virtual_machine</cite>][docs-virtual-machine-resource] resource.</p>
+<p>[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_datastore_cluster">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_datastore_cluster</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_datastore_cluster" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_datastore_cluster</cite> data source can be used to discover the ID of a
+datastore cluster in vSphere. This is useful to fetch the ID of a datastore
+cluster that you want to use to assign datastores to using the
+[<cite>vsphere_nas_datastore</cite>][docs-nas-datastore-resource] or
+[<cite>vsphere_vmfs_datastore</cite>][docs-vmfs-datastore-resource] resources, or create
+virtual machines in using the
+[<cite>vsphere_virtual_machine</cite>][docs-virtual-machine-resource] resource.</p>
+<p>[docs-nas-datastore-resource]: /docs/providers/vsphere/r/nas_datastore.html
+[docs-vmfs-datastore-resource]: /docs/providers/vsphere/r/vmfs_datastore.html
+[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_distributed_virtual_switch">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_distributed_virtual_switch</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_distributed_virtual_switch" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_distributed_virtual_switch</cite> data source can be used to discover
+the ID and uplink data of a of a vSphere distributed virtual switch (DVS). This
+can then be used with resources or data sources that require a DVS, such as the
+[<cite>vsphere_distributed_port_group</cite>][distributed-port-group] resource, for which
+an example is shown below.</p>
+<p>[distributed-port-group]: /docs/providers/vsphere/r/distributed_port_group.html</p>
+<p>&gt; <strong>NOTE:</strong> This data source requires vCenter and is not available on direct
+ESXi connections.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_host">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_host</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_host" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_host</cite> data source can be used to discover the ID of a vSphere
+host. This can then be used with resources or data sources that require a host
+managed object reference ID.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_network">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_network</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_network" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_network</cite> data source can be used to discover the ID of a network
+in vSphere. This can be any network that can be used as the backing for a
+network interface for <cite>vsphere_virtual_machine</cite> or any other vSphere resource
+that requires a network. This includes standard (host-based) port groups, DVS
+port groups, or opaque networks such as those managed by NSX.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_resource_pool">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_resource_pool</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_resource_pool" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_resource_pool</cite> data source can be used to discover the ID of a
+resource pool in vSphere. This is useful to fetch the ID of a resource pool
+that you want to use to create virtual machines in using the
+[<cite>vsphere_virtual_machine</cite>][docs-virtual-machine-resource] resource.</p>
+<p>[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_tag">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_tag</code><span class="sig-paren">(</span><em>category_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_tag" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_tag</cite> data source can be used to reference tags that are not
+managed by Terraform. Its attributes are exactly the same as the [<cite>vsphere_tag</cite>
+resource][resource-tag], and, like importing, the data source takes a name and
+category to search on. The <cite>id</cite> and other attributes are then populated with
+the data found by the search.</p>
+<p>[resource-tag]: /docs/providers/vsphere/r/tag.html</p>
+<p>&gt; <strong>NOTE:</strong> Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_tag_category">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_tag_category</code><span class="sig-paren">(</span><em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_tag_category" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_tag_category</cite> data source can be used to reference tag categories
+that are not managed by Terraform. Its attributes are exactly the same as the
+[<cite>vsphere_tag_category</cite> resource][resource-tag-category], and, like importing,
+the data source takes a name to search on. The <cite>id</cite> and other attributes are
+then populated with the data found by the search.</p>
+<p>[resource-tag-category]: /docs/providers/vsphere/r/tag_category.html</p>
+<p>&gt; <strong>NOTE:</strong> Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_vapp_container">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_vapp_container</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_vapp_container" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_vapp_container</cite> data source can be used to discover the ID of a
+vApp container in vSphere. This is useful to fetch the ID of a vApp container
+that you want to use to create virtual machines in using the
+[<cite>vsphere_virtual_machine</cite>][docs-virtual-machine-resource] resource.</p>
+<p>[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_virtual_machine">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_virtual_machine</code><span class="sig-paren">(</span><em>datacenter_id=None</em>, <em>name=None</em>, <em>scsi_controller_scan_count=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_virtual_machine" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_virtual_machine</cite> data source can be used to find the UUID of an
+existing virtual machine or template. Its most relevant purpose is for finding
+the UUID of a template to be used as the source for cloning into a new
+[<cite>vsphere_virtual_machine</cite>][docs-virtual-machine-resource] resource. It also
+reads the guest ID so that can be supplied as well.</p>
+<p>[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html</p>
+</dd></dl>
+
+<dl class="function">
+<dt id="pulumi_vsphere.get_vmfs_disks">
+<code class="descclassname">pulumi_vsphere.</code><code class="descname">get_vmfs_disks</code><span class="sig-paren">(</span><em>filter=None</em>, <em>host_system_id=None</em>, <em>rescan=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pulumi_vsphere.get_vmfs_disks" title="Permalink to this definition">¶</a></dt>
+<dd><p>The <cite>vsphere_vmfs_disks</cite> data source can be used to discover the storage
+devices available on an ESXi host. This data source can be combined with the
+[<cite>vsphere_vmfs_datastore</cite>][data-source-vmfs-datastore] resource to create VMFS
+datastores based off a set of discovered disks.</p>
+<p>[data-source-vmfs-datastore]: /docs/providers/vsphere/r/vmfs_datastore.html</p>
+</dd></dl>
+
 </div>

--- a/scripts/generate_python_docs.sh
+++ b/scripts/generate_python_docs.sh
@@ -13,6 +13,7 @@ PACKAGES=(
   "pulumi_openstack"
   "pulumi_f5bigip"
   "pulumi_packet"
+  "pulumi_kubernetes"
 )
 
 run_pydocgen() {

--- a/tools/pydocgen/pulumi-docs.json
+++ b/tools/pydocgen/pulumi-docs.json
@@ -38,6 +38,10 @@
     {
       "name": "Pulumi Packet",
       "package_name": "pulumi_packet"
+    },
+    {
+      "name": "Pulumi Kubernetes",
+      "package_name": "pulumi_kubernetes"
     }
   ]
 }

--- a/tools/pydocgen/pydocgen/__init__.py
+++ b/tools/pydocgen/pydocgen/__init__.py
@@ -153,9 +153,9 @@ def generate_module(ctx, provider, import_path, output_path, use_provider_metada
     # Construct the "metadata" for this module. This metadata bag is passed verbatim to the template engine.
     module_name = module.__name__.split(".").pop()
     if use_provider_metadata:
-        meta = { "name": provider.name, "package_name": provider.package_name }
+        meta = { "name": provider.name, "package_name": provider.package_name, "directory_name": provider.package_name }
     else:
-        meta = { "name": module_name, "package_name": module.__name__ }
+        meta = { "name": module_name, "package_name": module.__name__, "directory_name": module_name }
 
     # If this module doesn't have any submodules, we're going to generate all of the type documentation in a single file
     # and not proceed any further.

--- a/tools/pydocgen/pydocgen/templates/providers/provider_with_module.rst
+++ b/tools/pydocgen/pydocgen/templates/providers/provider_with_module.rst
@@ -3,4 +3,4 @@
 
 .. toctree::
     {% for module in submodules %}
-    {{provider.package_name}}/{{module}}{% endfor %}
+    {{provider.directory_name}}/{{module}}{% endfor %}

--- a/tools/pydocgen/pydocgen/templates/providers/provider_with_module.rst
+++ b/tools/pydocgen/pydocgen/templates/providers/provider_with_module.rst
@@ -1,5 +1,5 @@
 {{ provider.name }}
-===================
+====================================
 
 .. toctree::
     {% for module in submodules %}

--- a/tools/pydocgen/pydocgen/templates/providers/provider_without_module.rst
+++ b/tools/pydocgen/pydocgen/templates/providers/provider_without_module.rst
@@ -1,5 +1,5 @@
 {{ provider.name }}
-===================
+====================================
 
 .. automodule:: {{ provider.package_name }}
     :ignore-module-all:


### PR DESCRIPTION
The Python documentation code generator works well for packages that
don't have more than one layer of nested submodules. Unfortunately, the
Kubernetes package has many nested submodules and the documentation tool
did not handle them well at all.

This commit is a partial rewrite of the core module rendering logic that
generates Sphinx inputs from provider packages. The logic is basically
the same as before except that it is correct in the face of deeply
nested submodules.

Unfortunately, this revealed a few bugs in tfgen, which will be
addressed in follow-up PRs to pulumi-terraform and this repo. The
documentation generator skips packages that tfgen messed up.

Despite the rewrite, the only documentation diffs are due to the
documentation generator skipping modules that exhibit bugs in tfgen.

Finally, this commit enables the generation of Kubernetes documentation
from the `pulumi_kubernetes` package.