### PR TITLE
Fix typo in programming-model.md

### DIFF
--- a/reference/programming-model.md
+++ b/reference/programming-model.md
@@ -121,7 +121,7 @@ A parent for the resource. See [Components](#components).  The default is to par
 A provider for the resource. See [Providers](#providers).  The default is to inherit this value from the parent resource, and to use the ambient provider specified by Pulumi configuration for resources without a parent.
 
 ###### `deleteBeforeReplace`
-Specify that replacements of the resource will delete the existing resource before creating it's replacement.  This will lead to downtime during the replacement, but may be necessary for some resources that manage scarce resources behind the scenes.  The default is `false`.
+Specify that replacements of the resource will delete the existing resource before creating its replacement.  This will lead to downtime during the replacement, but may be necessary for some resources that manage scarce resources behind the scenes.  The default is `false`.
 
 ###### `ignoreChanges`
 Provides a list of properties which will be ignored as part of updates. The value of the property will be used for newly created resources, but will not be used as part of updates. This is typically used to avoid changes in properties leading to diffs or to change defaults for a property without forcing all existing deployed stacks to update or replace the affected resource.


### PR DESCRIPTION
https://www.grammarly.com/blog/its-vs-its/