### PR TITLE
Handle placeholder text that look like HTML tags in the Kubernetes API docs

### DIFF
--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/admissionregistration/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/admissionregistration/v1beta1/_index.md
@@ -65,8 +65,8 @@ Create a admissionregistration.v1beta1.MutatingWebhookConfiguration resource wit
 
 
 Get the state of an existing `MutatingWebhookConfiguration` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -209,8 +209,8 @@ Create a admissionregistration.v1beta1.MutatingWebhookConfigurationList resource
 
 
 Get the state of an existing `MutatingWebhookConfigurationList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -354,8 +354,8 @@ Create a admissionregistration.v1beta1.ValidatingWebhookConfiguration resource w
 
 
 Get the state of an existing `ValidatingWebhookConfiguration` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -498,8 +498,8 @@ Create a admissionregistration.v1beta1.ValidatingWebhookConfigurationList resour
 
 
 Get the state of an existing `ValidatingWebhookConfigurationList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apiextensions/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apiextensions/_index.md
@@ -79,8 +79,8 @@ Create a CustomResource resource with the given unique name, arguments, and opti
 
 
 Get the state of an existing `CustomResource`, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -330,8 +330,8 @@ An optional additional explicit dependencies on other resources.
 <pre class="highlight"><span class='kd'></span>id: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ID'>pulumi.ID</a>&gt;;</pre>
 {{% md %}}
 
-An ID for the Kubernetes resource to retrive. Takes the form <namespace>/<name> or
-<name>.
+An ID for the Kubernetes resource to retrive. Takes the form &lt;namespace&gt;/&lt;name&gt; or
+&lt;name&gt;.
 
 {{% /md %}}
 </div>

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apiextensions/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apiextensions/v1beta1/_index.md
@@ -33,7 +33,7 @@ title: Module apiextensions/v1beta1
 {{% md %}}
 
 CustomResourceDefinition represents a resource that should be exposed on the API server.  Its
-name MUST be in the format <.spec.name>.<.spec.group>.
+name MUST be in the format &lt;.spec.name&gt;.&lt;.spec.group&gt;.
 
 {{% /md %}}
 <h3 class="pdoc-member-header" id="CustomResourceDefinition-constructor">
@@ -63,8 +63,8 @@ Create a apiextensions.v1beta1.CustomResourceDefinition resource with the given 
 
 
 Get the state of an existing `CustomResourceDefinition` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -214,8 +214,8 @@ Create a apiextensions.v1beta1.CustomResourceDefinitionList resource with the gi
 
 
 Get the state of an existing `CustomResourceDefinitionList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apiregistration/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apiregistration/v1/_index.md
@@ -62,8 +62,8 @@ Create a apiregistration.v1.APIService resource with the given unique name, argu
 
 
 Get the state of an existing `APIService` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -213,8 +213,8 @@ Create a apiregistration.v1.APIServiceList resource with the given unique name, 
 
 
 Get the state of an existing `APIServiceList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apiregistration/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apiregistration/v1beta1/_index.md
