### PR TITLE
Add a robots.txt file

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://pulumi.com/"
+baseURL = "https://www.pulumi.com/"
 languageCode = "en-us"
 title = "Pulumi"
 

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://pulumi.io/"
+baseURL = "https://pulumi.com/"
 languageCode = "en-us"
 title = "Pulumi"
 
@@ -6,6 +6,7 @@ disableKinds = ["category", "taxonomyTerm"]
 sectionPagesMenu = "main"
 pygmentsCodeFences = true
 pygmentsUseClasses = true
+enableRobotsTXT = true
 
 [outputFormats.RSS]
     baseName = "rss"

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+{{- /* baseURL is a template.URL, so we need to convert it before we compare it.  */ -}}
+{{- if ne (string .Site.BaseURL) "https://pulumi.com/" }}
+Disallow: *
+{{ end }}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 {{- /* baseURL is a template.URL, so we need to convert it before we compare it.  */ -}}
-{{- if ne (string .Site.BaseURL) "https://pulumi.com/" }}
+{{- if ne (string .Site.BaseURL) "https://www.pulumi.com/" }}
 Disallow: *
 {{ end }}


### PR DESCRIPTION
This change adds a robots.txt template authorizing seach-engine indexing for all pages of the production site.

It assumes that all non-production builds will override the `baseURL` configuration property with something other than `https://pulumi.com/`.

Part of #1213.

Signed-off-by: Christian Nunciato <c@nunciato.org>