### PR TITLE
Emit `types` module consistently

### DIFF
--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -705,17 +705,31 @@ func (e *emitter) gatherModules(doc *typeDocNode, parentModule string, k8s bool)
 		root = newModule(rootModule)
 		mods[rootModule] = root
 	}
-	for modname, mod := range mods {
+
+	// Copy the names to an array and then process until empty. This allows us to add new names while iterating.
+	var modnames []string
+	for modname := range mods {
+		modnames = append(modnames, modname)
+	}
+	for len(modnames) > 0 {
+		// Get an item to process (the last item) and remove it.
+		lastIndex := len(modnames) - 1
+		modname := modnames[lastIndex]
+		modnames = modnames[:lastIndex]
+
 		if modname != rootModule {
 			parname := getModuleParentName(modname)
 			par := mods[parname]
 			if par == nil {
 				par = newModule(parname)
 				mods[parname] = par
+				// Add to the array for further processing.
+				modnames = append(modnames, parname)
 			}
-			par.Modules[modname] = mod
+			par.Modules[modname] = mods[modname]
 		}
 	}
+
 	return root, nil
 }
 


### PR DESCRIPTION
Sometimes when generating the docs, we'd leave out the `types` module. Other times, it would be included.

This nondeterministic behavior was due to us modifying a map while iterating over it. According to the [Go "for statements" spec](https://golang.org/ref/spec#For_statements):

>  If a map entry is created during iteration, that entry may be produced during the iteration or may be skipped. The choice may vary for each entry created and from one iteration to the next.

This started becoming an issue when we recently started including `types` module. Previously, all other modules were parented under the root "index" module, which is always present. But now we have a `types` module which gets added during processing, and sometimes that entry would be included and other times it would be skipped during the iteration.

To address this, we now copy the entries to an array, which will be processed until it is empty, allowing for items to be added during the iteration.

Fixes #1685