### PR TITLE
Fix some titles and meta descriptions

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -38,4 +38,4 @@ enableRobotsTXT = true
     canonicalURL = "https://www.pulumi.com"
     repositoryURL = "https://github.com/pulumi/docs"
     repositoryBranch = "master"
-    summary = "Pulumi's open source infrastructure as code SDK enables you and your team to create, deploy, and manage infrastructure on any cloud, reliably and productively, using your favorite languages."
+    meta_desc = "Pulumi's open source infrastructure as code SDK enables you and your team to create, deploy, and manage infrastructure on any cloud, reliably and productively, using your favorite languages."

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,5 +1,5 @@
 languageCode = "en-us"
-title = "Pulumi"
+title = "Pulumi - Modern Infrastructure as Code"
 
 disableKinds = ["category", "taxonomyTerm"]
 sectionPagesMenu = "main"
@@ -38,3 +38,4 @@ enableRobotsTXT = true
     canonicalURL = "https://www.pulumi.com"
     repositoryURL = "https://github.com/pulumi/docs"
     repositoryBranch = "master"
+    summary = "Pulumi's open source infrastructure as code SDK enables you and your team to create, deploy, and manage infrastructure on any cloud, reliably and productively, using your favorite languages."

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,6 +1,6 @@
 ---
 title: About
-summary: Pulumi is a Seattle-based company that enables teams to create, deploy, and manage modern cloud applications and infrastructure.
+meta_desc: Pulumi is a Seattle-based company that enables teams to create, deploy, and manage modern cloud applications and infrastructure.
 type: page
 layout: about
 menu:

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,5 +1,6 @@
 ---
 title: About
+summary: Pulumi is a Seattle-based company that enables teams to create, deploy, and manage modern cloud applications and infrastructure.
 type: page
 layout: about
 menu:

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Blog
-summary: Articles, resources, and posts on modern infrastructure as code best practices.
+meta_desc: Articles, resources, and posts on modern infrastructure as code best practices.
 outputs: ["html", "rss"]
 menu:
     header:

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Blog
+summary: Articles, resources, and posts on modern infrastructure as code best practices.
 outputs: ["html", "rss"]
 menu:
     header:

--- a/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
+++ b/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
@@ -4,7 +4,7 @@ authors: ["luke-hoban"]
 tags: ["Pulumi", "New-Features", "CI/CD"]
 date: "2018-08-15"
 
-summary: "Pulumi can now deploy and manage Kubernetes resources using the same
+meta_desc: "Pulumi can now deploy and manage Kubernetes resources using the same
 familiar programming model supported for AWS, Azure, and Google Cloud
 Platform. In this post, we'll take a quick tour of these new features."
 ---

--- a/content/blog/announcing-support-for-email-based-identities/index.md
+++ b/content/blog/announcing-support-for-email-based-identities/index.md
@@ -4,7 +4,7 @@ authors: ["praneet-loke"]
 tags: ["Pulumi-News","Features"]
 date: "2019-03-21"
 
-summary: "Today, we are pleased to announce that we are launching support for email-based identities. You no longer need to use a social identity to sign-up for an account on Pulumi. Just fill out the signup form, and you are ready to go."
+meta_desc: "Today, we are pleased to announce that we are launching support for email-based identities. You no longer need to use a social identity to sign-up for an account on Pulumi. Just fill out the signup form, and you are ready to go."
 meta_image: "email-signup.png"
 ---
 

--- a/content/blog/code-deploy-and-manage-a-serverless-rest-api-on-aws-with-pulumi/index.md
+++ b/content/blog/code-deploy-and-manage-a-serverless-rest-api-on-aws-with-pulumi/index.md
@@ -4,7 +4,7 @@ authors: ["donna-malayeri"]
 tags: ["JavaScript","Serverless","AWS"]
 date: "2018-06-22"
 
-summary: "In this post, we'll use Pulumi to create a simple serverless REST API that counts the number of times a route has been hit, using JavaScript to define both the infrastructure and application code."
+meta_desc: "In this post, we'll use Pulumi to create a simple serverless REST API that counts the number of times a route has been hit, using JavaScript to define both the infrastructure and application code."
 meta_image: "counter-arch.png"
 ---
 

