### PR TITLE
Fix broken images

### DIFF
--- a/layouts/partials/benefits-v1.html
+++ b/layouts/partials/benefits-v1.html
@@ -3,7 +3,7 @@
 
     <div class="md:flex my-8">
         <div>
-            <img class="h-12 mb-6" src="{{ .Site.BaseURL }}/icons/realCode_icon.svg">
+            <img class="h-12 mb-6" src="/icons/realCode_icon.svg">
             <h3>Real Code</h3>
             <p>
                 Pulumi is infrastructure as real code. This means you get all the benefits
@@ -13,7 +13,7 @@
             </p>
         </div>
         <div class="md:mx-8">
-            <img class="h-12 mb-6" src="{{ .Site.BaseURL }}/icons/reusable-component.svg">
+            <img class="h-12 mb-6" src="/icons/reusable-component.svg">
             <h3>Reusable Components</h3>
             <p>
                 As Pulumi is code, you can build up a library of packages to further
@@ -23,7 +23,7 @@
             </p>
         </div>
         <div>
-            <img class="h-12 mb-6" src="{{ .Site.BaseURL }}/icons/immutable_infastrc_icon.svg">
+            <img class="h-12 mb-6" src="/icons/immutable_infastrc_icon.svg">
             <h3>Immutable Infrastructure</h3>
             <p>
                 Pulumi provides the computation of necessary cloud resources with a 'Cloud

--- a/layouts/partials/benefits-v2.html
+++ b/layouts/partials/benefits-v2.html
@@ -3,7 +3,7 @@
 
         <div class="md:flex my-8">
             <div>
-                <img class="h-12 mb-6" src="{{ .Site.BaseURL }}/icons/realCode_icon.svg">
+                <img class="h-12 mb-6" src="/icons/realCode_icon.svg">
                 <h3>Real Code</h3>
                 <p>
                     Pulumi is infrastructure as real code. This means you get all the benefits
@@ -13,7 +13,7 @@
                 </p>
             </div>
             <div class="mx-8">
-                <img class="h-12 mb-6" src="{{ .Site.BaseURL }}/icons/reusable-component.svg">
+                <img class="h-12 mb-6" src="/icons/reusable-component.svg">
                 <h3>Familiar Constructs</h3>
                 <p>
                     Real languages means you get familiar constructs like for loops,
@@ -23,7 +23,7 @@
                 </p>
             </div>
              <div class="mx-8">
-                <img class="h-12 mb-6" src="{{ .Site.BaseURL }}/icons/immutable_infastrc_icon.svg">
+                <img class="h-12 mb-6" src="/icons/immutable_infastrc_icon.svg">
                 <h3>Ephemeral Infrastructure</h3>
                 <p>
                     Pulumi has deep support for cloud native technologies, like
@@ -33,7 +33,7 @@
                 </p>
             </div>
             <div>
-                <img class="h-12 mb-6" src="{{ .Site.BaseURL }}/icons/icon-core3.svg">
+                <img class="h-12 mb-6" src="/icons/icon-core3.svg">
                 <h3>TF Provider Integration</h3>
                 <p>
                     Pulumi is able to adapt any Terraform Provider for use with Pulumi,

--- a/layouts/partials/learning-machine.html
+++ b/layouts/partials/learning-machine.html
@@ -17,13 +17,13 @@
         </p>
         <div class="md:flex my-8 md:max-w-32">
             <figure class="md:w-1/2">
-                <img class="mb-4" src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-1.svg">
+                <img class="mb-4" src="/images/customers/learning_machine_info-1.svg">
                 <figcaption class="text-gray-600 text-xs">
                     25,000 Lines of CloudFormation reduced to 500 Lines of JavaScript
                 </figcaption>
             </figure>
             <figure class="md:w-1/2">
-                <img class="mb-4" src="{{ .Site.BaseURL }}/images/customers/learning_machine_info-2.svg">
+                <img class="mb-4" src="/images/customers/learning_machine_info-2.svg">
                 <figcaption class="text-gray-600 text-xs">
                     New customer provisioning time reduced from 3 weeks to 1 hour
                 </figcaption>


### PR DESCRIPTION
Remove unnecessary `{{ .Site.BaseURL }}` prefix from image URLs.

Note: The reason the broken link checker didn't catch these is because when `hugo serve` is run, the baseURL doesn't include a trailing slash. But in the Hugo documentation, it always shows configuring the baseURL with a trailing slash. In any case, there's no need to prefix these URLs with the baseURL, which avoids the issue.

Follow-up from #1129 
Part of #1213 