### PR TITLE
Update the quickstart examples for Azure to not specify the location explicitly

### DIFF
--- a/content/docs/quickstart/azure/review-project.md
+++ b/content/docs/quickstart/azure/review-project.md
@@ -21,14 +21,11 @@ const pulumi = require("@pulumi/pulumi");
 const azure = require("@pulumi/azure");
 
 // Create an Azure Resource Group
-const resourceGroup = new azure.core.ResourceGroup("resourceGroup", {
-    location: "WestUS",
-});
+const resourceGroup = new azure.core.ResourceGroup("resourceGroup");
 
 // Create an Azure resource (Storage Account)
 const account = new azure.storage.Account("storage", {
     resourceGroupName: resourceGroup.name,
-    location: resourceGroup.location,
     accountTier: "Standard",
     accountReplicationType: "LRS",
 });
@@ -42,14 +39,11 @@ import * as pulumi from "@pulumi/pulumi";
 import * as azure from "@pulumi/azure";
 
 // Create an Azure Resource Group
-const resourceGroup = new azure.core.ResourceGroup("resourceGroup", {
-    location: "WestUS",
-});
+const resourceGroup = new azure.core.ResourceGroup("resourceGroup");
 
 // Create an Azure resource (Storage Account)
 const account = new azure.storage.Account("storage", {
     resourceGroupName: resourceGroup.name,
-    location: resourceGroup.location,
     accountTier: "Standard",
     accountReplicationType: "LRS",
 });
@@ -63,13 +57,11 @@ import pulumi
 from pulumi_azure import core, storage
 
 # Create an Azure Resource Group
-resource_group = core.ResourceGroup("resource_group",
-    location='WestUS')
+resource_group = core.ResourceGroup("resource_group")
 
 # Create an Azure resource (Storage Account)
 account = storage.Account("storage",
     resource_group_name=resource_group.name,
-    location=resource_group.location,
     account_tier='Standard',
     account_replication_type='LRS')
 
@@ -78,6 +70,8 @@ pulumi.export('connection_string', account.primary_connection_string)
 ```
 
 This Pulumi program creates an Azure resource group and storage account and exports the storage account's connection string.
+
+**Note**: In this program, the location of the resource group is set in the configuration setting `azure:location` (check the `Pulumi.dev.yaml` file). This is an easy way to set a global location for your program so you don't have to specify the location for each resource manually. The location for the storage account is automatically derived from the location of the resource group. To override the location for a resource, simply set the location property to one of Azure's [supported locations](https://azure.microsoft.com/en-us/global-infrastructure/locations/).
 
 {{% lang python %}}
 For Python, before we deploy the stack, the following commands need to be run to create a virtual environment, activate it, and install dependencies:

--- a/content/docs/reference/clouds/azure/_index.md
+++ b/content/docs/reference/clouds/azure/_index.md
@@ -58,7 +58,7 @@ The Azure provider is open source and available in the [pulumi/pulumi-azure](htt
 The Azure provider accepts the following configuration settings.  These can be provided to the default Azure provider via `pulumi config set azure:<option>`, or passed to the constructor of `new azure.Provider` to construct a specific instance of the Azure provider.
 
 * `environment`: (Required) The cloud environment to use. It can also be sourced from the ARM_ENVIRONMENT environment variable. Supported values are: `public` (default), `usgovernment`, `german`, `china`.
-* `location`: (Required) The location to use. ResourceGroups will consult this property for a default location, if one was not supplied explicitly.
+* `location`: (Optional) The location to use. ResourceGroups will consult this property for a default location, if one was not supplied explicitly.
 * `clientId`: (Optional) The client ID to use. It can also be sourced from the `ARM_CLIENT_ID` environment variable.
 * `clientSecret`: (Optional) The client secret to use. It can also be sourced from the `ARM_CLIENT_SECRET` environment variable.
 * `msiEndpoint`: (Optional) The REST endpoint to retrieve an MSI token from. Pulumi will attempt to discover this automatically but it can be specified manually here. It can also be sourced from the `ARM_MSI_ENDPOINT` environment variable.

--- a/content/docs/reference/clouds/azure/_index.md
+++ b/content/docs/reference/clouds/azure/_index.md
@@ -58,6 +58,7 @@ The Azure provider is open source and available in the [pulumi/pulumi-azure](htt
 The Azure provider accepts the following configuration settings.  These can be provided to the default Azure provider via `pulumi config set azure:<option>`, or passed to the constructor of `new azure.Provider` to construct a specific instance of the Azure provider.
 
 * `environment`: (Required) The cloud environment to use. It can also be sourced from the ARM_ENVIRONMENT environment variable. Supported values are: `public` (default), `usgovernment`, `german`, `china`.
+* `location`: (Required) The location to use. ResourceGroups will consult this property for a default location, if one was not supplied explicitly.
 * `clientId`: (Optional) The client ID to use. It can also be sourced from the `ARM_CLIENT_ID` environment variable.
 * `clientSecret`: (Optional) The client secret to use. It can also be sourced from the `ARM_CLIENT_SECRET` environment variable.
 * `msiEndpoint`: (Optional) The REST endpoint to retrieve an MSI token from. Pulumi will attempt to discover this automatically but it can be specified manually here. It can also be sourced from the `ARM_MSI_ENDPOINT` environment variable.


### PR DESCRIPTION
Fixes #1535. Also requires https://github.com/pulumi/templates/pull/60.