### PR TITLE
Remove unneeded import

### DIFF
--- a/quickstart/gcp/tutorial-gke.md
+++ b/quickstart/gcp/tutorial-gke.md
@@ -36,7 +36,6 @@ In this tutorial, we'll launch a new Managed Kubernetes cluster in Google Kubern
     cluster.
 
     ```typescript
-    import * as pulumi from "@pulumi/pulumi";
     import { Config } from "@pulumi/pulumi";
 
     const config = new Config();


### PR DESCRIPTION
We only care about importing the Config type from `@pulumi/pulumi` so
the line that imported everything was un-needed.