### PR TITLE
Make tutorial buttons consistent

### DIFF
--- a/content/docs/tutorials/aws/aws-go-s3-folder.md
+++ b/content/docs/tutorials/aws/aws-go-s3-folder.md
@@ -2,12 +2,14 @@
 title: "Static Website Hosted on AWS S3 in Go"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-go-s3-folder" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-go-s3-folder" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-go-s3-folder" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-go-s3-folder" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-js-containers.md
+++ b/content/docs/tutorials/aws/aws-js-containers.md
@@ -2,12 +2,14 @@
 title: "Easy container example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-containers" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-js-containers" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-js-containers" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-containers" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-js-s3-folder-component.md
+++ b/content/docs/tutorials/aws/aws-js-s3-folder-component.md
@@ -2,12 +2,14 @@
 title: "Static Website Hosted on AWS S3"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-s3-folder-component" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-js-s3-folder-component" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-js-s3-folder-component" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-s3-folder-component" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-js-s3-folder.md
+++ b/content/docs/tutorials/aws/aws-js-s3-folder.md
@@ -2,12 +2,14 @@
 title: "Static Website Hosted on AWS S3"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-s3-folder" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-js-s3-folder" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-js-s3-folder" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-s3-folder" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-js-sqs-slack.md
+++ b/content/docs/tutorials/aws/aws-js-sqs-slack.md
@@ -2,12 +2,14 @@
 title: "Post AWS SQS Messages to Slack using Serverless Lambdas"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-sqs-slack" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-js-sqs-slack" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-js-sqs-slack" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-sqs-slack" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-js-webserver-component.md
+++ b/content/docs/tutorials/aws/aws-js-webserver-component.md
@@ -2,12 +2,14 @@
 title: "AWS Web Server component example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-webserver-component" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-js-webserver-component" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-js-webserver-component" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-webserver-component" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-js-webserver.md
+++ b/content/docs/tutorials/aws/aws-js-webserver.md
@@ -2,12 +2,14 @@
 title: "AWS EC2 Web Server"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-webserver" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-js-webserver" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-js-webserver" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-js-webserver" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-py-s3-folder.md
+++ b/content/docs/tutorials/aws/aws-py-s3-folder.md
@@ -2,12 +2,14 @@
 title: "Static Website Hosted on AWS S3"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-py-s3-folder" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-py-s3-folder" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-py-s3-folder" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-py-s3-folder" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-py-stepfunctions.md
+++ b/content/docs/tutorials/aws/aws-py-stepfunctions.md
@@ -2,12 +2,14 @@
 title: "AWS Step Functions (Python)"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-py-stepfunctions" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-py-stepfunctions" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-py-stepfunctions" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-py-stepfunctions" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-py-webserver.md
+++ b/content/docs/tutorials/aws/aws-py-webserver.md
@@ -2,12 +2,14 @@
 title: "AWS Web Server example in Python"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-py-webserver" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-py-webserver" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-py-webserver" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-py-webserver" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-airflow.md
+++ b/content/docs/tutorials/aws/aws-ts-airflow.md
@@ -2,12 +2,14 @@
 title: "AWS RDS and Airflow example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-airflow" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-airflow" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-airflow" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-airflow" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-apigateway-auth0.md
+++ b/content/docs/tutorials/aws/aws-ts-apigateway-auth0.md
@@ -2,12 +2,14 @@
 title: "Auth0 Protected Serverless REST API on AWS"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-apigateway-auth0" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-apigateway-auth0" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-apigateway-auth0" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-apigateway-auth0" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-apigateway.md
+++ b/content/docs/tutorials/aws/aws-ts-apigateway.md
@@ -2,12 +2,14 @@
 title: "Serverless REST API on AWS"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-apigateway" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-apigateway" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-apigateway" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-apigateway" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-appsync.md
+++ b/content/docs/tutorials/aws/aws-ts-appsync.md
@@ -2,12 +2,14 @@
 title: "Defining an AWS AppSync Endpoint"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-appsync" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-appsync" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-appsync" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-appsync" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-assume-role.md
