### PR TITLE
Fix page titles and errant anchors

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -61,7 +61,7 @@
         <meta property="og:image" content="{{ "/social/pulumi.png" | absURL }}">
     {{ end }}
 
-    <title>{{ .Title }}{{if not .IsHome}} - {{ end }}{{ .Site.Title }}</title>
+    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - Pulumi{{ end }}</title>
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico" />
 
     <!-- RSS link for the blog. -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -80,7 +80,7 @@
     <script> !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0"; analytics.load("mNROzbfcr6gi80tV37QuBcL0tK1DWvte"); analytics.page(); }}();</script>
 
     <!-- Apply anchor links to headings in the docs, blog and taxonomy pages. -->
-    {{ if in "docs blog authors tags" .Section }}
+    {{ if and (not .IsHome) (in "docs blog authors tags" .Section) }}
         <script src="//cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js"></script>
         <script>
             document.addEventListener("DOMContentLoaded", function(event) {


### PR DESCRIPTION
This change adjusts page titles to be 

```
Pulumi - Modern Infrastructure as Code
```

on the home page, and 

```
[Frontmatter Title] - Pulumi
```

everywhere else. It also fixes a bug that allowed page anchors to be rendered on the home page.

Part of #1213.
