### PR TITLE
Make header selection state more noticeable

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -35,7 +35,7 @@
                 {{ range $.Site.Menus.header }}
                     <li class="whitespace-no-wrap">
                         {{ $active := hasPrefix $.RelPermalink .URL }}
-                        <a href="{{ .URL }}" data-submenu="{{ .Identifier }}" class="block py-2 px-4 md:px-0 md:py-0 md:px-4 md:py-2 my-2 md:my-0 lg:mx-4 border hover:border-purple-500 hover:bg-purple-600 rounded {{ if $active }}border-purple-500 bg-purple-600{{ else }}border-purple-700{{ end }}">
+                        <a href="{{ .URL }}" data-submenu="{{ .Identifier }}" class="block py-2 px-4 md:px-0 md:py-0 md:px-4 md:py-2 my-2 md:my-0 lg:mx-4 rounded {{ if $active }}bg-purple-400 hover:bg-purple-400{{ else }}hover:bg-purple-500{{ end }}">
                             {{ .Name }}
                         </a>
                     </li>


### PR DESCRIPTION
This change attempts to make the selected item in our main navigation a bit more obvious by using a lighter tint from the purple palette (one a step lighter than than the background of hero sections), and removing the border, as it looks out of place (IMO) with the lighter colors and the dark background.

Closes #1277.

![](https://cl.ly/01c1a72adbcb/Screen%252520Recording%2525202019-07-24%252520at%25252003.00%252520PM.gif)