### PR TITLE
Fix Hugo build warning about non-relative ref/relref page reference

### DIFF
--- a/content/blog/happy-birthday-to-pulumi-open-source/index.md
+++ b/content/blog/happy-birthday-to-pulumi-open-source/index.md
@@ -25,7 +25,7 @@ since launching:
     [AWS]({{< ref "/docs/quickstart/aws" >}}),
     [Azure]({{< ref "/docs/quickstart/azure" >}}), and
     [Google Cloud]({{< ref "/docs/quickstart/gcp" >}}) providers.
--   [Pulumi Crosswalk for AWS, a framework with built-in AWS infrastructure best practices.]({{< relref "crosswalk/aws" >}})
+-   [Pulumi Crosswalk for AWS, a framework with built-in AWS infrastructure best practices.]({{< relref "/crosswalk/aws" >}})
 -   Over 20 additional providers, including
     [CloudFlare](https://github.com/pulumi/pulumi-cloudflare),
     [Digital Ocean](https://github.com/pulumi/pulumi-digitalocean), and


### PR DESCRIPTION
Avoids the following warning when building the site:

```
WARN 2019/06/25 23:07:08 make non-relative ref/relref page reference(s) in page %q absolute, e.g. {{< ref "/blog/my-post.md" >}}
```