### PR TITLE
Provide friendlier error message when `node_modules` doesn't exist

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -71,13 +71,19 @@
     <link rel="alternate" type="application/rss+xml" href="{{ "/blog/rss.xml" | absURL }}" title="Pulumi Blog" />
 
     <!--
-        Build Sass. Generated file will contain content hash in filename,
-        so no need to add query param to cache bust.
+        Build Sass. Generated file will contain content hash in filename, so no need to add query param to cache bust.
+        We check if `postcss-cli` has been installed, which is required by Hugo to use PostCSS, to provide a more
+        relevant error message.
     -->
-    {{ $toCSS := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" true) }}
-    {{ $postCSS := (dict "config" "assets/config/postcss.config.js") }}
-    {{ $styles := resources.Get "sass/styles.scss" | resources.ToCSS $toCSS | resources.PostCSS $postCSS | resources.Fingerprint }}
-    <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
+    {{ $postCSSCLIFile := "node_modules/postcss-cli" }}
+    {{ if fileExists $postCSSCLIFile }}
+        {{ $toCSS := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" true) }}
+        {{ $postCSS := (dict "config" "assets/config/postcss.config.js") }}
+        {{ $styles := resources.Get "sass/styles.scss" | resources.ToCSS $toCSS | resources.PostCSS $postCSS | resources.Fingerprint }}
+        <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
+    {{ else }}
+        {{ errorf "%q does not exist. Run `make ensure` to install required dependencies." $postCSSCLIFile }}
+    {{ end }}
 
     <script async defer src="https://buttons.github.io/buttons.js"></script>
     {{- if eq hugo.Environment "production" }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -11,7 +11,15 @@
 {{ $s = $s | append (resources.Get "js/carousel.js") }}
 {{ $s = $s | append (resources.Get "js/langchoose.js") }}
 {{ $s = $s | append (resources.Get "js/noselect.js") }}
-{{ $s = $s | append (readFile "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js" | resources.FromString "js/node/clipboard-polyfill.js") }}
+
+<!-- We use the `clipboard-polyfill` npm package. If it hasn't been installed, show a friendlier error message. -->
+{{ $clipboardFile := "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js" }}
+{{ if fileExists $clipboardFile }}
+    {{ $s = $s | append (readFile $clipboardFile | resources.FromString "js/node/clipboard-polyfill.js") }}
+{{ else }}
+    {{ errorf "%q does not exist. Run `make ensure` to install required dependencies." $clipboardFile }}
+{{ end }}
+
 {{ $s = $s | append (resources.Get "js/copybutton.js") }}
 {{ $js := $s | resources.Concat "js/bundle.js" | resources.Minify | resources.Fingerprint }}
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}"></script>


### PR DESCRIPTION
Our use of PostCSS in Hugo requires the `postcss-cli` npm package to be installed. If it isn't, Hugo will print an error:

> PostCSS not found; install with "npm install postcss-cli". See https://gohugo.io/hugo-pipes/postcss/

However, this isn't ideal for us, as we use `yarn` in this repo, and don't use it directly. Instead, `make ensure` should be used.

My recent change to add a copy button to code snippets also depends on an npm package (`clipboard-polyfill`) to be installed. If it isn't, Hugo fails with several error messages about not being able to read the file, and it isn't immediately obvious how to address the issue.

This change makes it very clear how to address the issue. If the relevant directories do not exist in `node_modules`, we fail the Hugo build and print an error that says "Run `make ensure`".

---

Before:

```
$ make serve
-e SERVE:
hugo server --buildDrafts --environment default
Building sites … ERROR 2019/07/16 21:59:36 error: failed to transform resource: POSTCSS: failed to transform "css/styles.css" (text/css): PostCSS not found; install with "npm install postcss-cli". See https://gohugo.io/hugo-pipes/postcss/
ERROR 2019/07/16 21:59:40 render of "section" failed: execute of template failed: template: docs/list.html:16:11: executing "docs/list.html" at <partial "scripts.html" .>: error calling partial: "/Users/justin/go/src/github.com/pulumi/docs/layouts/partials/scripts.html:14:21": execute of template failed: template: partials/scripts.html:14:21: executing "partials/scripts.html" at <readFile "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js">: error calling readFile: stat /Users/justin/go/src/github.com/pulumi/docs/content/node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js: no such file or directory
ERROR 2019/07/16 21:59:40 render of "page" failed: execute of template failed: template: docs/single.html:16:11: executing "docs/single.html" at <partial "scripts.html" .>: error calling partial: "/Users/justin/go/src/github.com/pulumi/docs/layouts/partials/scripts.html:14:21": execute of template failed: template: partials/scripts.html:14:21: executing "partials/scripts.html" at <readFile "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js">: error calling readFile: stat /Users/justin/go/src/github.com/pulumi/docs/content/node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js: no such file or directory
ERROR 2019/07/16 21:59:40 render of "page" failed: execute of template failed: template: docs/single.html:16:11: executing "docs/single.html" at <partial "scripts.html" .>: error calling partial: "/Users/justin/go/src/github.com/pulumi/docs/layouts/partials/scripts.html:14:21": execute of template failed: template: partials/scripts.html:14:21: executing "partials/scripts.html" at <readFile "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js">: error calling readFile: stat /Users/justin/go/src/github.com/pulumi/docs/content/node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js: no such file or directory
ERROR 2019/07/16 21:59:40 render of "section" failed: execute of template failed: template: docs/list.html:16:11: executing "docs/list.html" at <partial "scripts.html" .>: error calling partial: "/Users/justin/go/src/github.com/pulumi/docs/layouts/partials/scripts.html:14:21": execute of template failed: template: partials/scripts.html:14:21: executing "partials/scripts.html" at <readFile "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js">: error calling readFile: stat /Users/justin/go/src/github.com/pulumi/docs/content/node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js: no such file or directory
Total in 4628 ms
Error: Error building site: failed to render pages: render of "section" failed: execute of template failed: template: docs/list.html:16:11: executing "docs/list.html" at <partial "scripts.html" .>: error calling partial: "/Users/justin/go/src/github.com/pulumi/docs/layouts/partials/scripts.html:14:21": execute of template failed: template: partials/scripts.html:14:21: executing "partials/scripts.html" at <readFile "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js">: error calling readFile: stat /Users/justin/go/src/github.com/pulumi/docs/content/node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js: no such file or directory
make: *** [serve] Error 255
```

After:

```
$ make serve
-e SERVE:
hugo server --buildDrafts --environment default
Building sites … ERROR 2019/07/16 23:12:53 "node_modules/postcss-cli" does not exist. Run `make ensure` to install required dependencies.
ERROR 2019/07/16 23:12:53 "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js" does not exist. Run `make ensure` to install required dependencies.
Total in 10711 ms
Error: Error building site: logged 2 error(s)
make: *** [serve] Error 255
```