### PR TITLE
Add a "copy to clipboard" icon to the langchooser

### DIFF
--- a/assets/js/langchoose.js
+++ b/assets/js/langchoose.js
@@ -84,6 +84,45 @@ function selectLanguage(lang) {
     });
 }
 
+// copyNextCodeBlock copies the contents of the currently active code block following the element,
+// elem, which is the "copy" icon being clicked.
+function copyNextCodeBlock(elem) {
+    // Select the next visible code block.
+    var codes = $(elem).closest(".mdl-tabs").siblings(".highlight:visible");
+    if (codes.length) {
+        // Create an invisible text block containing the text from the code block, copy it to the
+        // clipboard, and then delete the invisible textarea.
+        var code = codes[0];
+        var text = document.createElement("textarea");
+        text.style.position = "fixed";
+        text.style.top = text.style.left = 0;
+        text.style.width = "2em";
+        text.style.height = "2em";
+        text.style.padding = 0;
+        text.style.border = "none";
+        text.style.outline = "none";
+        text.style.boxShadow = "none";
+        text.style.background = "transparent";
+        text.value = code.innerText;
+        document.body.appendChild(text);
+
+        // Copy the text.
+        text.focus();
+        text.select();
+        try {
+            document.execCommand("copy");
+        } catch (e) {
+            // Ignore errors for extremely old browsers.
+        } finally {
+            document.body.removeChild(text);
+        }
+
+        // Hide the element and fade it back in, so it's more evident it has been clicked.
+        $(code).hide();
+        $(code).fadeIn(500);
+    }
+}
+
 // The first time the DOM is finished loading, select the right language.  If no language is set as the preferred
 // language yet, then JavaScript is chosen as the preferred language as a default.
 $(function() {

--- a/assets/sass/_pulumi.scss
+++ b/assets/sass/_pulumi.scss
@@ -717,6 +717,23 @@ h4 { font-size: 22px; font-weight: 500; }
     cursor: pointer;
 }
 
+.langtab-copycode {
+    float: right;
+    position: relative;
+    top: 50%;
+    cursor: pointer;
+}
+
+.langtab-copybutton {
+}
+.langtab-copybutton:hover {
+    color: $blue;
+}
+.langtab-copybutton:active {
+    color: $blue-hover;
+    transform: translateY(1px);
+}
+
 .pdoc-module-header {
     border-radius: 4px;
     background-color: #f5e0f5;

--- a/content/quickstart/aws/create-project.md
+++ b/content/quickstart/aws/create-project.md
@@ -9,7 +9,7 @@ menu:
 
 Let's get started with a new project in a new directory.
 
-{{< langchoose nogo >}}
+{{< langchoose nogo nocode >}}
 
 <div class="language-prologue-javascript"></div>
 

--- a/content/quickstart/aws/install-language-runtime.md
+++ b/content/quickstart/aws/install-language-runtime.md
@@ -9,7 +9,7 @@ menu:
 
 ## Choose Your Language
 
-{{< langchoose nogo >}}
+{{< langchoose nogo nocode >}}
 
 {{% lang nodejs %}}
 {{< install-node >}}

--- a/content/quickstart/azure/install-language-runtime.md
+++ b/content/quickstart/azure/install-language-runtime.md
@@ -9,7 +9,7 @@ menu:
 
 ## Choose Your Language
 
-{{< langchoose nogo >}}
+{{< langchoose nogo nocode >}}
 
 {{% lang nodejs %}}
 {{< install-node >}}

--- a/content/quickstart/gcp/install-language-runtime.md
+++ b/content/quickstart/gcp/install-language-runtime.md
@@ -9,7 +9,7 @@ menu:
 
 ## Choose Your Language
 
-{{< langchoose nogo >}}
+{{< langchoose nogo nocode >}}
 
 {{% lang nodejs %}}
 {{< install-node >}}

--- a/content/quickstart/kubernetes/install-language-runtime.md
+++ b/content/quickstart/kubernetes/install-language-runtime.md
@@ -9,7 +9,7 @@ menu:
 
 ## Choose Your Language
 
-{{< langchoose nogo >}}
+{{< langchoose nogo nocode >}}
 
 {{% lang nodejs %}}
 {{< install-node >}}

--- a/layouts/shortcodes/langchoose.html
+++ b/layouts/shortcodes/langchoose.html
@@ -2,9 +2,14 @@
     <div class="mdl-tabs__tab-dir langtab-tabstrip">
         <a class="mdl-tabs__tab langtab is-active">JavaScript</a>
         <a class="mdl-tabs__tab langtab">TypeScript</a>
-        {{ if not (eq (.Get 0) "nodeonly") }}
+        {{ if not (in .Params "nodeonly") }}
         <a class="mdl-tabs__tab langtab">Python</a>
-        {{ if not (eq (.Get 0) "nogo") }}<a class="mdl-tabs__tab langtab">Go</a>{{ end }}
+        {{ if not (in .Params "nogo") }}<a class="mdl-tabs__tab langtab">Go</a>{{ end }}
+        {{ end }}
+        {{ if not (in .Params "nocode") }}
+            <span class="langtab-copycode">
+                <i class="far fa-copy langtab-copybutton" onclick="copyNextCodeBlock(this)"></i>
+            </span>
         {{ end }}
     </div>
 </div>


### PR DESCRIPTION
This change adds a copy icon to the upper right of the langchooser,
and copies the selected code body to the clipboard when clicked.

This is part of pulumi/docs#1023. I do think we should explore whether
we can use this in other places -- e.g., none of the API docs samples
will benefit from this because they don't use the langchooser -- but
doing so is a little more complex. We could just look for <div
class="highlight"> elements, but it's not clear, visually, where we'd
put the icon. Perhaps floating with a negative offset in the upper
right would work, but there are also plenty of <div class="highlight">
elements we probably wouldn't want this for.