### PR TITLE
Remove top margin from code snippets under lang tabs

### DIFF
--- a/assets/sass/_langchoose.scss
+++ b/assets/sass/_langchoose.scss
@@ -117,6 +117,21 @@ $tab-font-size: 14px !default;
     cursor: pointer;
 }
 
+// Remove the top margin from code snippets under lang chooser tabs so the tabs sit directly on top.
+.langtab-tabs + .clearfix + .highlight,
+.langtab-tabs + .clearfix + .highlight + .highlight,
+.langtab-tabs + .clearfix + .highlight + .highlight + .highlight,
+.langtab-tabs + .clearfix + .highlight + .highlight + .highlight + .highlight,
+.language-prologue-javascript + .highlight,
+.language-prologue-typescript + .highlight,
+.language-prologue-python + .highlight,
+.language-prologue-go + .highlight
+{
+    .chroma {
+        margin-top: 0;
+    }
+}
+
 // Hide adjacent siblings of .language-prologue-* classes from the outset, so they don't all initially
 // show as visible before all but the selected language are hidden.
 .language-prologue-javascript + *,

--- a/assets/sass/_langchoose.scss
+++ b/assets/sass/_langchoose.scss
@@ -117,17 +117,9 @@ $tab-font-size: 14px !default;
     cursor: pointer;
 }
 
-// Remove the top margin from code snippets under lang chooser tabs so the tabs sit directly on top.
-.langtab-tabs + .clearfix + .highlight,
-.langtab-tabs + .clearfix + .highlight + .highlight,
-.langtab-tabs + .clearfix + .highlight + .highlight + .highlight,
-.langtab-tabs + .clearfix + .highlight + .highlight + .highlight + .highlight,
-.language-prologue-javascript + .highlight,
-.language-prologue-typescript + .highlight,
-.language-prologue-python + .highlight,
-.language-prologue-go + .highlight
-{
-    .chroma {
+.langtab-tabs {
+    // Remove the top margin from code snippets under lang chooser tabs so the tabs sit directly on top.
+    ~ .highlight > .chroma {
         margin-top: 0;
     }
 }


### PR DESCRIPTION
Before (master)

<img width="980" alt="Screen Shot 2019-06-25 at 9 44 40 AM" src="https://user-images.githubusercontent.com/710598/60116921-eb638080-972d-11e9-8029-7526a33a25dd.png">

<img width="979" alt="Screen Shot 2019-06-25 at 9 44 48 AM" src="https://user-images.githubusercontent.com/710598/60116922-ed2d4400-972d-11e9-8c07-d3dcb0a4d9ab.png">

Before (fusion)

<img width="776" alt="Screen Shot 2019-06-25 at 9 40 29 AM" src="https://user-images.githubusercontent.com/710598/60116807-9d4e7d00-972d-11e9-9658-0d9868997e43.png">

<img width="764" alt="Screen Shot 2019-06-25 at 9 40 55 AM" src="https://user-images.githubusercontent.com/710598/60116804-9d4e7d00-972d-11e9-8f90-ad420acbc6f5.png">

After (fusion)

<img width="770" alt="Screen Shot 2019-06-25 at 9 39 55 AM" src="https://user-images.githubusercontent.com/710598/60116808-9d4e7d00-972d-11e9-852a-787e67456466.png">

<img width="767" alt="Screen Shot 2019-06-25 at 9 40 45 AM" src="https://user-images.githubusercontent.com/710598/60116805-9d4e7d00-972d-11e9-9b86-689d9195de65.png">