+++ b/content/docs/tutorials/aws/aws-ts-assume-role.md
@@ -2,9 +2,11 @@
 title: "AWS AssumeRole Example"
 ---
 
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-assume-role" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-assume-role" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-containers.md
+++ b/content/docs/tutorials/aws/aws-ts-containers.md
@@ -2,12 +2,14 @@
 title: "Easy container example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-containers" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-containers" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-containers" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-containers" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-eks-hello-world.md
+++ b/content/docs/tutorials/aws/aws-ts-eks-hello-world.md
@@ -2,12 +2,14 @@
 title: "AWS EKS Cluster"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-eks-hello-world" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-eks-hello-world" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-eks-hello-world" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-eks-hello-world" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-eks-migrate-nodegroups.md
+++ b/content/docs/tutorials/aws/aws-ts-eks-migrate-nodegroups.md
@@ -2,9 +2,11 @@
 title: "examples/aws-ts-eks-migrate-nodegroups"
 ---
 
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-eks-migrate-nodegroups" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-eks-migrate-nodegroups" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-eks.md
+++ b/content/docs/tutorials/aws/aws-ts-eks.md
@@ -2,12 +2,14 @@
 title: "AWS EKS Cluster"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-eks" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-eks" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-eks" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-eks" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-hello-fargate.md
+++ b/content/docs/tutorials/aws/aws-ts-hello-fargate.md
@@ -2,12 +2,14 @@
 title: "Get Started with Docker on AWS Fargate"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-hello-fargate" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-hello-fargate" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-hello-fargate" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-hello-fargate" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-pulumi-webhooks.md
+++ b/content/docs/tutorials/aws/aws-ts-pulumi-webhooks.md
@@ -2,12 +2,14 @@
 title: "Pulumi Webhook Handler"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-pulumi-webhooks" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-pulumi-webhooks" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-pulumi-webhooks" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-pulumi-webhooks" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-resources.md
+++ b/content/docs/tutorials/aws/aws-ts-resources.md
@@ -2,12 +2,14 @@
 title: "AWS Resources"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-resources" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-resources" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-resources" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-resources" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-ruby-on-rails.md
+++ b/content/docs/tutorials/aws/aws-ts-ruby-on-rails.md
@@ -2,12 +2,14 @@
 title: "AWS EC2 Ruby on Rails"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-ruby-on-rails" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-ruby-on-rails" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-ruby-on-rails" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-ruby-on-rails" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-s3-lambda-copyzip.md
+++ b/content/docs/tutorials/aws/aws-ts-s3-lambda-copyzip.md
@@ -2,12 +2,14 @@
 title: "Serverless App to Copy and Zip S3 Objects Between Buckets"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-s3-lambda-copyzip" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-s3-lambda-copyzip" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-s3-lambda-copyzip" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-s3-lambda-copyzip" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-serverless-raw.md
+++ b/content/docs/tutorials/aws/aws-ts-serverless-raw.md
@@ -2,12 +2,14 @@
 title: "serverless-raw"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-serverless-raw" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-serverless-raw" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-serverless-raw" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-serverless-raw" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-slackbot.md
+++ b/content/docs/tutorials/aws/aws-ts-slackbot.md
@@ -2,12 +2,14 @@
 title: "A simple Slackbot running in AWS using Pulumi."
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-slackbot" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-slackbot" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-slackbot" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-slackbot" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-stackreference.md
+++ b/content/docs/tutorials/aws/aws-ts-stackreference.md
@@ -2,9 +2,11 @@
 title: "StackReference Example"
 ---
 
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-stackreference" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-stackreference" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-static-website.md
+++ b/content/docs/tutorials/aws/aws-ts-static-website.md
@@ -2,12 +2,14 @@
 title: "Static Website using AWS and TypeScript"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-static-website" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-static-website" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-static-website" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-static-website" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-stepfunctions.md
+++ b/content/docs/tutorials/aws/aws-ts-stepfunctions.md
@@ -2,12 +2,14 @@
 title: "AWS Step Functions"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-stepfunctions" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-stepfunctions" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-stepfunctions" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-stepfunctions" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-thumbnailer.md
