### PR TITLE
Fix broken images in fusion branch

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -28,7 +28,7 @@
                         <div class="shadow-boxed bg-purple-dark">
                             <div class="content text-center">
                                 <div class="eqh margin-bottom-20" data-mh="copy"> <!--put in equal heights to align buttons-->
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-feature-containers.svg" alt="" class="margin-bottom-30" width="125">
+                                    <img src="/icons/icon-feature-containers.svg" alt="" class="margin-bottom-30" width="125">
                                     <h3 class="h4">Containers</h3>
                                     <p>Rapidly deploy container-based apps into any cloud or cloud-native infrastructure from AWS Fargate to Kubernetes</p>
                                 </div>
@@ -40,7 +40,7 @@
                         <div class="shadow-boxed bg-purple-dark">
                             <div class="content text-center">
                                 <div class="eqh margin-bottom-20"  data-mh="copy"> <!--put in equal heights to align buttons-->
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-feature-serverless.svg" alt="" class="margin-bottom-30" width="125">
+                                    <img src="/icons/icon-feature-serverless.svg" alt="" class="margin-bottom-30" width="125">
                                     <h3 class="h4">Serverless</h3>
                                     <p>Flexibly solve a wide variety of tasks including scalable websites and APIs, event streaming and processing, all through multi-cloud and multi-language microservices.</p>
                                 </div>
@@ -52,7 +52,7 @@
                         <div class="shadow-boxed bg-purple-dark">
                             <div class="content text-center">
                                 <div class="eqh margin-bottom-20"  data-mh="copy"> <!--put in equal heights to align buttons-->
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-feature-data.svg" alt="" class="margin-bottom-30" width="125">
+                                    <img src="/icons/icon-feature-data.svg" alt="" class="margin-bottom-30" width="125">
                                     <h3 class="h4">Infrastructure</h3>
                                     <p>Define cloud services and infrastructure in code, then continuously deploy. Correct issues in infrastructure automatically to return to the desired state.</p>
                                 </div>
@@ -64,7 +64,7 @@
                         <div class="shadow-boxed bg-purple-dark">
                             <div class="content text-center">
                                 <div class="eqh margin-bottom-20"  data-mh="copy"> <!--put in equal heights to align buttons-->
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-feature-kubernetes.svg" alt="" class="margin-bottom-30" width="125">
+                                    <img src="/icons/icon-feature-kubernetes.svg" alt="" class="margin-bottom-30" width="125">
                                     <h3 class="h4">Kubernetes</h3>
                                     <p>Deploy and orchestrate cloud native container-based apps on Kubernetes, either on-premises or in the cloud. Use real code to define and deploy Kubernetes services.</p>
                                 </div>
@@ -112,7 +112,7 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-audience-dev.svg" alt="" class="margin-bottom-30" width="134">
+                                    <img src="/icons/icon-audience-dev.svg" alt="" class="margin-bottom-30" width="134">
                                     <sup>For Developers</sup>
                                     <h3 class="h5">Any Code.</h3>
                                     <p>Maximize your productivity by defining cloud apps and resources as code in familiar languages.</p>
@@ -121,7 +121,7 @@
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-audience-devops.svg" alt="" class="margin-bottom-30" width="134">
+                                    <img src="/icons/icon-audience-devops.svg" alt="" class="margin-bottom-30" width="134">
                                     <sup>For DevOps</sup>
                                     <h3 class="h5">Any Cloud.</h3>
                                     <p>Deploy cloud apps and infrastructure anywhere. Eliminate cloud specific DSLs to simplify multi cloud management.</p>
@@ -130,7 +130,7 @@
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-audience-enterprise.svg" alt="" class="margin-bottom-30" width="134">
+                                    <img src="/icons/icon-audience-enterprise.svg" alt="" class="margin-bottom-30" width="134">
                                     <sup>For Enterprises</sup>
                                     <h3 class="h5">Any Team.</h3>
                                     <p>Make use of preferred practices to deliver cloud native apps and infrastructure with enterprise-grade workflows.</p>

--- a/layouts/migrate/cloudformation.html
+++ b/layouts/migrate/cloudformation.html
@@ -31,21 +31,21 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
+                                    <img src="/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Real Code</h3>
                                     <p>Pulumi is infrastructure as real code. This means you get all the benefits of your favorite language and tool for provisioning cloud infrastructure: code completion, error checking, versioning, IDE support, and general productivity gains - without the need to manage YAML and DSL syntax.</p>
                                 </div>
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
+                                    <img src="/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Reusable Components</h3>
                                     <p>As Pulumi is code, you can build up a library of packages to further enhance efficiency. Build repeatable practices through versioned packages such as: standard policies, network best practices, architecture blueprints - and deploy them to your team. </p>
                                 </div>
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
+                                    <img src="/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Immutable Infrastructure</h3>
                                     <p>Pulumi provides the computation of necessary cloud resources with a 'Cloud Resource DAG' ensuring successful deployment of cloud infrastructure - efficiently building, updating, and destroying cloud resources as required. </p>
                                 </div>
@@ -128,7 +128,7 @@ exports.publicHostName = server.publicDns;
                         <div class="row">
                             <div class="col-md-3 col-md-push-9 text-center">
                                 <div style="height: 17px;"><!--custom spacer--></div>
-                                <img src="{{ .Site.BaseURL }}/logos/customers/learning-machine_logo.svg" alt="Learning Machine" width="208" class="margin-bottom-30">
+                                <img src="/logos/customers/learning-machine_logo.svg" alt="Learning Machine" width="208" class="margin-bottom-30">
                             </div>
                             <div class="col-md-9 col-md-pull-3 content">
                                 <h2>Learning Machine</h2>
@@ -145,13 +145,13 @@ exports.publicHostName = server.publicDns;
                         <div class="row cols-are-spaced-md">
                             <div class="col col-sm-6 col-md-4 col-md-offset-2">
                                 <figure>
-                                    <img src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-1.svg" width="210">
+                                    <img src="/images/customers/learning_machine_info-1.svg" width="210">
                                     <figcaption> 25,000 Lines of CloudFormation reduced to 500 Lines of JavaScript </figcaption>
                                 </figure>
                             </div>
                             <div class="col col-sm-6 col-md-4">
                                 <figure>
-                                    <img src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-2.svg" width="234">
+                                    <img src="/images/customers/learning_machine_info-2.svg" width="234">
                                     <figcaption> New customer provisioning time reduced from 3 weeks to 1 hour </figcaption>
                                 </figure>
                             </div>

--- a/layouts/migrate/terraform.html
+++ b/layouts/migrate/terraform.html
@@ -29,28 +29,28 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-3">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
+                                    <img src="/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
                                     <h3 class="h6">Real Code</h3>
                                     <p>Pulumi is infrastructure as real code. This means you get all the benefits of your favorite language and tool for provisioning infrastructure: code completion, error checking, versioning, IDE support, etc. - without the need to manage limited DSL syntax.</p>
                                 </div>
                             </div>
                             <div class="col col-md-3">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
+                                    <img src="/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
                                     <h3 class="h6">Familiar Constructs</h3>
                                     <p>Real languages means you get familiar constructs like for loops, functions, and classes - cutting boilerplate and enforcing best practices. Pulumi lets you leverage existing package management tools and techniques. </p>
                                 </div>
                             </div>
                             <div class="col col-md-3">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