@@ -62,8 +62,8 @@ Create a apiregistration.v1beta1.APIService resource with the given unique name,
 
 
 Get the state of an existing `APIService` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -213,8 +213,8 @@ Create a apiregistration.v1beta1.APIServiceList resource with the given unique n
 
 
 Get the state of an existing `APIServiceList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apps/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apps/v1/_index.md
@@ -77,8 +77,8 @@ Create a apps.v1.ControllerRevision resource with the given unique name, argumen
 
 
 Get the state of an existing `ControllerRevision` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -232,8 +232,8 @@ Create a apps.v1.ControllerRevisionList resource with the given unique name, arg
 
 
 Get the state of an existing `ControllerRevisionList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -375,8 +375,8 @@ Create a apps.v1.DaemonSet resource with the given unique name, arguments, and o
 
 
 Get the state of an existing `DaemonSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -533,8 +533,8 @@ Create a apps.v1.DaemonSetList resource with the given unique name, arguments, a
 
 
 Get the state of an existing `DaemonSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -677,8 +677,8 @@ Create a apps.v1.Deployment resource with the given unique name, arguments, and 
 
 
 Get the state of an existing `Deployment` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -831,8 +831,8 @@ Create a apps.v1.DeploymentList resource with the given unique name, arguments, 
 
 
 Get the state of an existing `DeploymentList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -974,8 +974,8 @@ Create a apps.v1.ReplicaSet resource with the given unique name, arguments, and 
 
 
 Get the state of an existing `ReplicaSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1133,8 +1133,8 @@ Create a apps.v1.ReplicaSetList resource with the given unique name, arguments, 
 
 
 Get the state of an existing `ReplicaSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1282,8 +1282,8 @@ Create a apps.v1.StatefulSet resource with the given unique name, arguments, and
 
 
 Get the state of an existing `StatefulSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1434,8 +1434,8 @@ Create a apps.v1.StatefulSetList resource with the given unique name, arguments,
 
 
 Get the state of an existing `StatefulSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apps/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apps/v1beta1/_index.md
@@ -75,8 +75,8 @@ Create a apps.v1beta1.ControllerRevision resource with the given unique name, ar
 
 
 Get the state of an existing `ControllerRevision` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -230,8 +230,8 @@ Create a apps.v1beta1.ControllerRevisionList resource with the given unique name
 
 
 Get the state of an existing `ControllerRevisionList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -375,8 +375,8 @@ Create a apps.v1beta1.Deployment resource with the given unique name, arguments,
 
 
 Get the state of an existing `Deployment` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -529,8 +529,8 @@ Create a apps.v1beta1.DeploymentList resource with the given unique name, argume
 
 
 Get the state of an existing `DeploymentList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -678,8 +678,8 @@ Create a apps.v1beta1.StatefulSet resource with the given unique name, arguments
 
 
 Get the state of an existing `StatefulSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -830,8 +830,8 @@ Create a apps.v1beta1.StatefulSetList resource with the given unique name, argum
 
 
 Get the state of an existing `StatefulSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apps/v1beta2/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/apps/v1beta2/_index.md
@@ -79,8 +79,8 @@ Create a apps.v1beta2.ControllerRevision resource with the given unique name, ar
 
 
 Get the state of an existing `ControllerRevision` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -234,8 +234,8 @@ Create a apps.v1beta2.ControllerRevisionList resource with the given unique name
 
 
 Get the state of an existing `ControllerRevisionList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -379,8 +379,8 @@ Create a apps.v1beta2.DaemonSet resource with the given unique name, arguments, 
 
 
 Get the state of an existing `DaemonSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -537,8 +537,8 @@ Create a apps.v1beta2.DaemonSetList resource with the given unique name, argumen
 
 
 Get the state of an existing `DaemonSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -683,8 +683,8 @@ Create a apps.v1beta2.Deployment resource with the given unique name, arguments,
 
 
 Get the state of an existing `Deployment` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -837,8 +837,8 @@ Create a apps.v1beta2.DeploymentList resource with the given unique name, argume
 
 
 Get the state of an existing `DeploymentList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -982,8 +982,8 @@ Create a apps.v1beta2.ReplicaSet resource with the given unique name, arguments,
 
 
 Get the state of an existing `ReplicaSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1141,8 +1141,8 @@ Create a apps.v1beta2.ReplicaSetList resource with the given unique name, argume
 
 
 Get the state of an existing `ReplicaSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1292,8 +1292,8 @@ Create a apps.v1beta2.StatefulSet resource with the given unique name, arguments
 
 
 Get the state of an existing `StatefulSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1444,8 +1444,8 @@ Create a apps.v1beta2.StatefulSetList resource with the given unique name, argum
 
 
 Get the state of an existing `StatefulSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/auditregistration/v1alpha1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/auditregistration/v1alpha1/_index.md
@@ -62,8 +62,8 @@ Create a auditregistration.v1alpha1.AuditSink resource with the given unique nam
 
 
 Get the state of an existing `AuditSink` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -202,8 +202,8 @@ Create a auditregistration.v1alpha1.AuditSinkList resource with the given unique
 
 
 Get the state of an existing `AuditSinkList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/authentication/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/authentication/v1/_index.md
@@ -62,8 +62,8 @@ Create a authentication.v1.TokenReview resource with the given unique name, argu
 
 
 Get the state of an existing `TokenReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/authentication/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/authentication/v1beta1/_index.md
@@ -62,8 +62,8 @@ Create a authentication.v1beta1.TokenReview resource with the given unique name,
 
 
 Get the state of an existing `TokenReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/authorization/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/authorization/v1/_index.md
@@ -66,8 +66,8 @@ Create a authorization.v1.LocalSubjectAccessReview resource with the given uniqu
 
 
 Get the state of an existing `LocalSubjectAccessReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -220,8 +220,8 @@ Create a authorization.v1.SelfSubjectAccessReview resource with the given unique
 
 
 Get the state of an existing `SelfSubjectAccessReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -378,8 +378,8 @@ Create a authorization.v1.SelfSubjectRulesReview resource with the given unique 
 
 
 Get the state of an existing `SelfSubjectRulesReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -529,8 +529,8 @@ Create a authorization.v1.SubjectAccessReview resource with the given unique nam
 
 
 Get the state of an existing `SubjectAccessReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/authorization/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/authorization/v1beta1/_index.md
