### PR TITLE
Make community edition links more discoverable

### DIFF
--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -9,7 +9,8 @@
                 Pulumi has a solution for you.
             </p>
             <p>
-                <a class="text-orange-500 underline" href="{{ relref . "/docs" }}">Pulumi Community Edition</a>
+                <a class="rounded text-orange-400 font-bold underline md:font-normal md:no-underline md:border-2 md:border-orange-400 md:py-1 md:px-2 md:mr-1 hover:text-orange-300 hover:border-orange-300 transition-all"
+                    href="{{ relref . "/docs" }}">Pulumi Community Edition</a>
                 is free forever for unlimited individual use.
             </p>
         </div>
@@ -141,7 +142,10 @@
                     From teams just getting started, to established organizations running Pulumi at scale, we have an option for you.
                 </p>
                 <p>
-                    And remember, <a href="{{ relref . "/docs" }}">Pulumi Community Edition</a> is free forever for unlimited individual use.
+                    And remember,
+                    <a class="rounded text-blue-500 font-bold underline md:font-normal md:no-underline md:border-2 border-blue-500 md:py-1 md:px-2 md:mx-1 hover:text-blue-400 hover:border-blue-400 transition-all"
+                        href="{{ relref . "/docs" }}">Pulumi Community Edition</a>
+                    is free forever for unlimited individual use.
                 </p>
             </div>
 


### PR DESCRIPTION
Use a bold font on mobile, and use a normal weight with a two-pixel border at medium and above.

Part of #1287.

![image](https://user-images.githubusercontent.com/274700/62338697-42c3e180-b48e-11e9-9ec4-270898ac85e2.png)
