### PR TITLE
Fix typo in example

### DIFF
--- a/content/docs/reference/crosswalk/aws/eks.md
+++ b/content/docs/reference/crosswalk/aws/eks.md
@@ -262,7 +262,7 @@ const allVpcSubnets = vpc.privateSubnetIds.concat(vpc.publicSubnetIds);
 const cluster2 = new eks.Cluster("my-cluster", {
     vpcId: vpc.vpcId,
     subnetIds: allVpcSubnets,
-    nodeAssociatedPublicIpAddress: false,
+    nodeAssociatePublicIpAddress: false,
 });
 
 // Export the cluster's kubeconfig.


### PR DESCRIPTION
No 'd' in the param: https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/eks/#ClusterOptions-nodeAssociatePublicIpAddress