@@ -66,8 +66,8 @@ Create a authorization.v1beta1.LocalSubjectAccessReview resource with the given 
 
 
 Get the state of an existing `LocalSubjectAccessReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -220,8 +220,8 @@ Create a authorization.v1beta1.SelfSubjectAccessReview resource with the given u
 
 
 Get the state of an existing `SelfSubjectAccessReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -378,8 +378,8 @@ Create a authorization.v1beta1.SelfSubjectRulesReview resource with the given un
 
 
 Get the state of an existing `SelfSubjectRulesReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -529,8 +529,8 @@ Create a authorization.v1beta1.SubjectAccessReview resource with the given uniqu
 
 
 Get the state of an existing `SubjectAccessReview` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/autoscaling/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/autoscaling/v1/_index.md
@@ -62,8 +62,8 @@ Create a autoscaling.v1.HorizontalPodAutoscaler resource with the given unique n
 
 
 Get the state of an existing `HorizontalPodAutoscaler` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -218,8 +218,8 @@ Create a autoscaling.v1.HorizontalPodAutoscalerList resource with the given uniq
 
 
 Get the state of an existing `HorizontalPodAutoscalerList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/autoscaling/v2beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/autoscaling/v2beta1/_index.md
@@ -64,8 +64,8 @@ Create a autoscaling.v2beta1.HorizontalPodAutoscaler resource with the given uni
 
 
 Get the state of an existing `HorizontalPodAutoscaler` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -220,8 +220,8 @@ Create a autoscaling.v2beta1.HorizontalPodAutoscalerList resource with the given
 
 
 Get the state of an existing `HorizontalPodAutoscalerList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/autoscaling/v2beta2/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/autoscaling/v2beta2/_index.md
@@ -64,8 +64,8 @@ Create a autoscaling.v2beta2.HorizontalPodAutoscaler resource with the given uni
 
 
 Get the state of an existing `HorizontalPodAutoscaler` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -220,8 +220,8 @@ Create a autoscaling.v2beta2.HorizontalPodAutoscalerList resource with the given
 
 
 Get the state of an existing `HorizontalPodAutoscalerList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/batch/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/batch/v1/_index.md
@@ -62,8 +62,8 @@ Create a batch.v1.Job resource with the given unique name, arguments, and option
 
 
 Get the state of an existing `Job` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -219,8 +219,8 @@ Create a batch.v1.JobList resource with the given unique name, arguments, and op
 
 
 Get the state of an existing `JobList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/batch/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/batch/v1beta1/_index.md
@@ -62,8 +62,8 @@ Create a batch.v1beta1.CronJob resource with the given unique name, arguments, a
 
 
 Get the state of an existing `CronJob` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -219,8 +219,8 @@ Create a batch.v1beta1.CronJobList resource with the given unique name, argument
 
 
 Get the state of an existing `CronJobList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/batch/v2alpha1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/batch/v2alpha1/_index.md
@@ -62,8 +62,8 @@ Create a batch.v2alpha1.CronJob resource with the given unique name, arguments, 
 
 
 Get the state of an existing `CronJob` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -219,8 +219,8 @@ Create a batch.v2alpha1.CronJobList resource with the given unique name, argumen
 
 
 Get the state of an existing `CronJobList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/certificates/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/certificates/v1beta1/_index.md
@@ -62,8 +62,8 @@ Create a certificates.v1beta1.CertificateSigningRequest resource with the given 
 
 
 Get the state of an existing `CertificateSigningRequest` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -208,8 +208,8 @@ Create a certificates.v1beta1.CertificateSigningRequestList resource with the gi
 
 
 Get the state of an existing `CertificateSigningRequestList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/coordination/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/coordination/v1/_index.md
@@ -62,8 +62,8 @@ Create a coordination.v1.Lease resource with the given unique name, arguments, a
 
 
 Get the state of an existing `Lease` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -206,8 +206,8 @@ Create a coordination.v1.LeaseList resource with the given unique name, argument
 
 
 Get the state of an existing `LeaseList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/coordination/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/coordination/v1beta1/_index.md
@@ -62,8 +62,8 @@ Create a coordination.v1beta1.Lease resource with the given unique name, argumen
 
 
 Get the state of an existing `Lease` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -206,8 +206,8 @@ Create a coordination.v1beta1.LeaseList resource with the given unique name, arg
 
 
 Get the state of an existing `LeaseList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/core/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/core/v1/_index.md
