### PR TITLE
Update pulumi/eks docs for v0.18.10

### DIFF
--- a/content/docs/reference/pkg/nodejs/pulumi/eks/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/eks/_index.md
@@ -51,14 +51,14 @@ import * as eks from "@pulumi/eks";
 <li><a href="#EBSVolumeType">type EBSVolumeType</a></li>
 </ul>
 
-<a href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts">cluster.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts">cni.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/dashboard.ts">dashboard.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts">nodegroup.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/securitygroup.ts">securitygroup.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/servicerole.ts">servicerole.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts">storageclass.ts</a> 
+<a href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts">cluster.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts">cni.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/dashboard.ts">dashboard.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts">nodegroup.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/securitygroup.ts">securitygroup.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/servicerole.ts">servicerole.ts</a> <a href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts">storageclass.ts</a> 
 </div>
 </div>
 </div>
 
 
 <h2 class="pdoc-module-header" id="Cluster">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L512">class <b>Cluster</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L602">class <b>Cluster</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <pre class="highlight"><span class='kd'>extends</span> <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResource'>ComponentResource</a></pre>
@@ -69,7 +69,7 @@ nodes, its optional StorageClasses, and an optional deployment of the Kubernetes
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="Cluster-constructor">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L562"> <b>constructor</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L652"> <b>constructor</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -87,7 +87,7 @@ requested.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-createNodeGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L651">method <b>createNodeGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L732">method <b>createNodeGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -97,7 +97,7 @@ requested.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-getProvider">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L19">method <b>getProvider</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L19">method <b>getProvider</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -107,7 +107,7 @@ requested.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-isInstance">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L233">method <b>isInstance</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L258">method <b>isInstance</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -121,7 +121,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-registerOutputs">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L248">method <b>registerOutputs</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L273">method <b>registerOutputs</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -131,7 +131,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-clusterSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L532">property <b>clusterSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L622">property <b>clusterSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>clusterSecurityGroup: aws.ec2.SecurityGroup;</pre>
@@ -142,7 +142,7 @@ The security group for the EKS cluster.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-core">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L562">property <b>core</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L652">property <b>core</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>core: <a href='#CoreData'>CoreData</a>;</pre>
@@ -153,7 +153,7 @@ The EKS cluster and it's dependencies.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-defaultNodeGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L552">property <b>defaultNodeGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L642">property <b>defaultNodeGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>defaultNodeGroup: <a href='#NodeGroupData'>NodeGroupData</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</pre>
@@ -164,7 +164,7 @@ The default Node Group configuration, or undefined if `skipDefaultNodeGroup` was
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-eksCluster">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L557">property <b>eksCluster</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L647">property <b>eksCluster</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>eksCluster: aws.eks.Cluster;</pre>
@@ -175,7 +175,7 @@ The EKS cluster.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-eksClusterIngressRule">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L547">property <b>eksClusterIngressRule</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L637">property <b>eksClusterIngressRule</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>eksClusterIngressRule: aws.ec2.SecurityGroupRule;</pre>
@@ -186,7 +186,7 @@ The ingress rule that gives node group access to cluster API server
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-instanceRoles">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L537">property <b>instanceRoles</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L627">property <b>instanceRoles</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>instanceRoles: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.iam.Role[]&gt;;</pre>
@@ -197,7 +197,7 @@ The service roles used by the EKS cluster.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-kubeconfig">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L517">property <b>kubeconfig</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L607">property <b>kubeconfig</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>kubeconfig: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#any'>any</a></span>&gt;;</pre>
@@ -209,7 +209,7 @@ to the Kubernetes provider.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-nodeSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L542">property <b>nodeSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L632">property <b>nodeSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>nodeSecurityGroup: aws.ec2.SecurityGroup;</pre>
@@ -220,7 +220,7 @@ The security group for the cluster's nodes.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-provider">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L527">property <b>provider</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L617">property <b>provider</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>provider: k8s.Provider;</pre>
@@ -236,7 +236,7 @@ create a new Pod in the EKS cluster.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Cluster-urn">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L17">property <b>urn</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L17">property <b>urn</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>urn: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#URN'>URN</a>&gt;;</pre>
@@ -249,7 +249,7 @@ deployments.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="NodeGroup">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L204">class <b>NodeGroup</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L223">class <b>NodeGroup</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <pre class="highlight"><span class='kd'>extends</span> <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResource'>ComponentResource</a></pre>
@@ -260,7 +260,7 @@ NodeGroup is a component that wraps the AWS EC2 instances that provide compute c
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="NodeGroup-constructor">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L218"> <b>constructor</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L237"> <b>constructor</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -278,7 +278,7 @@ requested.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroup-getProvider">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L19">method <b>getProvider</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L19">method <b>getProvider</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -288,7 +288,7 @@ requested.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroup-isInstance">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L233">method <b>isInstance</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L258">method <b>isInstance</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -302,7 +302,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroup-registerOutputs">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L248">method <b>registerOutputs</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L273">method <b>registerOutputs</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -312,7 +312,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroup-autoScalingGroupName">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L218">property <b>autoScalingGroupName</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L237">property <b>autoScalingGroupName</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>autoScalingGroupName: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -323,7 +323,7 @@ The AutoScalingGroup name for the Node group.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroup-cfnStack">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L213">property <b>cfnStack</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L232">property <b>cfnStack</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>cfnStack: aws.cloudformation.Stack;</pre>
@@ -334,7 +334,7 @@ The CloudFormation Stack which defines the Node AutoScalingGroup.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroup-nodeSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L208">property <b>nodeSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L227">property <b>nodeSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>nodeSecurityGroup: aws.ec2.SecurityGroup;</pre>
@@ -345,7 +345,7 @@ The security group for the cluster's nodes.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroup-urn">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L17">property <b>urn</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L17">property <b>urn</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>urn: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#URN'>URN</a>&gt;;</pre>
@@ -358,7 +358,7 @@ deployments.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="ServiceRole">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/servicerole.ts#L49">class <b>ServiceRole</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/servicerole.ts#L49">class <b>ServiceRole</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <pre class="highlight"><span class='kd'>extends</span> <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResource'>ComponentResource</a></pre>
@@ -369,7 +369,7 @@ managed policies.
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="ServiceRole-constructor">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/servicerole.ts#L51"> <b>constructor</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/servicerole.ts#L51"> <b>constructor</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -386,7 +386,7 @@ Create a new ServiceRole.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ServiceRole-getProvider">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L19">method <b>getProvider</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L19">method <b>getProvider</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -396,7 +396,7 @@ Create a new ServiceRole.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ServiceRole-isInstance">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L233">method <b>isInstance</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L258">method <b>isInstance</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -410,7 +410,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ServiceRole-registerOutputs">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L248">method <b>registerOutputs</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L273">method <b>registerOutputs</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -420,7 +420,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ServiceRole-role">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/servicerole.ts#L51">property <b>role</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/servicerole.ts#L51">property <b>role</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'>public </span>role: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.iam.Role&gt;;</pre>
@@ -428,7 +428,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ServiceRole-urn">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L17">property <b>urn</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L17">property <b>urn</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>urn: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#URN'>URN</a>&gt;;</pre>
@@ -441,7 +441,7 @@ deployments.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="VpcCni">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts#L125">class <b>VpcCni</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L162">class <b>VpcCni</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <pre class="highlight"><span class='kd'>extends</span> <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>Resource</a></pre>
@@ -452,7 +452,7 @@ able to programatically manage existing infrastructure, we can replace this with
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="VpcCni-constructor">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts#L125"> <b>constructor</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L162"> <b>constructor</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -462,7 +462,7 @@ able to programatically manage existing infrastructure, we can replace this with
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="VpcCni-getProvider">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L19">method <b>getProvider</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L19">method <b>getProvider</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -472,7 +472,7 @@ able to programatically manage existing infrastructure, we can replace this with
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="VpcCni-isInstance">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L192">method <b>isInstance</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L217">method <b>isInstance</b></a>
 </h3>
 <div class="pdoc-member-contents">
 {{% md %}}
