### PR TITLE
Make `master` deploy to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: true
 branches:
   only:
   - master
-  - production
+  - staging
 before_install:
 # Download and install required tools.
 # Limit to one push build per branch.

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ validate:
 travis_push::
 	$(MAKE) banner
 	$(MAKE) ensure
-ifeq ($(TRAVIS_BRANCH),master)
+ifeq ($(TRAVIS_BRANCH),staging)
 	HUGO_ENVIRONMENT=staging $(MAKE) build
 	$(MAKE) validate
 	./scripts/run-pulumi.sh update staging
-else ifeq ($(TRAVIS_BRANCH),production)
+else ifeq ($(TRAVIS_BRANCH),master)
 	HUGO_ENVIRONMENT=production $(MAKE) build
 	$(MAKE) validate
 	./scripts/run-pulumi.sh update production
@@ -86,11 +86,11 @@ endif
 travis_pull_request::
 	$(MAKE) banner
 	$(MAKE) ensure
-ifeq ($(TRAVIS_BRANCH),master)
+ifeq ($(TRAVIS_BRANCH),staging)
 	HUGO_ENVIRONMENT=staging $(MAKE) build
 	$(MAKE) validate
 	./scripts/run-pulumi.sh preview staging
-else ifeq ($(TRAVIS_BRANCH),production)
+else ifeq ($(TRAVIS_BRANCH),master)
 	HUGO_ENVIRONMENT=production $(MAKE) build
 	$(MAKE) validate
 	./scripts/run-pulumi.sh preview production


### PR DESCRIPTION
Changes to `master` will now be deployed to production.

Also, since we already have a staging stack available, we'll keep it around for the time being. Any changes to a `staging` branch will update the staging stack.

Fixes #1384