### PR TITLE
Remove Python & Go tabs from Node.js API docs

### DIFF
--- a/_includes/langchoose.html
+++ b/_includes/langchoose.html
@@ -2,8 +2,10 @@
     <div class="mdl-tabs__tab-dir langtab-tabstrip">
         <a class="mdl-tabs__tab langtab is-active">JavaScript</a>
         <a class="mdl-tabs__tab langtab">TypeScript</a>
+        {% unless include.nodeonly %}
         <a class="mdl-tabs__tab langtab">Python</a>
         <a class="mdl-tabs__tab langtab">Go</a>
+        {% endunless %}
     </div>
 </div>
 

--- a/reference/pkg/nodejs/@pulumi/aws-infra/index.md
+++ b/reference/pkg/nodejs/@pulumi/aws-infra/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/aws-infra
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var awsInfra = require("@pulumi/aws-infra");
@@ -15,12 +15,6 @@ var awsInfra = require("@pulumi/aws-infra");
 ```typescript
 import * as awsInfra from "@pulumi/aws-infra";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/aws-serverless/index.md
+++ b/reference/pkg/nodejs/@pulumi/aws-serverless/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/aws-serverless
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var awsServerless = require("@pulumi/aws-serverless");
@@ -15,12 +15,6 @@ var awsServerless = require("@pulumi/aws-serverless");
 ```typescript
 import * as awsServerless from "@pulumi/aws-serverless";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/aws/index.md
+++ b/reference/pkg/nodejs/@pulumi/aws/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/aws
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var aws = require("@pulumi/aws");
@@ -15,12 +15,6 @@ var aws = require("@pulumi/aws");
 ```typescript
 import * as aws from "@pulumi/aws";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/azure-serverless/index.md
+++ b/reference/pkg/nodejs/@pulumi/azure-serverless/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/azure-serverless
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var azureServerless = require("@pulumi/azure-serverless");
@@ -15,12 +15,6 @@ var azureServerless = require("@pulumi/azure-serverless");
 ```typescript
 import * as azureServerless from "@pulumi/azure-serverless";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 

--- a/reference/pkg/nodejs/@pulumi/azure/index.md
+++ b/reference/pkg/nodejs/@pulumi/azure/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/azure
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var azure = require("@pulumi/azure");
@@ -15,12 +15,6 @@ var azure = require("@pulumi/azure");
 ```typescript
 import * as azure from "@pulumi/azure";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/cloud-aws/index.md
+++ b/reference/pkg/nodejs/@pulumi/cloud-aws/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/cloud-aws
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var cloudAws = require("@pulumi/cloud-aws");
@@ -15,12 +15,6 @@ var cloudAws = require("@pulumi/cloud-aws");
 ```typescript
 import * as cloudAws from "@pulumi/cloud-aws";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/cloud-azure/index.md
+++ b/reference/pkg/nodejs/@pulumi/cloud-azure/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/cloud-azure
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var cloudAzure = require("@pulumi/cloud-azure");
@@ -15,12 +15,6 @@ var cloudAzure = require("@pulumi/cloud-azure");
 ```typescript
 import * as cloudAzure from "@pulumi/cloud-azure";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 

--- a/reference/pkg/nodejs/@pulumi/cloud/index.md
+++ b/reference/pkg/nodejs/@pulumi/cloud/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/cloud
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var cloud = require("@pulumi/cloud");
@@ -15,12 +15,6 @@ var cloud = require("@pulumi/cloud");
 ```typescript
 import * as cloud from "@pulumi/cloud";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/docker/index.md
+++ b/reference/pkg/nodejs/@pulumi/docker/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/docker
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var docker = require("@pulumi/docker");
@@ -15,12 +15,6 @@ var docker = require("@pulumi/docker");
 ```typescript
 import * as docker from "@pulumi/docker";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/eks/index.md
+++ b/reference/pkg/nodejs/@pulumi/eks/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/eks
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var eks = require("@pulumi/eks");
@@ -15,12 +15,6 @@ var eks = require("@pulumi/eks");
 ```typescript
 import * as eks from "@pulumi/eks";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/f5bigip/index.md
