### PR TITLE
Single place to update the latest-version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Which, on a page inside the `./content/reference` directory, will generate:
     {{ partial "head.html" . }}
     ```
 
-- **Front-matter variables.** You can define a front-matter variable in the YAML section at the top of a file. For instance, the installer page defines `installer_version: "0.10.0"`. You  can then reference the variable in either markdown with the syntax `{{< param installer_version >}}`.
+- **Front-matter variables.** You can define a front-matter variable in the YAML section at the top of a file. For instance, the you could add the following front matter `foo: "bar"`, and then reference the variable in markdown with the syntax `{{< param foo >}}`.
 
 ## Style guide
 

--- a/content/quickstart/install.md
+++ b/content/quickstart/install.md
@@ -1,6 +1,5 @@
 ---
 title: "Download and Install"
-installer_version: "0.17.16"
 aliases:
     - install.html
     - /install/
@@ -11,8 +10,8 @@ menu:
 
 <!--
 NOTE: To update this page with a new binary release, do the following:
-- Update `installer_version` in the YAML front matter above.
-- Update changelog.md with the latest fixes in the release
+- Update `static/latest-version`
+- Update `content/reference/changelog.md`
 -->
 
 First things first, let's install the Pulumi CLI on your machine.
@@ -158,7 +157,7 @@ Raw binaries are available for all major operating systems if you prefer to inst
 
 macOS Sierra (10.12) or later is required.
 
-1. Download [Pulumi {{< param installer_version >}} for macOS](https://get.pulumi.com/releases/sdk/pulumi-v{{< param installer_version >}}-darwin-x64.tar.gz).
+1. Download [Pulumi {{< latest-version >}} for macOS](https://get.pulumi.com/releases/sdk/pulumi-v{{< latest-version >}}-darwin-x64.tar.gz).
 
 2. Unzip the tarball and either copy the binaries in the `pulumi` directory on your `$PATH`.
 
@@ -166,7 +165,7 @@ macOS Sierra (10.12) or later is required.
 
 We provide a pre-built binary for Linux.
 
-1. Download [Pulumi {{< param installer_version >}} for Linux x64](https://get.pulumi.com/releases/sdk/pulumi-v{{< param installer_version >}}-linux-x64.tar.gz).
+1. Download [Pulumi {{< latest-version >}} for Linux x64](https://get.pulumi.com/releases/sdk/pulumi-v{{< latest-version >}}-linux-x64.tar.gz).
 
 2. Unzip the tarball and either copy the binaries in the `pulumi` directory on your `$PATH`.
 
@@ -174,7 +173,7 @@ We provide a pre-built binary for Linux.
 
 Windows 8 and 10 are supported.
 
-1. Download [Pulumi {{< param installer_version >}} for Windows x64](https://get.pulumi.com/releases/sdk/pulumi-v{{< param installer_version >}}-windows-x64.zip).
+1. Download [Pulumi {{< latest-version >}} for Windows x64](https://get.pulumi.com/releases/sdk/pulumi-v{{< latest-version >}}-windows-x64.zip).
 
 2. Copy the extracted zipfile contents to a folder such as `C:\pulumi`.
 
@@ -185,7 +184,7 @@ Windows 8 and 10 are supported.
 To uninstall Pulumi, delete the `.pulumi` folder in your home directory. If you used the manual installer, you should
 also delete the `pulumi` folder that was created.
 
-The current stable version is **{{< param installer_version >}}**. For a full history of prior versions, including
+The current stable version is **{{< latest-version >}}**. For a full history of prior versions, including
 release notes, please visit <a href="{{< relref "/reference/changelog.md" >}}">the Change Log</a>.
 
 {{% /md %}}
@@ -210,7 +209,7 @@ After installing, verify everything is in working order by running the `pulumi` 
 
 ```bash
 $ pulumi version
-v{{< param installer_version >}}
+v{{< latest-version >}}
 ```
 
 If you get an error that `pulumi` could not be found, it means your path has not been configured correctly. Please go

--- a/layouts/shortcodes/latest-version.html
+++ b/layouts/shortcodes/latest-version.html
@@ -1,0 +1,1 @@
+{{- readFile "/static/latest-version" -}}


### PR DESCRIPTION
(Extracted out of Get Started work)

When publishing a new version of the SDK, we must update the latest
version in two places:

  1. In the front matter of `content/quickstart/install.md`, and
  2. In the `static/latest-version` file.

There's no reason we need to update these separately, so converge on
only needing to update `latest-version`, and provide a shortcode to make
it easy to include the latest version in content files.