+++ b/content/docs/tutorials/aws/aws-ts-thumbnailer.md
@@ -2,12 +2,14 @@
 title: "Video Thumbnailer"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-thumbnailer" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-thumbnailer" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-thumbnailer" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-thumbnailer" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-twitter-athena.md
+++ b/content/docs/tutorials/aws/aws-ts-twitter-athena.md
@@ -2,12 +2,14 @@
 title: "Twitter Search in Athena"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-twitter-athena" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-twitter-athena" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-twitter-athena" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-twitter-athena" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-url-shortener-cache-http.md
+++ b/content/docs/tutorials/aws/aws-ts-url-shortener-cache-http.md
@@ -2,12 +2,14 @@
 title: "Serverless URL Shortener with Redis Cache and HttpServer"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-url-shortener-cache-http" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-url-shortener-cache-http" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-url-shortener-cache-http" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-url-shortener-cache-http" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/aws/aws-ts-voting-app.md
+++ b/content/docs/tutorials/aws/aws-ts-voting-app.md
@@ -2,12 +2,14 @@
 title: "Voting app with two containers"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-voting-app" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/aws-ts-voting-app" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/aws-ts-voting-app" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/aws-ts-voting-app" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-js-webserver.md
+++ b/content/docs/tutorials/azure/azure-js-webserver.md
@@ -2,12 +2,14 @@
 title: "Pulumi web server (Azure)"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-js-webserver" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-js-webserver" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-js-webserver" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-js-webserver" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-py-aks.md
+++ b/content/docs/tutorials/azure/azure-py-aks.md
@@ -2,12 +2,14 @@
 title: "Azure Kubernetes Service (AKS) Cluster"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-py-aks" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-py-aks" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-py-aks" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-py-aks" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-py-webserver.md
+++ b/content/docs/tutorials/azure/azure-py-webserver.md
@@ -2,12 +2,14 @@
 title: "Azure Web Server example in Python"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-py-webserver" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-py-webserver" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-py-webserver" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-py-webserver" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-aks-helm.md
+++ b/content/docs/tutorials/azure/azure-ts-aks-helm.md
@@ -2,12 +2,14 @@
 title: "Azure Kubernetes Service (AKS) Cluster and Helm Chart"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-aks-helm" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-aks-helm" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-aks-helm" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-aks-helm" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-aks-keda.md
+++ b/content/docs/tutorials/azure/azure-ts-aks-keda.md
@@ -2,12 +2,14 @@
 title: "Azure Kubernetes Service (AKS) cluster and Azure Functions with KEDA"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-aks-keda" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-aks-keda" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-aks-keda" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-aks-keda" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-aks-mean.md
+++ b/content/docs/tutorials/azure/azure-ts-aks-mean.md
@@ -2,12 +2,14 @@
 title: "A Node.js demo app deployed on AKS, using CosmosDB"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-aks-mean" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-aks-mean" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-aks-mean" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-aks-mean" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-aks-multicluster.md
+++ b/content/docs/tutorials/azure/azure-ts-aks-multicluster.md
@@ -2,12 +2,14 @@
 title: "Multiple Azure Kubernetes Service (AKS) Clusters"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-aks-multicluster" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-aks-multicluster" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-aks-multicluster" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-aks-multicluster" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-api-management.md
+++ b/content/docs/tutorials/azure/azure-ts-api-management.md
@@ -2,12 +2,14 @@
 title: "Azure API Management"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-api-management" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-api-management" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-api-management" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-api-management" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-appservice-devops.md
+++ b/content/docs/tutorials/azure/azure-ts-appservice-devops.md
@@ -2,12 +2,14 @@
 title: "A Todo App on Azure App Service with SQL Database and Application Insights and deploys it to Azure DevOps"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops/infra" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-devops/infra" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-appservice-docker.md
+++ b/content/docs/tutorials/azure/azure-ts-appservice-docker.md
@@ -2,12 +2,14 @@
 title: "Azure App Service running Docker containers on Linux"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-docker" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice-docker" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice-docker" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice-docker" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-appservice-springboot.md
