### PR TITLE
update python version of aws ec2 tutorial

### DIFF
--- a/content/docs/tutorials/aws/ec2-webserver.md
+++ b/content/docs/tutorials/aws/ec2-webserver.md
@@ -113,7 +113,7 @@ aws:region: (us-east-1)
     server = ec2.Instance('webserver-www',
         instance_type=size,
         security_groups=[group.name], # reference security group from above
-        ami=get_linux_ami(size))
+        ami='ami-0ff8a91507f77f867')
 
     pulumi.export('publicIp', server.public_ip)
     pulumi.export('publicHostName', server.public_dns)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Running through the python version of the ec2 webserver tutorial in it's current form doesn't work (https://www.pulumi.com/docs/tutorials/aws/ec2-webserver/).  The code is based on this example from https://github.com/pulumi/examples/tree/master/aws-py-webserver but doesn't include instructions to add the ami.py file that would let them get any ami.  The other languages hard-code the ami value so updating the python version to do the same.   

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
