### PR TITLE
Always show code examples for Node packages

### DIFF
--- a/js/langchoose.js
+++ b/js/langchoose.js
@@ -2,6 +2,16 @@ function getElemClasses(e) {
     return ($(e).attr("class") || "").split(/\s+/);
 }
 
+function elementHasLanguageClass(e) {
+    var classes = getElemClasses(e);
+    for (var i = 0; i < classes.length; i++) {
+        if (classes[i].startsWith("language-")) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // selectLanguage will remember a given language as a preferred setting using a cookie and walk the DOM enabling
 // all code tabs and snippets for this language, and disabling those for unselected languages.
 function selectLanguage(lang) {
@@ -32,7 +42,24 @@ function selectLanguage(lang) {
                 var classes = getElemClasses(e);
                 for (var i = 0; i < classes.length; i++) {
                     if (classes[i].startsWith("language-") && classes[i] !== "language-bash") {
-                        if (classes[i] === "language-"+lang) {
+                        // Our Node reference docs contain examples written in TypeScript, and
+                        // don't currently have JavaScript examples above.
+                        // Ensure these TypeScript examples are always visible, even when
+                        // JavaScript is the selected language.
+                        if (lang === "javascript" &&
+                            (classes[i] === "language-typescript" || classes[i] === "language-ts")) {
+                            // If the previous element doesn't have a class that starts with "language-",
+                            // show the element.
+                            var prev = $(e).prev();
+                            if (prev && !elementHasLanguageClass(prev)) {
+                                $(e).show();
+                                break;
+                            }
+                        }
+
+                        if (classes[i] === "language-"+lang ||
+                            (lang === "typescript" && classes[i] === "language-ts") ||
+                            (lang === "javascript" && classes[i] === "language-js")) {
                             $(e).show();
                         } else {
                             $(e).hide();


### PR DESCRIPTION
Code examples in doc comments for our Node packages are written in TypeScript and use `ts` as the language type, which means they end up being rendered as `<div class="language-ts">...</div>`.

This means that when JavaScript is selected (the default), these code examples are hidden.

But since they are denoted as `ts` and not `typescript`, even when TypeScript is selected, the examples are still hidden.

This change ensures these code snippets are always visible, when either JavaScript or TypeScript are selected.

Fixes #884