### PR TITLE
Add a trailing slash to the tutorial URL

### DIFF
--- a/layouts/shortcodes/tutorials-index-aws.html
+++ b/layouts/shortcodes/tutorials-index-aws.html
@@ -8,32 +8,32 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-webserver">AWS EC2 Web Server</a>
+                <a href="/docs/tutorials/aws/aws-js-webserver/">AWS EC2 Web Server</a>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-webserver-component">AWS Web Server component example</a>
+                <a href="/docs/tutorials/aws/aws-js-webserver-component/">AWS Web Server component example</a>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-containers">Easy container example</a>
+                <a href="/docs/tutorials/aws/aws-js-containers/">Easy container example</a>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-sqs-slack">Post AWS SQS Messages to Slack using Serverless Lambdas</a>
+                <a href="/docs/tutorials/aws/aws-js-sqs-slack/">Post AWS SQS Messages to Slack using Serverless Lambdas</a>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-s3-folder">Static Website Hosted on AWS S3</a>
+                <a href="/docs/tutorials/aws/aws-js-s3-folder/">Static Website Hosted on AWS S3</a>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-s3-folder-component">Static Website Hosted on AWS S3</a>
+                <a href="/docs/tutorials/aws/aws-js-s3-folder-component/">Static Website Hosted on AWS S3</a>
             </td>
         </tr>
     </tbody>
@@ -49,117 +49,117 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-slackbot">A simple Slackbot running in AWS using Pulumi.</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-slackbot/">A simple Slackbot running in AWS using Pulumi.</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-assume-role">AWS AssumeRole Example</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-assume-role/">AWS AssumeRole Example</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-ruby-on-rails">AWS EC2 Ruby on Rails</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-ruby-on-rails/">AWS EC2 Ruby on Rails</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-eks">AWS EKS Cluster</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-eks/">AWS EKS Cluster</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-eks-hello-world">AWS EKS Cluster</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-eks-hello-world/">AWS EKS Cluster</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-airflow">AWS RDS and Airflow example</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-airflow/">AWS RDS and Airflow example</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-resources">AWS Resources</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-resources/">AWS Resources</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-stepfunctions">AWS Step Functions</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-stepfunctions/">AWS Step Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-apigateway-auth0">Auth0 Protected Serverless REST API on AWS</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-apigateway-auth0/">Auth0 Protected Serverless REST API on AWS</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-appsync">Defining an AWS AppSync Endpoint</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-appsync/">Defining an AWS AppSync Endpoint</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-containers">Easy container example</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-containers/">Easy container example</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-hello-fargate">Get Started with Docker on AWS Fargate</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-hello-fargate/">Get Started with Docker on AWS Fargate</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-pulumi-webhooks">Pulumi Webhook Handler</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-pulumi-webhooks/">Pulumi Webhook Handler</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-s3-lambda-copyzip">Serverless App to Copy and Zip S3 Objects Between Buckets</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-s3-lambda-copyzip/">Serverless App to Copy and Zip S3 Objects Between Buckets</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-apigateway">Serverless REST API on AWS</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-apigateway/">Serverless REST API on AWS</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-url-shortener-cache-http">Serverless URL Shortener with Redis Cache and HttpServer</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-url-shortener-cache-http/">Serverless URL Shortener with Redis Cache and HttpServer</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-stackreference">StackReference Example</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-stackreference/">StackReference Example</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-static-website">Static Website using AWS and TypeScript</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-static-website/">Static Website using AWS and TypeScript</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-twitter-athena">Twitter Search in Athena</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-twitter-athena/">Twitter Search in Athena</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-thumbnailer">Video Thumbnailer</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-thumbnailer/">Video Thumbnailer</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-voting-app">Voting app with two containers</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-voting-app/">Voting app with two containers</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-eks-migrate-nodegroups">examples/aws-ts-eks-migrate-nodegroups</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-eks-migrate-nodegroups/">examples/aws-ts-eks-migrate-nodegroups</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-serverless-raw">serverless-raw</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-serverless-raw/">serverless-raw</a></td>
             </td>
         </tr>
     </tbody>
@@ -175,17 +175,17 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-py-stepfunctions">AWS Step Functions (Python)</a></td>
+                <a href="/docs/tutorials/aws/aws-py-stepfunctions/">AWS Step Functions (Python)</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-py-webserver">AWS Web Server example in Python</a></td>
+                <a href="/docs/tutorials/aws/aws-py-webserver/">AWS Web Server example in Python</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/aws/aws-py-s3-folder">Static Website Hosted on AWS S3</a></td>
+                <a href="/docs/tutorials/aws/aws-py-s3-folder/">Static Website Hosted on AWS S3</a></td>
             </td>
         </tr>
     </tbody>

