### PR TITLE
Remove uppercasing from H6 headings

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -56,7 +56,7 @@ h5 {
 }
 
 h6 {
-    @apply text-sm uppercase;
+    @apply text-sm;
 }
 
 p {

--- a/content/legal/privacy.md
+++ b/content/legal/privacy.md
@@ -11,11 +11,11 @@ menu:
 <p>Please read this Privacy Statement carefully to learn how we collect, use, share and otherwise process information relating to individuals ("Personal Data"), and your rights and choices regarding our processing of your Personal Data.</p>
 <p>If you have questions or complaints regarding Pulumi's Privacy Statement or associated practices, please contact us at <a href="mailto:privacy@pulumi.com">privacy@pulumi.com</a>.</p>
 <br />
-<h2 class="h4">1. Processing activities covered</h2>
+<h2>1. Processing activities covered</h2>
 <p>This Privacy Statement applies to the following processing activities:
 </p>
 <br />
-<ul class="list-indent">
+<ul>
 	<li>Visiting our websites which display or link through to this Privacy Statement;</li>
 	<li>Visiting our offices;</li>
 	<li>Receiving communications from us, including emails, texts or fax;</li>
@@ -25,15 +25,15 @@ menu:
 <br />
 <p>Our websites may contain links to other websites, applications and services maintained by third parties. The information practices of such other services are governed by the third-party privacy statements, which we encourage you to review to better understand those third parties’ privacy practices.</p>
 <br />
-<h2 class="h4">2. Responsible Pulumi entity</h2>
+<h2>2. Responsible Pulumi entity</h2>
 <p>Pulumi is the controller of your Personal Data and responsible for the collection, processing and disclosure of your Personal Data as described in this Privacy Statement, unless expressly specified otherwise.</p>
 
 <p>This Privacy Statement does not apply to the extent we offer our customers various cloud products and services through which our customers may create their own websites and applications running on our platforms, sell or offer their own products and services, send electronic communications to other individuals, and collect and analyze Personal Data from individuals.</p>
 <br />
-<h2 class="h4">3. What Personal Data do we collect?</h2>
-<h3 class="h6">3.1 Personal Data we collect directly from you</h3>
+<h2>3. What Personal Data do we collect?</h2>
+<h3>3.1 Personal Data we collect directly from you</h3>
 <p>The Personal Data that we collect directly from you may include the following:</p>
-<ul class="list-indent">
+<ul>
 	<li>if you express an interest in obtaining additional information about our services, request customer support, use our "Contact Us" or similar features, register to use our websites, sign up for an event or webinar, or download certain content, we generally require you to provide us with your contact information, such as your name, job title, company name, address, phone number, email address, or username and password;</li>
 	<li>if you makes purchases via our websites or register for an event, we may also require you to provide us with financial information and billing information, such as billing name and address, credit card number, or bank account information;</li>
 	<li>if you attend an event, we may, upon your consent, scan your attendee badge which will provide us with your name, title and company name, address, country, phone number and email address;</li>
@@ -42,21 +42,21 @@ menu:
 	<li>if you visit our offices, you may be required to register as a visitor and to provide your name, email address, phone number, company name and time and date of arrival.</li>
 </ul>
 <br />
-<h3 class="h6">3.2 Personal Data we collect from other sources</h3>
+<h3>3.2 Personal Data we collect from other sources</h3>
 <p>We may also collect information about you from other sources, including third parties from whom we have purchased Personal Data, and combine this information with Personal Data provided by you. This helps us to update, expand and analyze our records, identify new customers, and create more tailored advertising to provide services that may be of interest to you. In particular, we collect Personal Data from the following sources:</p>
 <br />
-<ul class="list-indent">
+<ul>
 	<li>Business contact information, including mailing address, job title, email address,  phone number, ‘intent data’ which is web user behavior data, IP addresses, social handles, LinkedIn URL and custom profiles from third party data providers for the purposes of targeted advertising, delivering relevant email content, event promotion and profiling;</li>
 	<li>Pulumi uses platforms such as GitHub to manage code check-ins and pull requests. If you participate in an open source or community development project, we may associate your code repository username with your community account so that we can inform you of program changes that are important to your participation or additional security requirements.</li>
 </ul>
 <br />
-<h2 class="h4">4. What device and usage data we process</h2>
+<h2>4. What device and usage data we process</h2>
 <p>We use common information-gathering tools, such as log files, cookies, web beacons and similar technologies to automatically collect information, which may contain Personal Data, from your computer or mobile device as you navigate our websites or interact with emails we have sent you.</p>
 <br />
-<h3 class="h6">4.1 Log Files</h3>
+<h3>4.1 Log Files</h3>
 <p>As is true of most websites, we gather certain information automatically via log files. This collected information may include your Internet Protocol (IP) address (or proxy server), device and application identification numbers, your location, your browser type, your Internet service provider and/or mobile carrier, the pages and files you viewed, your searches, your operating system and system configuration information, and date/time stamps associated with your usage. This information is used to analyze overall trends, to help us provide and improve our websites and to guarantee their security and continued proper functioning. We also collect IP addresses from users when they log into the services as part of the Company’s security features.</p>
 <br />
-<h3 class="h6">4.2 Cookies, web beacons and other tracking technologies</h3>
+<h3>4.2 Cookies, web beacons and other tracking technologies</h3>
 <p>We use cookies and similar technologies such as web beacons, tags and JavaScript alone or in conjunction with cookies to compile information about usage of our websites and interaction with emails from us.</p>
 
 <p>When you visit our websites, our servers or an authorized third party may place a cookie on your browser, which can collect information, including Personal Data, about your online activities over time and across different sites. Cookies allow us to track overall usage, determine areas that you prefer, make your usage easier by recognizing you and providing you with a customized experience.
@@ -67,8 +67,8 @@ menu:
 <br />
 <p>The following sets out how we use different categories of cookies and similar technologies, as well as information on your options for managing the settings for the data collection by these technologies:</p>
 <br />
-<table class="rwd-table">
-	<thead class="table-col-headers">
+<table>
+	<thead>
 		<tr>
 			<th>Type of Cookies</th>
 			<th>Description</th>
@@ -129,29 +129,29 @@ menu:
 <p>All cookies placed by Pulumi and listed above expire after 12 months.
 </p>
 <br />
-<h3 class="h6">4.3 Notices on behavioral advertising and opt-out</h3>
+<h3>4.3 Notices on behavioral advertising and opt-out</h3>
 <p>As described above, we or third parties may place or recognize a unique cookie on your browser when you visit our websites for the purposes of serving you targeted advertising (also referred to as “online behavioral advertising” or “interest-based advertising”). To learn more about targeted advertising, advertising networks and your ability to opt out of collection by certain third parties, please visit the opt-out pages of the Network Advertising Initiative, <a target="_blank" href="http://optout.networkadvertising.org/?c=1">here</a>, and the Digital Advertising Alliance, <a target="_blank" href="http://optout.aboutads.info/?c=2">here</a>.</p>
 
 <p>To manage the use of targeting or advertising cookies on this website, consult your individual browser settings for cookies. To learn how to manage privacy and storage settings for Flash cookies <a href="https://www.macromedia.com/support/documentation/en/flashplayer/help/settings_manager.html#117118" target="_blank">click here</a>. Various browsers may offer their own management tools for removing HTML5 local storage.</p>
 <br />
-<h3 class="h6">4.4 Opt-Out from the collection of device and usage data</h3>
+<h3>4.4 Opt-Out from the collection of device and usage data</h3>
 <p>You may opt-out from the collection of device and usage data (see "What device and usage data we process" section above) by managing your cookies at the individual browser level. In addition, if you wish to opt-out of interest-based advertising <a target="_blank" href="http://preferences-mgr.truste.com/">click here</a>, or if located in the European Union <a target="_blank" href="http://www.youronlinechoices.eu/">click here</a>). Please note, however, that by blocking or deleting cookies and similar technologies used on our websites, you may not be able to take full advantage of the website.</p>
 
 <p>While some internet browsers offer a “do not track” or “DNT” option that lets you tell websites that you do not want to have your online activities tracked, these features are not yet uniform and there is no common standard that has been adopted by industry groups, technology companies or regulators. Therefore, we do not currently commit to responding to browsers' DNT signals with respect to our websites. Pulumi takes privacy and meaningful choice seriously and will make efforts to continue to monitor developments around DNT browser technology and the implementation of a standard.</p>
 <br />