+++ b/content/docs/tutorials/azure/azure-ts-appservice-springboot.md
@@ -2,9 +2,11 @@
 title: "Deploy a Spring Boot App using Jenkins and Pulumi"
 ---
 
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice-springboot" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice-springboot" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-appservice.md
+++ b/content/docs/tutorials/azure/azure-ts-appservice.md
@@ -2,12 +2,14 @@
 title: "Azure App Service with SQL Database and Application Insights"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-appservice" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-appservice" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-arm-template.md
+++ b/content/docs/tutorials/azure/azure-ts-arm-template.md
@@ -2,12 +2,14 @@
 title: "Deploy an Azure Resource Manager (ARM) Template in Pulumi"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-arm-template" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-arm-template" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-arm-template" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-arm-template" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-cosmosdb-logicapp.md
+++ b/content/docs/tutorials/azure/azure-ts-cosmosdb-logicapp.md
@@ -2,12 +2,14 @@
 title: "Deploy an Azure Cosmos DB container, an API Connection, and a Logic App"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-cosmosdb-logicapp" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-cosmosdb-logicapp" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-cosmosdb-logicapp" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-cosmosdb-logicapp" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-dynamicresource.md
+++ b/content/docs/tutorials/azure/azure-ts-dynamicresource.md
@@ -2,12 +2,14 @@
 title: "Azure CDN Custom Domain Dynamic Provider"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-dynamicresource" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-dynamicresource" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-dynamicresource" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-dynamicresource" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-functions-raw.md
+++ b/content/docs/tutorials/azure/azure-ts-functions-raw.md
@@ -2,12 +2,14 @@
 title: "Azure Functions"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-functions-raw" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-functions-raw" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-functions-raw" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-functions-raw" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-functions.md
+++ b/content/docs/tutorials/azure/azure-ts-functions.md
@@ -2,12 +2,14 @@
 title: "Azure Functions"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-functions" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-functions" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-functions" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-functions" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-hdinsight-spark.md
+++ b/content/docs/tutorials/azure/azure-ts-hdinsight-spark.md
@@ -2,12 +2,14 @@
 title: "Spark on Azure HDInsight example"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-hdinsight-spark" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-hdinsight-spark" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-hdinsight-spark" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-hdinsight-spark" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-msi-keyvault-rbac.md
+++ b/content/docs/tutorials/azure/azure-ts-msi-keyvault-rbac.md
@@ -2,12 +2,14 @@
 title: "Managing Secrets and Secure Access in Azure Applications"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-msi-keyvault-rbac" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-msi-keyvault-rbac" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-msi-keyvault-rbac" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-msi-keyvault-rbac" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-serverless-url-shortener-global.md
+++ b/content/docs/tutorials/azure/azure-ts-serverless-url-shortener-global.md
@@ -2,12 +2,14 @@
 title: "Globally distributed serverless URL-shortener"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-serverless-url-shortener-global" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-serverless-url-shortener-global" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-serverless-url-shortener-global" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-serverless-url-shortener-global" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-static-website.md
+++ b/content/docs/tutorials/azure/azure-ts-static-website.md
@@ -2,12 +2,14 @@
 title: "A Static Website Hosted on Azure Blob Storage + Azure CDN"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-static-website" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-static-website" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-static-website" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-static-website" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-stream-analytics.md
+++ b/content/docs/tutorials/azure/azure-ts-stream-analytics.md
@@ -2,12 +2,14 @@
 title: "Azure Stream Analytics"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-stream-analytics" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-stream-analytics" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-stream-analytics" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-stream-analytics" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-vm-scaleset.md
+++ b/content/docs/tutorials/azure/azure-ts-vm-scaleset.md
@@ -2,12 +2,14 @@
 title: "Azure VM Scale Sets"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-vm-scaleset" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-vm-scaleset" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-vm-scaleset" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-vm-scaleset" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-webserver-component.md
+++ b/content/docs/tutorials/azure/azure-ts-webserver-component.md
@@ -2,12 +2,14 @@
 title: "Azure Web Server Virtual Machine Component"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-webserver-component" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-webserver-component" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-webserver-component" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-webserver-component" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/azure/azure-ts-webserver.md
