### PR TITLE
Expandable/collapsable second level TOC items

### DIFF
--- a/assets/sass/_toc.scss
+++ b/assets/sass/_toc.scss
@@ -25,7 +25,7 @@
 }
 
 .sidenav-subsection {
-    @apply mb-2 ml-2;
+    @apply mb-2 ml-2 text-sm;
 }
 
 .sidenav-parent {

--- a/content/docs/guides/continuous-delivery/aws-code-services.md
+++ b/content/docs/guides/continuous-delivery/aws-code-services.md
@@ -1,5 +1,11 @@
 ---
 title: AWS Code Services
+
+menu:
+    userguides:
+        parent: cont_delivery
+        weight: 1
+
 aliases:
 - /docs/reference/cd-aws-code-services/
 - /docs/console/continuous-delivery/aws-code-services/

--- a/content/docs/guides/continuous-delivery/azure-devops.md
+++ b/content/docs/guides/continuous-delivery/azure-devops.md
@@ -2,8 +2,9 @@
 title: Azure DevOps
 
 menu:
-    guides:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases:
 - /docs/reference/cd-azure-devops/

--- a/content/docs/guides/continuous-delivery/circleci.md
+++ b/content/docs/guides/continuous-delivery/circleci.md
@@ -2,8 +2,9 @@
 title: CircleCI
 
 menu:
-    guides:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases:
 - /docs/reference/cd-circleci/

--- a/content/docs/guides/continuous-delivery/codefresh.md
+++ b/content/docs/guides/continuous-delivery/codefresh.md
@@ -2,8 +2,9 @@
 title: Codefresh
 
 menu:
-    guides:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases:
 - /docs/reference/cd-codefresh/

--- a/content/docs/guides/continuous-delivery/github-actions.md
+++ b/content/docs/guides/continuous-delivery/github-actions.md
@@ -2,8 +2,9 @@
 title: Pulumi GitHub Actions
 
 menu:
-    guides:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases:
 - /docs/reference/cd-github-actions/

--- a/content/docs/guides/continuous-delivery/github-app.md
+++ b/content/docs/guides/continuous-delivery/github-app.md
@@ -2,8 +2,9 @@
 title: Pulumi GitHub App
 
 menu:
-    console:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases:
 - /docs/reference/cd-github/

--- a/content/docs/guides/continuous-delivery/gitlab-ci.md
+++ b/content/docs/guides/continuous-delivery/gitlab-ci.md
@@ -2,8 +2,9 @@
 title: GitLab CI
 
 menu:
-    guides:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases:
 - /docs/reference/cd-gitlab-ci/

--- a/content/docs/guides/continuous-delivery/google-cloud-build.md
+++ b/content/docs/guides/continuous-delivery/google-cloud-build.md
@@ -2,8 +2,9 @@
 title: Google Cloud Build
 
 menu:
-    guides:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases:
 - /docs/reference/cd-google-cloud-build/

--- a/content/docs/guides/continuous-delivery/jenkins.md
+++ b/content/docs/guides/continuous-delivery/jenkins.md
@@ -2,8 +2,9 @@
 title: Jenkins
 
 menu:
-    console:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases: ["/docs/console/continuous-delivery/jenkins/"]
 ---

--- a/content/docs/guides/continuous-delivery/other.md
+++ b/content/docs/guides/continuous-delivery/other.md
@@ -2,8 +2,9 @@
 title: Other
 
 menu:
-    guides:
+    userguides:
         parent: cont_delivery
+        weight: 2
 
 aliases:
 - /docs/reference/cd-supporting-new-ci/

--- a/content/docs/guides/continuous-delivery/travis.md
+++ b/content/docs/guides/continuous-delivery/travis.md
@@ -2,8 +2,9 @@
 title: Travis CI
 
 menu:
-    guides:
+    userguides:
         parent: cont_delivery
+        weight: 1
 
 aliases:
 - /docs/reference/cd-travis/

--- a/content/docs/guides/saml/aad.md
+++ b/content/docs/guides/saml/aad.md
@@ -1,6 +1,11 @@
 ---
 title: Azure Active Directory
 
+menu:
+    userguides:
+        parent: saml
+        weight: 2
+
 aliases:
 - /docs/reference/service/saml-aad/
 - /docs/console/accounts/saml/aad/

--- a/content/docs/guides/saml/gsuite.md
+++ b/content/docs/guides/saml/gsuite.md
@@ -1,6 +1,11 @@
 ---
 title: G Suite (Google)
 
+menu:
+    userguides:
+        parent: saml
+        weight: 2
+
 aliases:
 - /docs/reference/service/saml-gsuite/
 - /docs/console/accounts/saml/gsuite/

--- a/content/docs/guides/saml/okta.md
+++ b/content/docs/guides/saml/okta.md
@@ -1,6 +1,11 @@
 ---
 title: Okta
 
+menu:
+    userguides:
+        parent: saml
+        weight: 2
+
 aliases:
 - /docs/reference/service/saml-okta/
 - /docs/console/accounts/saml/okta/

--- a/content/docs/guides/saml/sso.md
+++ b/content/docs/guides/saml/sso.md
@@ -2,9 +2,9 @@
 title: Single Sign-on (SSO)
 
 menu:
-    console:
-        parent: accounts
-        identifier: saml
+    userguides:
+        parent: saml
+        weight: 1
 
 aliases:
 - /docs/intro/console/accounts/saml/

--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -4,6 +4,8 @@ menu:
   reference:
     name: Overview
     weight: 1
+
+toc_nochildren: true
 ---
 
 This section includes all reference documentation for Pulumi.

--- a/content/docs/troubleshooting/_index.md
+++ b/content/docs/troubleshooting/_index.md
@@ -5,6 +5,8 @@ menu:
     weight: 1
 
 aliases: ["/docs/reference/troubleshooting/"]
+
+toc_nochildren: true
 ---
 
 Pulumi tries very hard to ensure that your infrastructure is always in a known and predictable state.

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -29,9 +29,8 @@
 
 {{ define "toc" }}
     {{ $page := .page }}
-    {{ $lastindex := (sub (len .menu) 1) }}
 
-    {{ range $index, $element := .menu }}
+    {{ range .menu }}
         {{ $toggle_state := "toggle" }}
         {{ $sidenav_selected := "" }}
 
@@ -42,60 +41,32 @@
             {{ $toggle_state = "toggleVisible" }}
         {{ end }}
 
-        <div class="toggleVisible{{ if ne $lastindex $index }} separator{{ end }}">
-            <div class="{{ $toggle_state }}" data-title="{{ .Name }}">
-                <div class="collapsed">
-                    <div class="sidenav-topic {{ $sidenav_selected }}">
-                        <a data-title="{{ .Name }}" href="{{ .URL }}">{{ .Name }}</a>
-                        {{- if .HasChildren -}}
-                            <span class="toggleButton">
-                                <i class="fas fa-caret-right"></i>
-                            </span>
-                        {{- end -}}
-                    </div>
+        <div class="{{ $toggle_state }}">
+            <div class="collapsed">
+                <div class="sidenav-topic {{ $sidenav_selected }}">
+                    <a href="{{ .URL }}">{{ .Name }}</a>
+                    {{- if .HasChildren -}}
+                        <span class="toggleButton">
+                            <i class="fas fa-caret-right"></i>
+                        </span>
+                    {{- end -}}
                 </div>
-                <div class="expanded">
-                    <div class="sidenav-topic {{ if .HasChildren }} sidenav-parent {{ end }} {{ $sidenav_selected }}">
-                        <a data-title="{{ .Name }}" href="{{ .URL }}">{{ .Name }}</a>
-                        {{- if .HasChildren -}}
-                            <span class="toggleButton">
-                                <i class="fas fa-caret-down"></i>
-                            </span>
-                        {{- end -}}
-                    </div>
-                    {{ if .HasChildren }}
-                        <div class="sidenav-subsection text-sm">
-                            {{ template "tocsub" (dict "page" $page "menu" .) }}
-                        </div>
-                    {{ end }}
+            </div>
+            <div class="expanded">
+                <div class="sidenav-topic {{ if .HasChildren }} sidenav-parent {{ end }} {{ $sidenav_selected }}">
+                    <a href="{{ .URL }}">{{ .Name }}</a>
+                    {{- if .HasChildren -}}
+                        <span class="toggleButton">
+                            <i class="fas fa-caret-down"></i>
+                        </span>
+                    {{- end -}}
                 </div>
+                {{ if .HasChildren }}
+                    <div class="sidenav-subsection">
+                        {{ template "toc" (dict "page" $page "menu" .Children) }}
+                    </div>
+                {{ end }}
             </div>
         </div>
-    {{ end }}
-{{ end }}
-
-{{ define "tocsub" }}
-    {{ $page := .page }}
-
-    {{ range .menu.Children }}
-        {{ $sidenav_selected := "" }}
-        {{ if or (eq $page.RelPermalink .URL) (and (not .HasChildren) (hasPrefix $page.RelPermalink .URL)) }}
-            {{ $sidenav_selected = "active" }}
-        {{ end }}
-
-        {{ if .HasChildren }}
-            <div data-title="{{ .Name }}">
-                <div class="sidenav-topic {{ $sidenav_selected }}">
-                    <a data-title="{{ .Name }}" href="{{ .URL }}">{{ .Name }}</a>
-                </div>
-                <div class="sidenav-subsection">
-                    {{ template "tocsub" (dict "page" $page "menu" .) }}
-                </div>
-            </div>
-        {{ else }}
-            <div class="sidenav-topic mb-2 {{ $sidenav_selected }}">
-                <a data-title="{{ .Name }}" href="{{ .URL }}">{{ .Name }}</a>
-            </div>
-        {{ end }}
     {{ end }}
 {{ end }}

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -35,7 +35,7 @@
         {{ $toggle_state := "toggle" }}
         {{ $sidenav_selected := "" }}
 
-        {{ if or (eq $page.RelPermalink .URL) (and (not .HasChildren) (hasPrefix $page.RelPermalink .URL) (ne .Name "Overview") (ne .Name "Troubleshooting")) }}
+        {{ if or (eq $page.RelPermalink .URL) (and (not .HasChildren) (hasPrefix $page.RelPermalink .URL) $page.Params.toc_nochildren) }}
             {{ $toggle_state = "toggleVisible" }}
             {{ $sidenav_selected = "active" }}
         {{ else if hasPrefix $page.RelPermalink .URL }}


### PR DESCRIPTION
This adds support for expandable/collapsable second level TOC items and makes the CI/CD & SAML sub-pages true nav items to match Crosswalk.

<img width="224" alt="Screen Shot 2019-09-11 at 3 28 42 PM" src="https://user-images.githubusercontent.com/710598/64740127-26618e80-d4a9-11e9-913d-a177783e2203.png">

<img width="294" alt="Screen Shot 2019-09-11 at 3 31 11 PM" src="https://user-images.githubusercontent.com/710598/64740139-311c2380-d4a9-11e9-9899-c38fb3356863.png">

Also, some cleanup of the TOC implementation while making changes here.

Fixes #1614