### PR TITLE
Use a fixed height for the utility bar

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -110,4 +110,10 @@ main {
     @include transition(all);
 }
 
+.github-widget {
+    > span {
+        @apply flex;
+    }
+}
+
 @tailwind utilities;

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,10 +1,10 @@
 <nav class="bg-black text-white text-sm py-2 px-8 md:px-0">
     <div class="container mx-auto">
-        <ul class="flex justify-end">
+        <ul class="flex justify-end items-center h-6">
             <li class="mr-8"><a href="https://slack.pulumi.io/" target="_blank">Slack</a></li>
             <li class="mr-8"><a href="https://github.com/pulumi" target="_blank">GitHub</a></li>
             <li class="mr-8"><a href="https://app.pulumi.com/" target="_blank">Console</a></li>
-            <li class="gh-widget">
+            <li class="github-widget">
                 <a class="github-button" href="https://github.com/pulumi/pulumi" data-size="small" data-show-count="true" aria-label="Star pulumi/pulumi on GitHub">Star</a>
             </li>
         </ul>


### PR DESCRIPTION
When the GitHub widget loads asynchronously and pops into view, it causes the whole page to shift downward a few pixels, because the widget is taller than the links beside it. Applying an explicit hight to the utility bar fixes this.

Before: 

![](https://cl.ly/a943ab8eaef3/Screen%252520Recording%2525202019-06-26%252520at%25252009.52%252520AM.gif)

After:

![](https://cl.ly/00df00add58a/Screen%252520Recording%2525202019-06-26%252520at%25252009.51%252520AM.gif)

Part of #1213.
