### PR TITLE
Fix link to GCP serviceAccount module

### DIFF
--- a/content/docs/reference/pkg/nodejs/pulumi/gcp/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/gcp/_index.md
@@ -74,7 +74,7 @@ import * as gcp from "@pulumi/gcp";
     <li><a href="resourcemanager/"><span class="symbol module"></span>resourcemanager</a></li>
     <li><a href="runtimeconfig/"><span class="symbol module"></span>runtimeconfig</a></li>
     <li><a href="serverless/"><span class="symbol module"></span>serverless</a></li>
-    <li><a href="serviceAccount/"><span class="symbol module"></span>serviceAccount</a></li>
+    <li><a href="serviceaccount/"><span class="symbol module"></span>serviceAccount</a></li>
     <li><a href="servicenetworking/"><span class="symbol module"></span>servicenetworking</a></li>
     <li><a href="sourcerepo/"><span class="symbol module"></span>sourcerepo</a></li>
     <li><a href="spanner/"><span class="symbol module"></span>spanner</a></li>

--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -438,6 +438,9 @@ func (e *emitter) emitMarkdownModule(name string, mod *module, root bool) error 
 			link = modname
 		}
 
+		// Hugo converts all paths to lowercase by default when publishing, so we make these links lowercase as well.
+		link = strings.ToLower(link)
+
 		// Ensure the link has a trailing slash to avoid the S3 302 redirect dance.
 		if !strings.HasSuffix(link, "/") {
 			link = link + "/"


### PR DESCRIPTION
By default, Hugo publishes all paths as lowercase, so ensure the link to this module is lowercase as well.

Fixes #1314