### PR TITLE
Make broken link checker force follow robot exclusions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,23 +39,24 @@ build:
 
 .PHONY: test
 test:
-	# We exclude a few links:
+	# We exclude some links:
 	#     - Our generated API docs have lots of broken links
 	#     - Our changelog includes links to private repos
 	#     - GitHub Edit Links may be broken, because the page might not yet exist!
 	#     - Our LinkedIn page, for some reason, returns an HTTP error (despite being valid)
 	#     - Our Visual Studio Marketplace link for the Azure Pipelines task extension,
 	#       although valid and publicly available, is reported as a broken link.
-	# Fixes for the former two are tracked by https://github.com/pulumi/docs/issues/568.
 	./node_modules/.bin/blc http://localhost:1313 --recursive --follow \
 		--exclude "/docs/reference/pkg" \
 		--exclude "/docs/reference/changelog" \
 		--exclude "https://api.pulumi.com/" \
+		--exclude "https://github.com/pulls?" \
 		--exclude "https://github.com/pulumi/docs/edit/master" \
+		--exclude "https://github.com/pulumi/docs/issues/new" \
 		--exclude "https://www.linkedin.com/" \
 		--exclude "https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task" \
 		--exclude "https://blog.mapbox.com/" \
-		--exclude "https://github.com/pulls?"
+		--exclude "https://www.youtube.com/pulumitv"
 
 .PHONY: validate
 validate:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test:
 	#     - Our Visual Studio Marketplace link for the Azure Pipelines task extension,
 	#       although valid and publicly available, is reported as a broken link.
 	# Fixes for the former two are tracked by https://github.com/pulumi/docs/issues/568.
-	./node_modules/.bin/blc http://localhost:1313 -r \
+	./node_modules/.bin/blc http://localhost:1313 --recursive --follow \
 		--exclude "/docs/reference/pkg" \
 		--exclude "/docs/reference/changelog" \
 		--exclude "https://github.com/pulumi/docs/edit/master" \

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ test:
 	./node_modules/.bin/blc http://localhost:1313 --recursive --follow \
 		--exclude "/docs/reference/pkg" \
 		--exclude "/docs/reference/changelog" \
+		--exclude "https://api.pulumi.com/" \
 		--exclude "https://github.com/pulumi/docs/edit/master" \
 		--exclude "https://www.linkedin.com/" \
 		--exclude "https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task" \

