### PR TITLE
Add body of blog post to RSS feed

### DIFF
--- a/content/blog/build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws/index.md
+++ b/content/blog/build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws/index.md
@@ -42,8 +42,8 @@ Then, run the following command to install the Pulumi CLI:
 
 If you're on Windows, run this:
 
-    @"%SystemRoot%System32WindowsPowerShell1.0powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))" 
-    SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
+    @"%SystemRoot%System32WindowsPowerShell1.0powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))"
+    SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
 
 You'll deploy this app to your own AWS account, so follow the steps
 to [configure your AWS account]({{< ref "/docs/reference/clouds/aws/setup.md" >}}).
@@ -86,7 +86,7 @@ const ffmpegThumbnailTask = new cloud.Task("ffmpegThumbTask", {
 bucket.onPut("onNewVideo", async (bucketArgs) => {
     console.log(`*** New video: file ${bucketArgs.key} was uploaded at ${bucketArgs.eventTime}.`);
     const file = bucketArgs.key;
-    
+
     const thumbnailFile = file.substring(0, file.indexOf('_')) + '.jpg';
     const framePos = file.substring(file.indexOf('_')+1, file.indexOf('.')).replace('-',':');
 
@@ -124,20 +124,20 @@ runs `ffmpeg`, and copies the output back to S3.
 
         FROM jrottenberg/ffmpeg
 
-        RUN apt-get update && 
-            apt-get install python-dev python-pip -y && 
+        RUN apt-get update &&
+            apt-get install python-dev python-pip -y &&
             apt-get clean
 
         RUN pip install awscli
 
         WORKDIR /tmp/workdir
 
-        ENTRYPOINT 
-          echo "Starting ffmpeg task..." && 
-          echo "Copying video from S3" && 
-          aws s3 cp s3://${S3_BUCKET}/${INPUT_VIDEO} ./${INPUT_VIDEO} && 
-          ffmpeg -v error -i ./${INPUT_VIDEO} -ss ${TIME_OFFSET} -vframes 1 -f image2 -an -y ${OUTPUT_FILE} && 
-          echo "Copying thumbnail to S3" && 
+        ENTRYPOINT
+          echo "Starting ffmpeg task..." &&
+          echo "Copying video from S3" &&
+          aws s3 cp s3://${S3_BUCKET}/${INPUT_VIDEO} ./${INPUT_VIDEO} &&
+          ffmpeg -v error -i ./${INPUT_VIDEO} -ss ${TIME_OFFSET} -vframes 1 -f image2 -an -y ${OUTPUT_FILE} &&
+          echo "Copying thumbnail to S3" &&
           aws s3 cp ./${OUTPUT_FILE} s3://${S3_BUCKET}/${OUTPUT_FILE}
 
 Install the `@pulumi/cloud-aws` NPM package:
@@ -203,7 +203,7 @@ Fargate task are all in one place!
 Once the thumbnail has been generated, either view it in the S3 console,
 or download it with the AWS CLI:
 
-    $ aws s3 cp s3://$(pulumi stack output bucketName)/cat.jpg . 
+    $ aws s3 cp s3://$(pulumi stack output bucketName)/cat.jpg .
     download: s3://bucket-0c91106/cat.jpg to ./cat.jpg
 
 ## Clean Up

--- a/content/blog/code-deploy-and-manage-a-serverless-rest-api-on-aws-with-pulumi/index.md
+++ b/content/blog/code-deploy-and-manage-a-serverless-rest-api-on-aws-with-pulumi/index.md
@@ -50,8 +50,8 @@ Then, run the following command to install the Pulumi CLI:
 
 If you're on Windows, run this:
 
-    @"%SystemRoot%System32WindowsPowerShell1.0powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))" 
-    SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
+    @"%SystemRoot%System32WindowsPowerShell1.0powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))"
+    SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
 
 You'll deploy this app to your own AWS account, so follow the steps to
 [configure your AWS account]({{< ref "/docs/quickstart/aws" >}}).
@@ -76,17 +76,17 @@ This creates a new project in the directory `hello-http`.
 2. Replace the contents of `index.js` with the following:
 
 ``` {style="padding-left: 30px;"}
-const cloud = require("@pulumi/cloud-aws"); 
+const cloud = require("@pulumi/cloud-aws");
 
-/* Create a mapping from 'route' to a count */ 
-let counterTable = new cloud.Table("counterTable", "route"); 
+/* Create a mapping from 'route' to a count */
+let counterTable = new cloud.Table("counterTable", "route");
 
-/* Create an REST API endpoint */ 
-let endpoint = new cloud.API("hello-world"); 
+/* Create an REST API endpoint */
+let endpoint = new cloud.API("hello-world");
 
-endpoint.get("/{route+}", (req, res) => { 
-    let route = req.params["route"]; 
-    console.log(`Getting count for '${route}'`); 
+endpoint.get("/{route+}", (req, res) => {
+    let route = req.params["route"];
+    console.log(`Getting count for '${route}'`);
 
     /* get previous value and increment */
     /* reference outer counterTable object */
@@ -97,7 +97,7 @@ endpoint.get("/{route+}", (req, res) => {
             console.log(`Got count ${count} for '${route}'`);
         });
     });
-}); 
+});
 
 exports.endpoint = endpoint.publish().url;
 ```
@@ -151,9 +151,9 @@ exports.endpoint = endpoint.publish().url;
 You can view stack outputs in the Pulumi Console, or via
 `pulumi stack output`:
 
-    $ pulumi stack output 
-    Current stack outputs (1): 
-    OUTPUT    VALUE 
+    $ pulumi stack output
+    Current stack outputs (1):
+    OUTPUT    VALUE
     endpoint  https://5e8xrktey3.execute-api.us-west-2.amazonaws.com/stage/
 
 Now, let's curl some routes!

--- a/content/blog/deploying-production-ready-containers-with-pulumi/index.md
+++ b/content/blog/deploying-production-ready-containers-with-pulumi/index.md
@@ -30,8 +30,8 @@ Then, run the following command to install the Pulumi CLI:
 
 If you're on Windows, run this:
 
-    @"%SystemRoot%System32WindowsPowerShell1.0powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))" 
-    SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
+    @"%SystemRoot%System32WindowsPowerShell1.0powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))"
+    SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
 
 You'll deploy this app to your own AWS account, so follow the steps to
 [configure your AWS account]({{< ref "/docs/reference/clouds/aws/setup.md" >}}).
@@ -57,17 +57,17 @@ pulumi new aws-javascript
 This creates a new project in the directory `hello-containers`. Next, replace the contents of `index.js` with the following:
 
 ```javascript
-const cloud = require("@pulumi/cloud-aws"); 
-let service = new cloud.Service("pulumi-nginx", { 
-    containers: { 
-        nginx: { 
-            build: "./app", 
-            memory: 128, 
-            ports: [{ port: 80 }], 
-        }, 
-    }, 
-    replicas: 2, 
-}); 
+const cloud = require("@pulumi/cloud-aws");
+let service = new cloud.Service("pulumi-nginx", {
+    containers: {
+        nginx: {
+            build: "./app",
+            memory: 128,
+            ports: [{ port: 80 }],
+        },
+    },
+    replicas: 2,
+});
 
 /* export just the hostname property of the container frontend */
 exports.url = service.defaultEndpoint.apply(e => `http://${e.hostname}`);
@@ -172,7 +172,7 @@ site traffic.
      2018-06-15T15:27:47.468-07:00[                  pulumi-nginx] 2018/06/15 22:27:47 [error] 5#5: *4 open() "/usr/share/nginx/html/proxychecker.axd" failed (2: No such file or directory), client: 62.210.157.152, server: localhost, request: "GET http://proxy.dazhou.net/proxychecker.axd?e=457758511%40qq.com&p=http%3A%2F%2F34.201.27.186%3A80&s=AS HTTP/1.1", host: "proxy.dazhou.net"
      2018-06-15T15:27:47.468-07:00[                  pulumi-nginx] 62.210.157.152 - - [15/Jun/2018:22:27:47 +0000] "GET http://proxy.dazhou.net/proxychecker.axd?e=457758511%40qq.com&p=http%3A%2F%2F34.201.27.186%3A80&s=AS HTTP/1.1" 404 170 "-" "Go-http-client/1.1" "-"
      2018-06-15T15:32:02.128-07:00[                  pulumi-nginx] 2018/06/15 22:32:02 [error] 5#5: *382 "/usr/share/nginx/html/phpmyadmin/index.html" is not found (2: No such file or directory), client: 178.239.177.212, server: localhost, request: "HEAD http://34.201.27.186:80/phpmyadmin/ HTTP/1.1", host: "34.201.27.186"
-     2018-06-15T16:07:05.874-07:00[                  pulumi-nginx] 172.31.44.144 - - [15/Jun/2018:23:07:05 +0000] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36" "-" 
+     2018-06-15T16:07:05.874-07:00[                  pulumi-nginx] 172.31.44.144 - - [15/Jun/2018:23:07:05 +0000] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36" "-"
 
 ## Clean up
 

--- a/content/blog/level-up-your-azure-platform-as-a-service-applications-with-pulumi/index.md
+++ b/content/blog/level-up-your-azure-platform-as-a-service-applications-with-pulumi/index.md
@@ -80,12 +80,12 @@ The following snippet shows the essential elements of the solution:
     infra                    # Cloud infrastructure definition goes here
        index.ts             # Pulumi program in TypeScript
     src
-       Controllers          # 
+       Controllers          #
        Models               #  ASP.NET Core web app
        Views                # /
        Data                 # EF Core Data Context
        wwwroot              # Static assets (JavaScript/CSS/Images)
-    zure-pipelines.yml      # Azure DevOps pipeline definition
+    azure-pipelines.yml      # Azure DevOps pipeline definition
 
 As a first step, I cloned the [Todo List
 app](https://github.com/azure-samples/dotnetcore-sqldb-tutorial) into

--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -12,7 +12,7 @@
                 <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
                 <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
                 <guid>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</guid>
-                <description>{{ .Summary | html }}</description>
+                <description>{{ .Content | html }}</description>
                 {{ range $id := .Params.authors }}
                     {{ $author := index $.Site.Data.team.team $id }}
                     {{ if $author }}

--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -6,7 +6,7 @@
         <description>Infrastructure as Code for AWS, Azure, Google Cloud, including Kubernetes, Serverless, Containers, for Developers and DevOps.</description>
         <language>{{ .Site.LanguageCode }}</language>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-        {{ range where .Data.Pages "Type" "in" "blog" }}
+        {{ range first 20 (where .Data.Pages "Type" "in" "blog") }}
             <item>
                 <title>{{ .Title }}</title>
                 <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>


### PR DESCRIPTION
This change adds the full text of blog posts to the RSS feed. (It also removes some invisible characters from a few posts, which prevented them from being parsed by feed readers.) 

It's worth noting that this brings the size of the feed from 152K to a little over 2MB (!), so we might want to consider paging, capping or breaking it up at some point, probably soonish.

![](https://cl.ly/34d8111529f4/Screen%252520Recording%2525202019-07-30%252520at%25252005.29%252520PM.gif)

Fixes #1349.