@@ -94,8 +94,8 @@ Create a core.v1.Binding resource with the given unique name, arguments, and opt
 
 
 Get the state of an existing `Binding` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -238,8 +238,8 @@ Create a core.v1.ComponentStatus resource with the given unique name, arguments,
 
 
 Get the state of an existing `ComponentStatus` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -382,8 +382,8 @@ Create a core.v1.ComponentStatusList resource with the given unique name, argume
 
 
 Get the state of an existing `ComponentStatusList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -526,8 +526,8 @@ Create a core.v1.ConfigMap resource with the given unique name, arguments, and o
 
 
 Get the state of an existing `ConfigMap` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -687,8 +687,8 @@ Create a core.v1.ConfigMapList resource with the given unique name, arguments, a
 
 
 Get the state of an existing `ConfigMapList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -841,8 +841,8 @@ Create a core.v1.Endpoints resource with the given unique name, arguments, and o
 
 
 Get the state of an existing `Endpoints` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -990,8 +990,8 @@ Create a core.v1.EndpointsList resource with the given unique name, arguments, a
 
 
 Get the state of an existing `EndpointsList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1134,8 +1134,8 @@ Create a core.v1.Event resource with the given unique name, arguments, and optio
 
 
 Get the state of an existing `Event` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1422,8 +1422,8 @@ Create a core.v1.EventList resource with the given unique name, arguments, and o
 
 
 Get the state of an existing `EventList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1566,8 +1566,8 @@ Create a core.v1.LimitRange resource with the given unique name, arguments, and 
 
 
 Get the state of an existing `LimitRange` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1711,8 +1711,8 @@ Create a core.v1.LimitRangeList resource with the given unique name, arguments, 
 
 
 Get the state of an existing `LimitRangeList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1856,8 +1856,8 @@ Create a core.v1.Namespace resource with the given unique name, arguments, and o
 
 
 Get the state of an existing `Namespace` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -2013,8 +2013,8 @@ Create a core.v1.NamespaceList resource with the given unique name, arguments, a
 
 
 Get the state of an existing `NamespaceList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -2159,8 +2159,8 @@ Create a core.v1.Node resource with the given unique name, arguments, and option
 
 
 Get the state of an existing `Node` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -2316,8 +2316,8 @@ Create a core.v1.NodeList resource with the given unique name, arguments, and op
 
 
 Get the state of an existing `NodeList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -2461,8 +2461,8 @@ Create a core.v1.PersistentVolume resource with the given unique name, arguments
 
 
 Get the state of an existing `PersistentVolume` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -2620,8 +2620,8 @@ Create a core.v1.PersistentVolumeClaim resource with the given unique name, argu
 
 
 Get the state of an existing `PersistentVolumeClaim` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -2778,8 +2778,8 @@ Create a core.v1.PersistentVolumeClaimList resource with the given unique name, 
 
 
 Get the state of an existing `PersistentVolumeClaimList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -2923,8 +2923,8 @@ Create a core.v1.PersistentVolumeList resource with the given unique name, argum
 
 
 Get the state of an existing `PersistentVolumeList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -3069,8 +3069,8 @@ Create a core.v1.Pod resource with the given unique name, arguments, and options
 
 
 Get the state of an existing `Pod` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -3227,8 +3227,8 @@ Create a core.v1.PodList resource with the given unique name, arguments, and opt
 
 
 Get the state of an existing `PodList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -3371,8 +3371,8 @@ Create a core.v1.PodTemplate resource with the given unique name, arguments, and
 
 
 Get the state of an existing `PodTemplate` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -3516,8 +3516,8 @@ Create a core.v1.PodTemplateList resource with the given unique name, arguments,
 
 
 Get the state of an existing `PodTemplateList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -3660,8 +3660,8 @@ Create a core.v1.ReplicationController resource with the given unique name, argu
 
 
 Get the state of an existing `ReplicationController` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -3819,8 +3819,8 @@ Create a core.v1.ReplicationControllerList resource with the given unique name, 
 
 
 Get the state of an existing `ReplicationControllerList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -3964,8 +3964,8 @@ Create a core.v1.ResourceQuota resource with the given unique name, arguments, a
 
 
 Get the state of an existing `ResourceQuota` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -4121,8 +4121,8 @@ Create a core.v1.ResourceQuotaList resource with the given unique name, argument
 
 
 Get the state of an existing `ResourceQuotaList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -4267,8 +4267,8 @@ Create a core.v1.Secret resource with the given unique name, arguments, and opti
 
 
 Get the state of an existing `Secret` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -4438,8 +4438,8 @@ Create a core.v1.SecretList resource with the given unique name, arguments, and 
 
 
 Get the state of an existing `SecretList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -4585,8 +4585,8 @@ Create a core.v1.Service resource with the given unique name, arguments, and opt
 
 
 Get the state of an existing `Service` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -4744,8 +4744,8 @@ Create a core.v1.ServiceAccount resource with the given unique name, arguments, 
 
 
 Get the state of an existing `ServiceAccount` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -4916,8 +4916,8 @@ Create a core.v1.ServiceAccountList resource with the given unique name, argumen
 
 
 Get the state of an existing `ServiceAccountList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -5061,8 +5061,8 @@ Create a core.v1.ServiceList resource with the given unique name, arguments, and
 
 
 Get the state of an existing `ServiceList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/events/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/events/v1beta1/_index.md
