### PR TITLE
WIP - Filter out BLC log spam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test:
 	#     - Our LinkedIn page, for some reason, returns an HTTP error (despite being valid)
 	#     - Our Visual Studio Marketplace link for the Azure Pipelines task extension,
 	#       although valid and publicly available, is reported as a broken link.
+	# The odd grepping is to reduce log spam. https://github.com/stevenvachon/broken-link-checker/issues/133
 	./node_modules/.bin/blc http://localhost:1313 --recursive --follow \
 		--exclude "/docs/reference/pkg" \
 		--exclude "/docs/reference/changelog" \
@@ -56,7 +57,15 @@ test:
 		--exclude "https://www.linkedin.com/" \
 		--exclude "https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task" \
 		--exclude "https://blog.mapbox.com/" \
-		--exclude "https://www.youtube.com/"
+		--exclude "https://www.youtube.com/" \
+		| grep --invert-match '^\\' \
+		| grep --invert-match "^|" \
+		| grep --invert-match "^/" \
+		| grep --invert-match "^-" \
+		| grep --invert-match "Getting links from: " \
+		| grep --invert-match "├───OK───" \
+		| grep --invert-match "└───OK───" \
+		| grep --invert-match "Finished! \d+ links found.( \d+ excluded.)? 0 broken."
 
 .PHONY: validate
 validate:

--- a/content/blog/happy-birthday-to-pulumi-open-source/index.md
+++ b/content/blog/happy-birthday-to-pulumi-open-source/index.md
@@ -33,7 +33,7 @@ since launching:
 -   Brought our [Python 3 SDK]({{< ref "/docs/reference/pkg/python" >}})
     to parity with our
     [Node.js-based JavaScript and TypeScript SDKs]({{< ref "/docs/reference/pkg/nodejs" >}}).
--   [Team and Enterprise SaaS editions for teams managing infrastructure in production.](https://www.pulumi.com/pricing)
+-   [Team and Enterprise SaaS editions for teams managing infrastructure in production.](https://www.pulumi.com/pricing--broken)
 -   [GitHub, GitLab, Atlassian, and SAML/SSO identity providers.]({{< ref "/docs/console/orgs" >}})
 -   [CI/CD integrations with GitHub, GitLab, Codefresh, CircleCI, major clouds, and more.]({{< ref "/docs/console/continuous-delivery" >}})
 -   [Pluggable secrets management and transitive state encryption.]({{< relref "managing-secrets-with-pulumi" >}})


### PR DESCRIPTION
Trying to see if this works for filtering out blog log spam from `https://github.com/stevenvachon/broken-link-checker/issues/133`.