--- a/content/blog/delivering-cloud-native-infrastructure-as-code-a-pulumi-white-paper/index.md
+++ b/content/blog/delivering-cloud-native-infrastructure-as-code-a-pulumi-white-paper/index.md
@@ -4,7 +4,7 @@ authors: ["marc-holmes"]
 tags: ["Cloud-Native"]
 date: "2018-12-05"
 
-summary: "In our latest white paper, Delivering Cloud Native Infrastructure as Code, we we make the case for a consistent programming model for the cloud."
+meta_desc: "In our latest white paper, Delivering Cloud Native Infrastructure as Code, we we make the case for a consistent programming model for the cloud."
 meta_image: "graph.png"
 ---
 

--- a/content/blog/hosting-a-static-website-on-azure-with-pulumi/index.md
+++ b/content/blog/hosting-a-static-website-on-azure-with-pulumi/index.md
@@ -4,7 +4,7 @@ authors: ["mikhail-shilkov"]
 tags: ["Azure"]
 date: "2019-06-27"
 
-summary: "Static websites are back in the mainstream these days. Website generators like Jekyll, Hugo, or Gatsby, make it fairly easy to combine templates and markdown pages to produce static HTML files. Static assets are the simplest thing to serve and cache, so the whole setup ends up being fast and cost-efficient."
+meta_desc: "Static websites are back in the mainstream these days. Website generators like Jekyll, Hugo, or Gatsby, make it fairly easy to combine templates and markdown pages to produce static HTML files. Static assets are the simplest thing to serve and cache, so the whole setup ends up being fast and cost-efficient."
 meta_image: "feature.jpg"
 ---
 

--- a/content/blog/introducing-pulumi-a-cloud-development-platform/index.md
+++ b/content/blog/introducing-pulumi-a-cloud-development-platform/index.md
@@ -4,7 +4,7 @@ authors: ["joe-duffy"]
 tags: ["Pulumi-News"]
 date: "2018-06-18"
 
-summary: "Ahoy! Today we are thrilled to be announcing the launch of Pulumi, the Cloud Development Platform."
+meta_desc: "Ahoy! Today we are thrilled to be announcing the launch of Pulumi, the Cloud Development Platform."
 ---
 
 Ahoy!

--- a/content/blog/programming-the-cloud-with-python/index.md
+++ b/content/blog/programming-the-cloud-with-python/index.md
@@ -4,7 +4,7 @@ authors: ["sean-gillespie"]
 tags: ["Serverless","AWS","Python"]
 date: "2019-04-04"
 
-summary: "Python is awesome for automating manual tasks. So let's use it for cloud infrastructure as code!"
+meta_desc: "Python is awesome for automating manual tasks. So let's use it for cloud infrastructure as code!"
 ---
 
 Across the industry, the popularity of Python is exploding. Amongst our

--- a/content/blog/simplified-outputs-in-pulumi-0.17.0/index.md
+++ b/content/blog/simplified-outputs-in-pulumi-0.17.0/index.md
@@ -4,7 +4,7 @@ authors: ["cyrus-najmabadi"]
 tags: ["New-Features"]
 date: "2019-03-19"
 
-summary: "Based on much feedback from cloud developers, Pulumi Outputs have been simplified for JavaScript and TypeScript making the user experience simpler while maintaining the rich dependency tracking and type checking that Pulumi has always provided for cloud infrastructure."
+meta_desc: "Based on much feedback from cloud developers, Pulumi Outputs have been simplified for JavaScript and TypeScript making the user experience simpler while maintaining the rich dependency tracking and type checking that Pulumi has always provided for cloud infrastructure."
 meta_image: "comp-list.png"
 ---
 

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,4 +1,5 @@
 ---
 title: Contact Us
+summary: Contact Pulumi for any general inquiries, including requests for pricing, support, or training.
 layout: contact
 ---

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,5 +1,5 @@
 ---
 title: Contact Us
-summary: Contact Pulumi for any general inquiries, including requests for pricing, support, or training.
+meta_desc: Contact Pulumi for any general inquiries, including requests for pricing, support, or training.
 layout: contact
 ---