@@ -63,8 +63,8 @@ Create a events.v1beta1.Event resource with the given unique name, arguments, an
 
 
 Get the state of an existing `Event` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -350,8 +350,8 @@ Create a events.v1beta1.EventList resource with the given unique name, arguments
 
 
 Get the state of an existing `EventList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/extensions/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/extensions/v1beta1/_index.md
@@ -73,8 +73,8 @@ Create a extensions.v1beta1.DaemonSet resource with the given unique name, argum
 
 
 Get the state of an existing `DaemonSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -231,8 +231,8 @@ Create a extensions.v1beta1.DaemonSetList resource with the given unique name, a
 
 
 Get the state of an existing `DaemonSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -377,8 +377,8 @@ Create a extensions.v1beta1.Deployment resource with the given unique name, argu
 
 
 Get the state of an existing `Deployment` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -531,8 +531,8 @@ Create a extensions.v1beta1.DeploymentList resource with the given unique name, 
 
 
 Get the state of an existing `DeploymentList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -678,8 +678,8 @@ Create a extensions.v1beta1.Ingress resource with the given unique name, argumen
 
 
 Get the state of an existing `Ingress` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -835,8 +835,8 @@ Create a extensions.v1beta1.IngressList resource with the given unique name, arg
 
 
 Get the state of an existing `IngressList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -981,8 +981,8 @@ Create a extensions.v1beta1.NetworkPolicy resource with the given unique name, a
 
 
 Get the state of an existing `NetworkPolicy` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1126,8 +1126,8 @@ Create a extensions.v1beta1.NetworkPolicyList resource with the given unique nam
 
 
 Get the state of an existing `NetworkPolicyList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1272,8 +1272,8 @@ Create a extensions.v1beta1.PodSecurityPolicy resource with the given unique nam
 
 
 Get the state of an existing `PodSecurityPolicy` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1417,8 +1417,8 @@ Create a extensions.v1beta1.PodSecurityPolicyList resource with the given unique
 
 
 Get the state of an existing `PodSecurityPolicyList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1563,8 +1563,8 @@ Create a extensions.v1beta1.ReplicaSet resource with the given unique name, argu
 
 
 Get the state of an existing `ReplicaSet` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1722,8 +1722,8 @@ Create a extensions.v1beta1.ReplicaSetList resource with the given unique name, 
 
 
 Get the state of an existing `ReplicaSetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/meta/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/meta/v1/_index.md
@@ -61,8 +61,8 @@ Create a meta.v1.Status resource with the given unique name, arguments, and opti
 
 
 Get the state of an existing `Status` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/networking/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/networking/v1/_index.md
@@ -62,8 +62,8 @@ Create a networking.v1.NetworkPolicy resource with the given unique name, argume
 
 
 Get the state of an existing `NetworkPolicy` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -206,8 +206,8 @@ Create a networking.v1.NetworkPolicyList resource with the given unique name, ar
 
 
 Get the state of an existing `NetworkPolicyList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/networking/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/networking/v1beta1/_index.md
@@ -64,8 +64,8 @@ Create a networking.v1beta1.Ingress resource with the given unique name, argumen
 
 
 Get the state of an existing `Ingress` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -221,8 +221,8 @@ Create a networking.v1beta1.IngressList resource with the given unique name, arg
 
 
 Get the state of an existing `IngressList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/node/v1alpha1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/node/v1alpha1/_index.md
@@ -67,8 +67,8 @@ Create a node.v1alpha1.RuntimeClass resource with the given unique name, argumen
 
 
 Get the state of an existing `RuntimeClass` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -211,8 +211,8 @@ Create a node.v1alpha1.RuntimeClassList resource with the given unique name, arg
 
 
 Get the state of an existing `RuntimeClassList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/node/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/node/v1beta1/_index.md
@@ -67,8 +67,8 @@ Create a node.v1beta1.RuntimeClass resource with the given unique name, argument
 
 
 Get the state of an existing `RuntimeClass` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -216,8 +216,8 @@ Create a node.v1beta1.RuntimeClassList resource with the given unique name, argu
 
 
 Get the state of an existing `RuntimeClassList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/policy/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/policy/v1beta1/_index.md
