### PR TITLE
Various mobile adjustments and cleanup

### DIFF
--- a/assets/sass/_hero.scss
+++ b/assets/sass/_hero.scss
@@ -1,0 +1,70 @@
+header {
+
+    &.header-hero {
+        @apply bg-purple-500 text-white py-8 px-4;
+
+        &-dark {
+            @apply bg-purple-800;
+        }
+
+        @screen lg {
+            @apply py-24;
+        }
+
+        h1 {
+            @apply text-white;
+        }
+
+        .header-hero-items {
+
+            @screen lg {
+                @apply flex;
+            }
+
+            .header-hero-item {
+
+                // On large screens, hero items are distributed evenly with intersticial padding.
+
+                @screen lg {
+                    @apply px-4 flex-1;
+                }
+
+                &:first-of-type {
+                    @apply pr-0;
+
+                    @screen lg {
+                        @apply pl-0;
+                    }
+
+                    p {
+                        @apply text-xl text-purple-100 leading-relaxed;
+                    }
+
+                    .header-hero-actions {
+                        @apply flex flex-col items-center mt-4;
+
+                        @screen lg {
+                            @apply inline-flex flex-row mt-2;
+                        }
+
+                        .btn-lg {
+                            @apply w-full text-center mb-4;
+
+                            @screen lg {
+                                @apply mb-0 mr-4;
+                            }
+                        }
+                    }
+                }
+
+                &:last-of-type {
+                    @apply text-white mt-0;
+
+                    @screen lg {
+                        @apply pr-0;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assets/sass/_section-nav.scss
+++ b/assets/sass/_section-nav.scss
@@ -1,0 +1,32 @@
+nav {
+
+    &.nav-section-sticky {
+        @apply bg-black text-base text-white px-4;
+
+        @screen md {
+            @apply px-0 sticky top-0;
+        }
+
+        ul {
+            @apply flex list-none justify-around items-center flex-wrap text-sm py-2 p-0;
+
+            @screen md {
+                @apply text-base py-0;
+            }
+
+            li {
+                > a {
+                    @apply block py-2 px-4 text-white text-center;
+
+                    @screen md {
+                        @apply py-4;
+                    }
+
+                    &:hover {
+                        @apply text-gray-300;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -10,12 +10,14 @@
 @import "buttons";
 @import "code";
 @import "fonts";
+@import "hero";
 @import "hubspot";
 @import "icons";
 @import "langchoose";
 @import "no-select";
 @import "pagination";
 @import "search";
+@import "section-nav";
 @import "tables";
 @import "toc";
 

--- a/layouts/careers/list.html
+++ b/layouts/careers/list.html
@@ -1,7 +1,9 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24 text-white px-4 md:px-0">
-        <div class="container mx-auto text-white text-center">
-            <h1 class="text-white">Want to help program the cloud?</h1>
+    <header class="header-hero">
+        <div class="container mx-auto">
+            <div class="mx-auto text-center">
+                <h1>Want to help program the cloud?</h1>
+            </div>
         </div>
     </header>
 {{ end }}

--- a/layouts/crosswalk/aws.html
+++ b/layouts/crosswalk/aws.html
@@ -1,26 +1,27 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24 text-white px-4 md:px-0">
-        <div class="container mx-auto text-white text-center">
+    <header class="header-hero">
+        <div class="container mx-auto text-center flex-col">
             <img class="block mx-auto max-w-md mb-12" src="/images/product/PulumiCrosswalkWhite.png">
-            <h1 class="text-white">Well-Architected Infrastructure as Code for AWS</h1>
-            <p class="text-purple-100 text-xl max-w-xl mx-auto mb-12">
+            <h1>Well-Architected Infrastructure as Code for AWS</h1>
+            <p>
                 The easiest way to AWS &mdash; from development to production.
             </p>
-            <a class="mx-auto font-bold text-xl" href="/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws">
-                Read the blog</a>.
+            <span>
+                <a class="mx-auto font-bold text-xl" href="/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws">Read the blog</a>.
+            </span>
         </div>
     </header>
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black text-white px-4 sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#benefits">Benefits </a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#case-study">Case Study </a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#architecture">Architecture </a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#applications">Applications </a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#infrastructure">Infrastructure</a></li>
+            <ul>
+                <li><a href="#benefits">Benefits </a></li>
+                <li><a href="#case-study">Case Study </a></li>
+                <li><a href="#architecture">Architecture </a></li>
+                <li><a href="#applications">Applications </a></li>
+                <li><a href="#infrastructure">Infrastructure</a></li>
             </ul>
         </div>
     </nav>

--- a/layouts/crosswalk/aws.html
+++ b/layouts/crosswalk/aws.html
@@ -1,7 +1,7 @@
 {{ define "hero" }}
     <header class="header-hero">
         <div class="container mx-auto text-center flex-col">
-            <img class="block mx-auto max-w-md mb-12" src="/images/product/PulumiCrosswalkWhite.png">
+            <img class="block mx-auto max-w-xs lg:max-w-md mb-12" src="/images/product/PulumiCrosswalkWhite.png">
             <h1>Well-Architected Infrastructure as Code for AWS</h1>
             <p>
                 The easiest way to AWS &mdash; from development to production.
@@ -63,7 +63,7 @@
     <section id="case-study" class="bg-gray-200 py-16 px-4 md:px-0">
         <div class="container mx-auto text-center px-4 md:px-0">
             <div class="flex justify-center mb-4">
-                <img class="h-20" src="/logos/customers/tableau_logo.png" alt="Tableau Software">
+                <img class="md:max-w-sm" src="/logos/customers/tableau_logo.png" alt="Tableau Software">
             </div>
             <blockquote class="border-orange-500 italic text-gray-800 mb-8 max-w-5xl mx-auto">
                 We've been happily using Pulumi’s EKS support for more than three months
@@ -85,7 +85,7 @@
 
     <section id="architecture" class="py-16 px-4 md:px-0">
         <div class="container mx-auto">
-            <img class="block mx-auto max-w-5xl" src="/images/docs/reference/crosswalk/aws/arch.png" alt="Pulumi Crosswalk architecture">
+            <img class="block mx-auto lg:max-w-5xl" src="/images/docs/reference/crosswalk/aws/arch.png" alt="Pulumi Crosswalk architecture">
         </div>
     </section>
 
@@ -107,7 +107,7 @@
                         configuration languages.
                     </p>
                     <p>
-                        <a class="btn" href="/docs/reference/crosswalk/aws">Get Started</a>
+                        <a class="btn inline-block my-2" href="/docs/reference/crosswalk/aws">Get Started</a>
                     </p>
                 </div>
                 <div class="md:w-1/2 md:ml:4">
@@ -138,7 +138,7 @@ export const url = lb.endpoint.hostname;` }}
         </div>
     </section>
 
-    <section id="infrastructure" class="bg-gray-200 py-16 px-4 md:px-0">
+    <section id="infrastructure" class="bg-gray-100 py-16 px-4 md:px-0">
         <div class="container mx-auto">
             <div class="md:flex my-8">
                 <div class="md:w-1/2 md:mr-4">
@@ -156,7 +156,7 @@ export const url = lb.endpoint.hostname;` }}
                         best practices within your team.
                     </p>
                     <p>
-                        <a class="btn" href="/docs/reference/crosswalk/aws">Get Started</a>
+                        <a class="btn inline-block my-2" href="/docs/reference/crosswalk/aws">Get Started</a>
                     </p>
                 </div>
                 <div class="md:w-1/2 md:ml:4">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
             </div>
             <div class="header-hero-item">
                 <iframe class="rounded shadow-lg max-w-full"
-                    width="642" height="351"
+                    width="648" height="356"
                     src="https://www.youtube.com/embed/B2Z2bT4Q-NY?rel=0"
                     allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                     frameborder="0"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,18 +1,18 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 text-white py-24 px-4">
-        <div class="container mx-auto text-white lg:flex">
-            <div class="lg:w-1/2 lg:mr-8">
-                <h1 class="text-white">Modern Infrastructure as Code</h1>
-                <p class="text-xl leading-relaxed text-purple-100">
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>Modern Infrastructure as Code</h1>
+                <p>
                     Create, deploy, and manage infrastructure on any cloud using your
                     favorite language.
                 </p>
-                <div class="flex md:inline-flex items-center mt-4 md:mt-2 flex-col md:flex-row">
-                    <a class="w-full text-center btn btn-lg mb-4 md:mb-0 md:mr-4" href="{{ relref . "/docs/quickstart" }}">Try Pulumi for Free</a>
-                    <a class="w-full text-center btn btn-lg btn-orange-translucent" href="{{ relref . "/why-pulumi" }}">Why Pulumi</a>
+                <div class="header-hero-actions">
+                    <a class="btn btn-lg" href="{{ relref . "/docs/quickstart" }}">Try Pulumi for Free</a>
+                    <a class="btn btn-lg btn-orange-translucent" href="{{ relref . "/why-pulumi" }}">Why Pulumi</a>
                 </div>
             </div>
-            <div class="lg:w-1/2 text-white mt-8 lg:mt-0">
+            <div class="header-hero-item">
                 <iframe class="rounded shadow-lg max-w-full"
                     width="642" height="351"
                     src="https://www.youtube.com/embed/B2Z2bT4Q-NY?rel=0"

--- a/layouts/migrate/cloudformation.html
+++ b/layouts/migrate/cloudformation.html
@@ -1,8 +1,8 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 text-white py-24 px-4">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2">
-                <h1 class="text-white">Migrating to Pulumi from CloudFormation</h1>
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>Migrating to Pulumi from CloudFormation</h1>
                 <p>
                     AWS CloudFormation provides a configuration DSL for you to describe and
                     provision infrastructure resources on AWS.
@@ -13,7 +13,7 @@
                     of YAML-based configuration files.
                 </p>
             </div>
-            <div class="md:w-1/2 md:ml-8 text-white">
+            <div class="header-hero-item">
                 <div class="hs-form hs-form-fg-light">
                     {{ partial "hubspot-form.html" (dict "hubspotFormID" "1b19f76c-0405-4a38-8a45-7f6a499db8ea") }}
                 </div>
@@ -23,15 +23,15 @@
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black text-white px-4 sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#benefits">Benefits</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#code">Code</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#how-it-works">How it Works</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#case-study">Case Study</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#get-started">Get Started</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#contact-us">Contact Us</a></li>
+            <ul>
+                <li><a href="#benefits">Benefits</a></li>
+                <li><a href="#code">Code</a></li>
+                <li><a href="#how-it-works">How it Works</a></li>
+                <li><a href="#case-study">Case Study</a></li>
+                <li><a href="#get-started">Get Started</a></li>
+                <li><a href="#contact-us">Contact Us</a></li>
             </ul>
         </div>
     </nav>

--- a/layouts/migrate/terraform.html
+++ b/layouts/migrate/terraform.html
@@ -1,8 +1,8 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24 text-white">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2">
-                <h1 class="text-white">Migrating to Pulumi from Terraform</h1>
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>Migrating to Pulumi from Terraform</h1>
                 <p>
                     HashiCorp Terraform provides a custom DSL called Hashicorp
                     Configuration Language (HCL) to describe and provision infrastructure
@@ -15,7 +15,7 @@
                     programming.
                 </p>
             </div>
-            <div class="md:w-1/2 md:ml-8 text-white">
+            <div class="header-hero-item">
                 {{ partial "hubspot-form.html" (dict "hubspotFormID" "123cfbdb-9ce4-4d33-a9b7-c30302463d7a") }}
             </div>
         </div>
@@ -23,22 +23,22 @@
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#benefits">Benefits</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#code">Code</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#how-it-works">How it Works</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#case-study">Case Study</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#get-started">Get Started</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#contact-us">Contact Us</a></li>
+            <ul>
+                <li><a href="#benefits">Benefits</a></li>
+                <li><a href="#code">Code</a></li>
+                <li><a href="#how-it-works">How it Works</a></li>
+                <li><a href="#case-study">Case Study</a></li>
+                <li><a href="#get-started">Get Started</a></li>
+                <li><a href="#contact-us">Contact Us</a></li>
             </ul>
         </div>
     </nav>
 
     {{ partial "benefits-v2.html" . }}
 
-    <section id="code" class="bg-gray-200 py-16">
+    <section id="code" class="bg-gray-200 py-16 px-4 md:px-0">
         <div class="container mx-auto">
             <div class="md:flex my-8">
                 <div class="md:w-1/2 md:mr-4">

--- a/layouts/page/about.html
+++ b/layouts/page/about.html
@@ -1,19 +1,21 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24 text-white px-4 md:px-0">
-        <div class="container mx-auto text-white text-center">
-            <h1 class="text-white">Program the cloud.</h1>
+    <header class="header-hero">
+        <div class="container mx-auto">
+            <div class="mx-auto text-center">
+                <h1>Program the cloud.</h1>
+            </div>
         </div>
     </header>
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#team">Team</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#board">Board</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#newsroom">Newsroom</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#contact">Contact Us</a></li>
+            <ul>
+                <li><a href="#team">Team</a></li>
+                <li><a href="#board">Board</a></li>
+                <li><a href="#newsroom">Newsroom</a></li>
+                <li><a href="#contact">Contact Us</a></li>
             </ul>
         </div>
     </nav>
@@ -34,8 +36,8 @@
     </section>
 
     <section id="team" class="px-4 md:px-0">
-        <div class="container md:mx-auto max-w-5xl">
-            <ul class="inline-flex flex-wrap list-none justify-center">
+        <div class="container md:mx-auto max-w-5xl text-center">
+            <ul class="inline-flex flex-wrap list-none justify-center p-0">
                 {{ range $.Site.Data.team.team }}
                     {{ if eq .status "active" }}
                         <li class="text-center w-48 mx-4 mb-8">
@@ -49,8 +51,7 @@
                     {{ end }}
                 {{ end }}
             </ul>
-
-            <div class="text-center ml-4 mb-16 mt-8">
+            <div class="text-center mb-16 mt-8">
                 <h3>Join the Team</h3>
                 <p>
                     <a href="{{ relref . "/careers" }}">Browse our open positions</a>.
@@ -60,9 +61,9 @@
     </section>
 
     <section id="board" class="bg-gray-200 py-16 px-4 md:px-0">
-        <div class="container md:mx-auto max-w-5xl">
+        <div class="container md:mx-auto max-w-5xl text-center">
             <h2 class="mb-8 text-center">Board of Directors</h2>
-            <ul class="inline-flex flex-wrap list-none justify-center">
+            <ul class="inline-flex flex-wrap list-none justify-center p-0">
                 {{ range $.Site.Data.team.board }}
                     <li class="text-center w-48 mx-4 mb-8">
                         <img class="rounded mb-4 shadow-md mx-auto" src="/images/team/{{ .id }}.jpg" alt="{{ .name }}" >

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -1,8 +1,8 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24 text-white px-4 lg:px-0">
-        <div class="container mx-auto text-white text-center lg:max-w-4xl">
-            <h1 class="text-white">Plans for teams of all sizes.</h1>
-            <p class="text-xl leading-relaxed text-purple-100">
+    <header class="header-hero">
+        <div class="container mx-auto text-center flex-col max-w-2xl">
+            <h1>Plans for teams of all sizes.</h1>
+            <p>
                 Enable your developers and operators to create, deploy, and manage
                 applications and infrastructure on AWS, Azure, Google Cloud, and
                 Kubernetes. Whether you are a growing startup, or established Enterprise,

--- a/layouts/page/product.html
+++ b/layouts/page/product.html
@@ -1,20 +1,20 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 text-white py-24 px-4">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2 md:mr-8">
-                <h1 class="text-white">The Pulumi Platform</h1>
-                <p class="text-xl leading-relaxed text-purple-100">
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>The Pulumi Platform</h1>
+                <p>
                     Create, deploy, and manage cloud apps and infrastructure, for any
                     cloud, in your favorite language. From infrastructure to containers to
                     Kubernetes to serverless. Solutions for teams of all sizes, Dev and
                     DevOps alike.
                 </p>
-                <div class="mt-4">
-                    <a class="inline-block btn btn-lg mr-2" href="{{ relref . "/docs/quickstart" }}">Try Pulumi for Free</a>
-                    <a class="inline-block btn btn-lg btn-orange-translucent mt-4" href="{{ relref . "/docs" }}">Read the Docs</a>
+                <div class="header-hero-actions">
+                    <a class="btn btn-lg" href="{{ relref . "/docs/quickstart" }}">Try Pulumi for Free</a>
+                    <a class="btn btn-lg btn-orange-translucent" href="{{ relref . "/docs" }}">Read the Docs</a>
                 </div>
             </div>
-            <div class="md:w-1/2 md:ml-8">
+            <div class="header-hero-item">
                 {{ $code := `$ pulumi up
 
 Previewing update of stack 'mystack-dev'
@@ -45,14 +45,14 @@ info: 33 changes previewed:
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black text-white px-4 sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#pulumi-sdk">Pulumi SDK</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#pulumi-crosswalk">Pulumi Crosswalk</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#pulumi-saas">Pulumi SaaS</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#multi-cloud-subscription">Multi-Cloud Subscription</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#how-it-works">How it Works</a></li>
+            <ul>
+                <li><a href="#pulumi-sdk">Pulumi SDK</a></li>
+                <li><a href="#pulumi-crosswalk">Pulumi Crosswalk</a></li>
+                <li><a href="#pulumi-saas">Pulumi SaaS</a></li>
+                <li><a href="#multi-cloud-subscription">Multi-Cloud Subscription</a></li>
+                <li><a href="#how-it-works">How it Works</a></li>
             </ul>
         </div>
     </nav>
@@ -391,22 +391,6 @@ info: 33 changes previewed:
             </div>
         </div>
     </section>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     {{ partial "how-pulumi-works.html" . }}
 

--- a/layouts/page/support.html
+++ b/layouts/page/support.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
-    <section id="contact" class="bg-gray-200 py-16 shadow-inner">
+    <section id="contact" class="bg-gray-200 py-8 md:py-16 px-4 md:px-0">
         <div class="container md:mx-auto md:flex">
-            <div class="w-1/2 md:mr-8">
+            <div class="md:w-1/2 md:mp-8">
                 <h1>Need help with an account issue?</h1>
                 <p>
                     Let us know here, and we'll respond as quickly as we can.
@@ -15,7 +15,7 @@
                     </p>
                 </div>
             </div>
-            <div class="w-1/2">
+            <div class="md:w-1/2">
                 <div class="hs-form hs-form-fg-dark">
                     {{ partial "hubspot-form.html" (dict "hubspotFormID" "30a5fc96-1b95-477a-8992-d46f6585b2ef") }}
                 </div>

--- a/layouts/page/whitepaper.html
+++ b/layouts/page/whitepaper.html
@@ -1,21 +1,21 @@
 {{ define "hero" }}
-    <header class="bg-blue-600 text-white px-4">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2 md:mr-8 py-16">
-                <h1 class="text-white font-bold">
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>
                     {{ .Title }}
                 </h1>
-                <p class="text-xl leading-relaxed text-blue-100">
+                <p>
                     {{ .Params.description }}
                 </p>
-                <div class="mt-4">
-                    <a class="inline-block btn btn-lg btn-translucent text-sm mt-4" href="{{ .Params.download_url }}">
+                <div class="header-hero-actions">
+                    <a class="btn btn-lg btn-translucent" href="{{ .Params.download_url }}">
                         <i class="far fa-file-pdf mr-1"></i>
                         Download the Whitepaper
                     </a>
                 </div>
             </div>
-            <div class="md:w-1/2 md:ml-8 pt-16 text-white text-center">
+            <div class="header-hero-item text-center">
                 <img class="inline-block w-64" src="{{ .Params.hero_image }}" alt="Whitepaper image">
             </div>
         </div>
@@ -23,11 +23,11 @@
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black text-white px-4 sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
+            <ul>
                 {{ range .Params.sections }}
-                    <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#{{ .anchor }}">{{ .label }}</a></li>
+                    <li><a href="#{{ .anchor }}">{{ .label }}</a></li>
                 {{ end }}
             </ul>
         </div>

--- a/layouts/page/why-pulumi.html
+++ b/layouts/page/why-pulumi.html
@@ -1,38 +1,38 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 text-white py-24 px-4">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2 md:mr-8">
-                <h1 class="text-white">Cloud Apps and Infrastructure</h1>
-                <p class="text-xl leading-relaxed text-purple-100">
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>Cloud Apps and Infrastructure</h1>
+                <p>
                     The Pulumi Platform includes an open source SDK and freemium SaaS to
                     help developers, DevOps, and IT teams alike create, deploy, and manage
                     cloud apps and infrastructure, across any clouds, with one consistent
                     workflow.
                 </p>
-                <div class="mt-4">
-                    <a class="inline-block btn btn-lg mr-2" href="{{ relref . "/docs/quickstart" }}">
+                <div class="header-hero-actions">
+                    <a class="btn btn-lg" href="{{ relref . "/docs/quickstart" }}">
                         Try Pulumi for Free
                     </a>
-                    <a class="inline-block btn btn-lg btn-orange-translucent mt-4" href="{{ relref . "/why-pulumi/delivering-cloud-native-infrastructure-as-code" }}">
+                    <a class="btn btn-lg btn-orange-translucent" href="{{ relref . "/why-pulumi/delivering-cloud-native-infrastructure-as-code" }}">
                         <i class="far fa-file-pdf mr-1"></i>
                         Download the Whitepaper
                     </a>
                 </div>
             </div>
-            <div class="md:w-1/2 md:ml-8 text-white text-center">
-                <img class="inline-block h-64" src="/images/logo-neon.png" alt="Pulumi logo">
+            <div class="header-hero-item">
+                <img class="mx-auto h-64" src="/images/logo-neon.png" alt="Pulumi logo">
             </div>
         </div>
     </header>
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black text-white px-4 sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#for-developers">For Developers</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#for-operators">For Operators</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#for-business-leaders">For Business Leaders</a></li>
+            <ul>
+                <li><a href="#for-developers">For Developers</a></li>
+                <li><a href="#for-operators">For Operators</a></li>
+                <li><a href="#for-business-leaders">For Business Leaders</a></li>
             </ul>
         </div>
     </nav>

--- a/layouts/partials/benefits-v1.html
+++ b/layouts/partials/benefits-v1.html
@@ -3,7 +3,7 @@
 
     <div class="md:flex my-8">
         <div>
-            <img class="h-12 mb-6" src="/icons/realCode_icon.svg">
+            <img class="h-12 mb-2" src="/icons/realCode_icon.svg">
             <h3>Real Code</h3>
             <p>
                 Pulumi is infrastructure as real code. This means you get all the benefits
@@ -13,7 +13,7 @@
             </p>
         </div>
         <div class="md:mx-8">
-            <img class="h-12 mb-6" src="/icons/reusable-component.svg">
+            <img class="h-12 mb-2" src="/icons/reusable-component.svg">
             <h3>Reusable Components</h3>
             <p>
                 As Pulumi is code, you can build up a library of packages to further
@@ -23,7 +23,7 @@
             </p>
         </div>
         <div>
-            <img class="h-12 mb-6" src="/icons/immutable_infastrc_icon.svg">
+            <img class="h-12 mb-2" src="/icons/immutable_infastrc_icon.svg">
             <h3>Immutable Infrastructure</h3>
             <p>
                 Pulumi provides the computation of necessary cloud resources with a 'Cloud

--- a/layouts/partials/benefits-v2.html
+++ b/layouts/partials/benefits-v2.html
@@ -1,46 +1,46 @@
-<section id="benefits" class="container mx-auto py-16">
-        <h2>Benefits of Pulumi</h2>
+<section id="benefits" class="container mx-auto py-16 px-4 md:px-0">
+    <h2>Benefits of Pulumi</h2>
 
-        <div class="md:flex my-8">
-            <div>
-                <img class="h-12 mb-6" src="/icons/realCode_icon.svg">
-                <h3>Real Code</h3>
-                <p>
-                    Pulumi is infrastructure as real code. This means you get all the benefits
-                    of your favorite language and tool for provisioning cloud infrastructure:
-                    code completion, error checking, versioning, IDE support, and general
-                    productivity gains &mdash; without the need to manage YAML and DSL syntax.
-                </p>
-            </div>
-            <div class="mx-8">
-                <img class="h-12 mb-6" src="/icons/reusable-component.svg">
-                <h3>Familiar Constructs</h3>
-                <p>
-                    Real languages means you get familiar constructs like for loops,
-                    functions, and classes - cutting boilerplate and enforcing best
-                    practices. Pulumi lets you leverage existing package management tools
-                    and techniques.
-                </p>
-            </div>
-             <div class="mx-8">
-                <img class="h-12 mb-6" src="/icons/immutable_infastrc_icon.svg">
-                <h3>Ephemeral Infrastructure</h3>
-                <p>
-                    Pulumi has deep support for cloud native technologies, like
-                    Kubernetes, and supports advanced deployment scenarios that cannot be
-                    expressed with Terraform. Pulumi is a proud member of the Cloud Native
-                    Computing Foundation (CNCF).
-                </p>
-            </div>
-            <div>
-                <img class="h-12 mb-6" src="/icons/icon-core3.svg">
-                <h3>TF Provider Integration</h3>
-                <p>
-                    Pulumi is able to adapt any Terraform Provider for use with Pulumi,
-                    enabling management of any infrastructure supported by the Terraform
-                    Providers ecosystem using Pulumi programs.
-                    <a href="https://github.com/pulumi/pulumi-terraform">Find out more here</a>.
-                </p>
-            </div>
+    <div class="md:flex my-8">
+        <div class="md:w-1/4 ">
+            <img class="h-12 mb-2" src="/icons/realCode_icon.svg">
+            <h3>Real Code</h3>
+            <p>
+                Pulumi is infrastructure as real code. This means you get all the benefits
+                of your favorite language and tool for provisioning cloud infrastructure:
+                code completion, error checking, versioning, IDE support, and general
+                productivity gains &mdash; without the need to manage YAML and DSL syntax.
+            </p>
         </div>
-    </section>
+        <div class="md:w-1/4 md:mx-8 my-12 md:my-0">
+            <img class="h-12 mb-2" src="/icons/reusable-component.svg">
+            <h3>Familiar Constructs</h3>
+            <p>
+                Real languages means you get familiar constructs like for loops,
+                functions, and classes - cutting boilerplate and enforcing best
+                practices. Pulumi lets you leverage existing package management tools
+                and techniques.
+            </p>
+        </div>
+        <div class="md:w-1/4 md:mx-8 my-12 md:my-0">
+            <img class="h-12 mb-2" src="/icons/immutable_infastrc_icon.svg">
+            <h3>Ephemeral Infrastructure</h3>
+            <p>
+                Pulumi has deep support for cloud native technologies, like
+                Kubernetes, and supports advanced deployment scenarios that cannot be
+                expressed with Terraform. Pulumi is a proud member of the Cloud Native
+                Computing Foundation (CNCF).
+            </p>
+        </div>
+        <div class="md:w-1/4 ">
+            <img class="h-12 mb-2" src="/icons/icon-core3.svg">
+            <h3>TF Provider Integration</h3>
+            <p>
+                Pulumi is able to adapt any Terraform Provider for use with Pulumi,
+                enabling management of any infrastructure supported by the Terraform
+                Providers ecosystem using Pulumi programs.
+                <a href="https://github.com/pulumi/pulumi-terraform">Find out more here</a>.
+            </p>
+        </div>
+    </div>
+</section>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -83,7 +83,7 @@
     <script> !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0"; analytics.load("mNROzbfcr6gi80tV37QuBcL0tK1DWvte"); analytics.page(); }}();</script>
 
     <!-- Apply anchor links to headings in the docs, blog and taxonomy pages. -->
-    {{ if and (not .IsHome) (in "docs blog authors tags" .Section) }}
+    {{ if and (not .IsHome) (.Section) (in "docs blog authors tags" .Section) }}
         <script src="//cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js"></script>
         <script>
             document.addEventListener("DOMContentLoaded", function(event) {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,4 @@
-<nav class="bg-black text-white text-sm py-2 px-8 md:px-0">
+<nav class="bg-black text-white text-sm py-2 px-4 md:px-0 transition-all max-h-screen md:max-h-full">
     <div class="container mx-auto">
         <ul class="flex justify-end items-center h-6">
             <li class="mr-8"><a href="https://slack.pulumi.io/" target="_blank">Slack</a></li>
@@ -16,7 +16,7 @@
     <a class="underline" href="/crosswalk/aws">Learn more</a>.
 </div> -->
 
-<nav class="nav-main bg-purple-700 py-6 px-8 md:px-0 border-t border-purple-500">
+<nav class="nav-main bg-purple-700 py-6 px-4 md:px-0 border-t border-purple-500">
     <div class="container mx-auto">
         <header class="flex items-center justify-between flex-wrap">
             <div class="flex items-center flex-shrink-0 text-white mr-6">
@@ -32,7 +32,7 @@
                 </button>
             </div>
 
-            <ul class="nav-header-items hidden w-full flex-grow md:flex md:items-center md:w-auto text-white uppercase pt-4 md:pt-0">
+            <ul class="nav-header-items hidden w-full flex-grow md:flex md:items-center md:w-auto text-white text-xs lg:text-base uppercase pt-4 md:pt-0">
                 {{ range $.Site.Menus.header }}
                     <li>
                         {{ $active := hasPrefix $.RelPermalink .URL }}

--- a/layouts/partials/how-pulumi-works.html
+++ b/layouts/partials/how-pulumi-works.html
@@ -1,6 +1,6 @@
 <section id="how-it-works" class="bg-purple-500 py-16 px-4 md:px-0">
     <div class="container mx-auto">
         <h2 class="text-white text-center">How Pulumi Works</h2>
-        <img class="mx-auto md:max-w-5xl mt-12" src="/images/infographics@2x.jpg" alt="How Pulumi works">
+        <img class="mx-auto w-full md:max-w-5xl mt-12" src="/images/infographics@2x.jpg" alt="How Pulumi works">
     </div>
 </section>

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -1,4 +1,4 @@
-<section class="bg-purple-800 text-white py-8">
+<section class="bg-purple-800 text-white py-8 px-4 md:px-0">
     <div class="container mx-auto">
         <div class="flex justify-center flex-col md:flex-row text-center">
             <h4 class="text-gray-100 md:mr-8 mt-2">Sign up for our newsletter</h4>

--- a/layouts/partials/section-nav.html
+++ b/layouts/partials/section-nav.html
@@ -1,8 +1,8 @@
-<nav class="bg-black sticky top-0 px-4 md:px-0">
+<nav class="nav-section-sticky">
     <div class="container mx-auto">
-        <ul class="flex list-none justify-between">
+        <ul>
             {{ range .sections }}
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#{{ .id }}">{{ .label }}</a></li>
+                <li><a href="#{{ .id }}">{{ .label }}</a></li>
             {{ end }}
         </ul>
     </div>

--- a/layouts/partner/aws.html
+++ b/layouts/partner/aws.html
@@ -1,11 +1,11 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24">
-        <div class="container mx-auto text-white md:flex px-4 md:px-0">
-            <div class="md:w-1/2">
-                <h1 class="text-white">Modern Infrastructure as Code for AWS</h1>
-                <div class="flex">
-                    <img class="md:w-48 h-48 mr-4" src="/images/partners/aws-apn.png" alt="AWS Technology Partner">
-                    <p class="w-3/4">
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>Modern Infrastructure as Code for AWS</h1>
+                <div class="flex flex-col md:flex-row">
+                    <img class="w-48 h-48 md:mr-4" src="/images/partners/aws-apn.png" alt="AWS Technology Partner">
+                    <p class="md:w-3/4">
                         Pulumi's infrastructure-as-code SDK helps create, deploy, and manage AWS containers, serverless functions, and infrastructure using real programming languages.
                     </p>
                 </div>
@@ -16,7 +16,7 @@
                     </a>
                 </p>
             </div>
-            <div class="md:w-1/2 md:ml-8">
+            <div class="header-hero-item">
                 {{ $code := `const aws = require("@pulumi/aws");
 
 let size = "t2.micro";
@@ -46,22 +46,22 @@ let server = new aws.ec2.Instance("web-server-www", {
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#benefits">Benefits</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#code">Code</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#how-it-works">How it Works</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#case-study">Case Study</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#get-started">Get Started</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#contact-us">Contact Us</a></li>
+            <ul>
+                <li><a href="#benefits">Benefits</a></li>
+                <li><a href="#code">Code</a></li>
+                <li><a href="#how-it-works">How it Works</a></li>
+                <li><a href="#case-study">Case Study</a></li>
+                <li><a href="#get-started">Get Started</a></li>
+                <li><a href="#contact-us">Contact Us</a></li>
             </ul>
         </div>
     </nav>
 
     {{ partial "benefits-v1.html" . }}
 
-    <section id="code" class="bg-gray-200 py-16">
+    <section id="code" class="bg-gray-200 py-16 px-4 md:px-0">
         <div class="container mx-auto">
 
             <!-- Example 1 -->
@@ -262,7 +262,7 @@ exports.publicHostName = server.publicDns;` }}
 
     {{ partial "get-started.html" . }}
 
-    <section id="contact-us" class="bg-purple-500 mb-0 py-16 text-white">
+    <section id="contact-us" class="bg-purple-500 mb-0 py-16 px-4 md:px-0 text-white">
         <div class="container mx-auto max-w-5xl">
             <div class="md:flex my-8 md:max-w-32 align-top">
                 <div class="md:w-1/2">

--- a/layouts/partner/azure.html
+++ b/layouts/partner/azure.html
@@ -1,8 +1,8 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2">
-                <h1 class="text-white">Modern Infrastructure as Code for Azure</h1>
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>Modern Infrastructure as Code for Azure</h1>
                 <p>
                     Pulumi's infrastructure-as-code SDK helps create, deploy, and manage
                     Azure containers, serverless functions, and infrastructure using real
@@ -12,7 +12,7 @@
                     Find out how to program the cloud with Pulumi and Azure.
                 </p>
             </div>
-            <div class="md:w-1/2 md:ml-8">
+            <div class="header-hero-item">
                 {{ $code := `import * as helm from "@pulumi/kubernetes/helm";
 import * as k8s from "@pulumi/kubernetes";
 import { k8sCluster, k8sProvider } from "./cluster";
@@ -36,22 +36,22 @@ export let serviceIP =
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#benefits">Benefits</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#code">Code</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#how-it-works">How it Works</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#case-study">Case Study</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#get-started">Get Started</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#contact-us">Contact Us</a></li>
+            <ul>
+                <li><a href="#benefits">Benefits</a></li>
+                <li><a href="#code">Code</a></li>
+                <li><a href="#how-it-works">How it Works</a></li>
+                <li><a href="#case-study">Case Study</a></li>
+                <li><a href="#get-started">Get Started</a></li>
+                <li><a href="#contact-us">Contact Us</a></li>
             </ul>
         </div>
     </nav>
 
     {{ partial "benefits-v1.html" . }}
 
-    <section id="code" class="bg-gray-200 py-16">
+    <section id="code" class="bg-gray-200 py-16 px-4 md:px-0">
         <div class="container mx-auto">
 
             <!-- Example 1 -->
@@ -271,7 +271,7 @@ exports.publicIP = vm.id.apply(_ =>
 
     {{ partial "get-started.html" . }}
 
-    <section id="contact-us" class="bg-purple-500 mb-0 py-16 text-white">
+    <section id="contact-us" class="bg-purple-500 mb-0 py-16 px-4 md:px-0 text-white">
         <div class="container mx-auto max-w-5xl">
             <div class="md:flex my-8 md:max-w-32 align-top">
                 <div class="md:w-1/2">

--- a/layouts/partner/gcp.html
+++ b/layouts/partner/gcp.html
@@ -1,8 +1,8 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2">
-                <h1 class="text-white">Modern Infrastructure as Code for Google Cloud</h1>
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>Modern Infrastructure as Code for Google Cloud</h1>
                 <p>
                     Pulumi's infrastructure as code SDK helps create, deploy, and manage
                     GCP containers, serverless functions, and infrastructure using real
@@ -12,7 +12,7 @@
                     Find out how to program the cloud with Pulumi and Google Cloud.
                 </p>
             </div>
-            <div class="md:w-1/2 md:ml-8">
+            <div class="header-hero-item">
                 {{ $code := `import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import { k8sProvider, k8sConfig } from "./cluster";
@@ -38,22 +38,22 @@ export let kubeConfig = k8sConfig;` }}
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-between">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#benefits">Benefits</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#code">Code</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#how-it-works">How it Works</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#case-study">Case Study</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#get-started">Get Started</a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300" href="#contact-us">Contact Us</a></li>
+            <ul>
+                <li><a href="#benefits">Benefits</a></li>
+                <li><a href="#code">Code</a></li>
+                <li><a href="#how-it-works">How it Works</a></li>
+                <li><a href="#case-study">Case Study</a></li>
+                <li><a href="#get-started">Get Started</a></li>
+                <li><a href="#contact-us">Contact Us</a></li>
             </ul>
         </div>
     </nav>
 
     {{ partial "benefits-v1.html" . }}
 
-    <section id="code" class="bg-gray-200 py-16">
+    <section id="code" class="bg-gray-200 py-16 px-4 md:px-0">
         <div class="container mx-auto">
 
             <!-- Example 1 -->
@@ -71,7 +71,7 @@ export let kubeConfig = k8sConfig;` }}
                         app to the cluster.
                     </p>
                     <p>
-                        <a class="btn" href="{{ relref . "/docs/quickstart" }}">Get Started</a>
+                        <a class="btn inline-block my-2" href="{{ relref . "/docs/quickstart" }}">Get Started</a>
                     </p>
                     <p>
                         Pulumi can be used on any resource covering serverless,
@@ -118,7 +118,7 @@ export const k8sCluster = new gcp.container.Cluster("gke-cluster", {
                         deploys an nginx canary onto the cluster with 1 replica.
                     </p>
                     <p>
-                        <a class="btn" href="{{ relref . "/docs/quickstart" }}">Get Started</a>
+                        <a class="btn inline-block my-2" href="{{ relref . "/docs/quickstart" }}">Get Started</a>
                     </p>
                     <p>
                         Pulumi can be used on any resource covering serverless,
@@ -166,7 +166,7 @@ export let kubeConfig = k8sConfig;` }}
                         the instance, before exporting the IP and Hostname.
                     </p>
                     <p>
-                        <a class="btn" href="{{ relref . "/docs/quickstart" }}">Get Started</a>
+                        <a class="btn inline-block my-2" href="{{ relref . "/docs/quickstart" }}">Get Started</a>
                     </p>
                     <p>
                         Pulumi can be used on any resource covering serverless,
@@ -233,7 +233,7 @@ exports.instanceIP = computeInstance.networkInterfaces.apply(ni => ni[0].accessC
                         This example shows how to create a simple Google Cloud Function that returns a message when invoked.
                     </p>
                     <p>
-                        <a class="btn" href="{{ relref . "/docs/quickstart" }}">Get Started</a>
+                        <a class="btn inline-block my-2" href="{{ relref . "/docs/quickstart" }}">Get Started</a>
                     </p>
                     <p>
                         Pulumi can be used on any resource covering serverless, containers, and infrastructure using JavaScript, TypeScript, Python, and Go.
@@ -260,7 +260,7 @@ export let url = greetingFunction.httpsTriggerUrl;` }}
 
     {{ partial "get-started.html" . }}
 
-    <section id="contact-us" class="bg-purple-500 mb-0 py-16 text-white">
+    <section id="contact-us" class="bg-purple-500 mb-0 py-16 px-4 md:px-0 text-white">
         <div class="container mx-auto max-w-5xl">
             <div class="md:flex my-8 md:max-w-32 align-top">
                 <div class="md:w-1/2">

--- a/layouts/product/github-actions.html
+++ b/layouts/product/github-actions.html
@@ -1,23 +1,23 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 text-white py-24 px-4">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2 md:mr-8 mb-8 md:mb-0">
-                <h1 class="text-white">GitHub Actions with Pulumi</h1>
-                <p class="text-xl leading-relaxed text-purple-100">
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>GitHub Actions with Pulumi</h1>
+                <p>
                     Pulumi and GitHub Actions combine to provide the easiest, most
                     capable, and friction-free way to achieve continuous delivery of cloud
                     applications and infrastructure.
                 </p>
-                <div class="mt-4">
-                    <a class="inline-block btn btn-lg mr-2" href="{{ relref . "/docs/reference/cd-github-actions" }}">
+                <div class="header-hero-actions">
+                    <a class="btn btn-lg" href="{{ relref . "/docs/reference/cd-github-actions" }}">
                         Get Started
                     </a>
-                    <a class="inline-block btn btn-orange-translucent btn-lg mt-4" href="{{ relref . "/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi" }}">
+                    <a class="btn btn-lg btn-orange-translucent" href="{{ relref . "/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi" }}">
                         Read the Blog
                     </a>
                 </div>
             </div>
-            <div class="md:w-1/2 md:ml-8">
+            <div class="header-hero-item">
                 <iframe class="rounded shadow-md max-w-full"
                     width="560" height="315"
                     src="https://www.youtube.com/embed/59SxB2uY9E0?rel=0&amp;showinfo=0"
@@ -30,11 +30,11 @@
 {{ end }}
 
 {{ define "main" }}
-    <nav class="bg-black text-white px-4 sticky top-0">
+    <nav class="nav-section-sticky">
         <div class="container mx-auto">
-            <ul class="flex list-none justify-around">
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300 ml-auto" href="#continuous-delivery">Continuous Delivery </a></li>
-                <li><a class="block py-4 px-4 text-white hover:text-gray-300 mr-auto" href="#gitops">GitOps</a></li>
+            <ul>
+                <li><a href="#continuous-delivery">Continuous Delivery </a></li>
+                <li><a href="#gitops">GitOps</a></li>
             </ul>
         </div>
     </nav>
@@ -144,20 +144,5 @@
             </div>
         </div>
     </section>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 {{ end }}

--- a/layouts/topics/containers.html
+++ b/layouts/topics/containers.html
@@ -1,11 +1,11 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24 text-white px-4 md:px-0">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2">
-                <h1 class="text-white">{{ .Params.hero.title }}</h1>
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>{{ .Params.hero.title }}</h1>
                 {{ .Params.hero.body | markdownify }}
             </div>
-            <div class="md:w-1/2 md:ml-8 text-white">
+            <div class="header-hero-item">
                 {{ partial "code" (dict "code" .Params.hero.code "lang" "js" "mode" "dark" "chrome" true) }}
             </div>
         </div>
@@ -78,7 +78,7 @@
                     <p>
                         {{ .body | safeHTML }}
                     </p>
-                    <a class="btn" href="{{ .cta.url }}">
+                    <a class="btn inline-block my-2" href="{{ .cta.url }}">
                         {{ .cta.label }}
                     </a>
                 </div>

--- a/layouts/topics/kubernetes.html
+++ b/layouts/topics/kubernetes.html
@@ -1,11 +1,11 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24 text-white px-4 md:px-0">
-        <div class="container mx-auto text-white md:flex">
-            <div class="md:w-1/2">
-                <h1 class="text-white">{{ .Params.hero.title }}</h1>
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>{{ .Params.hero.title }}</h1>
                 {{ .Params.hero.body | markdownify }}
             </div>
-            <div class="md:w-1/2 md:ml-8 text-white">
+            <div class="header-hero-item">
                 {{ partial "code" (dict "code" .Params.hero.code "lang" "js" "mode" "dark" "chrome" true) }}
             </div>
         </div>

--- a/layouts/topics/serverless.html
+++ b/layouts/topics/serverless.html
@@ -1,11 +1,11 @@
 {{ define "hero" }}
-    <header class="bg-purple-500 py-24 text-white">
-        <div class="container mx-auto text-white md:flex px-4 md:px-0">
-            <div class="md:w-1/2">
-                <h1 class="text-white">{{ .Params.hero.title }}</h1>
+    <header class="header-hero">
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>{{ .Params.hero.title }}</h1>
                 {{ .Params.hero.body | markdownify }}
             </div>
-            <div class="md:w-1/2 md:ml-8 text-white">
+            <div class="header-hero-item">
                 {{ partial "code" (dict "code" .Params.hero.code "lang" "js" "mode" "dark" "chrome" true) }}
             </div>
         </div>


### PR DESCRIPTION
* Pull the hero and section nav into Tailwind "components" and apply them.
* Adjust home-page video dimensions accordingly.
* Add mobile x-padding to sections that hadn't gotten it yet.
* Add an anchor exclusion to the `head` for the About page.
* Fix mobile layout for the Support page. 
* Fix centering and item distribution on the About page.
* Additional minor mobile-related adjustments as encountered.


Part of #1213.