### PR TITLE
Add some spacing between sections of the install page

### DIFF
--- a/content/docs/reference/install.md
+++ b/content/docs/reference/install.md
@@ -86,7 +86,7 @@ This page contains detailed instructions for [installing Pulumi](#install-pulumi
     <p>Please select your operating system.</p>
 </div>
 
-<div id="macos_installation">
+<div id="macos_installation" class="mt-8">
 {{% md %}}
 
 
@@ -133,7 +133,7 @@ If you do not wish to use the previous options, you can install Pulumi manually.
 {{% /md %}}
 </div>
 
-<div id="linux_installation">
+<div id="linux_installation" class="mt-8">
 {{% md %}}
 
 ### Installation Script
@@ -159,7 +159,7 @@ Alternatively, you can install Pulumi manually. We provide a prebuilt binary for
 {{% /md %}}
 </div>
 
-<div id="windows_installation">
+<div id="windows_installation" class="mt-8">
 {{% md %}}
 
 ### Installation Script
@@ -198,7 +198,7 @@ Alternatively, you can install Pulumi manually.
     }
 </script>
 
-<div id="installation_post">
+<div id="installation_post" class="mt-8">
 {{% md %}}
 ## Verify your Installation
 


### PR DESCRIPTION
[Heading tags that aren't the first child in a container get `mt-8` applied](https://github.com/pulumi/docs/blob/250cb526b5dbf24f6c5b3014bad5b6f785882f6a/assets/sass/styles.scss#L28-L38), but we have a few heading tags on the install page as the first child inside divs, so they don't get this margin. This change adds some margin to the divs on the page to add some breathing room between sections.

## Before

<img width="780" alt="Screen Shot 2019-07-31 at 5 20 59 PM" src="https://user-images.githubusercontent.com/710598/62257197-33269900-b3b9-11e9-9712-f0fc4af7c482.png">

## After

<img width="793" alt="Screen Shot 2019-07-31 at 5 21 09 PM" src="https://user-images.githubusercontent.com/710598/62257196-33269900-b3b9-11e9-9a24-4e580db2bc0e.png">