@@ -65,8 +65,8 @@ Create a policy.v1beta1.PodDisruptionBudget resource with the given unique name,
 
 
 Get the state of an existing `PodDisruptionBudget` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -216,8 +216,8 @@ Create a policy.v1beta1.PodDisruptionBudgetList resource with the given unique n
 
 
 Get the state of an existing `PodDisruptionBudgetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -354,8 +354,8 @@ Create a policy.v1beta1.PodSecurityPolicy resource with the given unique name, a
 
 
 Get the state of an existing `PodSecurityPolicy` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -498,8 +498,8 @@ Create a policy.v1beta1.PodSecurityPolicyList resource with the given unique nam
 
 
 Get the state of an existing `PodSecurityPolicyList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/rbac/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/rbac/v1/_index.md
@@ -69,8 +69,8 @@ Create a rbac.v1.ClusterRole resource with the given unique name, arguments, and
 
 
 Get the state of an existing `ClusterRole` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -226,8 +226,8 @@ Create a rbac.v1.ClusterRoleBinding resource with the given unique name, argumen
 
 
 Get the state of an existing `ClusterRoleBinding` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -381,8 +381,8 @@ Create a rbac.v1.ClusterRoleBindingList resource with the given unique name, arg
 
 
 Get the state of an existing `ClusterRoleBindingList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -524,8 +524,8 @@ Create a rbac.v1.ClusterRoleList resource with the given unique name, arguments,
 
 
 Get the state of an existing `ClusterRoleList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -668,8 +668,8 @@ Create a rbac.v1.Role resource with the given unique name, arguments, and option
 
 
 Get the state of an existing `Role` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -814,8 +814,8 @@ Create a rbac.v1.RoleBinding resource with the given unique name, arguments, and
 
 
 Get the state of an existing `RoleBinding` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -969,8 +969,8 @@ Create a rbac.v1.RoleBindingList resource with the given unique name, arguments,
 
 
 Get the state of an existing `RoleBindingList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1112,8 +1112,8 @@ Create a rbac.v1.RoleList resource with the given unique name, arguments, and op
 
 
 Get the state of an existing `RoleList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/rbac/v1alpha1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/rbac/v1alpha1/_index.md
@@ -69,8 +69,8 @@ Create a rbac.v1alpha1.ClusterRole resource with the given unique name, argument
 
 
 Get the state of an existing `ClusterRole` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -226,8 +226,8 @@ Create a rbac.v1alpha1.ClusterRoleBinding resource with the given unique name, a
 
 
 Get the state of an existing `ClusterRoleBinding` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -381,8 +381,8 @@ Create a rbac.v1alpha1.ClusterRoleBindingList resource with the given unique nam
 
 
 Get the state of an existing `ClusterRoleBindingList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -524,8 +524,8 @@ Create a rbac.v1alpha1.ClusterRoleList resource with the given unique name, argu
 
 
 Get the state of an existing `ClusterRoleList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -668,8 +668,8 @@ Create a rbac.v1alpha1.Role resource with the given unique name, arguments, and 
 
 
 Get the state of an existing `Role` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -814,8 +814,8 @@ Create a rbac.v1alpha1.RoleBinding resource with the given unique name, argument
 
 
 Get the state of an existing `RoleBinding` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -969,8 +969,8 @@ Create a rbac.v1alpha1.RoleBindingList resource with the given unique name, argu
 
 
 Get the state of an existing `RoleBindingList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1112,8 +1112,8 @@ Create a rbac.v1alpha1.RoleList resource with the given unique name, arguments, 
 
 
 Get the state of an existing `RoleList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/rbac/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/rbac/v1beta1/_index.md
