### PR TITLE
Enable CI/CD for PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 # Download and install required tools.
 # Limit to one push build per branch.
 - go get github.com/pulumi/travisqueue
-- travisqueue start
+- if [ ! -z ${TRAVIS_TOKEN} ]; travisqueue start; fi
 # Install assume-role tool for use when deploying
 - go get -u github.com/remind101/assume-role
 # AWS CLI
@@ -31,6 +31,6 @@ script:
 - make travis_${TRAVIS_EVENT_TYPE}
 after_script:
 # Maybe kick off next build.
-- travisqueue finish
+- if [ ! -z ${TRAVIS_TOKEN} ]; travisqueue finish; fi
 notifications:
   webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ script:
 - make travis_${TRAVIS_EVENT_TYPE}
 after_script:
 # Maybe kick off next build.
-- if [ ! -z ${TRAVIS_TOKEN} ]; travisqueue finish; fi
+- if [ ! -z ${TRAVIS_TOKEN} ]; then travisqueue finish; fi
 notifications:
   webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 # Download and install required tools.
 # Limit to one push build per branch.
 - go get github.com/pulumi/travisqueue
-- if [ ! -z ${TRAVIS_TOKEN} ]; travisqueue start; fi
+- if [ ! -z ${TRAVIS_TOKEN} ]; then travisqueue start; fi
 # Install assume-role tool for use when deploying
 - go get -u github.com/remind101/assume-role
 # AWS CLI

--- a/scripts/run-pulumi.sh
+++ b/scripts/run-pulumi.sh
@@ -13,6 +13,14 @@ fi
 export PULUMI_ACTION=${1}
 export STACK_NAME=${2}
 
+# Double check we have the right credentials. If CI/CD is running from a repo's fork,
+# they won't be available. In which case, skip the preview step and just rely on
+# make build/validate.
+if [ -z ${PULUMI_ACCESS_TOKEN:-} ]; then
+    echo "PULUMI_ACCESS_TOKEN not set. Skipping ${PULUMI_ACTION} on pulumi/${STACK_NAME}."
+    exit 0
+fi
+
 cd ./infrastructure
 
 # Sync dependencies and build the Pulumi program.


### PR DESCRIPTION
Tweak the Travis CI/CD configuration so that it won't fail when running on forks of the repo. This is because Travis will run the PRs, but not provide any secret configuration values (as to keep them, well, secret).