### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ There are several other Go-based tools to install as well.
 ```bash
 go get -u github.com/cbroglie/mustache
 go get -u github.com/gobuffalo/packr
+go get -u github.com/pkg/errors
 ```
 
 ### Makefile

--- a/scripts/run_typedoc.sh
+++ b/scripts/run_typedoc.sh
@@ -63,6 +63,7 @@ generate_docs() {
         # Generate the docs, copy any READMEs, and remember the Git hash.
         ${TOOL_TYPEDOC} --json "${PULUMI_DOC_TMP}/$1.docs.json" \
             --mode modules --includeDeclarations --excludeExternals --excludePrivate
+        mkdir -p ${PULUMI_DOC_TMP}/readmes
         find . -name 'README.md' -exec rsync -R {} ${PULUMI_DOC_TMP}/readmes \;
         HEAD_COMMIT=$(git rev-parse HEAD)
 


### PR DESCRIPTION
- Update the README to mention the dependency on pkg/errors
- Fix run_typedoc.sh so that it runs properly with versions of rsync
  that do not create the target directory if it does not exist