### PR TITLE
Change /docs/tour to redirect to the Get Started guide

### DIFF
--- a/content/docs/tour/_index.md
+++ b/content/docs/tour/_index.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /docs/reference/concepts/
+redirect_to: /docs/quickstart/
 ---


### PR DESCRIPTION
Since the tour was mostly a walkthrough on getting started with Pulumi anyway.

Addresses feedback: https://github.com/pulumi/docs/pull/1462#discussion_r308318572