--- a/layouts/shortcodes/tutorials-index-azure.html
+++ b/layouts/shortcodes/tutorials-index-azure.html
@@ -8,7 +8,7 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-js-webserver">Pulumi web server (Azure)</a>
+                <a href="/docs/tutorials/azure/azure-js-webserver/">Pulumi web server (Azure)</a>
             </td>
         </tr>
     </tbody>
@@ -24,112 +24,112 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-aks-mean">A Node.js demo app deployed on AKS, using CosmosDB</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-aks-mean/">A Node.js demo app deployed on AKS, using CosmosDB</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-static-website">A Static Website Hosted on Azure Blob Storage + Azure CDN</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-static-website/">A Static Website Hosted on Azure Blob Storage + Azure CDN</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-appservice-devops">A Todo App on Azure App Service with SQL Database and Application Insights and deploys it to Azure DevOps</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-appservice-devops/">A Todo App on Azure App Service with SQL Database and Application Insights and deploys it to Azure DevOps</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-api-management">Azure API Management</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-api-management/">Azure API Management</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-appservice-docker">Azure App Service running Docker containers on Linux</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-appservice-docker/">Azure App Service running Docker containers on Linux</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-appservice">Azure App Service with SQL Database and Application Insights</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-appservice/">Azure App Service with SQL Database and Application Insights</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-dynamicresource">Azure CDN Custom Domain Dynamic Provider</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-dynamicresource/">Azure CDN Custom Domain Dynamic Provider</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-functions-raw">Azure Functions</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-functions-raw/">Azure Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-functions">Azure Functions</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-functions/">Azure Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-aks-helm">Azure Kubernetes Service (AKS) Cluster and Helm Chart</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-aks-helm/">Azure Kubernetes Service (AKS) Cluster and Helm Chart</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-aks-keda">Azure Kubernetes Service (AKS) cluster and Azure Functions with KEDA</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-aks-keda/">Azure Kubernetes Service (AKS) cluster and Azure Functions with KEDA</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-stream-analytics">Azure Stream Analytics</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-stream-analytics/">Azure Stream Analytics</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-vm-scaleset">Azure VM Scale Sets</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-vm-scaleset/">Azure VM Scale Sets</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-webserver">Azure Web Server Virtual Machine</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-webserver/">Azure Web Server Virtual Machine</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-webserver-component">Azure Web Server Virtual Machine Component</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-webserver-component/">Azure Web Server Virtual Machine Component</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-appservice-springboot">Deploy a Spring Boot App using Jenkins and Pulumi</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-appservice-springboot/">Deploy a Spring Boot App using Jenkins and Pulumi</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-cosmosdb-logicapp">Deploy an Azure Cosmos DB container, an API Connection, and a Logic App</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-cosmosdb-logicapp/">Deploy an Azure Cosmos DB container, an API Connection, and a Logic App</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-arm-template">Deploy an Azure Resource Manager (ARM) Template in Pulumi</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-arm-template/">Deploy an Azure Resource Manager (ARM) Template in Pulumi</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-serverless-url-shortener-global">Globally distributed serverless URL-shortener</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-serverless-url-shortener-global/">Globally distributed serverless URL-shortener</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-msi-keyvault-rbac">Managing Secrets and Secure Access in Azure Applications</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-msi-keyvault-rbac/">Managing Secrets and Secure Access in Azure Applications</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-aks-multicluster">Multiple Azure Kubernetes Service (AKS) Clusters</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-aks-multicluster/">Multiple Azure Kubernetes Service (AKS) Clusters</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-hdinsight-spark">Spark on Azure HDInsight example</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-hdinsight-spark/">Spark on Azure HDInsight example</a></td>
             </td>
         </tr>
     </tbody>
@@ -145,12 +145,12 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-py-aks">Azure Kubernetes Service (AKS) Cluster</a></td>
+                <a href="/docs/tutorials/azure/azure-py-aks/">Azure Kubernetes Service (AKS) Cluster</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/azure/azure-py-webserver">Azure Web Server example in Python</a></td>
+                <a href="/docs/tutorials/azure/azure-py-webserver/">Azure Web Server example in Python</a></td>
             </td>
         </tr>
     </tbody>