--- a/content/crosswalk/_index.md
+++ b/content/crosswalk/_index.md
@@ -1,0 +1,3 @@
+---
+private: true
+---

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,5 +1,6 @@
 ---
-title: Pulumi Documentation
+title: Documentation
+summary: Learn how to create, deploy, and manage infrastructure on any cloud using Pulumi's open source infrastructure as code SDK.
 noindex: true
 no_on_this_page: true
 menu:

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Documentation
-summary: Learn how to create, deploy, and manage infrastructure on any cloud using Pulumi's open source infrastructure as code SDK.
+meta_desc: Learn how to create, deploy, and manage infrastructure on any cloud using Pulumi's open source infrastructure as code SDK.
 noindex: true
 no_on_this_page: true
 menu:

--- a/content/docs/quickstart/k8s-the-prod-way/_index.md
+++ b/content/docs/quickstart/k8s-the-prod-way/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes the Prod Way
+nosummary: true
 ---
 
 **Kubernetes the Prod Way** is a tutorial, reference architecture, and collection of prod-first code

--- a/content/docs/quickstart/k8s-the-prod-way/_index.md
+++ b/content/docs/quickstart/k8s-the-prod-way/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Kubernetes the Prod Way
-nosummary: true
 ---
 
 **Kubernetes the Prod Way** is a tutorial, reference architecture, and collection of prod-first code

--- a/content/docs/quickstart/k8s-the-prod-way/checklist.md
+++ b/content/docs/quickstart/k8s-the-prod-way/checklist.md
@@ -1,3 +1,7 @@
+---
+title: Kubernetes Checklist
+---
+
 ## Identity
 
 * Set up cloud provider IAM roles, groups for service accounts, team.

--- a/content/docs/search.md
+++ b/content/docs/search.md
@@ -2,5 +2,4 @@
 title: Search Results
 layout: search
 noindex: true
-nosummary: true
 ---

--- a/content/docs/search.md
+++ b/content/docs/search.md
@@ -2,4 +2,5 @@
 title: Search Results
 layout: search
 noindex: true
+nosummary: true
 ---

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Pricing
-summary: Pulumi's open source infrastructure as code SDK and enterprise SaaS products together provide plans for teams of all sizes.
+meta_desc: Pulumi's open source infrastructure as code SDK and enterprise SaaS products together provide plans for teams of all sizes.
 type: page
 layout: pricing
 menu:

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Pricing
+summary: Pulumi's open source infrastructure as code SDK and enterprise SaaS products together provide plans for teams of all sizes.
 type: page
 layout: pricing
 menu:

--- a/content/product/_index.md
+++ b/content/product/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Products
-summary: Learn how Pulumi's products enable your team to get code to any cloud productively, securely, and reliably, using your favorite languages.
+meta_desc: Learn how Pulumi's products enable your team to get code to any cloud productively, securely, and reliably, using your favorite languages.
 type: page
 layout: product
 menu:

--- a/content/product/_index.md
+++ b/content/product/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Products
+summary: Learn how Pulumi's products enable your team to get code to any cloud productively, securely, and reliably, using your favorite languages.
 type: page
 layout: product
 menu:

--- a/content/support.md
+++ b/content/support.md
@@ -1,4 +1,5 @@
 ---
 title: Support
+summary: Get support for general infrastructure as code inquiries or help using Pulumi's products.
 layout: support
 ---

--- a/content/support.md
+++ b/content/support.md
@@ -1,5 +1,5 @@
 ---
 title: Support
-summary: Get support for general infrastructure as code inquiries or help using Pulumi's products.
+meta_desc: Get support for general infrastructure as code inquiries or help using Pulumi's products.
 layout: support
 ---

--- a/content/why-pulumi/delivering-cloud-native-infrastructure-as-code.md
+++ b/content/why-pulumi/delivering-cloud-native-infrastructure-as-code.md
@@ -8,8 +8,6 @@ meta_desc: In this paper, we make the case for a consistent cloud programming mo
 
 hero_image: /images/whitepaper/cloud-native-infrastructure/deliveringCloudNative_pdf_large.png
 
