### PR TITLE
Skip ksonnet.io in broken link checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ test:
 		--exclude "https://apps.twitter.com/" \
 		--exclude "https://www.googleapis.com/" \
 		--exclude "https://us-central1-/" \
-		--exclude "https://www.mysql.com/"
+		--exclude "https://www.mysql.com/" \
+		--exclude "https://ksonnet.io/"
 
 .PHONY: validate
 validate:


### PR DESCRIPTION
It seems the SSL cert has gone and expired. Given that the
project is defunct, it's no surprise -- let's just skip it.