### PR TITLE
Fix iOS rendering of search box

### DIFF
--- a/_sass/_pulumi.scss
+++ b/_sass/_pulumi.scss
@@ -58,15 +58,11 @@ $primary2: #00acf2; // primary blue
         padding: 0 12px;
         width: 100%;
         flex: 1;
+        box-sizing: content-box;
 
         @media(min-width: $screen-md) {
             width: 180px;
         }
-
-        // WebKit hijacks the size of search forms. Old blog post for context:
-        // http://tonibarrett.com/forcing-my-style-onto-input-typesearch/
-        -webkit-appearance: textfield;
-        box-sizing: content-box;
     }
 
     .button {


### PR DESCRIPTION
This removes the `-webkit-appearance` property to allow the search box be styled as intended.

![image](https://user-images.githubusercontent.com/274700/57636837-d4dade80-755e-11e9-9ae6-8aec26a1b607.png)

Signed-off-by: Christian Nunciato <c@nunciato.org>