--- a/layouts/shortcodes/tutorials-index-gcp.html
+++ b/layouts/shortcodes/tutorials-index-gcp.html
@@ -8,7 +8,7 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-js-webserver">Pulumi web server (GCP)</a>
+                <a href="/docs/tutorials/gcp/gcp-js-webserver/">Pulumi web server (GCP)</a>
             </td>
         </tr>
     </tbody>
@@ -24,32 +24,32 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-slackbot">A simple Slackbot running in GCP using Pulumi.</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-slackbot/">A simple Slackbot running in GCP using Pulumi.</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-k8s-ruby-on-rails-postgresql">Containerized Ruby on Rails App Delivery on GCP</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-k8s-ruby-on-rails-postgresql/">Containerized Ruby on Rails App Delivery on GCP</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-functions">GCP Functions</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-functions/">GCP Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-serverless-raw">Google Cloud Functions in Python and Go deployed with TypeScript</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-serverless-raw/">Google Cloud Functions in Python and Go deployed with TypeScript</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-gke-hello-world">Google Kubernetes Engine (GKE) Cluster</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-gke-hello-world/">Google Kubernetes Engine (GKE) Cluster</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-gke">Google Kubernetes Engine (GKE) with a Canary Deployment</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-gke/">Google Kubernetes Engine (GKE) with a Canary Deployment</a></td>
             </td>
         </tr>
     </tbody>
@@ -65,17 +65,17 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-py-functions">GCP Functions</a></td>
+                <a href="/docs/tutorials/gcp/gcp-py-functions/">GCP Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-py-gke">Google Kubernetes Engine (GKE) with a Canary Deployment</a></td>
+                <a href="/docs/tutorials/gcp/gcp-py-gke/">Google Kubernetes Engine (GKE) with a Canary Deployment</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-py-instance-nginx">Pulumi Nginx Server in a instance (GCP)</a></td>
+                <a href="/docs/tutorials/gcp/gcp-py-instance-nginx/">Pulumi Nginx Server in a instance (GCP)</a></td>
             </td>
         </tr>
     </tbody>

--- a/layouts/shortcodes/tutorials-index-kubernetes.html
+++ b/layouts/shortcodes/tutorials-index-kubernetes.html
@@ -26,52 +26,52 @@
     <tbody>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-multicloud">Kubernetes Application Deployed To Multiple Clusters</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-multicloud/">Kubernetes Application Deployed To Multiple Clusters</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-guestbook">Kubernetes Guestbook (Two Ways)</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-guestbook/">Kubernetes Guestbook (Two Ways)</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-jenkins">Kubernetes Jenkins</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-jenkins/">Kubernetes Jenkins</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-sock-shop">Kubernetes Sock Shop</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-sock-shop/">Kubernetes Sock Shop</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-helm-wordpress">Kubernetes: Deploying the Wordpress Helm chart</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-helm-wordpress/">Kubernetes: Deploying the Wordpress Helm chart</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-exposed-deployment">Kubernetes: Exposing a Deployment with a public IP address</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-exposed-deployment/">Kubernetes: Exposing a Deployment with a public IP address</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-staged-rollout-with-prometheus">Kubernetes: Staged application rollout gated by Prometheus checks</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-staged-rollout-with-prometheus/">Kubernetes: Staged application rollout gated by Prometheus checks</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-configmap-rollout">Kubernetes: Triggering a rollout of an app by changing ConfigMap data</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-configmap-rollout/">Kubernetes: Triggering a rollout of an app by changing ConfigMap data</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-s3-rollout">Kubernetes: Triggering a rollout of an app by changing data in S3</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-s3-rollout/">Kubernetes: Triggering a rollout of an app by changing data in S3</a></td>
             </td>
         </tr>
         <tr>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-nginx">Run a Stateless Application Using a Deployment</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-nginx/">Run a Stateless Application Using a Deployment</a></td>
             </td>
         </tr>
     </tbody>

