### PR TITLE
Change Modify step in AWS Get Started to truly modify

### DIFF
--- a/content/docs/quickstart/aws/deploy-changes.md
+++ b/content/docs/quickstart/aws/deploy-changes.md
@@ -18,15 +18,14 @@ Pulumi computes the minimally disruptive change to achieve the desired state des
 ```
 Previewing update (dev):
 
-     Type                      Name            Plan
-     pulumi:pulumi:Stack       quickstart-dev
- +   ├─ aws:ec2:SecurityGroup  web-secgrp      create
- +   ├─ aws:ec2:Instance       web-server-www  create
- -   └─ aws:s3:Bucket          my-bucket       delete
+     Type                 Name            Plan       Info
+     pulumi:pulumi:Stack  quickstart-dev
+ +   ├─ aws:kms:Key       my-key          create
+ ~   └─ aws:s3:Bucket     my-bucket       update     [diff: +serverSideEncryptionConfiguration]
 
 Resources:
-    + 2 to create
-    - 1 to delete
+    + 1 to create
+    ~ 1 to update
     2 changes. 1 unchanged
 
 Do you want to perform this update?
@@ -35,7 +34,7 @@ Do you want to perform this update?
   details
 ```
 
-Pulumi will delete the bucket since we're no longer defining it in our program, and it will create the EC2 security group and EC2 instance since those are now defined in the program.
+Pulumi will create the KMS key and update the bucket with the new encryption configuration.
 
 Choosing `yes` will proceed with the update.
 
@@ -43,29 +42,20 @@ Choosing `yes` will proceed with the update.
 Do you want to perform this update? yes
 Updating (dev):
 
-     Type                      Name            Status
-     pulumi:pulumi:Stack       quickstart-dev
- +   ├─ aws:ec2:SecurityGroup  web-secgrp      created
- +   ├─ aws:ec2:Instance       web-server-www  created
- -   └─ aws:s3:Bucket          my-bucket       deleted
+     Type                 Name            Status      Info
+     pulumi:pulumi:Stack  quickstart-dev
+ +   ├─ aws:kms:Key       my-key          created
+ ~   └─ aws:s3:Bucket     my-bucket       updated     [diff: +serverSideEncryptionConfiguration]
 
 Outputs:
-  - bucketName : "my-bucket-68e33ec"
-  + host       : "ec2-3-86-229-103.compute-1.amazonaws.com"
+    bucket_name: "my-bucket-de014a8"
 
 Resources:
-    + 2 created
-    - 1 deleted
+    + 1 created
+    ~ 1 updated
     2 changes. 1 unchanged
 
-Duration: 44s
-```
-
-We can use `pulumi stack output` to get the value of [stack outputs]({{< relref "/docs/reference/stack.md#outputs" >}}) from the CLI. So we can `curl` the EC2 instance to see the HTTP server running there.
-
-```bash
-$ curl $(pulumi stack output host)
-Hello, World!
+Duration: 10s
 ```
 
 Next, we'll destroy the stack.

--- a/content/docs/quickstart/aws/destroy-stack.md
+++ b/content/docs/quickstart/aws/destroy-stack.md
@@ -20,10 +20,10 @@ You'll be prompted to make sure you really want to delete these resources. This 
 ```
 Previewing destroy (dev):
 
-     Type                      Name            Plan
- -   pulumi:pulumi:Stack       quickstart-dev  delete
- -   ├─ aws:ec2:Instance       web-server-www  delete
- -   └─ aws:ec2:SecurityGroup  web-secgrp      delete
+     Type                 Name            Plan
+ -   pulumi:pulumi:Stack  quickstart-dev  delete
+ -   ├─ aws:s3:Bucket     my-bucket       delete
+ -   └─ aws:kms:Key       my-key          delete
 
 Resources:
     - 3 to delete
@@ -31,15 +31,15 @@ Resources:
 Do you want to perform this destroy? yes
 Destroying (dev):
 
-     Type                      Name            Status
- -   pulumi:pulumi:Stack       quickstart-dev  deleted
- -   ├─ aws:ec2:Instance       web-server-www  deleted
- -   └─ aws:ec2:SecurityGroup  web-secgrp      deleted
+     Type                 Name            Status
+ -   pulumi:pulumi:Stack  quickstart-dev  deleted
+ -   ├─ aws:s3:Bucket     my-bucket       deleted
+ -   └─ aws:kms:Key       my-key          deleted
 
 Resources:
     - 3 deleted
 
-Duration: 36s
+Duration: 26s
 ```
 
 To delete the stack itself, run `pulumi stack rm`.

--- a/content/docs/quickstart/aws/next-steps.md
+++ b/content/docs/quickstart/aws/next-steps.md
@@ -12,6 +12,7 @@ We've seen how to quickly get started using AWS with Pulumi.
 From here, you can dive deeper with additional AWS tutorials:
 
 * [Containers on ECS "Fargate"]({{< relref "/docs/reference/tutorials/aws/tutorial-service.md" >}}): Deploy containers to Amazon
+* [EC2 Linux WebServer VM]({{< relref "/docs/reference/tutorials/aws/tutorial-ec2-webserver.md" >}}): Create an EC2 Linux Web Server virtual machine
 * [Serverless REST API Gateways using Lambda]({{< relref "/docs/reference/tutorials/aws/tutorial-rest-api.md" >}}): Create simple RESTful web server using AWS Lambdas
 * [Serve a Static Website from S3]({{< relref "/docs/reference/tutorials/aws/tutorial-s3-website.md" >}}): Serve a static website out of content in an S3 bucket
 * [Serverless + Containers + Infrastructure]({{< relref "/docs/reference/tutorials/aws/tutorial-thumbnailer.md" >}}): Deploy a complete  application using a combination of buckets, serverless functions and containers.


### PR DESCRIPTION
(Replaces #1253, which was closed when the `fusion` branch was deleted).

Updates the AWS Get Started modify step to truly modify -- adding encryption to the S3 bucket via KMS key.

This also addreses an issue that prevented the modified program from working if you had an older AWS account (created prior to 2013) that uses EC2-Classic by default.

Part of #1177 