### PR TITLE
Change the cmd seq in the Pulumi new example

### DIFF
--- a/quickstart/aws/tutorial-rest-api.md
+++ b/quickstart/aws/tutorial-rest-api.md
@@ -23,8 +23,9 @@ concepts to explore additional containers, serverless, and infrastructure tutori
 Let's use the Pulumi CLI to initialize a new project:
 
 ```
-pulumi new hello-aws-javascript --dir ahoy-pulumi
+mkdir ahoy-pulumi 
 cd ahoy-pulumi
+pulumi new hello-aws-javascript
 ```
 
 You can accept the defaults for this command. For instance, you can change the AWS region to `us-west-2`.


### PR DESCRIPTION
Change the sequence of commands in the Pulumi new example per Luke's suggestion to avoid using the --dir option and instead use and explicit mkdir followed by cd.

If this is approved, we should make corresponding changes in the other tutorials.

(For Luke's suggestion and the discussion, see Update tutorial-rest-api.md #762 .)