+++ b/reference/pkg/nodejs/@pulumi/f5bigip/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/f5bigip
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var f5bigip = require("@pulumi/f5bigip");
@@ -15,12 +15,6 @@ var f5bigip = require("@pulumi/f5bigip");
 ```typescript
 import * as f5bigip from "@pulumi/f5bigip";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/gcp/index.md
+++ b/reference/pkg/nodejs/@pulumi/gcp/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/gcp
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var gcp = require("@pulumi/gcp");
@@ -15,12 +15,6 @@ var gcp = require("@pulumi/gcp");
 ```typescript
 import * as gcp from "@pulumi/gcp";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/kubernetes/index.md
+++ b/reference/pkg/nodejs/@pulumi/kubernetes/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/kubernetes
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var kubernetes = require("@pulumi/kubernetes");
@@ -15,12 +15,6 @@ var kubernetes = require("@pulumi/kubernetes");
 ```typescript
 import * as kubernetes from "@pulumi/kubernetes";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/openstack/index.md
+++ b/reference/pkg/nodejs/@pulumi/openstack/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/openstack
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var openstack = require("@pulumi/openstack");
@@ -15,12 +15,6 @@ var openstack = require("@pulumi/openstack");
 ```typescript
 import * as openstack from "@pulumi/openstack";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/packet/index.md
+++ b/reference/pkg/nodejs/@pulumi/packet/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/packet
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var packet = require("@pulumi/packet");
@@ -15,12 +15,6 @@ var packet = require("@pulumi/packet");
 ```typescript
 import * as packet from "@pulumi/packet";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/pulumi/index.md
+++ b/reference/pkg/nodejs/@pulumi/pulumi/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/pulumi
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var pulumi = require("@pulumi/pulumi");
@@ -15,12 +15,6 @@ var pulumi = require("@pulumi/pulumi");
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/reference/pkg/nodejs/@pulumi/vsphere/index.md
+++ b/reference/pkg/nodejs/@pulumi/vsphere/index.md
@@ -6,7 +6,7 @@ title: Package @pulumi/vsphere
 <!-- To change it, please see https://github.com/pulumi/docs/tree/master/tools/tscdocgen. -->
 
 
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var vsphere = require("@pulumi/vsphere");
@@ -15,12 +15,6 @@ var vsphere = require("@pulumi/vsphere");
 ```typescript
 import * as vsphere from "@pulumi/vsphere";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 
 <div class="toggleVisible" markdown="1">

--- a/tools/tscdocgen/templates/nodejs.tmpl
+++ b/tools/tscdocgen/templates/nodejs.tmpl
@@ -7,7 +7,7 @@ title: {{Title}}
 
 {{#Breadcrumbs}}{{{.}}}{{/Breadcrumbs}}
 {{#Package}}
-{% include langchoose.html %}
+{% include langchoose.html nodeonly=true %}
 
 ```javascript
 var {{PackageVar}} = require("{{Package}}");
@@ -16,12 +16,6 @@ var {{PackageVar}} = require("{{Package}}");
 ```typescript
 import * as {{PackageVar}} from "{{Package}}";
 ```
-
-<div class="language-prologue-python"></div>
-> Python API documentation is [coming soon](https://github.com/pulumi/docs/issues/630).
-
-<div class="language-prologue-go"></div>
-> Go API documentation is [coming soon](https://github.com/pulumi/docs/issues/722).
 
 {{/Package}}
 


### PR DESCRIPTION
For now, we'll just remove the Python and Go tabs from the Node.js API Reference docs. We can revisit when we have a global language picker or unified API Reference.

I kept the JavaScript and TypeScript tabs as they seemed relevant for Node.js, but I'm certainly open to removing them if we think having them will confuse folks looking for other languages.

Before:

<img width="960" alt="screen shot 2019-02-06 at 11 21 21 am" src="https://user-images.githubusercontent.com/710598/52367677-75ba7a80-2a01-11e9-9681-ea706ae91178.png">

After:

<img width="961" alt="screen shot 2019-02-06 at 11 21 27 am" src="https://user-images.githubusercontent.com/710598/52367681-79e69800-2a01-11e9-9f06-cfbe7c3cc379.png">

Fixes #837