### PR TITLE
Emit `{ }` instead of `__type` for empty type literals

### DIFF
--- a/content/docs/reference/pkg/nodejs/pulumi/aws/s3/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/aws/s3/_index.md
@@ -2032,7 +2032,7 @@ The S3 bucket configuration where inventory results are published (documented be
             sseKms: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | {
                 keyId: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;
             };
-            sseS3: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | __type;
+            sseS3: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | { };
         };
         format: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;
         prefix: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;
@@ -4594,7 +4594,7 @@ The S3 bucket configuration where inventory results are published (documented be
             sseKms: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;{
                 keyId: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;
             }&gt;;
-            sseS3: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;__type&gt;;
+            sseS3: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;{ }&gt;;
         }&gt;;
         format: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;
         prefix: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;
@@ -4709,7 +4709,7 @@ The S3 bucket configuration where inventory results are published (documented be
             sseKms: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;{
                 keyId: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;
             }&gt;;
-            sseS3: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;__type&gt;;
+            sseS3: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;{ }&gt;;
         }&gt;;
         format: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;
         prefix: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;

--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -186,7 +186,7 @@ var gitHubBaseURLs = map[string]string{
 	"@pulumi/packet":       "https://github.com/pulumi/pulumi-packet/blob/{githash}/sdk/nodejs",
 	"@pulumi/random":       "https://github.com/pulumi/pulumi-random/blob/{githash}/sdk/nodejs",
 	"@pulumi/terraform":    "https://github.com/pulumi/pulumi-terraform/blob/{githash}/sdk/nodejs",
-	"@pulumi/tls":    		"https://github.com/pulumi/pulumi-tls/blob/{githash}/sdk/nodejs",
+	"@pulumi/tls":          "https://github.com/pulumi/pulumi-tls/blob/{githash}/sdk/nodejs",
 	"@pulumi/vsphere":      "https://github.com/pulumi/pulumi-vsphere/blob/{githash}/sdk/nodejs",
 }
 
@@ -984,6 +984,11 @@ func createTypeLabel(t *typeDocType, indent int) string {
 			label += fmt.Sprintf("<a href='%s'>%s</a>", hyperlink, t.Name)
 		} else {
 			label += t.Name
+		}
+
+		// If it's a reference type named `__type`, it's an empty type literal.
+		if t.Type == typeDocReferenceType && label == "__type" {
+			label = "{ }"
 		}
 
 		if t.Type == typeDocIntrinsicType {


### PR DESCRIPTION
If we have a reference type named `__type`, it's an empty type literal that should be emitted as `{ }`.

Fixes #1429