@@ -486,7 +486,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="VpcCni-id">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L187">property <b>id</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L212">property <b>id</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>id: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ID'>ID</a>&gt;;</pre>
@@ -498,7 +498,7 @@ deployments and may be missing (undefined) during planning phases.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="VpcCni-urn">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L17">property <b>urn</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/node_modules/@pulumi/pulumi/resource.d.ts#L17">property <b>urn</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>urn: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#URN'>URN</a>&gt;;</pre>
@@ -511,7 +511,7 @@ deployments.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="createCore">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L88">function <b>createCore</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L105">function <b>createCore</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -521,7 +521,7 @@ deployments.
 {{% /md %}}
 </div>
 <h2 class="pdoc-module-header" id="createDashboard">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/dashboard.ts#L22">function <b>createDashboard</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/dashboard.ts#L22">function <b>createDashboard</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -531,7 +531,7 @@ deployments.
 {{% /md %}}
 </div>
 <h2 class="pdoc-module-header" id="createNodeGroup">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L245">function <b>createNodeGroup</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L264">function <b>createNodeGroup</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -541,27 +541,32 @@ deployments.
 {{% /md %}}
 </div>
 <h2 class="pdoc-module-header" id="createNodeGroupSecurityGroup">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/securitygroup.ts#L42">function <b>createNodeGroupSecurityGroup</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/securitygroup.ts#L47">function <b>createNodeGroupSecurityGroup</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
 
