### PR TITLE
Update links to slack.pulumi.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Docs for additional packages can be added by updating `./scripts/run_typedoc.sh`
 
 ## Deploying updates
 
-When changes are merged into `master` our staging website (https://staging.pulumi.io/) is automatically deployed. You can use the [Travis UI](https://travis-ci.com/pulumi/docs) to check on the status of the deployment. Once it has been deployed, browse around the staging website and ensure the changes you expected were made and render correctly. Then, open a Pull Request to merge `master` into `production`.
+When changes are merged into `master`, https://www.pulumi.com/ is automatically deployed. You can use the [Travis UI](https://travis-ci.com/pulumi/docs) to check on the status of the deployment.
 
 ## Design Reference
 

--- a/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
+++ b/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
@@ -273,8 +273,7 @@ documentation]({{< ref "/docs/reference/cd-github" >}}).
 We're excited about all the new features in this release and the new
 scenarios they enable for the Pulumi community . If you are new to
 Pulumi, [download the tools and get started
-today]({{< ref "/docs/quickstart" >}}), or [join us in
-Slack](https://slack.pulumi.io). A big thanks to all the users and
+today]({{< ref "/docs/quickstart" >}}), or [join us in Slack](https://slack.pulumi.com). A big thanks to all the users and
 contributors who have helped shape this release -- we can't wait to see
 what you build next !
 

--- a/content/blog/announcing-support-for-email-based-identities/index.md
+++ b/content/blog/announcing-support-for-email-based-identities/index.md
@@ -36,5 +36,5 @@ Haven't setup your CLI for a specific cloud yet? Check out this docs page on how
 
 Once you've deployed your first stack, the next step is up to you. You can refer to our documentation on integrating Pulumi into your CI/CD pipeline, setting up chat-ops workflows via Webhooks, or taking your Kubernetes solutions to the next level!
 
-We'd love to hear what you're up to. Say 👋 in the [Pulumi Community Slack](https://slack.pulumi.io/)
+We'd love to hear what you're up to. Say 👋 in the [Pulumi Community Slack](https://slack.pulumi.com/)
 or [drop us a line]({{< ref "/contact" >}}).

--- a/content/blog/building-a-future-of-cloud-engineering/index.md
+++ b/content/blog/building-a-future-of-cloud-engineering/index.md
@@ -29,7 +29,7 @@ orchestrators, managed data and AI services, and serverless
 capabilities.
 
 The best part of this journey has been hearing from our [passionate
-community](https://slack.pulumi.io/). Thousands of engineers, and
+community](https://slack.pulumi.com/). Thousands of engineers, and
 hundreds of companies, have created and deployed cloud applications and
 infrastructure using Pulumi. We are proud to be [an open source
 company](https://github.com/pulumi/pulumi), and thrive on the daily

--- a/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
+++ b/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
@@ -78,7 +78,7 @@ the stack code meaning you can build your own templates and share them.
 
 We hope you like these helpers. If you're keen to get stuck in:
 
-- [Join the Slack conversation](https://slack.pulumi.io) - it's
+- [Join the Slack conversation](https://slack.pulumi.com) - it's
   heating up in there.
 - Try out the [many examples we have](https://app.pulumi.com), and
   [dive into the docs]({{< ref "/docs/reference" >}}).

--- a/content/blog/building-your-first-serverless-app-using-only-javascript/index.md
+++ b/content/blog/building-your-first-serverless-app-using-only-javascript/index.md
@@ -135,7 +135,7 @@ To learn more take a look at more tutorials and example code:
 - Tutorial: [Deploying Containers with Pulumi]({{< relref "deploying-production-ready-containers-with-pulumi" >}})
 - Tutorial: [Build a video thumbnailer using AWS Lambda, Fargate, and S3 in JavaScript]({{< relref "build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws" >}})
 - [Pulumi Quickstart]({{< ref "/docs/quickstart" >}})
-- [Pulumi Community Slack](https://slack.pulumi.io)
+- [Pulumi Community Slack](https://slack.pulumi.com)
 - [Pulumi Examples on GitHub](https://github.com/pulumi/examples)
 
  

--- a/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
+++ b/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
@@ -81,7 +81,7 @@ Once you've configured your Pulumi task extensions for your Azure Pipelines, you
 easily integrate Pulumi into your CI/CD pipeline, and take advantage of previews to infrastructure
 changes in pull requests, push-to-deploy, and ultimately removing the friction for your DevOps. 
 
-As always, we'd love to hear what you think. Say 👋 in the [Pulumi Community Slack](https://slack.pulumi.io)
+As always, we'd love to hear what you think. Say 👋 in the [Pulumi Community Slack](https://slack.pulumi.com)
 or [drop us a line]({{< ref "/contact" >}}).
 
 Want to learn more? Check out [this post from Mikhail Shilkov]({{< relref "level-up-your-azure-platform-as-a-service-applications-with-pulumi" >}})

--- a/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
+++ b/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
@@ -236,4 +236,4 @@ applications and infrastructure needs.
 
 If you've created a Pulumi component that is useful or want some design
 advice, come and join us in the [Pulumi Community
-Slack](https://slack.pulumi.io/) -- we'd love to hear from you!
+Slack](https://slack.pulumi.com/) -- we'd love to hear from you!

--- a/content/blog/day-2-kubernetes-migrating-eks-nodegroups-with-zero-downtime/index.md
+++ b/content/blog/day-2-kubernetes-migrating-eks-nodegroups-with-zero-downtime/index.md
@@ -158,7 +158,7 @@ As always, you can check out our code on
 [GitHub](https://github.com/pulumi), follow us on
 [Twitter](https://twitter.com/pulumicorp), subscribe to our [YouTube
 channel](https://www.youtube.com/channel/UC2Dhyn4Ev52YSbcpfnfP0Mw), or
-join our [Community Slack](https://slack.pulumi.io/) channel if you have
+join our [Community Slack](https://slack.pulumi.com/) channel if you have
 any questions, need support, or just want to say hello.
 
 If you'd like to chat with our team, or get hands-on assistance with

--- a/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
+++ b/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
@@ -157,5 +157,5 @@ we'll quickly be expanding coverage in the coming weeks.
 Get started with Pulumi Webhooks on the [Pulumi app](https://app.pulumi.com), and let us know how you're using them so
 we can continue to extend their capabilities. We'd love to hear your
 ideas, as well as any feedback you have on the
-[Pulumi Community Slack](https://slack.pulumi.io).
+[Pulumi Community Slack](https://slack.pulumi.com).
 

--- a/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
+++ b/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
@@ -156,7 +156,7 @@ As always, you can check out our code on
 [GitHub](https://github.com/pulumi), follow us on
 [Twitter](https://twitter.com/pulumicorp), subscribe to our [YouTube
 channel](https://www.youtube.com/channel/UC2Dhyn4Ev52YSbcpfnfP0Mw), or
-join our [Community Slack](https://slack.pulumi.io/) channel if you have
+join our [Community Slack](https://slack.pulumi.com/) channel if you have
 any questions, need support, or just want to say hello.
 
 If you'd like to chat with our team, or get hands-on assistance with

--- a/content/blog/improving-kubernetes-management-with-pulumis-await-logic/index.md
+++ b/content/blog/improving-kubernetes-management-with-pulumis-await-logic/index.md
@@ -130,7 +130,7 @@ As always, you can check out our code
 on [GitHub](https://github.com/pulumi), follow us
 on [Twitter](https://twitter.com/pulumicorp), subscribe to our [YouTube
 channel](https://www.youtube.com/channel/UC2Dhyn4Ev52YSbcpfnfP0Mw), or
-join our [Community Slack](https://slack.pulumi.io/) channel if you have
+join our [Community Slack](https://slack.pulumi.com/) channel if you have
 any questions, need support, or just want to say hello.
 
 If you'd like to chat with our team, or get hands-on assistance with

--- a/content/blog/managing-your-mysql-databases-with-pulumi/index.md
+++ b/content/blog/managing-your-mysql-databases-with-pulumi/index.md
@@ -163,4 +163,4 @@ users and more. Together, this enables end-to-end provisioning of your applicati
 Read more about the [Pulumi MySQL provider]({{< ref "/docs/reference/pkg/nodejs/pulumi/mysql" >}}).
 
 We’ve only shown a little bit of what Pulumi can do. If you need any help, feel free to create an issue
-[on GitHub](https://github.com/pulumi/) or join the [Pulumi Community Slack](https://slack.pulumi.io) channel.
+[on GitHub](https://github.com/pulumi/) or join the [Pulumi Community Slack](https://slack.pulumi.com) channel.

--- a/content/blog/program-kubernetes-with-11-cloud-native-pulumi-pearls/index.md
+++ b/content/blog/program-kubernetes-with-11-cloud-native-pulumi-pearls/index.md
@@ -828,5 +828,5 @@ here.
 
 To get started, head over to the [Pulumi Quickstart]({{< ref "/docs/quickstart" >}}),
 meet us over on GitHub where all the goodies are open source <https://github.com/pulumi/pulumi>, and/or join our
-[Pulumi Community Slack](https://slack.pulumi.io). We can't wait to hear
+[Pulumi Community Slack](https://slack.pulumi.com). We can't wait to hear
 from you. Happy hacking!

--- a/content/blog/pulumi-a-better-way-to-kubernetes/index.md
+++ b/content/blog/pulumi-a-better-way-to-kubernetes/index.md
@@ -142,7 +142,7 @@ As always, you can check out our code on
 [GitHub](https://github.com/pulumi), follow us on
 [Twitter](https://twitter.com/pulumicorp), subscribe to our
 [YouTube channel](https://www.youtube.com/channel/UC2Dhyn4Ev52YSbcpfnfP0Mw), or
-join our [Community Slack](https://slack.pulumi.io/) channel if you have
+join our [Community Slack](https://slack.pulumi.com/) channel if you have
 any questions, need support, or just want to say hello.
 
 If you'd like to chat with our team, or get hands-on assistance with

--- a/content/blog/pulumi-heart-google-cloud-platform/index.md
+++ b/content/blog/pulumi-heart-google-cloud-platform/index.md
@@ -270,4 +270,4 @@ GCP:
 - [GCE Tutorial]({{< ref "/docs/reference/tutorials/gcp/tutorial-gce-webserver" >}})
 - Example: [Serverless Slackbot with Cloud Functions in JavaScript](https://github.com/pulumi/examples/tree/master/gcp-ts-slackbot)
 - Example: [GKE + Kubernetes Pod Deployment in Python](https://github.com/pulumi/examples/tree/master/gcp-py-gke)
-- [Pulumi Community Slack](https://slack.pulumi.io/)
+- [Pulumi Community Slack](https://slack.pulumi.com/)

--- a/content/blog/pulumi-meetup-recap-apis-custom-resources-and-github-webhooks/index.md
+++ b/content/blog/pulumi-meetup-recap-apis-custom-resources-and-github-webhooks/index.md
@@ -7,7 +7,7 @@ date: "2019-07-16"
 meta_image: "meta.jpg"
 ---
 
-Last Wednesday, we invited members of our local Seattle community to Pulumi HQ for the [July Pulumi Up meetup](https://www.meetup.com/Pulumi-Seattle/events/262610954/). The evening began with some networking time wherein our guests met some Pulumi engineers and users they may have only ever interacted with over [Pulumi’s Community Slack](https://slack.pulumi.io/) while enjoying free pizza and beverages. This month’s meetup featured two talks by Pulumi engineers.
+Last Wednesday, we invited members of our local Seattle community to Pulumi HQ for the [July Pulumi Up meetup](https://www.meetup.com/Pulumi-Seattle/events/262610954/). The evening began with some networking time wherein our guests met some Pulumi engineers and users they may have only ever interacted with over [Pulumi’s Community Slack](https://slack.pulumi.com/) while enjoying free pizza and beverages. This month’s meetup featured two talks by Pulumi engineers.
 
 ## Application code isn’t the only code that can have APIs
 

--- a/content/blog/pulumi-now-supports-atlassian-identity/index.md
+++ b/content/blog/pulumi-now-supports-atlassian-identity/index.md
@@ -70,4 +70,4 @@ Don't see docs for a particular CI system? Let us know or better yet
 file an issue [here](https://github.com/pulumi/docs/issues).
 
 Having trouble? Questions? Join our
-[community Slack](https://slack.pulumi.io/) or send us an email.
+[community Slack](https://slack.pulumi.com/) or send us an email.

--- a/content/blog/reusable-cicd-components-with-circleci-orbs-for-pulumi/index.md
+++ b/content/blog/reusable-cicd-components-with-circleci-orbs-for-pulumi/index.md
@@ -84,7 +84,7 @@ Deployment" part of CI/CD workflows, and with the release of CircleCIs
 Orbs, it's just that much easier.
 
 
-Having trouble? Questions? Join our [community Slack](https://slack.pulumi.io/)
+Having trouble? Questions? Join our [community Slack](https://slack.pulumi.com/)
 or [drop us a line]({{< ref "/contact" >}}).
 
 Links:

--- a/content/blog/serverless-as-simple-callbacks-with-pulumi-and-azure-functions/index.md
+++ b/content/blog/serverless-as-simple-callbacks-with-pulumi-and-azure-functions/index.md
@@ -209,6 +209,6 @@ us answer the questions:
 Feel free to create an issue on
 [GitHub](https://github.com/pulumi/pulumi-azure/), tag us on
 [Twitter](https://twitter.com/PulumiCorp), or join our
-[community Slack channel](https://slack.pulumi.io/).
+[community Slack channel](https://slack.pulumi.com/).
 
 Happy serverless programming!

--- a/content/blog/serving-a-static-website-on-aws-with-pulumi/index.md
+++ b/content/blog/serving-a-static-website-on-aws-with-pulumi/index.md
@@ -198,4 +198,4 @@ Pulumi opens up a lot of possibilities and we are excited to see what
 sorts of things people build using it. If you are interested in using
 Pulumi for more sophisticated website hosting, or just have questions
 about serving static files like described here, feel free to ask away on
-our [Pulumi Community Slack](http://slack.pulumi.io/).
+our [Pulumi Community Slack](http://slack.pulumi.com/).

--- a/content/blog/simple-reproducible-kubernetes-deployments/index.md
+++ b/content/blog/simple-reproducible-kubernetes-deployments/index.md
@@ -315,4 +315,4 @@ based on ConfigMap changes... And much, much, more.
 If you have specific use cases you'd like to see us tackle, don't
 hesitate to reach out, either
 [on GitHub](https://github.com/pulumi/pulumi) or in our
-[Pulumi Community Slack](https://slack.pulumi.io/). We'd love to hear from you!
+[Pulumi Community Slack](https://slack.pulumi.com/). We'd love to hear from you!

--- a/content/blog/unified-logs-with-pulumi-logs/index.md
+++ b/content/blog/unified-logs-with-pulumi-logs/index.md
@@ -179,7 +179,7 @@ something we're also excited to enable in the near future.
 You can take `pulumi` for a spin today by checking out the
 [Getting Started Guide]({{< ref "/docs/quickstart" >}}) guide or some of the
 [Pulumi Examples](https://github.com/pulumi/examples) on GitHub. Then join us in the
-[Pulumi Community Slack](https://slack.pulumi.io) to chat about where
+[Pulumi Community Slack](https://slack.pulumi.com) to chat about where
 you want to see us go (and where you'd like to help out!) with
 `pulumi logs` and other features of the Pulumi open source project in
 the coming weeks and months.

--- a/content/blog/using-helm-and-pulumi-to-define-cloud-native-infrastructure-as-code/index.md
+++ b/content/blog/using-helm-and-pulumi-to-define-cloud-native-infrastructure-as-code/index.md
@@ -117,4 +117,4 @@ complex architectures.
 
 - Find out more about our [Azure]({{< ref "/azure" >}}) and
   [Kubernetes]({{< ref "/kubernetes" >}}) support
-- Join the Slack community at <https://slack.pulumi.io> 
+- Join the Slack community at <https://slack.pulumi.com> 

--- a/content/blog/using-terraform-remote-state-with-pulumi/index.md
+++ b/content/blog/using-terraform-remote-state-with-pulumi/index.md
@@ -178,5 +178,5 @@ To learn more about migrating
 from Terraform to Pulumi, check out
 [From Terraform to Infrastructure as Software]({{< relref "from-terraform-to-infrastructure-as-software" >}})
 and the [Terraform comparison documentation]({{< ref "/docs/reference/vs/terraform" >}}), or join us in
-the [Pulumi Community Slack](https://slack.pulumi.io/) to discuss with
+the [Pulumi Community Slack](https://slack.pulumi.com/) to discuss with
 the Pulumi community.

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -111,5 +111,5 @@ functions -- and the CLI safely and reliably manages your cloud resources using 
     </div>
 </div>
 
-For questions or feedback, reach us in our [community Slack channel](https://slack.pulumi.io),
+For questions or feedback, reach us in our [community Slack channel](https://slack.pulumi.com),
 on [GitHub](https://github.com/pulumi), or by emailing [support@pulumi.com](mailto:support@pulumi.com).

--- a/content/docs/reference/crosswalk/aws/other.md
+++ b/content/docs/reference/crosswalk/aws/other.md
@@ -14,7 +14,7 @@ menu:
 Pulumi Crosswalk for AWS supports all AWS services, not just those with dedicated articles in this User Guide.
 This includes services like DynamoDB, EC2, S3, and RDS, to name a few, and includes support for all of their features.
 If your favorite service isn't listed here, please contact us by [filing an issue in the docs repo](
-https://github.com/pulumi/docs) or by [joining the Pulumi Community Slack channel](https://slack.pulumi.io).
+https://github.com/pulumi/docs) or by [joining the Pulumi Community Slack channel](https://slack.pulumi.com).
 
 ## Index of Services
 

--- a/content/docs/reference/service/webhooks.md
+++ b/content/docs/reference/service/webhooks.md
@@ -142,7 +142,7 @@ identity of the user who triggered the webhook, e.g. the person who initiated
 the stack update or performed the action.
 
 > The Pulumi Webhook payloads are under development, and may be changed from
-> time to time. See the [Pulumi Community Slack](http://slack.pulumi.io/) for
+> time to time. See the [Pulumi Community Slack](http://slack.pulumi.com/) for
 > any announcements or changes.
 
 ### `stack` event

--- a/content/docs/reference/troubleshooting.md
+++ b/content/docs/reference/troubleshooting.md
@@ -14,7 +14,7 @@ preventing you from being productive with a Pulumi stack, you've come to the rig
 ## Contact Us
 
 First thing's first, we are always happy to hear from you and will try to help. Please
-[join our Community Slack](https://slack.pulumi.io), where our whole team, in addition to a passionate
+[join our Community Slack](https://slack.pulumi.com), where our whole team, in addition to a passionate
 community of users, are there to help out. Any and all questions are welcome!
 
 ## Common Problems
@@ -77,7 +77,7 @@ safely disregarded and it is safe to re-start the update. You may need to
 In the second case, you may see an additional error message "after mutation of snapshot". This error
 message is **always a bug in Pulumi**. If you see this error message, we would greatly appreciate a
 bug report on our [official bug tracker](https://github.com/pulumi/pulumi/issues). We also
-recommend joining our [Pulumi Community Slack](https://slack.pulumi.io/) and sharing your problem
+recommend joining our [Pulumi Community Slack](https://slack.pulumi.com/) and sharing your problem
 if you experience this error message.
 
 #### Quick Summary
@@ -258,7 +258,7 @@ $ pulumi stack import --file state.json
 
 Depending on the class of error that you are experiencing, you may need to edit one or more of these resource fields,
 as well as potentially change the location of particular resources in the list. Since this is an advanced operation,
-we recommend you check-in with the [Pulumi Community Slack](https://slack.pulumi.io) first before editing your snapshot.
+we recommend you check-in with the [Pulumi Community Slack](https://slack.pulumi.com) first before editing your snapshot.
 
 ## Provider-specific problems {#provider-problems}
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -168,9 +168,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
 //
 // This is due to https://github.com/pulumi/pulumi/issues/1449:
 // Error "CloudFront ETag Out Of Sync" when externally modifying CloudFront resource
-//
-// For information on how to work around this error, see "CloudFront ETag Out Of Sync":
-// https://pulumi.io/reference/known-issues.html
 const cdn = new aws.cloudfront.Distribution(
     "cdn",
     distributionArgs,

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,7 +13,7 @@
                         <li class="mr-4"><a class="hover:text-blue-200" href="https://www.linkedin.com/company/pulumi/" target="_blank"><i class="fab fa-linkedin"></i></a></li>
                         <li class="mr-4"><a class="hover:text-blue-200" href="https://github.com/pulumi/" target="_blank"><i class="fab fa-github"></i></a></li>
                         <li class="mr-4"><a class="hover:text-blue-200" href="https://www.youtube.com/channel/UC2Dhyn4Ev52YSbcpfnfP0Mw" target="_blank"><i class="fab fa-youtube"></i></a></li>
-                        <li><a class="hover:text-blue-200" href="https://slack.pulumi.io/" target="_blank"><i class="fab fa-slack-hash"></i></a></li>
+                        <li><a class="hover:text-blue-200" href="https://slack.pulumi.com/" target="_blank"><i class="fab fa-slack-hash"></i></a></li>
                     </ul>
                 </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <nav class="bg-black text-white text-sm py-2 px-4 lg:px-0 transition-all max-h-screen md:max-h-full">
     <div class="container mx-auto">
         <ul class="flex justify-end items-center h-6">
-            <li class="mr-8"><a href="https://slack.pulumi.io/" target="_blank">Slack</a></li>
+            <li class="mr-8"><a href="https://slack.pulumi.com/" target="_blank">Slack</a></li>
             <li class="mr-8"><a href="https://github.com/pulumi" target="_blank">GitHub</a></li>
             <li class="mr-8"><a href="https://app.pulumi.com/" target="_blank">Console</a></li>
             <li class="github-widget">

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -6,7 +6,7 @@
             <li class="mx-12"><a class="text-gray-900 hover:text-gray-800" href="https://github.com/pulumi/" target="_blank"><i class="fab fa-github"></i></a></li>
             <li class="mx-12"><a class="text-red-600 hover:text-red-500" href="https://www.youtube.com/channel/UC2Dhyn4Ev52YSbcpfnfP0Mw" target="_blank"><i class="fab fa-youtube"></i></a></li>
             <li class="mx-12"><a class="text-blue-700 hover:text-blue-400" href="https://www.linkedin.com/company/pulumi/" target="_blank"><i class="fab fa-linkedin"></i></a></li>
-            <li class="mx-12"><a class="text-green-600 hover:text-green-500" href="https://slack.pulumi.io/" target="_blank"><i class="fab fa-slack-hash"></i></a></li>
+            <li class="mx-12"><a class="text-green-600 hover:text-green-500" href="https://slack.pulumi.com/" target="_blank"><i class="fab fa-slack-hash"></i></a></li>
         </ul>
     </div>
 </section>

--- a/scripts/run_typedoc.sh
+++ b/scripts/run_typedoc.sh
@@ -62,7 +62,7 @@ generate_docs() {
 
         # Change back to the origin directory and create the API documents.
         popd
-        echo -e "\033[0;93mGenerating pulumi.io API docs\033[0m"
+        echo -e "\033[0;93mGenerating pulumi.com API docs\033[0m"
         echo -e ${TOOL_APIDOCGEN} "${PKGPATH}" "${PULUMI_DOC_TMP}/$1.docs.json" "${PULUMI_DOC_BASE}/$1" $HEAD_COMMIT
         ${TOOL_APIDOCGEN} "${PKGPATH}" "${PULUMI_DOC_TMP}/$1.docs.json" "${PULUMI_DOC_BASE}/$1" $HEAD_COMMIT
     fi


### PR DESCRIPTION
Update all references to slack.pulumi.io to point to the new location, slack.pulumi.com. The older site is still up, and I'll put up a redirect soon, but it would be nice to continue to deprecate links to pulumi.io when not using short links.