### PR TITLE
Add links to cloud logos

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,16 +29,16 @@
                 </div>
                 <ul class="inline-flex list-none p-0 items-center mx-8">
                     <li class="mr-2">
-                        <img class="w-8" src="/logos/tech/logo-aws.png" alt="aws">
+                        <a href="{{ relref . "/partner/aws" }}"><img class="w-8" src="/logos/tech/logo-aws_white.png" alt="aws"></a>
                     </li>
                     <li class="mr-2">
-                        <img class="w-8" src="/logos/tech/logo-azure.png" alt="azure">
+                        <a href="{{ relref . "/partner/azure" }}"><img class="w-8" src="/logos/tech/logo-azure.png" alt="azure"></a>
                     </li>
                     <li class="mr-2">
-                        <img class="w-8" src="/logos/tech/logo-gd.png" alt="google cloud platform">
+                        <a href="{{ relref . "/partner/gcp" }}"><img class="w-8" src="/logos/tech/logo-gd.png" alt="google cloud platform"></a>
                     </li>
                     <li class="mr-2">
-                        <img class="w-8" src="/logos/tech/logo-kubernetes.png" alt="kubernetes">
+                        <a href="{{ relref . "/topics/kubernetes" }}"><img class="w-8" src="/logos/tech/logo-kubernetes.png" alt="kubernetes"></a>
                     </li>
                 </ul>
                 <ul class="inline-flex list-none p-0 items-center mx-8">


### PR DESCRIPTION
And use `logo-aws_white.png` for AWS.

Before

<img width="790" alt="Screen Shot 2019-06-24 at 11 02 58 PM" src="https://user-images.githubusercontent.com/710598/60073134-7a43af00-96d4-11e9-9576-ffd0514af483.png">

After

<img width="745" alt="Screen Shot 2019-06-24 at 11 01 50 PM" src="https://user-images.githubusercontent.com/710598/60073128-7748be80-96d4-11e9-987a-327dc4c67f54.png">

Part of #1213