### PR TITLE
Wrap long unbroken strings on mobile

### DIFF
--- a/assets/sass/_api-nodejs.scss
+++ b/assets/sass/_api-nodejs.scss
@@ -48,3 +48,8 @@
         }
     }
 }
+
+.pdoc-module-header,
+.pdoc-module-contents {
+    @apply break-all;
+}

--- a/assets/sass/_api-python.scss
+++ b/assets/sass/_api-python.scss
@@ -113,4 +113,8 @@ div.section[id]:not([id=""]) {
             }
         }
     }
+
+    table td, .pre {
+        @apply break-all;
+    }
 }

--- a/assets/sass/_code.scss
+++ b/assets/sass/_code.scss
@@ -1,7 +1,7 @@
 @import "pygments";
 
 code {
-    @apply bg-gray-100 rounded py-1 px-2 text-sm;
+    @apply bg-gray-100 rounded py-1 px-2 text-sm break-words;
 }
 
 pre {
@@ -25,5 +25,9 @@ pre {
 
     .code-plain.code-mode-dark & {
         @apply text-gray-300;
+    }
+
+    code {
+        @apply break-normal;
     }
 }

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -1,10 +1,6 @@
 table {
     @apply border-separate rounded bg-gray-200;
 
-    thead {
-
-    }
-
     th, td {
         @apply px-4 py-2;
     }

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -76,10 +76,10 @@ body {
 main {
     @apply text-gray-700;
 
-    p, li {
+    p, li, blockquote {
 
         a {
-            @apply text-blue-600;
+            @apply text-blue-600 break-words;
 
             &:hover {
                 @apply text-blue-700;


### PR DESCRIPTION
This change adds CSS that instructs the browser to wrap long, unbroken strings where possible on mobile.

Before:

![](https://cl.ly/cb8eab00a0e7/Screen%252520Recording%2525202019-07-22%252520at%25252012.23%252520PM.gif)

After: 

![](https://cl.ly/df1f53fe9555/Screen%252520Recording%2525202019-07-22%252520at%25252012.24%252520PM.gif)

Part of #1402.

Signed-off-by: Christian Nunciato <c@nunciato.org>