### PR TITLE
Fix bundler issue in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby AS builder
 
 COPY Gemfile* /src/
 WORKDIR /src
-RUN bundle install
+RUN gem install bundler -v '2.0.1' && bundle install
 
 RUN apt-get update && apt-get -y install \
   curl


### PR DESCRIPTION
Explicitly install bundler matching Gemfile.lock to work around
error: "Could not find 'bundler' (2.0.1) required by your
/src/Gemfile.lock. (Gem::GemNotFoundException)"