### PR TITLE
Fix mktutorial tool to detemine the correct Pulumi.yaml path for Deploy With Pulumi buttons

### DIFF
--- a/content/docs/tutorials/aws/aws-ts-assume-role.md
+++ b/content/docs/tutorials/aws/aws-ts-assume-role.md
@@ -2,9 +2,6 @@
 title: "AWS AssumeRole Example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-assume-role/assume-role" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
 
 <p class="mb-4">
     <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-assume-role" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>

--- a/content/docs/tutorials/aws/aws-ts-assume-role.md
+++ b/content/docs/tutorials/aws/aws-ts-assume-role.md
@@ -2,7 +2,7 @@
 title: "AWS AssumeRole Example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-assume-role" target="_blank">
+<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-assume-role/assume-role" target="_blank">
     <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
 </a>
 

--- a/content/docs/tutorials/aws/aws-ts-eks-migrate-nodegroups.md
+++ b/content/docs/tutorials/aws/aws-ts-eks-migrate-nodegroups.md
@@ -2,9 +2,6 @@
 title: "examples/aws-ts-eks-migrate-nodegroups"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-eks-migrate-nodegroups" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
 
 <p class="mb-4">
     <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-eks-migrate-nodegroups" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>

--- a/content/docs/tutorials/aws/aws-ts-stackreference.md
+++ b/content/docs/tutorials/aws/aws-ts-stackreference.md
@@ -2,7 +2,7 @@
 title: "StackReference Example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-stackreference" target="_blank">
+<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-stackreference/company" target="_blank">
     <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
 </a>
 

--- a/content/docs/tutorials/aws/aws-ts-stackreference.md
+++ b/content/docs/tutorials/aws/aws-ts-stackreference.md
@@ -2,9 +2,6 @@
 title: "StackReference Example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-stackreference/company" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
 
 <p class="mb-4">
     <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-stackreference" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>

--- a/content/docs/tutorials/azure/azure-ts-appservice-devops.md
+++ b/content/docs/tutorials/azure/azure-ts-appservice-devops.md
@@ -2,6 +2,9 @@
 title: "A Todo App on Azure App Service with SQL Database and Application Insights and deploys it to Azure DevOps"
 ---
 
+<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops/infra" target="_blank">
+    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
+</a>
 
 <p class="mb-4">
     <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