+                                    <img src="/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
                                     <h3 class="h6">Ephemeral Infrastructure</h3>
                                     <p>Pulumi has deep support for cloud native technologies, like Kubernetes, and supports advanced deployment scenarios that cannot be expressed with Terraform. Pulumi is a proud member of the Cloud Native Computing Foundation (CNCF).</p>
                                 </div>
                             </div>
                             <div class="col col-md-3">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-core3.svg" width="45" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-core3.svg" width="45" alt="" class="margin-bottom-30">
                                     <h3 class="h6">TF Provider Integration</h3>
                                     <p>Pulumi is able to adapt any Terraform Provider for use with Pulumi, enabling management of any infrastructure supported by the Terraform Providers ecosystem using Pulumi programs. <a href="https://github.com/pulumi/pulumi-terraform">Find out more here.</a></p>
                                 </div>

--- a/layouts/page/about.html
+++ b/layouts/page/about.html
@@ -58,7 +58,7 @@
                                 {{ if eq .status "active" }}
                                 <div class="col-xxs-12 col-xs-6 col-sm-6 col-md-4 col-lg-3 col-centered col">
                                     <div class="content">
-                                        <img style="height: 180px; padding-bottom: 16px;" src="{{ $.Site.BaseURL }}/images/team/{{ .id }}.jpg" alt="{{ .name }}" >
+                                        <img style="height: 180px; padding-bottom: 16px;" src="/images/team/{{ .id }}.jpg" alt="{{ .name }}" >
                                         <h3 class="h6 {{if .bio }}cursor-pointer{{ end }}" {{ if .bio }}data-toggle="modal" data-target="#{{ .id }}"{{ end }}>{{ .name }}</h3>
                                         <p>{{ .title }}</p>
                                         {{ partial "widgets/social-icons.html" (dict "social" .social)}}
@@ -109,7 +109,7 @@
                             {{ range sort $.Site.Data.team.board "weight" }}
                                 <div class="col-xxs-12 col-xs-6 col-sm-6 col-md-4 col-lg-3 col-centered col">
                                     <div class="content">
-                                        <img style="height: 180px; padding-bottom: 16px;" src="{{ $.Site.BaseURL }}/images/team/{{ .id }}.jpg" alt="{{ .name }}" >
+                                        <img style="height: 180px; padding-bottom: 16px;" src="/images/team/{{ .id }}.jpg" alt="{{ .name }}" >
                                         <h3 class="h6 cursor-pointer" data-toggle="modal" data-target="#{{ .id }}">{{ .name }}</h3>
                                         <p>{{ .title }}<br><strong>{{ .investor }}</strong></p>
                                         {{ partial "widgets/social-icons.html" (dict "social" .social)}}
@@ -145,12 +145,12 @@
                         <div class="row row-centered cols-are-spaced-vert-md">
                             <div class="col-xxs-12 col-xs-6 col-sm-6 col-md-6 col-lg-6 col-centered col">
                                 <div class="content">
-                                    <a href="https://www.madrona.com/" target="_blank"><img src="{{ .Site.BaseURL }}/logos/investors/madrona.png" alt="" width="100"></a>
+                                    <a href="https://www.madrona.com/" target="_blank"><img src="/logos/investors/madrona.png" alt="" width="100"></a>
                                 </div>
                             </div>
                             <div class="col-xxs-12 col-xs-6 col-sm-6 col-md-6 col-lg-6 col-centered col">
                                 <div class="content">
-                                    <a href="https://www.tolacapital.com/" target="_blank"><img src="{{ .Site.BaseURL }}/logos/investors/tola.png" alt="" width="100"></a>
+                                    <a href="https://www.tolacapital.com/" target="_blank"><img src="/logos/investors/tola.png" alt="" width="100"></a>
                                 </div>
                             </div>
                         </div>
@@ -167,7 +167,7 @@
             <div class="row">
                 <div class="col-md-8 col-md-offset-2">
                     <div class="content">
-                        <img src="{{ .Site.BaseURL }}/images/cloud.png" alt="">
+                        <img src="/images/cloud.png" alt="">
                         <h2>Why Pulumi?</h2>
                         <p class="intro">Find out how Pulumi provides a programming model for the cloud, designed to unlock the full power of serverless, container, and data service architectures with Cloud Native Infrastructure as Code. </p>
                         <p><a href="/why-pulumi/" class="button">Learn more</a></p>

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -394,27 +394,27 @@
                                     </th>
                                     <td>
                                         <ul class="logo-roll text-center-md inline-block">
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-github2.png" alt="github" title="GitHub" width="30"></li>
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-GitLab.png" alt="gitlab" title="GitLab" width="32"></li>
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-atlassian.png" alt="atlassian identity" title="Atlassian Identity" width="33"></li>
+                                            <li><img src="/logos/tech/logo-github2.png" alt="github" title="GitHub" width="30"></li>
+                                            <li><img src="/logos/tech/logo-GitLab.png" alt="gitlab" title="GitLab" width="32"></li>
+                                            <li><img src="/logos/tech/logo-atlassian.png" alt="atlassian identity" title="Atlassian Identity" width="33"></li>
                                             <li><i class="fa fa-2x fa-envelope"></i></li>
                                         </ul>
                                     </td>
                                     <td>
                                         <ul class="logo-roll text-center-md inline-block">
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-github2.png" alt="github" title="GitHub" width="30"></li>
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-GitLab.png" alt="gitlab" title="GitLab" width="32"></li>
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-atlassian.png" alt="atlassian identity" title="Atlassian Identity" width="33"></li>
+                                            <li><img src="/logos/tech/logo-github2.png" alt="github" title="GitHub" width="30"></li>
+                                            <li><img src="/logos/tech/logo-GitLab.png" alt="gitlab" title="GitLab" width="32"></li>
+                                            <li><img src="/logos/tech/logo-atlassian.png" alt="atlassian identity" title="Atlassian Identity" width="33"></li>
                                             <li><i class="fa fa-2x fa-envelope"></i></li>
                                         </ul>
                                     </td>
                                     <td>
                                         <ul class="logo-roll text-center-md inline-block">
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-github2.png" alt="github" title="GitHub" width="30"></li>
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-GitLab.png" alt="gitlab" title="GitLab" width="32"></li>
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-atlassian.png" alt="atlassian identity" title="Atlassian Identity" width="33"></li>
+                                            <li><img src="/logos/tech/logo-github2.png" alt="github" title="GitHub" width="30"></li>
+                                            <li><img src="/logos/tech/logo-GitLab.png" alt="gitlab" title="GitLab" width="32"></li>
+                                            <li><img src="/logos/tech/logo-atlassian.png" alt="atlassian identity" title="Atlassian Identity" width="33"></li>
                                             <li><i class="fa fa-2x fa-envelope"></i></li>
-                                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-saml.svg" alt="SAML/SSO identity" title="SAML/SSO Identity" width="20"></li>
+                                            <li><img src="/logos/tech/logo-saml.svg" alt="SAML/SSO identity" title="SAML/SSO Identity" width="20"></li>
                                         </ul>
                                     </td>
                                 </tr>

--- a/layouts/page/product.html
+++ b/layouts/page/product.html
@@ -51,10 +51,10 @@
                                         </p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-js.png?v1" alt="js" width="36"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-python.png?v1" alt="python" width="34"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-golang.png?v1" alt="golang" width="63"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-ts.png?v1" alt="typescript" width="36"></li>
