### PR TITLE
Update build status in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Pulumi Documentation Site
 
-| Staging | Production |
-|---|---|
-| [![Build Status](https://travis-ci.com/pulumi/docs.svg?token=eHg7Zp5zdDDJfTjY8ejq&branch=master)](https://travis-ci.com/pulumi/docs) | [![Build Status](https://travis-ci.com/pulumi/docs.svg?token=eHg7Zp5zdDDJfTjY8ejq&branch=production)](https://travis-ci.com/pulumi/docs) |
+[![Build Status](https://travis-ci.com/pulumi/docs.svg?token=eHg7Zp5zdDDJfTjY8ejq&branch=master)](https://travis-ci.com/pulumi/docs)
 
 ## Contributing
 


### PR DESCRIPTION
`master` now deploys the production site. I decided to just remove staging as we haven't used it yet, and may soon find we don't need it at all.