### PR TITLE
Fix Python docs regression

### DIFF
--- a/assets/sass/_api-python.scss
+++ b/assets/sass/_api-python.scss
@@ -22,8 +22,8 @@ div.section[id^="pulumi"] {
     }
 }
 
-// This selector is for the module page and for the Pulumi Python SDK page.
-div[id^="module-"], div[id="pulumi-python-sdk"] {
+// We rely on the Python docs that begin with `<div class="section" id="foo">` to target these styles.
+div.section[id]:not([id=""]) {
     // Don't show the header link - there's an anchorjs link on this header that does the
     // job just as well.
     h1[id$="\B6"],
@@ -50,9 +50,6 @@ div[id^="module-"], div[id="pulumi-python-sdk"] {
     // subchildren:
     dl.class, dl.function, dl.exception {
         > dt {
-            // Top-level definitions get larger text.
-            @apply text-lg;
-
             // Hide the header link when not hovering.
             > a.headerlink {
                 @apply invisible;
@@ -61,7 +58,7 @@ div[id^="module-"], div[id="pulumi-python-sdk"] {
 
         dt {
             // Use the same styling as our `pre` tags for definitions.
-            @apply bg-gray-100 py-4 px-5 rounded border border-gray-200 scrolling-auto overflow-scroll my-4 leading-normal;
+            @apply font-mono bg-gray-100 py-4 px-5 rounded border border-gray-200 scrolling-auto overflow-scroll my-4 leading-normal;
 
             // Remove italics in these definitions.
             em {


### PR DESCRIPTION
I'd made some [improvements](https://github.com/pulumi/docs/pull/1247) to the styling of the Python API docs before the website merge, but it regressed last week when the structure of the docs changed in a way that the CSS selectors no longer applied.

This fixes the selectors for the new structure, and makes some minor other tweaks while making changes here.

(BTW, I still don't think this is "great" but it's definitely an improvement over the regressed version).

Fixes #1396

---

## Before (regression)

<img width="808" alt="Screen Shot 2019-07-18 at 11 27 23 AM" src="https://user-images.githubusercontent.com/710598/61482254-0f8e3800-a94f-11e9-91f1-4389c9292241.png">

## After

<img width="802" alt="Screen Shot 2019-07-18 at 11 27 36 AM" src="https://user-images.githubusercontent.com/710598/61482259-12892880-a94f-11e9-9f04-3a3298cd21b0.png">