@@ -69,8 +69,8 @@ Create a rbac.v1beta1.ClusterRole resource with the given unique name, arguments
 
 
 Get the state of an existing `ClusterRole` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -226,8 +226,8 @@ Create a rbac.v1beta1.ClusterRoleBinding resource with the given unique name, ar
 
 
 Get the state of an existing `ClusterRoleBinding` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -381,8 +381,8 @@ Create a rbac.v1beta1.ClusterRoleBindingList resource with the given unique name
 
 
 Get the state of an existing `ClusterRoleBindingList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -524,8 +524,8 @@ Create a rbac.v1beta1.ClusterRoleList resource with the given unique name, argum
 
 
 Get the state of an existing `ClusterRoleList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -668,8 +668,8 @@ Create a rbac.v1beta1.Role resource with the given unique name, arguments, and o
 
 
 Get the state of an existing `Role` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -814,8 +814,8 @@ Create a rbac.v1beta1.RoleBinding resource with the given unique name, arguments
 
 
 Get the state of an existing `RoleBinding` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -969,8 +969,8 @@ Create a rbac.v1beta1.RoleBindingList resource with the given unique name, argum
 
 
 Get the state of an existing `RoleBindingList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1112,8 +1112,8 @@ Create a rbac.v1beta1.RoleList resource with the given unique name, arguments, a
 
 
 Get the state of an existing `RoleList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/scheduling/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/scheduling/v1/_index.md
@@ -63,8 +63,8 @@ Create a scheduling.v1.PriorityClass resource with the given unique name, argume
 
 
 Get the state of an existing `PriorityClass` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -248,8 +248,8 @@ Create a scheduling.v1.PriorityClassList resource with the given unique name, ar
 
 
 Get the state of an existing `PriorityClassList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/scheduling/v1alpha1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/scheduling/v1alpha1/_index.md
@@ -64,8 +64,8 @@ Create a scheduling.v1alpha1.PriorityClass resource with the given unique name, 
 
 
 Get the state of an existing `PriorityClass` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -249,8 +249,8 @@ Create a scheduling.v1alpha1.PriorityClassList resource with the given unique na
 
 
 Get the state of an existing `PriorityClassList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/scheduling/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/scheduling/v1beta1/_index.md
@@ -64,8 +64,8 @@ Create a scheduling.v1beta1.PriorityClass resource with the given unique name, a
 
 
 Get the state of an existing `PriorityClass` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -249,8 +249,8 @@ Create a scheduling.v1beta1.PriorityClassList resource with the given unique nam
 
 
 Get the state of an existing `PriorityClassList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/settings/v1alpha1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/settings/v1alpha1/_index.md
@@ -62,8 +62,8 @@ Create a settings.v1alpha1.PodPreset resource with the given unique name, argume
 
 
 Get the state of an existing `PodPreset` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -199,8 +199,8 @@ Create a settings.v1alpha1.PodPresetList resource with the given unique name, ar
 
 
 Get the state of an existing `PodPresetList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/storage/v1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/storage/v1/_index.md
@@ -68,8 +68,8 @@ Create a storage.v1.StorageClass resource with the given unique name, arguments,
 
 
 Get the state of an existing `StorageClass` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -287,8 +287,8 @@ Create a storage.v1.StorageClassList resource with the given unique name, argume
 
 
 Get the state of an existing `StorageClassList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -434,8 +434,8 @@ Create a storage.v1.VolumeAttachment resource with the given unique name, argume
 
 
 Get the state of an existing `VolumeAttachment` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -591,8 +591,8 @@ Create a storage.v1.VolumeAttachmentList resource with the given unique name, ar
 
 
 Get the state of an existing `VolumeAttachmentList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/storage/v1alpha1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/storage/v1alpha1/_index.md
@@ -65,8 +65,8 @@ Create a storage.v1alpha1.VolumeAttachment resource with the given unique name, 
 
 
 Get the state of an existing `VolumeAttachment` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -222,8 +222,8 @@ Create a storage.v1alpha1.VolumeAttachmentList resource with the given unique na
 
 
 Get the state of an existing `VolumeAttachmentList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/kubernetes/storage/v1beta1/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/kubernetes/storage/v1beta1/_index.md
@@ -74,8 +74,8 @@ Create a storage.v1beta1.CSIDriver resource with the given unique name, argument
 
 
 Get the state of an existing `CSIDriver` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -221,8 +221,8 @@ Create a storage.v1beta1.CSIDriverList resource with the given unique name, argu
 
 
 Get the state of an existing `CSIDriverList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -371,8 +371,8 @@ Create a storage.v1beta1.CSINode resource with the given unique name, arguments,
 
 
 Get the state of an existing `CSINode` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -514,8 +514,8 @@ Create a storage.v1beta1.CSINodeList resource with the given unique name, argume
 
 
 Get the state of an existing `CSINodeList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -662,8 +662,8 @@ Create a storage.v1beta1.StorageClass resource with the given unique name, argum
 
 
 Get the state of an existing `StorageClass` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -881,8 +881,8 @@ Create a storage.v1beta1.StorageClassList resource with the given unique name, a
 
 
 Get the state of an existing `StorageClassList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1028,8 +1028,8 @@ Create a storage.v1beta1.VolumeAttachment resource with the given unique name, a
 
 
 Get the state of an existing `VolumeAttachment` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 
