### PR TITLE
Apply Console, Service and backend naming changes

### DIFF
--- a/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
+++ b/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
@@ -121,7 +121,7 @@ in touch.
 ### What payment options do you accept?
 
 All subscriptions can be paid with a credit card (we use Stripe for
-processing). The SaaS is meant to be easy to sign up for, so feel free
+processing). The Pulumi Service is meant to be easy to sign up for, so feel free
 to simply begin your trial, and then you may enter your credit card on
 your organization's Settings page.
 

--- a/content/blog/connecting-multiple-identities-to-pulumi/index.md
+++ b/content/blog/connecting-multiple-identities-to-pulumi/index.md
@@ -2,7 +2,7 @@
 title: "Connecting multiple identities to Pulumi"
 authors: ["praneet-loke"]
 tags: ["CI/CD"]
-meta_desc: "Pulumi now supports multiple identities for a single Pulumi account in the Pulumi Cloud Console."
+meta_desc: "Pulumi now supports multiple identities for a single Pulumi account in the Pulumi Console."
 date: "2018-12-14"
 
 meta_image: "multi-id.gif"
@@ -12,7 +12,7 @@ meta_image: "multi-id.gif"
 Hot on the heels of our
 [GitLab sign-in support]({{< relref "welcoming-gitlab-users-to-pulumi" >}}),
 we've just released support for multiple identities for a single Pulumi
-account in the Pulumi Cloud Console. Previously, you could only sign-up
+account in the Pulumi Console. Previously, you could only sign-up
 for a new Pulumi account using a GitHub or GitLab identity. Starting
 today, you can connect your Pulumi account with additional identities,
 beyond what you first signed-up with.

