### PR TITLE
Remove hard-coded version is CI example scripts

### DIFF
--- a/content/reference/cd-aws-code-services.md
+++ b/content/reference/cd-aws-code-services.md
@@ -63,7 +63,7 @@ phases:
   install:
     commands:
       # pulumi
-      - curl -L https://get.pulumi.com/ | bash -s -- --version 0.16.2
+      - curl -L https://get.pulumi.com/ | sh
       - export PATH=$PATH:$HOME/.pulumi/bin
   build:
     commands:

--- a/content/reference/cd-aws-code-services.md
+++ b/content/reference/cd-aws-code-services.md
@@ -63,7 +63,7 @@ phases:
   install:
     commands:
       # pulumi
-      - curl -L https://get.pulumi.com/ | sh
+      - curl -fsSL https://get.pulumi.com/ | sh
       - export PATH=$PATH:$HOME/.pulumi/bin
   build:
     commands:

--- a/content/reference/cd-azure-devops.md
+++ b/content/reference/cd-azure-devops.md
@@ -328,7 +328,7 @@ In your pipeline configuration, you need to then call these scripts when appropr
 set -e -x
 # Download and install required tools.
 # pulumi
-curl -L https://get.pulumi.com/ | bash
+curl -fsSL https://get.pulumi.com/ | bash
 export PATH=$PATH:$HOME/.pulumi/bin
 # Login into pulumi. This will require the PULUMI_ACCESS_TOKEN environment variable
 pulumi login

--- a/content/reference/cd-gitlab-ci.md
+++ b/content/reference/cd-gitlab-ci.md
@@ -153,7 +153,7 @@ It also installs `yarn` and `nodejs` since that's the runtime for this sample pr
 set -e -x
 # Download and install required tools.
 # pulumi
-curl -L https://get.pulumi.com/ | bash
+curl -fsSL https://get.pulumi.com/ | bash
 export PATH=$PATH:$HOME/.pulumi/bin
 # Login into pulumi. This will require the PULUMI_ACCESS_TOKEN environment variable
 pulumi login

--- a/content/reference/cd-travis.md
+++ b/content/reference/cd-travis.md
@@ -74,7 +74,7 @@ to run Pulumi to that.
 ```yaml
 language: generic
 before_install:
-  - curl -L https://get.pulumi.com/ | sh
+  - curl -fsSL https://get.pulumi.com/ | sh
   - export PATH=$PATH:$HOME/.pulumi/bin
 script:
   - ./scripts/travis_${TRAVIS_EVENT_TYPE}.sh

--- a/content/reference/cd-travis.md
+++ b/content/reference/cd-travis.md
@@ -74,7 +74,7 @@ to run Pulumi to that.
 ```yaml
 language: generic
 before_install:
-  - curl -L https://get.pulumi.com/ | bash -s -- --version 0.14.3
+  - curl -L https://get.pulumi.com/ | sh
   - export PATH=$PATH:$HOME/.pulumi/bin
 script:
   - ./scripts/travis_${TRAVIS_EVENT_TYPE}.sh


### PR DESCRIPTION
For folks who are going to copy these scripts, it's likely better for
them to just be flowing to the newest version instead of being locked
to an increasingly out of date CLI.

Fixes #1145