### PR TITLE
Add ToC entry for @pulumi/digitalocean package

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -148,6 +148,11 @@ sectionPagesMenu = "main"
 
 [[menu.reference]]
     parent = "node"
+    name = "digitalocean"
+    url = "/reference/pkg/nodejs/pulumi/digitalocean/"
+
+[[menu.reference]]
+    parent = "node"
     name = "docker"
     url = "/reference/pkg/nodejs/pulumi/docker/"
 


### PR DESCRIPTION
When I [added the docs for the DigitalOcean provider](https://github.com/pulumi/docs/pull/1094), I added a menu item for Python, but forgot to add one for the Node.js package, which means we're missing a ToC entry for the @pulumi/digitalocean node package.

Aside: We should fix-up our doc generator tools to include these menu entries in the generated page's front matter, so we don't have to maintain these manually. Opened https://github.com/pulumi/docs/issues/1104