### PR TITLE
Change “Sign Up” to “Get Started” in the main nav

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -42,10 +42,18 @@
                 {{ end }}
 
                 <li class="md:ml-auto md:mr-2 lg:mr-4">
-                    <a class="block mt-4 md:mt-0 md:text-xs lg:text-sm btn btn-orange-translucent" href="https://app.pulumi.com/">Sign In</a>
+                    <a class="block mt-4 md:mt-0 md:text-xs lg:text-sm btn btn-orange-translucent"
+                        href="https://app.pulumi.com/"
+                        title="Sign into the Pulumi Cloud Console">
+                        Sign In
+                    </a>
                 </li>
                 <li>
-                    <a class="block mt-4 md:mt-0 md:text-xs lg:text-sm btn" href="https://app.pulumi.com/signup">Sign Up</a>
+                    <a class="block mt-4 md:mt-0 md:text-xs lg:text-sm btn"
+                        href="{{ relref . "/docs/quickstart" }}"
+                        title="Get started with Pulumi by creating your first project">
+                        Get Started
+                    </a>
                 </li>
             </ul>
         </header>


### PR DESCRIPTION
The goal of this change is to introduce new users to Pulumi through the Getting Started guide, rather than have them sign up and begin working with the service first.

![image](https://user-images.githubusercontent.com/274700/62903001-335a5900-bd16-11e9-8990-239381099e88.png)
