### PR TITLE
Add a mktutorial tool

### DIFF
--- a/scripts/mktutorial.sh
+++ b/scripts/mktutorial.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+TUTORIAL_OUT=$(mktemp -d)
+go run ./tools/mktutorial/*.go https://github.com/pulumi/examples $TUTORIAL_OUT
+cp $TUTORIAL_OUT/shortcodes/* ./layouts/shortcodes/
+for cloud in "aws" "azure" "gcp" "kubernetes"; do
+    cp $TUTORIAL_OUT/tutorials/$cloud/* ./content/docs/reference/tutorials/$cloud/
+done
+rm -rf $TUTORIAL_OUT

--- a/tools/mktutorial/README.md
+++ b/tools/mktutorial/README.md
@@ -1,0 +1,6 @@
+# mktutorial
+
+This tool takes the [Pulumi examples repo](https://github.com/pulumi/examples) and generates tutorials
+for this website out of them. The tool generally prefers that those tutorials follow the [standard format](
+https://github.com/pulumi/examples/blob/master/TUTORIALS.md), however is fairly resilient provided the
+tutorials have `README.md` files that are authored in legal Markdown.

--- a/tools/mktutorial/main.go
+++ b/tools/mktutorial/main.go
@@ -1,0 +1,342 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/russross/blackfriday.v2"
+)
+
+// clouds contains an index of the clouds for which we want to publish tutorials.
+var clouds = []string{"aws", "azure", "gcp", "kubernetes"}
+
+func main() {
+	// Parse and validate the args.
+	flag.Parse()
+	args := flag.Args()
+	if len(args) < 2 {
+		exitErr("usage: %s <tutorial-repo> <docs-root-dir>", os.Args[0])
+	}
+	repo := os.Args[1]
+	docsRoot := os.Args[2]
+
+	// Clone the tutorial repo at master/HEAD so the tool isn't dependent on the local filesystem.
+	fmt.Printf("Gathering tutorials from %s...\n", repo)
+	tmp, err := ioutil.TempDir("", "")
+	if err != nil {
+		exitErr("creating temp dir for tutorial repo: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+	cmd := exec.Command("git", "clone", repo, "--depth=1", tmp)
+	cmd.Stdout = os.Stdout
+	if err = cmd.Run(); err != nil {
+		exitErr("cloning tutorial repo: %v", err)
+	}
+
+	// Now, for every directory in the tutorial repo, accumulate metadata.
+	tuts, err := gatherTutorials(tmp)
+	if err != nil {
+		exitErr("gathering tutorials: %v", err)
+	}
+	fmt.Printf("\tGathered %d tutorials.\n", len(tuts))
+
+	// Emit the shortcode indexes; one global index and another per-cloud index.
+	shortcodesDir := filepath.Join(docsRoot, "shortcodes")
+	fmt.Printf("Generating shortcode pages...\n")
+	if err = emitGlobalIndexShortcode(shortcodesDir, tuts); err != nil {
+		exitErr("emitting global index shortcode: %v", err)
+	}
+	for _, cloud := range clouds {
+		if err = emitCloudIndexShortcode(shortcodesDir, cloud, tuts); err != nil {
+			exitErr("emitting cloud %s index shortcode: %v", cloud, err)
+		}
+	}
+
+	// And now finally create the actual tutorial pages, primarily by copying the tutorial READMEs.
+	fmt.Printf("Generating template pages...\n")
+	templatesDir := filepath.Join(docsRoot, "tutorials")
+	if err = emitTutorialDocs(templatesDir, tuts); err != nil {
+		exitErr("emitting templates: %v", err)
+	}
+}
+
+type tutorial struct {
+	Name      string
+	Title     string
+	MetaDesc  string
+	Cloud     string
+	Language  string
+	Body      string
+	URL       string
+	GitHubURL string
+}
+
+func gatherTutorials(root string) ([]tutorial, error) {
+	files, err := ioutil.ReadDir(root)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading tutorial repo")
+	}
+
+	// For all tutorials, gather up the metadata.
+	var tutorials []tutorial
+	for _, file := range files {
+		name := file.Name()
+		if !file.IsDir() || name[0] == '.' {
+			continue
+		}
+
+		// Each tutorial directory follows a convention: <cloud>-<language>-<short-name>. Parse it.
+		// Warn and ignore any that don't follow this convention (ideally we'd fix them).
+		var parts []string
+		for i, rem := 0, file.Name(); i < 2; i++ {
+			dashIx := strings.Index(rem, "-")
+			if dashIx == -1 {
+				break
+			}
+			parts = append(parts, rem[:dashIx])
+			rem = rem[dashIx+1:]
+		}
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			warn("malformed tutorial name; expected <cloud>-<language>-<short-name>, got '%s'", name)
+			continue
+		}
+
+		// Now that we've got the cloud and language, parse the contents to get extra metadata.
+		body, err := ioutil.ReadFile(filepath.Join(root, name, "README.md"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				warn("tutorial is missing a README: %s", name)
+				continue
+			}
+			return nil, errors.Wrapf(err, "reading tutorial '%s' README", name)
+		}
+		md := blackfriday.New()
+		top := md.Parse(body)
+
+		// The first H1 is assumed to be the title.
+		var title string
+		top.Walk(func(node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+			if node.Type == blackfriday.Heading && node.HeadingData.Level == 1 {
+				node.Walk(func(inner *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+					if inner.Type == blackfriday.Text {
+						title += string(inner.Literal)
+					}
+					return blackfriday.GoToNext
+				})
+				return blackfriday.Terminate
+			}
+			return blackfriday.GoToNext
+		})
+		if title == "" {
+			warn("tutorial is missing an H1 title: %s", name)
+			continue
+		}
+
+		// Great! We have a new tutorial. Append it and let's move on to the next one.
+		tutorials = append(tutorials, tutorial{
+			Name:      name,
+			Title:     title,
+			MetaDesc:  "",
+			Cloud:     parts[0],
+			Language:  parts[1],
+			Body:      cleanMarkdownBody(string(body)),
+			URL:       fmt.Sprintf("/docs/reference/tutorials/%s/%s", parts[0], name),
+			GitHubURL: fmt.Sprintf("https://github.com/pulumi/examples/tree/master/%s", name),
+		})
+	}
+
+	return tutorials, nil
+}
+
+const (
+	tutorialsIndexShortcodePrefix = "tutorials-index"
+)
+
+func cleanMarkdownBody(body string) string {
+	// HACK: for now, skip everything leading up to, and including, the H1. The reason is otherwise
+	// Hugo will add an H1 (due to our template). And we want to ensure we can add the badge explicitly.
+	h1ix := strings.Index(body, "# ")
+	if h1ix == -1 {
+		return body
+	}
+	body = body[h1ix:]
+	nlix := strings.Index(body, "\n")
+	if nlix == -1 {
+		return body
+	}
+	return body[nlix+1:]
+}
+
+func makeLangMap(tutorials []tutorial, include []string, exclude []string) (map[string][]tutorial, int) {
+	// Split tutorials out into respective languages.
+	tuts := map[string][]tutorial{
+		"js": nil,
+		"ts": nil,
+		"py": nil,
+	}
+	var c int
+	for _, tut := range tutorials {
+		cloud := tut.Cloud
+		lang := tut.Language
+		if _, has := tuts[lang]; has {
+			// Filter out any specific included or excluded clouds.
+			if len(include) > 0 {
+				var found bool
+				for _, incl := range include {
+					if incl == cloud {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+			if len(exclude) > 0 {
+				var found bool
+				for _, excl := range exclude {
+					if excl == cloud {
+						found = true
+						break
+					}
+				}
+				if found {
+					continue
+				}
+			}
+			tuts[lang] = append(tuts[lang], tut)
+			c++
+		}
+	}
+
+	// Sort the tutorials: first by cloud then by title.
+	for _, ts := range tuts {
+		sort.Slice(ts, func(i, j int) bool {
+			if ts[i].Cloud == ts[j].Cloud {
+				if ts[i].Language == ts[j].Language {
+					return ts[i].Title < ts[j].Title
+				}
+				return ts[i].Language < ts[j].Language
+			}
+			return ts[i].Cloud < ts[j].Cloud
+		})
+	}
+
+	return tuts, c
+}
+
+func emitGlobalIndexShortcode(root string, tutorials []tutorial) error {
+	// Open the global shortcode file.
+	fn := tutorialsIndexShortcodePrefix + ".html"
+	path := filepath.Join(root, fn)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Get the full list of tutorials, by language, excluding some of them.
+	tuts, c := makeLangMap(tutorials, clouds, nil)
+
+	// Render the template using the tutorials data.
+	if err = globalIndexTemplate.FRender(f, map[string]interface{}{
+		"JavaScriptTutorials": tuts["js"],
+		"TypeScriptTutorials": tuts["ts"],
+		"PythonTutorials":     tuts["py"],
+	}); err != nil {
+		return err
+	}
+	fmt.Printf("\tEmitted global index: %s (%d tutorials).\n", fn, c)
+	return nil
+}
+
+func emitCloudIndexShortcode(root, cloud string, tutorials []tutorial) error {
+	// Open the cloud-specific shortcode file.
+	fn := tutorialsIndexShortcodePrefix + "-" + cloud + ".html"
+	path := filepath.Join(root, fn)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Filter the tutorials down to just this cloud.
+	tuts, c := makeLangMap(tutorials, []string{cloud}, nil)
+
+	// Render the template using the tutorials data.
+	if err = cloudIndexTemplate.FRender(f, map[string]interface{}{
+		"JavaScriptTutorials": tuts["js"],
+		"TypeScriptTutorials": tuts["ts"],
+		"PythonTutorials":     tuts["py"],
+	}); err != nil {
+		return err
+	}
+	fmt.Printf("\tEmitted cloud index: %s (%d tutorials).\n", fn, c)
+	return nil
+}
+
+func emitTutorialDocs(root string, tutorials []tutorial) error {
+	// For each cloud, create a sub-directory, and then render the README bodies into the right content.
+	for _, tut := range tutorials {
+		// Open the file for writing and ensure the cloud directory exists.
+		path := filepath.Join(root, tut.Cloud, tut.Name+".md")
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return err
+		}
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+
+		// Now render this specific tutorial file.
+		err = tutorialTemplate.FRender(f, tut)
+
+		// Close the file explicitly here so defer doesn't end up waiting until the end of the function.
+		f.Close()
+
+		// Now check the error after we're sure we closed the file.
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("\tEmitted %d tutorial docs.\n", len(tutorials))
+	return nil
+}
+
+func warn(msg string, a ...interface{}) {
+	msg = fmt.Sprintf(msg, a...)
+	fmt.Fprintf(os.Stderr, "warning: %s\n", msg)
+}
+
+func exitErr(msg string, a ...interface{}) {
+	msg = fmt.Sprintf(msg, a...)
+	fmt.Fprintf(os.Stderr, "error: %s\n", msg)
+	os.Exit(1)
+}

--- a/tools/mktutorial/templates.go
+++ b/tools/mktutorial/templates.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/cbroglie/mustache"
+	"github.com/gobuffalo/packr"
+)
+
+var (
+	templates = packr.NewBox("./templates")
+
+	cloudIndexTemplate  = parseTemplate("cloud_index.tmpl")
+	globalIndexTemplate = parseTemplate("global_index.tmpl")
+	tutorialTemplate    = parseTemplate("tutorial.tmpl")
+)
+
+func parseTemplate(name string) *mustache.Template {
+	tstr, err := templates.FindString(name)
+	if err != nil {
+		panic(fmt.Sprintf("missing templates/%s template: %v", name, err))
+	}
+
+	t, err := mustache.ParseString(tstr)
+	if err != nil {
+		panic(fmt.Sprintf("error parsing templates/%s template: %v", name, err))
+	}
+
+	return t
+}

--- a/tools/mktutorial/templates/cloud_index.tmpl
+++ b/tools/mktutorial/templates/cloud_index.tmpl
@@ -1,0 +1,89 @@
+<div class="language-prologue-javascript"></div>
+<table width=100%>
+    <thead>
+        <tr>
+            <th>Tutorial</th>
+        </tr>
+    </thead>
+    <tbody>
+{{#JavaScriptTutorials}}
+        <tr>
+            <td>
+                <a href="{{URL}}">{{Title}}</a>
+{{#Description}}
+                <p style="font-size: .875rem">{{.}}</p>
+{{/Description}}
+            </td>
+        </tr>
+{{/JavaScriptTutorials}}
+{{^JavaScriptTutorials}}
+        <tr>
+            <td>
+                <p style="font-size: .875rem; color: crimson">
+                    Uh-oh! There are no JavaScript tutorials for this cloud :-(
+                </p>
+            </td>
+        </tr>
+{{/JavaScriptTutorials}}
+    </tbody>
+</table>
+
+<div class="language-prologue-typescript"></div>
+<table width=100%>
+    <thead>
+        <tr>
+            <th>Tutorial</th>
+        </tr>
+    </thead>
+    <tbody>
+{{#TypeScriptTutorials}}
+        <tr>
+            <td>
+                <a href="{{URL}}">{{Title}}</a></td>
+{{#Description}}
+                <p style="font-size: .875rem">{{.}}</p>
+{{/Description}}
+            </td>
+        </tr>
+{{/TypeScriptTutorials}}
+{{^TypeScriptTutorials}}
+        <tr>
+            <td>
+                <p style="font-size: .875rem; color: crimson">
+                    Uh-oh! There are no TypeScript tutorials for this cloud :-(
+                </p>
+            </td>
+        </tr>
+{{/TypeScriptTutorials}}
+    </tbody>
+</table>
+
+<div class="language-prologue-python"></div>
+<table width=100%>
+    <thead>
+        <tr>
+            <th>Tutorial</th>
+        </tr>
+    </thead>
+    <tbody>
+{{#PythonTutorials}}
+        <tr>
+            <td>
+                <a href="{{URL}}">{{Title}}</a></td>
+{{#Description}}
+                <p style="font-size: .875rem">{{.}}</p>
+{{/Description}}
+            </td>
+        </tr>
+{{/PythonTutorials}}
+{{^PythonTutorials}}
+        <tr>
+            <td>
+                <p style="font-size: .875rem; color: crimson">
+                    Uh-oh! There are no Python tutorials for this cloud :-(
+                </p>
+            </td>
+        </tr>
+{{/PythonTutorials}}
+    </tbody>
+</table>

--- a/tools/mktutorial/templates/global_index.tmpl
+++ b/tools/mktutorial/templates/global_index.tmpl
@@ -1,0 +1,68 @@
+<div class="language-prologue-javascript"></div>
+<table width=100%>
+    <thead>
+        <tr>
+            <th width=20%>Cloud</th>
+            <th width=*>Tutorial</th>
+        </tr>
+    </thead>
+    <tbody>
+{{#JavaScriptTutorials}}
+        <tr>
+            <td>{{Cloud}}</td>
+            <td>
+                <a href="{{URL}}">{{Title}}</a>
+{{#Description}}
+                <p style="font-size: .875rem">{{.}}</p>
+{{/Description}}
+            </td>
+        </tr>
+{{/JavaScriptTutorials}}
+    </tbody>
+</table>
+
+<div class="language-prologue-typescript"></div>
+<table width=100%>
+    <thead>
+        <tr>
+            <th width=20%>Cloud</th>
+            <th width=*>Tutorial</th>
+        </tr>
+    </thead>
+    <tbody>
+{{#TypeScriptTutorials}}
+        <tr>
+            <td>{{Cloud}}</td>
+            <td>
+                <a href="{{URL}}">{{Title}}</a></td>
+{{#Description}}
+                <p style="font-size: .875rem">{{.}}</p>
+{{/Description}}
+            </td>
+        </tr>
+{{/TypeScriptTutorials}}
+    </tbody>
+</table>
+
+<div class="language-prologue-python"></div>
+<table width=100%>
+    <thead>
+        <tr>
+            <th width=20%>Cloud</th>
+            <th width=*>Tutorial</th>
+        </tr>
+    </thead>
+    <tbody>
+{{#PythonTutorials}}
+        <tr>
+            <td>{{Cloud}}</td>
+            <td>
+                <a href="{{URL}}">{{Title}}</a></td>
+{{#Description}}
+                <p style="font-size: .875rem">{{.}}</p>
+{{/Description}}
+            </td>
+        </tr>
+{{/PythonTutorials}}
+    </tbody>
+</table>

--- a/tools/mktutorial/templates/tutorial.tmpl
+++ b/tools/mktutorial/templates/tutorial.tmpl
@@ -1,0 +1,12 @@
+---
+title: "{{Title}}"
+{{#MetaDesc}}
+meta_desc: "{{MetaDesc}}"
+{{/MetaDesc}}
+---
+
+<a href="https://app.pulumi.com/new?template={{GitHubURL}}" target="_blank">
+    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px">
+</a>
+
+{{{Body}}}


### PR DESCRIPTION
This change adds a new mktutorial tool. It takes our examples repo,
gathers up the examples as a series of tutorials, and emits three things:

1) A global index of tutorials, available as the shortcode
   {{< tutorials-index >}}.

2) A cloud index of tutorials, one per cloud, available as the
   shortcode {{< tutorials-index-[cloud] >}}.

3) A page per tutorial.

We currently filter out anything that isn't using the AWS, Azure,
Google Cloud, or Kubernetes cloud providers, and/or anything that
isn't using the TypeScript, JavaScript, or Python language.

This isn't actually wired up and used yet -- that will come shortly.