+                                        <li><img src="/logos/tech/logo-js.png?v1" alt="js" width="36"></li>
+                                        <li><img src="/logos/tech/logo-python.png?v1" alt="python" width="34"></li>
+                                        <li><img src="/logos/tech/logo-golang.png?v1" alt="golang" width="63"></li>
+                                        <li><img src="/logos/tech/logo-ts.png?v1" alt="typescript" width="36"></li>
                                     </ul>
                                 </div>
                             </div>
@@ -69,10 +69,10 @@
                                         </p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-aws.png?v1" alt="aws" width="37"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-azure.png?v1" alt="azure" width="39"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-gd.png?v1" alt="gd" width="38"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></li>
+                                        <li><img src="/logos/tech/logo-aws.png?v1" alt="aws" width="37"></li>
+                                        <li><img src="/logos/tech/logo-azure.png?v1" alt="azure" width="39"></li>
+                                        <li><img src="/logos/tech/logo-gd.png?v1" alt="gd" width="38"></li>
+                                        <li><img src="/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></li>
                                     </ul>
                                 </div>
                             </div>
@@ -87,10 +87,10 @@
                                         </p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-github.png" alt="github"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-vs.png" alt="vs"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-npm.png" alt="npm"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-travisci.png" alt="travisci"></li>
+                                        <li><img src="/logos/tech/logo-github.png" alt="github"></li>
+                                        <li><img src="/logos/tech/logo-vs.png" alt="vs"></li>
+                                        <li><img src="/logos/tech/logo-npm.png" alt="npm"></li>
+                                        <li><img src="/logos/tech/logo-travisci.png" alt="travisci"></li>
                                     </ul>
                                 </div>
                             </div>
@@ -122,7 +122,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-core-1.svg" width="47">
+                                                    <img src="/icons/icon-core-1.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -140,7 +140,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-core2.svg" width="47">
+                                                    <img src="/icons/icon-core2.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -160,7 +160,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-core3.svg" width="47">
+                                                    <img src="/icons/icon-core3.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -178,7 +178,7 @@
                                         <div class="row">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-core4.svg" width="47">
+                                                    <img src="/icons/icon-core4.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -220,7 +220,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-service1.svg" width="47">
+                                                    <img src="/icons/icon-service1.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -239,7 +239,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-service2.svg" width="47">
+                                                    <img src="/icons/icon-service2.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -258,7 +258,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-service3.svg" width="47">
+                                                    <img src="/icons/icon-service3.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -276,7 +276,7 @@
                                         <div class="row">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-service4.svg" width="47">
+                                                    <img src="/icons/icon-service4.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -318,7 +318,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-core4.svg" width="47">
+                                                    <img src="/icons/icon-core4.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -337,7 +337,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-core-1.svg" width="47">
+                                                    <img src="/icons/icon-core-1.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -356,7 +356,7 @@
                                         <div class="row margin-bottom-40">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-core3.svg" width="47">
+                                                    <img src="/icons/icon-core3.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -374,7 +374,7 @@
                                         <div class="row">
                                             <div class="col col-md-2 col-lg-4">
                                                 <div class="content text-center">
-                                                    <img src="{{ .Site.BaseURL }}/icons/icon-core2.svg" width="47">
+                                                    <img src="/icons/icon-core2.svg" width="47">
                                                 </div>
                                             </div>
                                             <div class="col col-md-10 col-lg-8">
@@ -403,7 +403,7 @@
                 <div class="col-lg-10 col-lg-offset-1">
                     <div class="content">
                         <h2 class="margin-bottom-50">How Pulumi Works</h2>
-                        <img src="{{ .Site.BaseURL }}/images/infographics@2x.jpg" width="895">
+                        <img src="/images/infographics@2x.jpg" width="895">
                     </div>
                 </div>
             </div>

--- a/layouts/page/support.html
+++ b/layouts/page/support.html
@@ -13,7 +13,7 @@
                             WA<br>
                             98101<br>
                         </address>
-                        <img src="{{ .Site.BaseURL }}/images/pricing.png" class="padding-top-30">
+                        <img src="/images/pricing.png" class="padding-top-30">
                     </div>
                 </div>
             </div>

--- a/layouts/page/why-pulumi.html
+++ b/layouts/page/why-pulumi.html
@@ -39,7 +39,7 @@
                     <div class="col-lg-10 col-lg-offset-1">
                         <div class="row">
                             <div class="col-sm-3">
-                                <img src="{{ .Site.BaseURL }}/icons/icon-for-devs.png" alt="">
+                                <img src="/icons/icon-for-devs.png" alt="">
                             </div>
                             <div class="col-sm-9">
                                 <h2>For Developers</h2>
@@ -59,7 +59,7 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-dev-lang.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-dev-lang.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Familiar Languages</h3>
                                     <p>Maximize productivity by defining cloud apps and services as code using
                                         familiar languages and IDEs: JavaScript, Python, or Go.</p>
@@ -67,7 +67,7 @@
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-dev-model.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-dev-model.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Programming Model</h3>
                                     <p>Use a programming model designed to make you maximally
                                         productive across any clouds, AWS, Azure, GCP, or Kubernetes.</p>
@@ -75,7 +75,7 @@
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-dev-packages.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-dev-packages.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Real Abstractions</h3>
                                     <p>Build true cloud abstractions, reducing copy-and-paste,
                                         and share and reuse them in your favorite package manager.</p>
@@ -107,7 +107,7 @@
                     <div class="col-lg-10 col-lg-offset-1">
                         <div class="row">
                             <div class="col-sm-3">
-                                <img src="{{ .Site.BaseURL }}/icons/icon-for-devops.png" alt="">
+                                <img src="/icons/icon-for-devops.png" alt="">
                             </div>
                             <div class="col-sm-9">
                                 <h2>For Operators</h2>
@@ -125,7 +125,7 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-devops-workflow.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-devops-workflow.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Infrastructure as Code</h3>
                                     <p>Use robust infrastructure as code practices to plan and version deployments,
                                         and perform them with perfect auditability.</p>
@@ -133,7 +133,7 @@
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-devops-multicloud.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-devops-multicloud.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Multi-Cloud DevOps</h3>
                                     <p>Empower your team to go multi-cloud by leveraging a single model,
                                         tool, and service -- eliminating YAML and DSL explosion.</p>
@@ -141,7 +141,7 @@
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-devops-deploy.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-devops-deploy.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Deploy Continuously</h3>
                                     <p>Integrate with existing SCM and ALM systems to continuously deliver
                                         to many clouds with a single consistent workflow.</p>
@@ -173,7 +173,7 @@
                     <div class="col-lg-10 col-lg-offset-1">
                         <div class="row">
                             <div class="col-sm-3">
-                                <img src="{{ .Site.BaseURL }}/icons/icon-for-enterprises.png" alt="">
+                                <img src="/icons/icon-for-enterprises.png" alt="">
                             </div>
                             <div class="col-sm-9">
                                 <h2>For Business Leaders</h2>
@@ -192,7 +192,7 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-ent-architecture.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-ent-architecture.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Modernize</h3>
                                     <p>Deliver on modern container and serverless architectures across applications
                                         and infrastructure, and Dev and DevOps.</p>