@@ -1185,8 +1185,8 @@ Create a storage.v1beta1.VolumeAttachmentList resource with the given unique nam
 
 
 Get the state of an existing `VolumeAttachmentList` resource, as identified by `id`.
-Typically this ID  is of the form <namespace>/<name>; if <namespace> is omitted, then (per
-Kubernetes convention) the ID becomes default/<name>.
+Typically this ID  is of the form &lt;namespace&gt;/&lt;name&gt;; if &lt;namespace&gt; is omitted, then (per
+Kubernetes convention) the ID becomes default/&lt;name&gt;.
 
 Pulumi will keep track of this resource using `name` as the Pulumi ID.
 

--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -207,7 +207,7 @@ func emitMarkdownDocs(srcdir, pkgname string, doc *typeDocNode, outdir, outdatad
 	if err != nil {
 		return err
 	}
-	e.augmentNode(doc, nil)
+	e.augmentNode(doc, nil, k8s)
 	return e.emitMarkdownModule(rootModule, root, true)
 }
 
@@ -259,7 +259,7 @@ func (e *emitter) emitPackageDataFile(pkgRepoDir, githash string) error {
 }
 
 // augmentNode recurses throughout a tree AST, adding information that we'll need when translating it to Markdown.
-func (e *emitter) augmentNode(node *typeDocNode, parent *typeDocNode) {
+func (e *emitter) augmentNode(node *typeDocNode, parent *typeDocNode, k8s bool) {
 	// Add some labels.
 	node.AnchorName = node.Name
 	if parent != nil && (parent.Kind == typeDocClassNode || parent.Kind == typeDocInterfaceNode) {
@@ -268,6 +268,14 @@ func (e *emitter) augmentNode(node *typeDocNode, parent *typeDocNode) {
 	node.Label = createLabel(node, parent)
 	node.CodeDetails = createCodeDetails(node)
 	node.URLPath = getURLPath(node, parent)
+	if k8s && node.Comment.ShortText != "" &&
+		strings.Contains(node.Comment.ShortText, "<") &&
+		strings.Contains(node.Comment.ShortText, ">") {
+		// To avoid double-encoding strings that are already encoded, we make a targeted replacement
+		// of the < and > characters alone.
+		node.Comment.ShortText = strings.ReplaceAll(node.Comment.ShortText, "<", "&lt;")
+		node.Comment.ShortText = strings.ReplaceAll(node.Comment.ShortText, ">", "&gt;")
+	}
 
 	// If this extends or implements other types, render them.
 	if len(node.ExtendedTypes) > 0 {
@@ -291,13 +299,13 @@ func (e *emitter) augmentNode(node *typeDocNode, parent *typeDocNode) {
 
 	// Augment everything deeply.
 	for _, child := range node.Children {
-		e.augmentNode(child, node)
+		e.augmentNode(child, node, k8s)
 	}
 	for _, sig := range node.Signatures {
-		e.augmentNode(sig, node)
+		e.augmentNode(sig, node, k8s)
 	}
 	for _, param := range node.Parameters {
-		e.augmentNode(param, node)
+		e.augmentNode(param, node, k8s)
 	}
 
 	// Reorder children based on their labels.

--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -268,7 +268,16 @@ func (e *emitter) augmentNode(node *typeDocNode, parent *typeDocNode, k8s bool) 
 	node.Label = createLabel(node, parent)
 	node.CodeDetails = createCodeDetails(node)
 	node.URLPath = getURLPath(node, parent)
-	if k8s && node.Comment.ShortText != "" &&
+
+	// In K8S docs, ShortText can contain placeholder references that look like HTML tags.
+	// We need to replace those with the HTML-encoded characters.
+	// For example, the text might contain references like this:
+	// "<namespace>/<name>", where <namespace> is a placeholder for an actual namespace value,
+	// and <name> is a placeholder for an actual name value.
+	//
+	// This is done specifically for K8S because other providers can contain valid use of the
+	// > and < characters, which we don't want to escape.
+	if k8s &&
 		strings.Contains(node.Comment.ShortText, "<") &&
 		strings.Contains(node.Comment.ShortText, ">") {
 		// To avoid double-encoding strings that are already encoded, we make a targeted replacement


### PR DESCRIPTION
### Proposed changes
I have reduced the scope of the previous attempt at fixing this to only do this for the Kubernetes API docs. This at least fixes the known-issue that affects the readability of our Kubernetes nodejs API docs.

### Unreleased product version (optional)
N/A

### Related issues (optional)
Fixes #1534.