-<pre class="highlight"><span class='kd'></span>createNodeGroupSecurityGroup(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='#NodeGroupSecurityGroupOptions'>NodeGroupSecurityGroupOptions</a>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResource'>pulumi.ComponentResource</a>): aws.ec2.SecurityGroup</pre>
+<pre class="highlight"><span class='kd'></span>createNodeGroupSecurityGroup(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='#NodeGroupSecurityGroupOptions'>NodeGroupSecurityGroupOptions</a>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResource'>pulumi.ComponentResource</a>): [, aws.ec2.SecurityGroup, aws.ec2.SecurityGroupRule]</pre>
+
+
+createNodeGroupSecurityGroup creates a security group for node groups with the
+default ingress & egress rules required to connect and work with the EKS
+cluster security group.
 
 {{% /md %}}
 </div>
 <h2 class="pdoc-module-header" id="createStorageClass">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L98">function <b>createStorageClass</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L107">function <b>createStorageClass</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
 
-<pre class="highlight"><span class='kd'></span>createStorageClass(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, storageClass: <a href='#StorageClass'>StorageClass</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></pre>
+<pre class="highlight"><span class='kd'></span>createStorageClass(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, storageClass: <a href='#StorageClass'>StorageClass</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): k8s.storage.v1.StorageClass</pre>
 
 {{% /md %}}
 </div>
 <h2 class="pdoc-module-header" id="ClusterNodeGroupOptions">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L506">interface <b>ClusterNodeGroupOptions</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L596">interface <b>ClusterNodeGroupOptions</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <pre class="highlight"><span class='kd'>extends</span> <a href='#NodeGroupBaseOptions'>NodeGroupBaseOptions</a></pre>
@@ -572,7 +577,7 @@ to create its own node groups. It's a subset of NodeGroupOptions.
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-amiId">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L120">property <b>amiId</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L121">property <b>amiId</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>amiId?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -586,7 +591,7 @@ you want to build your own AMI.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-autoScalingGroupTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L164">property <b>autoScalingGroupTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L183">property <b>autoScalingGroupTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>autoScalingGroupTags?: InputTags;</pre>
@@ -606,8 +611,22 @@ Note: Given the inheritance of auto-generated CF tags and
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-bootstrapExtraArgs">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L149">property <b>bootstrapExtraArgs</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>bootstrapExtraArgs?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;</pre>
+{{% md %}}
+
+Additional args to pass directly to `/etc/eks/bootstrap.sh`.  Fror details on available options, see:
+https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh.  Note that the `--apiserver-endpoint`,
+`--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration
+parameters.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-cloudFormationTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L173">property <b>cloudFormationTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L192">property <b>cloudFormationTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>cloudFormationTags?: InputTags;</pre>
@@ -622,7 +641,7 @@ Note: Given the inheritance of auto-generated CF tags and
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-clusterIngressRule">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L73">property <b>clusterIngressRule</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L74">property <b>clusterIngressRule</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>clusterIngressRule?: aws.ec2.SecurityGroupRule;</pre>
@@ -633,7 +652,7 @@ The ingress rule that gives node group access.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-desiredCapacity">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L102">property <b>desiredCapacity</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L103">property <b>desiredCapacity</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>desiredCapacity?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -644,7 +663,7 @@ The number of worker nodes that should be running in the cluster. Defaults to 2.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-instanceProfile">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L149">property <b>instanceProfile</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L168">property <b>instanceProfile</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceProfile?: aws.iam.InstanceProfile;</pre>
@@ -656,7 +675,7 @@ must be supplied in the ClusterOptions as either: 'instanceRole', or as a role o
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-instanceType">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L55">property <b>instanceType</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L56">property <b>instanceType</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceType?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ec2.InstanceType&gt;;</pre>
@@ -667,7 +686,7 @@ The instance type to use for the cluster's nodes. Defaults to "t2.medium".
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-keyName">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L85">property <b>keyName</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L86">property <b>keyName</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>keyName?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -677,19 +696,34 @@ Name of the key pair to use for SSH access to worker nodes.
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-kubeletExtraArgs">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L141">property <b>kubeletExtraArgs</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>kubeletExtraArgs?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;</pre>
+{{% md %}}
+
+Extra args to pass to the Kubelet.  Corresponds to the options passed in the `--kubeletExtraArgs` flag to
+`/etc/eks/bootstrap.sh`.  For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints`
+properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after
+to the expicit `kubeletExtraArgs`.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-labels">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L125">property <b>labels</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L127">property <b>labels</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>labels?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | {[key: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>]: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>};</pre>
 {{% md %}}
 
-Custom k8s node labels to be attached to each woker node
+Custom k8s node labels to be attached to each woker node.  Adds the given key/value pairs to the `--node-labels`
+kubelet argument.
 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-maxSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L112">property <b>maxSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L113">property <b>maxSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>maxSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -700,7 +734,7 @@ The maximum number of worker nodes running in the cluster. Defaults to 2.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-minSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L107">property <b>minSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L108">property <b>minSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>minSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -711,7 +745,7 @@ The minimum number of worker nodes running in the cluster. Defaults to 1.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-nodeAssociatePublicIpAddress">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L138">property <b>nodeAssociatePublicIpAddress</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L157">property <b>nodeAssociatePublicIpAddress</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeAssociatePublicIpAddress?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>;</pre>
@@ -725,7 +759,7 @@ public IPs.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-nodePublicKey">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L80">property <b>nodePublicKey</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L81">property <b>nodePublicKey</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodePublicKey?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -738,7 +772,7 @@ If not provided, no SSH access is enabled on VMs.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-nodeRootVolumeSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L90">property <b>nodeRootVolumeSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L91">property <b>nodeRootVolumeSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeRootVolumeSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -749,7 +783,7 @@ The size in GiB of a cluster node's root volume. Defaults to 20.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-nodeSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L68">property <b>nodeSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L69">property <b>nodeSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSecurityGroup?: aws.ec2.SecurityGroup;</pre>
@@ -763,7 +797,7 @@ Note: The `nodeSecurityGroup` option and the cluster option
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-nodeSubnetIds">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L50">property <b>nodeSubnetIds</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L51">property <b>nodeSubnetIds</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSubnetIds?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -776,7 +810,7 @@ This option overrides clusterSubnetIds option.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-nodeUserData">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L97">property <b>nodeUserData</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L98">property <b>nodeUserData</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeUserData?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -789,7 +823,7 @@ critically it must begin with an interpreter directive (i.e. a `#!`).
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-spotPrice">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L60">property <b>spotPrice</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L61">property <b>spotPrice</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>spotPrice?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -800,18 +834,19 @@ Bidding price for spot instance. If set, only spot instances will be added as wo
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-taints">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L130">property <b>taints</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L133">property <b>taints</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>taints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | {[key: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>]: <a href='#Taint'>Taint</a>};</pre>
 {{% md %}}
 
-Custom k8s node taints to be attached to each worker node
+Custom k8s node taints to be attached to each worker node.  Adds the given taints to the `--register-with-taints`
+kubelet argument.
 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterNodeGroupOptions-version">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L143">property <b>version</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L162">property <b>version</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>version?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -823,7 +858,7 @@ Desired Kubernetes master / control plane version. If you do not specify a value
 </div>
 </div>
 <h2 class="pdoc-module-header" id="ClusterOptions">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L319">interface <b>ClusterOptions</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L376">interface <b>ClusterOptions</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -831,8 +866,20 @@ Desired Kubernetes master / control plane version. If you do not specify a value
 ClusterOptions describes the configuration options accepted by an EKSCluster component.
 
 {{% /md %}}
+<h3 class="pdoc-member-header" id="ClusterOptions-clusterSecurityGroup">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L479">property <b>clusterSecurityGroup</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>clusterSecurityGroup?: aws.ec2.SecurityGroup;</pre>
+{{% md %}}
+
+The security group to use for the cluster API endpoint.  If not provided, a new security group will be created
+with full internet egress and ingress from node groups.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="ClusterOptions-clusterSecurityGroupTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L411">property <b>clusterSecurityGroupTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L484">property <b>clusterSecurityGroupTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>clusterSecurityGroupTags?: InputTags;</pre>
@@ -843,43 +890,15 @@ The tags to apply to the cluster security group.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-customInstanceRolePolicy">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L387">property <b>customInstanceRolePolicy</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L454">property <b>customInstanceRolePolicy</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>customInstanceRolePolicy?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
 {{% md %}}
 {{% /md %}}
 </div>
-<h3 class="pdoc-member-header" id="ClusterOptions-deployDashboard">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L481">property <b>deployDashboard</b></a>
-</h3>
-<div class="pdoc-member-contents">
-<pre class="highlight"><span class='kd'></span>deployDashboard?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>;</pre>
-{{% md %}}
-
-Whether or not to deploy the Kubernetes dashboard to the cluster. If the dashboard is deployed, it can be
-accessed as follows:
-
-1. Retrieve an authentication token for the dashboard by running the following and copying the value of `token`
-  from the output of the last command:
-
-    $ kubectl -n kube-system get secret | grep eks-admin | awk '{print $1}'
-    $ kubectl -n kube-system describe secret <output from previous command>
-
-2. Start the kubectl proxy:
-
-    $ kubectl proxy
-
-3. Open `http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/` in a
-   web browser.
-4. Choose `Token` authentication, paste the token retrieved earlier into the `Token` field, and sign in.
-
-Defaults to `true`.
-
-{{% /md %}}
-</div>
 <h3 class="pdoc-member-header" id="ClusterOptions-desiredCapacity">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L436">property <b>desiredCapacity</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L509">property <b>desiredCapacity</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>desiredCapacity?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -890,7 +909,7 @@ The number of worker nodes that should be running in the cluster. Defaults to 2.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-enabledClusterLogTypes">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L499">property <b>enabledClusterLogTypes</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L579">property <b>enabledClusterLogTypes</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>enabledClusterLogTypes?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -902,8 +921,41 @@ By default it is off.
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="ClusterOptions-endpointPrivateAccess">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L589">property <b>endpointPrivateAccess</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>endpointPrivateAccess?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>;</pre>
+{{% md %}}
+
+Indicates whether or not the Amazon EKS private API server endpoint is enabled.  The default is `false`.
+
+{{% /md %}}
+</div>
+<h3 class="pdoc-member-header" id="ClusterOptions-endpointPublicAccess">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L584">property <b>endpointPublicAccess</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>endpointPublicAccess?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>;</pre>
+{{% md %}}
+
+Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default is `true`.
+
+{{% /md %}}
+</div>
+<h3 class="pdoc-member-header" id="ClusterOptions-instanceProfileName">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L432">property <b>instanceProfileName</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>instanceProfileName?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
+{{% md %}}
+
+The default IAM InstanceProfile to use on the Worker NodeGroups, if one is not already set in the NodeGroup.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="ClusterOptions-instanceRole">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L370">property <b>instanceRole</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L427">property <b>instanceRole</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceRole?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.iam.Role&gt;;</pre>
@@ -918,7 +970,7 @@ Note: options `instanceRole` and `instanceRoles` are mutually exclusive.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-instanceRoles">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L378">property <b>instanceRoles</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L445">property <b>instanceRoles</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceRoles?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.iam.Role&gt;[]&gt;;</pre>
@@ -932,7 +984,7 @@ Note: options `instanceRole` and `instanceRoles` are mutually exclusive.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-instanceType">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L361">property <b>instanceType</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L418">property <b>instanceType</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceType?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ec2.InstanceType&gt;;</pre>
@@ -943,7 +995,7 @@ The instance type to use for the cluster's nodes. Defaults to "t2.medium".
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-maxSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L446">property <b>maxSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L519">property <b>maxSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>maxSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -954,7 +1006,7 @@ The maximum number of worker nodes running in the cluster. Defaults to 2.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-minSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L441">property <b>minSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L514">property <b>minSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>minSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -965,7 +1017,7 @@ The minimum number of worker nodes running in the cluster. Defaults to 1.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-nodeAmiId">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L394">property <b>nodeAmiId</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L461">property <b>nodeAmiId</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeAmiId?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -978,7 +1030,7 @@ Use the information provided by AWS if you want to build your own AMI.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-nodeAssociatePublicIpAddress">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L340">property <b>nodeAssociatePublicIpAddress</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L397">property <b>nodeAssociatePublicIpAddress</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeAssociatePublicIpAddress?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>;</pre>
@@ -992,7 +1044,7 @@ public IPs.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-nodePublicKey">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L401">property <b>nodePublicKey</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L468">property <b>nodePublicKey</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodePublicKey?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1005,7 +1057,7 @@ If not provided, no SSH access is enabled on VMs.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-nodeRootVolumeSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L424">property <b>nodeRootVolumeSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L497">property <b>nodeRootVolumeSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeRootVolumeSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1016,7 +1068,7 @@ The size in GiB of a cluster node's root volume. Defaults to 20.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-nodeSecurityGroupTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L419">property <b>nodeSecurityGroupTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L492">property <b>nodeSecurityGroupTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSecurityGroupTags?: InputTags;</pre>
@@ -1030,7 +1082,7 @@ Note: The `nodeSecurityGroupTags` option and the node group option
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-nodeSubnetIds">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L406">property <b>nodeSubnetIds</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L473">property <b>nodeSubnetIds</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSubnetIds?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -1041,7 +1093,7 @@ The subnets to use for worker nodes. Defaults to the value of subnetIds.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-nodeUserData">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L431">property <b>nodeUserData</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L504">property <b>nodeUserData</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeUserData?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1054,7 +1106,7 @@ critically it must begin with an interpreter directive (i.e. a `#!`).
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-roleMappings">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L345">property <b>roleMappings</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L402">property <b>roleMappings</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>roleMappings?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='#RoleMapping'>RoleMapping</a>&gt;[]&gt;;</pre>
@@ -1064,8 +1116,19 @@ Optional mappings from AWS IAM roles to Kubernetes users and groups.
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="ClusterOptions-serviceRole">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L437">property <b>serviceRole</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>serviceRole?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.iam.Role&gt;;</pre>
+{{% md %}}
+
+IAM Service Role for EKS to use to manage the cluster.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="ClusterOptions-skipDefaultNodeGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L459">property <b>skipDefaultNodeGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L534">property <b>skipDefaultNodeGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>skipDefaultNodeGroup?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>;</pre>
@@ -1076,21 +1139,23 @@ If this toggle is set to true, the EKS cluster will be created without node grou
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-storageClasses">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L454">property <b>storageClasses</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L529">property <b>storageClasses</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>storageClasses?: {[name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>]: <a href='#StorageClass'>StorageClass</a>} | <a href='#EBSVolumeType'>EBSVolumeType</a>;</pre>
 {{% md %}}
 
 An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map,
-a single StorageClass will be created for that volume type and made the cluster's default StorageClass.
+a single StorageClass will be created for that volume type.
 
-Defaults to "gp2".
+Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will
+always be created automatically for the cluster by the EKS service. See
+https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-subnetIds">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L332">property <b>subnetIds</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L389">property <b>subnetIds</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>subnetIds?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -1104,7 +1169,7 @@ https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html for more deta
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-tags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L487">property <b>tags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L567">property <b>tags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>tags?: InputTags;</pre>
@@ -1116,7 +1181,7 @@ resources directly under management with this cluster, which support tagging.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-userMappings">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L350">property <b>userMappings</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L407">property <b>userMappings</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>userMappings?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='#UserMapping'>UserMapping</a>&gt;[]&gt;;</pre>
@@ -1127,7 +1192,7 @@ Optional mappings from AWS IAM users to Kubernetes users and groups.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-version">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L492">property <b>version</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L572">property <b>version</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>version?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1138,7 +1203,7 @@ Desired Kubernetes master / control plane version. If you do not specify a value
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-vpcCniOptions">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L356">property <b>vpcCniOptions</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L413">property <b>vpcCniOptions</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>vpcCniOptions?: <a href='#VpcCniOptions'>VpcCniOptions</a>;</pre>
@@ -1150,7 +1215,7 @@ for the VpcCniOptions type.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ClusterOptions-vpcId">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L324">property <b>vpcId</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L381">property <b>vpcId</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>vpcId?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1163,7 +1228,7 @@ default VPC.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="CoreData">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L72">interface <b>CoreData</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L74">interface <b>CoreData</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -1172,7 +1237,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="CoreData-cluster">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L73">property <b>cluster</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L75">property <b>cluster</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>cluster: aws.eks.Cluster;</pre>
@@ -1180,7 +1245,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-clusterSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L76">property <b>clusterSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L78">property <b>clusterSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>clusterSecurityGroup: aws.ec2.SecurityGroup;</pre>
@@ -1188,7 +1253,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-eksNodeAccess">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L80">property <b>eksNodeAccess</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L82">property <b>eksNodeAccess</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>eksNodeAccess?: k8s.core.v1.ConfigMap;</pre>
@@ -1196,7 +1261,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-instanceProfile">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L79">property <b>instanceProfile</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L81">property <b>instanceProfile</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceProfile?: aws.iam.InstanceProfile;</pre>
@@ -1204,7 +1269,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-instanceRoles">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L78">property <b>instanceRoles</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L80">property <b>instanceRoles</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceRoles: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.iam.Role[]&gt;;</pre>
@@ -1212,7 +1277,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-kubeconfig">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L81">property <b>kubeconfig</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L84">property <b>kubeconfig</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>kubeconfig?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#any'>any</a></span>&gt;;</pre>
@@ -1220,7 +1285,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-nodeSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L84">property <b>nodeSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L87">property <b>nodeSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSecurityGroup?: aws.ec2.SecurityGroup;</pre>
@@ -1228,7 +1293,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-nodeSecurityGroupTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L85">property <b>nodeSecurityGroupTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L88">property <b>nodeSecurityGroupTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSecurityGroupTags?: InputTags;</pre>
@@ -1236,15 +1301,23 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-provider">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L77">property <b>provider</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L79">property <b>provider</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>provider: k8s.Provider;</pre>
 {{% md %}}
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="CoreData-storageClasses">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L83">property <b>storageClasses</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>storageClasses?: UserStorageClasses;</pre>
+{{% md %}}
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="CoreData-subnetIds">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L75">property <b>subnetIds</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L77">property <b>subnetIds</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>subnetIds: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[]&gt;;</pre>
@@ -1252,7 +1325,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-tags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L83">property <b>tags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L86">property <b>tags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>tags?: InputTags;</pre>
@@ -1260,7 +1333,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-vpcCni">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L82">property <b>vpcCni</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L85">property <b>vpcCni</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>vpcCni?: <a href='#VpcCni'>VpcCni</a>;</pre>
@@ -1268,7 +1341,7 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="CoreData-vpcId">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L74">property <b>vpcId</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L76">property <b>vpcId</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>vpcId: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1277,12 +1350,12 @@ CoreData defines the core set of data associated with an EKS cluster, including 
 </div>
 </div>
 <h2 class="pdoc-module-header" id="DashboardOptions">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/dashboard.ts#L20">interface <b>DashboardOptions</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/dashboard.ts#L20">interface <b>DashboardOptions</b></a>
 </h2>
 <div class="pdoc-module-contents">
 </div>
 <h2 class="pdoc-module-header" id="NodeGroupBaseOptions">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L43">interface <b>NodeGroupBaseOptions</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L44">interface <b>NodeGroupBaseOptions</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -1291,7 +1364,7 @@ NodeGroupArgs represents the common configuration settings for NodeGroups.
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-amiId">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L120">property <b>amiId</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L121">property <b>amiId</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>amiId?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1305,7 +1378,7 @@ you want to build your own AMI.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-autoScalingGroupTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L164">property <b>autoScalingGroupTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L183">property <b>autoScalingGroupTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>autoScalingGroupTags?: InputTags;</pre>
@@ -1325,8 +1398,22 @@ Note: Given the inheritance of auto-generated CF tags and
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="NodeGroupBaseOptions-bootstrapExtraArgs">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L149">property <b>bootstrapExtraArgs</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>bootstrapExtraArgs?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;</pre>
+{{% md %}}
+
+Additional args to pass directly to `/etc/eks/bootstrap.sh`.  Fror details on available options, see:
+https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh.  Note that the `--apiserver-endpoint`,
+`--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration
+parameters.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-cloudFormationTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L173">property <b>cloudFormationTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L192">property <b>cloudFormationTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>cloudFormationTags?: InputTags;</pre>
@@ -1341,7 +1428,7 @@ Note: Given the inheritance of auto-generated CF tags and
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-clusterIngressRule">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L73">property <b>clusterIngressRule</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L74">property <b>clusterIngressRule</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>clusterIngressRule?: aws.ec2.SecurityGroupRule;</pre>
@@ -1352,7 +1439,7 @@ The ingress rule that gives node group access.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-desiredCapacity">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L102">property <b>desiredCapacity</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L103">property <b>desiredCapacity</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>desiredCapacity?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1363,7 +1450,7 @@ The number of worker nodes that should be running in the cluster. Defaults to 2.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-instanceProfile">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L149">property <b>instanceProfile</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L168">property <b>instanceProfile</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceProfile?: aws.iam.InstanceProfile;</pre>
@@ -1375,7 +1462,7 @@ must be supplied in the ClusterOptions as either: 'instanceRole', or as a role o
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-instanceType">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L55">property <b>instanceType</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L56">property <b>instanceType</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceType?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ec2.InstanceType&gt;;</pre>
@@ -1386,7 +1473,7 @@ The instance type to use for the cluster's nodes. Defaults to "t2.medium".
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-keyName">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L85">property <b>keyName</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L86">property <b>keyName</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>keyName?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1396,19 +1483,34 @@ Name of the key pair to use for SSH access to worker nodes.
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="NodeGroupBaseOptions-kubeletExtraArgs">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L141">property <b>kubeletExtraArgs</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>kubeletExtraArgs?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;</pre>
+{{% md %}}
+
+Extra args to pass to the Kubelet.  Corresponds to the options passed in the `--kubeletExtraArgs` flag to
+`/etc/eks/bootstrap.sh`.  For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints`
+properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after
+to the expicit `kubeletExtraArgs`.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-labels">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L125">property <b>labels</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L127">property <b>labels</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>labels?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | {[key: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>]: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>};</pre>
 {{% md %}}
 
-Custom k8s node labels to be attached to each woker node
+Custom k8s node labels to be attached to each woker node.  Adds the given key/value pairs to the `--node-labels`
+kubelet argument.
 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-maxSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L112">property <b>maxSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L113">property <b>maxSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>maxSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1419,7 +1521,7 @@ The maximum number of worker nodes running in the cluster. Defaults to 2.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-minSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L107">property <b>minSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L108">property <b>minSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>minSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1430,7 +1532,7 @@ The minimum number of worker nodes running in the cluster. Defaults to 1.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-nodeAssociatePublicIpAddress">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L138">property <b>nodeAssociatePublicIpAddress</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L157">property <b>nodeAssociatePublicIpAddress</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeAssociatePublicIpAddress?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>;</pre>
@@ -1444,7 +1546,7 @@ public IPs.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-nodePublicKey">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L80">property <b>nodePublicKey</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L81">property <b>nodePublicKey</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodePublicKey?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1457,7 +1559,7 @@ If not provided, no SSH access is enabled on VMs.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-nodeRootVolumeSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L90">property <b>nodeRootVolumeSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L91">property <b>nodeRootVolumeSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeRootVolumeSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1468,7 +1570,7 @@ The size in GiB of a cluster node's root volume. Defaults to 20.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-nodeSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L68">property <b>nodeSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L69">property <b>nodeSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSecurityGroup?: aws.ec2.SecurityGroup;</pre>
@@ -1482,7 +1584,7 @@ Note: The `nodeSecurityGroup` option and the cluster option
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-nodeSubnetIds">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L50">property <b>nodeSubnetIds</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L51">property <b>nodeSubnetIds</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSubnetIds?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -1495,7 +1597,7 @@ This option overrides clusterSubnetIds option.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-nodeUserData">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L97">property <b>nodeUserData</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L98">property <b>nodeUserData</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeUserData?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1508,7 +1610,7 @@ critically it must begin with an interpreter directive (i.e. a `#!`).
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-spotPrice">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L60">property <b>spotPrice</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L61">property <b>spotPrice</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>spotPrice?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1519,18 +1621,19 @@ Bidding price for spot instance. If set, only spot instances will be added as wo
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-taints">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L130">property <b>taints</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L133">property <b>taints</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>taints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | {[key: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>]: <a href='#Taint'>Taint</a>};</pre>
 {{% md %}}
 
-Custom k8s node taints to be attached to each worker node
+Custom k8s node taints to be attached to each worker node.  Adds the given taints to the `--register-with-taints`
+kubelet argument.
 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupBaseOptions-version">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L143">property <b>version</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L162">property <b>version</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>version?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1542,11 +1645,11 @@ Desired Kubernetes master / control plane version. If you do not specify a value
 </div>
 </div>
 <h2 class="pdoc-module-header" id="NodeGroupData">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L186">interface <b>NodeGroupData</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L205">interface <b>NodeGroupData</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <h3 class="pdoc-member-header" id="NodeGroupData-autoScalingGroupName">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L198">property <b>autoScalingGroupName</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L217">property <b>autoScalingGroupName</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>autoScalingGroupName: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1557,7 +1660,7 @@ The AutoScalingGroup name for the node group.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupData-cfnStack">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L194">property <b>cfnStack</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L213">property <b>cfnStack</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>cfnStack: aws.cloudformation.Stack;</pre>
@@ -1568,7 +1671,7 @@ The CloudFormation Stack which defines the node group's AutoScalingGroup.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupData-nodeSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L190">property <b>nodeSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L209">property <b>nodeSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSecurityGroup: aws.ec2.SecurityGroup;</pre>
@@ -1580,7 +1683,7 @@ The security group for the node group.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="NodeGroupOptions">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L179">interface <b>NodeGroupOptions</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L198">interface <b>NodeGroupOptions</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <pre class="highlight"><span class='kd'>extends</span> <a href='#NodeGroupBaseOptions'>NodeGroupBaseOptions</a></pre>
@@ -1590,7 +1693,7 @@ NodeGroupOptions describes the configuration options accepted by a NodeGroup com
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="NodeGroupOptions-amiId">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L120">property <b>amiId</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L121">property <b>amiId</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>amiId?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1604,7 +1707,7 @@ you want to build your own AMI.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-autoScalingGroupTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L164">property <b>autoScalingGroupTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L183">property <b>autoScalingGroupTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>autoScalingGroupTags?: InputTags;</pre>
@@ -1624,8 +1727,22 @@ Note: Given the inheritance of auto-generated CF tags and
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="NodeGroupOptions-bootstrapExtraArgs">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L149">property <b>bootstrapExtraArgs</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>bootstrapExtraArgs?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;</pre>
+{{% md %}}
+
+Additional args to pass directly to `/etc/eks/bootstrap.sh`.  Fror details on available options, see:
+https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh.  Note that the `--apiserver-endpoint`,
+`--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration
+parameters.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-cloudFormationTags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L173">property <b>cloudFormationTags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L192">property <b>cloudFormationTags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>cloudFormationTags?: InputTags;</pre>
@@ -1640,7 +1757,7 @@ Note: Given the inheritance of auto-generated CF tags and
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-cluster">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L183">property <b>cluster</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L202">property <b>cluster</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>cluster: <a href='#Cluster'>Cluster</a> | <a href='#CoreData'>CoreData</a>;</pre>
@@ -1651,7 +1768,7 @@ The target EKS cluster.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-clusterIngressRule">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L73">property <b>clusterIngressRule</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L74">property <b>clusterIngressRule</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>clusterIngressRule?: aws.ec2.SecurityGroupRule;</pre>
@@ -1662,7 +1779,7 @@ The ingress rule that gives node group access.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-desiredCapacity">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L102">property <b>desiredCapacity</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L103">property <b>desiredCapacity</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>desiredCapacity?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1673,7 +1790,7 @@ The number of worker nodes that should be running in the cluster. Defaults to 2.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-instanceProfile">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L149">property <b>instanceProfile</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L168">property <b>instanceProfile</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceProfile?: aws.iam.InstanceProfile;</pre>
@@ -1685,7 +1802,7 @@ must be supplied in the ClusterOptions as either: 'instanceRole', or as a role o
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-instanceType">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L55">property <b>instanceType</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L56">property <b>instanceType</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>instanceType?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ec2.InstanceType&gt;;</pre>
@@ -1696,7 +1813,7 @@ The instance type to use for the cluster's nodes. Defaults to "t2.medium".
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-keyName">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L85">property <b>keyName</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L86">property <b>keyName</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>keyName?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1706,19 +1823,34 @@ Name of the key pair to use for SSH access to worker nodes.
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="NodeGroupOptions-kubeletExtraArgs">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L141">property <b>kubeletExtraArgs</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>kubeletExtraArgs?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;</pre>
+{{% md %}}
+
+Extra args to pass to the Kubelet.  Corresponds to the options passed in the `--kubeletExtraArgs` flag to
+`/etc/eks/bootstrap.sh`.  For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints`
+properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after
+to the expicit `kubeletExtraArgs`.
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-labels">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L125">property <b>labels</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L127">property <b>labels</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>labels?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | {[key: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>]: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>};</pre>
 {{% md %}}
 
-Custom k8s node labels to be attached to each woker node
+Custom k8s node labels to be attached to each woker node.  Adds the given key/value pairs to the `--node-labels`
+kubelet argument.
 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-maxSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L112">property <b>maxSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L113">property <b>maxSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>maxSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1729,7 +1861,7 @@ The maximum number of worker nodes running in the cluster. Defaults to 2.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-minSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L107">property <b>minSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L108">property <b>minSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>minSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1740,7 +1872,7 @@ The minimum number of worker nodes running in the cluster. Defaults to 1.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-nodeAssociatePublicIpAddress">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L138">property <b>nodeAssociatePublicIpAddress</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L157">property <b>nodeAssociatePublicIpAddress</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeAssociatePublicIpAddress?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>;</pre>
@@ -1754,7 +1886,7 @@ public IPs.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-nodePublicKey">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L80">property <b>nodePublicKey</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L81">property <b>nodePublicKey</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodePublicKey?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1767,7 +1899,7 @@ If not provided, no SSH access is enabled on VMs.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-nodeRootVolumeSize">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L90">property <b>nodeRootVolumeSize</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L91">property <b>nodeRootVolumeSize</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeRootVolumeSize?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -1778,7 +1910,7 @@ The size in GiB of a cluster node's root volume. Defaults to 20.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-nodeSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L68">property <b>nodeSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L69">property <b>nodeSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSecurityGroup?: aws.ec2.SecurityGroup;</pre>
@@ -1792,7 +1924,7 @@ Note: The `nodeSecurityGroup` option and the cluster option
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-nodeSubnetIds">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L50">property <b>nodeSubnetIds</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L51">property <b>nodeSubnetIds</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeSubnetIds?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -1805,7 +1937,7 @@ This option overrides clusterSubnetIds option.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-nodeUserData">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L97">property <b>nodeUserData</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L98">property <b>nodeUserData</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodeUserData?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1818,7 +1950,7 @@ critically it must begin with an interpreter directive (i.e. a `#!`).
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-spotPrice">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L60">property <b>spotPrice</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L61">property <b>spotPrice</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>spotPrice?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1829,18 +1961,19 @@ Bidding price for spot instance. If set, only spot instances will be added as wo
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-taints">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L130">property <b>taints</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L133">property <b>taints</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>taints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | {[key: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>]: <a href='#Taint'>Taint</a>};</pre>
 {{% md %}}
 
-Custom k8s node taints to be attached to each worker node
+Custom k8s node taints to be attached to each worker node.  Adds the given taints to the `--register-with-taints`
+kubelet argument.
 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupOptions-version">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L143">property <b>version</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L162">property <b>version</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>version?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1852,11 +1985,11 @@ Desired Kubernetes master / control plane version. If you do not specify a value
 </div>
 </div>
 <h2 class="pdoc-module-header" id="NodeGroupSecurityGroupOptions">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/securitygroup.ts#L20">interface <b>NodeGroupSecurityGroupOptions</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/securitygroup.ts#L20">interface <b>NodeGroupSecurityGroupOptions</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <h3 class="pdoc-member-header" id="NodeGroupSecurityGroupOptions-clusterSecurityGroup">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/securitygroup.ts#L29">property <b>clusterSecurityGroup</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/securitygroup.ts#L29">property <b>clusterSecurityGroup</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>clusterSecurityGroup: aws.ec2.SecurityGroup;</pre>
@@ -1867,7 +2000,7 @@ The security group associated with the EKS cluster.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupSecurityGroupOptions-eksCluster">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/securitygroup.ts#L39">property <b>eksCluster</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/securitygroup.ts#L39">property <b>eksCluster</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>eksCluster: aws.eks.Cluster;</pre>
@@ -1878,7 +2011,7 @@ The security group associated with the EKS cluster.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupSecurityGroupOptions-tags">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/securitygroup.ts#L34">property <b>tags</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/securitygroup.ts#L34">property <b>tags</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>tags?: InputTags;</pre>
@@ -1886,7 +2019,7 @@ The security group associated with the EKS cluster.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="NodeGroupSecurityGroupOptions-vpcId">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/securitygroup.ts#L24">property <b>vpcId</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/securitygroup.ts#L24">property <b>vpcId</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>vpcId: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1898,7 +2031,7 @@ The VPC in which to create the worker node group.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="RoleMapping">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L32">interface <b>RoleMapping</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L34">interface <b>RoleMapping</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -1907,7 +2040,7 @@ RoleMapping describes a mapping from an AWS IAM role to a Kubernetes user and gr
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="RoleMapping-groups">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L46">property <b>groups</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L48">property <b>groups</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>groups: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -1918,7 +2051,7 @@ A list of groups within Kubernetes to which the role is mapped.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="RoleMapping-roleArn">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L36">property <b>roleArn</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L38">property <b>roleArn</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>roleArn: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ARN&gt;;</pre>
@@ -1929,7 +2062,7 @@ The ARN of the IAM role to add.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="RoleMapping-username">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L41">property <b>username</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L43">property <b>username</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>username: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1941,7 +2074,7 @@ The user name within Kubernetes to map to the IAM role. By default, the user nam
 </div>
 </div>
 <h2 class="pdoc-module-header" id="ServiceRoleArgs">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/servicerole.ts#L30">interface <b>ServiceRoleArgs</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/servicerole.ts#L30">interface <b>ServiceRoleArgs</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -1950,7 +2083,7 @@ ServiceRoleArgs describe the parameters to a ServiceRole component.
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="ServiceRoleArgs-description">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/servicerole.ts#L38">property <b>description</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/servicerole.ts#L38">property <b>description</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1961,7 +2094,7 @@ The description of the role.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ServiceRoleArgs-managedPolicyArns">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/servicerole.ts#L42">property <b>managedPolicyArns</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/servicerole.ts#L42">property <b>managedPolicyArns</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>managedPolicyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[];</pre>
@@ -1972,7 +2105,7 @@ One or more managed policy ARNs to attach to this role.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="ServiceRoleArgs-service">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/servicerole.ts#L34">property <b>service</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/servicerole.ts#L34">property <b>service</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>service: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -1984,7 +2117,7 @@ The service associated with this role.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="StorageClass">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L30">interface <b>StorageClass</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L30">interface <b>StorageClass</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -1995,7 +2128,7 @@ storage class for the cluster.
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="StorageClass-allowVolumeExpansion">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L68">property <b>allowVolumeExpansion</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L77">property <b>allowVolumeExpansion</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>allowVolumeExpansion?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'>boolean</a></span>&gt;;</pre>
@@ -2006,18 +2139,27 @@ AllowVolumeExpansion shows whether the storage class allow volume expand
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-default">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L63">property <b>default</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L72">property <b>default</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>default?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'>boolean</a></span>&gt;;</pre>
 {{% md %}}
 
-True if this storage class should be the default storage class for the cluster.
+True if this storage class should be a default storage class for the cluster.
+
+Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will
+always be created automatically for the cluster by the EKS service. See
+https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
+
+Please note that at most one storage class can be marked as default. If
+two or more of them are marked as default, a PersistentVolumeClaim
+without `storageClassName` explicitly specified cannot be created. See:
+https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/#changing-the-default-storageclass
 
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-encrypted">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L52">property <b>encrypted</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L52">property <b>encrypted</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>encrypted?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'>boolean</a></span>&gt;;</pre>
@@ -2028,7 +2170,7 @@ Denotes whether the EBS volume should be encrypted.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-iopsPerGb">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L47">property <b>iopsPerGb</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L47">property <b>iopsPerGb</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>iopsPerGb?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -2040,7 +2182,7 @@ requested volume to compute IOPS of the volume and caps the result at 20,000 IOP
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-kmsKeyId">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L58">property <b>kmsKeyId</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L58">property <b>kmsKeyId</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>kmsKeyId?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -2052,7 +2194,7 @@ true, a key is generated by AWS.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-metadata">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L74">property <b>metadata</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L83">property <b>metadata</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>metadata?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;k8sInputs.meta.v1.ObjectMeta&gt;;</pre>
@@ -2064,7 +2206,7 @@ https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-mountOptions">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L81">property <b>mountOptions</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L90">property <b>mountOptions</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>mountOptions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[]&gt;;</pre>
@@ -2077,7 +2219,7 @@ is invalid.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-reclaimPolicy">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L87">property <b>reclaimPolicy</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L96">property <b>reclaimPolicy</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>reclaimPolicy?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -2089,7 +2231,7 @@ reclaimPolicy. Defaults to Delete.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-type">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L34">property <b>type</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L34">property <b>type</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>type: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='#EBSVolumeType'>EBSVolumeType</a>&gt;;</pre>
@@ -2100,7 +2242,7 @@ The EBS volume type.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-volumeBindingMode">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L94">property <b>volumeBindingMode</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L103">property <b>volumeBindingMode</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>volumeBindingMode?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -2113,7 +2255,7 @@ by servers that enable the VolumeScheduling feature.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="StorageClass-zones">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L41">property <b>zones</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L41">property <b>zones</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>zones?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -2127,7 +2269,7 @@ time.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="Taint">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L29">interface <b>Taint</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L30">interface <b>Taint</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -2137,7 +2279,7 @@ https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="Taint-effect">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L37">property <b>effect</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L38">property <b>effect</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>effect: <span class='s2'>"NoSchedule"</span> | <span class='s2'>"NoExecute"</span> | <span class='s2'>"PreferNoSchedule"</span>;</pre>
@@ -2148,7 +2290,7 @@ The effect of the taint.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="Taint-value">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/nodegroup.ts#L33">property <b>value</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/nodegroup.ts#L34">property <b>value</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>value: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>;</pre>
@@ -2160,7 +2302,7 @@ The value of the taint.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="UserMapping">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L52">interface <b>UserMapping</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L54">interface <b>UserMapping</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -2169,7 +2311,7 @@ UserMapping describes a mapping from an AWS IAM user to a Kubernetes user and gr
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="UserMapping-groups">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L66">property <b>groups</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L68">property <b>groups</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>groups: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt;;</pre>
@@ -2180,7 +2322,7 @@ A list of groups within Kubernetes to which the user is mapped to.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="UserMapping-userArn">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L56">property <b>userArn</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L58">property <b>userArn</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>userArn: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ARN&gt;;</pre>
@@ -2191,7 +2333,7 @@ The ARN of the IAM user to add.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="UserMapping-username">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cluster.ts#L61">property <b>username</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cluster.ts#L63">property <b>username</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>username: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
@@ -2203,7 +2345,7 @@ The user name within Kubernetes to map to the IAM user. By default, the user nam
 </div>
 </div>
 <h2 class="pdoc-module-header" id="VpcCniOptions">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts#L28">interface <b>VpcCniOptions</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L28">interface <b>VpcCniOptions</b></a>
 </h2>
 <div class="pdoc-module-contents">
 {{% md %}}
@@ -2212,7 +2354,7 @@ VpcCniOptions describes the configuration options available for the Amazon VPC C
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="VpcCniOptions-customNetworkConfig">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts#L43">property <b>customNetworkConfig</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L43">property <b>customNetworkConfig</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>customNetworkConfig?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'>boolean</a></span>&gt;;</pre>
@@ -2226,7 +2368,7 @@ Defaults to false.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="VpcCniOptions-externalSnat">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts#L52">property <b>externalSnat</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L52">property <b>externalSnat</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>externalSnat?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'>boolean</a></span>&gt;;</pre>
@@ -2240,8 +2382,48 @@ Defaults to false.
 
 {{% /md %}}
 </div>
+<h3 class="pdoc-member-header" id="VpcCniOptions-image">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L88">property <b>image</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>image?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
+{{% md %}}
+
+Specifies the container image to use in the AWS CNI cluster DaemonSet.
+
+Defaults to the official AWS CNI image in ECR.
+
+{{% /md %}}
+</div>
+<h3 class="pdoc-member-header" id="VpcCniOptions-logFile">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L81">property <b>logFile</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>logFile?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
+{{% md %}}
+
+Specifies the file path used for logs.
+
+Defaults to "stdout" to emit Pod logs for `kubectl logs`.
+
+{{% /md %}}
+</div>
+<h3 class="pdoc-member-header" id="VpcCniOptions-logLevel">
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L74">property <b>logLevel</b></a>
+</h3>
+<div class="pdoc-member-contents">
+<pre class="highlight"><span class='kd'></span>logLevel?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</pre>
+{{% md %}}
+
+Specifies the log level used for logs.
+
+Defaults to "DEBUG".
+See more options: https://git.io/fj92K
+
+{{% /md %}}
+</div>
 <h3 class="pdoc-member-header" id="VpcCniOptions-nodePortSupport">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts#L35">property <b>nodePortSupport</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L35">property <b>nodePortSupport</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>nodePortSupport?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'>boolean</a></span>&gt;;</pre>
@@ -2255,7 +2437,7 @@ Defaults to true.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="VpcCniOptions-warmEniTarget">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts#L60">property <b>warmEniTarget</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L60">property <b>warmEniTarget</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>warmEniTarget?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -2269,7 +2451,7 @@ Defaults to 1.
 {{% /md %}}
 </div>
 <h3 class="pdoc-member-header" id="VpcCniOptions-warmIpTarget">
-<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/cni.ts#L66">property <b>warmIpTarget</b></a>
+<a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/cni.ts#L66">property <b>warmIpTarget</b></a>
 </h3>
 <div class="pdoc-member-contents">
 <pre class="highlight"><span class='kd'></span>warmIpTarget?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>&gt;;</pre>
@@ -2282,7 +2464,7 @@ assignment on the node.
 </div>
 </div>
 <h2 class="pdoc-module-header" id="EBSVolumeType">
-<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/d6bc48fad5bbafa8a2b6e9756d67c1f55e0e20de/nodejs/eks/storageclass.ts#L23">type <b>EBSVolumeType</b></a>
+<a class="pdoc-member-name" href="https://github.com/pulumi/pulumi-eks/blob/08c61734457ad56e88f8449cf7b97b9fa8f7b8d0/nodejs/eks/storageclass.ts#L23">type <b>EBSVolumeType</b></a>
 </h2>
 <div class="pdoc-module-contents">
 <pre class="highlight"><span class='kd'>type</span> EBSVolumeType = <span class='s2'>"io1"</span> | <span class='s2'>"gp2"</span> | <span class='s2'>"sc1"</span> | <span class='s2'>"st1"</span>;</pre>


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Update `pulumi/eks` docs for recent [release](https://github.com/pulumi/pulumi-eks/blob/master/CHANGELOG.md#01810-released-august-8-2019) of `v0.18.10`

@lukehoban @justinvp Note that I am *not* seeing the `deprecated` being marked here in the doc updates for options like [here](https://github.com/pulumi/pulumi-eks/blob/master/nodejs/eks/cluster.ts#L448) and [here](https://github.com/pulumi/pulumi-eks/blob/master/nodejs/eks/cluster.ts#L537) for the `Cluster` class. Thoughts?