### PR TITLE
Fix issue preventing use of fixed width font in code snippets

### DIFF
--- a/assets/sass/partials/_forms.scss
+++ b/assets/sass/partials/_forms.scss
@@ -1,10 +1,10 @@
 //basic form styles
 label{
-    @extend .p;
+    @extend p;
 }
 
 input[type="text"], input[type="email"], input[type="password"] {
-	@extend .p;
+	@extend p;
 	margin-bottom: 0;
     border: 1px solid #CECECE;
     padding: 16px 17px;

--- a/assets/sass/partials/_typography.scss
+++ b/assets/sass/partials/_typography.scss
@@ -12,7 +12,7 @@ h2, .h2,
 h3, .h3,
 h4, .h4,
 h5, .h5,
-h6, .h6,{
+h6, .h6 {
     margin: 0;
 
     & > a {
@@ -108,7 +108,7 @@ h5, .h5 {
     }
 }
 
-h6, .h6, {
+h6, .h6 {
     @include ubuntu(400);
     font-size: 16px;
     line-height: 1.2;
@@ -124,7 +124,7 @@ h6, .h6, {
     }
 }
 
-p, .p {
+p {
     @include base-type();
     margin-bottom: 10px;
 
@@ -140,7 +140,7 @@ ul, ol {
     margin-bottom: 28px;
 
     li {
-        @extend .p;
+        @extend p;
     }
 
     &.list-indent {


### PR DESCRIPTION
We have some typography scss copied over from the www site that defines styles for both the `p` tag as well as a `p` class. This isn't ideal because portions of code snippets are now annotated with a `p` class by Chroma for code highlighting, resulting in the wrong font being used.

The fix is to simply remove the `p` class as it's not needed (it was only being used elsewhere in the scss with `@extend .p`, but those uses can just extend the tag instead of the class, e.g. `@extend p`.

Before

<img width="256" alt="Screen Shot 2019-06-13 at 9 53 15 AM" src="https://user-images.githubusercontent.com/710598/59451782-1ca09000-8dc1-11e9-973b-e66444a0fd17.png">

After

<img width="345" alt="Screen Shot 2019-06-13 at 9 52 26 AM" src="https://user-images.githubusercontent.com/710598/59451791-1f9b8080-8dc1-11e9-8674-ccf3473d2b11.png">

Fixes #1162

Note: I've only removed the unnecessary `p` class in this change, but as part of the website work this milestone, we should rationalize this scss. There's really no need to have all these classes with the same name as the tags.