### PR TITLE
Enable no-select for Safari

### DIFF
--- a/_sass/_pulumi.scss
+++ b/_sass/_pulumi.scss
@@ -924,6 +924,9 @@ table.clouds-table td {
 }
 
 .no-select {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
     user-select: none;
 }
 


### PR DESCRIPTION
Safari still only supports `-webkit-user-select`. Include prefixes for other browsers as well.