### PR TITLE
Add blackfriday dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ There are several other Go-based tools to install as well.
 go get -u github.com/cbroglie/mustache
 go get -u github.com/gobuffalo/packr
 go get -u github.com/pkg/errors
+go get -u gopkg.in/russross/blackfriday.v2
 ```
 
 ### Makefile


### PR DESCRIPTION
The `mktutorial` tool depends on it.