--- a/layouts/shortcodes/tutorials-index.html
+++ b/layouts/shortcodes/tutorials-index.html
@@ -10,49 +10,49 @@
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-webserver">AWS EC2 Web Server</a>
+                <a href="/docs/tutorials/aws/aws-js-webserver/">AWS EC2 Web Server</a>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-webserver-component">AWS Web Server component example</a>
+                <a href="/docs/tutorials/aws/aws-js-webserver-component/">AWS Web Server component example</a>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-containers">Easy container example</a>
+                <a href="/docs/tutorials/aws/aws-js-containers/">Easy container example</a>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-sqs-slack">Post AWS SQS Messages to Slack using Serverless Lambdas</a>
+                <a href="/docs/tutorials/aws/aws-js-sqs-slack/">Post AWS SQS Messages to Slack using Serverless Lambdas</a>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-s3-folder">Static Website Hosted on AWS S3</a>
+                <a href="/docs/tutorials/aws/aws-js-s3-folder/">Static Website Hosted on AWS S3</a>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-js-s3-folder-component">Static Website Hosted on AWS S3</a>
+                <a href="/docs/tutorials/aws/aws-js-s3-folder-component/">Static Website Hosted on AWS S3</a>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-js-webserver">Pulumi web server (Azure)</a>
+                <a href="/docs/tutorials/azure/azure-js-webserver/">Pulumi web server (Azure)</a>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-js-webserver">Pulumi web server (GCP)</a>
+                <a href="/docs/tutorials/gcp/gcp-js-webserver/">Pulumi web server (GCP)</a>
             </td>
         </tr>
     </tbody>