@@ -200,7 +200,7 @@
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-ent-multicloud.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-ent-multicloud.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Go Multi-Cloud</h3>
                                     <p>A single workflow across all clouds -- AWS, Azure, GCP,
                                         Kubernetes, and hybrid/on-prem -- to achieve true multi-cloud delivery.</p>
@@ -208,7 +208,7 @@
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/icon-why-ent-grade.svg" width="134" alt="" class="margin-bottom-30">
+                                    <img src="/icons/icon-why-ent-grade.svg" width="134" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Enterprise Grade</h3>
                                     <p>Robust security, compliance, and auditing tools with an
                                         extensible policy engine for enforcing your organization's practices.</p>
@@ -238,7 +238,7 @@
             <div class="row">
                 <div class="col-md-8 col-md-offset-2">
                     <div class="content">
-                        <img src="{{ .Site.BaseURL }}/images/cloud.png" alt="">
+                        <img src="/images/cloud.png" alt="">
                         <h2>Toward a Cloud Native Programming Model</h2>
                         <p class="intro">See how Pulumi delivers a Cloud Development Platform for the cloud to deliver on the full potential of Container-, Lambda-, and Data-based cloud architectures.</p>
                         <p><a href="{{ relref . "/why-pulumi/point-of-view.md" }}"class="button">Learn more</a></p>

--- a/layouts/partials/blog/authors.html
+++ b/layouts/partials/blog/authors.html
@@ -6,7 +6,7 @@
         <span class="flex items-center mr-2">
             {{ if $authorData }}
                 <a class="rounded-full p-1 bg-gray-300 mr-2" href="{{ $authorPage.Permalink }}">
-                    <img class="w-8 rounded-full" src="{{ $.context.Site.BaseURL }}images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}" title="{{ $authorData.name }}">
+                    <img class="w-8 rounded-full" src="/images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}" title="{{ $authorData.name }}">
                 </a>
                 <a class="" href="{{ $authorPage.Permalink }}">{{ $authorData.name }}</a>
             {{ end }}

--- a/layouts/partials/blog/poster.html
+++ b/layouts/partials/blog/poster.html
@@ -7,6 +7,6 @@
         {{ $imagePath := replace .Params.meta_image "RELATIVE_TO_PAGE/" "" }}
         <img class="rounded-lg my-8 border-2 border-gray-100" src="{{ .Page.Permalink }}{{ $imagePath }}" alt="{{ .Title }}">
     {{ else }}
-        <img class="rounded-lg my-8 border-2 border-gray-100" src="{{ .Site.BaseURL }}{{ .Params.meta_image }}" alt="{{ .Title }}">
+        <img class="rounded-lg my-8 border-2 border-gray-100" src="{{ .Params.meta_image }}" alt="{{ .Title }}">
     {{ end }}
 {{ end }}

--- a/layouts/partials/cloud-lang-logos.html
+++ b/layouts/partials/cloud-lang-logos.html
@@ -11,10 +11,10 @@
                             <div class="col col-lg-6">
                                 <div class="content">
                                     <ul class="logo-roll text-center-xs text-center-sm text-center-md">
-                                        <li><a href="/aws"><img src="{{ .Site.BaseURL }}/logos/tech/logo-aws_white.png?v1" alt="aws" width="47"></a></li>
-                                        <li><a href="/azure"><img src="{{ .Site.BaseURL }}/logos/tech/logo-azure.png?v1" alt="azure" width="39"></a></li>
-                                        <li><a href="/gcp"><img src="{{ .Site.BaseURL }}/logos/tech/logo-gd.png?v1" alt="gd" width="38"></a></li>
-                                        <li><a href="/kubernetes"><img src="{{ .Site.BaseURL }}/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></a></li>
+                                        <li><a href="/aws"><img src="/logos/tech/logo-aws_white.png?v1" alt="aws" width="47"></a></li>
+                                        <li><a href="/azure"><img src="/logos/tech/logo-azure.png?v1" alt="azure" width="39"></a></li>
+                                        <li><a href="/gcp"><img src="/logos/tech/logo-gd.png?v1" alt="gd" width="38"></a></li>
+                                        <li><a href="/kubernetes"><img src="/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></a></li>
                                     </ul>
                                 </div>
                             </div>
@@ -25,10 +25,10 @@
                             <div class="col col-lg-6">
                                 <div class="content">
                                     <ul class="logo-roll text-center-xs text-center-sm text-center-md">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-js.png?v1" alt="js" width="36"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-python.png?v1" alt="python" width="34"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-golang.png?v1" alt="golang" width="63"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-ts.png?v1" alt="typescript" width="36"></li>
+                                        <li><img src="/logos/tech/logo-js.png?v1" alt="js" width="36"></li>
+                                        <li><img src="/logos/tech/logo-python.png?v1" alt="python" width="34"></li>
+                                        <li><img src="/logos/tech/logo-golang.png?v1" alt="golang" width="63"></li>
+                                        <li><img src="/logos/tech/logo-ts.png?v1" alt="typescript" width="36"></li>
                                     </ul>
                                 </div>
                             </div>

--- a/layouts/partials/code-display.html
+++ b/layouts/partials/code-display.html
@@ -9,9 +9,9 @@
                 </div>
             </div>
             <div class="anim_textbox code_display_textbox">
-                <img src="{{ .Site.BaseURL }}/images/home/Home1-Code.png" class="code-display" width="600">
-                <img src="{{ .Site.BaseURL }}/images/home/Home2-CLI.png" class="code-display" width="600">
-                <img src="{{ .Site.BaseURL }}/images/home/Home3-Console.png" class="code-display" width="600">
+                <img src="/images/home/Home1-Code.png" class="code-display" width="600">
+                <img src="/images/home/Home2-CLI.png" class="code-display" width="600">
+                <img src="/images/home/Home3-Console.png" class="code-display" width="600">
             </div>
         </div>
     </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -55,17 +55,17 @@
             {{ $imagePath := replace .Params.meta_image "RELATIVE_TO_PAGE/" "" }}
             <meta property="og:image" content="{{ .Page.Permalink }}{{ $imagePath }}">
         {{ else }}
-            <meta property="og:image" content="{{ .Site.BaseURL }}{{ .Params.meta_image }}">
+            <meta property="og:image" content="{{ .Params.meta_image | absURL }}">
         {{ end }}
     {{ else }}
-        <meta property="og:image" content="{{ .Site.BaseURL }}/social/pulumi.png">
+        <meta property="og:image" content="{{ "/social/pulumi.png" | absURL }}">
     {{ end }}
 
     <title>{{ .Title }}{{if not .IsHome}} - {{ end }}{{ .Site.Title }}</title>
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico" />
 
     <!-- RSS link for the blog. -->
-    <link rel="alternate" type="application/rss+xml" href="{{ .Site.BaseURL }}blog/rss.xml" title="Pulumi Blog" />
+    <link rel="alternate" type="application/rss+xml" href="{{ "/blog/rss.xml" | absURL }}" title="Pulumi Blog" />
 
     <!--
         Build Sass. Generated file will contain content hash in filename,

--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -4,7 +4,7 @@
 		<div class="row valign-center cols-are-spaced-md">
 			<div class="col col-md-5 col-md-push-7 col-lg-5 col-lg-push-7 col-right col-img hidden-xs hidden-sm">
 				<div class="content">