-<h3 class="h6">4.5 Social Media Features</h3>
+<h3>4.5 Social Media Features</h3>
 <p>Our websites may use social media features, such as the Facebook “like” button, the “Tweet” button and other sharing widgets (“Social Media Features”). You may be given the option by such Social Media Features to post information about your activities on a website to a profile page of yours that is provided by a third party social media network in order to share with others within your network. Social Media Features are either hosted by the respective social media network or hosted directly on our website. To the extent the Social Media Features are hosted by the respective social media networks, the latter may receive information that you have visited our website from your IP address. If you are logged into your social media account, it is possible that the respective social media network can link your visit of our websites with your social media profile.</p>
 
 <p>Pulumi also allows you to log in to certain of our websites using sign-in services such as Sign in with GitHub. These services will authenticate your identity and provide you the option to share certain Personal Data with us such as your name and email address to pre-populate our sign-up form.</p>
 
 <p>Your interactions with Social Media Features are governed by the privacy policies of the companies providing the relevant Social Media Features.</p>
 <br />
-<h3 class="h6">4.6 Telephony log information</h3>
+<h3>4.6 Telephony log information</h3>
 <p>If you use certain service features, we may also collect telephony log information (like phone numbers, time and date of calls, duration of calls, SMS routing information and types of calls), device event information (such as crashes, system activity, hardware settings, browser language), and location information (through IP address, GPS, and other sensors that may, for example, provide us with information on nearby devices, Wi-Fi access points and cell towers).</p>
 <br />
