### PR TITLE
Make label on blog sidebar an H1

### DIFF
--- a/layouts/partials/blog/sidebar.html
+++ b/layouts/partials/blog/sidebar.html
@@ -11,9 +11,9 @@
         <a href="{{relref . "/blog" }}">🍹 Pulumi Blog</a>
     </div>
 
-    <h3 class="no-anchor hidden md:flex mt-4">
+    <h1 class="no-anchor hidden md:flex mt-4 text-2xl">
         <a href="{{relref . "/blog" }}">🍹 Pulumi Blog</a>
-    </h3>
+    </h1>
 
     <!-- Sidebar content. Hidden on smaller displays unless toggled. -->
     <div class="blog-sidebar-content hidden md:block">

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -11,7 +11,7 @@
                 {{ $paginator := .Paginate .Data.Pages.ByDate.Reverse }}
 
                 <header>
-                    <h3 class="no-anchor">Posts Tagged {{ .Data.Term }}</h3>
+                    <h1 class="no-anchor">Posts Tagged {{ .Data.Term }}</h1>
                 </header>
 
                 {{ range $paginator.Pages }}


### PR DESCRIPTION
There are a lot of pages on pulumi.com that Moz complains about with "Pages with Missing or Invalid H1". A significant number of those are pages where we list a series of blog posts, such as:

https://www.pulumi.com/blog/
https://www.pulumi.com/blog/page/6/
https://www.pulumi.com/blog/tag/infrastructure/
https://www.pulumi.com/blog/tag/aws/page/2/

For all of these pages, we list blog entires with an `<h2>`, but nowhere on the page is there actually an `<h1>`.

For `taxonomy/tag.html` I just promoted the existing header to be an `<h1>`, as this just makes a ton of sense. However, for the general "blog entries" listing, there isn't an element in there already.

I didn't want to add one and clutter up the page, so I just changed the "🍹 Pulumi Blog" on the left sidebar to be an `<h1>`. (It will be sized the same as it is today, since otherwise it would look a bit jarring.)

The downside is that for these pages there will be possibly two H1 tags. However, the current advice seems to be that having multiple H1s on a page isn't bad for SEO. (And if anything, seems appropriate in this case, too.)

- "🍹 Pulumi Blog" and "Posts Tagged Azure" (for the tag page)
- "🍹 Pulumi Blog" and "Chris Smith" (for the author's page)
 
If you have a suggestion for a better fix let me know. Part of https://github.com/pulumi/home/issues/514