### PR TITLE
Update the GitHub Actions docs

### DIFF
--- a/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
+++ b/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
@@ -21,7 +21,7 @@ why, and how to get up and running. It's refreshingly easy!
 
 ## GitHub Actions + Pulumi == ❤️
 
-Pulumi's lets you write cloud applications and infrastructure in your
+Pulumi lets you write cloud applications and infrastructure in your
 favorite language. This includes containers, serverless, and even
 VM-based infrastructure. Combined with GitHub Actions, we can get
 continuous deployment to any cloud -- AWS, Azure, Google Cloud,
@@ -52,6 +52,8 @@ This capability enables some exciting scenarios:
 To see things in action, check out the video shown at the GitHub
 Universe keynote today:
 
+{{< youtube 59SxB2uY9E0 >}}
+
 In this short video, we see a Ruby on Rails application that is
 continuously deployed to our Kubernetes cluster ([full code available
 here](https://github.com/pulumi/actions-example-gke-rails)). It's just a
@@ -78,7 +80,7 @@ can be previewed, diffed, and are recorded so that you'll always know
 who changed what, when, and why -- all very "Git-like." Pulumi's
 [GitHub App]({{< ref "/docs/console/continuous-delivery/github-app" >}})
 adds to this and enables "GitOps" so that teams can propose, approve,
-and promote code from "staging" to "production" using pull requests\
+and promote code from "staging" to "production" using pull requests
 (more on that below).
 
 We've chosen GKE here as an illustration because it's amazing how
@@ -86,7 +88,7 @@ powerful such a simple example can be, but this works just as well if
 you're using AKS, EKS, on-premises clusters -- and of course works for
 non-Kubernetes scenarios, like VMs, ECS, and Serverless applications.
 
-All of this with just handful of TypeScript and GitHub Actions set up to
+All of this with just a handful of TypeScript and GitHub Actions set up to
 work with Pulumi -- despite being quite capable, it's super easy to get
 all of this up and running. Let's see how!
 
@@ -140,7 +142,7 @@ integration and, more importantly, context added by the Pulumi bot to
 your Pull Requests about what a deployment will do before it's even
 done, as shown above.
 
-Note that this is optional with GitHub Actions, but worthwhile -- it
+Note that this is optional with GitHub Actions, but worthwhile -- it's
 much easier for your teams to collaborate on deployments, including
 knowing whether a change might lead to downtime before it's even
 triggered. "GitOps" ahoy!
@@ -168,7 +170,7 @@ This is an exciting day for developers, DevOps engineers, and SREs
 alike. The combination of GitHub Actions and Pulumi gives us all an
 easy, automated solution for continuous deployment of cloud applications
 and infrastructure to any cloud, purely using code and Git. What's best
-about it is that *it's fun *in the same way programming is fun.
+about it is that *it's fun* in the same way programming is fun.
 
 If you're not yet in the GitHub Actions private beta, but want to try
 Pulumi, head on over to our

--- a/content/docs/console/continuous-delivery/github-actions.md
+++ b/content/docs/console/continuous-delivery/github-actions.md
@@ -16,7 +16,7 @@ or promotions between different environments by merging or directly committing c
 Let's see how to get started -- it's easy!
 
 > **Note**: GitHub Actions is currently in public beta. Please [register for
-> access](https://github.com/features/actions) here. Until you've been added, the
+> access](https://github.com/features/actions) to start using the feature. Until you've been added, the
 > **Actions** tab won't show in your repos, and the `.pulumi/main.workflow` file described
 > below will not be recognized by GitHub. Also note that these features only work on
 > private repos in the specific account that has been granted access.

--- a/content/docs/console/continuous-delivery/github-actions.md
+++ b/content/docs/console/continuous-delivery/github-actions.md
@@ -102,7 +102,7 @@ specific version of Pulumi, you can replace all occurrences of `uses =
 "docker://pulumi/actions"` with a container image that contains the version as a tag. For
 instance `uses = "docker://pulumi/actions:v0.16.6"`.
 
-We've also included a prelimarily `Build` action &mdash; and declared it as a
+We've also included a preliminary `Build` action &mdash; and declared it as a
 dependency of both the Preview and Update actions &mdash; in order to demonstrate running
 a setup script in advance of Pulumi. Feel free to remove this block (and the `needs`
 references to it) if it doesn't suit your particular situation.

--- a/content/docs/console/continuous-delivery/github-actions.md
+++ b/content/docs/console/continuous-delivery/github-actions.md
@@ -78,7 +78,7 @@ action "Pulumi Preview (Merged Stack)" {
     ]
 }
 
-workflow "Update " {
+workflow "Update" {
     on = "push"
     resolves = ["Pulumi Deploy (Current Stack)"]
 }

--- a/content/docs/console/continuous-delivery/github-actions.md
+++ b/content/docs/console/continuous-delivery/github-actions.md
@@ -202,7 +202,7 @@ the GitHub Actions container directly.
 ## Pulumi GitHub App
 
 The [Pulumi GitHub App]({{< relref "github.md" >}}) is something you install on your
-GitHub organization. It allows the Pulumi service to leave comments on Pull Requests. (It
+GitHub organization. It allows the Pulumi service to leave comments on Pull Requests but does not give it access to your source code.
 does not have access to your source code.)
 
 Once the Pulumi GitHub App is installed, when your GitHub Actions run Pulumi, a summary of

--- a/content/docs/console/continuous-delivery/github-actions.md
+++ b/content/docs/console/continuous-delivery/github-actions.md
@@ -99,7 +99,7 @@ action "Pulumi Deploy (Current Stack)" {
 Note that by using the `pulumi/actions` Docker image, these workflow actions will
 automatically download and use the latest version of Pulumi. If you prefer to use a
 specific version of Pulumi, you can replace all occurrences of `uses =
-"docker://pulumi/actions"` with a container image that contains the version as a tag, for
+"docker://pulumi/actions"` with a container image that contains the version as a tag. For
 instance `uses = "docker://pulumi/actions:v0.16.6"`.
 
 We've also included a prelimarily `Build` action &mdash; and declared it as a

--- a/content/docs/console/continuous-delivery/github-actions.md
+++ b/content/docs/console/continuous-delivery/github-actions.md
@@ -15,54 +15,50 @@ or promotions between different environments by merging or directly committing c
 
 Let's see how to get started -- it's easy!
 
-> **Note**: Remember that GitHub Actions is in private beta right now. Please
-> [register for access](https://github.com/features/actions) here. Until you've been added, the **Actions**
-> tab won't show in your repos, and the `.pulumi/main.workflow` file will do nothing. Also note that these
-> features will only work on private repos in the specific account that has been granted access.
+> **Note**: GitHub Actions is currently in public beta. Please [register for
+> access](https://github.com/features/actions) here. Until you've been added, the
+> **Actions** tab won't show in your repos, and the `.pulumi/main.workflow` file described
+> below will not be recognized by GitHub. Also note that these features only work on
+> private repos in the specific account that has been granted access.
 
 # Pre-Requisites
 
 Before proceeding, you'll need to [Sign Up for Pulumi](https://app.pulumi.com/) (if you haven't already).
 
-For your workflow to do anything interesting, you'll want to create a new project. There are three ways to do this:
+For your workflow to do anything interesting, you'll want to create a new Pulumi project.
+There are three ways to do this:
 
-1. [Clone an Existing Example](https://github.com/pulumi/examples)
-2. [Use the New Project Wizard](https://app.pulumi.com/site/new-project)
+1. [Clone an existing Pulumi example](https://github.com/pulumi/examples)
+2. [Use the New Project wizard](https://app.pulumi.com/site/new-project)
 3. [Download the CLI]({{< relref "/docs/reference/install.md" >}}) and run `pulumi new` to select a template
 
 # Creating a Workflow
 
 Although the full power of the Pulumi CLI is available to use with GitHub Actions, we recommend starting with
-our standard workflow. This workflow consists of two actions
+our standard workflow, which consists of two actions, both triggered by GitHub events:
 
-1. **Pulumi Deploy (Current Stack)** deploys a commit to the current branch by running `pulumi up`
-2. **Pulumi Preview (Merged Stack)** shows a preview of what would happen if a PR was merged, by running `pulumi preview`
+1. **Pulumi Preview (Merged Stack)** runs `pulumi preview` in response to a Pull Request, showing what would happen if the PR were merged into the target branch.
+2. **Pulumi Deploy (Current Stack)** runs `pulumi up` on the target branch, in response to a commit on that branch.
 
-From here, there are two ways to configure actions in your repo: doing it manually by committing workflow files and
-configuring secrets, or using the visual editor. We'll start with the file-based approach -- but, if you prefer the
-interactive workflow editor, please scroll down.
+From here, there are two ways to configure actions in your repo: in code, by committing a
+workflow file in your project repository, or by using the visual editor on GitHub.com.
+
+We'll start with the file-based approach, but if you'd prefer to use the visual editor
+instead, you can [skip to that section now](#using-the-visual-editor).
 
 ## Committing the Workflow File
 
-Let's get started by adding the workflow file.
+Let's get started by adding a new workflow file to the GitHub repository containing your
+Pulumi project.
 
-To set up the workflow to run anytime you commit or modify a PR, add the following to `.github/main.workflow`:
+To set up the workflow to run anytime you make a commit or a Pull Request (including
+successive commits on PR branches), add a new file to the repository at
+`.github/main.workflow`:
 
 ```hcl
-workflow "Update" {
-    on = "push"
-    resolves = [ "Pulumi Deploy (Current Stack)" ]
-}
-
-action "Pulumi Deploy (Current Stack)" {
-    uses = "docker://pulumi/actions"
-    args = [ "up" ]
-    env = {
-        "PULUMI_CI" = "up"
-    }
-    secrets = [
-        "PULUMI_ACCESS_TOKEN"
-    ]
+action "Build" {
+    uses = "docker://alpine"
+    runs = ["scripts/build"]
 }
 
 workflow "Preview" {
@@ -71,10 +67,28 @@ workflow "Preview" {
 }
 
 action "Pulumi Preview (Merged Stack)" {
+    needs = ["Build"]
     uses = "docker://pulumi/actions"
-    args = [ "preview" ]
+    args = ["preview"]
     env = {
-        "PULUMI_CI" = "pr"
+        PULUMI_CI = "pr"
+    }
+    secrets = [
+        "PULUMI_ACCESS_TOKEN"
+    ]
+}
+
+workflow "Update " {
+    on = "push"
+    resolves = ["Pulumi Deploy (Current Stack)"]
+}
+
+action "Pulumi Deploy (Current Stack)" {
+    needs = ["Build"]
+    uses = "docker://pulumi/actions"
+    args = ["up"]
+    env = {
+        PULUMI_CI = "up"
     }
     secrets = [
         "PULUMI_ACCESS_TOKEN"
@@ -82,57 +96,52 @@ action "Pulumi Preview (Merged Stack)" {
 }
 ```
 
-This file is also available [here](https://github.com/pulumi/actions/blob/master/examples/main.workflow).
+Note that by using the `pulumi/actions` Docker image, these workflow actions will
+automatically download and use the latest version of Pulumi. If you prefer to use a
+specific version of Pulumi, you can replace all occurrences of `uses =
+"docker://pulumi/actions"` with a container image that contains the version as a tag, for
+instance `uses = "docker://pulumi/actions:v0.16.6"`.
 
-Also note that this workflow file will automatically download and use the latest version of Pulumi. If you prefer
-to use a specific version of Pulumi, you can replace all occurrences of `uses = "docker://pulumi/actions"` with
-a container image that contains the version as a tag, for instance `uses = "docker://pulumi/actions:v0.16.6"`.
+We've also included a prelimarily `Build` action &mdash; and declared it as a
+dependency of both the Preview and Update actions &mdash; in order to demonstrate running
+a setup script in advance of Pulumi. Feel free to remove this block (and the `needs`
+references to it) if it doesn't suit your particular situation.
 
-Now you've got a workflow defined, but before you're ready to use it, you'll need to configure your secrets.
+Now that you've got a workflow defined, you'll need to configure your secrets. Secrets are
+exposed as environment variables to the GitHub Actions runtime environment. Minimally,
+we'll need to supply a Pulumi access token in order to allow Pulumi CLI to communicate
+with the Pulumi Service on your behalf, and you'll probably want to provide credentials
+for communicating with your cloud provider as well.
 
 ## Configuring Your Secrets
 
-After committing the workflow file into your repo as `.github/main.workflow`, head on over to your
-repo's **Settings tab**, where you will find the new **Secrets area**:
+After committing the workflow file into your repo as `.github/main.workflow`, head on over
+to your repo's **Settings tab**, where you'll find the new **Secrets area**:
 
 ![Secrets](/images/docs/reference/gh-actions-secrets.png)
 
-First, [create a Pulumi Access Token](https://app.pulumi.com/account/tokens), and enter it as `PULUMI_ACCESS_TOKEN`.
-This enables your GitHub Action to communicate with the Pulumi service.
+First, [create a new Pulumi Access Token](https://app.pulumi.com/account/tokens), then
+submit that token as a new secret named named `PULUMI_ACCESS_TOKEN`. This enables your
+GitHub Action to communicate with the Pulumi service.
 
-Next, you'll need to configure your cloud credentials. This is dependent on your cloud of choice; for example
+Next, add secrets for your cloud credentials, just as you did `PULUMI_ACCESS_TOKEN` above,
+based on your provider of choice. For example:
 
 * `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for [AWS]({{< relref "/docs/reference/clouds/aws/setup.md" >}})
 * `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID` for [Azure]({{< relref "/docs/reference/clouds/azure/setup.md" >}})
 * `GOOGLE_CREDENTIALS` for [GCP]({{< relref "/docs/reference/clouds/gcp/setup.md" >}})
 * `KUBECONFIG` for [Kubernetes]({{< relref "/docs/reference/clouds/kubernetes/setup.md" >}})
 
-Enter these as secrets, just like you did `PULUMI_ACCESS_TOKEN`, so that your GitHub Action can deploy to your cloud.
-
-> **Important**: Make sure to also add these to your workflow action's `secrets` section, otherwise GitHub Actions
-> won't make them available to the running container, and things will behave as if you didn't set them at all!
-
-# Try It Out!
-
-To try things out, simply create a Pull Request or commit, and you will see these new actions showing up in
-the usual GitHub Checks dialog, with a green checkmark if everything went as planned:
-
-![Action Checks](/images/docs/reference/gh-actions-checks.png)
-
-Click the Logs pane to see the full output of the Pulumi CLI, along with a hyperlink to your deployment on
-Pulumi's Cloud Console with more details:
-
-![Action Logs](/images/docs/reference/gh-actions-logs.png)
-
-For even better Pull Request integration, make sure to also [install our GitHub App]({{< ref "/docs/console/continuous-delivery/github-app" >}})!
-
-![Action Pull Requests](/images/docs/reference/gh-actions-prs.png)
+> **Important**: Remember to add these variable names to the `secrets` lists in your
+> workflow `action` blocks, or GitHub Actions won't make them available to the running
+> container, and things will behave as if you hadn't set them at all!
 
 # Using the Visual Editor
 
-All of the above can be done using the visual editor if you prefer. We have listed the manual instructions
-because not everybody will see the new UI while GitHub Actions is in preview. But after your initial setup,
-this UI will become available, and you may find it more convenient to edit things visually.
+All of the above can be done using GitHub's visual editor if you prefer. We have listed
+the manual instructions because not everybody will see the new UI while GitHub Actions is
+in preview. But after your initial setup, this UI will become available, and you may find
+it more convenient to edit things visually.
 
 1. Go to your repo on GitHub, and click on the new **Actions** tab:
 
@@ -142,12 +151,11 @@ this UI will become available, and you may find it more convenient to edit thing
 
     ![Editor Create Workflow](/images/docs/reference/gh-actions-editor-create.png)
 
-3. Click the **&lt;&gt; Edit new file** tab:
+3. Click the **Edit new file** tab:
 
     ![Editor New File](/images/docs/reference/gh-actions-editor-newfile.png)
 
-4. Replace the default workflow with the suggested Pulumi workflow described above (
-   [see here](https://github.com/pulumi/actions/blob/master/examples/main.workflow)):
+4. Replace the default workflow with the one we provided described above, along with your customizations:
 
     ![Editor Workflow Edit](/images/docs/reference/gh-actions-editor-edit.png)
 
@@ -159,31 +167,50 @@ To edit your secrets, scroll down and select the first Pulumi action, and click 
 
 ![Editor Edit](/images/docs/reference/gh-actions-editor-configure.png)
 
-This will open the action editor on the right-hand side, in which you'll enter your various credentials (for Pulumi and
-your cloud). After configuring these, you should see the green secrets with lock icons show up for your actions:
+This will open the action editor on the right-hand side, in which you'll enter your
+various credentials (for Pulumi and your cloud). After configuring these, you should see
+the green secrets with lock icons show up for your actions:
 
 ![Editor Secrets](/images/docs/reference/gh-actions-editor-secrets.png)
 
+# Try It Out!
+
+To try things out, simply create a Pull Request or commit, and you will see these new
+actions showing up in the usual GitHub Checks dialog, with a green checkmark if everything
+went as planned:
+
+![Action Checks](/images/docs/reference/gh-actions-checks.png)
+
+Click the Logs pane to see the full output of the Pulumi CLI, along with the URL of your
+deployment on the Pulumi Cloud Console with more details:
+
+![Action Logs](/images/docs/reference/gh-actions-logs.png)
+
+For even better Pull Request integration, make sure to also [install our GitHub App]({{< relref "github.md" >}})!
+
+![Action Pull Requests](/images/docs/reference/gh-actions-prs.png)
+
 # Pull Request Flow
 
-If you are using Pulumi's GitHub Actions to preview infrastructure changes from Pull Requests, you may want to
-have Pulumi comment on those PRs so that you don't need to look at the specific update logs to see if there
-were any changes.
+If you are using Pulumi's GitHub Actions to preview infrastructure changes from Pull
+Requests, you may want to have Pulumi comment on those PRs so that you don't need to look
+at the specific update logs to see if there were any changes.
 
-There are two ways to do this: using the Pulumi GitHub App (recommended), or configuring the GitHub Actions
-container directly.
+There are two ways to do this: using the Pulumi GitHub App (recommended), or configuring
+the GitHub Actions container directly.
 
 ## Pulumi GitHub App
 
-The [Pulumi GitHub App]({{< relref "github.md" >}}) is something you install into your GitHub
-organization, that will allow the Pulumi service to leave comments on Pull Requests. (It will not have access
-to your source code.)
+The [Pulumi GitHub App]({{< relref "github.md" >}}) is something you install into your
+GitHub organization. It allows the Pulumi service to leave comments on Pull Requests. (It
+does not have access to your source code.)
 
-Once the Pulumi GitHub App is installed, when your GitHub Actions run Pulumi, a summary of any resource changes
-is left on the Pull Request. As well as links to the Pulumi Cloud Console for more detailed information.
+Once the Pulumi GitHub App is installed, when your GitHub Actions run Pulumi, a summary of
+any resource changes will be left on the Pull Request, as well as links to the Pulumi
+Cloud Console for more detailed information.
 
-You can install the Pulumi GitHub App now, by visiting [github.com/apps/pulumi](https://github.com/apps/pulumi)
-or clicking the button below.
+You can install the Pulumi GitHub App now, by visiting
+[github.com/apps/pulumi](https://github.com/apps/pulumi) or clicking the button below.
 
 <a class="btn" href="https://github.com/apps/pulumi" target="_blank">
     INSTALL
@@ -195,12 +222,15 @@ Example comment when using the Pulumi GitHub App:
 
 ## Comments By GitHub Actions
 
-If you don't want to use the Pulumi GitHub App, you can configure Pulumi's GitHub Actions to copy the output
-of the pulumi invocation on the pull request. This option doesn't have as rich of an output display as the
-Pulumi GitHub App, and just copies the raw output of the Pulumi command-line.
+If you don't want to use the Pulumi GitHub App, you can configure Pulumi's GitHub Actions
+to copy the output of the `pulumi` invocation on the Pull Request. This option doesn't
+have as rich an output display as the Pulumi GitHub App, as it simply copies the raw
+output of the Pulumi CLI.
 
-To do this you need to set the `COMMENT_ON_PR` environment variable, and add the `GITHUB_TOKEN` value to
-the secrets passed to the GitHub Action step. For example,
+To allow your GitHub Action to leave Pull Request comments, you'll need to set the
+`COMMENT_ON_PR` environment variable, and add `GITHUB_TOKEN` to the list of `secrets`
+passed to the action. (The `GITHUB_TOKEN` value will already be set in the running
+environment, so there's no need to add one explicitly as a secret.) For example:
 
 ```hcl
 action "Pulumi Preview (Merged Stack)" {
@@ -212,7 +242,7 @@ action "Pulumi Preview (Merged Stack)" {
   }
   secrets = [
     "PULUMI_ACCESS_TOKEN",
-    "GITHUB_TOKEN",
+    "GITHUB_TOKEN"
   ]
 }
 ```
@@ -227,14 +257,16 @@ You can configure how Pulumi's GitHub Actions work to have more control about wh
 
 ## Using a Different Root Directory
 
-By default, the Pulumi GitHub Action assumes your Pulumi project is in your repo's root directory. If you are using a
-different root directory for your project, simply set the `PULUMI_ROOT` variable in your workflow. For example
+By default, the Pulumi GitHub Action assumes your Pulumi project is in your repo's root
+directory. If you are using a different root directory for your project, simply set the
+`PULUMI_ROOT` variable in your workflow action, with a relative path to your Pulumi
+project directory. For example:
 
 ```hcl
 action "Pulumi Deploy (Current Stack)" {
     ...
     env = {
-        "PULUMI_ROOT" = "infra"
+        PULUMI_ROOT = "infra"
     }
 }
 ```
@@ -243,11 +275,13 @@ This tells Pulumi that the project can be found underneath the repo's `infra` di
 
 ## Branch Mappings
 
-Pulumi has a concept of *stacks*, which are isolated environments for your application (e.g., production, staging, or
-even distinct services). By default, the GitHub Action will assume a project has a single stack, and will associate the
-`master` branch with it. For sophisticated scenarios, this can be overridden in the `.pulumi/ci.json` file.
+Pulumi has a concept of *stacks*, which are isolated environments for your application
+(e.g., production, staging, or even distinct services). By default, the GitHub Action will
+assume a project has a single stack, and will associate the `master` branch with it. For
+more sophisticated scenarios, this can be overridden by adding a `.pulumi/ci.json` file to
+your repository as well.
 
-This is simply a JSON map. For example:
+This file is simply a JSON map of GitHub branch names to Pulumi stacks. For example:
 
 ```json
 {
@@ -256,11 +290,13 @@ This is simply a JSON map. For example:
 }
 ```
 
-Often, we'll map `master` to a `production` stack, and `staging` to a distinct `staging` stack, for example, and then
-use Pull Requests to promote code between the two. This mappings file is intentionally flexible.
+Often, we'll map `master` to a `production` stack, and `staging` to a distinct `staging`
+stack, and then use Pull Requests to promote code between the two. This mappings file is
+intentionally flexible.
 
-Note that you'll need to create these stacks in the usual way using Pulumi's service console or CLI. After setting this
-up, everything will be on autopilot.
+Note that you'll need to create these stacks [in the usual
+way](https://www.pulumi.com/docs/reference/stack/) using the Pulumi Cloud Console or CLI.
+After setting this up, everything will be on autopilot.
 
 # Demos and Examples
 

--- a/content/docs/console/continuous-delivery/github-actions.md
+++ b/content/docs/console/continuous-delivery/github-actions.md
@@ -201,7 +201,7 @@ the GitHub Actions container directly.
 
 ## Pulumi GitHub App
 
-The [Pulumi GitHub App]({{< relref "github.md" >}}) is something you install into your
+The [Pulumi GitHub App]({{< relref "github.md" >}}) is something you install on your
 GitHub organization. It allows the Pulumi service to leave comments on Pull Requests. (It
 does not have access to your source code.)
 


### PR DESCRIPTION
This change updates the GitHub Actions docs to better reflect current behavior. It also includes an example of running a preliminary (e.g., build) step in advance of a Pulumi command.

Fixes #1399.