-<h2 class="h4">5. Purposes for which we process Personal Data and the legal basis on which we rely</h2>
+<h2>5. Purposes for which we process Personal Data and the legal basis on which we rely</h2>
 <p>We collect, process your Personal Data for the purposes and on the legal bases identified in the following:</p>
-<ul class="list-indent">
+<ul>
 	<li>Providing our websites: We will process your Personal Data to the extent this is necessary for the performance of our contract with you for the use of our websites and to fulfill our obligations under the applicable terms of use/service; where we have not entered into a contract with you, we base the processing of your Personal Data on our legitimate interest to operate and administer our websites and to provide you with content you access and request (e.g., download of certain content from our websites);</li>
 	<li>Promoting security of our websites: We will process your Personal Data by tracking use of our websites, creating aggregated, non-personal data, verifying accounts and activity, investigating suspicious activity, as well as violations of and enforcement of our terms and policies, to the extent this is necessary for the purpose of our legitimate interests in promoting the safety and security of the systems and application used for our websites, and protecting our rights and the rights of others;</li>
 	<li>Managing user registrations: We will process your Personal Data by managing your user account for the purpose of performing the contract with you according to any applicable terms of service;</li>
@@ -166,9 +166,9 @@ menu:
 </ul>
 <p>Where we need to collect and process Personal Data by law, or under a contract we have entered into with you and you fail to provide that required Personal Data when requested, we may not be able to perform the contract. </p>
 <br />
-<h2 class="h4">6. Who do we share Personal Data with?</h2>
+<h2>6. Who do we share Personal Data with?</h2>
 <p>We may share your Personal Data with the following recipients:</p>
-<ul class="list-indent">
+<ul>
 	<li>Our contracted service providers which provide services such as IT and system administration and hosting, credit card processing, research and analytics, marketing, customer support and data enrichment;</li>
 	<li>If you use our websites to register for an event or webinar organized by a one of our affiliates, we may share your Personal Data with the affiliate to the extent this is required on the basis of the contract with you to process your registration and ensure your participation in the event; in such case, our affiliate will process the relevant Personal Data as a separate controller and will provide you with further information on the processing of your Personal Data, where required;</li>
 	<li>If you attend an event or webinar organized by us, we may share your information with sponsors of the event if: (1) you consent to such sharing via an event registration form; or (2) you allow your attendee badge to be scanned at a sponsor booth. In that event, your information will be subject to the business partners’ respective privacy statements. If you do not wish for your information to be shared, you may choose not to opt-in via event registration or elect not to have your badge scanned at our events;</li>
@@ -178,23 +178,23 @@ menu:
 	<li>Any Personal Data or other information you choose to submit in communities, forums, blogs, or chat rooms on our websites may be read, collected, and/or used by others who visit these forums, depending on your account settings.</li>
 </ul>
 <br />
