### PR TITLE
update guestbook.yaml location

### DIFF
--- a/quickstart/aws/tutorial-eks.md
+++ b/quickstart/aws/tutorial-eks.md
@@ -396,7 +396,7 @@ LoadBalancer typed Service to expose it publicly.
 // Create resources for the Kubernetes Guestbook from its YAML manifests
 const guestbook = new k8s.yaml.ConfigFile("guestbook",
     {
-        file: "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/examples/yaml-guestbook/yaml/guestbook.yaml",
+        file: "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/tests/examples/yaml-guestbook/yaml/guestbook.yaml",
         transformations: [
             (obj: any) => {
                 // Do transformations on the YAML to use the same namespace and


### PR DESCRIPTION
It looks like the guestbook.yaml used near the end of this page has a new path.  The current path comes up 404, which causes `pulumi up` to fail.