### PR TITLE
Update Python component examples

### DIFF
--- a/content/reference/programming-model.md
+++ b/content/reference/programming-model.md
@@ -612,9 +612,9 @@ class MyResource extends pulumi.ComponentResource {
 ```
 
 ```python
-class MyResource(ComponentResource):
+class MyResource(pulumi.ComponentResource):
     def __init__(self, name, opts = None):
-        super(MyResource, self).__init__('pkg:MyResource', name, None, opts)
+        super().__init__('pkg:MyResource', name, None, opts)
 ```
 
 ```go
@@ -640,7 +640,7 @@ let bucket = new aws.s3.Bucket(`${name}-bucket`, {}, { parent: this });
 ```
 
 ```python
-bucket = s3.Bucket(f"{name}-bucket", __opts__=ResourceOptions(parent=self))
+bucket = s3.Bucket(f"{name}-bucket", opts=pulumi.ResourceOptions(parent=self))
 ```
 
 ```go


### PR DESCRIPTION
The Python examples in the programming model components docs seem unnecessarily baroque - this is likely a holdover from Python 2.x as per @joeduffy. This commit simplifies them for Python 3, and adds import qualifiers where one is likely to need them.