--- a/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
+++ b/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
@@ -62,7 +62,7 @@ please refer to our documentation
 - Pulumi Stacks have associated metadata in the form of key/value
     tags.
 - You can assign custom tags to stacks (when logged into the
-  [web backend]({{< ref "/docs/intro/concepts/state" >}}) to customize how
+  [Pulumi Service backend]({{< ref "/docs/intro/concepts/state" >}}) to customize how
   stacks are listed in the [Pulumi Console](https://app.pulumi.com/).
   - In our example below we have two environments _prod_ and _dev_.
     - To group stacks by environment we assign custom tags

--- a/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
+++ b/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
@@ -85,7 +85,7 @@ Let's now work through our example with GitLab Pipelines.
 1.  We created a GitLab Group called **pulumi-gitlab**.
 2.  We created three GitLab projects called **sample-iam**,
     **sample-eks** and **sample-k8sapp**. These projects match the
-    project names in Pulumi SaaS platform.
+    project names in the Pulumi Service.
 3.  We have two pipelines: **environment:dev** and **environment:prod**.
     In the two pipelines, we have a total of six pulumi stacks:
     -   `<org-name-in-pulumi>/sample-iam/dev`, and `<org-name-in-pulumi>/sample-iam/prod`.

--- a/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
+++ b/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
@@ -63,12 +63,12 @@ please refer to our documentation
     tags.
 - You can assign custom tags to stacks (when logged into the
   [web backend]({{< ref "/docs/intro/concepts/state" >}}) to customize how
-  stacks are listed in the [Pulumi Cloud Console](https://app.pulumi.com/).
+  stacks are listed in the [Pulumi Console](https://app.pulumi.com/).
   - In our example below we have two environments _prod_ and _dev_.
     - To group stacks by environment we assign custom tags
       `environment: prod` and `environment: dev` to the respective
       stacks
-    - In the Pulumi Cloud Console, you'll be able to group stacks by
+    - In the Pulumi Console, you'll be able to group stacks by
       tag: `environment:dev` and tag: `environment:prod`.
 
 Please read more about managing [stack tags in Pulumi]({{< ref "/docs/intro/concepts/stack#stack-tags" >}}).

--- a/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
+++ b/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
@@ -133,7 +133,7 @@ The stack emits the URL to the webhook handler in the stack's outputs.
 That URL is what will receive and process Pulumi webhooks.
 
 With the infrastructure in-place, we just need to register the webhook
-on the Pulumi Cloud Console. Organization administrators can do so under
+on the Pulumi Console. Organization administrators can do so under
 the organization's **SETTINGS** tab.
 
 ![webhooks3](./pulumi-webhooks-3.png)

--- a/content/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws/index.md
+++ b/content/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws/index.md
@@ -53,7 +53,7 @@ The fun part -- Pulumi Service console helps you map your cloud
 architecture shown above as a connected set of DAG resources so you need
 not remember what you deployed as your cloud environments scale:
 
-![Pulumi SaaS Console](./pulumi-saas-console-iot.png)
+![Pulumi Console](./pulumi-saas-console-iot.png)
 
 Lets now work through the solution flow with some sample snippets of
 code. To get access to the complete piece of code, please connect with

--- a/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
+++ b/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
@@ -442,7 +442,7 @@ For instance, let's say somehow the VPC wasn't known at preview time, and ended 
 resolving to the default VPC. Even though the deployment occurred, we'd want to
 know that we now have an issue that we need to go track down.
 
-We can very clearly see such failures on the Pulumi SaaS console:
+We can very clearly see such failures in the Pulumi Console:
 
 ![Failed Deployment](./failed-deployment.png)
 

--- a/content/docs/guides/continuous-delivery/github-actions.md
+++ b/content/docs/guides/continuous-delivery/github-actions.md
@@ -209,7 +209,7 @@ does not have access to your source code.)
 
 Once the Pulumi GitHub App is installed, when your GitHub Actions run Pulumi, a summary of
 any resource changes will be left on the Pull Request, as well as links to the Pulumi
-Cloud Console for more detailed information.
+Console for more detailed information.
 
 You can install the Pulumi GitHub App now, by visiting
 [github.com/apps/pulumi](https://github.com/apps/pulumi) or clicking the button below.

--- a/content/docs/guides/crosswalk/aws/_index.md
+++ b/content/docs/guides/crosswalk/aws/_index.md
@@ -127,7 +127,7 @@ https://github.com/pulumi/pulumi-aws), [`pulumi/pulumi-awsx`](https://github.com
 ### If I'm an Existing User, What Has Changed?
 
 The primary change is new functionality added to the above packages, and the availability of these User Guides.
-Pulumi Crosswalk for AWS continues to work with the standard Pulumi CLI and SaaS. If you already use the free Community
+Pulumi Crosswalk for AWS continues to work with the standard Pulumi CLI and Pulumi Service. If you already use the free Community
 Edition, or paid Team or Enterprise Edition, you can continue to do so now with Pulumi Crosswalk for AWS functionality.
 
 ### Is Support or Training Available for Pulumi Crosswalk for AWS?

--- a/content/docs/intro/concepts/organizing-stacks-projects.md
+++ b/content/docs/intro/concepts/organizing-stacks-projects.md
@@ -183,7 +183,7 @@ its associated Pulumi stack. Please read more about
 
 ## Tagging Stacks
 
-Stacks have associated metadata in the form of name/value tags. You can assign custom tags to stacks (when logged into the [web backend]({{< relref "state.md" >}})) to customize how stacks are listed in the [Pulumi Console](https://app.pulumi.com). For example, if you have many projects with separate stacks for production, staging, and testing environments, it may be useful to group stacks by environment instead of by project. To do this, you could assign a custom `environment` tag to each stack, assigning a value of `production` to each production stack, `staging` to each staging stack, etc. Then in the Pulumi Console, you'll be able to group stacks by `Tag: environment`. Please read more about [how to manage stack tags here]({{< relref "stack.md#stack-tags" >}}).
+Stacks have associated metadata in the form of name/value tags. You can assign custom tags to stacks (when logged into the [Pulumi Service backend]({{< relref "state.md" >}})) to customize how stacks are listed in the [Pulumi Console](https://app.pulumi.com). For example, if you have many projects with separate stacks for production, staging, and testing environments, it may be useful to group stacks by environment instead of by project. To do this, you could assign a custom `environment` tag to each stack, assigning a value of `production` to each production stack, `staging` to each staging stack, etc. Then in the Pulumi Console, you'll be able to group stacks by `Tag: environment`. Please read more about [how to manage stack tags here]({{< relref "stack.md#stack-tags" >}}).
 
 ## Examples
 

--- a/content/docs/intro/concepts/stack.md
+++ b/content/docs/intro/concepts/stack.md
@@ -139,7 +139,7 @@ To force the deletion of a stack that still contains resources --- potentially o
 
 Stacks have associated metadata in the form of tags, with each tag consisting of a name and value. A set of built-in tags are automatically assigned and updated each time a stack is updated (such as `pulumi:project`, `pulumi:runtime`, `pulumi:description`, `gitHub:owner`, `gitHub:repo`, `vcs:owner`, `vcs:repo`, and `vcs:kind`). To view a stack's tags, run [`pulumi stack tag ls`]({{< relref "/docs/reference/cli/pulumi_stack_tag_ls.md" >}}).
 
-> **Note:** Stack tags are only supported when logged into the [web backend]({{< relref "state.md" >}}).
+> **Note:** Stack tags are only supported when logged into the [Pulumi Service backend]({{< relref "state.md" >}}).
 
 Custom tags can be assigned to a stack by running [`pulumi stack tag set <name> <value>`]({{< relref "/docs/reference/cli/pulumi_stack_tag_set.md" >}}) and can be used to customize the grouping of stacks in the [Pulumi Console](https://app.pulumi.com). For example, if you have many projects with separate stacks for production, staging, and testing environments, it may be useful to group stacks by environment instead of by project. To do this, you could assign a custom tag named `environment` to each stack. For example, running `pulumi stack tag set environment production` assigns a custom `environment` tag with a value of `production` to the active stack. Once you've assigned an `environment` tag to each stack, you'll be able to group by `Tag: environment` in the Pulumi Console.
 

--- a/content/docs/intro/concepts/state.md
+++ b/content/docs/intro/concepts/state.md
@@ -86,7 +86,7 @@ At a glance, the `pulumi.com` backend provides the following benefits:
 
 #### app.pulumi.com architecture
 
-<img src="/images/docs/reference/state_saas.png" alt="Pulumi SaaS Architecture"
+<img src="/images/docs/reference/state_saas.png" alt="Pulumi Service Architecture"
 class="img-bordered">
 
 #### Enterprise web architecture
@@ -245,7 +245,7 @@ This stores all stack checkpoints as JSON files to the `.pulumi` directory of
 your specified cloud URL.
 
 To control where these checkpoints get stored, refer to your cloud storage
-provider's documentation. See [Self-managed backend](#self-managed-backend) 
+provider's documentation. See [Self-managed backend](#self-managed-backend)
 for quick links to Amazon, Google, and Microsoft Azure's storage service quickstarts.
 
 You may omit `--cloud-url` or `-c` when logging in to a remote backend and just
@@ -276,8 +276,8 @@ to be managed separately when you opt into the local or remote state backend.
 
 ### Going back to the pulumi.com backend
 
-If you are currently using a self-managed backend, but would now prefer to 
-simplify things, just run `pulumi login`again, and you’ll be back to 
+If you are currently using a self-managed backend, but would now prefer to
+simplify things, just run `pulumi login`again, and you’ll be back to
 using `app.pulumi.com`.
 
 > **Note:** Existing stacks on a self-managed backend have to be migrated. It's

--- a/content/docs/intro/concepts/state.md
+++ b/content/docs/intro/concepts/state.md
@@ -28,20 +28,20 @@ Pulumi operates, we'll cover a few of the state backend options on this page.
 Pulumi supports multiple  _backends_ for storing your infrastructure
 state:
 
-- The `pulumi.com` backend
+- The Pulumi Service backend
 - A self-managed backend, either stored locally on your filesystem or remotely using
 a cloud storage service
 
 
-### pulumi.com backend
+### Pulumi Service backend
 
-The `pulumi.com` backend requires no additional configuration after
+The Pulumi Service backend requires no additional configuration after
 [installing the CLI]({{< relref "/docs/get-started/install" >}}). By default, the CLI
-uses a web backend hosted at [app.pulumi.com](https://app.pulumi.com).
+uses the Service backend hosted at [app.pulumi.com](https://app.pulumi.com).
 
 Pulumi offers this backend as a free service with
 [advanced tiers]({{< relref "/pricing" >}}) for team and
-enterprise features. Using the [`pulumi.com` backend](#pulumi-backend-features)
+enterprise features. Using the [Pulumi Service backend](#pulumi-backend-features)
 and the CLI together provides a great combination of usability, safety, and
 security for most users.
 
@@ -74,9 +74,9 @@ and Microsoft's [Storage Blobs Quickstart](https://docs.microsoft.com/en-us/azur
 - **Google Cloud Storage.** _See [GCP Setup]({{< relref "/docs/intro/cloud-providers/gcp/setup" >}})
 and [Google's Cloud Storage Quickstarts](https://cloud.google.com/storage/docs/quickstarts)._
 
-### Pulumi backend features
+### Pulumi Service backend features
 
-At a glance, the `pulumi.com` backend provides the following benefits:
+At a glance, the Pulumi Service backend provides the following benefits:
 
 - Secure checkpoint storage, with client-side authentication to your cloud provider
 - Encrypted state in transit and at rest
@@ -91,7 +91,7 @@ class="img-bordered">
 
 #### Enterprise web architecture
 
-Pulumi enterprise users have a self-hosting option, for using the Pulumi backend features without depending on
+Pulumi enterprise users have a self-hosting option, for using the Pulumi Service backend features without depending on
 `app.pulumi.com`.
 
 <img src="/images/docs/reference/state_enterprise.png" alt="Pulumi Enterprise
@@ -123,9 +123,9 @@ User: <your-username>
 Backend URL: https://app.pulumi.com/<your-username>
 ```
 
-### To the pulumi.com backend
+### To the Pulumi Service backend
 
-The `pulumi.com` backend login process involves using access tokens.
+The Pulumi Service backend login process involves using access tokens.
 
 ```sh
 $ pulumi login
@@ -172,7 +172,7 @@ service instead of `app.pulumi.com`.
 The filesystem or cloud storage backend allows you to store state locally on
 your machine, or remotely with your cloud storage provider. For self-managed backends,
 state management including backup, sharing, and team access synchronization is
-entirely up to you. Pulumi built the `pulumi.com` backend to solve all of these
+entirely up to you. Pulumi built the Pulumi Service backend to solve all of these
 problems "out of the box", but we understand that some users prefer to have
 more control.
 
@@ -274,7 +274,7 @@ your stack. If you want to collaborate with another person, you'll need to
 share this passphrase with them as well. All of these overhead tasks will have
 to be managed separately when you opt into the local or remote state backend.
 
-### Going back to the pulumi.com backend
+### Going back to the Pulumi Service backend
 
 If you are currently using a self-managed backend, but would now prefer to
 simplify things, just run `pulumi login`again, and you’ll be back to
@@ -288,10 +288,10 @@ using `app.pulumi.com`.
 `pulumi config set --secret <key> <value>` because `pulumi.com` uses
 a different key to encrypt your secrets than the local endpoint.
 
-If you'd like to migrate your stacks from the filesystem to the `pulumi.com`
+If you'd like to migrate your stacks from the filesystem to the Pulumi Service
 backend, you can follow the steps below. Suppose the stack "my-app-production"
 has been managed with a local checkpoint file, and you want to migrate it to
-`pulumi.com`, run the following commands if you are logged in to the local
+the Pulumi Service. Run the following commands if you are logged in to the local
 endpoint:
 
 ```sh
@@ -312,10 +312,10 @@ When a secret value is provided via secret configuration---either by passing
 `pulumi.secret` (JavaScript) or `Output.secret` (Python)---the value is
 encrypted with a key managed by the backend you are connected to.  When using
 the local or remote backend, this key is derived from a passphrase you set when
-creating your stack. When using the `pulumi.com` backend, it is handled by
+creating your stack. When using the Pulumi Service backend, it is handled by
 a key managed by the service.
 
-For new stacks managed with the `pulumi.com` backend, you may choose to use the
+For new stacks managed with the Pulumi Service backend, you may choose to use the
 passphrase-based key instead. Pass `--secrets-provider passphrase` when you
 create the stack---either via `pulumi new` or `pulumi stack init`. You will be
 prompted to choose a passphrase which will be required for future operations

--- a/content/docs/intro/console/accounts-and-organizations/accounts.md
+++ b/content/docs/intro/console/accounts-and-organizations/accounts.md
@@ -25,7 +25,7 @@ following:
 ## Profile
 
 Your Pulumi user account profile is used to identify you across the Pulumi
-Cloud Console.  Your account display name, avatar URL, and email address are
+Console.  Your account display name, avatar URL, and email address are
 obtained from the identity provider you used for signing up. For example, your
 GitHub identity.
 

--- a/content/docs/reference/cli/pulumi_new.md
+++ b/content/docs/reference/cli/pulumi_new.md
@@ -14,12 +14,12 @@ To create a project from a specific template, pass the template name (such as `a
 or `azure-python`).  If no template name is provided, a list of suggested templates will be presented
 which can be selected interactively.
 
-By default, a stack created using the pulumi.com backend will use the pulumi.com secrets
+By default, a stack created using the Pulumi Service backend will use the Pulumi Service secrets
 provider and a stack created using the local or cloud object storage backend will use the
 `passphrase` secrets provider.  A different secrets provider can be selected by passing the
 `--secrets-provider` flag.
 
-To use the `passphrase` secrets provider with the pulumi.com backend, use:
+To use the `passphrase` secrets provider with the Pulumi Service backend, use:
 * `pulumi new --secrets-provider=passphrase`
 
 To use a cloud secrets provider with any backend, use one of the following:

--- a/content/docs/reference/cli/pulumi_stack_init.md
+++ b/content/docs/reference/cli/pulumi_stack_init.md
@@ -16,12 +16,12 @@ but afterwards it can become the target of a deployment using the `update` comma
 To create a stack in an organization when logged in to the Pulumi service,
 prefix the stack name with the organization name and a slash (e.g. 'acmecorp/dev')
 
-By default, a stack created using the pulumi.com backend will use the pulumi.com secrets
+By default, a stack created using the Pulumi Service backend will use the Pulumi Service secrets
 provider and a stack created using the local or cloud object storage backend will use the
 `passphrase` secrets provider.  A different secrets provider can be selected by passing the
 `--secrets-provider` flag.
 
-To use the `passphrase` secrets provider with the pulumi.com backend, use:
+To use the `passphrase` secrets provider with the Pulumi Service backend, use:
 * `pulumi stack init --secrets-provider=passphrase`
 
 To use a cloud secrets provider with any backend, use one of the following:

--- a/content/webinar/aws-mapbox.md
+++ b/content/webinar/aws-mapbox.md
@@ -34,7 +34,7 @@ main:
         - Why current technologies fall short—especially at scale
         - How to compile an asset tracking solution using modern, serverless technology with Pulumi, AWS, and Mapbox
         - "Pulumi Live demo: Asset tracking at work"
-        - "Programing your cloud applications with TypeScript, JavaScript, or Python: Pulumi SDKs and SaaS console"
+        - "Programing your cloud applications with TypeScript, JavaScript, or Python: Pulumi SDKs and Service"
         - Why serverless tech matters and what it enables
 
 webinar:

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -240,7 +240,7 @@
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
             <div class="pricing-item">
-                <span class="pricing-item-label">Cloud Console</span>
+                <span class="pricing-item-label">Pulumi Console</span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
@@ -436,7 +436,7 @@
                     <div class="text-black font-display font-bold text-4xl">FREE</div>
                     <p class="text-sm text-gray-700">
                         Includes unlimited individual use of the Pulumi CLI, cloud SDKs, and the
-                        <a href="{{ relref . "/docs/intro/console" }}">Pulumi Cloud Console</a>.
+                        <a href="{{ relref . "/docs/intro/console" }}">Pulumi Console</a>.
                     </p>
                     <ul class="list-none mt-0 mb-auto mx-auto justify-center text-left text-sm text-gray-700 px-0">
                         <li class="flex items-center">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -39,7 +39,7 @@
                 <li class="md:ml-auto md:mr-2 lg:mr-4">
                     <a class="block mt-4 md:mt-0 md:text-xs lg:text-sm btn btn-orange-translucent"
                         href="https://app.pulumi.com/"
-                        title="Sign into the Pulumi Cloud Console">
+                        title="Sign into the Pulumi Console">
                         Sign In
                     </a>
                 </li>


### PR DESCRIPTION
We [recently agreed](https://pulumi.slack.com/archives/C7XHM1GNT/p1566057328001800) to standardize on the way we refer to the various parts of the Pulumi platform: 

* "Pulumi Console" for app.pulumi.com
* "Pulumi Service" for the service generally
* "Pulumi Service API" for the REST API specifically
* "Pulumi Service backend" for the service backend

This PR takes a pass through the site to apply those changes.
