### PR TITLE
Fix an incorrect statement in the AWS quickstart

### DIFF
--- a/content/docs/quickstart/aws/destroy-stack.md
+++ b/content/docs/quickstart/aws/destroy-stack.md
@@ -15,7 +15,7 @@ To destroy resources, run the following:
 $ pulumi destroy
 ```
 
-You'll be prompted to make sure you really want to delete these resources. This can take a minute or two; Pulumi waits for the EC2 instance to finish shutting down before it considers the destroy operation to be complete.
+You'll be prompted to make sure you really want to delete these resources. This can take a minute or two; Pulumi waits until all resources are shut down and deleted before it considers the destroy operation to be complete.
 
 ```
 Previewing destroy (dev):


### PR DESCRIPTION
We reference the "EC2 instance shutting down," which is no
longer correct. The initial quickstart used EC2 instances but
it now uses an S3 bucket. This fix just tweaks the statement.