-<h2 class="h4">7. International transfer of information collected</h2>
+<h2>7. International transfer of information collected</h2>
 <p>Your Personal Data may be collected, transferred to and stored by us in the United States and by our affiliates in other countries where we operate.</p>
 
 <p>Therefore, your Personal Data may be processed outside the EEA, and in countries which are not subject to an adequacy decision by the European Commission and which may not provide for the same level of data protection in the EEA. In this event, we will ensure that such recipient offers an adequate level of protection, for instance by entering into standard contractual clauses for the transfer of data as approved by the European Commission (Art. 46 GDPR), or we will ask you for your prior consent to such international data transfers.</p>
 <br />
-<h2 class="h4">8. Children</h2>
+<h2>8. Children</h2>
 <p>Our websites are not directed at children. We do not knowingly collect Personal Data from children under the age of 16. If you are a parent or guardian and believe your child has provided us with Personal Data without your consent, please contact us as described in the “Contacting Us” section below and we will take steps to delete such Personal Data from our systems.</p>
 <br />
-<h2 class="h4">9. How long do we keep your Personal Data?</h2>
+<h2>9. How long do we keep your Personal Data?</h2>
 <p>We may retain your Personal Data for a period of time consistent with the original purpose of collection (see "Purposes for which we process Personal Data and on what legal basis" section above). We determine the appropriate retention period for Personal Data on the basis of the amount, nature, and sensitivity of your Personal Data, the potential risk of harm from unauthorized use or disclosure, and whether we can achieve the purposes of the processing through other means, as well as the applicable legal requirements (such as applicable statutes of limitation).</p>
 
 <p>After expiry of the retention periods, your Personal Data will be deleted. If there is any information that we are unable, for technical reasons, to delete entirely from our systems, we will put in place appropriate measures to prevent any further use of the data.</p>
 <br />
-<h2 class="h4">10. Your rights relating to your Personal Data</h2>
-<h3 class="h6">10.1 Your rights</h3>
+<h2>10. Your rights relating to your Personal Data</h2>
+<h3>10.1 Your rights</h3>
 <p>You have certain rights regarding your Personal Data, subject to local data protection laws. These may include the following rights:</p>
-<ul class="list-indent">
+<ul>
 	<li>to access your Personal Data held by us (right to access);</li>
 	<li>to rectify inaccurate Personal Data and ensure it is complete (right to rectification);</li>
 	<li>to erase/delete your Personal Data to the extent permitted by other legal obligations (right to erasure; right to be forgotten);</li>
@@ -205,26 +205,26 @@ menu:
 	<li>to the extent we base the collection, processing and sharing of your Personal Data on your consent, to withdraw your consent at any time, without affecting the lawfulness of the processing based on such consent before its withdrawal.</li>
 </ul>
 <br />
-<h3 class="h6">10.2 How to exercise your rights</h3>
+<h3>10.2 How to exercise your rights</h3>
 <p>To exercise your rights, please contact us in accordance with the “Contacting Us” section below. We try to respond to all legitimate requests within one month and will contact you if we need additional information from you in order to honor your request. Occasionally it may take us longer than a month, taking into account the complexity and number of requests we receive.</p>
 <p>In addition, if you have registered for an account with us, you may generally update your user settings, profile, organization’s settings or event registration by logging into the applicable website with your username and password and editing your settings or profile. To update your billing information, discontinue your account, and/or request return or deletion of your Personal Data and other information associated with your account, please contact us.</p>
 <br />
-<h3 class="h6">10.3 Your rights relating to Customer Data</h3>
+<h3>10.3 Your rights relating to Customer Data</h3>
 <p>As described above, we may also process Personal Data in the role of a processor (see "Responsible Pulumi entity" section above). If your data has been submitted to us by a Pulumi customer and you wish to exercise any rights you may have under applicable data protection laws, please inquire with our customer directly. Because we may only access our customer’s data upon instruction from the respective customer, if you wish to make your request directly to us, please provide the name of the Pulumi customer who submitted your data when you contact us. We will refer your request to that customer, and will support them as needed in responding to your request within a reasonable timeframe.</p>
 <br />
