### PR TITLE
Add a note about summary contents

### DIFF
--- a/archetypes/blog-post/index.md
+++ b/archetypes/blog-post/index.md
@@ -36,6 +36,8 @@ What you put here will appear on the index page. In most cases, you'll also want
 
 And then everything _after_ that comment will appear on the post page itself.
 
+Either way, avoid using images or code samples [in the first 70 words](https://gohugo.io/content-management/summaries/#automatic-summary-splitting) of your post, as these may not render properly in summary contexts (e.g., on the blog home page or in social-media previews).
+
 ## Writing the Post
 
 For help assembling the content of your post, see [BLOGGING.md](https://github.com/pulumi/docs/blob/master/BLOGGING.md). For general formatting guidelines, see the Style Guide section of [CONTRIBUTING.md](https://github.com/pulumi/docs/blob/master/CONTRIBUTING.md#style-guide).


### PR DESCRIPTION
This adds a reminder to the blog archetype to refrain from using images or code snippets before the `<!--more-->` comment. 