### PR TITLE
Only generate an RSS feed for the blog

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -13,6 +13,16 @@ enableRobotsTXT = true
 [outputFormats.RSS]
     baseName = "rss"
 
+# We set the outputs explicitly to just "HTML" as otherwise they default to both
+# "HTML" and "RSS", and we only want to generate RSS for the blog section -- not
+# all sections/taxonomies. We enable RSS as an output for the blog section alone
+# in the front matter of content/blog/_index.md and have a custom RSS template
+# in layouts/blog/rss.xml.
+[outputs]
+    home = ["HTML"]
+    section = ["HTML"]
+    taxonomy = ["HTML"]
+
 [taxonomies]
     author = "authors"
     tag = "tags"

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Blog
+outputs: ["html", "rss"]
 authors: []
 tags: []
 summary: ""


### PR DESCRIPTION
We currently generate RSS feeds for all sections/taxonomies, which means we're generating and publishing a large number of `rss.xml` files. This change makes it so we only generate a single RSS feed for the blog at `/blog/rss.xml`.

Part of #1277