### PR TITLE
Fix word-splitting wrapping behavior

### DIFF
--- a/assets/sass/_api-nodejs.scss
+++ b/assets/sass/_api-nodejs.scss
@@ -51,5 +51,6 @@
 
 .pdoc-module-header,
 .pdoc-module-contents {
-    @apply break-all;
+    @apply break-words;
+    word-break: break-word;
 }

--- a/assets/sass/_api-python.scss
+++ b/assets/sass/_api-python.scss
@@ -115,6 +115,7 @@ div.section[id]:not([id=""]) {
     }
 
     table td, .pre {
-        @apply break-all;
+        @apply break-words;
+        word-break: break-word;
     }
 }


### PR DESCRIPTION
The `break-all`s replaced here were intended to encourage the browser to wrap long unbroken strings (as they’d been breaking the docs layout on mobile), but that rule was more aggressive than I realized. 

This change aims to wrap at the usual places where possible (e.g., when a line contains multiple words, wrapping will happen between words), but fall back to splitting words if necessary (for URLs, long APIs, examples, etc.).

Fixes #1457.
