### PR TITLE
Add "copy to clipboard" button to code snippets

### DIFF
--- a/assets/js/copybutton.js
+++ b/assets/js/copybutton.js
@@ -1,0 +1,102 @@
+// When the DOM is ready, add copy buttons to code snippets.
+$(function() {
+    "use strict";
+
+    // Used to "normalize" code snippet text that will be written to the clipboard.
+    function normalizeText(lang, text) {
+        if (!text) {
+            return "";
+        }
+
+        // Replace all "\r\n" with "\n" to ensure consistent newlines.
+        text = text.replace("\r\n", "\n");
+
+        // Trim whitespace.
+        text = text.trim();
+
+        // For bash and shell code snippets:
+        //   1. Strip any lines that are prefixed with "$ "
+        //   2. Discard subsequent lines that don't start with "$ " (i.e. output)
+        //   3. Combine multiple lines that start with "$ " into a single line, e.g.
+        //      "$ mkdir mydir && mydir\n$ pulumi new typescript" =>
+        //      "mkdir mydir && mydir && pulumi new typescript"
+        if (lang === "bash" || lang === "shell" || lang === "sh") {
+            var results = [];
+            var lines = text.split("\n");
+            for (var i = 0; i < lines.length; i++) {
+                var line = lines[i].trim();
+
+                // If the first line doesn't start with "$ ", break out of the loop to avoid any
+                // further processing, so the whole thing is returned.
+                if (i === 0 && !line.startsWith("$ ")) {
+                    break;
+                }
+
+                // Skip empty lines and comments.
+                if (line.length === 0 || line.startsWith("#")) {
+                    continue;
+                }
+
+                // Include all initial lines that start with "$ " and discard subsequent lines after
+                // a line is reached that doesn't start with "$ ".
+                if (line.startsWith("$ ")) {
+                    results.push(line.substring(2));
+                } else {
+                    break;
+                }
+            }
+
+            // If we have results, combine into a single line, with commands separated by " && ".
+            if (results.length > 0) {
+                text = results.join(" && ");
+            }
+        }
+
+        // If on Windows, ensure the appropriate line endings are applied.
+        if (navigator.appVersion.indexOf("Win") !== -1) {
+            text = text.replace("\n", "\r\n");
+        }
+
+        return text;
+    }
+
+    var buttonHtml =
+        '<button class="copy-button">\n' +
+        '    <i class="material-icons copy" title="Copy code snippet">content_copy</i>\n' +
+        '    <i class="material-icons copied hidden text-green-500">check</i>\n' +
+        '</button>\n' +
+        '<span class="copy-button-tooltip hidden">Copied!</span>';
+
+    $("div:not(.code-hero) > div.highlight")
+        .addClass("relative")
+        .append(buttonHtml)
+        .on("click", "button.copy-button", function() {
+            var $b = $(this);
+            var $code = $b.siblings("pre").children("code");
+
+            // Get the lang and code.
+            var lang = $code.attr("data-lang");
+            var text = $code.text();
+
+            // Write the text to the clipboard.
+            var normalized = normalizeText(lang, text);
+            if (normalized && normalized.length > 0) {
+                clipboard.writeText(normalized);
+            }
+
+            // Remove focus from the button.
+            $b.blur();
+
+            // Show a green check mark and "Copied!" tooltip for a couple seconds.
+            var duration = 2000;
+            var $copy = $b.children(".copy").hide();
+            var $copied = $b.children(".copied").fadeIn();
+            var $tooltip = $b.siblings(".copy-button-tooltip").fadeIn();
+            setTimeout(function() {
+                $tooltip.fadeOut();
+                $copied.fadeOut(function() {
+                    $copy.show();
+                });
+            }, duration);
+        })
+});

