### PR TITLE
Use Pulumify for live website previews

### DIFF
--- a/.github/workflows/pulumify.yml
+++ b/.github/workflows/pulumify.yml
@@ -1,0 +1,16 @@
+name: Pulumify
+on: [pull_request, delete]
+jobs:
+  updateLivePreview:
+    name: Update Live Preview
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker://joeduffy/pulumify
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        PULUMIFY_BUILD: make ensure && hugo --buildFuture -e $GITHUB_SHA
+        PULUMIFY_ROOT: public
+        PULUMIFY_ORGANIZATION: pulumi


### PR DESCRIPTION
This adopts Pulumify, powered by GitHub Actions, to generate
live previews of our websites in response to Pull Requests.

The primary workhorse here is at
https://github.com/pulumi/actions-pulumify. In a nutshell

- Upon a new PR opening,

    * Create a new Pulumi stack, optionally inside the
      organization specified by `PULUMIFY_ORGANIZATION`. It
      will be named `pulumify_{repo}_{branch}`, with the
      necessary substitutions to make this a valid name.

    * Create an AWS S3 bucket configured to serve static
      content as a website.

- Upon a PR opening, reopening, or changing,

    * Synch the Git repo.

    * Optionally rebuild the content, using the
      `PULUMIFY_BUILD` command.

    * Synch the files at `PULUMIFY_ROOT` as AWS S3
      objects into the aforementioned target S3 bucket.
      Note that this uses an optimized synch mechanism that
      uploads a zipped file to the Amazon data center and
      then runs an `aws s3 sync` to copy the expanded files.
      This brings transfer times down from ~20 minutes (on
      our crappy WiFi) to ~2 minutes.

    * Post a comment to the PR with a link to the newly
      updated website, with a link to the Pulumi job.

- Upon a PR closing (or branch deletion),

    * Delete all of the above and remove the stack.

I've included a workaround to a seemingly new problem that
began as soon as I switched to the new GitHub Actions that
just shipped, which is that merging (and now even closing)
a PR doesn't actually trigger the action to run. For now, we
can key off the branch deletion which, given how good we are
at deleting branches, should be a reasonable approximation.