@@ -70,367 +70,367 @@
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-slackbot">A simple Slackbot running in AWS using Pulumi.</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-slackbot/">A simple Slackbot running in AWS using Pulumi.</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-assume-role">AWS AssumeRole Example</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-assume-role/">AWS AssumeRole Example</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-ruby-on-rails">AWS EC2 Ruby on Rails</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-ruby-on-rails/">AWS EC2 Ruby on Rails</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-eks">AWS EKS Cluster</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-eks/">AWS EKS Cluster</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-eks-hello-world">AWS EKS Cluster</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-eks-hello-world/">AWS EKS Cluster</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-airflow">AWS RDS and Airflow example</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-airflow/">AWS RDS and Airflow example</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-resources">AWS Resources</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-resources/">AWS Resources</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-stepfunctions">AWS Step Functions</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-stepfunctions/">AWS Step Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-apigateway-auth0">Auth0 Protected Serverless REST API on AWS</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-apigateway-auth0/">Auth0 Protected Serverless REST API on AWS</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-appsync">Defining an AWS AppSync Endpoint</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-appsync/">Defining an AWS AppSync Endpoint</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-containers">Easy container example</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-containers/">Easy container example</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-hello-fargate">Get Started with Docker on AWS Fargate</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-hello-fargate/">Get Started with Docker on AWS Fargate</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-pulumi-webhooks">Pulumi Webhook Handler</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-pulumi-webhooks/">Pulumi Webhook Handler</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-s3-lambda-copyzip">Serverless App to Copy and Zip S3 Objects Between Buckets</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-s3-lambda-copyzip/">Serverless App to Copy and Zip S3 Objects Between Buckets</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-apigateway">Serverless REST API on AWS</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-apigateway/">Serverless REST API on AWS</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-url-shortener-cache-http">Serverless URL Shortener with Redis Cache and HttpServer</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-url-shortener-cache-http/">Serverless URL Shortener with Redis Cache and HttpServer</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-stackreference">StackReference Example</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-stackreference/">StackReference Example</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-static-website">Static Website using AWS and TypeScript</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-static-website/">Static Website using AWS and TypeScript</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-twitter-athena">Twitter Search in Athena</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-twitter-athena/">Twitter Search in Athena</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-thumbnailer">Video Thumbnailer</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-thumbnailer/">Video Thumbnailer</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-voting-app">Voting app with two containers</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-voting-app/">Voting app with two containers</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-eks-migrate-nodegroups">examples/aws-ts-eks-migrate-nodegroups</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-eks-migrate-nodegroups/">examples/aws-ts-eks-migrate-nodegroups</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-ts-serverless-raw">serverless-raw</a></td>
+                <a href="/docs/tutorials/aws/aws-ts-serverless-raw/">serverless-raw</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-aks-mean">A Node.js demo app deployed on AKS, using CosmosDB</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-aks-mean/">A Node.js demo app deployed on AKS, using CosmosDB</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-static-website">A Static Website Hosted on Azure Blob Storage + Azure CDN</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-static-website/">A Static Website Hosted on Azure Blob Storage + Azure CDN</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-appservice-devops">A Todo App on Azure App Service with SQL Database and Application Insights and deploys it to Azure DevOps</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-appservice-devops/">A Todo App on Azure App Service with SQL Database and Application Insights and deploys it to Azure DevOps</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-api-management">Azure API Management</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-api-management/">Azure API Management</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-appservice-docker">Azure App Service running Docker containers on Linux</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-appservice-docker/">Azure App Service running Docker containers on Linux</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-appservice">Azure App Service with SQL Database and Application Insights</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-appservice/">Azure App Service with SQL Database and Application Insights</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-dynamicresource">Azure CDN Custom Domain Dynamic Provider</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-dynamicresource/">Azure CDN Custom Domain Dynamic Provider</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-functions-raw">Azure Functions</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-functions-raw/">Azure Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-functions">Azure Functions</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-functions/">Azure Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-aks-helm">Azure Kubernetes Service (AKS) Cluster and Helm Chart</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-aks-helm/">Azure Kubernetes Service (AKS) Cluster and Helm Chart</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-aks-keda">Azure Kubernetes Service (AKS) cluster and Azure Functions with KEDA</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-aks-keda/">Azure Kubernetes Service (AKS) cluster and Azure Functions with KEDA</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-stream-analytics">Azure Stream Analytics</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-stream-analytics/">Azure Stream Analytics</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-vm-scaleset">Azure VM Scale Sets</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-vm-scaleset/">Azure VM Scale Sets</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-webserver">Azure Web Server Virtual Machine</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-webserver/">Azure Web Server Virtual Machine</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-webserver-component">Azure Web Server Virtual Machine Component</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-webserver-component/">Azure Web Server Virtual Machine Component</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-appservice-springboot">Deploy a Spring Boot App using Jenkins and Pulumi</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-appservice-springboot/">Deploy a Spring Boot App using Jenkins and Pulumi</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-cosmosdb-logicapp">Deploy an Azure Cosmos DB container, an API Connection, and a Logic App</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-cosmosdb-logicapp/">Deploy an Azure Cosmos DB container, an API Connection, and a Logic App</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-arm-template">Deploy an Azure Resource Manager (ARM) Template in Pulumi</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-arm-template/">Deploy an Azure Resource Manager (ARM) Template in Pulumi</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-serverless-url-shortener-global">Globally distributed serverless URL-shortener</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-serverless-url-shortener-global/">Globally distributed serverless URL-shortener</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-msi-keyvault-rbac">Managing Secrets and Secure Access in Azure Applications</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-msi-keyvault-rbac/">Managing Secrets and Secure Access in Azure Applications</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-aks-multicluster">Multiple Azure Kubernetes Service (AKS) Clusters</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-aks-multicluster/">Multiple Azure Kubernetes Service (AKS) Clusters</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-ts-hdinsight-spark">Spark on Azure HDInsight example</a></td>
+                <a href="/docs/tutorials/azure/azure-ts-hdinsight-spark/">Spark on Azure HDInsight example</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-slackbot">A simple Slackbot running in GCP using Pulumi.</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-slackbot/">A simple Slackbot running in GCP using Pulumi.</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-k8s-ruby-on-rails-postgresql">Containerized Ruby on Rails App Delivery on GCP</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-k8s-ruby-on-rails-postgresql/">Containerized Ruby on Rails App Delivery on GCP</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-functions">GCP Functions</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-functions/">GCP Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-serverless-raw">Google Cloud Functions in Python and Go deployed with TypeScript</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-serverless-raw/">Google Cloud Functions in Python and Go deployed with TypeScript</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-gke-hello-world">Google Kubernetes Engine (GKE) Cluster</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-gke-hello-world/">Google Kubernetes Engine (GKE) Cluster</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-ts-gke">Google Kubernetes Engine (GKE) with a Canary Deployment</a></td>
+                <a href="/docs/tutorials/gcp/gcp-ts-gke/">Google Kubernetes Engine (GKE) with a Canary Deployment</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-multicloud">Kubernetes Application Deployed To Multiple Clusters</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-multicloud/">Kubernetes Application Deployed To Multiple Clusters</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-guestbook">Kubernetes Guestbook (Two Ways)</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-guestbook/">Kubernetes Guestbook (Two Ways)</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-jenkins">Kubernetes Jenkins</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-jenkins/">Kubernetes Jenkins</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-sock-shop">Kubernetes Sock Shop</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-sock-shop/">Kubernetes Sock Shop</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-helm-wordpress">Kubernetes: Deploying the Wordpress Helm chart</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-helm-wordpress/">Kubernetes: Deploying the Wordpress Helm chart</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-exposed-deployment">Kubernetes: Exposing a Deployment with a public IP address</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-exposed-deployment/">Kubernetes: Exposing a Deployment with a public IP address</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-staged-rollout-with-prometheus">Kubernetes: Staged application rollout gated by Prometheus checks</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-staged-rollout-with-prometheus/">Kubernetes: Staged application rollout gated by Prometheus checks</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-configmap-rollout">Kubernetes: Triggering a rollout of an app by changing ConfigMap data</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-configmap-rollout/">Kubernetes: Triggering a rollout of an app by changing ConfigMap data</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-s3-rollout">Kubernetes: Triggering a rollout of an app by changing data in S3</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-s3-rollout/">Kubernetes: Triggering a rollout of an app by changing data in S3</a></td>
             </td>
         </tr>
         <tr>
             <td>kubernetes</td>
             <td>
