### PR TITLE
Rework "Home Pulumi Works"

### DIFF
--- a/content/docs/reference/programming-model.md
+++ b/content/docs/reference/programming-model.md
@@ -204,22 +204,22 @@ Set this option to `true` to specify that replacements of the resource will dele
 {{< langchoose >}}
 
 ```javascript
-// The resource will be deleted before it's replacement is creater
+// The resource will be deleted before it's replacement is created
 let db = new Database("db", {}, { deleteBeforeReplace: true});
 ```
 
 ```typescript
-// The resource will be deleted before it's replacement is creater
+// The resource will be deleted before it's replacement is created
 let db = new Database("db", {}, { deleteBeforeReplace: true});
 ```
 
 ```python
-# The resource will be deleted before it's replacement is creater
+# The resource will be deleted before it's replacement is created
 db = Database("db", opts=ResourceOptions(delete_before_replace=True))
 ```
 
 ```go
-// The resource will be deleted before it's replacement is creater
+// The resource will be deleted before it's replacement is created
 db, _ := Database(ctx, "db", &DatabaseArgs{}, pulumi.ResourceOpt{DeleteBeforeReplace: true});
 ```
 


### PR DESCRIPTION
This is a set of changes to "How pulumi works" which expands on some
of the core components of Pulumi.

Major changes:

1. Add an introduction section that explains that Pulumi is a desired
state system and made up of three components (the deplyoment engine,
the language host and the resource providers).

2. Add sections specific to each component explaining in more depth
what they do and how they are distributed.

3. Explicitly call out that resource operations happen concurrently
with program execution.

4. Add some notes about updates vs replaces.

5. Expand the walk-through to show a case where there is a diff that
causes a resource to be updated.

In addition, I've added links back to our programming model page for a
few key concepts like auto-namming, dependsOn and deleteBeforeReplace

Fixes #1541