### PR TITLE
Hide scrollbars if not needed

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -104,6 +104,11 @@ main {
     blockquote {
         @apply border-l-4 rounded border-orange-300 px-4 py-1 text-sm;
     }
+
+    pre {
+        // For our code snippets, only show scrollbars if needed.
+        overflow: auto;
+    }
 }
 
 .link {


### PR DESCRIPTION
Fixes #1255

Scrollbar visibility is determined by `x-overflow` or `y-overflow`, and when combined the `overflow` CSS property.

I don't know why this particular thing isn't consistent across machines, but the artifact appears to go away by just setting the `overflow` property for `pre` elements.

[Overflow docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)

<img width="461" alt="image" src="https://user-images.githubusercontent.com/4029847/60391310-61eede00-9aa0-11e9-9f21-7104e9514faa.png">

<img width="468" alt="image" src="https://user-images.githubusercontent.com/4029847/60391316-69ae8280-9aa0-11e9-830e-ce85e3870aff.png">

Note will expand the pre element if too large. So for super-long code examples, we won't scroll vertically. (Could be controlled...)