### PR TITLE
Specify the length of trial on the pricing page

### DIFF
--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -50,8 +50,14 @@
                             <i class="w-8 text-center fas fa-check-square text-orange-500"></i>
                             <span class="flex-1">CI/CD integration</span>
                         </li>
+                        <li class="flex items-center">
+                            <i class="w-8 text-center fas fa-heart text-orange-500"></i>
+                            <span class="flex-1">Try it free for 14 days</span>
+                        </li>
                     </ul>
-                    <a class="text-center btn btn-lg btn-orange mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">Start Your Free Trial</a>
+                    <a class="text-center btn btn-lg btn-orange mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
+                        Start Your Free Trial
+                    </a>
                 </div>
             </div>
             <div class="bg-white rounded py-8 px-8 lg:mx-5 lg:w-1/3 mb-4 lg:mb-0">
@@ -85,8 +91,14 @@
                             <i class="w-8 text-center fas fa-check-square text-blue-500"></i>
                             <span class="flex-1">12×5 support available</span>
                         </li>
+                        <li class="flex items-center">
+                            <i class="w-8 text-center fas fa-heart text-blue-500"></i>
+                            <span class="flex-1">Try it free for 14 days</span>
+                        </li>
                     </ul>
-                    <a class="text-center btn btn-lg mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">Start Your Free Trial</a>
+                    <a class="text-center btn btn-lg mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
+                        Start Your Free Trial
+                    </a>
                 </div>
             </div>
             <div class="bg-white rounded py-8 px-8 lg:w-1/3 mb-4 lg:mb-0">


### PR DESCRIPTION
Adds a bullet under the Team plans indicating trial duration:

![image](https://user-images.githubusercontent.com/274700/62332197-69c0ea00-b473-11e9-9793-e5bb753a622d.png)

Fixes https://github.com/pulumi/www.pulumi.com-old/issues/285.