-<h3 class="h6">10.4 Your preferences for marketing communications</h3>
+<h3>10.4 Your preferences for marketing communications</h3>
 <p>If we process your Personal Data for the purpose of sending you marketing communications, you may manage your receipt of marketing and non-transactional communications from us by clicking on the “unsubscribe” link located on the bottom of our marketing emails, by replying or texting ‘STOP’ if you receive SMS communications, or by turning off push notifications on our apps on your device. Additionally, you may unsubscribe by contacting us using the information in the “Contacting Us" section below. Please note that opting-out of marketing communications does not opt you out of receiving important business communications related to your current relationship with us, such as information about your subscriptions or event registrations, service announcements or security information.</p>
 <br />
-<h2 class="h4">11. Security</h2>
+<h2>11. Security</h2>
 <p>We take precautions including organizational, technical, and physical measures, to help safeguard against accidental or unlawful destruction, loss, alteration, unauthorized disclosure of, or access to, the Personal Data we process or use.</p>
 <p>While we follow generally accepted standards to protect Personal Data, no method of storage or transmission is 100% secure. You are solely responsible for protecting your password, limiting access to your devices, and signing out of websites after your sessions. If you have any questions about the security of our websites, please contact us via the “Contacting Us” section
 below.</p>
 <br />
-<h2 class="h4">12. Changes to this Privacy Statement</h2>
+<h2>12. Changes to this Privacy Statement</h2>
 <p>We will update this Privacy Statement from time to time to reflect changes in our practices, technology, legal requirements and other factors. If we do, we will update the “effective date” at the top of this Privacy Statement. If we make an update, we may provide you with notice prior to the update taking effect, such as by posting a conspicuous notice on our website or by contacting you using the email address you provided.</p>
 <p>We encourage you to periodically review this Privacy Statement to stay informed about our collection, processing and sharing of your Personal Data.</p>
 <br />
-<h2 class="h4">13. Contacting us</h2>
+<h2>13. Contacting us</h2>
 <p>To exercise your rights regarding your Personal Data, or if you have questions regarding this Privacy Statement or our privacy practices please fill mail us at:</p>
 <br />
 <p>Pulumi Privacy Officer

--- a/layouts/partials/learning-machine.html
+++ b/layouts/partials/learning-machine.html
@@ -1,6 +1,6 @@
 <section id="case-study" class="py-16 px-4">
     <div class="container mx-auto max-w-5xl">
-        <h6 class="text-gray-500">Featured Customer</h6>
+        <h6 class="text-gray-500 uppercase">Featured Customer</h6>
         <h2 class="mt-0">Learning Machine</h2>
         <p>
             <a href="https://www.learningmachine.com/" target="_blank">Learning

--- a/layouts/webinar/webinar.html
+++ b/layouts/webinar/webinar.html
@@ -59,7 +59,7 @@
                     <p class="text-gray-600">
                         {{ .description }}
                     </p>
-                    <h6>Presenters</h6>
+                    <h6 class="uppercase">Presenters</h6>
                     <ul class="list-none p-0">
                         {{ range .presenters }}
                             <li class="mb-4">
@@ -68,7 +68,7 @@
                             </li>
                         {{ end }}
                     </ul>
-                    <h6>Who Should Attend</h6>
+                    <h6 class="uppercase">Who Should Attend</h6>
                     <div class="text-gray-600 text-sm">
                         {{ delimit .audience ", " }}
                     </div>
@@ -84,7 +84,7 @@
                     <img src="/icons/case_study.svg">
                 </div>
                 <div>
-                    <h6 class="text-gray-600">Study</h6>
+                    <h6 class="text-gray-600 uppercase">Study</h6>
                     <div class="text-xl">How Learning Machine Improved Time to Ship</div>
                     <p class="text-gray-600">
                         Pulumi helped Learning Machine delivered a more agile, streamlined
@@ -101,7 +101,7 @@
                     <img src="/icons/ebook.svg">
                 </div>
                 <div>
-                    <h6 class="text-gray-600">Ebook</h6>
+                    <h6 class="text-gray-600 uppercase">Ebook</h6>
                     <div class="text-xl">Implementing Cloud Native Infrastructure for your Organization</div>
                     <p class="text-gray-600">
                         Learn how Pulumi's cloud native development platform provides a


### PR DESCRIPTION
This change removes the `uppercase` text transformation currently applied to `h6` elements, and applies it instead to the instances that call for it.

Also removes unused class references (brought over from the previous version of the site) from the privacy policy.

Part of #1277.

![](https://cl.ly/61ef3857957e/Screen%252520Recording%2525202019-07-24%252520at%25252002.23%252520PM.gif)