+++ b/content/docs/tutorials/azure/azure-ts-webserver.md
@@ -2,12 +2,14 @@
 title: "Azure Web Server Virtual Machine"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-webserver" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/azure-ts-webserver" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/azure-ts-webserver" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-webserver" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-js-webserver.md
+++ b/content/docs/tutorials/gcp/gcp-js-webserver.md
@@ -2,12 +2,14 @@
 title: "Pulumi web server (GCP)"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-js-webserver" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-js-webserver" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-js-webserver" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-js-webserver" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-py-functions.md
+++ b/content/docs/tutorials/gcp/gcp-py-functions.md
@@ -2,12 +2,14 @@
 title: "GCP Functions"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-py-functions" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-py-functions" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-py-functions" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-py-functions" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-py-gke.md
+++ b/content/docs/tutorials/gcp/gcp-py-gke.md
@@ -2,12 +2,14 @@
 title: "Google Kubernetes Engine (GKE) with a Canary Deployment"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-py-gke" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-py-gke" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-py-gke" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-py-gke" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-py-instance-nginx.md
+++ b/content/docs/tutorials/gcp/gcp-py-instance-nginx.md
@@ -2,12 +2,14 @@
 title: "Pulumi Nginx Server in a instance (GCP)"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-py-instance-nginx" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-py-instance-nginx" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-py-instance-nginx" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-py-instance-nginx" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-ts-functions.md
+++ b/content/docs/tutorials/gcp/gcp-ts-functions.md
@@ -2,12 +2,14 @@
 title: "GCP Functions"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-functions" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-ts-functions" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-ts-functions" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-functions" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-ts-gke-hello-world.md
+++ b/content/docs/tutorials/gcp/gcp-ts-gke-hello-world.md
@@ -2,12 +2,14 @@
 title: "Google Kubernetes Engine (GKE) Cluster"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-gke-hello-world" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-ts-gke-hello-world" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-ts-gke-hello-world" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-gke-hello-world" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-ts-gke.md
+++ b/content/docs/tutorials/gcp/gcp-ts-gke.md
@@ -2,12 +2,14 @@
 title: "Google Kubernetes Engine (GKE) with a Canary Deployment"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-gke" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-ts-gke" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-ts-gke" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-gke" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-ts-k8s-ruby-on-rails-postgresql.md
+++ b/content/docs/tutorials/gcp/gcp-ts-k8s-ruby-on-rails-postgresql.md
@@ -2,12 +2,14 @@
 title: "Containerized Ruby on Rails App Delivery on GCP"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-k8s-ruby-on-rails-postgresql/infra" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-ts-k8s-ruby-on-rails-postgresql" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-ts-k8s-ruby-on-rails-postgresql" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-k8s-ruby-on-rails-postgresql/infra" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-ts-serverless-raw.md
+++ b/content/docs/tutorials/gcp/gcp-ts-serverless-raw.md
@@ -2,12 +2,14 @@
 title: "Google Cloud Functions in Python and Go deployed with TypeScript"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-serverless-raw" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-ts-serverless-raw" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-ts-serverless-raw" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-serverless-raw" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/gcp/gcp-ts-slackbot.md
+++ b/content/docs/tutorials/gcp/gcp-ts-slackbot.md
@@ -2,12 +2,14 @@
 title: "A simple Slackbot running in GCP using Pulumi."
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-slackbot" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/gcp-ts-slackbot" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/gcp-ts-slackbot" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/gcp-ts-slackbot" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-configmap-rollout.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-configmap-rollout.md
@@ -2,12 +2,14 @@
 title: "Kubernetes: Triggering a rollout of an app by changing ConfigMap data"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-configmap-rollout" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-configmap-rollout" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-configmap-rollout" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-configmap-rollout" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-exposed-deployment.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-exposed-deployment.md
@@ -2,12 +2,14 @@
 title: "Kubernetes: Exposing a Deployment with a public IP address"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-exposed-deployment" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-exposed-deployment" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-exposed-deployment" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-exposed-deployment" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-guestbook.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-guestbook.md
