### PR TITLE
Enable travisqueue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ branches:
   - fusion
 before_install:
 # Download and install required tools.
+# Limit to one push build per branch.
+- go get github.com/pulumi/travisqueue
+- travisqueue start
 # Install assume-role tool for use when deploying
 - go get -u github.com/remind101/assume-role
 # AWS CLI
@@ -25,6 +28,9 @@ before_install:
 script:
 - echo "TRAVIS_EVENT_TYPE=${TRAVIS_EVENT_TYPE}"
 - make travis_${TRAVIS_EVENT_TYPE}
+after_script:
+# Maybe kick off next build.
+- travisqueue finish
 # TODO: Reenable once kinks worked out.
 # notifications:
 #   webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis


### PR DESCRIPTION
As part of redoing the CI/CD setup, I removed our ability to run concurrent jobs. (This is to prevent Pulumi updates from blocking one another.) Now that things are done getting set up, we can reenable concurrent jobs by using `travisqueue`.

For more information see:
https://github.com/pulumi/travisqueue