### PR TITLE
Use a canonical URL

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -26,5 +26,6 @@ enableRobotsTXT = true
     fractions = false
 
 [params]
+    canonicalURL = "https://www.pulumi.com"
     repositoryURL = "https://github.com/pulumi/docs"
     repositoryBranch = "master"

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -3,19 +3,19 @@
   {{ range .Data.Pages }}
   {{ if not .Params.private }}
   <url>
-    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Lang }}"
-                href="{{ .Permalink }}"
+                href="{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}"
                 />{{ end }}
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Lang }}"
-                href="{{ .Permalink }}"
+                href="{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}"
                 />{{ end }}
   </url>
   {{ end }}

--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -2,16 +2,16 @@
 <rss version="2.0">
     <channel>
         <title>Pulumi Blog</title>
-        <link>{{ .Permalink }}</link>
+        <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
         <description>Infrastructure as Code for AWS, Azure, Google Cloud, including Kubernetes, Serverless, Containers, for Developers and DevOps.</description>
         <language>{{ .Site.LanguageCode }}</language>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
         {{ range where .Data.Pages "Type" "in" "blog" }}
             <item>
                 <title>{{ .Title }}</title>
-                <link>{{ .Permalink }}</link>
+                <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
                 <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-                <guid>{{ .Permalink }}</guid>
+                <guid>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</guid>
                 <description>{{ .Summary | html }}</description>
                 {{ range $id := .Params.authors }}
                     {{ $author := index $.Site.Data.team.team $id }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -66,6 +66,14 @@
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - Pulumi{{ end }}</title>
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico" />
 
+    <!--
+        The canonical URL for the website. In all cases, this should be the public-facing
+        production URL of the site, to avoid SEO penalties for duplicate content.
+        https://support.google.com/webmasters/answer/139066?hl=en
+        https://en.wikipedia.org/wiki/Canonical_link_element
+    -->
+    <link rel="canonical" href="{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}" >
+
     <!-- RSS link for the blog. -->
     <link rel="alternate" type="application/rss+xml" href="{{ "/blog/rss.xml" | absURL }}" title="Pulumi Blog" />
 


### PR DESCRIPTION
Since we serve this site at multiple URLs (sometimes intentionally, others just by virtue of the way we build and deploy it -- e.g., "www-*", public buckets URLs, etc.), we should specify that the "real" URL is always, ultimately, https://www.pulumi.com. This change makes that clear in the HEAD, sitemap and RSS templates. 