### PR TITLE
Add breadcrumb to docs pages

### DIFF
--- a/assets/sass/_breadcrumb.scss
+++ b/assets/sass/_breadcrumb.scss
@@ -1,0 +1,20 @@
+ol.breadcrumb {
+    @apply flex flex-wrap py-0 px-0 mt-2 mb-4 list-none;
+
+    li {
+        @apply my-0;
+
+        &.active a {
+            color: inherit;
+        }
+
+        & + li {
+            @apply pl-2;
+
+            &::before {
+                @apply inline-block pr-2;
+                content: "/";
+            }
+        }
+    }
+}

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -7,6 +7,7 @@
 @import "animation";
 @import "api-nodejs";
 @import "api-python";
+@import "breadcrumb";
 @import "buttons";
 @import "code";
 @import "copy-button";

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,9 +1,9 @@
 ---
 title: Pulumi Documentation
+linktitle: Docs
 noindex: true
 menu:
     header:
-        name: Docs
         weight: 4
 ---
 

--- a/content/docs/quickstart/aws/_index.md
+++ b/content/docs/quickstart/aws/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Get Started with AWS
+linktitle: AWS
 weight: 1
 menu:
   quickstart:
     identifier: aws
-    name: AWS
     weight: 2
 ---
 

--- a/content/docs/quickstart/azure/_index.md
+++ b/content/docs/quickstart/azure/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Get Started with Azure
+linktitle: Azure
 weight: 1
 menu:
   quickstart:
     identifier: azure
-    name: Azure
     weight: 2
 ---
 

--- a/content/docs/quickstart/gcp/_index.md
+++ b/content/docs/quickstart/gcp/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Get Started with Google Cloud
+linktitle: Google Cloud
 weight: 1
 menu:
   quickstart:
     identifier: gcp
-    name: Google Cloud
     weight: 2
 ---
 

--- a/content/docs/quickstart/kubernetes/_index.md
+++ b/content/docs/quickstart/kubernetes/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Get Started with Kubernetes
+linktitle: Kubernetes
 weight: 1
 menu:
   quickstart:
     identifier: kubernetes
-    name: Kubernetes
     weight: 2
 ---
 

--- a/content/docs/reference/pkg/nodejs/_index.md
+++ b/content/docs/reference/pkg/nodejs/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Node.js Packages
+linktitle: Node.js
 menu:
   reference:
     parent: api
     identifier: node
-    name: Node.js
 ---
 
 ### General Purpose Packages

--- a/content/docs/reference/pkg/nodejs/pulumi/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/_index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/reference/pkg/nodejs/
+---

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -17,6 +17,8 @@
             </div>
 
             <div class="md:w-7/12">
+                {{ partial "docs/breadcrumb.html" . }}
+
                 {{ if ne .Title "" }}
                     <h1>{{ .Title }}</h1>
                 {{ end }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -17,7 +17,12 @@
             </div>
 
             <div class="md:w-7/12">
-                <h1>{{ .Title }}</h1>
+                {{ partial "docs/breadcrumb.html" . }}
+
+                {{ if ne .Title "" }}
+                    <h1>{{ .Title }}</h1>
+                {{ end }}
+
                 {{ .Content }}
             </div>
         </div>

--- a/layouts/partials/docs/breadcrumb.html
+++ b/layouts/partials/docs/breadcrumb.html
@@ -1,0 +1,19 @@
+<!-- Based on https://gohugo.io/content-management/sections/#example-breadcrumb-navigation -->
+
+<!-- Don't show the breadcrumb on the main docs landing page. -->
+{{ if ne .RelPermalink "/docs/" }}
+    <ol class="breadcrumb">
+        {{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
+    </ol>
+{{ end }}
+
+{{ define "breadcrumbnav" }}
+    <!-- Don't include the website home page in the breadcrumb. -->
+    {{ if and .p1.Parent (ne .p1.Parent .p1.Site.Home) }}
+        {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2) }}
+    {{ end }}
+    <!-- If the page is a redirect page, don't include it in the breadcrumb. -->
+    {{ if not (isset .p1.Params "redirect_to") }}
+        <li {{ if eq .p1 .p2 }}class="active"{{ end }}><a href="{{ .p1.Permalink }}">{{ .p1.LinkTitle }}</a></li>
+    {{ end }}
+{{ end }}


### PR DESCRIPTION
Draft as this is still a work-in-progress and not ready for review. FYI, @bermudezmt.

Initial breadcrumb for second level nav inside the docs section of the site. Still needs some style/design work.

![breadcrumb](https://user-images.githubusercontent.com/710598/61734009-e5b18880-ad35-11e9-8742-293d56f510dc.gif)

---

As part of cleaning up the TOC, we should consider getting rid of the top-level "Docs" link in the left nav, as it'd be redundant with the breadcrumbs:

<img width="855" alt="Screen Shot 2019-07-23 at 10 25 03 AM" src="https://user-images.githubusercontent.com/710598/61734069-05e14780-ad36-11e9-85b0-9881ea6358c9.png">

---

Will need to fix-up the code-gen of the API docs to have `linktitle` front matter that provides a shorter title for the breadcrumb, e.g. the breadcrumb item should probably be the shorter `@pulumi/pulumi` rather than `Package @pulumi/pulumi`:

<img width="647" alt="Screen Shot 2019-07-23 at 10 26 02 AM" src="https://user-images.githubusercontent.com/710598/61734075-0843a180-ad36-11e9-9546-b6e8bbbb8479.png">

---

The breadcrumb is based on the directory structure of the files on disk in `content/docs`... Currently, there are some places where the hierarchy of the pages on disk doesn't match our "fabricated" TOC hierarchy, which makes the breadcrumbs confusing in those areas.

Examples:

  - Many of the pages under `Teams & Collaboration` TOC live on disk under `content/docs/reference/service`, but some pages listed there in the TOC aren't, like `Pulumi GitHub App` which actually lives at `content/docs/reference/cd-github.md`.

  <img width="756" alt="Screen Shot 2019-07-23 at 10 27 07 AM" src="https://user-images.githubusercontent.com/710598/61734081-0aa5fb80-ad36-11e9-9809-e7b0133960b2.png">

  - The pages under the `Continuous Delivery` are all just in `content/docs/reference/*` instead of being in something like `content/docs/reference/cd/*`.
  - The `Command Line` TOC page is at  `content/docs/reference/commands.md` but the actual commands are under `content/docs/reference/cli/*`.

We should fix-up the on-disk structure as part of reorganizing the TOC in #831, which will make the breadcrumbs make more sense.

Part of #831