### PR TITLE
Hide "Edit this Page" link for generated pages

### DIFF
--- a/layouts/partials/docs/edit.html
+++ b/layouts/partials/docs/edit.html
@@ -1,16 +1,23 @@
 {{ with .File }}
     <ul class="p-0 list-none">
+        <!-- Only show "Edit this Page" for pages that are not generated. -->
+        {{ $isCLICommand := hasPrefix .Path "docs/reference/cli/" }}
+        {{ $isNodePackage := hasPrefix .Path "docs/reference/pkg/nodejs/pulumi" }}
+        {{ $isPythonPackage := hasPrefix .Path "docs/reference/pkg/python/pulumi" }}
+        {{ if not (or $isCLICommand $isNodePackage $isPythonPackage) }}
+            <li>
+                <a class="text-gray-600 hover:text-blue-700 text-xs" href="{{ $.Site.Params.repositoryURL }}/edit/{{ $.Site.Params.repositoryBranch }}/content/{{ .Path }}" target="_blank">
+                    <i class="fas fa-edit mr-2"></i>
+                    Edit this Page
+                </a>
+            </li>
+        {{ end }}
+
         <li>
-	    <a class="text-gray-600 hover:text-blue-700 text-xs" href="{{ $.Site.Params.repositoryURL }}/edit/{{ $.Site.Params.repositoryBranch }}/content/{{ .Path }}" target="_blank">
-		<i class="fas fa-edit mr-2"></i>
-		Edit this Page
-	    </a>
-	</li>
-        <li>
-	    <a class="text-gray-600 hover:text-blue-700 text-xs" href="{{ $.Site.Params.repositoryURL }}/issues/new?body=File: [{{ .Path }}]({{ $.Page.Permalink }})">
-		<i class="far fa-check-square mr-2"></i>
-	        Request a Change
-	    </a>
-	</li>
+            <a class="text-gray-600 hover:text-blue-700 text-xs" href="{{ $.Site.Params.repositoryURL }}/issues/new?body=File: [{{ .Path }}]({{ $.Page.Permalink }})" target="_blank">
+                <i class="far fa-check-square mr-2"></i>
+                Request a Change
+            </a>
+        </li>
     </ul>
 {{ end }}


### PR DESCRIPTION
We currently invite folks to edit these pages, but they can't be edited like other non-generated content. This change hides the "Edit this Page" link on generated pages. The "Request a Change" link remains visible for all pages.

While making changes here, fixed-up the indentation (looks like tabs were being used instead of our standard 4 spaces) and added `target="_blank"` to the "Request a Change" link.

Fixes #1235