### PR TITLE
Fix TOC expansion for the tour

### DIFF
--- a/content/docs/tour/programs-configuration.md
+++ b/content/docs/tour/programs-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Custom configuration
-expanded_url: /tour/programs/
+expanded_url: /docs/tour/programs/
 menu:
   tour:
     parent: programs

--- a/content/docs/tour/programs-configuring.md
+++ b/content/docs/tour/programs-configuring.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring your stack
-expanded_url: /tour/programs/
+expanded_url: /docs/tour/programs/
 menu:
   tour:
     parent: programs

--- a/content/docs/tour/programs-exports.md
+++ b/content/docs/tour/programs-exports.md
@@ -1,6 +1,6 @@
 ---
 title: Stack exports
-expanded_url: /tour/programs/
+expanded_url: /docs/tour/programs/
 menu:
   tour:
     parent: programs

--- a/content/docs/tour/programs-packages.md
+++ b/content/docs/tour/programs-packages.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-expanded_url: /tour/programs/
+expanded_url: /docs/tour/programs/
 menu:
   tour:
     parent: programs

--- a/content/docs/tour/programs-properties.md
+++ b/content/docs/tour/programs-properties.md
@@ -1,6 +1,6 @@
 ---
 title: Resource properties
-expanded_url: /tour/programs/
+expanded_url: /docs/tour/programs/
 menu:
   tour:
     parent: programs

--- a/content/docs/tour/programs-resources.md
+++ b/content/docs/tour/programs-resources.md
@@ -1,6 +1,6 @@
 ---
 title: Resources
-expanded_url: /tour/programs/
+expanded_url: /docs/tour/programs/
 menu:
   tour:
     parent: programs

--- a/content/docs/tour/programs-stacks.md
+++ b/content/docs/tour/programs-stacks.md
@@ -1,6 +1,6 @@
 ---
 title: Stacks
-expanded_url: /tour/programs/
+expanded_url: /docs/tour/programs/
 menu:
   tour:
     parent: programs

--- a/content/docs/tour/programs.md
+++ b/content/docs/tour/programs.md
@@ -1,6 +1,6 @@
 ---
 title: Beyond the Basics
-expanded_url: /tour/programs/
+expanded_url: /docs/tour/programs/
 menu:
   tour:
     identifier: programs


### PR DESCRIPTION
We're very likely soon going to remove `/docs/tour` and disperse its content elsewhere, but in the meantime, fix the TOC expansion for "Beyond the Basics" items. Noticed while working on `/docs` page and TOC, and decided to fix in its own PR...

Before

<img width="1093" alt="Screen Shot 2019-06-26 at 10 09 53 AM" src="https://user-images.githubusercontent.com/710598/60200399-e587a100-97fa-11e9-9d73-7b4b9f3e191f.png">

After

<img width="1101" alt="Screen Shot 2019-06-26 at 10 09 20 AM" src="https://user-images.githubusercontent.com/710598/60200407-e7516480-97fa-11e9-9dcf-c169f76c747e.png">