### PR TITLE
Handle ad-blocked GitHub star widget

### DIFF
--- a/_sass/partials/_header.scss
+++ b/_sass/partials/_header.scss
@@ -97,13 +97,20 @@ body{
                 margin-right: 4px;
             }
         }
-    }
-}
 
-.gh-widget {
-    > span {
-        position: relative;
-        top: 3px;
+        &.gh-widget {
+            margin-left: 0;
+
+            > a {
+                display: none;
+            }
+
+            > span {
+                margin-left: 40px;
+                position: relative;
+                top: 4px;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This change adjusts the layout of the main nav to hide the word “Star” and right-align remaining nav elements when the GitHub star-widget script fails to load.

Companion to https://github.com/pulumi/www.pulumi.com/issues/279.

Signed-off-by: Christian Nunciato <c@nunciato.org>