### PR TITLE
Make the alert badge more noticeable

### DIFF
--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,6 +1,6 @@
 <div class="mx-auto mb-12">
     <a href="{{ relref . "/blog/pulumi-1-0" }}" class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex">
-        <span class="flex rounded-full bg-purple-500 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New</span>
+        <span class="flex rounded-full bg-orange-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New</span>
         <span class="text-left flex-auto text-white text-sm md:text-base leading-normal">We've reached 1.0! Check out the blog.</span>
         <i class="fill-current fas fa-chevron-right text-xs opacity-75 ml-2 mr-1"></i>
     </a>


### PR DESCRIPTION
We've heard it's somewhat easy to miss, so this makes it a bit more alerty.

Before:

![image](https://user-images.githubusercontent.com/274700/64560201-e9f12f80-d2fc-11e9-9ac6-1d3398c43d29.png)

After:

![image](https://user-images.githubusercontent.com/274700/64559446-2b80db00-d2fb-11e9-8d8e-0b0bde2b8abe.png)

Or alternatively, we could use contrast, rather than color, which I think I might slightly prefer:

![image](https://user-images.githubusercontent.com/274700/64560146-cd54f780-d2fc-11e9-8d81-20fca55707d6.png)

