### PR TITLE
Fix bug in lang chooser

### DIFF
--- a/assets/js/langchoose.js
+++ b/assets/js/langchoose.js
@@ -13,18 +13,12 @@ function selectLanguage(lang) {
 
         // Change the active tab.
         var langTabs = 0;
-        $("a").each(function (i, e) {
-            var classes = getElemClasses(e);
-            for (var i = 0; i < classes.length; i++) {
-                if (classes[i] === "langtab") {
-                    langTabs++;
-                    if (e.innerText.toLowerCase() === lang) {
-                        $(e).addClass("is-active");
-                    } else {
-                        $(e).removeClass("is-active");
-                    }
-                    break;
-                }
+        $("a.langtab").each(function (i, e) {
+            langTabs++;
+            if (e.innerText.toLowerCase() === lang) {
+                $(e).addClass("is-active");
+            } else {
+                $(e).removeClass("is-active");
             }
         });
 
@@ -87,26 +81,36 @@ function selectLanguage(lang) {
 // The first time the DOM is finished loading, select the right language.  If no language is set as the preferred
 // language yet, then JavaScript is chosen as the preferred language as a default.
 $(function() {
-    // For every language tab, inject a handler and make the correct one hidden.
-    $("a").each(function (i, e) {
-        var classes = getElemClasses(e);
-        for (var i = 0; i < classes.length; i++) {
-            if (classes[i] === "langtab") {
-                var lang = e.innerText.toLowerCase();
-                e.addEventListener("click", function() {
-                    selectLanguage(lang);
-                });
-                break;
-            }
-        }
+    var tabLangsOnPage = {};
+    $("a.langtab").each(function (i, e) {
+        var lang = e.innerText.toLowerCase();
+
+        // Save the languages we've seen.
+        tabLangsOnPage[lang] = true;
+
+        // For every language tab, inject a handler and make the correct one hidden.
+        e.addEventListener("click", function() {
+            selectLanguage(lang);
+        });
     });
 
-    // Now select the right language based on whether there's a cookie (defaulting to JavaScript).
+    var tabLangsOnPageKeys = Object.keys(tabLangsOnPage);
+
+    // If we didn't find any lang tabs, there's nothing else to do.
+    if (tabLangsOnPageKeys.length === 0) {
+        return;
+    }
+
+    // Now select the right language based on whether there's a cookie, defaulting to JavaScript,
+    // if it's among the tabs, otherwise falling back to the first lang we find.
     var langCookie = decodeURIComponent(
         document.cookie.replace(/(?:(?:^|.*;\s*)pulumi_language\s*\=\s*([^;]*).*$)|^.*$/, "$1"));
-    if (langCookie) {
+
+    if (langCookie && tabLangsOnPage.hasOwnProperty(langCookie)) {
         selectLanguage(langCookie);
-    } else {
+    } else if (tabLangsOnPage.hasOwnProperty("javascript")) {
         selectLanguage("javascript");
+    } else if (tabLangsOnPageKeys.length > 0) {
+        selectLanguage(tabLangsOnPageKeys[0]);
     }
 });


### PR DESCRIPTION
Ran into this while working on cleaning up the API docs styles...

If I've previously viewed a page in our docs with the language tabs, such as the Get Started guide, and I click the Python tab, that language choice will be persisted to a cookie.

If I then visit our Node.js API docs, the lang chooser will see the saved value of "Python" and try to select that tab, hiding all other language snippets. But our Node.js API docs only contain JavaScript and TypeScript snippets, so the end result is that all snippets are hidden and no tab is selected.

This change fixes that. If the value in the cookie does not exist in any of the tabs on the page, fallback to the default (JavaScript), otherwise fallback to the first tab that is available on the page.