### PR TITLE
Fix code snippet scroll behavior

### DIFF
--- a/assets/sass/_pulumi.scss
+++ b/assets/sass/_pulumi.scss
@@ -1,22 +1,14 @@
 @import "pulumi-constants";
 @import "pulumi-toc";
 
-// Drop the rounded corners for code snippets. Ideally we would just do this
-// for the code associated with our language chooser. However, there isn't a
-// way to associate the two. (Since the N language code blocks are siblings
-// to the lang chooser tabs.)
-pre.highlight {
-    border-radius: 0 !important;
-}
-
 // Force code snippets to scroll horizontally rather than word wrapping.
-pre.highlight code {
+pre.chroma code {
     white-space: pre;
 }
 
 // On MacOS the scrollbar is hidden by default. But without it there
 // isn't any clear indication that you can/should scroll.
-pre.highlight {
+pre.chroma {
     &::-webkit-scrollbar {
         -webkit-appearance: none;
         height: 7px;
@@ -321,10 +313,6 @@ pre {
     font-size: 14px;
     line-height: 1.5;
     margin-bottom: 24px;
-}
-
-pre.highlight {
-    border-radius: 2px !important;
 }
 
 h2, h3, h4 {


### PR DESCRIPTION
I noticed this while working on the get started changes. Fix code snippet scroll behavior after the Hugo move, where the generated code for code snippets is slightly different.

Before

<img width="399" alt="Screen Shot 2019-06-11 at 9 50 58 AM" src="https://user-images.githubusercontent.com/710598/59290980-af5cf580-8c2e-11e9-914b-9d2afd9f1b0f.png">

After

<img width="428" alt="Screen Shot 2019-06-11 at 9 50 28 AM" src="https://user-images.githubusercontent.com/710598/59290987-b1bf4f80-8c2e-11e9-91f7-b65e6f1566df.png">
