### PR TITLE
Link to versions page

### DIFF
--- a/content/docs/get-started/install/_index.md
+++ b/content/docs/get-started/install/_index.md
@@ -14,7 +14,7 @@ NOTE: To update this page with a new binary release, do the following:
 - Update `content/docs/get-started/install/versions.md`
 -->
 
-This page contains detailed instructions for [installing Pulumi](#install-pulumi) on your machine.
+This page contains detailed instructions for [installing Pulumi](#install-pulumi) on your machine. For links to detailed release notes, see the [Available Versions]({{< relref "versions" >}}) page.
 
 {{< get-started-note >}}
 


### PR DESCRIPTION
Since we added the OS chooser, it's not very obvious how to get to the release notes page. @joeduffy , we've talked about having a dedicated Release Notes page, but perhaps this will suffice for now?

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

Closes #1633 
