### PR TITLE
Deploy latest to production

### DIFF
--- a/content/quickstart/gcp/setup.md
+++ b/content/quickstart/gcp/setup.md
@@ -17,11 +17,11 @@ before it can be used to create resources.
 
 When developing locally, we recommend that you use `gcloud login` to configure your account credentials:
 
-    ```bash
-    $ gcloud auth login
-    $ gcloud config set project <YOUR_GCP_PROJECT_HERE>
-    $ gcloud auth application-default login
-    ```
+```bash
+$ gcloud auth login
+$ gcloud config set project <YOUR_GCP_PROJECT_HERE>
+$ gcloud auth application-default login
+```
 
 If you are using Pulumi in an non-interactive setting (such as a CI/CD system) you will need to [configure and use a service account]({{< relref "service-account.md" >}}) instead.
 

--- a/content/quickstart/kubernetes/tutorial-guestbook.md
+++ b/content/quickstart/kubernetes/tutorial-guestbook.md
@@ -391,18 +391,18 @@ To start, we'll need to create a project and stack (a deployment target) for our
 
     The output from running this command should look something like this:
 
-    ```
-    Updating stack 'k8s-guestbook-dev'
-    Performing changes:
 
-         Type                           Name                             Plan          Info
-     *   pulumi:pulumi:Stack            k8s-guestbook-k8s-guestbook-dev  no change
-     ~   └─ kubernetes:apps:Deployment  frontend                         updated       changes: ~ spec
+        Updating stack 'k8s-guestbook-dev'
+        Performing changes:
 
-    info: 1 change performed:
-        ~ 1 resource updated
-          6 resources unchanged
-    ```
+                Type                           Name                             Plan          Info
+            *   pulumi:pulumi:Stack            k8s-guestbook-k8s-guestbook-dev  no change
+            ~   └─ kubernetes:apps:Deployment  frontend                         updated       changes: ~ spec
+
+        info: 1 change performed:
+            ~ 1 resource updated
+              6 resources unchanged
+
 
 ### Cleaning Up
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -31,6 +31,15 @@ const contentBucket = new aws.s3.Bucket(
         website: {
             indexDocument: "index.html",
             errorDocument: "404.html",
+            routingRules: JSON.stringify([{
+                "Condition": {
+                    "KeyPrefixEquals": "reference/pkg/nodejs/@pulumi/",
+                },
+                "Redirect": {
+                    "HostName": config.targetDomain,
+                    "ReplaceKeyPrefixWith": "reference/pkg/nodejs/pulumi/",
+                },
+            }]),
         },
     },
     {


### PR DESCRIPTION
I confirmed the redirect fix on staging.pulumi.io, e.g. https://staging.pulumi.io/reference/pkg/nodejs/@pulumi/azure/keyvault/#example-usage-generating-a-new-certificate