### PR TITLE
Add trailing slash to a few more URLs in the Get Started index page.

### DIFF
--- a/layouts/partials/get-started.html
+++ b/layouts/partials/get-started.html
@@ -10,21 +10,21 @@
     <div class="container mx-auto max-w-5xl">
         <div class="flex flex-row max-w-full">
             <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 mr-4"
-                href="/docs/get-started/aws/">
+                href="{{ relref . "/docs/get-started/aws" }}">
                 <img class="h-10" src="/logos/tech/aws.svg" alt="AWS">
             </a>
             <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 ml-4"
-                href="/docs/get-started/azure/">
+                href="{{ relref . "/docs/get-started/azure" }}">
                 <img class="h-10" src="/logos/tech/azure.svg" alt="Azure">
             </a>
         </div>
         <div class="flex flex-row max-w-full">
             <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 mr-4"
-                href="/docs/get-started/gcp/">
+                href="{{ relref . "/docs/get-started/gcp" }}">
                 <img class="h-10" src="/logos/tech/gcp.svg" alt="Google Cloud">
             </a>
             <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 ml-4"
-                href="/docs/get-started/kubernetes/">
+                href="{{ relref . "/docs/get-started/kubernetes" }}">
                 <img class="h-10" src="/logos/tech/k8s.svg" alt="Kubernetes">
             </a>
         </div>

--- a/layouts/partials/get-started.html
+++ b/layouts/partials/get-started.html
@@ -9,18 +9,22 @@
     </div>
     <div class="container mx-auto max-w-5xl">
         <div class="flex flex-row max-w-full">
-            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 mr-4" href="/docs/get-started/aws">
+            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 mr-4"
+                href="/docs/get-started/aws/">
                 <img class="h-10" src="/logos/tech/aws.svg" alt="AWS">
             </a>
-            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 ml-4" href="/docs/get-started/azure">
+            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 ml-4"
+                href="/docs/get-started/azure/">
                 <img class="h-10" src="/logos/tech/azure.svg" alt="Azure">
             </a>
         </div>
         <div class="flex flex-row max-w-full">
-            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 mr-4" href="/docs/get-started/gcp">
+            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 mr-4"
+                href="/docs/get-started/gcp/">
                 <img class="h-10" src="/logos/tech/gcp.svg" alt="Google Cloud">
             </a>
-            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 ml-4" href="/docs/get-started/kubernetes">
+            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 ml-4"
+                href="/docs/get-started/kubernetes/">
                 <img class="h-10" src="/logos/tech/k8s.svg" alt="Kubernetes">
             </a>
         </div>


### PR DESCRIPTION
### Proposed changes
Adds a trailing slash to the URLs in the Get Started layout page. You can get to this page from **PRODUCT** (nav item) > (under **Migrate to Pulumi** header) click on **AWS CloudFormation** or **Terraform**. Scroll-down the **Get Started with Pulumi** section.

### Unreleased product version (optional)
N/A

### Related issues (optional)
N/A
