### PR TITLE
Avoid node_modules links in API docs

### DIFF
--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -736,7 +736,7 @@ func simplifyModuleName(modnode *typeDocNode, parentModule string) string {
 // isLocalSource returns true if this source is local to this repo. This filters out references to types or
 // members that might be defined elsewhere, to avoid generating bogus links.
 func isLocalSource(source typeDocSource) bool {
-	return source.FileName != "" && source.FileName[0] != '/'
+	return source.FileName != "" && source.FileName[0] != '/' && !strings.HasPrefix(source.FileName, "node_modules/")
 }
 
 // getURLPath returns a URL path to a given type node that is relative to a given repo.


### PR DESCRIPTION
This fix should unblock https://github.com/pulumi/docs/pull/1630#discussion_r318307803.

A recent change to the doc generator is causing links to `node_modules` to be inserted into the generated docs, but we'd rather emit links to the source file. This change avoids the regression.

The issue appears to have been introduced with #1601. Running the doc gen on e55cf59 and later has this issue, but running it on the parent commit 9a2ed53 does not. I wasn't able to narrow down the specific changes in #1601 that causes this.

Fixes #1634