-					<img src="{{ .Site.BaseURL }}{{ .Params.hero_img }}" alt="{{ .Params.hero_img_alt }}" width="{{ .Params.hero_img_width }}">
+					<img src="{{ .Params.hero_img }}" alt="{{ .Params.hero_img_alt }}" width="{{ .Params.hero_img_width }}">
 				</div>
 			</div>
 			<div class="col col-md-7 col-md-pull-5 col-lg-7 col-lg-pull-5 col-left col-text">
@@ -106,7 +106,7 @@
 
 {{ else if and (isset .Params "hero_title") (isset .Params "hero_bg_video") }}
 <section class="hero white-text bg-video text-center valign-center-md {{ with .Params.hero_classes }}{{ . }}{{ end }} {{ if .Params.hero_footer_waves }}has-footer-waves{{ end }}">
-	<div class="vbwrapper {{ if .Params.hero_bg_video_classes }}{{ .Params.hero_bg_video_classes }}{{ end }}"><div id="video-background" video="{{ .Params.hero_bg_video }}" class="video-background bg-cover" {{ if .Params.hero_bg_video_fb_img }} style="background-image: url({{ .Site.BaseURL }}{{ .Params.hero_bg_video_fb_img }});" {{ end }}><div class="video-overlay"></div></div></div>
+	<div class="vbwrapper {{ if .Params.hero_bg_video_classes }}{{ .Params.hero_bg_video_classes }}{{ end }}"><div id="video-background" video="{{ .Params.hero_bg_video }}" class="video-background bg-cover" {{ if .Params.hero_bg_video_fb_img }} style="background-image: url({{ .Params.hero_bg_video_fb_img }});" {{ end }}><div class="video-overlay"></div></div></div>
 	<div class="container-fluid">
 		<div class="row">
 			<div class="col col-sm-12">

--- a/layouts/partials/how-pulumi-works.html
+++ b/layouts/partials/how-pulumi-works.html
@@ -15,7 +15,7 @@
             <div class="row">
                 <div class="col-lg-10 col-lg-offset-1">
                     <div class="content">
-                        <p class="text-center"><img src="{{ .Site.BaseURL }}/images/infographics@2x.jpg" width="895"></p>
+                        <p class="text-center"><img src="/images/infographics@2x.jpg" width="895"></p>
                     </div>
                 </div>
             </div>

--- a/layouts/partials/learnmore-contactus.html
+++ b/layouts/partials/learnmore-contactus.html
@@ -3,7 +3,7 @@
         <div class="row cols-with-dividers-md cols-are-spaced-md">
             <div class="col col-md-6" data-mh="col">
                 <div class="row">
-                    <div class="col-md-4 text-center"><div class="with-glare-grey"><img src="{{ .Site.BaseURL }}/icons/icon-book-inv.svg" width="73"></div></div>
+                    <div class="col-md-4 text-center"><div class="with-glare-grey"><img src="/icons/icon-book-inv.svg" width="73"></div></div>
                     <div class="col-md-8">
                         <div class="content">
                             <div class="eqh margin-bottom-20" data-mh="copy"> <!--put in equal heights to align buttons-->
@@ -17,7 +17,7 @@
             </div>
             <div class="col col-md-6 overflow-hidden" data-mh="col">
                 <div class="row">
-                    <div class="col-md-4 text-center"><div class="with-glare-grey"><img src="{{ .Site.BaseURL }}/icons/icon-dialogue-inv.svg" width="74"></div></div>
+                    <div class="col-md-4 text-center"><div class="with-glare-grey"><img src="/icons/icon-dialogue-inv.svg" width="74"></div></div>
                     <div class="col-md-8">
                         <div class="content">
                             <div class="eqh margin-bottom-20" data-mh="copy"> <!--put in equal heights to align buttons-->

--- a/layouts/partials/newsroom.html
+++ b/layouts/partials/newsroom.html
@@ -46,7 +46,7 @@
                                             <p><small>22nd October 2018</small></p>
                                     </div>
                                     <div class="row">
-                                        <div class="col-md-2"><img src="{{ .Site.BaseURL }}/logos/press/techcrunch.png" alt="geekwire" style="width:50px;"></div>
+                                        <div class="col-md-2"><img src="/logos/press/techcrunch.png" alt="geekwire" style="width:50px;"></div>
                                         <div class="col-md-10">
                                             <p><b><small>
                                                     Pulumi raises $15M for its infrastructure as code platform <br><a href="https://techcrunch.com/2018/10/22/pulumi-raises-15m-for-its-infrastructure-as-code-platform/">Read more...</a></small></b></p>
@@ -65,7 +65,7 @@
                                         <p><small>22nd October 2018</small></p>
                                 </div>
                                 <div class="row">
-                                    <div class="col-md-2"><img src="{{ .Site.BaseURL }}/logos/press/eweek.jpg" alt="geekwire" style="width:50px;"></div>
+                                    <div class="col-md-2"><img src="/logos/press/eweek.jpg" alt="geekwire" style="width:50px;"></div>
                                     <div class="col-md-10">
                                         <p><b><small>Pulumi Launches Team Edition of Infrastructure as Code Platform <br><a href="http://www.eweek.com/cloud/pulumi-launches-team-edition-of-infrastructure-as-code-platform">Read more...</a></small></b></p>
                                     </div>
@@ -85,7 +85,7 @@
                                     <p><small>22nd October 2018</small></p>
                             </div>
                             <div class="row">
-                                <div class="col-md-2"><img src="{{ .Site.BaseURL }}/logos/press/forbes.png" alt="geekwire" style="width:50px;"></div>
+                                <div class="col-md-2"><img src="/logos/press/forbes.png" alt="geekwire" style="width:50px;"></div>
                                 <div class="col-md-10">
                                     <p><b><small>Pulumi Bridges The Gap Between Cloud-Native Development And Infrastructure As Code <br><a href="https://www.forbes.com/sites/janakirammsv/2018/10/16/pulumi-bridges-the-gap-between-cloud-native-development-and-infrastructure-as-code/">Read more...</a></small></b></p>
                                 </div>
@@ -102,7 +102,7 @@
                                     <p><small>12th September 2018</small></p>
                             </div>
                             <div class="row">
-                                <div class="col-md-2"><img src="{{ .Site.BaseURL }}/logos/press/geekwire.png" alt="geekwire" style="width:50px;"></div>
+                                <div class="col-md-2"><img src="/logos/press/geekwire.png" alt="geekwire" style="width:50px;"></div>
                                 <div class="col-md-10">
                                     <p><b><small>Pulumi releases software-development kit to unlock the multicloud potential of Kubernetes <br><a href="https://www.geekwire.com/2018/pulumi-releases-software-development-kit-unlock-multicloud-potential-kubernetes/">Read more...</a></small></b></p>
                                 </div>
@@ -119,7 +119,7 @@
                                         <p><small>19th June 2018</small></p>
                                 </div>
                                 <div class="row">
-                                    <div class="col-md-2"><img src="{{ .Site.BaseURL }}/logos/press/newstack.png" alt="newstack" style="width:50px;"></div>
+                                    <div class="col-md-2"><img src="/logos/press/newstack.png" alt="newstack" style="width:50px;"></div>
                                     <div class="col-md-10">
                                         <p><b><small>Pulumi: Using Languages to Program Across Clouds. <br><a href="https://thenewstack.io/pulumi-using-languages-to-program-across-clouds/">Read more...</a></small></b></p>
                                     </div>
