### PR TITLE
Use `pulumi new` consistently

### DIFF
--- a/quickstart/aws/tutorial-ec2-webserver.md
+++ b/quickstart/aws/tutorial-ec2-webserver.md
@@ -14,8 +14,8 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver EC2 instance
 1.  In a new folder `webserver`, create an empty project with `pulumi new`. Be sure to use `us-east-1` as the region:
 
     ```
-    $ pulumi new aws-javascript --dir webserver
-    $ cd webserver
+    $ mkdir webserver && cd webserver
+    $ pulumi new aws-javascript
     ...
     aws:region: (us-east-1) 
     ```

--- a/quickstart/aws/tutorial-eks.md
+++ b/quickstart/aws/tutorial-eks.md
@@ -15,20 +15,13 @@ In this tutorial, we'll launch a new Managed Kubernetes cluster in Elastic Conta
     recommendation to begin your journey.
 
     ```bash
-    $ pulumi new aws-typescript --dir eks-hello-world
+    $ mkdir eks-hello-world && cd eks-hello-world
+    $ pulumi new aws-typescript
     ```
 
     * Enter in a Pulumi project name, and description to detail what this
       Pulumi program does
     * Enter in a name for the [Pulumi stack](https://pulumi.io/reference/stack.html), which is an instance of our Pulumi program, and is used to distinguish amongst different development phases and environments of your work streams.
-    * Select 'no' when prompted to 'perform this update,' as we'll be
-    interactively editing files in the upcoming steps.
-
-    Change directories to the newly created Pulumi project.
-
-    ```bash
-    $ cd eks-hello-world
-    ```
 
 1. Add the required dependencies:
 
@@ -75,7 +68,7 @@ In this tutorial, we'll launch a new Managed Kubernetes cluster in Elastic Conta
     ```
 1.  To preview and deploy changes, run `pulumi up` and select "yes."
 
-    The `update` sub-command shows a preview of the resources that will be created
+    The `up` sub-command shows a preview of the resources that will be created
     and prompts on whether to proceed with the deployment. Note that the stack
     itself is counted as a resource, though it does not correspond
     to a physical cloud resource.

--- a/quickstart/aws/tutorial-rest-api.md
+++ b/quickstart/aws/tutorial-rest-api.md
@@ -23,8 +23,7 @@ concepts to explore additional containers, serverless, and infrastructure tutori
 Let's use the Pulumi CLI to initialize a new project:
 
 ```
-mkdir ahoy-pulumi 
-cd ahoy-pulumi
+mkdir ahoy-pulumi && cd ahoy-pulumi
 pulumi new hello-aws-javascript
 ```
 

--- a/quickstart/aws/tutorial-s3-website.md
+++ b/quickstart/aws/tutorial-s3-website.md
@@ -14,8 +14,8 @@ In this tutorial, we'll show how you can use [@pulumi/aws] to provision raw reso
 1.  Create an empty project with `pulumi new`:
 
     ```bash
-    $ pulumi new javascript --dir s3website
-    $ cd s3website
+    $ mkdir s3website && cd s3website
+    $ pulumi new javascript
     ```
 
 1.  Edit `index.js` and replace with the following. The code creates a new S3 bucket, then iterates over the files in the `www` folder to create an S3 Object for each file.

--- a/quickstart/aws/tutorial-service.md
+++ b/quickstart/aws/tutorial-service.md
@@ -19,8 +19,8 @@ In this tutorial, we'll use TypeScript to build and deploy a simple container us
 1.  Run `pulumi new`:
 
     ```bash
-    $ pulumi new aws-typescript --dir container-quickstart
-    $ cd container-quickstart
+    $ mkdir container-quickstart && cd container-quickstart
+    $ pulumi new aws-typescript
     ```
 
 1.  Replace the contents of `index.ts` with the following:

--- a/quickstart/aws/tutorial-thumbnailer.md
+++ b/quickstart/aws/tutorial-thumbnailer.md
@@ -21,8 +21,8 @@ and a video walkthrough of this example is [available on YouTube](https://www.yo
 1.  Run `pulumi new`:
 
     ```bash
-    $ pulumi new aws-typescript --dir video-thumbnail
-    $ cd video-thumbnail
+    $ mkdir video-thumbnail && cd video-thumbnail
+    $ pulumi new aws-typescript
     ```
 
 1.  Replace the contents of `index.ts` with the following:

--- a/quickstart/azure/tutorial-azure-kubernetes-service.md
+++ b/quickstart/azure/tutorial-azure-kubernetes-service.md
@@ -14,7 +14,8 @@ In this tutorial, we'll use Python to deploy an instance of Azure Kubernetes Ser
     recommendation to begin your journey.
 
     ```bash
-    $ pulumi new azure-python --dir aks-hello-world
+    $ mkdir aks-hello-world && cd aks-hello-world
+    $ pulumi new azure-python
     ```
 
     * Enter in a Pulumi project name, and description to detail what this
@@ -190,7 +191,7 @@ In this tutorial, we'll use Python to deploy an instance of Azure Kubernetes Ser
 
 1.  To preview and deploy changes, run `pulumi up` and select "yes."
 
-    The `update` sub-command shows a preview of the resources that will be created
+    The `up` sub-command shows a preview of the resources that will be created
     and prompts on whether to proceed with the deployment. Note that the stack
     itself is counted as a resource, though it does not correspond
     to a physical cloud resource.

--- a/quickstart/azure/tutorial-container-webserver.md
+++ b/quickstart/azure/tutorial-container-webserver.md
@@ -13,8 +13,8 @@ In this tutorial, we'll use JavaScript to deploy a simple nginx container to Azu
 
 1.  In a new folder `webserver`, create an empty project with `pulumi new`. Make sure you have run `az login` or configured credentials for Azure.
     ```
-    $ pulumi new azure-javascript --dir webserver
-    $ cd webserver
+    $ mkdir webserver && cd webserver
+    $ pulumi new azure-javascript
     ```
 
 1.  Open `index.js` and replace the contents with the following:

--- a/quickstart/cloudfx/tutorial-rest-api.md
+++ b/quickstart/cloudfx/tutorial-rest-api.md
@@ -14,8 +14,8 @@ In this tutorial, we'll show how to create a simple REST API that counts the num
 1.  Run `pulumi new`:
 
     ```bash
-    $ pulumi new aws-javascript --dir hello-http
-    $ cd hello-http
+    $ mkdir hello-http && cd hello-http
+    $ pulumi new aws-javascript
     ```
 
 1.  Replace the contents of `index.js` with the following:

--- a/quickstart/cloudfx/tutorial-service.md
+++ b/quickstart/cloudfx/tutorial-service.md
@@ -19,8 +19,8 @@ In this tutorial, we'll use JavaScript to build and deploy a simple container us
 1.  Run `pulumi new`:
 
     ```bash
-    $ pulumi new javascript --dir container-quickstart
-    $ cd container-quickstart
+    $ mkdir container-quickstart && cd container-quickstart
+    $ pulumi new javascript
     ```
 
 1.  Replace the contents of `index.js` with the following:

--- a/quickstart/cloudfx/tutorial-thumbnailer.md
+++ b/quickstart/cloudfx/tutorial-thumbnailer.md
@@ -22,8 +22,8 @@ and a video walkthrough of this example is [available on YouTube](https://www.yo
 1.  Run `pulumi new`:
 
     ```bash
-    $ pulumi new aws-javascript --dir video-thumbnail
-    $ cd video-thumbnail
+    $ mkdir video-thumbnail && cd video-thumbnail
+    $ pulumi new aws-javascript
     ```
 
 1.  Replace the contents of `index.js` with the following:

--- a/quickstart/gcp/tutorial-gce-webserver.md
+++ b/quickstart/gcp/tutorial-gce-webserver.md
@@ -11,11 +11,11 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver Virtual Mach
 
 ## Create a Virtual Machine with SSH access {#webserver}
 
-1.  In a new folder `webserver`, create an empty project with `pulumi new`. Choose a Google Cloud `project` you have access to creater Virtual Machines within.
+1.  In a new folder `webserver`, create an empty project with `pulumi new`. Choose a Google Cloud `project` you have access to create Virtual Machines within.
 
     ```
-    $ pulumi new gcp-javascript --dir webserver
-    $ cd webserver
+    $ mkdir webserver && cd webserver
+    $ pulumi new gcp-javascript
     ...
     gcp:project: The Google Cloud project to deploy into: <your project>
     ```

--- a/quickstart/gcp/tutorial-gke.md
+++ b/quickstart/gcp/tutorial-gke.md
@@ -32,23 +32,14 @@ In this tutorial, we'll launch a new Managed Kubernetes cluster in Google Kubern
 
 1.  In a new folder `gke-hello-world`, create an empty project with `pulumi new`.
 
-    Alternatively, the following command will create a base Pulumi program in TypeScript as well as the `gke-hello-world` folder:
-
     ```bash
-    pulumi new typescript --dir gke-hello-world
+    $ mkdir gke-hello-world && cd gke-hello-world
+    $ pulumi new typescript
     ```
 
     * Enter in a Pulumi project name, and description to detail what this
       Pulumi program does
     * Enter in a name for the [Pulumi stack](https://pulumi.io/reference/stack.html), which is an instance of our Pulumi program, and is used to distinguish amongst different development phases and environments of your work streams.
-    * Select 'no' when prompted to 'perform this update,' as we'll be
-    interactively editing files in the upcoming steps.
-
-    Change directories to the newly created Pulumi project.
-
-    ```bash
-    cd gke-hello-world
-    ```
 
 1. Add the required dependencies:
 

--- a/quickstart/kubernetes/tutorial-guestbook.md
+++ b/quickstart/kubernetes/tutorial-guestbook.md
@@ -45,10 +45,11 @@ To start, we'll need to create a project and stack (a deployment target) for our
 1.  To create a new Pulumi project, let's use a template:
 
     ```shell
-    $ pulumi new kubernetes-typescript --dir k8s-guestbook && cd k8s-guestbook
+    $ mkdir k8s-guestbook && cd k8s-guestbook
+    $ pulumi new kubernetes-typescript
     ```
 
-    This command will have initialized a fresh project in the `k8s-guestbook` directory and `cd`'d into it.
+    This command will initialize a fresh project in the `k8s-guestbook` newly-created directory.
 
 2.  Next, replace the minimal contents of the template's `index.ts` file with the full guestbook:
 

--- a/reference/javascript.md
+++ b/reference/javascript.md
@@ -17,11 +17,11 @@ Any Node.js version after 6.10.x is supported, as long it is under **Active LTS*
 
 ## Getting Started
 
-The fastest way to get started in JavaScript is using a template.  From the directory in which you'd like to create a new project:
+The fastest way to get started in JavaScript is using a template.  From an empty directory in which you'd like to create a new project:
 
 ```bash
+$ mkdir myproject && cd myproject
 $ pulumi new javascript
-Your project was created successfully.
 ```
 
 This will create a `Pulumi.yaml` [project file](./project.html), a `package.json` file for dependencies, and an `index.js` file, containing your program. The name of the directory is used as the project name in `Pulumi.yaml`.
@@ -35,8 +35,8 @@ If you would like full control of the TypeScript build process, you can compile 
 The fastest way to get started with Pulumi in TypeScript, is to use a template:
 
 ```bash
+$ mkdir myproject && cd myproject
 $ pulumi new typescript
-Your project was created successfully.
 ```
 
 This will auto-generate all the basic artifacts required to use TypeScript. If you prefer, you can instead run the following manual steps.

--- a/reference/python.md
+++ b/reference/python.md
@@ -12,11 +12,11 @@ Pulumi supports programs written in Python 3.
 
 ## Getting Started
 
-The fastest way to get started with Pulumi Python is by using a template.  From the directory in which you'd like to create a new project:
+The fastest way to get started with Pulumi Python is by using a template.  From an empty directory in which you'd like to create a new project:
 
 ```
+$ mkdir myproject && cd myproject
 $ pulumi new python
-Your project was created successfully.
 ```
 
 This will leave behind a `Pulumi.yaml` file, containing some minimal metadata about your project (including a name and description which you may wish to change), a `requirements.txt` file, where you will specify your dependencies (see #pypi-packages below), and a `__main__.py` file, containing your program.

--- a/tour/basics-projects.md
+++ b/tour/basics-projects.md
@@ -14,7 +14,8 @@ Use [`pulumi new <template-name>`](/reference/cli/pulumi_new.html) to quickly sc
 
 <div class="language-prologue-javascript"></div>
 ```bash
-$ pulumi new aws-javascript --dir ahoy-pulumi
+$ mkdir ahoy-pulumi && cd ahoy-pulumi
+$ pulumi new aws-javascript
 This command will walk you through creating a new Pulumi project.
 Enter a value or leave blank to accept the default, and press <ENTER>.
 Press ^C at any time to quit.
@@ -29,7 +30,8 @@ New project is configured and ready to deploy with 'pulumi up'.
 
 <div class="language-prologue-typescript"></div>
 ```bash
-$ pulumi new aws-typescript --dir ahoy-pulumi
+$ mkdir ahoy-pulumi && cd ahoy-pulumi
+$ pulumi new aws-typescript
 This command will walk you through creating a new Pulumi project.
 Enter a value or leave blank to accept the default, and press <ENTER>.
 Press ^C at any time to quit.
@@ -44,7 +46,8 @@ New project is configured and ready to deploy with 'pulumi up'.
 
 <div class="language-prologue-python"></div>
 ```bash
-$ pulumi new aws-python --dir ahoy-pulumi
+$ mkdir ahoy-pulumi && cd ahoy-pulumi
+$ pulumi new aws-python
 This command will walk you through creating a new Pulumi project.
 Enter a value or leave blank to accept the default, and press <ENTER>.
 Press ^C at any time to quit.
@@ -59,7 +62,8 @@ New project is configured and ready to deploy with 'pulumi up'.
 
 <div class="language-prologue-go"></div>
 ```bash
-$ pulumi new aws-go --dir ahoy-pulumi
+$ mkdir ahoy-pulumi && cd ahoy-pulumi
+$ pulumi new aws-go
 This command will walk you through creating a new Pulumi project.
 Enter a value or leave blank to accept the default, and press <ENTER>.
 Press ^C at any time to quit.


### PR DESCRIPTION
Use `mkdir foo && cd foo` before the `pulumi new` command consistently throughout.

Part of #964 (I want to keep the issue open to do a subsequent scrub of the `examples` and package repos).