### PR TITLE
Avoid nil pointer dereference in doc generation

### DIFF
--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -1092,8 +1092,13 @@ func (e *emitter) createTypeLabel(t *typeDocType, indent int) string {
 			label := "{\n"
 			indent++
 			for _, child := range decl.Children {
-				label += fmt.Sprintf("%s%s: %s;\n",
-					strings.Repeat(" ", indent*4), child.Name, e.createTypeLabel(child.Type, indent))
+				if child.Kind == typeDocFunctionNode && len(child.Signatures) > 0 {
+					label += fmt.Sprintf("%s%s;\n",
+						strings.Repeat(" ", indent*4), e.createSignature(child.Signatures[0], decl, false))
+				} else {
+					label += fmt.Sprintf("%s%s: %s;\n",
+						strings.Repeat(" ", indent*4), child.Name, e.createTypeLabel(child.Type, indent))
+				}
 			}
 			indent--
 			return fmt.Sprintf("%s%s}", label, strings.Repeat(" ", indent*4))


### PR DESCRIPTION
The doc generation for beta releases of `@pulumi/pulumi` was failing with a nil pointer dereference because some new files were added to the `tsconfig.json`, which included a case we haven't seen before.

This is the type that's causing the issue: https://github.com/pulumi/pulumi/blob/8da252270f7734a8c16d3bd4ce8e208509865d47/sdk/nodejs/runtime/closure/v8_v11andHigher.ts#L99-L101

When generating the type label for type literals, and looping through the node's children, it's possible the `child.Type` node to be nil with this case. Instead, it is a function and needs to be processed as such.

Note: This particular type doesn't actually end up in the docs, but we still process the TypeDoc node for it. This avoids the nil pointer dereference.

Fixes #1631