--- a/assets/js/copybutton.js
+++ b/assets/js/copybutton.js
@@ -61,18 +61,19 @@ $(function() {
     }
 
     var buttonHtml =
-        '<button class="copy-button">\n' +
-        '    <i class="material-icons copy" title="Copy code snippet">content_copy</i>\n' +
-        '    <i class="material-icons copied hidden text-green-500">check</i>\n' +
-        '</button>\n' +
-        '<span class="copy-button-tooltip hidden">Copied!</span>';
+        '<div class="copy-button-container">\n' +
+        '    <button class="copy-button">\n' +
+        '        <i class="far fa-copy copy text-xl" title="Copy code snippet"></i>\n' +
+        '    </button>\n' +
+        '    <span class="copy-button-tooltip">Copied!</span>\n'+
+        '</div>';
 
     $(":not(.no-copy) > div.highlight")
         .addClass("relative")
         .append(buttonHtml)
         .on("click", "button.copy-button", function() {
             var $b = $(this);
-            var $code = $b.siblings("pre").children("code");
+            var $code = $b.parent().siblings("pre").children("code");
 
             // Get the lang and code.
             var lang = $code.attr("data-lang");
@@ -87,16 +88,11 @@ $(function() {
             // Remove focus from the button.
             $b.blur();
 
-            // Show a green check mark and "Copied!" tooltip for a couple seconds.
-            var duration = 2000;
-            var $copy = $b.children(".copy").hide();
-            var $copied = $b.children(".copied").fadeIn();
+            // Show a "Copied!" tooltip for a second.
+            var duration = 1000;
             var $tooltip = $b.siblings(".copy-button-tooltip").fadeIn();
             setTimeout(function() {
                 $tooltip.fadeOut();
-                $copied.fadeOut(function() {
-                    $copy.show();
-                });
             }, duration);
         })
 });

--- a/assets/js/copybutton.js
+++ b/assets/js/copybutton.js
@@ -67,7 +67,7 @@ $(function() {
         '</button>\n' +
         '<span class="copy-button-tooltip hidden">Copied!</span>';
 
-    $("div:not(.code-hero) > div.highlight")
+    $(":not(.no-copy) > div.highlight")
         .addClass("relative")
         .append(buttonHtml)
         .on("click", "button.copy-button", function() {

--- a/assets/js/noselect.js
+++ b/assets/js/noselect.js
@@ -2,7 +2,7 @@ $(function() {
     // Make "$ " inside bash and shell code snippets unselectable.
     var pattern = /([ |\t]*\$ )/mig;
     var replaceWith = '<span class="no-select">$1</span>';
-    $(".highlight .chroma .language-bash, .highlight .chroma .language-shell").each(function() {
+    $(".highlight .chroma .language-bash, .highlight .chroma .language-shell, .highlight .chroma .language-sh").each(function() {
         $(this).html($(this).html().replace(pattern, replaceWith));
     });
 });

--- a/assets/sass/_code.scss
+++ b/assets/sass/_code.scss
@@ -5,7 +5,7 @@ code {
 }
 
 pre {
-    @apply bg-gray-100 py-4 px-5 rounded border border-gray-200 scrolling-auto overflow-scroll my-4 leading-normal;
+    @apply bg-gray-100 py-4 px-5 pr-8 rounded border border-gray-200 scrolling-auto overflow-x-auto my-4 leading-normal;
 
     .code-mode-dark & {
         @apply bg-gray-900 border-none shadow-md;

--- a/assets/sass/_copy-button.scss
+++ b/assets/sass/_copy-button.scss
@@ -1,0 +1,28 @@
+@import "colors";
+@import "mixins";
+
+.copy-button {
+    @include transition;
+
+    @apply absolute top-0 right-0 h-6 w-6 mt-3 mr-2 text-gray-500 bg-gray-100;
+
+    &:hover {
+        @apply text-gray-600;
+    }
+}
+
+.copy-button-tooltip {
+    @apply absolute text-white text-xs text-center bg-gray-900 rounded p-2 z-0 opacity-75 top-0 right-0 mt-10 -mr-2;
+
+    // Arrow on top of the tooltip.
+    &::after {
+        @apply absolute border-solid;
+
+        content: " ";
+        bottom: 100%;
+        left: 50%;
+        margin-left: -5px;
+        border-width: 5px;
+        border-color: transparent transparent map-get($gray, 900) transparent;
+    }
+}

--- a/assets/sass/_copy-button.scss
+++ b/assets/sass/_copy-button.scss
@@ -1,17 +1,25 @@
 @import "colors";
 @import "mixins";
 
+.copy-button-container {
+    @apply absolute top-0 right-0 mt-px mr-px p-1 pt-2 pr-2 rounded bg-gray-100;
+
+    .code-mode-dark & {
+        @apply bg-gray-900;
+    }
+}
+
 .copy-button {
     @include transition;
 
-    @apply absolute top-0 right-0 mt-px mr-px pt-3 pr-2 rounded text-gray-500 bg-gray-100;
+    @apply text-gray-500;
 
     &:hover {
         @apply text-gray-600;
     }
 
     .code-mode-dark & {
-        @apply bg-gray-900 text-gray-600;
+        @apply text-gray-600;
 
         &:hover {
             @apply text-gray-500;
@@ -20,7 +28,7 @@
 }
 
 .copy-button-tooltip {
-    @apply absolute text-white text-xs text-center bg-gray-900 rounded p-2 z-0 opacity-75 top-0 right-0 mt-10 -mr-2;
+    @apply absolute hidden text-white text-xs text-center bg-gray-900 rounded p-2 z-0 opacity-75 top-0 right-0 mt-10 -mr-3;
 
     // Arrow on top of the tooltip.
     &::after {

--- a/assets/sass/_copy-button.scss
+++ b/assets/sass/_copy-button.scss
@@ -4,10 +4,18 @@
 .copy-button {
     @include transition;
 
-    @apply absolute top-0 right-0 h-6 w-6 mt-3 mr-2 text-gray-500 bg-gray-100;
+    @apply absolute top-0 right-0 mt-px mr-px pt-3 pr-2 rounded text-gray-500 bg-gray-100;
 
     &:hover {
         @apply text-gray-600;
+    }
+
+    .code-mode-dark & {
+        @apply bg-gray-900 text-gray-600;
+
+        &:hover {
+            @apply text-gray-500;
+        }
     }
 }
 

--- a/assets/sass/_fonts.scss
+++ b/assets/sass/_fonts.scss
@@ -1,3 +1,2 @@
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,400i,400,700|Ubuntu:400,700');
 @import url('https://fonts.googleapis.com/css?family=PT+Mono');
-@import url('https://fonts.googleapis.com/css?family=Material+Icons');

--- a/assets/sass/_fonts.scss
+++ b/assets/sass/_fonts.scss
@@ -1,2 +1,3 @@
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,400i,400,700|Ubuntu:400,700');
 @import url('https://fonts.googleapis.com/css?family=PT+Mono');
+@import url('https://fonts.googleapis.com/css?family=Material+Icons');

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -106,11 +106,6 @@ main {
     blockquote {
         @apply border-l-4 rounded border-orange-300 px-4 py-1 text-sm;
     }
-
-    pre {
-        // For our code snippets, only show scrollbars if needed.
-        overflow: auto;
-    }
 }
 
 .link {

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -9,6 +9,7 @@
 @import "api-python";
 @import "buttons";
 @import "code";
+@import "copy-button";
 @import "fonts";
 @import "hero";
 @import "hubspot";

--- a/content/docs/reference/tutorials/aws/tutorial-ec2-webserver.md
+++ b/content/docs/reference/tutorials/aws/tutorial-ec2-webserver.md
@@ -13,7 +13,7 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver EC2 instance
 
 1.  In a new folder `webserver`, create an empty project with `pulumi new`. Be sure to use `us-east-1` as the region:
 
-    ```
+    ```bash
     $ mkdir webserver && cd webserver
     $ pulumi new aws-javascript
     ...

--- a/content/docs/reference/tutorials/aws/tutorial-rest-api.md
+++ b/content/docs/reference/tutorials/aws/tutorial-rest-api.md
@@ -24,9 +24,9 @@ concepts to explore additional containers, serverless, and infrastructure tutori
 
 Let's use the Pulumi CLI to initialize a new project:
 
-```
-mkdir ahoy-pulumi && cd ahoy-pulumi
-pulumi new hello-aws-javascript
+```bash
+$ mkdir ahoy-pulumi && cd ahoy-pulumi
+$ pulumi new hello-aws-javascript
 ```
 
 You can accept the defaults for this command. For instance, you can change the AWS region to `us-west-2`.
@@ -89,7 +89,7 @@ See the [reference documentation]({{< relref "/docs/reference" >}}) for details 
 The stack is ready to deploy, which is done as follows:
 
 ```bash
-pulumi up
+$ pulumi up
 ```
 
 This command instructs Pulumi to determine the resources needed to create the stack. First, a preview is shown of the changes that will be made:
@@ -103,7 +103,7 @@ Choosing `yes` will create resources in AWS. This may take a minute or two.
 Since there was a stack export (via `exports.url` in the code), this is printed in the output of `pulumi up`. We can easily `curl` this URL via `pulumi stack output`:
 
 ```bash
-curl $(pulumi stack output url)
+$ curl $(pulumi stack output url)
 ```
 
 For a more interesting view that shows the result of calling a Lambda function, open the page in a browser:
@@ -121,7 +121,7 @@ Our output also contained a permalink to the Pulumi dashboard. We can review the
 To destroy resources, run the following:
 
 ```bash
-pulumi destroy
+$ pulumi destroy
 ```
 
 Once confirmed, Pulumi will remove all of the resources you've created. The stack itself is preserved in the Pulumi dashboard and is ready to go again as needed.

--- a/content/docs/reference/tutorials/aws/tutorial-service.md
+++ b/content/docs/reference/tutorials/aws/tutorial-service.md
@@ -77,7 +77,7 @@ To get started, we will create a project, initialize it, then run `pulumi up`:
 
 1.  Ensure you have the following directory structure:
 
-    ```bash
+    ```
     Pulumi.yaml
     index.ts
     app/
@@ -95,7 +95,7 @@ To get started, we will create a project, initialize it, then run `pulumi up`:
     provisions an ECR container registry, builds the Docker container, and pushed the image into the repository. This
     all happens automatically and does not require manual configuration on your part:
 
-    ```
+    ```bash
     $ pulumi up
     Previewing changes:
     ...

--- a/content/docs/reference/tutorials/aws/tutorial-thumbnailer.md
+++ b/content/docs/reference/tutorials/aws/tutorial-thumbnailer.md
@@ -182,7 +182,7 @@ To test the application, we'll upload a video to S3, view the running applicatio
 
 -  Copy the video to S3, encoding the time index in the filename (00:01 becomes `00-01`):
 
-    ```
+    ```bash
     $ aws s3 cp cat.mp4 s3://$(pulumi stack output bucketName)/cat_00-01.mp4
     upload: cat.mp4 to s3://bucket-0c91106/cat_00-01.mp4
     ```
@@ -191,7 +191,7 @@ To test the application, we'll upload a video to S3, view the running applicatio
 
 Run `pulumi logs -f` for the streaming logs of the Lambda functions as well as the Fargate task. Note that the log contains a prefix that matches the functions and tasks in your code, such as `onNewVideo` and `ffmpegThumbTask`:
 
-```
+```bash
 $ pulumi logs -f
 Collecting logs for stack thumbnail-quickstart-dev since 2018-05-25T13:32:27.000-07:00.
 

--- a/content/docs/reference/tutorials/gcp/tutorial-gce-webserver.md
+++ b/content/docs/reference/tutorials/gcp/tutorial-gce-webserver.md
@@ -16,7 +16,7 @@ In this tutorial, we'll use JavaScript to deploy a simple webserver Virtual Mach
 
 1.  In a new folder `webserver`, create an empty project with `pulumi new`. Choose a Google Cloud `project` you have access to create Virtual Machines within.
 
-    ```
+    ```bash
     $ mkdir webserver && cd webserver
     $ pulumi new gcp-javascript
     ...

--- a/content/docs/reference/tutorials/kubernetes/tutorial-configmap-rollout.md
+++ b/content/docs/reference/tutorials/kubernetes/tutorial-configmap-rollout.md
@@ -52,10 +52,10 @@ To provision the application, we need to:
 1. **Run** `pulumi new`**.**
 
     ```sh
-    mkdir test-pulumi && cd test-pulumi
+    $ mkdir test-pulumi && cd test-pulumi
     # Clones the application into the current directory, and begins provisioning it in the active
     # context of your kubeconfig file.
-    pulumi new https://github.com/pulumi/examples/tree/master/kubernetes-ts-configmap-rollout
+    $ pulumi new https://github.com/pulumi/examples/tree/master/kubernetes-ts-configmap-rollout
     ```
 
 1. **Answer the questions prompted by** `pulumi new`**.** This will bring up a CLI prompt that looks
@@ -71,7 +71,7 @@ To provision the application, we need to:
 1. **Accept the update.** After all the questions are answered, you should see a prompt like the
    following, asking if you'd like to proceed with the update. You can opt to view the diff, if you like, but we'll also do this later when we update the application.
 
-    ```sh
+    ```
     Resources:
         + 4 to create
 
@@ -158,13 +158,13 @@ Here are the steps to make this change:
 1. **Change the configuration file.** If you're on macOS, you can run:
 
     ```sh
-    sed -i bak "s/pulumi.github.io/google.com/g" default.conf
+    $ sed -i bak "s/pulumi.github.io/google.com/g" default.conf
     ```
 
     If you're running a platform that does not support `sed`, paste the following into your
     `default.conf` file:
 
-    ```
+    ```conf
     upstream node {
       server google.com;
     }
@@ -201,8 +201,8 @@ Once we're confident this is what we want, we can run the update:
 
 1. **Run** `pulumi up`**.**
 
-    ```typescript
-    pulumi up
+    ```sh
+    $ pulumi up
     ```
 
     The output should look something like this.
@@ -220,8 +220,8 @@ Once we're confident this is what we want, we can run the update:
 
 Once we're done with the application, it's possible to destroy it using:
 
-```typescript
-pulumi destroy
+```sh
+$ pulumi destroy
 ```
 
 [ts]: https://www.typescriptlang.org/

--- a/content/docs/reference/tutorials/kubernetes/tutorial-exposed-deployment.md
+++ b/content/docs/reference/tutorials/kubernetes/tutorial-exposed-deployment.md
@@ -30,7 +30,7 @@ Pulumi and Kubernetes.
 Now, install dependencies:
 
 ```sh
-npm install
+$ npm install
 ```
 
 Create a new stack:
@@ -45,7 +45,7 @@ This example will attempt to expose the `nginx` deployment Internet with a `Serv
 type `ClusterIP` instead; all you need to do is to tell it whether you're deploying to minikube:
 
 ```sh
-pulumi config set isMinikube <value>
+$ pulumi config set isMinikube <value>
 ```
 
 Perform the deployment:

--- a/content/docs/reference/tutorials/kubernetes/tutorial-guestbook.md
+++ b/content/docs/reference/tutorials/kubernetes/tutorial-guestbook.md
@@ -412,7 +412,7 @@ To start, we'll need to create a project and stack (a deployment target) for our
 
     Afterwards, query the list of pods to verify that none are remaining:
 
-    ```
+    ```shell
     $ kubectl get pods
     ```
 

--- a/content/docs/reference/tutorials/kubernetes/tutorial-p8s-rollout.md
+++ b/content/docs/reference/tutorials/kubernetes/tutorial-p8s-rollout.md
@@ -55,16 +55,16 @@ can see `canary-example-app` and `canary-staging-app` created.
 
 1. Now, install dependencies:
 
-   ```sh
-   npm install
-   ```
+    ```sh
+    $ npm install
+    ```
 
 1. Create a new stack:
 
-   ```sh
-   $ pulumi stack init
-   Enter a stack name: staged-rollout
-   ```
+    ```sh
+    $ pulumi stack init
+    Enter a stack name: staged-rollout
+    ```
 
 1. **IMPORTANT NOTE:** The code in `index.ts` is meant to be run out-of-cluster (_e.g._, on your
    local machine). It will thus call `kubectl port-forward` on your behalf so that the Prometheus
@@ -73,54 +73,52 @@ can see `canary-example-app` and `canary-staging-app` created.
 
 1. Perform the deployment:
 
-   ```sh
-   $ pulumi up
-   Updating stack 'staged-rollout'
-   Performing changes:
+        $ pulumi up
+        Updating stack 'staged-rollout'
+        Performing changes:
 
-        Type                           Name                 Status      Info
-    +   pulumi:pulumi:Stack                                            prometheus-staged-rollout
-    +   ├─ kubernetes:helm.sh:Chart                                    p8s                                created
-    +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-alertmanager        created
-    +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-pushgateway         created
-    +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-kube-state-metrics  created
-    +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-server              created
-    +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-node-exporter       created
-    +   │  ├─ kubernetes:core:ConfigMap                                p8s-prometheus-alertmanager        created
-    +   │  ├─ kubernetes:rbac.authorization.k8s.io:ClusterRoleBinding  p8s-prometheus-server              created
-    +   │  ├─ kubernetes:core:PersistentVolumeClaim                    p8s-prometheus-server              created
-    +   │  ├─ kubernetes:rbac.authorization.k8s.io:ClusterRoleBinding  p8s-prometheus-kube-state-metrics  created
-    +   │  ├─ kubernetes:core:ConfigMap                                p8s-prometheus-server              created
-    +   │  ├─ kubernetes:core:PersistentVolumeClaim                    p8s-prometheus-alertmanager        created
-    +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-alertmanager        created
-    +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-kube-state-metrics  created
-    +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-pushgateway         created
-    +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-node-exporter       created
-    +   │  ├─ kubernetes:extensions:Deployment                         p8s-prometheus-kube-state-metrics  created
-    +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-server              created
-    +   │  ├─ kubernetes:extensions:Deployment                         p8s-prometheus-pushgateway         created
-    +   │  ├─ kubernetes:rbac.authorization.k8s.io:ClusterRole         p8s-prometheus-kube-state-metrics  created
-    +   │  ├─ kubernetes:extensions:DaemonSet                          p8s-prometheus-node-exporter       created
-    +   │  ├─ kubernetes:extensions:Deployment                         p8s-prometheus-alertmanager        created
-    +   │  ├─ kubernetes:extensions:Deployment                         p8s-prometheus-server              created
-    +   │  └─ kubernetes:rbac.authorization.k8s.io:ClusterRole         p8s-prometheus-server              created
-    +   ├─ kubernetes:apps:Deployment                                  canary-example-app                 created
-    +   └─ kubernetes:apps:Deployment                                  staging-example-app                created
+            Type                           Name                 Status      Info
+        +   pulumi:pulumi:Stack                                            prometheus-staged-rollout
+        +   ├─ kubernetes:helm.sh:Chart                                    p8s                                created
+        +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-alertmanager        created
+        +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-pushgateway         created
+        +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-kube-state-metrics  created
+        +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-server              created
+        +   │  ├─ kubernetes:core:ServiceAccount                           p8s-prometheus-node-exporter       created
+        +   │  ├─ kubernetes:core:ConfigMap                                p8s-prometheus-alertmanager        created
+        +   │  ├─ kubernetes:rbac.authorization.k8s.io:ClusterRoleBinding  p8s-prometheus-server              created
+        +   │  ├─ kubernetes:core:PersistentVolumeClaim                    p8s-prometheus-server              created
+        +   │  ├─ kubernetes:rbac.authorization.k8s.io:ClusterRoleBinding  p8s-prometheus-kube-state-metrics  created
+        +   │  ├─ kubernetes:core:ConfigMap                                p8s-prometheus-server              created
+        +   │  ├─ kubernetes:core:PersistentVolumeClaim                    p8s-prometheus-alertmanager        created
+        +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-alertmanager        created
+        +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-kube-state-metrics  created
+        +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-pushgateway         created
+        +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-node-exporter       created
+        +   │  ├─ kubernetes:extensions:Deployment                         p8s-prometheus-kube-state-metrics  created
+        +   │  ├─ kubernetes:core:Service                                  p8s-prometheus-server              created
+        +   │  ├─ kubernetes:extensions:Deployment                         p8s-prometheus-pushgateway         created
+        +   │  ├─ kubernetes:rbac.authorization.k8s.io:ClusterRole         p8s-prometheus-kube-state-metrics  created
+        +   │  ├─ kubernetes:extensions:DaemonSet                          p8s-prometheus-node-exporter       created
+        +   │  ├─ kubernetes:extensions:Deployment                         p8s-prometheus-alertmanager        created
+        +   │  ├─ kubernetes:extensions:Deployment                         p8s-prometheus-server              created
+        +   │  └─ kubernetes:rbac.authorization.k8s.io:ClusterRole         p8s-prometheus-server              created
+        +   ├─ kubernetes:apps:Deployment                                  canary-example-app                 created
+        +   └─ kubernetes:apps:Deployment                                  staging-example-app                created
 
-   Diagnostics:
-     pulumi:pulumi:Stack: prometheus-test-p8s
-       info: Checking HTTP metrics
+        Diagnostics:
+            pulumi:pulumi:Stack: prometheus-test-p8s
+            info: Checking HTTP metrics
 
-       ---outputs:---
-     + p90ResponseTime: "8221.236"
+            ---outputs:---
+            + p90ResponseTime: "8221.236"
 
-   info: 2 changes performed:
-       + 2 resources created
-         26 resources unchanged
-   Update duration: 7.362744393s
+        info: 2 changes performed:
+            + 2 resources created
+                26 resources unchanged
+        Update duration: 7.362744393s
 
-   Permalink: https://app.pulumi.com/hausdorff/test-p8s/updates/1
-   ```
+        Permalink: https://app.pulumi.com/hausdorff/test-p8s/updates/1
 
    One useful sidenote, we can see here in the `---outputs:---` section that the `p90ResponseTime`
    that was computed by the promise is `export`ed, which causes Pulumi to report its value just

--- a/content/docs/reference/tutorials/kubernetes/tutorial-stateless-app.md
+++ b/content/docs/reference/tutorials/kubernetes/tutorial-stateless-app.md
@@ -87,7 +87,7 @@ To start, we'll need to create a project and stack (a deployment target) for our
 
 3.  Now we're ready to deploy our code. To do so, simply run `pulumi up`:
 
-    ```
+    ```shell
     $ pulumi up
     ```
 
@@ -174,7 +174,7 @@ To start, we'll need to create a project and stack (a deployment target) for our
 
     Let's also list the pods created by this deployment:
 
-    ```
+    ```shell
     $ kubectl get pods -l app=nginx
     ```
 
@@ -274,7 +274,7 @@ $ pulumi stack rm --yes
 
 Afterwards, query the list of pods to verify that none are remaining:
 
-```
+```shell
 $ kubectl get pods -l app=nginx
 ```
 

--- a/content/docs/reference/tutorials/kubernetes/tutorial-wordpress-chart.md
+++ b/content/docs/reference/tutorials/kubernetes/tutorial-wordpress-chart.md
@@ -27,13 +27,13 @@ Use the [Helm installation guide](https://docs.helm.sh/using_helm/#installing-he
 `helm` CLI. On macOS this might look something like:
 
 ```sh
-brew install kubernetes-helm
+$ brew install kubernetes-helm
 ```
 
 Once `helm` is installed, initialize it with:
 
 ```sh
-helm init --client-only
+$ helm init --client-only
 ```
 
 If you haven't already, follow the steps in [Pulumi Installation and
@@ -44,7 +44,7 @@ Pulumi and Kubernetes.
 Now, install dependencies:
 
 ```sh
-npm install
+$ npm install
 ```
 
 Create a new stack:

--- a/layouts/partials/code.html
+++ b/layouts/partials/code.html
@@ -3,7 +3,7 @@
     {{ $lang = "cql" }}
 {{ end }}
 
-<div class="code-hero code-mode-{{ default "light" .mode }} {{ if .chrome }} code-chrome {{ end }} code-{{ .lang }}">
+<div class="code-mode-{{ default "light" .mode }} {{ if .chrome }} code-chrome no-copy {{ end }} code-{{ .lang }}">
     {{ if .chrome }}
         {{ partial "chrome.html" . }}
     {{ end }}

--- a/layouts/partials/code.html
+++ b/layouts/partials/code.html
@@ -3,7 +3,7 @@
     {{ $lang = "cql" }}
 {{ end }}
 
-<div class="code-mode-{{ default "light" .mode }} {{ if .chrome }} code-chrome {{ end }} code-{{ .lang }}">
+<div class="code-hero code-mode-{{ default "light" .mode }} {{ if .chrome }} code-chrome {{ end }} code-{{ .lang }}">
     {{ if .chrome }}
         {{ partial "chrome.html" . }}
     {{ end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,10 +6,12 @@
     Concatenate, minify, and fingerprint scripts. Generated file will contain content
     hash in filename, so no need to add query param to cache bust.
 -->
-{{ $main := resources.Get "js/main.js" }}
-{{ $nav := resources.Get "js/nav.js" }}
-{{ $carousel := resources.Get "js/carousel.js" }}
-{{ $langchoose := resources.Get "js/langchoose.js" }}
-{{ $noselect := resources.Get "js/noselect.js" }}
-{{ $js := slice $main $nav $carousel $langchoose $noselect | resources.Concat "js/bundle.js" | resources.Minify | resources.Fingerprint }}
+{{ $s := slice (resources.Get "js/main.js") }}
+{{ $s = $s | append (resources.Get "js/nav.js") }}
+{{ $s = $s | append (resources.Get "js/carousel.js") }}
+{{ $s = $s | append (resources.Get "js/langchoose.js") }}
+{{ $s = $s | append (resources.Get "js/noselect.js") }}
+{{ $s = $s | append (readFile "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js" | resources.FromString "js/node/clipboard-polyfill.js") }}
+{{ $s = $s | append (resources.Get "js/copybutton.js") }}
+{{ $js := $s | resources.Concat "js/bundle.js" | resources.Minify | resources.Fingerprint }}
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}"></script>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "broken-link-checker": "^0.7.8",
+    "clipboard-polyfill": "^2.8.1",
     "typedoc": "^0.15.0-0",
     "typescript": "^3.4.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,6 +505,11 @@ cli-table@~0.3.1:
   dependencies:
     colors "1.0.3"
 
+clipboard-polyfill@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/clipboard-polyfill/-/clipboard-polyfill-2.8.1.tgz#a53fb77e9d8bac0a3db6792f5815a8979e585f61"
+  integrity sha512-2qclMYSM/L5Wv8mNeF2rvvtaKFJiG3y5mI2wwsFIUt0yE2hWjNg6qvsRo6D8TTaLTNXDfEI47TyaxSxjwD8ADQ==
+
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"


### PR DESCRIPTION
This PR adds a "Copy to Clipboard" button to code snippets.

![copybutton](https://user-images.githubusercontent.com/710598/61249508-43c4e700-a70a-11e9-81f8-4b436db2f6b8.gif)

Right now it adds it to any snippet that has a language specified, which covers the vast majority of uses throughout the site. There are cases that specify code snippets without a language, and right now those won't have a copy button. And I'm deliberately disabling it for the code snippets used for marketing content. We should prob follow-up and enable it across the board, and provide a first-class way to opt-out of the copy button when it isn't desired.

Copying `bash`, `shell`, and `sh`, snippets has some extra functionality. `$` prefixes are stripped, comments and empty lines are stripped, multiple lines are collapsed down to a single line, and any "output" lines that aren't prefixed with `$` are stripped.

Examples:

This:

```bash
$ mkdir hello-fargate && cd hello-fargate
$ pulumi new aws-typescript
```

...will have the this written to the clipboard:

```
mkdir hello-fargate && cd hello-fargate && pulumi new aws-typescript
```

And this:

```bash
$ curl http://$(pulumi stack output url)
<html>
    <head>
        <title>Hello Fargate</title>
    </head>
    <body>
        <p>Hello, containers!</p>
        <p>Made with ❤️ with <a href="https://pulumi.com">Pulumi</a></p>
    </body>
</html>
```

...will have this written to the clipboard:

```
curl http://$(pulumi stack output url)
```

Fixes #1023
Replaces #1204