### PR TITLE
fix(gcp): add GCP web server tutorial to quickstart nav menu

### DIFF
--- a/_data/quickstart.yaml
+++ b/_data/quickstart.yaml
@@ -23,6 +23,7 @@ toc:
   path: /quickstart/gcp/index
   section:
    - quickstart/gcp/setup.md
+   - quickstart/gcp/tutorial-gce-webserver.md
 - title: Kubernetes
   path: /quickstart/kubernetes/index
   section:


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/850