-                <a href="/docs/tutorials/kubernetes/kubernetes-ts-nginx">Run a Stateless Application Using a Deployment</a></td>
+                <a href="/docs/tutorials/kubernetes/kubernetes-ts-nginx/">Run a Stateless Application Using a Deployment</a></td>
             </td>
         </tr>
     </tbody>
@@ -448,49 +448,49 @@
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-py-stepfunctions">AWS Step Functions (Python)</a></td>
+                <a href="/docs/tutorials/aws/aws-py-stepfunctions/">AWS Step Functions (Python)</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-py-webserver">AWS Web Server example in Python</a></td>
+                <a href="/docs/tutorials/aws/aws-py-webserver/">AWS Web Server example in Python</a></td>
             </td>
         </tr>
         <tr>
             <td>aws</td>
             <td>
-                <a href="/docs/tutorials/aws/aws-py-s3-folder">Static Website Hosted on AWS S3</a></td>
+                <a href="/docs/tutorials/aws/aws-py-s3-folder/">Static Website Hosted on AWS S3</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-py-aks">Azure Kubernetes Service (AKS) Cluster</a></td>
+                <a href="/docs/tutorials/azure/azure-py-aks/">Azure Kubernetes Service (AKS) Cluster</a></td>
             </td>
         </tr>
         <tr>
             <td>azure</td>
             <td>
-                <a href="/docs/tutorials/azure/azure-py-webserver">Azure Web Server example in Python</a></td>
+                <a href="/docs/tutorials/azure/azure-py-webserver/">Azure Web Server example in Python</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-py-functions">GCP Functions</a></td>
+                <a href="/docs/tutorials/gcp/gcp-py-functions/">GCP Functions</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-py-gke">Google Kubernetes Engine (GKE) with a Canary Deployment</a></td>
+                <a href="/docs/tutorials/gcp/gcp-py-gke/">Google Kubernetes Engine (GKE) with a Canary Deployment</a></td>
             </td>
         </tr>
         <tr>
             <td>gcp</td>
             <td>
-                <a href="/docs/tutorials/gcp/gcp-py-instance-nginx">Pulumi Nginx Server in a instance (GCP)</a></td>
+                <a href="/docs/tutorials/gcp/gcp-py-instance-nginx/">Pulumi Nginx Server in a instance (GCP)</a></td>
             </td>
         </tr>
     </tbody>

--- a/tools/mktutorial/main.go
+++ b/tools/mktutorial/main.go
@@ -173,7 +173,7 @@ func gatherTutorials(root string) ([]tutorial, error) {
 			Cloud:             parts[0],
 			Language:          parts[1],
 			Body:              cleanMarkdownBody(name, string(body)),
-			URL:               fmt.Sprintf("/docs/tutorials/%s/%s", parts[0], name),
+			URL:               fmt.Sprintf("/docs/tutorials/%s/%s/", parts[0], name),
 			GitHubURL:         githubURL,
 			PulumiTemplateURL: pulumiTemplateURL,
 		})


### PR DESCRIPTION
### Proposed changes
As the title says, adding a trailing slash to the tutorial index page URL so that S3 doesn't issue a 302 Found to redirect to the index document for the object.

Here's an example:

<img width="564" alt="Screen Shot 2019-09-06 at 09 00 43" src="https://user-images.githubusercontent.com/1466314/64442551-d89dee00-d084-11e9-95d6-2d4de81b763f.png">

### Unreleased product version (optional)
N/A

### Related issues (optional)
N/A
