### PR TITLE
Fix strange markdown rendering in API docs

### DIFF
--- a/layouts/shortcodes/md.html
+++ b/layouts/shortcodes/md.html
@@ -1,5 +1,9 @@
 {{/*
     This shortcode is used to render markdown inside HTML tags, which Blackfriday,
     the markdown processor that Hugo uses, doesn't currently support.
+    We specify version = 1 so that `.Inner` is rendered as markdown consistently,
+    whether it ends up being within HTML tags or not.
+    See https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown.
 */}}
-{{ markdownify .Inner }}
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ .Inner }}


### PR DESCRIPTION
Hugo's markdown renderer does not support rendering markdown inside HTML tags and does not support the `markdown="1"` attribute on HTML tags that Jekyll supports to enable markdown rendering inside the tags.

To work around this limitation, we have a custom `md` shortcode that can be used inside HTML tags to wrap markdown that should be rendered. However, there was a bug in our `md` shortcode. We use the `{{% md %}}` syntax instead of `{{< md >}}` because we intend to have markdown inside the shortcode, and inside our `md` layout, we use `{{ markdownify .Inner }}` to render the `.Inner` content as markdown. However, in some cases, when not actually inside HTML tags, `.Inner` will end up being already rendered markdown. So we end up passing the already rendered markdown through the `markdownify` function, resulting in some wacky rendering.

The fix is to specify the behavior of `{{% %}}` per https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown, to consistently render `.Inner` as markdown whether it's inside HTML tags or not, and emit `.Inner` directly without passing it through `markdownify`.

## Before

https://pulumi.io/reference/pkg/nodejs/pulumi/aws/s3/#static-website-hosting

<img width="1010" alt="Screen Shot 2019-06-04 at 5 51 22 PM" src="https://user-images.githubusercontent.com/710598/58922808-66b6b100-86f1-11e9-8bd1-60f64917f15f.png">

## After

<img width="1007" alt="Screen Shot 2019-06-04 at 5 51 35 PM" src="https://user-images.githubusercontent.com/710598/58922812-6f0eec00-86f1-11e9-9fd4-7bb3c02ce34c.png">

Fixes #1118