### PR TITLE
Change Twitter card type

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,7 +14,7 @@
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{ .Permalink }}">
     <meta property="og:site_name" content="pulumi">
-    <meta name="twitter:card" content="summary">
+    <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@PulumiCorp">
 
     {{ if isset .Params "meta_twitter_creator" }}


### PR DESCRIPTION
We set the `twitter:card` `<meta>` header to provide instructions for how the page should be displayed when shared on Twitter. #1342 reports that the format used by Twitter has changed for blog posts shared.

We have been using the same `twitter:card` value of `"summary"` in this repository [since before](https://github.com/pulumi/docs/blob/59d8d7ac1b9c433e74baee42eca6475174f80881/layouts/partials/head.html#L43) TGWMO2019. So it doesn't look like this was a regression per-say, but just blog.pulumi.com having used a different value for that.

Changes the value to be `summary_large_image` as described on the [Twitter documentation site](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image.html).

Fixes #1342