@@ -136,7 +136,7 @@
                                         <p><small>18th June 2018</small></p>
                                 </div>
                                 <div class="row">
-                                    <div class="col-md-2"><img src="{{ .Site.BaseURL }}/logos/press/geekwire.png" alt="geekwire" style="width:50px"></div>
+                                    <div class="col-md-2"><img src="/logos/press/geekwire.png" alt="geekwire" style="width:50px"></div>
                                     <div class="col-md-10">
                                         <p><b><small>Meet Pulumi, a Seattle-grown cloud startup that wants to be the development platform for the multicloud era. <br><a href="https://www.geekwire.com/2018/meet-pulumi-seattle-grown-cloud-startup-wants-development-platform-multicloud-era/">Read more...</a></small></b></p>
                                     </div>
@@ -153,7 +153,7 @@
                                             <p><small>18th June 2018</small></p>
                                     </div>
                                     <div class="row">
-                                        <div class="col-md-2"><img src="{{ .Site.BaseURL }}/logos/press/techcrunch.png" alt="techcrunch" style="width:50px;padding-top: 10px"></div>
+                                        <div class="col-md-2"><img src="/logos/press/techcrunch.png" alt="techcrunch" style="width:50px;padding-top: 10px"></div>
                                         <div class="col-md-10">
                                             <p><b><small>Pulumi wants to let you manage your infrastructure with code. <br><a href="https://techcrunch.com/2018/06/18/pulumi-wants-to-let-you-manage-your-infrastructure-with-code/">Read more...</a></small></b></p>
                                         </div>

--- a/layouts/partials/testimonials-top.html
+++ b/layouts/partials/testimonials-top.html
@@ -18,13 +18,13 @@
                     <div class="testimonials-dots text-center margin-bottom-50"></div>
                     <div class="testimonials row text-center">
                         <div class="item col-md-4 h-100 testimonial">
-                            <img src="{{ .Site.BaseURL }}/logos/customers/tableau_logo.png">
+                            <img src="/logos/customers/tableau_logo.png">
                         </div>
                         <div class="item col-md-4 h-100 testimonial">
-                            <img src="{{ .Site.BaseURL }}/logos/customers/mercedes-benz_logo.png">
+                            <img src="/logos/customers/mercedes-benz_logo.png">
                         </div>
                         <div class="item col-md-4 h-100 testimonial">
-                            <img src="{{ .Site.BaseURL }}/logos/customers/mindbody_logo.svg">
+                            <img src="/logos/customers/mindbody_logo.svg">
                         </div>
                     </div>
                 </div>

--- a/layouts/partner/aws.html
+++ b/layouts/partner/aws.html
@@ -26,21 +26,21 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
+                                    <img src="/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Real Code</h3>
                                     <p>Pulumi is infrastructure as real code. This means you get all the benefits of your favorite language and tool for provisioning cloud infrastructure: code completion, error checking, versioning, IDE support, and general productivity gains - without the need to manage YAML and DSL syntax.</p>
                                 </div>
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
+                                    <img src="/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Reusable Components</h3>
                                     <p>As Pulumi is code, you can build up a library of packages to further enhance efficiency. Build repeatable practices through versioned packages such as: standard policies, network best practices, architecture blueprints - and deploy them to your team. </p>
                                 </div>
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
+                                    <img src="/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Ephemeral Infrastructure</h3>
                                     <p>Pulumi provides the computation of necessary cloud resources with a 'Cloud Resource DAG' ensuring successful deployment of cloud infrastructure - efficiently building, updating, and destroying cloud resources as required. </p>
                                 </div>
@@ -285,7 +285,7 @@ exports.publicHostName = server.publicDns;
                         <div class="row">
                             <div class="col-md-3 col-md-push-9 text-center">
                                 <div style="height: 17px;"><!--custom spacer--></div>
-                                <img src="{{ .Site.BaseURL }}/logos/customers/learning-machine_logo.svg" alt="Learning Machine" width="208" class="margin-bottom-30">
+                                <img src="/logos/customers/learning-machine_logo.svg" alt="Learning Machine" width="208" class="margin-bottom-30">
                             </div>
                             <div class="col-md-9 col-md-pull-3 content">
                                 <h2>Learning Machine</h2>
@@ -302,13 +302,13 @@ exports.publicHostName = server.publicDns;
                         <div class="row cols-are-spaced-md">
                             <div class="col col-sm-6 col-md-4 col-md-offset-2">
                                 <figure>
-                                    <img src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-1.svg" width="210">
+                                    <img src="/images/customers/learning_machine_info-1.svg" width="210">
                                     <figcaption> 25,000 Lines of CloudFormation reduced to 500 Lines of JavaScript </figcaption>
                                 </figure>
                             </div>
                             <div class="col col-sm-6 col-md-4">
                                 <figure>
-                                    <img src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-2.svg" width="234">
+                                    <img src="/images/customers/learning_machine_info-2.svg" width="234">
                                     <figcaption> New customer provisioning time reduced from 3 weeks to 1 hour </figcaption>
                                 </figure>
                             </div>

--- a/layouts/partner/azure.html
+++ b/layouts/partner/azure.html
@@ -26,21 +26,21 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
+                                    <img src="/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Real Code</h3>
                                     <p>Pulumi is infrastructure as real code. This means you get all the benefits of your favorite language and tool for provisioning cloud infrastructure: code completion, error checking, versioning, IDE support, and general productivity gains - without the need to manage YAML and DSL syntax.</p>
                                 </div>
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
+                                    <img src="/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Reusable Components</h3>
                                     <p>As Pulumi is code, you can build up a library of packages to further enhance efficiency. Build repeatable practices through versioned packages such as: standard policies, network best practices, architecture blueprints - and deploy them to your team. </p>
                                 </div>
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
+                                    <img src="/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Ephemeral Infrastructure</h3>
                                     <p>Pulumi provides the computation of necessary cloud resources with a 'Cloud Resource DAG' ensuring successful deployment of cloud infrastructure - efficiently building, updating, and destroying cloud resources as required. </p>
                                 </div>