@@ -2,12 +2,14 @@
 title: "Kubernetes Guestbook (Two Ways)"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-guestbook/components" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-guestbook" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-guestbook" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-guestbook/components" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-helm-wordpress.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-helm-wordpress.md
@@ -2,12 +2,14 @@
 title: "Kubernetes: Deploying the Wordpress Helm chart"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-helm-wordpress" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-helm-wordpress" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-helm-wordpress" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-helm-wordpress" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-jenkins.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-jenkins.md
@@ -2,12 +2,14 @@
 title: "Kubernetes Jenkins"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-jenkins" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-jenkins" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-jenkins" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-jenkins" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-multicloud.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-multicloud.md
@@ -2,12 +2,14 @@
 title: "Kubernetes Application Deployed To Multiple Clusters"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-multicloud" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-multicloud" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-multicloud" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-multicloud" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-nginx.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-nginx.md
@@ -2,12 +2,14 @@
 title: "Run a Stateless Application Using a Deployment"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-nginx" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-nginx" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-nginx" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-nginx" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-s3-rollout.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-s3-rollout.md
@@ -2,12 +2,14 @@
 title: "Kubernetes: Triggering a rollout of an app by changing data in S3"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-s3-rollout" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-s3-rollout" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-s3-rollout" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-s3-rollout" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-sock-shop.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-sock-shop.md
@@ -2,12 +2,14 @@
 title: "Kubernetes Sock Shop"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-sock-shop" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-sock-shop" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-sock-shop" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-sock-shop" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/content/docs/tutorials/kubernetes/kubernetes-ts-staged-rollout-with-prometheus.md
+++ b/content/docs/tutorials/kubernetes/kubernetes-ts-staged-rollout-with-prometheus.md
@@ -2,12 +2,14 @@
 title: "Kubernetes: Staged application rollout gated by Prometheus checks"
 ---
 
-<a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-staged-rollout-with-prometheus" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-staged-rollout-with-prometheus" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="https://github.com/pulumi/examples/tree/master/kubernetes-ts-staged-rollout-with-prometheus" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/kubernetes-ts-staged-rollout-with-prometheus" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
 </p>
 
 

--- a/tools/mktutorial/templates/tutorial.tmpl
+++ b/tools/mktutorial/templates/tutorial.tmpl
@@ -5,14 +5,16 @@ meta_desc: "{{MetaDesc}}"
 {{/MetaDesc}}
 ---
 
-{{#PulumiTemplateURL}}
-<a href="https://app.pulumi.com/new?template={{PulumiTemplateURL}}" target="_blank">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Deploy" style="float: right; padding: 8px; margin-top: -65px; margin-right: 8px">
-</a>
-{{/PulumiTemplateURL}}
+<p class="mb-4 flex">
+    <a class="flex flex-wrap items-center rounded text-xs text-white bg-blue-600 border-2 border-blue-600 px-2 mr-2 whitespace-no-wrap hover:text-white" style="height: 32px" href="{{GitHubURL}}" target="_blank">
+        <span><i class="fab fa-github pr-2"></i> View Code</span>
+    </a>
 
-<p class="mb-4">
-    <a class="btn btn-secondary" href="{{GitHubURL}}" target="_blank"><i class="fab fa-github pr-2"></i> VIEW CODE</a>
+    {{#PulumiTemplateURL}}
+    <a href="https://app.pulumi.com/new?template={{PulumiTemplateURL}}" target="_blank">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+    </a>
+    {{/PulumiTemplateURL}}
 </p>
 
 {{{Body}}}


### PR DESCRIPTION
Place the "View Code" and "Deploy with Pulumi" buttons next to each other and style them consitently.

## Before

<img width="765" alt="Screen Shot 2019-09-13 at 8 54 20 AM" src="https://user-images.githubusercontent.com/710598/64876521-1611f680-d604-11e9-8455-db0b32dc00f7.png">

## After

<img width="781" alt="Screen Shot 2019-09-13 at 8 53 28 AM" src="https://user-images.githubusercontent.com/710598/64876539-1e6a3180-d604-11e9-9136-6bb460f1bfe0.png">

Fixes #1635