### PR TITLE
Fixes a few headings, links, and examples

### DIFF
--- a/quickstart/azure/tutorial-container-webserver.md
+++ b/quickstart/azure/tutorial-container-webserver.md
@@ -9,7 +9,7 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver Container In
 1.  [Install Pulumi](../install.html)
 1.  [Configure Azure credentials](./setup.html)
 
-## Create a Virtual Machine with SSH access {#webserver}
+## Create a Azure Container Instances Web Server {#webserver}
 
 1.  In a new folder `webserver`, create an empty project with `pulumi new`. Make sure you have run `az login` or configured credentials for Azure.
     ```
@@ -33,7 +33,10 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver Container In
             image: "nginx",
             memory: 1,
             cpu: 1,
-            port: 80,
+            ports: [{
+                    port: 80,
+                    protocol: "TCP"
+            }],
         }],
         osType: "Linux",
         resourceGroupName: resourceGroup.name,
@@ -43,7 +46,7 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver Container In
     exports.publicIP = container.ipAddress;
     ```
 
-    This example uses the [@pulumi/azure](https://pulumi.io/reference/pkg/nodejs/@pulumi/azure/) package to create and manage two Azure resources including: an [azure.containerservice.Group](https://pulumi.io/reference/pkg/nodejs/@pulumi/azure/core/#ResourceGroup) which will run an `nginx` Docker container using the Azure Container Instances.
+    This example uses the [@pulumi/azure](https://pulumi.io/reference/pkg/nodejs/@pulumi/azure/) package to create and manage two Azure resources including an [azure.containerservice.Group](https://pulumi.io/reference/pkg/nodejs/@pulumi/azure/containerservice/#Group) which will run an `nginx` Docker container using the Azure Container Instances.
 
 1.  To preview and deploy changes, run `pulumi update`. The command shows a preview of the resources that will be created and prompts on whether to proceed with the deployment.  Note that the stack itself is counted as a resource, though it does not correspond to a physical cloud resource.
 

--- a/reference/cd-gitlab-ci.md
+++ b/reference/cd-gitlab-ci.md
@@ -12,7 +12,7 @@ altered to fit into any existing type of deployment setup.
 
 ## Prerequisites
 - An account on https://app.pulumi.com and that you have created a new project.
-  - This just means you will sign-in using your GitHub credentials.
+  - This just means you will sign-in using your GitLab credentials.
   - However, pulumi can be run from anywhere and your infrastrucutre code itself can be hosted anywhere.
 - The latest CLI. Installation instructions are [here](https://pulumi.io/quickstart/install.html).
 - A bare repo and set the remote URL to be your GitLab project.


### PR DESCRIPTION
- s/GitHub/GitLab/ on Gitlab CI page
- Fix Azure container heading and links
- Update example to remove deprecation warning in `pulumi up` output