### PR TITLE
Fix broken link in the Python API docs

### DIFF
--- a/tools/pydocgen/pydocgen/templates/providers/pulumi.rst
+++ b/tools/pydocgen/pydocgen/templates/providers/pulumi.rst
@@ -9,7 +9,7 @@ module.
 .. epigraph::
 
   **Note**: The Pulumi Python SDK requires Python version 3.6 or greater. Please see the
-  `Python getting started </reference/python.html#getting-started>`_ documentation for details on how to get started with
+  `Python getting started </docs/reference/python/#getting-started>`_ documentation for details on how to get started with
   Python.
 
 The Pulumi Python Resource Model


### PR DESCRIPTION
We didn't catch this because we exclude checking the API docs due to the large number of broken links. As a separate effort, we should consider more granular exclusions.

Fixes #1559