@@ -288,7 +288,7 @@ exports.publicIP = vm.id.apply(_ =>
                         <div class="row">
                             <div class="col-md-3 col-md-push-9 text-center">
                                 <div style="height: 17px;"><!--custom spacer--></div>
-                                <img src="{{ .Site.BaseURL }}/logos/customers/learning-machine_logo.svg" alt="Learning Machine" width="208" class="margin-bottom-30">
+                                <img src="/logos/customers/learning-machine_logo.svg" alt="Learning Machine" width="208" class="margin-bottom-30">
                             </div>
                             <div class="col-md-9 col-md-pull-3 content">
                                 <h2>Learning Machine</h2>
@@ -305,13 +305,13 @@ exports.publicIP = vm.id.apply(_ =>
                         <div class="row cols-are-spaced-md">
                             <div class="col col-sm-6 col-md-4 col-md-offset-2">
                                 <figure>
-                                    <img src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-1.svg" width="210">
+                                    <img src="/images/customers/learning_machine_info-1.svg" width="210">
                                     <figcaption> 25,000 Lines of CloudFormation reduced to 500 Lines of JavaScript </figcaption>
                                 </figure>
                             </div>
                             <div class="col col-sm-6 col-md-4">
                                 <figure>
-                                    <img src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-2.svg" width="234">
+                                    <img src="/images/customers/learning_machine_info-2.svg" width="234">
                                     <figcaption> New customer provisioning time reduced from 3 weeks to 1 hour </figcaption>
                                 </figure>
                             </div>

--- a/layouts/partner/gcp.html
+++ b/layouts/partner/gcp.html
@@ -26,21 +26,21 @@
                         <div class="row cols-are-spaced-md">
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
+                                    <img src="/icons/realCode_icon.svg" width="65" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Real Code</h3>
                                     <p>Pulumi is infrastructure as real code. This means you get all the benefits of your favorite language and tool for provisioning cloud infrastructure: code completion, error checking, versioning, IDE support, and general productivity gains - without the need to manage YAML and DSL syntax.</p>
                                 </div>
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
+                                    <img src="/icons/reusable-component.svg" width="88" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Reusable Components</h3>
                                     <p>As Pulumi is code, you can build up a library of packages to further enhance efficiency. Build repeatable practices through versioned packages such as: standard policies, network best practices, architecture blueprints - and deploy them to your team. </p>
                                 </div>
                             </div>
                             <div class="col col-md-4">
                                 <div class="content">
-                                    <img src="{{ .Site.BaseURL }}/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
+                                    <img src="/icons/immutable_infastrc_icon.svg" width="78" alt="" class="margin-bottom-30">
                                     <h3 class="h5">Ephemeral Infrastructure</h3>
                                     <p>Pulumi provides the computation of necessary cloud resources with a 'Cloud Resource DAG' ensuring successful deployment of cloud infrastructure - efficiently building, updating, and destroying cloud resources as required. </p>
                                 </div>
@@ -270,7 +270,7 @@ exports.instanceIP = computeInstance.networkInterfaces.apply(ni => ni[0].accessC
                         <div class="row">
                             <div class="col-md-3 col-md-push-9 text-center">
                                 <div style="height: 17px;"><!--custom spacer--></div>
-                                <img src="{{ .Site.BaseURL }}/logos/customers/learning-machine_logo.svg" alt="Learning Machine" width="208" class="margin-bottom-30">
+                                <img src="/logos/customers/learning-machine_logo.svg" alt="Learning Machine" width="208" class="margin-bottom-30">
                             </div>
                             <div class="col-md-9 col-md-pull-3 content">
                                 <h2>Learning Machine</h2>
@@ -287,13 +287,13 @@ exports.instanceIP = computeInstance.networkInterfaces.apply(ni => ni[0].accessC
                         <div class="row cols-are-spaced-md">
                             <div class="col col-sm-6 col-md-4 col-md-offset-2">
                                 <figure>
-                                    <img src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-1.svg" width="210">
+                                    <img src="/images/customers/learning_machine_info-1.svg" width="210">
                                     <figcaption> 25,000 Lines of CloudFormation reduced to 500 Lines of JavaScript </figcaption>
                                 </figure>
                             </div>
                             <div class="col col-sm-6 col-md-4">
                                 <figure>
-                                    <img src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-2.svg" width="234">
+                                    <img src="/images/customers/learning_machine_info-2.svg" width="234">
                                     <figcaption> New customer provisioning time reduced from 3 weeks to 1 hour </figcaption>
                                 </figure>
                             </div>

--- a/layouts/product/cloud-delivery-service.html
+++ b/layouts/product/cloud-delivery-service.html
@@ -42,10 +42,10 @@
                                         <p>Work with preferred languages for maximum productivity.</p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-js.png?v1" alt="js" width="36"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-python.png?v1" alt="python" width="34"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-golang.png?v1" alt="golang" width="63"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-ts.png?v1" alt="typescript" width="36"></li>
+                                        <li><img src="/logos/tech/logo-js.png?v1" alt="js" width="36"></li>
+                                        <li><img src="/logos/tech/logo-python.png?v1" alt="python" width="34"></li>
+                                        <li><img src="/logos/tech/logo-golang.png?v1" alt="golang" width="63"></li>
+                                        <li><img src="/logos/tech/logo-ts.png?v1" alt="typescript" width="36"></li>
                                     </ul>
                                 </div>
                             </div>
@@ -56,10 +56,10 @@
                                         <p>Deploy apps and infrastructure to any cloud.</p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-aws.png?v1" alt="aws" width="37"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-azure.png?v1" alt="azure" width="39"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-gd.png?v1" alt="gd" width="38"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></li>
+                                        <li><img src="/logos/tech/logo-aws.png?v1" alt="aws" width="37"></li>
+                                        <li><img src="/logos/tech/logo-azure.png?v1" alt="azure" width="39"></li>
+                                        <li><img src="/logos/tech/logo-gd.png?v1" alt="gd" width="38"></li>
+                                        <li><img src="/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></li>
                                     </ul>
                                 </div>
                             </div>
@@ -70,10 +70,10 @@
                                         <p>Implement workflows with familiar tools and workflows. </p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-github.png" alt="github"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-vs.png" alt="vs"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-npm.png" alt="npm"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-travisci.png" alt="travisci"></li>
+                                        <li><img src="/logos/tech/logo-github.png" alt="github"></li>
+                                        <li><img src="/logos/tech/logo-vs.png" alt="vs"></li>
+                                        <li><img src="/logos/tech/logo-npm.png" alt="npm"></li>
+                                        <li><img src="/logos/tech/logo-travisci.png" alt="travisci"></li>
                                     </ul>
                                 </div>
                             </div>

--- a/layouts/product/cloud-native-sdk.html
+++ b/layouts/product/cloud-native-sdk.html
@@ -42,10 +42,10 @@
                                         <p>Work with preferred languages for maximum productivity.</p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-js.png?v1" alt="js" width="36"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-python.png?v1" alt="python" width="34"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-golang.png?v1" alt="golang" width="63"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-ts.png?v1" alt="typescript" width="36"></li>
+                                        <li><img src="/logos/tech/logo-js.png?v1" alt="js" width="36"></li>
+                                        <li><img src="/logos/tech/logo-python.png?v1" alt="python" width="34"></li>
+                                        <li><img src="/logos/tech/logo-golang.png?v1" alt="golang" width="63"></li>
+                                        <li><img src="/logos/tech/logo-ts.png?v1" alt="typescript" width="36"></li>
                                     </ul>
                                 </div>
                             </div>
@@ -56,10 +56,10 @@
                                         <p>Deploy apps and infrastructure to any cloud.</p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-aws.png?v1" alt="aws" width="37"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-azure.png?v1" alt="azure" width="39"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-gd.png?v1" alt="gd" width="38"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></li>
+                                        <li><img src="/logos/tech/logo-aws.png?v1" alt="aws" width="37"></li>
+                                        <li><img src="/logos/tech/logo-azure.png?v1" alt="azure" width="39"></li>
+                                        <li><img src="/logos/tech/logo-gd.png?v1" alt="gd" width="38"></li>
+                                        <li><img src="/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></li>
                                     </ul>
                                 </div>
                             </div>
@@ -70,10 +70,10 @@
                                         <p>Implement workflows with familiar tools and workflows. </p>
                                     </div>
                                     <ul class="logo-roll text-center-xs text-center-sm">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-github.png" alt="github"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-vs.png" alt="vs"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-npm.png" alt="npm"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-travisci.png" alt="travisci"></li>
+                                        <li><img src="/logos/tech/logo-github.png" alt="github"></li>
+                                        <li><img src="/logos/tech/logo-vs.png" alt="vs"></li>
+                                        <li><img src="/logos/tech/logo-npm.png" alt="npm"></li>
+                                        <li><img src="/logos/tech/logo-travisci.png" alt="travisci"></li>
                                     </ul>
                                 </div>
                             </div>

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -12,7 +12,7 @@
             <header>
                 <div class="flex items-top">
                     <span class="rounded-full bg-gray-300 mr-8">
-                        <img class="rounded-full h-32 p-1" src="{{ $.Site.BaseURL }}images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}">
+                        <img class="rounded-full h-32 p-1" src="/images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}">
                     </span>
                     <div>
                         <h1 class="no-anchor">{{ $authorData.name }}</h1>

--- a/layouts/topics/kubernetes.html
+++ b/layouts/topics/kubernetes.html
@@ -52,11 +52,11 @@
                                 </div>
                                     <div class="col-sm-8 col-sm-offset-2">
                                     <ul class="social-channels expanded">
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-minikube.png?v1" alt="minikube" width="37"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-aws.png?v1" alt="aws" width="37"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-azure.png?v1" alt="azure" width="39"></li>
-                                        <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-gd.png?v1" alt="gd" width="38"></li>
+                                        <li><img src="/logos/tech/logo-minikube.png?v1" alt="minikube" width="37"></li>
+                                        <li><img src="/logos/tech/logo-kubernetes.png?v1" alt="kubernetes" width="39"></li>
+                                        <li><img src="/logos/tech/logo-aws.png?v1" alt="aws" width="37"></li>
+                                        <li><img src="/logos/tech/logo-azure.png?v1" alt="azure" width="39"></li>
+                                        <li><img src="/logos/tech/logo-gd.png?v1" alt="gd" width="38"></li>
                                     </ul>
                                 </div>
                             </div>

--- a/layouts/webinar/aws-fargate-and-pulumi.html
+++ b/layouts/webinar/aws-fargate-and-pulumi.html
@@ -4,7 +4,7 @@
                 <div class="row valign-center cols-are-spaced-md">
                         <div class="col col-md-5 col-md-push-7 col-lg-5 col-lg-push-7 col-right col-img hidden-xs hidden-sm">
                                 <div class="content">
-                                        <img src="{{ .Site.BaseURL }}/icons/containers.svg" alt="Delivering Cloud-Native Infrastructure-as-Code with Pulumi" width="260">
+                                        <img src="/icons/containers.svg" alt="Delivering Cloud-Native Infrastructure-as-Code with Pulumi" width="260">
                                 </div>
                         </div>
                         <div class="col col-md-7 col-md-pull-5 col-lg-7 col-lg-pull-5 col-left col-text">
@@ -21,8 +21,8 @@
                 <div class="row">
                     <div class="col-sm-12">
                         <ul class="list-inline reset">
-                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-aws.png" alt="AWS" width="37"></li>
-                            <li><img src="{{ .Site.BaseURL }}/logos/logo.svg" alt="Pulumi" width="70"></li>
+                            <li><img src="/logos/tech/logo-aws.png" alt="AWS" width="37"></li>
+                            <li><img src="/logos/logo.svg" alt="Pulumi" width="70"></li>
                         </ul>
                     </div>
                 </div>
@@ -73,7 +73,7 @@
                     <div class="row cols-are-spaced-md margin-bottom-40">
                         <div class="col col-md-2">
                             <div class="content">
-                                <img src="{{ .Site.BaseURL }}/icons/case_study.svg" alt="case study" width="130">
+                                <img src="/icons/case_study.svg" alt="case study" width="130">
                             </div>
                         </div>
                         <div class="col col-md-10">
@@ -89,7 +89,7 @@
                     <div class="row cols-are-spaced-md margin-bottom-40">
                         <div class="col col-md-2">
                             <div class="content">
-                                <img src="{{ .Site.BaseURL }}/icons/ebook.svg" alt="ebook" width="130">
+                                <img src="/icons/ebook.svg" alt="ebook" width="130">
                             </div>
                         </div>
                         <div class="col col-md-10">
@@ -105,7 +105,7 @@
                     <!--<div class="row cols-are-spaced-md margin-bottom-40">
                         <div class="col col-md-2">
                             <div class="content">
-                                <img src="{{ .Site.BaseURL }}/icons/video.svg" alt="video" width="130">
+                                <img src="/icons/video.svg" alt="video" width="130">
                             </div>
                         </div>
                         <div class="col col-md-10">

--- a/layouts/webinar/aws-mapbox.html
+++ b/layouts/webinar/aws-mapbox.html
@@ -4,7 +4,7 @@
             <div class="row valign-center cols-are-spaced-md">
                 <div class="col col-md-5 col-md-push-7 col-lg-5 col-lg-push-7 col-right col-img hidden-xs hidden-sm">
                     <div class="content">
-                        <img src="{{ .Site.BaseURL }}/icons/containers.svg" alt="Delivering Cloud-Native Infrastructure-as-Code with Pulumi" width="260">
+                        <img src="/icons/containers.svg" alt="Delivering Cloud-Native Infrastructure-as-Code with Pulumi" width="260">
                     </div>
                 </div>
                 <div class="col col-md-7 col-md-pull-5 col-lg-7 col-lg-pull-5 col-left col-text">
@@ -21,9 +21,9 @@
                 <div class="row">
                     <div class="col-sm-12">
                         <ul class="list-inline reset">
-                            <li><img src="{{ .Site.BaseURL }}/logos/tech/logo-aws.png" alt="AWS" width="37"></li>
-                            <li><img src="{{ .Site.BaseURL }}/logos/logo.svg" alt="Pulumi" width="70"></li>
-                            <li><img src="{{ .Site.BaseURL }}/logos/customers/mapbox_logo.png" alt="Pulumi" width="100"></li>
+                            <li><img src="/logos/tech/logo-aws.png" alt="AWS" width="37"></li>
+                            <li><img src="/logos/logo.svg" alt="Pulumi" width="70"></li>
+                            <li><img src="/logos/customers/mapbox_logo.png" alt="Pulumi" width="100"></li>
                         </ul>
                     </div>
                 </div>
@@ -76,7 +76,7 @@
                     <div class="row cols-are-spaced-md margin-bottom-40">
                         <div class="col col-md-2">
                             <div class="content">
-                                <img src="{{ .Site.BaseURL }}/icons/case_study.svg" alt="case study" width="130">
+                                <img src="/icons/case_study.svg" alt="case study" width="130">
                             </div>
                         </div>
                         <div class="col col-md-10">
@@ -92,7 +92,7 @@
                     <div class="row cols-are-spaced-md margin-bottom-40">
                         <div class="col col-md-2">
                             <div class="content">
-                                <img src="{{ .Site.BaseURL }}/icons/ebook.svg" alt="ebook" width="130">
+                                <img src="/icons/ebook.svg" alt="ebook" width="130">
                             </div>
                         </div>
                         <div class="col col-md-10">


### PR DESCRIPTION
Fixes broken images in the fusion stack. See https://github.com/pulumi/docs/pull/1206#issuecomment-504700119).

Instead of trying to deal with whether `BaseURL` has a trailing slash or not, there were many places that were prefixing `BaseURL` where a relative URL would work just fine. In such cases, just delete the unnecessary `BaseURL`. In the small number of remaining cases where we want to emit an absolute URL, use the `absURL` function instead, which is smart about handling missing/extra slashes.