### PR TITLE
Make TypeScript the default language in docs

### DIFF
--- a/assets/js/langchoose.js
+++ b/assets/js/langchoose.js
@@ -79,7 +79,7 @@ function selectLanguage(lang) {
 }
 
 // The first time the DOM is finished loading, select the right language.  If no language is set as the preferred
-// language yet, then JavaScript is chosen as the preferred language as a default.
+// language yet, then TypeScript is chosen as the preferred language as a default.
 $(function() {
     var tabLangsOnPage = {};
     $("a.langtab").each(function (i, e) {
@@ -101,15 +101,15 @@ $(function() {
         return;
     }
 
-    // Now select the right language based on whether there's a cookie, defaulting to JavaScript,
+    // Now select the right language based on whether there's a cookie, defaulting to TypeScript,
     // if it's among the tabs, otherwise falling back to the first lang we find.
     var langCookie = decodeURIComponent(
         document.cookie.replace(/(?:(?:^|.*;\s*)pulumi_language\s*\=\s*([^;]*).*$)|^.*$/, "$1"));
 
     if (langCookie && tabLangsOnPage.hasOwnProperty(langCookie)) {
         selectLanguage(langCookie);
-    } else if (tabLangsOnPage.hasOwnProperty("javascript")) {
-        selectLanguage("javascript");
+    } else if (tabLangsOnPage.hasOwnProperty("typescript")) {
+        selectLanguage("typescript");
     } else if (tabLangsOnPageKeys.length > 0) {
         selectLanguage(tabLangsOnPageKeys[0]);
     }

--- a/layouts/shortcodes/langchoose.html
+++ b/layouts/shortcodes/langchoose.html
@@ -1,7 +1,7 @@
 <div class="mdl-tabs langtab-tabs">
     <div class="mdl-tabs__tab-dir langtab-tabstrip">
-        <a class="mdl-tabs__tab langtab is-active">JavaScript</a>
-        <a class="mdl-tabs__tab langtab">TypeScript</a>
+        <a class="mdl-tabs__tab langtab is-active">TypeScript</a>
+        <a class="mdl-tabs__tab langtab">JavaScript</a>
         {{ if not (eq (.Get 0) "nodeonly") }}
         <a class="mdl-tabs__tab langtab">Python</a>
         {{ if not (eq (.Get 0) "nogo") }}<a class="mdl-tabs__tab langtab">Go</a>{{ end }}


### PR DESCRIPTION
We default to JavaScript right now in our docs. It's not a big deal,
since the choice is sticky, however TypeScript is definitely our
"better" showing compared to JavaScript. Let's lead with that.