-summary: To a first approximation, all developers are cloud developers, all applications are cloud native, and all operations are cloud-first. Yet, there is a lack of a consistent approach to delivering cloud native applications and infrastructure. The tools and processes differ by technology generation, and even by cloud vendor, and so deny the full potential of cloud native application delivery.
-
 download_url: "https://cdn2.hubspot.net/hubfs/4429525/Content/Pulumi-Delivering-CNI-as-Code.pdf"
 
 sections:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,17 +41,12 @@
     {{ if .Params.meta_desc }}
         <meta name="description" content="{{ .Params.meta_desc }}">
         <meta property="og:description" content="{{ .Params.meta_desc }}">
-    {{ else if .Params.summary }}
-        <meta name="description" content="{{ .Params.summary }}">
-        <meta property="og:description" content="{{ .Params.summary }}">
+    {{ else if and .IsHome .Site.Params.meta_desc }}
+        <meta name="description" content="{{ .Site.Params.meta_desc }}">
+        <meta property="og:description" content="{{ .Site.Params.meta_desc }}">
     {{ else if .Summary }}
         <meta name="description" content="{{ .Summary }}">
         <meta property="og:description" content="{{ .Summary }}">
-    {{ else if .IsHome }}
-        <meta name="description" content="{{ .Site.Params.summary }}">
-        <meta property="og:description" content="{{ .Site.Params.summary }}">
-    {{ else if not (or .Params.redirect_to .Params.private .Params.nosummary (in "docs authors tags" .Section)) }}
-        {{ errorf "%q: Missing 'summary' directive; please specify this to improve search indexing (or set 'nosummary')." .Path }}
     {{ end }}
 
     {{ $image := "/social/pulumi.png" }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -47,10 +47,11 @@
     {{ else if .Summary }}
         <meta name="description" content="{{ .Summary }}">
         <meta property="og:description" content="{{ .Summary }}">
-    {{ else }}
-        {{ $defaultDescription := "Pulumi provides a cloud development model for serverless functions, container apps, and data infrastructure for any cloud." }}
-        <meta name="description" content="{{ $defaultDescription }}">
-        <meta property="og:description" content="{{ $defaultDescription }}">
+    {{ else if .IsHome }}
+        <meta name="description" content="{{ .Site.Params.summary }}">
+        <meta property="og:description" content="{{ .Site.Params.summary }}">
+    {{ else if not (or .Params.redirect_to .Params.private .Params.nosummary (in "docs authors tags" .Section)) }}
+        {{ errorf "%q: Missing 'summary' directive; please specify this to improve search indexing (or set 'nosummary')." .Path }}
     {{ end }}
 
     {{ $image := "/social/pulumi.png" }}
@@ -63,7 +64,16 @@
     {{ end }}
     <meta property="og:image" content="{{ $image | absURL }}">
 
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - Pulumi{{ end }}</title>
+    {{ if .IsHome }}
+        <title>{{ .Site.Title }}</title>
+    {{ else if .Title }}
+        <title>{{ .Title }}</title>
+    {{ else if not (or .Params.redirect_to .Params.private) }}
+        <!--
+            TODO[pulumi/docs#1127]: can't enable this until Python docs are fixed.
+            \{\{ /* errorf "%q: Missing 'title' directive; please specify this to improve search indexing." .Path */ \}\}
+        -->
+    {{ end }}
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico" />
 
     <!--


### PR DESCRIPTION
This change fixes up some titles and meta descriptions, in hopes
that it'll have a positive impact on our SEO (and SERP summary).

- Ensure all pages have titles and meaningful meta descriptions.

- Error out if pages lack a meta description. Also add the ability
  to write `nosummary: true` if it's intentionally omitted.

- I'd like to error out if pages lack a title too. Unfortunately,
  the Python API docs are missing titles (pulumi/docs#1127), so this
  check is not currently enabled (easy to uncomment out later).

I also made the possibly-controversial change to stop emitting an
automatic `- Pulumi` at the end of page titles. This

- Leads to illy things -- like `About Pulumi - Pulumi`.

- Might make it more difficult for Google to extract a good title for
  our SERP summary; is that why "Documentation" is currently
  awkwardly labeled simply "Pulumi" on Google at the moment?

- Probably has a net negative effect on things like blog articles,
  which we would like to index naturally based on the content.

I propose that anywhere we want Pulumi in the title, we manually add it.
