### PR TITLE
Shrink the margin on blockquotes slightly

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -110,6 +110,11 @@ main {
 
     blockquote {
         @apply border-l-4 rounded border-orange-300 px-4 py-1 text-sm;
+
+        p {
+            margin-top: 0.25rem;
+            margin-bottom: 0.25rem;
+        }
     }
 }
 


### PR DESCRIPTION
The margin on blockquotes, with the orange bar on the left,
looked a bit large to my eyes. This has the effect of making
the blockquote, which is often used as an aside, much more
disruptive to the flow -- particularly for smaller blockquotes
(like single liners). Especially with the smaller font we use
for blockquotes, this "feels" more appropriate.