--- a/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
+++ b/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
@@ -15,7 +15,7 @@ code to the rescue! We can now provision an entire EKS cluster with a
 CLI single gesture, thanks to [the `@pulumi/eks`
 package](https://github.com/pulumi/pulumi-eks). Let's see how.
 
-{{< img src="easy-eks.png" alt="Pulumi making EKS Easy" >}}
+![Pulumi making EKS Easy](./easy-eks.png)
 
 To get started, download the free and open source
 [Pulumi SDK]({{< ref "/docs/reference/install.md" >}}). The SDK includes

--- a/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
+++ b/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
@@ -14,6 +14,7 @@ it's still difficult to get up and running. Pulumi's infrastructure as
 code to the rescue! We can now provision an entire EKS cluster with a
 CLI single gesture, thanks to [the `@pulumi/eks`
 package](https://github.com/pulumi/pulumi-eks). Let's see how.
+<!--more-->
 
 ![Pulumi making EKS Easy](./easy-eks.png)
 
@@ -29,7 +30,6 @@ From here, there are two ways to proceed:
 
 - Provision a new cluster with a single CLI command
 - Use infrastructure as code to manage clusters ... including Kubernetes resources themselves!
-<!--more-->
 
 ## Installing Amazon EKS with Pulumi
 

--- a/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
+++ b/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
@@ -15,7 +15,7 @@ code to the rescue! We can now provision an entire EKS cluster with a
 CLI single gesture, thanks to [the `@pulumi/eks`
 package](https://github.com/pulumi/pulumi-eks). Let's see how.
 
-![Pulumi making EKS Easy](./easy-eks.png)
+{{< img src="easy-eks.png" alt="Pulumi making EKS Easy" >}}
 
 To get started, download the free and open source
 [Pulumi SDK]({{< ref "/docs/reference/install.md" >}}). The SDK includes

--- a/content/blog/kubespy-and-the-lifecycle-of-a-kubernetes-pod-in-four-images/index.md
+++ b/content/blog/kubespy-and-the-lifecycle-of-a-kubernetes-pod-in-four-images/index.md
@@ -19,6 +19,7 @@ One of the most popular features of the recent
 [v0.15.2 release]({{< relref "cloud-native-infrastructure-with-kubernetes-and-pulumi" >}})
 of Pulumi is fine-grained status updates for Kubernetes resources. On
 the CLI they look like this:
+<!--more-->
 
 ![status-rich](./status-rich.gif)
 
@@ -33,7 +34,6 @@ purpose-built to help you answer questions like this, by displaying the
 changes made to a Kubernetes object in real time. For example, in the
 following gif, we're running `kubespy status v1 Pod nginx` to watch the
 changes to a `Pod`'s status as it is booted up.
-<!--more-->
 
 We will spend the rest of this short post using `kubespy` to take a
 closer look at what happens to a `Pod` when it's deployed to the

--- a/content/blog/kubespy-and-the-lifecycle-of-a-kubernetes-pod-in-four-images/index.md
+++ b/content/blog/kubespy-and-the-lifecycle-of-a-kubernetes-pod-in-four-images/index.md
@@ -20,7 +20,7 @@ One of the most popular features of the recent
 of Pulumi is fine-grained status updates for Kubernetes resources. On
 the CLI they look like this:
 
-{{< img src="status-rich.gif" alt="status-rich" >}}
+![status-rich](./status-rich.gif)
 
 But wait --- how does this work exactly? What is *actually happening*
 when you deploy a `Pod` to a cluster? How does a `Service` go from

--- a/content/blog/kubespy-and-the-lifecycle-of-a-kubernetes-pod-in-four-images/index.md
+++ b/content/blog/kubespy-and-the-lifecycle-of-a-kubernetes-pod-in-four-images/index.md
@@ -20,7 +20,7 @@ One of the most popular features of the recent
 of Pulumi is fine-grained status updates for Kubernetes resources. On
 the CLI they look like this:
 
-![status-rich](./status-rich.gif)
+{{< img src="status-rich.gif" alt="status-rich" >}}
 
 But wait --- how does this work exactly? What is *actually happening*
 when you deploy a `Pod` to a cluster? How does a `Service` go from

--- a/content/docs/reference/service/saml-aad.md
+++ b/content/docs/reference/service/saml-aad.md
@@ -40,9 +40,9 @@ to replace `acmecorp` with whatever your specific Pulumi organization's name is.
 
 | SAML Setting | Value |
 | --------------- | ----- |
-| Identifier (Entity ID) | https://api.pulumi.com/login/**acmecorp**/sso/saml/metadata |
-| Reply URL | https://api.pulumi.com/login/**acmecorp**/sso/saml/acs |
-| Relay State | https://api.pulumi.com/login/**acmecorp**/sso |
+| Identifier (Entity ID) | `https://api.pulumi.com/login/**acmecorp**/sso/saml/metadata` |
+| Reply URL | `https://api.pulumi.com/login/**acmecorp**/sso/saml/acs` |
+| Relay State | `https://api.pulumi.com/login/**acmecorp**/sso` |
 
 
 <p><!-- space between table and image --></p>

--- a/content/docs/reference/service/saml-okta.md
+++ b/content/docs/reference/service/saml-okta.md
@@ -44,9 +44,9 @@ tbody tr td {
 
 | General Setting | Value |
 | --------------- | ----- |
-| Single sign on URL | https://api.pulumi.com/login/robot-co/sso/saml/acs |
-| Audience URI | https://api.pulumi.com/login/robot-co/sso/saml/metadata |
-| Default relay state | https://api.pulumi.com/login/robot-co/sso |
+| Single sign on URL | `https://api.pulumi.com/login/robot-co/sso/saml/acs` |
+| Audience URI | `https://api.pulumi.com/login/robot-co/sso/saml/metadata` |
+| Default relay state | `https://api.pulumi.com/login/robot-co/sso` |
 | Name ID format | EmailAddress or Persistent |
 | App username | Email |
 

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,6 +1,0 @@
-{{- if .Get "src" -}}
-    {{- $img := $.Page.Resources.GetMatch (.Get "src") -}}
-    <img src="{{ $img.RelPermalink }}" {{ with .Get "alt" }}alt="{{ . }}"{{ end }} />
-{{- else -}}
-    {{- errorf "missing value for param 'src': %s" .Position -}}
-{{- end -}}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,0 +1,6 @@
+{{- if .Get "src" -}}
+    {{- $img := $.Page.Resources.GetMatch (.Get "src") -}}
+    <img src="{{ $img.RelPermalink }}" {{ with .Get "alt" }}alt="{{ . }}"{{ end }} />
+{{- else -}}
+    {{- errorf "missing value for param 'src': %s" .Position -}}
+{{- end -}}


### PR DESCRIPTION
I noticed our broken link checker was checking the home page and then would complete without checking the rest of the site.

[For example](https://travis-ci.com/pulumi/docs/jobs/216974740#L338-L365):

```
make test
make[2]: Entering directory '/home/travis/build/pulumi/docs'
# We exclude a few links:
#     - Our generated API docs have lots of broken links
#     - Our changelog includes links to private repos
#     - GitHub Edit Links may be broken, because the page might not yet exist!
#     - Our LinkedIn page, for some reason, returns an HTTP error (despite being valid)
#     - Our Visual Studio Marketplace link for the Azure Pipelines task extension,
#       although valid and publicly available, is reported as a broken link.
# Fixes for the former two are tracked by https://github.com/pulumi/docs/issues/568.
./node_modules/.bin/blc http://localhost:1313 -r \
	--exclude "/docs/reference/pkg" \
	--exclude "/docs/reference/changelog" \
	--exclude "https://github.com/pulumi/docs/edit/master" \
	--exclude "https://www.linkedin.com/" \
	--exclude "https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task" \
	--exclude "https://blog.mapbox.com/" \
	--exclude "https://github.com/pulls?"
Getting links from: http://localhost:1313/
-├───OK─── https://www.learningmachine.com/
/├───OK─── https://www.iopipe.com/
├───OK─── https://app.pulumi.com/
-├───OK─── https://github.com/pulumi
/├───OK─── https://twitter.com/pulumicorp
├───OK─── https://app.pulumi.com/signup
-|├───OK─── https://github.com/pulumi/pulumi
-├───OK─── https://www.youtube.com/channel/UC2Dhyn4Ev52YSbcpfnfP0Mw
\├───OK─── https://github.com/pulumi/
├───OK─── https://slack.pulumi.io/
/-ake[2]: Leaving directory '/home/travis/build/pulumi/docs'
pkill -f hugo
```

It turns out our recent addition of adding a `robots.txt` with `Disallow: *` for non-production builds was preventing the checker from checking links throughout the rest of the site, as the checker honors `robots.txt`. This change passes the `--follow` flag to the checker, to force it to follow robot exclusions.

Fixes #1387