### PR TITLE
Add proper 301 redirects for our Node.js API docs

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -31,6 +31,15 @@ const contentBucket = new aws.s3.Bucket(
         website: {
             indexDocument: "index.html",
             errorDocument: "404.html",
+            routingRules: JSON.stringify([{
+                "Condition": {
+                    "KeyPrefixEquals": "reference/pkg/nodejs/@pulumi/",
+                },
+                "Redirect": {
+                    "HostName": config.targetDomain,
+                    "ReplaceKeyPrefixWith": "reference/pkg/nodejs/pulumi/",
+                },
+            }]),
         },
     },
     {


### PR DESCRIPTION
With the move to Hugo, the Node.js API docs have moved from `reference/pkg/nodejs/@pulumi/` to `reference/pkg/nodejs/pulumi/` as Hugo strips the `@` when generating the site.

We have Hugo aliases in place that redirect from the old locations to the new locations. However, these are based on client-side [meta refresh](https://www.w3.org/TR/WCAG20-TECHS/H76.html), which does not pass along any anchors that may be specified in the source URL. This is problematic as many of our API docs rely on anchors when linking to specific identifiers.

The fix is to use real 301 redirects instead of these client-side redirects, as browsers will pass along the anchor when 301 redirects are encountered.

---

I confirmed the fix in my dev stack. For example try navigating to: https://hugo.pulumi.io/reference/pkg/nodejs/@pulumi/azure/keyvault/#example-usage-generating-a-new-certificate

---

A follow-up would be to remove the Hugo aliases for the Node.js docs, as they are no longer needed with this in place. But I'll hold off on doing that, as we'll be removing unnecessary Hugo aliases and using proper 301 redirects as we migrate the docs from pulumi.io to www.pulumi.com.

Fixes #1119