@@ -94,3 +97,4 @@ Pulumi task expects a Pulumi access token to be configured as a build variable. 
 `alternative-pipeline` folder contains custom scripts and a pipeline to run Pulumi program in environments that have to access to the marketplace.
 
 Follow [Azure DevOps](https://www.pulumi.com/docs/reference/cd-azure-devops/) guide for more details.
+

--- a/content/docs/tutorials/azure/azure-ts-appservice-devops.md
+++ b/content/docs/tutorials/azure/azure-ts-appservice-devops.md
@@ -2,9 +2,6 @@
 title: "A Todo App on Azure App Service with SQL Database and Application Insights and deploys it to Azure DevOps"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops/infra" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
 
 <p class="mb-4">
     <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>

--- a/content/docs/tutorials/azure/azure-ts-appservice-devops.md
+++ b/content/docs/tutorials/azure/azure-ts-appservice-devops.md
@@ -2,7 +2,7 @@
 title: "A Todo App on Azure App Service with SQL Database and Application Insights and deploys it to Azure DevOps"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops" target="_blank">
+<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops/infra" target="_blank">
     <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
 </a>
 

--- a/content/docs/tutorials/azure/azure-ts-appservice-springboot.md
+++ b/content/docs/tutorials/azure/azure-ts-appservice-springboot.md
@@ -2,7 +2,7 @@
 title: "Deploy a Spring Boot App using Jenkins and Pulumi"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-springboot" target="_blank">
+<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-springboot/infrastructure" target="_blank">
     <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
 </a>
 

--- a/content/docs/tutorials/azure/azure-ts-cosmosdb-logicapp.md
+++ b/content/docs/tutorials/azure/azure-ts-cosmosdb-logicapp.md
@@ -1,0 +1,72 @@
+---
+title: "Deploy an Azure Cosmos DB container, an API Connection, and a Logic App"
+---
+
+<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-cosmosdb-logicapp" target="_blank">
+    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
+</a>
+
+<p class="mb-4">
+    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-cosmosdb-logicapp" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+</p>
+
+
+At the time of this writting, there is no native Pulumi resource to define API Connections and to link it to a Logic App. This example shows how to use an ARM templates to create an API Connection and a Logic App.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/en/download/)
+- [Download and install the Pulumi CLI](https://www.pulumi.com/docs/reference/install/)
+- [Connect Pulumi with your Azure account](https://www.pulumi.com/docs/reference/clouds/azure/setup/) (if your `az` CLI is configured, this will just work)
+
+## Running the App
+
+1. Create a new stack:
+
+    ```sh
+    $ pulumi stack init dev
+    ```
+
+2. Set the required configuration variables for this program, and log into Azure:
+
+    ```bash
+    $ pulumi config set azure:location westeurope
+    $ az login
+    ```
+
+3. Perform the deployment:
+
+    ```sh
+    $ pulumi up
+         Type                               Name                         Status
+     +   pulumi:pulumi:Stack                azure-cosmosdb-logicapp-dev  created
+     +   ├─ azure:core:ResourceGroup        logicappdemo-rg              created
+     +   ├─ azure:cosmosdb:Account          logicappdemo-cdb             created
+     +   ├─ azure:storage:Account           logicappdemosa               created
+     +   ├─ azure:cosmosdb:SqlDatabase      db                           created
+     +   ├─ azure:cosmosdb:SqlContainer     container                    created
+     +   ├─ azure:core:TemplateDeployment   db-connection                created
+     +   ├─ azure:core:TemplateDeployment   logic-app                    created
+     +   └─ azure:logicapps:ActionCustom    Create_or_update_document    created
+
+    Resources:
+        + 9 created
+
+    Duration: 15m10s
+    ```
+
+4. At this point, you have a Cosmos DB collection and a Logic App listening to HTTP requests. You can trigger the Logic App with a `curl` command:
+
+    ```
+    $ curl -X POST '$(pulumi stack output endpoint)' -d '"Hello World"' -H 'Content-Type: application/json'
+    ```
+
+    The POST body will be saved into a new document in the Cosmos DB collection.
+
+5. Once you are done, you can destroy all of the resources, and the stack:
+
+    ```bash
+    $ pulumi destroy
+    $ pulumi stack rm
+    ```
+

--- a/content/docs/tutorials/gcp/gcp-ts-k8s-ruby-on-rails-postgresql.md
+++ b/content/docs/tutorials/gcp/gcp-ts-k8s-ruby-on-rails-postgresql.md
@@ -2,7 +2,7 @@
 title: "Containerized Ruby on Rails App Delivery on GCP"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-k8s-ruby-on-rails-postgresql" target="_blank">
+<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-k8s-ruby-on-rails-postgresql/infra" target="_blank">
     <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
 </a>
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-guestbook.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-guestbook.md
@@ -2,7 +2,7 @@
 title: "Kubernetes Guestbook (Two Ways)"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-guestbook" target="_blank">
+<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-guestbook/components" target="_blank">
     <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
 </a>
 

--- a/layouts/shortcodes/tutorials-index-azure.html
+++ b/layouts/shortcodes/tutorials-index-azure.html
@@ -104,6 +104,11 @@
         </tr>
         <tr>
             <td>
+                <a href="/docs/tutorials/azure/azure-ts-cosmosdb-logicapp">Deploy an Azure Cosmos DB container, an API Connection, and a Logic App</a></td>
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <a href="/docs/tutorials/azure/azure-ts-arm-template">Deploy an Azure Resource Manager (ARM) Template in Pulumi</a></td>
             </td>
         </tr>

--- a/layouts/shortcodes/tutorials-index.html
+++ b/layouts/shortcodes/tutorials-index.html
@@ -304,6 +304,12 @@
         <tr>
             <td>azure</td>
             <td>
+                <a href="/docs/tutorials/azure/azure-ts-cosmosdb-logicapp">Deploy an Azure Cosmos DB container, an API Connection, and a Logic App</a></td>
+            </td>
+        </tr>
+        <tr>
+            <td>azure</td>
+            <td>
                 <a href="/docs/tutorials/azure/azure-ts-arm-template">Deploy an Azure Resource Manager (ARM) Template in Pulumi</a></td>
             </td>
         </tr>

--- a/tools/mktutorial/templates/tutorial.tmpl
+++ b/tools/mktutorial/templates/tutorial.tmpl
@@ -5,7 +5,7 @@ meta_desc: "{{MetaDesc}}"
 {{/MetaDesc}}
 ---
 
-<a href="https://app.pulumi.com/new?template={{GitHubURL}}" target="_blank">
+<a href="https://app.pulumi.com/new?template={{PulumiTemplateURL}}" target="_blank">
     <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
 </a>
 

--- a/tools/mktutorial/templates/tutorial.tmpl
+++ b/tools/mktutorial/templates/tutorial.tmpl
@@ -5,9 +5,11 @@ meta_desc: "{{MetaDesc}}"
 {{/MetaDesc}}
 ---
 
+{{#PulumiTemplateURL}}
 <a href="https://app.pulumi.com/new?template={{PulumiTemplateURL}}" target="_blank">
     <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
 </a>
+{{/PulumiTemplateURL}}
 
 <p class="mb-4">
     <a class="btn btn-secondary" href="{{GitHubURL}}" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>


### PR DESCRIPTION
### Proposed changes

Added a new function that searches each tutorial for the correct Pulumi.yaml. What led me to investigate/fix this, is this tutorial page: https://www.pulumi.com/docs/tutorials/azure/azure-ts-appservice-springboot/. But if you see my 2nd commit in this PR, there are other tutorials with the same problem apparently.

**Note**: I didn't make the search recursive intentionally to discourage burying the infra several folders deep.

### Unreleased product version (optional)
N/A

### Related issues (optional)

N/A
