### PR TITLE
Make `brew install pulumi` the default install choice on macOS

### DIFF
--- a/quickstart/install.md
+++ b/quickstart/install.md
@@ -86,19 +86,7 @@ After installation, or if you've already installed Pulumi, let's [choose a cloud
 <div id="macos_installation" markdown="1">
 ## macOS
 
-To install Pulumi, run our installation script:
-
-```bash
-$ curl -fsSL https://get.pulumi.com | sh
-```
-
-This will install the `pulumi` CLI to `~/.pulumi/bin` and add it to your path.
-
-The installer script can be rerun to subsequently install new updates.
-
-### (Alternative) Homebrew
-
-If you prefer, you can install Pulumi through the [Homebrew package manager](https://brew.sh/):
+You can install Pulumi through the [Homebrew package manager](https://brew.sh/):
 
 ```bash
 $ brew install pulumi
@@ -111,6 +99,18 @@ Subsequent updates can be installed in the usual way:
 ```bash
 $ brew upgrade pulumi
 ```
+
+### (Alternative) Installation script
+
+Alternatively, our installation script can be run:
+
+```bash
+$ curl -fsSL https://get.pulumi.com | sh
+```
+
+This will install the `pulumi` CLI to `~/.pulumi/bin` and add it to your path.
+
+The installer script can be rerun to subsequently install new updates.
 </div>
 
 <div id="linux_installation" markdown="1">


### PR DESCRIPTION
Note: I'm planning an overhaul of this whole page to be much simpler. This is just a small tactical change in the meantime as we now prefer `brew` for macOS.