### PR TITLE
Delete Pulumi.pulumi.io-hugo.yaml

### DIFF
--- a/infrastructure-old/Pulumi.pulumi.io-hugo.yaml
+++ b/infrastructure-old/Pulumi.pulumi.io-hugo.yaml
@@ -1,5 +1,0 @@
-config:
-  aws:region: us-west-2
-  pulumi.io:certificateArn: arn:aws:acm:us-east-1:058607598222:certificate/2781ea98-97cf-4a14-aaa6-f222c0c758e5
-  pulumi.io:pathToWebsiteContents: ../public
-  pulumi.io:targetDomain: hugo.pulumi.io


### PR DESCRIPTION
This stack has been destroyed and removed. Presumably this whole directory will be deleted soon, but I figured I'd go ahead and delete this file since the stack is gone.