### PR TITLE
Improved type linking in awsx API docs

### DIFF
--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/apigateway/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/apigateway/_index.md
@@ -666,7 +666,7 @@ information, see Amazon CloudWatch Pricing.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/metrics.ts#L31">property <b>restApi</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>restApi?: aws.apigateway.RestApi;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>restApi?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/apigateway/#RestApi'>aws.apigateway.RestApi</a>;</code></pre>
 
 Optional [RestApi] this metric should be filtered down to.  Only one of [RestApi] or
 [api] can be provided.
@@ -901,7 +901,7 @@ You can use the dimensions in the following table to filter API Gateway metrics.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>getFunction(route?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, method?: Method): aws.lambda.Function</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>getFunction(route?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, method?: Method): <a href='/docs/reference/pkg/nodejs/pulumi/aws/lambda/#Function'>aws.lambda.Function</a></code></pre>
 
 
 Returns the [aws.lambda.Function] an [EventHandlerRoute] points to.  This will either be for
@@ -946,22 +946,22 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L333">property <b>deployment</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>deployment: aws.apigateway.Deployment;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>deployment: <a href='/docs/reference/pkg/nodejs/pulumi/aws/apigateway/#Deployment'>aws.apigateway.Deployment</a>;</code></pre>
 <h4 class="pdoc-member-header" id="API-restAPI">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L332">property <b>restAPI</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>restAPI: aws.apigateway.RestApi;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>restAPI: <a href='/docs/reference/pkg/nodejs/pulumi/aws/apigateway/#RestApi'>aws.apigateway.RestApi</a>;</code></pre>
 <h4 class="pdoc-member-header" id="API-stage">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L334">property <b>stage</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>stage: aws.apigateway.Stage;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>stage: <a href='/docs/reference/pkg/nodejs/pulumi/aws/apigateway/#Stage'>aws.apigateway.Stage</a>;</code></pre>
 <h4 class="pdoc-member-header" id="API-staticRoutesBucket">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L340">property <b>staticRoutesBucket</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>staticRoutesBucket?: aws.s3.Bucket;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>staticRoutesBucket?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/s3/#Bucket'>aws.s3.Bucket</a>;</code></pre>
 
 Bucket where static resources were placed.  Only set if a Bucket was provided to the API at
 construction time, or if there were any [StaticRoute]s passed to the API.
@@ -1039,7 +1039,7 @@ The stage name for your API. This will get added as a base path to your API url.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L322">property <b>staticRoutesBucket</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>staticRoutesBucket?: aws.s3.Bucket | aws.s3.BucketArgs;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>staticRoutesBucket?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/s3/#Bucket'>aws.s3.Bucket</a> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/s3/#BucketArgs'>aws.s3.BucketArgs</a>;</code></pre>
 
 Bucket to use for placing resources for static resources.  If not provided a default one will
 be created on your behalf if any [StaticRoute]s are provided.
@@ -1115,7 +1115,7 @@ gateway will validate these before sending traffic to the event handler.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L281">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancer: aws.lb.LoadBalancer;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancer: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#LoadBalancer'>aws.lb.LoadBalancer</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Endpoint-port">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L280">property <b>port</b></a>
 </h4>
@@ -1150,7 +1150,7 @@ the route is called.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L94">property <b>eventHandler</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>eventHandler: aws.lambda.EventHandler&lt;<a href='#Request'>Request</a>, <a href='#Response'>Response</a>&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>eventHandler: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lambda/#EventHandler'>aws.lambda.EventHandler</a>&lt;<a href='#Request'>Request</a>, <a href='#Response'>Response</a>&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="EventHandlerRoute-method">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/apigateway/api.ts#L93">property <b>method</b></a>
 </h4>

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/autoscaling/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/autoscaling/_index.md
@@ -355,7 +355,7 @@ to [undefined] then the value will be set to the default.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/metrics.ts#L24">property <b>group</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>group?: aws.autoscaling.Group;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>group?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Group'>aws.autoscaling.Group</a>;</code></pre>
 
 Optional [Group] to filter down events to.
 
@@ -530,7 +530,7 @@ instances that are in service, pending, and terminating.
 </h3>
 
 
-<pre class="highlight"><code><span class='kd'></span>metric(metricName: aws.autoscaling.Metric, change: <a href='#AutoScalingMetricChange'>AutoScalingMetricChange</a>): <a href='#Metric'>Metric</a></code></pre>
+<pre class="highlight"><code><span class='kd'></span>metric(metricName: <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Metric'>aws.autoscaling.Metric</a>, change: <a href='#AutoScalingMetricChange'>AutoScalingMetricChange</a>): <a href='#Metric'>Metric</a></code></pre>
 
 
 Creates an AWS/AutoScaling metric with the requested [metricName]. See
@@ -620,7 +620,7 @@ See [StepScalingPolicy] for more details.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>scaleToTrackAverageCPUUtilization(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: targetTracking.TargetTrackingPolicyArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.autoscaling.Policy</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>scaleToTrackAverageCPUUtilization(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: targetTracking.TargetTrackingPolicyArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Policy'>aws.autoscaling.Policy</a></code></pre>
 
 
 Scales in response to the average CPU utilization of the [AutoScalingGroup].
@@ -630,7 +630,7 @@ Scales in response to the average CPU utilization of the [AutoScalingGroup].
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>scaleToTrackAverageNetworkIn(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: targetTracking.TargetTrackingPolicyArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.autoscaling.Policy</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>scaleToTrackAverageNetworkIn(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: targetTracking.TargetTrackingPolicyArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Policy'>aws.autoscaling.Policy</a></code></pre>
 
 
 Scales in response to the average number of bytes received on all network interfaces by the
@@ -641,7 +641,7 @@ Scales in response to the average number of bytes received on all network interf
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>scaleToTrackAverageNetworkOut(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: targetTracking.TargetTrackingPolicyArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.autoscaling.Policy</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>scaleToTrackAverageNetworkOut(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: targetTracking.TargetTrackingPolicyArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Policy'>aws.autoscaling.Policy</a></code></pre>
 
 
 Scales in response to the average number of bytes sent out on all network interfaces by the
@@ -652,7 +652,7 @@ Scales in response to the average number of bytes sent out on all network interf
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>scaleToTrackMetric(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: targetTracking.CustomMetricTargetTrackingPolicyArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.autoscaling.Policy</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>scaleToTrackMetric(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: targetTracking.CustomMetricTargetTrackingPolicyArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Policy'>aws.autoscaling.Policy</a></code></pre>
 
 
 With target tracking scaling policies, you select a scaling metric and set a target value.
@@ -698,7 +698,7 @@ when constructed using [AutoScalingGroupArgs.targetGroups].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/autoscaling.ts#L44">property <b>group</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>group: aws.autoscaling.Group;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>group: <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Group'>aws.autoscaling.Group</a>;</code></pre>
 
 Underlying [autoscaling.Group] that is created by cloudformation.
 
@@ -714,7 +714,7 @@ The launch configuration for this auto scaling group.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/autoscaling.ts#L34">property <b>stack</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>stack: aws.cloudformation.Stack;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>stack: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudformation/#Stack'>aws.cloudformation.Stack</a>;</code></pre>
 
 The [cloudformation.Stack] that was used to create this [AutoScalingGroup].  [CloudFormation]
 is used here as the existing AWS apis for creating [AutoScalingGroup]s are not rich enough to
@@ -724,7 +724,7 @@ express everything that can be configured through [CloudFormation] itself.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/autoscaling.ts#L51">property <b>targetGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>targetGroups: x.lb.TargetGroup[];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>targetGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#TargetGroup'>x.lb.TargetGroup</a>[];</code></pre>
 
 Target groups this [AutoScalingGroup] is attached to.  See
 https://docs.aws.amazon.com/autoscaling/ec2/userguide/attach-load-balancer-asg.html
@@ -743,7 +743,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/autoscaling.ts#L27">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="AutoScalingLaunchConfiguration" data-link-title="AutoScalingLaunchConfiguration">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L22">
         Resource <strong>AutoScalingLaunchConfiguration</strong>
@@ -756,14 +756,14 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> AutoScalingLaunchConfiguration(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpc: x.ec2.Vpc, args: <a href='#AutoScalingLaunchConfigurationArgs'>AutoScalingLaunchConfigurationArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> AutoScalingLaunchConfiguration(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>, args: <a href='#AutoScalingLaunchConfigurationArgs'>AutoScalingLaunchConfigurationArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="AutoScalingLaunchConfiguration-createInstanceProfile">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L95">method <b>createInstanceProfile</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createInstanceProfile(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.iam.PolicyDocument, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): InstanceProfile</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createInstanceProfile(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a>, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): InstanceProfile</code></pre>
 
 
 Creates the [instanceProfile] for a [ClusterAutoScalingLaunchConfiguration] if not provided
@@ -784,7 +784,7 @@ they will be used to create [RolePolicyAttachment]s for the Role.  Otherwise,
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>defaultInstanceProfilePolicyDocument(): aws.iam.PolicyDocument</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>defaultInstanceProfilePolicyDocument(): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a></code></pre>
 
 <h4 class="pdoc-member-header" id="AutoScalingLaunchConfiguration-getProvider">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L22">method <b>getProvider</b></a>
@@ -820,17 +820,17 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L27">property <b>instanceProfile</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>instanceProfile: aws.iam.InstanceProfile;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>instanceProfile: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#InstanceProfile'>aws.iam.InstanceProfile</a>;</code></pre>
 <h4 class="pdoc-member-header" id="AutoScalingLaunchConfiguration-launchConfiguration">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L23">property <b>launchConfiguration</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>launchConfiguration: aws.ec2.LaunchConfiguration;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>launchConfiguration: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#LaunchConfiguration'>aws.ec2.LaunchConfiguration</a>;</code></pre>
 <h4 class="pdoc-member-header" id="AutoScalingLaunchConfiguration-securityGroups">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L25">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroups: x.ec2.SecurityGroup[];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>[];</code></pre>
 <h4 class="pdoc-member-header" id="AutoScalingLaunchConfiguration-stackName">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L32">property <b>stackName</b></a>
 </h4>
@@ -924,7 +924,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/stepScaling.ts#L211">property <b>lowerAlarm</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>lowerAlarm: aws.cloudwatch.MetricAlarm | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>lowerAlarm: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#MetricAlarm'>aws.cloudwatch.MetricAlarm</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
 
 Alarm that invokes [lowerPolicy] when the metric goes below the highest value of the lower
 range of steps.
@@ -933,7 +933,7 @@ range of steps.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/stepScaling.ts#L205">property <b>lowerPolicy</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>lowerPolicy: aws.autoscaling.Policy | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>lowerPolicy: <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Policy'>aws.autoscaling.Policy</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
 
 Underlying [Policy] created to define the scaling strategy for the lower set of steps.
 
@@ -941,7 +941,7 @@ Underlying [Policy] created to define the scaling strategy for the lower set of 
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/stepScaling.ts#L200">property <b>upperAlarm</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>upperAlarm: aws.cloudwatch.MetricAlarm | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>upperAlarm: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#MetricAlarm'>aws.cloudwatch.MetricAlarm</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
 
 Alarm that invokes [upperPolicy] when the metric goes above the lowest value of the upper
 range of steps.
@@ -950,7 +950,7 @@ range of steps.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/stepScaling.ts#L194">property <b>upperPolicy</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>upperPolicy: aws.autoscaling.Policy | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>upperPolicy: <a href='/docs/reference/pkg/nodejs/pulumi/aws/autoscaling/#Policy'>aws.autoscaling.Policy</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
 
 Underlying [Policy] created to define the scaling strategy for the upper set of steps.
 
@@ -1004,7 +1004,7 @@ metrics. Without a value, AWS will default to the group's specified cooldown per
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/targetTracking.ts#L65">property <b>targetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>targetGroup: x.lb.ApplicationTargetGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>targetGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ApplicationTargetGroup'>x.lb.ApplicationTargetGroup</a>;</code></pre>
 
 The target group to scale [AutoScalingGroup] in response to number of requests to.
 This must be a [TargetGroup] that the [AutoScalingGroup] was created with.  These can
@@ -1084,7 +1084,7 @@ the `vpc` will be used.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/autoscaling.ts#L341">property <b>targetGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>targetGroups?: x.lb.TargetGroup[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>targetGroups?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#TargetGroup'>x.lb.TargetGroup</a>[];</code></pre>
 
 A list of target groups to associate with the Auto Scaling group.  All target groups must
 have the "instance" [targetType].
@@ -1102,7 +1102,7 @@ the defaults specified in TemplateParameters will be used.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/autoscaling.ts#L301">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this autoscaling group is for.  If not provided this autoscaling group will be
 created for the default vpc.
@@ -1129,7 +1129,7 @@ Associate a public ip address with an instance in a VPC.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L406">property <b>ebsBlockDevices</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>ebsBlockDevices?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LaunchConfigurationEbsBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEbsBlockDevice&gt; | OutputInstance&lt;LaunchConfigurationEbsBlockDevice&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEbsBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEbsBlockDevice&gt; | OutputInstance&lt;LaunchConfigurationEbsBlockDevice&gt;[]&gt; | OutputInstance&lt;LaunchConfigurationEbsBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEbsBlockDevice&gt; | OutputInstance&lt;LaunchConfigurationEbsBlockDevice&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>ebsBlockDevices?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LaunchConfigurationEbsBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEbsBlockDevice&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationEbsBlockDevice&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEbsBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEbsBlockDevice&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationEbsBlockDevice&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationEbsBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEbsBlockDevice&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationEbsBlockDevice&gt;[]&gt;;</code></pre>
 
 Additional EBS block devices to attach to the instance.  See Block Devices below for details.
 
@@ -1171,7 +1171,7 @@ Enables/disables detailed monitoring. This is enabled by default.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L299">property <b>ephemeralBlockDevices</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>ephemeralBlockDevices?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LaunchConfigurationEphemeralBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt; | OutputInstance&lt;LaunchConfigurationEphemeralBlockDevice&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEphemeralBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt; | OutputInstance&lt;LaunchConfigurationEphemeralBlockDevice&gt;[]&gt; | OutputInstance&lt;LaunchConfigurationEphemeralBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt; | OutputInstance&lt;LaunchConfigurationEphemeralBlockDevice&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>ephemeralBlockDevices?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LaunchConfigurationEphemeralBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEphemeralBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationEphemeralBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationEphemeralBlockDevice&gt;[]&gt;;</code></pre>
 
 Customize Ephemeral (also known as
 "Instance Store") volumes on the instance. See Block Devices below for details.
@@ -1180,7 +1180,7 @@ Customize Ephemeral (also known as
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L305">property <b>iamInstanceProfile</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>iamInstanceProfile?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.iam.InstanceProfile&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>iamInstanceProfile?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#InstanceProfile'>aws.iam.InstanceProfile</a>&gt;;</code></pre>
 
 The name attribute of the IAM instance profile to associate
 with launched instances.
@@ -1199,7 +1199,7 @@ used. If neither are provided the imageId for Amazon'
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L358">property <b>instanceProfile</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>instanceProfile?: aws.iam.InstanceProfile;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>instanceProfile?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#InstanceProfile'>aws.iam.InstanceProfile</a>;</code></pre>
 
 The instance profile to use for the autoscaling group.  If not provided, a default one will
 be created.
@@ -1208,7 +1208,7 @@ be created.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L382">property <b>instanceType</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>instanceType?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ec2.InstanceType&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>instanceType?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#InstanceType'>aws.ec2.InstanceType</a>&gt;;</code></pre>
 
 The size of instance to launch.  Defaults to t2.micro if unspecified.
 
@@ -1252,7 +1252,7 @@ for more details.  Default is "default" if unspecified.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L398">property <b>rootBlockDevice</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>rootBlockDevice?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LaunchConfigurationRootBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationRootBlockDevice&gt; | OutputInstance&lt;LaunchConfigurationRootBlockDevice&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>rootBlockDevice?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LaunchConfigurationRootBlockDevice | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LaunchConfigurationRootBlockDevice&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LaunchConfigurationRootBlockDevice&gt;;</code></pre>
 
 Customize details about the root block device of the instance. See Block Devices below for
 details.
@@ -1264,7 +1264,7 @@ termination.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/launchConfiguration.ts#L413">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>securityGroups?: x.ec2.SecurityGroupOrId[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>securityGroups?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroupOrId'>x.ec2.SecurityGroupOrId</a>[];</code></pre>
 
 A list of associated security group IDs.
 
@@ -1406,7 +1406,7 @@ metrics. Without a value, AWS will default to the group's specified cooldown per
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/targetTracking.ts#L104">property <b>metric</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>metric: x.cloudwatch.Metric;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>metric: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/cloudwatch/#Metric'>x.cloudwatch.Metric</a>;</code></pre>
 
 The metric to track
 
@@ -1671,7 +1671,7 @@ is fired.  Defaults to `1` if unspecified.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/autoscaling/stepScaling.ts#L122">property <b>metric</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>metric: x.cloudwatch.Metric;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>metric: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/cloudwatch/#Metric'>x.cloudwatch.Metric</a>;</code></pre>
 
 The metric to use to watch for changes.  An alarm will be created from this using
 [alarmArgs], which will invoke the actual autoscaling policy when triggered.

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/cloudfront/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/cloudfront/_index.md
@@ -86,7 +86,7 @@ cleared.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudfront/metrics.ts#L29">property <b>distribution</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>distribution?: aws.cloudfront.Distribution;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>distribution?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudfront/#Distribution'>aws.cloudfront.Distribution</a>;</code></pre>
 
 Optional [Distribution] this metric should be filtered down to.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/cloudwatch/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/cloudwatch/_index.md
@@ -288,7 +288,7 @@ cleared.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/metrics.ts#L30">property <b>eventRule</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>eventRule?: aws.cloudwatch.EventRule;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>eventRule?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#EventRule'>aws.cloudwatch.EventRule</a>;</code></pre>
 
 Filters down events to those from the specified [EventRule].
 
@@ -568,7 +568,7 @@ Only used if this metric is displayed in a [Dashboard] with a [MetricWidget].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/metrics.ts#L140">property <b>logGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>logGroup?: aws.cloudwatch.LogGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>logGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#LogGroup'>aws.cloudwatch.LogGroup</a>;</code></pre>
 
 Filters down events to those from the specified [LogGroup].
 
@@ -803,7 +803,7 @@ Defaults to `true`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/metric.ts#L480">property <b>alarmActions</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>alarmActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.sns.Topic&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>alarmActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/sns/#Topic'>aws.sns.Topic</a>&gt;[]&gt;;</code></pre>
 
 The list of actions to execute when this alarm transitions into an ALARM state from any other
 state. Each action is specified as an Amazon Resource Name (ARN).
@@ -870,7 +870,7 @@ p0.0 and p100.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/metric.ts#L523">property <b>insufficientDataActions</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>insufficientDataActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.sns.Topic&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>insufficientDataActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/sns/#Topic'>aws.sns.Topic</a>&gt;[]&gt;;</code></pre>
 
 The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state
 from any other state. Each action is specified as an Amazon Resource Name (ARN).
@@ -908,7 +908,7 @@ The descriptive name for the alarm. This name must be unique within the user's A
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/metric.ts#L532">property <b>okActions</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>okActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.sns.Topic&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>okActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/sns/#Topic'>aws.sns.Topic</a>&gt;[]&gt;;</code></pre>
 
 The list of actions to execute when this alarm transitions into an OK state from any other
 state. Each action is specified as an Amazon Resource Name (ARN).
@@ -970,7 +970,7 @@ height of this widget will be the sum of all the heights of all the widgets in t
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -1149,7 +1149,7 @@ obeyed.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/dashboard.ts#L34">property <b>region</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>region?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Region&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>region?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;;</code></pre>
 
 The region that widgets can say they're associated with.  If not provided, the region will be
 inferred by whatever provider the [Dashboard] ends up using.
@@ -1249,7 +1249,7 @@ vertically.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -1310,7 +1310,7 @@ details.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -1320,35 +1320,35 @@ For internal use only.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | OutputInstance&lt;MetricWidgetPropertiesJson&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;MetricWidgetPropertiesJson&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="GraphMetricWidget-computeType">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L251">method <b>computeType</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | OutputInstance&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="GraphMetricWidget-computeView">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L57">method <b>computeView</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="GraphMetricWidget-computeYAxis">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L58">method <b>computeYAxis</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | OutputInstance&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="GraphMetricWidget-computedStacked">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L248">method <b>computedStacked</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computedStacked(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>&gt; | OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computedStacked(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="GraphMetricWidget-height">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L65">method <b>height</b></a>
@@ -1446,7 +1446,7 @@ metric definition. The default is 300.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L199">property <b>region</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>region?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Region&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>region?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;;</code></pre>
 
 The region of the metric.  Defaults to the region of the stack if not specified.
 
@@ -1650,7 +1650,7 @@ Displays a set of metrics as a line graph.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -1660,28 +1660,28 @@ For internal use only.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | OutputInstance&lt;MetricWidgetPropertiesJson&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;MetricWidgetPropertiesJson&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="LineGraphMetricWidget-computeType">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L251">method <b>computeType</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | OutputInstance&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="LineGraphMetricWidget-computeView">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L57">method <b>computeView</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="LineGraphMetricWidget-computeYAxis">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L58">method <b>computeYAxis</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | OutputInstance&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="LineGraphMetricWidget-computedStacked">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L69">method <b>computedStacked</b></a>
@@ -2221,7 +2221,7 @@ displaying [Metric]s.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -2231,35 +2231,35 @@ For internal use only.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | OutputInstance&lt;MetricWidgetPropertiesJson&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;MetricWidgetPropertiesJson&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="MetricWidget-computeType">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L251">method <b>computeType</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | OutputInstance&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="MetricWidget-computeView">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L247">method <b>computeView</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="MetricWidget-computeYAxis">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L249">method <b>computeYAxis</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | OutputInstance&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="MetricWidget-computedStacked">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L248">method <b>computedStacked</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computedStacked(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>&gt; | OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computedStacked(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='kd'>false</span> | <span class='kd'>true</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="MetricWidget-height">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L65">method <b>height</b></a>
@@ -2357,7 +2357,7 @@ metric definition. The default is 300.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L199">property <b>region</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>region?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Region&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>region?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;;</code></pre>
 
 The region of the metric.  Defaults to the region of the stack if not specified.
 
@@ -2447,7 +2447,7 @@ wrapping. The final height of this widget will be the bottommost row that a widg
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -2500,7 +2500,7 @@ Base type of all non-flow Widgets to place in a DashboardGrid.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -2568,7 +2568,7 @@ Displays a set of metrics as a single number.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -2578,28 +2578,28 @@ For internal use only.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | OutputInstance&lt;MetricWidgetPropertiesJson&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;MetricWidgetPropertiesJson&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="SingleNumberMetricWidget-computeType">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L251">method <b>computeType</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | OutputInstance&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="SingleNumberMetricWidget-computeView">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L92">method <b>computeView</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="SingleNumberMetricWidget-computeYAxis">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L93">method <b>computeYAxis</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | OutputInstance&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="SingleNumberMetricWidget-computedStacked">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L91">method <b>computedStacked</b></a>
@@ -2685,7 +2685,7 @@ Displays a set of metrics as a stacked area graph.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -2695,28 +2695,28 @@ For internal use only.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | OutputInstance&lt;MetricWidgetPropertiesJson&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): MetricWidgetPropertiesJson | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;MetricWidgetPropertiesJson&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;MetricWidgetPropertiesJson&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="StackedAreaGraphMetricWidget-computeType">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L251">method <b>computeType</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | OutputInstance&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"metric"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"metric"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='s2'>"metric"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="StackedAreaGraphMetricWidget-computeView">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L57">method <b>computeView</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeView(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <span class='s2'>"timeSeries"</span> | <span class='s2'>"singleValue"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="StackedAreaGraphMetricWidget-computeYAxis">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L58">method <b>computeYAxis</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | OutputInstance&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeYAxis(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | <a href='#YAxis'>YAxis</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#YAxis'>YAxis</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#YAxis'>YAxis</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="StackedAreaGraphMetricWidget-computedStacked">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_graph.ts#L80">method <b>computedStacked</b></a>
@@ -2764,7 +2764,7 @@ Simple widget that displays a piece of text in the dashboard grid.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addWidgetJson(widgetJsons: wjson.WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 For internal use only.
@@ -2774,11 +2774,11 @@ For internal use only.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): {
+<pre class="highlight"><code><span class='kd'>protected </span>computeProperties(region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): {
     markdown: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;
 } | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;{
     markdown: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;
-}&gt; | OutputInstance&lt;{
+}&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;{
     markdown: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;
 }&gt;</code></pre>
 
@@ -2787,7 +2787,7 @@ For internal use only.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"text"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"text"</span>&gt; | OutputInstance&lt;<span class='s2'>"text"</span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>protected </span>computeType(): <span class='s2'>"text"</span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='s2'>"text"</span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='s2'>"text"</span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="TextWidget-height">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cloudwatch/widgets_simple.ts#L65">method <b>height</b></a>
@@ -2982,7 +2982,7 @@ Base type for all [Widget]s that can be placed in a [DashboardGrid].
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span>addWidgetJson(widgetJsons: WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;aws.Region&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'></span>addWidgetJson(widgetJsons: WidgetJson[], xOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, yOffset: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, region: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>&gt;): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 Converts this widget to an appropriate JSON pojo.  The [xOffset] and [yOffset] parameters

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/codebuild/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/codebuild/_index.md
@@ -126,7 +126,7 @@ to [undefined] then the value will be set to the default (300s).
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/codebuild/metrics.ts#L31">property <b>project</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>project?: aws.codebuild.Project;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>project?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/codebuild/#Project'>aws.codebuild.Project</a>;</code></pre>
 
 Optional Project this metric should be filtered down to.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/cognito/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/cognito/_index.md
@@ -119,7 +119,7 @@ to the default.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/cognito/metrics.ts#L28">property <b>userPool</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>userPool?: aws.cognito.UserPool;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>userPool?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cognito/#UserPool'>aws.cognito.UserPool</a>;</code></pre>
 
 Optional [UserPool] this metric should be filtered down to.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/dynamodb/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/dynamodb/_index.md
@@ -214,7 +214,7 @@ to [undefined] then the value will be set to the default (300s).
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/dynamodb/metrics.ts#L53">property <b>receivingRegion</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>receivingRegion?: aws.Region;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>receivingRegion?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>;</code></pre>
 
 This dimension limits the data to a particular AWS region. It is used with metrics
 originating from replica tables within a DynamoDB global table.
@@ -242,7 +242,7 @@ originating from Amazon DynamoDB Streams 'GetRecords' operations.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/dynamodb/metrics.ts#L34">property <b>table</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>table?: aws.dynamodb.Table;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>table?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/dynamodb/#Table'>aws.dynamodb.Table</a>;</code></pre>
 
 Optional [Table] this metric should be filtered down to.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/ebs/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/ebs/_index.md
@@ -150,7 +150,7 @@ Only used if this metric is displayed in a [Dashboard] with a [MetricWidget].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ebs/metrics.ts#L32">property <b>volume</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>volume?: aws.ebs.Volume;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>volume?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ebs/#Volume'>aws.ebs.Volume</a>;</code></pre>
 
 The only dimension that Amazon EBS sends to CloudWatch is the volume ID. This means that
 all available statistics are filtered by volume ID.

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/ec2/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/ec2/_index.md
@@ -581,7 +581,7 @@ Amazon Machine Image (AMI). Available for instances with Detailed Monitoring ena
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/metrics.ts#L33">property <b>instance</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>instance?: aws.ec2.Instance;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>instance?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#Instance'>aws.ec2.Instance</a>;</code></pre>
 
 Optional [Instance] this metric should be filtered down to.
 
@@ -589,7 +589,7 @@ Optional [Instance] this metric should be filtered down to.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/metrics.ts#L48">property <b>instanceType</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>instanceType?: aws.ec2.InstanceType;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>instanceType?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#InstanceType'>aws.ec2.InstanceType</a>;</code></pre>
 
 This dimension filters the data you request for all instances running with this specified
 instance type. This helps you categorize your data by the type of instance running. For
@@ -857,20 +857,20 @@ Units: Count
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>createEgressRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.ec2.SimpleSecurityGroupRuleArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): x.ec2.EgressSecurityGroupRule</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>createEgressRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SimpleSecurityGroupRuleArgs'>x.ec2.SimpleSecurityGroupRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#EgressSecurityGroupRule'>x.ec2.EgressSecurityGroupRule</a></code></pre>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>createEgressRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.ec2.EgressSecurityGroupRuleArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): x.ec2.EgressSecurityGroupRule</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>createEgressRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#EgressSecurityGroupRuleArgs'>x.ec2.EgressSecurityGroupRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#EgressSecurityGroupRule'>x.ec2.EgressSecurityGroupRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="SecurityGroup-createIngressRule">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L95">method <b>createIngressRule</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>createIngressRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.ec2.SimpleSecurityGroupRuleArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): x.ec2.IngressSecurityGroupRule</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>createIngressRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SimpleSecurityGroupRuleArgs'>x.ec2.SimpleSecurityGroupRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#IngressSecurityGroupRule'>x.ec2.IngressSecurityGroupRule</a></code></pre>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>createIngressRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.ec2.IngressSecurityGroupRuleArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): x.ec2.IngressSecurityGroupRule</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>createIngressRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#IngressSecurityGroupRuleArgs'>x.ec2.IngressSecurityGroupRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#IngressSecurityGroupRule'>x.ec2.IngressSecurityGroupRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="SecurityGroup-fromExistingId">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L79">method <b>fromExistingId</b></a>
@@ -913,7 +913,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L26">property <b>egressRules</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>egressRules: x.ec2.IngressSecurityGroupRule[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>egressRules: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#IngressSecurityGroupRule'>x.ec2.IngressSecurityGroupRule</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="SecurityGroup-id">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L23">property <b>id</b></a>
 </h4>
@@ -923,12 +923,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L27">property <b>ingressRules</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>ingressRules: x.ec2.IngressSecurityGroupRule[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>ingressRules: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#IngressSecurityGroupRule'>x.ec2.IngressSecurityGroupRule</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="SecurityGroup-securityGroup">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L22">property <b>securityGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroup: aws.ec2.SecurityGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#SecurityGroup'>aws.ec2.SecurityGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="SecurityGroup-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L21">property <b>urn</b></a>
 </h4>
@@ -942,7 +942,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L24">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="SecurityGroupRule" data-link-title="SecurityGroupRule">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L108">
         Resource <strong>SecurityGroupRule</strong>
@@ -955,14 +955,14 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> SecurityGroupRule(type: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, args: <a href='#SecurityGroupRuleArgs'>SecurityGroupRuleArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> SecurityGroupRule(type: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, args: <a href='#SecurityGroupRuleArgs'>SecurityGroupRuleArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="SecurityGroupRule-egress">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L152">method <b>egress</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>egress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, destination: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#EgressSecurityGroupRule'>EgressSecurityGroupRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>egress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, destination: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#EgressSecurityGroupRule'>EgressSecurityGroupRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="SecurityGroupRule-egressArgs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L126">method <b>egressArgs</b></a>
@@ -983,7 +983,7 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>ingress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, source: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#IngressSecurityGroupRule'>IngressSecurityGroupRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>ingress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, source: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#IngressSecurityGroupRule'>IngressSecurityGroupRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="SecurityGroupRule-ingressArgs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L133">method <b>ingressArgs</b></a>
@@ -1014,12 +1014,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L110">property <b>securityGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroup: x.ec2.SecurityGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="SecurityGroupRule-securityGroupRule">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L109">property <b>securityGroupRule</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroupRule: aws.ec2.SecurityGroupRule;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroupRule: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#SecurityGroupRule'>aws.ec2.SecurityGroupRule</a>;</code></pre>
 <h4 class="pdoc-member-header" id="SecurityGroupRule-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L108">property <b>urn</b></a>
 </h4>
@@ -1041,10 +1041,10 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> Subnet(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpc: x.ec2.Vpc, args: <a href='#SubnetArgs'>SubnetArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> Subnet(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>, args: <a href='#SubnetArgs'>SubnetArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> Subnet(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpc: x.ec2.Vpc, args: <a href='#ExistingSubnetArgs'>ExistingSubnetArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> Subnet(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>, args: <a href='#ExistingSubnetArgs'>ExistingSubnetArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="Subnet-createRoute">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L85">method <b>createRoute</b></a>
@@ -1094,22 +1094,22 @@ Output will only resolve once the route table and all associations are resolved.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L34">property <b>routeTable</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>routeTable: aws.ec2.RouteTable | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>routeTable: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#RouteTable'>aws.ec2.RouteTable</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
 <h4 class="pdoc-member-header" id="Subnet-routeTableAssociation">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L35">property <b>routeTableAssociation</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>routeTableAssociation: aws.ec2.RouteTableAssociation | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>routeTableAssociation: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#RouteTableAssociation'>aws.ec2.RouteTableAssociation</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
 <h4 class="pdoc-member-header" id="Subnet-routes">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L37">property <b>routes</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>routes: aws.ec2.Route[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>routes: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#Route'>aws.ec2.Route</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="Subnet-subnet">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L33">property <b>subnet</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>subnet: aws.ec2.Subnet;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>subnet: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#Subnet'>aws.ec2.Subnet</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Subnet-subnetName">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L26">property <b>subnetName</b></a>
 </h4>
@@ -1128,7 +1128,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L25">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="Vpc" data-link-title="Vpc">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L26">
         Resource <strong>Vpc</strong>
@@ -1151,7 +1151,7 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addInternetGateway(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, subnets?: x.ec2.Subnet[], args: aws.ec2.InternetGatewayArgs, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): InternetGateway</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addInternetGateway(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, subnets?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Subnet'>x.ec2.Subnet</a>[], args: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#InternetGatewayArgs'>aws.ec2.InternetGatewayArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): InternetGateway</code></pre>
 
 
 Adds an [awsx.ec2.InternetGateway] to this VPC.  Will fail if this Vpc already has an
@@ -1162,7 +1162,7 @@ InternetGateway.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addNatGateway(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.ec2.NatGatewayArgs, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): NatGateway</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addNatGateway(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#NatGatewayArgs'>x.ec2.NatGatewayArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): NatGateway</code></pre>
 
 
 Adds an [awsx.ec2.NatGateway] to this VPC. The NatGateway must be supplied a subnet (normally
@@ -1213,7 +1213,7 @@ version be used instead.  This version will properly respect providers.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>getSubnetIds(type: <a href='#VpcSubnetType'>VpcSubnetType</a>): OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt; &amp; { ... }[]</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>getSubnetIds(type: <a href='#VpcSubnetType'>VpcSubnetType</a>): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt; &amp; { ... }[]</code></pre>
 
 <h4 class="pdoc-member-header" id="Vpc-getSubnets">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L154">method <b>getSubnets</b></a>
@@ -1249,7 +1249,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L44">property <b>internetGateway</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>internetGateway?: x.ec2.InternetGateway;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>internetGateway?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#InternetGateway'>x.ec2.InternetGateway</a>;</code></pre>
 
 The internet gateway created to allow traffic to/from the internet to the public subnets.
 Only available if this was created using [VpcArgs].
@@ -1263,12 +1263,12 @@ Only available if this was created using [VpcArgs].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L38">property <b>isolatedSubnets</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>isolatedSubnets: x.ec2.Subnet[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>isolatedSubnets: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Subnet'>x.ec2.Subnet</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="Vpc-natGateways">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L50">property <b>natGateways</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>natGateways: x.ec2.NatGateway[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>natGateways: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#NatGateway'>x.ec2.NatGateway</a>[] =  [];</code></pre>
 
 The nat gateways created to allow private subnets access to the internet.
 Only available if this was created using [VpcArgs].
@@ -1282,7 +1282,7 @@ Only available if this was created using [VpcArgs].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L37">property <b>privateSubnets</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>privateSubnets: x.ec2.Subnet[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>privateSubnets: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Subnet'>x.ec2.Subnet</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="Vpc-publicSubnetIds">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L29">property <b>publicSubnetIds</b></a>
 </h4>
@@ -1292,7 +1292,7 @@ Only available if this was created using [VpcArgs].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L36">property <b>publicSubnets</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>publicSubnets: x.ec2.Subnet[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>publicSubnets: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Subnet'>x.ec2.Subnet</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="Vpc-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L26">property <b>urn</b></a>
 </h4>
@@ -1306,7 +1306,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L33">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: aws.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#Vpc'>aws.ec2.Vpc</a>;</code></pre>
 
 
 <h2 id="apis">Others</h2>
@@ -1487,7 +1487,7 @@ Alias for a cidr block.
 </h3>
 
 
-<pre class="highlight"><code><span class='kd'></span>create(resource: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>, vpcName: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpcCidr: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, ipv6CidrBlock: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt; | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>, availabilityZones: <a href='#AvailabilityZoneDescription'>AvailabilityZoneDescription</a>[], numberOfNatGateways: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, assignGeneratedIpv6CidrBlock: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'>boolean</a></span>&gt;, subnetArgsArray: x.ec2.VpcSubnetArgs[]): <a href='#VpcTopologyDescription'>VpcTopologyDescription</a></code></pre>
+<pre class="highlight"><code><span class='kd'></span>create(resource: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>, vpcName: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpcCidr: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, ipv6CidrBlock: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt; | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>, availabilityZones: <a href='#AvailabilityZoneDescription'>AvailabilityZoneDescription</a>[], numberOfNatGateways: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number'>number</a></span>, assignGeneratedIpv6CidrBlock: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean'>boolean</a></span>&gt;, subnetArgsArray: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#VpcSubnetArgs'>x.ec2.VpcSubnetArgs</a>[]): <a href='#VpcTopologyDescription'>VpcTopologyDescription</a></code></pre>
 
 <h3 class="pdoc-module-header" id="EgressSecurityGroupRule" data-link-title="EgressSecurityGroupRule">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L179">
@@ -1501,14 +1501,14 @@ Alias for a cidr block.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> EgressSecurityGroupRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, args: <a href='#SimpleSecurityGroupRuleArgs'>SimpleSecurityGroupRuleArgs</a> | <a href='#EgressSecurityGroupRuleArgs'>EgressSecurityGroupRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> EgressSecurityGroupRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, args: <a href='#SimpleSecurityGroupRuleArgs'>SimpleSecurityGroupRuleArgs</a> | <a href='#EgressSecurityGroupRuleArgs'>EgressSecurityGroupRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="EgressSecurityGroupRule-egress">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L152">method <b>egress</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>egress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, destination: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#EgressSecurityGroupRule'>EgressSecurityGroupRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>egress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, destination: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#EgressSecurityGroupRule'>EgressSecurityGroupRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="EgressSecurityGroupRule-egressArgs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L126">method <b>egressArgs</b></a>
@@ -1529,7 +1529,7 @@ Alias for a cidr block.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>ingress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, source: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#IngressSecurityGroupRule'>IngressSecurityGroupRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>ingress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, source: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#IngressSecurityGroupRule'>IngressSecurityGroupRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="EgressSecurityGroupRule-ingressArgs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L133">method <b>ingressArgs</b></a>
@@ -1560,12 +1560,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L110">property <b>securityGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroup: x.ec2.SecurityGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="EgressSecurityGroupRule-securityGroupRule">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L109">property <b>securityGroupRule</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroupRule: aws.ec2.SecurityGroupRule;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroupRule: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#SecurityGroupRule'>aws.ec2.SecurityGroupRule</a>;</code></pre>
 <h4 class="pdoc-member-header" id="EgressSecurityGroupRule-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L179">property <b>urn</b></a>
 </h4>
@@ -1668,7 +1668,7 @@ The end port (or ICMP code if protocol is "icmp").
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L122">property <b>subnet</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>subnet: aws.ec2.Subnet;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>subnet: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#Subnet'>aws.ec2.Subnet</a>;</code></pre>
 
 Optional existing instance to use to make the awsx Subnet out of.  If this is provided No
 RouteTable or RouteTableAssociation will be automatically be created.
@@ -1684,7 +1684,7 @@ RouteTable or RouteTableAssociation will be automatically be created.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L463">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc: aws.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#Vpc'>aws.ec2.Vpc</a>;</code></pre>
 
 The id of the VPC.
 
@@ -1793,14 +1793,14 @@ The id of the VPC.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> IngressSecurityGroupRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, args: <a href='#SimpleSecurityGroupRuleArgs'>SimpleSecurityGroupRuleArgs</a> | <a href='#IngressSecurityGroupRuleArgs'>IngressSecurityGroupRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> IngressSecurityGroupRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, args: <a href='#SimpleSecurityGroupRuleArgs'>SimpleSecurityGroupRuleArgs</a> | <a href='#IngressSecurityGroupRuleArgs'>IngressSecurityGroupRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="IngressSecurityGroupRule-egress">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L152">method <b>egress</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>egress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, destination: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#EgressSecurityGroupRule'>EgressSecurityGroupRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>egress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, destination: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#EgressSecurityGroupRule'>EgressSecurityGroupRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="IngressSecurityGroupRule-egressArgs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L126">method <b>egressArgs</b></a>
@@ -1821,7 +1821,7 @@ The id of the VPC.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>ingress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup, source: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#IngressSecurityGroupRule'>IngressSecurityGroupRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>ingress(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>, source: <a href='#SecurityGroupRuleLocation'>SecurityGroupRuleLocation</a>, ports: <a href='#SecurityGroupRulePorts'>SecurityGroupRulePorts</a>, description?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#IngressSecurityGroupRule'>IngressSecurityGroupRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="IngressSecurityGroupRule-ingressArgs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L133">method <b>ingressArgs</b></a>
@@ -1852,12 +1852,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L110">property <b>securityGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroup: x.ec2.SecurityGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="IngressSecurityGroupRule-securityGroupRule">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L109">property <b>securityGroupRule</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroupRule: aws.ec2.SecurityGroupRule;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroupRule: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#SecurityGroupRule'>aws.ec2.SecurityGroupRule</a>;</code></pre>
 <h4 class="pdoc-member-header" id="IngressSecurityGroupRule-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroupRule.ts#L197">property <b>urn</b></a>
 </h4>
@@ -2044,7 +2044,7 @@ you'd like to classify your security groups in a way that can be updated, use `t
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L162">property <b>egress</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>egress?: x.ec2.EgressSecurityGroupRuleArgs[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>egress?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#EgressSecurityGroupRuleArgs'>x.ec2.EgressSecurityGroupRuleArgs</a>[];</code></pre>
 
 Can be specified multiple times for each egress rule. Each egress block supports fields
 documented below.
@@ -2053,7 +2053,7 @@ documented below.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L168">property <b>ingress</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>ingress?: x.ec2.IngressSecurityGroupRuleArgs[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>ingress?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#IngressSecurityGroupRuleArgs'>x.ec2.IngressSecurityGroupRuleArgs</a>[];</code></pre>
 
 Can be specified multiple times for each ingress rule. Each ingress block supports fields
 documented below.
@@ -2074,7 +2074,7 @@ from being destroyed without removing the dependency first. Default `false`
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L144">property <b>securityGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>securityGroup?: aws.ec2.SecurityGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>securityGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#SecurityGroup'>aws.ec2.SecurityGroup</a>;</code></pre>
 
 An existing SecurityGroup to use for this awsx SecurityGroup.  If not provided, a default
 one will be created.
@@ -2083,12 +2083,12 @@ one will be created.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L179">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="SecurityGroupArgs-vpc">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/securityGroup.ts#L149">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this security group applies to.  Or [Vpc.getDefault] if unspecified.
 
@@ -2362,7 +2362,7 @@ IP address. Default is `false`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/subnet.ts#L211">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 A mapping of tags to assign to the resource.
 
@@ -2559,7 +2559,7 @@ one private subnet if unspecified.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L545">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 A mapping of tags to assign to the resource.
 
@@ -2648,7 +2648,7 @@ multiple subnets with the same type.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L414">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="VpcSubnetArgs-type">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ec2/vpc.ts#L364">property <b>type</b></a>
 </h4>

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/ecr/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/ecr/_index.md
@@ -314,7 +314,7 @@ destination registry.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>buildAndPushImage(pathOrBuild: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | docker.DockerBuild&gt;): OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt; &amp; { ... }</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>buildAndPushImage(pathOrBuild: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | docker.DockerBuild&gt;): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt; &amp; { ... }</code></pre>
 
 
 Builds the docker container specified by [pathOrBuild] and pushes it to this repository.
@@ -350,12 +350,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecr/repository.ts#L33">property <b>lifecyclePolicy</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>lifecyclePolicy: aws.ecr.LifecyclePolicy | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>lifecyclePolicy: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecr/#LifecyclePolicy'>aws.ecr.LifecyclePolicy</a> | <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span>;</code></pre>
 <h4 class="pdoc-member-header" id="Repository-repository">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecr/repository.ts#L32">property <b>repository</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>repository: aws.ecr.Repository;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>repository: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecr/#Repository'>aws.ecr.Repository</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Repository-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecr/repository.ts#L31">property <b>urn</b></a>
 </h4>
@@ -396,7 +396,7 @@ repo.  This result type can be passed in as `image: ecr.buildAndPushImage(...)` 
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> LifecyclePolicy(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, repository: aws.ecr.Repository, args?: <a href='#LifecyclePolicyArgs'>LifecyclePolicyArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> LifecyclePolicy(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, repository: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecr/#Repository'>aws.ecr.Repository</a>, args?: <a href='#LifecyclePolicyArgs'>LifecyclePolicyArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 
 Creates a new [LifecyclePolicy] for the given [repository].  If [args] is not provided, then
@@ -598,7 +598,7 @@ created using `LifecyclePolicy.getDefaultLifecyclePolicyArgs`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecr/repository.ts#L77">property <b>repository</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>repository?: aws.ecr.Repository;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>repository?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecr/#Repository'>aws.ecr.Repository</a>;</code></pre>
 
 Underlying repository.  If not provided, a new one will be created on your behalf.
 
@@ -640,7 +640,7 @@ be passed in as the `image: repoImage` value to an `ecs.Container`.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>image(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt; | OutputInstance&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>image(): <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="RepositoryImage-imageValue">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecr/repositoryImage.ts#L26">property <b>imageValue</b></a>

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/ecs/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/ecs/_index.md
@@ -382,7 +382,7 @@ Unit: Percent.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/metrics.ts#L32">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>cluster?: aws.ecs.Cluster | <a href='#Cluster'>Cluster</a>;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>cluster?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#Cluster'>aws.ecs.Cluster</a> | <a href='#Cluster'>Cluster</a>;</code></pre>
 
 This dimension filters the data that you request for all resources in a specified cluster.
 All Amazon ECS metrics can be filtered by this.
@@ -443,7 +443,7 @@ to [undefined] then the value will be set to the default (300s).
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/metrics.ts#L39">property <b>service</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>service?: aws.ecs.Service | <a href='#Service'>Service</a>;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>service?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#Service'>aws.ecs.Service</a> | <a href='#Service'>Service</a>;</code></pre>
 
 This dimension filters the data that you request for all resources in a specified service
 within a specified cluster.  If this is an [awsx.ecs.Service] then [cluster] is not required.
@@ -628,14 +628,14 @@ A Cluster is a general purpose ECS cluster configured to run in a provided Netwo
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addAutoScalingGroup(group: x.autoscaling.AutoScalingGroup): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addAutoScalingGroup(group: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/autoscaling/#AutoScalingGroup'>x.autoscaling.AutoScalingGroup</a>): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 <h4 class="pdoc-member-header" id="Cluster-createAutoScalingGroup">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L77">method <b>createAutoScalingGroup</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>createAutoScalingGroup(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.autoscaling.AutoScalingGroupArgs, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#AutoScalingGroup'>AutoScalingGroup</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>createAutoScalingGroup(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/autoscaling/#AutoScalingGroupArgs'>x.autoscaling.AutoScalingGroupArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#AutoScalingGroup'>AutoScalingGroup</a></code></pre>
 
 
 Creates a new autoscaling group and adds it to the list of autoscaling groups targeting this
@@ -648,21 +648,21 @@ launchConfiguration userData.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createDefaultSecurityGroup(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpc?: x.ec2.Vpc, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): x.ec2.SecurityGroup</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createDefaultSecurityGroup(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a></code></pre>
 
 <h4 class="pdoc-member-header" id="Cluster-createDefaultSecurityGroupEgressRules">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L125">method <b>createDefaultSecurityGroupEgressRules</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createDefaultSecurityGroupEgressRules(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup): <a href='#EgressSecurityGroupRule'>EgressSecurityGroupRule</a>[]</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createDefaultSecurityGroupEgressRules(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>): <a href='#EgressSecurityGroupRule'>EgressSecurityGroupRule</a>[]</code></pre>
 
 <h4 class="pdoc-member-header" id="Cluster-createDefaultSecurityGroupIngressRules">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L132">method <b>createDefaultSecurityGroupIngressRules</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createDefaultSecurityGroupIngressRules(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: x.ec2.SecurityGroup): <a href='#IngressSecurityGroupRule'>IngressSecurityGroupRule</a>[]</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createDefaultSecurityGroupIngressRules(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, securityGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>): <a href='#IngressSecurityGroupRule'>IngressSecurityGroupRule</a>[]</code></pre>
 
 <h4 class="pdoc-member-header" id="Cluster-getDefault">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L100">method <b>getDefault</b></a>
@@ -705,17 +705,17 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L43">property <b>autoScalingGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>autoScalingGroups: x.autoscaling.AutoScalingGroup[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>autoScalingGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/autoscaling/#AutoScalingGroup'>x.autoscaling.AutoScalingGroup</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="Cluster-cluster">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L29">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>cluster: aws.ecs.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>cluster: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#Cluster'>aws.ecs.Cluster</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Cluster-extraBootcmdLines">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L41">property <b>extraBootcmdLines</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>extraBootcmdLines: () => <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;x.autoscaling.UserDataLine[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>extraBootcmdLines: () => <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/autoscaling/#UserDataLine'>x.autoscaling.UserDataLine</a>[]&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="Cluster-id">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L30">property <b>id</b></a>
 </h4>
@@ -725,7 +725,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L39">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroups: x.ec2.SecurityGroup[];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>[];</code></pre>
 
 Security groups associated with this this ECS Cluster.
 
@@ -742,7 +742,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L35">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The network in which to create this cluster.
 
@@ -789,17 +789,17 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L24">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>cluster: ecs.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>cluster: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Cluster'>ecs.Cluster</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Service-service">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L23">property <b>service</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>service: aws.ecs.Service;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>service: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#Service'>aws.ecs.Service</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Service-taskDefinition">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L25">property <b>taskDefinition</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>taskDefinition: ecs.TaskDefinition;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>taskDefinition: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#TaskDefinition'>ecs.TaskDefinition</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Service-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L22">property <b>urn</b></a>
 </h4>
@@ -828,7 +828,7 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createExecutionRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.iam.PolicyDocument, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.iam.Role</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createExecutionRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a>, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a></code></pre>
 
 
 Creates the [executionRole] for a [TaskDefinition] if not provided explicitly. If
@@ -842,7 +842,7 @@ be used.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createTaskRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.iam.PolicyDocument, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.iam.Role</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createTaskRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a>, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a></code></pre>
 
 
 Creates the [taskRole] for a [TaskDefinition] if not provided explicitly. If
@@ -863,7 +863,7 @@ be used.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>defaultRoleAssumeRolePolicy(): aws.iam.PolicyDocument</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>defaultRoleAssumeRolePolicy(): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a></code></pre>
 
 <h4 class="pdoc-member-header" id="TaskDefinition-defaultTaskRolePolicyARNs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L150">method <b>defaultTaskRolePolicyARNs</b></a>
@@ -901,17 +901,17 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L27">property <b>containers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>containers: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, ecs.Container&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containers: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Container'>ecs.Container</a>&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="TaskDefinition-executionRole">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L29">property <b>executionRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>executionRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>executionRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TaskDefinition-logGroup">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L26">property <b>logGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>logGroup?: aws.cloudwatch.LogGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>logGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#LogGroup'>aws.cloudwatch.LogGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TaskDefinition-run">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L38">property <b>run</b></a>
 </h4>
@@ -928,12 +928,12 @@ This API is designed for use at runtime.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L25">property <b>taskDefinition</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>taskDefinition: aws.ecs.TaskDefinition;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>taskDefinition: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#TaskDefinition'>aws.ecs.TaskDefinition</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TaskDefinition-taskRole">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L28">property <b>taskRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>taskRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>taskRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TaskDefinition-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L24">property <b>urn</b></a>
 </h4>
@@ -960,7 +960,7 @@ Arguments bag for creating infrastructure for a new Cluster.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L185">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>cluster?: aws.ecs.Cluster | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>cluster?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#Cluster'>aws.ecs.Cluster</a> | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;;</code></pre>
 
 An existing Cluster (or Cluster-Id) to use for this awsx Cluster.  If not provided, a default
 one will be created.
@@ -977,7 +977,7 @@ The name of the cluster (up to 255 letters, numbers, hyphens, and underscores)
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L196">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>securityGroups?: x.ec2.SecurityGroupOrId[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>securityGroups?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroupOrId'>x.ec2.SecurityGroupOrId</a>[];</code></pre>
 
 The security group to place new instances into.  If not provided, a default will be
 created. Pass an empty array to create no security groups.
@@ -986,7 +986,7 @@ created. Pass an empty array to create no security groups.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L201">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 Key-value mapping of resource tags
 
@@ -994,7 +994,7 @@ Key-value mapping of resource tags
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/cluster.ts#L179">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The network in which to create this cluster.  If not provided, Vpc.getDefault() will be
 used.
@@ -1060,7 +1060,7 @@ used.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L174">property <b>extraHosts</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>extraHosts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.HostEntry[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>extraHosts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#HostEntry'>aws.ecs.HostEntry</a>[]&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="Container-hostname">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L175">property <b>hostname</b></a>
 </h4>
@@ -1086,12 +1086,12 @@ image from a local docker build.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L177">property <b>linuxParameters</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>linuxParameters?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.LinuxParameters&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>linuxParameters?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#LinuxParameters'>aws.ecs.LinuxParameters</a>&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="Container-logConfiguration">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L178">property <b>logConfiguration</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>logConfiguration?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.LogConfiguration&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>logConfiguration?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#LogConfiguration'>aws.ecs.LogConfiguration</a>&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="Container-memory">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L179">property <b>memory</b></a>
 </h4>
@@ -1106,12 +1106,12 @@ image from a local docker build.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L181">property <b>mountPoints</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>mountPoints?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.MountPoint[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>mountPoints?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#MountPoint'>aws.ecs.MountPoint</a>[]&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="Container-portMappings">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L199">property <b>portMappings</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>portMappings?: PortMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;PortMapping&gt; | OutputInstance&lt;PortMapping&gt; | <a href='#ContainerPortMappingProvider'>ContainerPortMappingProvider</a>[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>portMappings?: PortMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;PortMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;PortMapping&gt; | <a href='#ContainerPortMappingProvider'>ContainerPortMappingProvider</a>[];</code></pre>
 <h4 class="pdoc-member-header" id="Container-privileged">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L182">property <b>privileged</b></a>
 </h4>
@@ -1126,7 +1126,7 @@ image from a local docker build.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L184">property <b>ulimits</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>ulimits?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.Ulimit[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>ulimits?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#Ulimit'>aws.ecs.Ulimit</a>[]&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="Container-user">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L185">property <b>user</b></a>
 </h4>
@@ -1136,7 +1136,7 @@ image from a local docker build.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L186">property <b>volumesFrom</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>volumesFrom?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.VolumeFrom[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>volumesFrom?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#VolumeFrom'>aws.ecs.VolumeFrom</a>[]&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="Container-workingDirectory">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/container.ts#L187">property <b>workingDirectory</b></a>
 </h4>
@@ -1211,7 +1211,7 @@ image from a local docker build.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span>containerPortMapping(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.PortMapping&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>containerPortMapping(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#PortMapping'>aws.ecs.PortMapping</a>&gt;</code></pre>
 
 <h3 class="pdoc-module-header" id="EC2Service" data-link-title="EC2Service">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L65">
@@ -1256,12 +1256,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L24">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>cluster: ecs.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>cluster: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Cluster'>ecs.Cluster</a>;</code></pre>
 <h4 class="pdoc-member-header" id="EC2Service-service">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L23">property <b>service</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>service: aws.ecs.Service;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>service: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#Service'>aws.ecs.Service</a>;</code></pre>
 <h4 class="pdoc-member-header" id="EC2Service-taskDefinition">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L66">property <b>taskDefinition</b></a>
 </h4>
@@ -1287,7 +1287,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L275">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>cluster?: ecs.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>cluster?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Cluster'>ecs.Cluster</a>;</code></pre>
 
 Cluster this service will run in.
 
@@ -1345,7 +1345,7 @@ here.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L227">property <b>loadBalancers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancers?: <a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | OutputInstance&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='#ServiceLoadBalancerProvider'>ServiceLoadBalancerProvider</a>[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancers?: <a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='#ServiceLoadBalancerProvider'>ServiceLoadBalancerProvider</a>[];</code></pre>
 
 A load balancer block. Load balancers documented below.
 
@@ -1361,7 +1361,7 @@ The name of the service (up to 255 letters, numbers, hyphens, and underscores)
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L252">property <b>orderedPlacementStrategies</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>orderedPlacementStrategies?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[]&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>orderedPlacementStrategies?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[]&gt;;</code></pre>
 
 Service level strategy rules that are taken into consideration during task placement. List
 from top to bottom in order of precedence. The maximum number of `ordered_placement_strategy`
@@ -1376,7 +1376,7 @@ blocks is `5`. Defined below.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L258">property <b>placementConstraints</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[]&gt; | OutputInstance&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[]&gt;;</code></pre>
 
 rules that are taken into consideration during task placement. Maximum number of
 `placement_constraints` is `10`. Defined below.
@@ -1395,7 +1395,7 @@ strategy*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/schedulin
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L239">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>securityGroups?: x.ec2.SecurityGroupOrId[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>securityGroups?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroupOrId'>x.ec2.SecurityGroupOrId</a>[];</code></pre>
 
 The security groups to use for the instances.
 
@@ -1405,7 +1405,7 @@ Defaults to [cluster.securityGroups] if unspecified.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L270">property <b>serviceRegistries</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>serviceRegistries?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceServiceRegistries | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceServiceRegistries&gt; | OutputInstance&lt;ServiceServiceRegistries&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>serviceRegistries?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceServiceRegistries | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceServiceRegistries&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceServiceRegistries&gt;;</code></pre>
 
 The service discovery registries for the service. The maximum number of `service_registries` blocks is `1`.
 
@@ -1422,7 +1422,7 @@ subnets of the cluster's vpc.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L309">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 Key-value mapping of resource tags
 
@@ -1473,7 +1473,7 @@ before continuing. Defaults to `true`.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createExecutionRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.iam.PolicyDocument, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.iam.Role</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createExecutionRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a>, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a></code></pre>
 
 
 Creates the [executionRole] for a [TaskDefinition] if not provided explicitly. If
@@ -1487,7 +1487,7 @@ be used.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>createService(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: ecs.EC2ServiceArgs, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#EC2Service'>EC2Service</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>createService(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#EC2ServiceArgs'>ecs.EC2ServiceArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#EC2Service'>EC2Service</a></code></pre>
 
 
 Creates a service with this as its task definition.
@@ -1497,7 +1497,7 @@ Creates a service with this as its task definition.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createTaskRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.iam.PolicyDocument, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.iam.Role</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createTaskRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a>, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a></code></pre>
 
 
 Creates the [taskRole] for a [TaskDefinition] if not provided explicitly. If
@@ -1518,7 +1518,7 @@ be used.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>defaultRoleAssumeRolePolicy(): aws.iam.PolicyDocument</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>defaultRoleAssumeRolePolicy(): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a></code></pre>
 
 <h4 class="pdoc-member-header" id="EC2TaskDefinition-defaultTaskRolePolicyARNs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L150">method <b>defaultTaskRolePolicyARNs</b></a>
@@ -1556,17 +1556,17 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L27">property <b>containers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>containers: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, ecs.Container&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containers: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Container'>ecs.Container</a>&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="EC2TaskDefinition-executionRole">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L29">property <b>executionRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>executionRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>executionRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 <h4 class="pdoc-member-header" id="EC2TaskDefinition-logGroup">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L26">property <b>logGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>logGroup?: aws.cloudwatch.LogGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>logGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#LogGroup'>aws.cloudwatch.LogGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="EC2TaskDefinition-run">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L38">property <b>run</b></a>
 </h4>
@@ -1583,12 +1583,12 @@ This API is designed for use at runtime.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L25">property <b>taskDefinition</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>taskDefinition: aws.ecs.TaskDefinition;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>taskDefinition: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#TaskDefinition'>aws.ecs.TaskDefinition</a>;</code></pre>
 <h4 class="pdoc-member-header" id="EC2TaskDefinition-taskRole">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L28">property <b>taskRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>taskRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>taskRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 <h4 class="pdoc-member-header" id="EC2TaskDefinition-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L22">property <b>urn</b></a>
 </h4>
@@ -1609,7 +1609,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L168">property <b>container</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>container?: ecs.Container;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>container?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Container'>ecs.Container</a>;</code></pre>
 
 Single container to make a TaskDefinition from.  Useful for simple cases where there aren't
 multiple containers, especially when creating a TaskDefinition to call [run] on.
@@ -1620,7 +1620,7 @@ Either [container] or [containers] must be provided.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L176">property <b>containers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>containers?: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, ecs.Container&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>containers?: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Container'>ecs.Container</a>&gt;;</code></pre>
 
 All the containers to make a TaskDefinition from.  Useful when creating a
 Service that will contain many containers within.
@@ -1631,7 +1631,7 @@ Either [container] or [containers] must be provided.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L152">property <b>executionRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>executionRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>executionRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 
 The execution role that the Amazon ECS container agent and the Docker daemon can assume.
 
@@ -1641,7 +1641,7 @@ If `undefined`, a default will be created for the task.  If `null` no role will 
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L139">property <b>logGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>logGroup?: aws.cloudwatch.LogGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>logGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#LogGroup'>aws.cloudwatch.LogGroup</a>;</code></pre>
 
 Log group for logging information related to the service.  If `undefined` a default instance
 with a one-day retention policy will be created.  If `null` no log group will be created.
@@ -1659,7 +1659,7 @@ The Docker networking mode to use for the containers in the task. The valid valu
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L126">property <b>placementConstraints</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[]&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[]&gt;;</code></pre>
 
 A set of placement constraints rules that are taken into consideration during task placement.
 Maximum number of `placement_constraints` is `10`.
@@ -1668,7 +1668,7 @@ Maximum number of `placement_constraints` is `10`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L181">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 Key-value mapping of resource tags
 
@@ -1676,7 +1676,7 @@ Key-value mapping of resource tags
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L145">property <b>taskRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>taskRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>taskRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 
 IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
 `undefined`, a default will be created for the task.  If `null` no role will be created.
@@ -1685,7 +1685,7 @@ IAM role that allows your Amazon ECS container task to make calls to other AWS s
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/ec2Service.ts#L131">property <b>volumes</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>volumes?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[]&gt; | OutputInstance&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>volumes?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[]&gt;;</code></pre>
 
 A set of volume blocks that containers in your task may use.
 
@@ -1732,12 +1732,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L24">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>cluster: ecs.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>cluster: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Cluster'>ecs.Cluster</a>;</code></pre>
 <h4 class="pdoc-member-header" id="FargateService-service">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L23">property <b>service</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>service: aws.ecs.Service;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>service: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#Service'>aws.ecs.Service</a>;</code></pre>
 <h4 class="pdoc-member-header" id="FargateService-taskDefinition">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L193">property <b>taskDefinition</b></a>
 </h4>
@@ -1773,7 +1773,7 @@ Defaults to [true] if unspecified.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L422">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>cluster?: ecs.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>cluster?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Cluster'>ecs.Cluster</a>;</code></pre>
 
 Cluster this service will run in.  If unspecified, [Cluster.getDefault()] will be used.
 
@@ -1831,7 +1831,7 @@ here.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L364">property <b>loadBalancers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancers?: <a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | OutputInstance&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='#ServiceLoadBalancerProvider'>ServiceLoadBalancerProvider</a>[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancers?: <a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='#ServiceLoadBalancerProvider'>ServiceLoadBalancerProvider</a>[];</code></pre>
 
 A load balancer block. Load balancers documented below.
 
@@ -1847,7 +1847,7 @@ The name of the service (up to 255 letters, numbers, hyphens, and underscores)
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L397">property <b>orderedPlacementStrategies</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>orderedPlacementStrategies?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[]&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>orderedPlacementStrategies?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[]&gt;;</code></pre>
 
 Service level strategy rules that are taken into consideration during task placement. List
 from top to bottom in order of precedence. The maximum number of `ordered_placement_strategy`
@@ -1862,7 +1862,7 @@ blocks is `5`. Defined below.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L403">property <b>placementConstraints</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[]&gt; | OutputInstance&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[]&gt;;</code></pre>
 
 rules that are taken into consideration during task placement. Maximum number of
 `placement_constraints` is `10`. Defined below.
@@ -1881,7 +1881,7 @@ strategy*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/schedulin
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L383">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>securityGroups?: x.ec2.SecurityGroupOrId[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>securityGroups?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroupOrId'>x.ec2.SecurityGroupOrId</a>[];</code></pre>
 
 The security groups to use for the instances.
 
@@ -1891,7 +1891,7 @@ Defaults to [cluster.securityGroups] if unspecified.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L415">property <b>serviceRegistries</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>serviceRegistries?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceServiceRegistries | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceServiceRegistries&gt; | OutputInstance&lt;ServiceServiceRegistries&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>serviceRegistries?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceServiceRegistries | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceServiceRegistries&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceServiceRegistries&gt;;</code></pre>
 
 The service discovery registries for the service. The maximum number of `service_registries` blocks is `1`.
 
@@ -1909,7 +1909,7 @@ is false, then these will be the private subnets of the cluster's vpc.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L456">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 Key-value mapping of resource tags
 
@@ -1917,7 +1917,7 @@ Key-value mapping of resource tags
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L445">property <b>taskDefinition</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>taskDefinition?: ecs.FargateTaskDefinition;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>taskDefinition?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#FargateTaskDefinition'>ecs.FargateTaskDefinition</a>;</code></pre>
 
 The task definition to create the service from.  Either [taskDefinition] or
 [taskDefinitionArgs] must be provided.
@@ -1953,14 +1953,14 @@ before continuing. Defaults to `true`.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> FargateTaskDefinition(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: ecs.FargateTaskDefinitionArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> FargateTaskDefinition(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#FargateTaskDefinitionArgs'>ecs.FargateTaskDefinitionArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="FargateTaskDefinition-createExecutionRole">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L121">method <b>createExecutionRole</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createExecutionRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.iam.PolicyDocument, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.iam.Role</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createExecutionRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a>, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a></code></pre>
 
 
 Creates the [executionRole] for a [TaskDefinition] if not provided explicitly. If
@@ -1974,7 +1974,7 @@ be used.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>createService(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: ecs.FargateServiceArgs, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#FargateService'>FargateService</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>createService(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#FargateServiceArgs'>ecs.FargateServiceArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#FargateService'>FargateService</a></code></pre>
 
 
 Creates a service with this as its task definition.
@@ -1984,7 +1984,7 @@ Creates a service with this as its task definition.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>createTaskRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | aws.iam.PolicyDocument, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): aws.iam.Role</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>createTaskRole(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, assumeRolePolicy?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a>, policyArns?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>[], opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a></code></pre>
 
 
 Creates the [taskRole] for a [TaskDefinition] if not provided explicitly. If
@@ -2005,7 +2005,7 @@ be used.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>defaultRoleAssumeRolePolicy(): aws.iam.PolicyDocument</code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>defaultRoleAssumeRolePolicy(): <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#PolicyDocument'>aws.iam.PolicyDocument</a></code></pre>
 
 <h4 class="pdoc-member-header" id="FargateTaskDefinition-defaultTaskRolePolicyARNs">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L150">method <b>defaultTaskRolePolicyARNs</b></a>
@@ -2043,17 +2043,17 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L27">property <b>containers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>containers: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, ecs.Container&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containers: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Container'>ecs.Container</a>&gt;;</code></pre>
 <h4 class="pdoc-member-header" id="FargateTaskDefinition-executionRole">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L29">property <b>executionRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>executionRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>executionRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 <h4 class="pdoc-member-header" id="FargateTaskDefinition-logGroup">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L26">property <b>logGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>logGroup?: aws.cloudwatch.LogGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>logGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#LogGroup'>aws.cloudwatch.LogGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="FargateTaskDefinition-run">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L38">property <b>run</b></a>
 </h4>
@@ -2070,12 +2070,12 @@ This API is designed for use at runtime.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L25">property <b>taskDefinition</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>taskDefinition: aws.ecs.TaskDefinition;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>taskDefinition: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#TaskDefinition'>aws.ecs.TaskDefinition</a>;</code></pre>
 <h4 class="pdoc-member-header" id="FargateTaskDefinition-taskRole">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L28">property <b>taskRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>taskRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>taskRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 <h4 class="pdoc-member-header" id="FargateTaskDefinition-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L22">property <b>urn</b></a>
 </h4>
@@ -2096,7 +2096,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L305">property <b>container</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>container?: ecs.Container;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>container?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Container'>ecs.Container</a>;</code></pre>
 
 Single container to make a TaskDefinition from.  Useful for simple cases where there aren't
 multiple containers, especially when creating a TaskDefinition to call [run] on.
@@ -2107,7 +2107,7 @@ Either [container] or [containers] must be provided.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L313">property <b>containers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>containers?: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, ecs.Container&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>containers?: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Container'>ecs.Container</a>&gt;;</code></pre>
 
 All the containers to make a TaskDefinition from.  Useful when creating a Service that will
 contain many containers within.
@@ -2127,7 +2127,7 @@ based on the cumulative needs specified by [containerDefinitions]
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L285">property <b>executionRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>executionRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>executionRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 
 The execution role that the Amazon ECS container agent and the Docker daemon can assume.
 
@@ -2137,7 +2137,7 @@ The execution role that the Amazon ECS container agent and the Docker daemon can
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L272">property <b>logGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>logGroup?: aws.cloudwatch.LogGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>logGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#LogGroup'>aws.cloudwatch.LogGroup</a>;</code></pre>
 
 Log group for logging information related to the service.  If `undefined` a default instance
 with a one-day retention policy will be created.  If `null` no log group will be created.
@@ -2155,7 +2155,7 @@ based on the cumulative needs specified by [containerDefinitions]
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L259">property <b>placementConstraints</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[]&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[]&gt;;</code></pre>
 
 A set of placement constraints rules that are taken into consideration during task placement.
 Maximum number of `placement_constraints` is `10`.
@@ -2164,7 +2164,7 @@ Maximum number of `placement_constraints` is `10`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L318">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 Key-value mapping of resource tags
 
@@ -2172,7 +2172,7 @@ Key-value mapping of resource tags
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L278">property <b>taskRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>taskRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>taskRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 
 IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
 `undefined`, a default will be created for the task.  If `null` no role will be created.
@@ -2181,7 +2181,7 @@ IAM role that allows your Amazon ECS container task to make calls to other AWS s
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/fargateService.ts#L264">property <b>volumes</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>volumes?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[]&gt; | OutputInstance&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>volumes?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[]&gt;;</code></pre>
 
 A set of volume blocks that containers in your task may use.
 
@@ -2197,7 +2197,7 @@ A set of volume blocks that containers in your task may use.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>environment(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;ecs.KeyValuePair[]&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>environment(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#KeyValuePair'>ecs.KeyValuePair</a>[]&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="Image-fromDockerBuild">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/image.ts#L50">method <b>fromDockerBuild</b></a>
@@ -2214,7 +2214,7 @@ to.  If [repository] is provided, it will be used as-is.  Otherwise, a new one w
 created on-demand, using the [name] value.
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>fromDockerBuild(repository: aws.ecr.Repository, build: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;docker.DockerBuild&gt;): <a href='#Image'>Image</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>fromDockerBuild(repository: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecr/#Repository'>aws.ecr.Repository</a>, build: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;docker.DockerBuild&gt;): <a href='#Image'>Image</a></code></pre>
 
 <h4 class="pdoc-member-header" id="Image-fromFunction">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/image.ts#L63">method <b>fromFunction</b></a>
@@ -2241,7 +2241,7 @@ to.  If [repository] is provided, it will be used as-is.  Otherwise, a new one w
 created on-demand, using the [name] value.
 
 
-<pre class="highlight"><code><span class='kd'>public static </span>fromPath(repository: aws.ecr.Repository, path: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;): <a href='#Image'>Image</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public static </span>fromPath(repository: <a href='/docs/reference/pkg/nodejs/pulumi/aws/ecr/#Repository'>aws.ecr.Repository</a>, path: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;): <a href='#Image'>Image</a></code></pre>
 
 <h4 class="pdoc-member-header" id="Image-image">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/image.ts#L23">method <b>image</b></a>
@@ -2323,7 +2323,7 @@ The subnets associated with the task or service.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L169">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>cluster: ecs.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>cluster: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Cluster'>ecs.Cluster</a>;</code></pre>
 
 The Cluster to run the Task within.
 
@@ -2426,7 +2426,7 @@ The metadata that you apply to the task to help you categorize and organize them
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L285">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>cluster?: ecs.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>cluster?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Cluster'>ecs.Cluster</a>;</code></pre>
 
 Cluster this service will run in.  If not specified [Cluster.getDefault()] will be used.
 
@@ -2493,7 +2493,7 @@ Defaults to `EC2`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L241">property <b>loadBalancers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancers?: <a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | OutputInstance&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='#ServiceLoadBalancerProvider'>ServiceLoadBalancerProvider</a>[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancers?: <a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#ServiceLoadBalancer'>ServiceLoadBalancer</a>&gt; | <a href='#ServiceLoadBalancerProvider'>ServiceLoadBalancerProvider</a>[];</code></pre>
 
 A load balancer block. Load balancers documented below.
 
@@ -2519,7 +2519,7 @@ not supported for other network modes.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L260">property <b>orderedPlacementStrategies</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>orderedPlacementStrategies?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[]&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | OutputInstance&lt;ServiceOrderedPlacementStrategy&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>orderedPlacementStrategies?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceOrderedPlacementStrategy&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceOrderedPlacementStrategy&gt;[]&gt;;</code></pre>
 
 Service level strategy rules that are taken into consideration during task placement. List
 from top to bottom in order of precedence. The maximum number of `ordered_placement_strategy`
@@ -2529,7 +2529,7 @@ blocks is `5`. Defined below.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L266">property <b>placementConstraints</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[]&gt; | OutputInstance&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | OutputInstance&lt;ServicePlacementConstraint&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServicePlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServicePlacementConstraint&gt;[]&gt;;</code></pre>
 
 rules that are taken into consideration during task placement. Maximum number of
 `placement_constraints` is `10`. Defined below.
@@ -2548,7 +2548,7 @@ strategy*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/schedulin
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L295">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>securityGroups: x.ec2.SecurityGroup[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>securityGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>[];</code></pre>
 
 Security groups determining how this service can be reached.
 
@@ -2556,7 +2556,7 @@ Security groups determining how this service can be reached.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L278">property <b>serviceRegistries</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>serviceRegistries?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceServiceRegistries | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceServiceRegistries&gt; | OutputInstance&lt;ServiceServiceRegistries&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>serviceRegistries?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | ServiceServiceRegistries | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ServiceServiceRegistries&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ServiceServiceRegistries&gt;;</code></pre>
 
 The service discovery registries for the service. The maximum number of `service_registries` blocks is `1`.
 
@@ -2564,7 +2564,7 @@ The service discovery registries for the service. The maximum number of `service
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L319">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 Key-value mapping of resource tags
 
@@ -2572,7 +2572,7 @@ Key-value mapping of resource tags
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/service.ts#L290">property <b>taskDefinition</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>taskDefinition: ecs.TaskDefinition;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>taskDefinition: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#TaskDefinition'>ecs.TaskDefinition</a>;</code></pre>
 
 The task definition to create the service from.
 
@@ -2638,7 +2638,7 @@ before continuing. Defaults to `true`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L351">property <b>containers</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>containers: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, ecs.Container&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>containers: Record&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#Container'>ecs.Container</a>&gt;;</code></pre>
 
 All the containers to make a ClusterTaskDefinition from.  Useful when creating a
 ClusterService that will contain many containers within.
@@ -2658,7 +2658,7 @@ based on the cumulative needs specified by [containerDefinitions]
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L320">property <b>executionRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>executionRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>executionRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 
 The execution role that the Amazon ECS container agent and the Docker daemon can assume.
 
@@ -2668,7 +2668,7 @@ If `undefined`, a default will be created for the task.  If `null`, no task will
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L307">property <b>logGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>logGroup?: aws.cloudwatch.LogGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>logGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch/#LogGroup'>aws.cloudwatch.LogGroup</a>;</code></pre>
 
 Log group for logging information related to the service.  If `undefined` a default instance
 with a one-day retention policy will be created.  If `null`, no log group will be created.
@@ -2695,7 +2695,7 @@ The Docker networking mode to use for the containers in the task. The valid valu
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L294">property <b>placementConstraints</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[]&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | OutputInstance&lt;TaskDefinitionPlacementConstraint&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>placementConstraints?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionPlacementConstraint&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionPlacementConstraint&gt;[]&gt;;</code></pre>
 
 A set of placement constraints rules that are taken into consideration during task placement.
 Maximum number of `placement_constraints` is `10`.
@@ -2712,7 +2712,7 @@ A set of launch types required by the task. The valid values are `EC2` and `FARG
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L356">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 Key-value mapping of resource tags
 
@@ -2720,7 +2720,7 @@ Key-value mapping of resource tags
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L313">property <b>taskRole</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>taskRole?: aws.iam.Role;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>taskRole?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/iam/#Role'>aws.iam.Role</a>;</code></pre>
 
 IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
 `undefined`, a default will be created for the task.  If `null`, no task will be created.
@@ -2729,7 +2729,7 @@ IAM role that allows your Amazon ECS container task to make calls to other AWS s
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/ecs/taskDefinition.ts#L299">property <b>volumes</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>volumes?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[]&gt; | OutputInstance&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | OutputInstance&lt;TaskDefinitionVolume&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>volumes?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TaskDefinitionVolume&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TaskDefinitionVolume&gt;[]&gt;;</code></pre>
 
 A set of volume blocks that containers in your task may use.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/efs/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/efs/_index.md
@@ -160,7 +160,7 @@ to [undefined] then the value will be set to the default.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/efs/metrics.ts#L30">property <b>fileSystem</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>fileSystem?: aws.efs.FileSystem;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>fileSystem?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/efs/#FileSystem'>aws.efs.FileSystem</a>;</code></pre>
 
 Filters down events to the specified [FileSystem].
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/lambda/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/lambda/_index.md
@@ -193,7 +193,7 @@ to [undefined] then the value will be set to the default.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lambda/metrics.ts#L29">property <b>function</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>function?: aws.lambda.Function;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>function?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lambda/#Function'>aws.lambda.Function</a>;</code></pre>
 
 Optional Function this metric should be filtered down to.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/lb/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/lb/_index.md
@@ -270,7 +270,7 @@ Only used if this metric is displayed in a [Dashboard] with a [MetricWidget].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/metrics.ts#L31">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancer?: aws.lb.LoadBalancer | <a href='#LoadBalancer'>LoadBalancer</a>;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancer?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#LoadBalancer'>aws.lb.LoadBalancer</a> | <a href='#LoadBalancer'>LoadBalancer</a>;</code></pre>
 
 Filters the metric data by load balancer.
 
@@ -298,7 +298,7 @@ property, then no change will be made.  However, if the property is there by set
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/metrics.ts#L38">property <b>targetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>targetGroup?: aws.lb.TargetGroup | <a href='#TargetGroup'>TargetGroup</a>;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>targetGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#TargetGroup'>aws.lb.TargetGroup</a> | <a href='#TargetGroup'>TargetGroup</a>;</code></pre>
 
 Filters the metric data by target group.  If this is a [NetworkTargetGroup] then
 [loadBalancer] does not have to be provided.  If this is an
@@ -466,7 +466,7 @@ Only used if this metric is displayed in a [Dashboard] with a [MetricWidget].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/metrics.ts#L118">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancer?: aws.lb.LoadBalancer | <a href='#ApplicationLoadBalancer'>ApplicationLoadBalancer</a>;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancer?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#LoadBalancer'>aws.lb.LoadBalancer</a> | <a href='#ApplicationLoadBalancer'>ApplicationLoadBalancer</a>;</code></pre>
 
 Filters the metric data by load balancer.
 
@@ -494,7 +494,7 @@ property, then no change will be made.  However, if the property is there by set
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/metrics.ts#L125">property <b>targetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>targetGroup?: aws.lb.TargetGroup | <a href='#ApplicationTargetGroup'>ApplicationTargetGroup</a>;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>targetGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#TargetGroup'>aws.lb.TargetGroup</a> | <a href='#ApplicationTargetGroup'>ApplicationTargetGroup</a>;</code></pre>
 
 Filters the metric data by target group.  If this is an [ApplicationTargetGroup] then
 [loadBalancer] does not have to be provided.  If this is an
@@ -1197,7 +1197,7 @@ Only used if this metric is displayed in a [Dashboard] with a [MetricWidget].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/metrics.ts#L597">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancer?: aws.lb.LoadBalancer | <a href='#NetworkLoadBalancer'>NetworkLoadBalancer</a>;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancer?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#LoadBalancer'>aws.lb.LoadBalancer</a> | <a href='#NetworkLoadBalancer'>NetworkLoadBalancer</a>;</code></pre>
 
 Filters the metric data by load balancer.
 
@@ -1225,7 +1225,7 @@ property, then no change will be made.  However, if the property is there by set
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/metrics.ts#L604">property <b>targetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>targetGroup?: aws.lb.TargetGroup | <a href='#NetworkTargetGroup'>NetworkTargetGroup</a>;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>targetGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#TargetGroup'>aws.lb.TargetGroup</a> | <a href='#NetworkTargetGroup'>NetworkTargetGroup</a>;</code></pre>
 
 Filters the metric data by target group.  If this is a [NetworkTargetGroup] then
 [loadBalancer] does not have to be provided.  If this is an
@@ -1475,14 +1475,14 @@ Statistics: The most useful statistics are Maximum and Minimum.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addListenerRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.lb.ListenerRuleArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#ListenerRule'>ListenerRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addListenerRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerRuleArgs'>x.lb.ListenerRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#ListenerRule'>ListenerRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="Listener-attachTarget">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L109">method <b>attachTarget</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: mod.LoadBalancerTarget, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerTarget'>mod.LoadBalancerTarget</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
 
 
 Attaches a target to the `defaultTargetGroup` for this Listener.
@@ -1492,14 +1492,14 @@ Attaches a target to the `defaultTargetGroup` for this Listener.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt; | OutputInstance&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="Listener-containerPortMapping">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L86">method <b>containerPortMapping</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): PortMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;PortMapping&gt; | OutputInstance&lt;PortMapping&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): PortMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;PortMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;PortMapping&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="Listener-getProvider">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L29">method <b>getProvider</b></a>
@@ -1530,7 +1530,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L35">property <b>defaultTargetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>defaultTargetGroup?: x.lb.TargetGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>defaultTargetGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#TargetGroup'>x.lb.TargetGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Listener-endpoint">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L37">property <b>endpoint</b></a>
 </h4>
@@ -1540,12 +1540,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L33">property <b>listener</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>listener: aws.lb.Listener;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listener: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#Listener'>aws.lb.Listener</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Listener-loadBalancer">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L34">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: x.lb.LoadBalancer;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancer'>x.lb.LoadBalancer</a>;</code></pre>
 <h4 class="pdoc-member-header" id="Listener-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L29">property <b>urn</b></a>
 </h4>
@@ -1575,7 +1575,7 @@ https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-upd
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> ListenerRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, listener: x.lb.Listener, args: <a href='#ListenerRuleArgs'>ListenerRuleArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> ListenerRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, listener: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#Listener'>x.lb.Listener</a>, args: <a href='#ListenerRuleArgs'>ListenerRuleArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="ListenerRule-getProvider">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listenerRule.ts#L31">method <b>getProvider</b></a>
@@ -1606,7 +1606,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listenerRule.ts#L32">property <b>listenerRule</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>listenerRule: aws.lb.ListenerRule;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listenerRule: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#ListenerRule'>aws.lb.ListenerRule</a>;</code></pre>
 <h4 class="pdoc-member-header" id="ListenerRule-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listenerRule.ts#L31">property <b>urn</b></a>
 </h4>
@@ -1671,22 +1671,22 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L27">property <b>listeners</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>listeners: mod.Listener[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listeners: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#Listener'>mod.Listener</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="LoadBalancer-loadBalancer">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L23">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: aws.lb.LoadBalancer;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#LoadBalancer'>aws.lb.LoadBalancer</a>;</code></pre>
 <h4 class="pdoc-member-header" id="LoadBalancer-securityGroups">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L25">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroups: x.ec2.SecurityGroup[];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>[];</code></pre>
 <h4 class="pdoc-member-header" id="LoadBalancer-targetGroups">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L28">property <b>targetGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>targetGroups: mod.TargetGroup[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>targetGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#TargetGroup'>mod.TargetGroup</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="LoadBalancer-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L22">property <b>urn</b></a>
 </h4>
@@ -1700,7 +1700,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L24">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="TargetGroup" data-link-title="TargetGroup">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L24">
         Resource <strong>TargetGroup</strong>
@@ -1713,14 +1713,14 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> TargetGroup(type: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, loadBalancer: mod.LoadBalancer, args: <a href='#TargetGroupArgs'>TargetGroupArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> TargetGroup(type: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, loadBalancer: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancer'>mod.LoadBalancer</a>, args: <a href='#TargetGroupArgs'>TargetGroupArgs</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="TargetGroup-attachTarget">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L103">method <b>attachTarget</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: mod.LoadBalancerTarget, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerTarget'>mod.LoadBalancerTarget</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
 
 
 Attaches a target to this target group.  See
@@ -1732,14 +1732,14 @@ for more details.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;x.ecs.ContainerLoadBalancer&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#ContainerLoadBalancer'>x.ecs.ContainerLoadBalancer</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="TargetGroup-containerPortMapping">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L73">method <b>containerPortMapping</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.PortMapping&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#PortMapping'>aws.ecs.PortMapping</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="TargetGroup-getProvider">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L24">method <b>getProvider</b></a>
@@ -1764,14 +1764,14 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>listenerDefaultAction(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.ListenerDefaultActionArgs&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listenerDefaultAction(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultActionArgs'>mod.ListenerDefaultActionArgs</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="TargetGroup-registerListener">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L94">method <b>registerListener</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>registerListener(listener: x.lb.Listener): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>registerListener(listener: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#Listener'>x.lb.Listener</a>): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 Do not call directly.  Intended for use by [Listener] and [ListenerRule]
@@ -1787,17 +1787,17 @@ Do not call directly.  Intended for use by [Listener] and [ListenerRule]
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L34">property <b>listeners</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>listeners: x.lb.Listener[] =  [];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listeners: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#Listener'>x.lb.Listener</a>[] =  [];</code></pre>
 <h4 class="pdoc-member-header" id="TargetGroup-loadBalancer">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L30">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: mod.LoadBalancer;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancer'>mod.LoadBalancer</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TargetGroup-targetGroup">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L31">property <b>targetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>targetGroup: aws.lb.TargetGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>targetGroup: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#TargetGroup'>aws.lb.TargetGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TargetGroup-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L24">property <b>urn</b></a>
 </h4>
@@ -1811,7 +1811,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L32">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="TargetGroupAttachment" data-link-title="TargetGroupAttachment">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroupAttachment.ts#L22">
         Resource <strong>TargetGroupAttachment</strong>
@@ -1824,7 +1824,7 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> TargetGroupAttachment(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, targetGroup: mod.TargetGroup, args: mod.LoadBalancerTarget, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
+<pre class="highlight"><code><span class='kd'></span><span class='kd'>new</span> TargetGroupAttachment(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, targetGroup: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#TargetGroup'>mod.TargetGroup</a>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerTarget'>mod.LoadBalancerTarget</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>)</code></pre>
 
 <h4 class="pdoc-member-header" id="TargetGroupAttachment-getProvider">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroupAttachment.ts#L22">method <b>getProvider</b></a>
@@ -1855,17 +1855,17 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroupAttachment.ts#L25">property <b>func</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>func?: aws.lambda.Function;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>func?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lambda/#Function'>aws.lambda.Function</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TargetGroupAttachment-permission">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroupAttachment.ts#L24">property <b>permission</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>permission?: aws.lambda.Permission;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>permission?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lambda/#Permission'>aws.lambda.Permission</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TargetGroupAttachment-targetGroupAttachment">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroupAttachment.ts#L23">property <b>targetGroupAttachment</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>targetGroupAttachment: aws.lb.TargetGroupAttachment;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>targetGroupAttachment: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#TargetGroupAttachment'>aws.lb.TargetGroupAttachment</a>;</code></pre>
 <h4 class="pdoc-member-header" id="TargetGroupAttachment-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroupAttachment.ts#L22">property <b>urn</b></a>
 </h4>
@@ -1897,14 +1897,14 @@ deployments.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addListenerRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.lb.ListenerRuleArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#ListenerRule'>ListenerRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addListenerRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerRuleArgs'>x.lb.ListenerRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#ListenerRule'>ListenerRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="ApplicationListener-attachTarget">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L109">method <b>attachTarget</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: mod.LoadBalancerTarget, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerTarget'>mod.LoadBalancerTarget</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
 
 
 Attaches a target to the `defaultTargetGroup` for this Listener.
@@ -1914,14 +1914,14 @@ Attaches a target to the `defaultTargetGroup` for this Listener.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt; | OutputInstance&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="ApplicationListener-containerPortMapping">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L86">method <b>containerPortMapping</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): PortMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;PortMapping&gt; | OutputInstance&lt;PortMapping&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): PortMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;PortMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;PortMapping&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="ApplicationListener-getProvider">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L182">method <b>getProvider</b></a>
@@ -1952,7 +1952,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L184">property <b>defaultTargetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>defaultTargetGroup?: x.lb.ApplicationTargetGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>defaultTargetGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ApplicationTargetGroup'>x.lb.ApplicationTargetGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="ApplicationListener-endpoint">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L37">property <b>endpoint</b></a>
 </h4>
@@ -1962,7 +1962,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L33">property <b>listener</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>listener: aws.lb.Listener;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listener: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#Listener'>aws.lb.Listener</a>;</code></pre>
 <h4 class="pdoc-member-header" id="ApplicationListener-loadBalancer">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L183">property <b>loadBalancer</b></a>
 </h4>
@@ -1999,7 +1999,7 @@ resource](https://www.terraform.io/docs/providers/aws/r/lb_listener_certificate.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L492">property <b>defaultAction</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>defaultAction?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.ListenerDefaultActionArgs&gt; | x.lb.ListenerDefaultAction;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>defaultAction?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultActionArgs'>mod.ListenerDefaultActionArgs</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultAction'>x.lb.ListenerDefaultAction</a>;</code></pre>
 
 An Action block. If neither this nor [defaultActions] is provided, a suitable defaultAction
 will be chosen that forwards to a new [ApplicationTargetGroup] created from [port].
@@ -2010,7 +2010,7 @@ Do not provide both [defaultAction] and [defaultActions].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L501">property <b>defaultActions</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>defaultActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.ListenerDefaultActionArgs&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>defaultActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultActionArgs'>mod.ListenerDefaultActionArgs</a>&gt;[]&gt;;</code></pre>
 
 An list of Action blocks. If neither this nor [defaultActions] is provided, a suitable
 defaultAction will be chosen that forwards to a new [ApplicationTargetGroup] created from
@@ -2084,7 +2084,7 @@ The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L462">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
 unspecified.
@@ -2180,12 +2180,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L23">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: aws.lb.LoadBalancer;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#LoadBalancer'>aws.lb.LoadBalancer</a>;</code></pre>
 <h4 class="pdoc-member-header" id="ApplicationLoadBalancer-securityGroups">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L25">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroups: x.ec2.SecurityGroup[];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>[];</code></pre>
 <h4 class="pdoc-member-header" id="ApplicationLoadBalancer-targetGroups">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L38">property <b>targetGroups</b></a>
 </h4>
@@ -2204,7 +2204,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L24">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="ApplicationLoadBalancerArgs" data-link-title="ApplicationLoadBalancerArgs">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L269">
         interface <strong>ApplicationLoadBalancerArgs</strong>
@@ -2216,7 +2216,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L326">property <b>accessLogs</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>accessLogs?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LoadBalancerAccessLogs | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerAccessLogs&gt; | OutputInstance&lt;LoadBalancerAccessLogs&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>accessLogs?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LoadBalancerAccessLogs | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerAccessLogs&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerAccessLogs&gt;;</code></pre>
 
 An Access Logs block. Access Logs documented below.
 
@@ -2278,7 +2278,7 @@ LoadBalancer constructor will be hashed and used as the name.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L343">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>securityGroups?: x.ec2.SecurityGroupOrId[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>securityGroups?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroupOrId'>x.ec2.SecurityGroupOrId</a>[];</code></pre>
 
 A list of security group IDs to assign to the ALB.  If not provided, a default instance will
 be created for the ALB.  To prevent a default instance from being created, pass in an empty
@@ -2288,7 +2288,7 @@ array here.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L307">property <b>subnetMappings</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>subnetMappings?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[]&gt; | OutputInstance&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>subnetMappings?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[]&gt;;</code></pre>
 
 A subnet mapping block as documented below.
 
@@ -2296,7 +2296,7 @@ A subnet mapping block as documented below.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L314">property <b>subnets</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>subnets?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt; | x.lb.LoadBalancerSubnets;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>subnets?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerSubnets'>x.lb.LoadBalancerSubnets</a>;</code></pre>
 
 A list of subnet IDs to attach to the LB. Subnets cannot be updated for Load Balancers of
 type `network`. Changing this value for load balancers of type `network` will force a
@@ -2306,7 +2306,7 @@ recreation of the resource.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L319">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 A mapping of tags to assign to the resource.
 
@@ -2314,7 +2314,7 @@ A mapping of tags to assign to the resource.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L276">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
 unspecified.
@@ -2352,7 +2352,7 @@ balancer.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: mod.LoadBalancerTarget, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerTarget'>mod.LoadBalancerTarget</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
 
 
 Attaches a target to this target group.  See
@@ -2364,14 +2364,14 @@ for more details.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;x.ecs.ContainerLoadBalancer&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#ContainerLoadBalancer'>x.ecs.ContainerLoadBalancer</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="ApplicationTargetGroup-containerPortMapping">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L73">method <b>containerPortMapping</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.PortMapping&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#PortMapping'>aws.ecs.PortMapping</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="ApplicationTargetGroup-createListener">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L126">method <b>createListener</b></a>
@@ -2399,14 +2399,14 @@ for more details.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>listenerDefaultAction(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.ListenerDefaultActionArgs&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listenerDefaultAction(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultActionArgs'>mod.ListenerDefaultActionArgs</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="ApplicationTargetGroup-registerListener">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L94">method <b>registerListener</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>registerListener(listener: x.lb.Listener): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>registerListener(listener: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#Listener'>x.lb.Listener</a>): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 Do not call directly.  Intended for use by [Listener] and [ListenerRule]
@@ -2422,7 +2422,7 @@ Do not call directly.  Intended for use by [Listener] and [ListenerRule]
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L96">property <b>listeners</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>listeners: x.lb.ApplicationListener[];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listeners: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ApplicationListener'>x.lb.ApplicationListener</a>[];</code></pre>
 <h4 class="pdoc-member-header" id="ApplicationTargetGroup-loadBalancer">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L94">property <b>loadBalancer</b></a>
 </h4>
@@ -2432,7 +2432,7 @@ Do not call directly.  Intended for use by [Listener] and [ListenerRule]
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L31">property <b>targetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>targetGroup: aws.lb.TargetGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>targetGroup: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#TargetGroup'>aws.lb.TargetGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="ApplicationTargetGroup-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L93">property <b>urn</b></a>
 </h4>
@@ -2446,7 +2446,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L32">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="ApplicationTargetGroupArgs" data-link-title="ApplicationTargetGroupArgs">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L373">
         interface <strong>ApplicationTargetGroupArgs</strong>
@@ -2531,7 +2531,7 @@ requests. The range is 30-900 seconds or 0 to disable. The default value is 0 se
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L424">property <b>stickiness</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>stickiness?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TargetGroupStickiness | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TargetGroupStickiness&gt; | OutputInstance&lt;TargetGroupStickiness&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>stickiness?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TargetGroupStickiness | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TargetGroupStickiness&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TargetGroupStickiness&gt;;</code></pre>
 
 A Stickiness block. Stickiness blocks are documented below. `stickiness` is only valid if
 used with Load Balancers of type `Application`
@@ -2540,7 +2540,7 @@ used with Load Balancers of type `Application`
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L429">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 A mapping of tags to assign to the resource.
 
@@ -2548,7 +2548,7 @@ A mapping of tags to assign to the resource.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L441">property <b>targetType</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>targetType?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.TargetType&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>targetType?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#TargetType'>mod.TargetType</a>&gt;;</code></pre>
 
 The type of target that you must specify when registering targets with this target group. The
 possible values are `instance` (targets are specified by instance ID) or `ip` (targets are
@@ -2563,7 +2563,7 @@ IP addresses.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/application.ts#L378">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
 unspecified.
@@ -2676,7 +2676,7 @@ unhealthy. Defaults to 3.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span>actions(): ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | OutputInstance&lt;ListenerRuleAction&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | OutputInstance&lt;ListenerRuleAction&gt;[]&gt; | OutputInstance&lt;ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | OutputInstance&lt;ListenerRuleAction&gt;[]&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>actions(): ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleAction&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleAction&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleAction&gt;[]&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="ListenerActions-registerListener">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L284">method <b>registerListener</b></a>
@@ -2715,7 +2715,7 @@ An list of Action blocks. See [ListenerDefaultActionArgs] for more information.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L312">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancer: x.lb.LoadBalancer;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancer: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancer'>x.lb.LoadBalancer</a>;</code></pre>
 <h4 class="pdoc-member-header" id="ListenerArgs-port">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L330">property <b>port</b></a>
 </h4>
@@ -2880,7 +2880,7 @@ The type of routing action. Valid values are "forward", "redirect", "fixed-respo
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listenerRule.ts#L75">property <b>actions</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>actions: ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | OutputInstance&lt;ListenerRuleAction&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | OutputInstance&lt;ListenerRuleAction&gt;[]&gt; | OutputInstance&lt;ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | OutputInstance&lt;ListenerRuleAction&gt;[]&gt; | x.lb.ListenerActions;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>actions: ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleAction&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleAction&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleAction | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleAction&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleAction&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerActions'>x.lb.ListenerActions</a>;</code></pre>
 
 An Action block. Action blocks are documented below.
 
@@ -2888,7 +2888,7 @@ An Action block. Action blocks are documented below.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listenerRule.ts#L79">property <b>conditions</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>conditions: ListenerRuleCondition | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleCondition&gt; | OutputInstance&lt;ListenerRuleCondition&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleCondition | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleCondition&gt; | OutputInstance&lt;ListenerRuleCondition&gt;[]&gt; | OutputInstance&lt;ListenerRuleCondition | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleCondition&gt; | OutputInstance&lt;ListenerRuleCondition&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>conditions: ListenerRuleCondition | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleCondition&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleCondition&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleCondition | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleCondition&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleCondition&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleCondition | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;ListenerRuleCondition&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;ListenerRuleCondition&gt;[]&gt;;</code></pre>
 
 A Condition block. Condition blocks are documented below.
 
@@ -2946,7 +2946,7 @@ The type of load balancer to create. Possible values are `application` or `netwo
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L152">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>securityGroups?: x.ec2.SecurityGroupOrId[];</code></pre>
+<pre class="highlight"><code><span class='kd'></span>securityGroups?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroupOrId'>x.ec2.SecurityGroupOrId</a>[];</code></pre>
 
 A list of security group IDs to assign to the LB. Only valid for Load Balancers of type
 `application`.
@@ -2955,7 +2955,7 @@ A list of security group IDs to assign to the LB. Only valid for Load Balancers 
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L141">property <b>subnetMappings</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>subnetMappings?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[]&gt; | OutputInstance&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>subnetMappings?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[]&gt;;</code></pre>
 
 A subnet mapping block as documented below.
 
@@ -2972,7 +2972,7 @@ internal subnets of the [network] will be used.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L146">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 A mapping of tags to assign to the resource.
 
@@ -2980,7 +2980,7 @@ A mapping of tags to assign to the resource.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L101">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
 unspecified.
@@ -3005,7 +3005,7 @@ unspecified.
     </a>
 </h3>
 
-<pre class="highlight"><code><span class='kd'>type</span> LoadBalancerTarget = <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='#LoadBalancerTargetInfo'>LoadBalancerTargetInfo</a>&gt; | <a href='#LoadBalancerTargetInfoProvider'>LoadBalancerTargetInfoProvider</a> | aws.ec2.Instance | aws.lambda.EventHandler&lt;x.apigateway.Request, x.apigateway.Response&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'>type</span> LoadBalancerTarget = <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='#LoadBalancerTargetInfo'>LoadBalancerTargetInfo</a>&gt; | <a href='#LoadBalancerTargetInfoProvider'>LoadBalancerTargetInfoProvider</a> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/ec2/#Instance'>aws.ec2.Instance</a> | <a href='/docs/reference/pkg/nodejs/pulumi/aws/lambda/#EventHandler'>aws.lambda.EventHandler</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/apigateway/#Request'>x.apigateway.Request</a>, <a href='/docs/reference/pkg/nodejs/pulumi/awsx/apigateway/#Response'>x.apigateway.Response</a>&gt;;</code></pre>
 
 The types of things that can be the target of a load balancer.
 
@@ -3056,7 +3056,7 @@ ECS container. If the target type is `ip`, specify an IP address. If the target 
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'></span>loadBalancerTargetInfo(targetType: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.TargetType&gt;): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='#LoadBalancerTargetInfo'>LoadBalancerTargetInfo</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>loadBalancerTargetInfo(targetType: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#TargetType'>mod.TargetType</a>&gt;): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Output'>pulumi.Output</a>&lt;<a href='#LoadBalancerTargetInfo'>LoadBalancerTargetInfo</a>&gt;</code></pre>
 
 <h3 class="pdoc-module-header" id="NetworkListener" data-link-title="NetworkListener">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L122">
@@ -3085,14 +3085,14 @@ for more details.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>addListenerRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: x.lb.ListenerRuleArgs, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#ListenerRule'>ListenerRule</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>addListenerRule(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerRuleArgs'>x.lb.ListenerRuleArgs</a>, opts?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResourceOptions'>pulumi.ComponentResourceOptions</a>): <a href='#ListenerRule'>ListenerRule</a></code></pre>
 
 <h4 class="pdoc-member-header" id="NetworkListener-attachTarget">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L109">method <b>attachTarget</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: mod.LoadBalancerTarget, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerTarget'>mod.LoadBalancerTarget</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
 
 
 Attaches a target to the `defaultTargetGroup` for this Listener.
@@ -3102,14 +3102,14 @@ Attaches a target to the `defaultTargetGroup` for this Listener.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt; | OutputInstance&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a> | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;<a href='#ContainerLoadBalancer'>ContainerLoadBalancer</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="NetworkListener-containerPortMapping">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L86">method <b>containerPortMapping</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): PortMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;PortMapping&gt; | OutputInstance&lt;PortMapping&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): PortMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;PortMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;PortMapping&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="NetworkListener-getProvider">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L122">method <b>getProvider</b></a>
@@ -3141,13 +3141,13 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>target(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;x.apigateway.IntegrationTarget&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>target(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, parent: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource'>pulumi.Resource</a>): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/apigateway/#IntegrationTarget'>x.apigateway.IntegrationTarget</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="NetworkListener-defaultTargetGroup">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L127">property <b>defaultTargetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>defaultTargetGroup?: x.lb.NetworkTargetGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>defaultTargetGroup?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#NetworkTargetGroup'>x.lb.NetworkTargetGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="NetworkListener-endpoint">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L37">property <b>endpoint</b></a>
 </h4>
@@ -3157,7 +3157,7 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/listener.ts#L33">property <b>listener</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>listener: aws.lb.Listener;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listener: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#Listener'>aws.lb.Listener</a>;</code></pre>
 <h4 class="pdoc-member-header" id="NetworkListener-loadBalancer">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L126">property <b>loadBalancer</b></a>
 </h4>
@@ -3194,7 +3194,7 @@ resource](https://www.terraform.io/docs/providers/aws/r/lb_listener_certificate.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L411">property <b>defaultAction</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>defaultAction?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.ListenerDefaultActionArgs&gt; | x.lb.ListenerDefaultAction;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>defaultAction?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultActionArgs'>mod.ListenerDefaultActionArgs</a>&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultAction'>x.lb.ListenerDefaultAction</a>;</code></pre>
 
 An Action block. If neither this nor [defaultActions] is provided, a suitable defaultAction
 will be chosen that forwards to a new [NetworkTargetGroup] created from [port].
@@ -3205,7 +3205,7 @@ Do not provide both [defaultAction] and [defaultActions].
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L420">property <b>defaultActions</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>defaultActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.ListenerDefaultActionArgs&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>defaultActions?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultActionArgs'>mod.ListenerDefaultActionArgs</a>&gt;[]&gt;;</code></pre>
 
 An list of Action blocks. If neither this nor [defaultAction] is provided, a suitable
 defaultAction will be chosen that forwards to a new [NetworkTargetGroup] created from
@@ -3260,7 +3260,7 @@ The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L380">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
 unspecified.
@@ -3339,12 +3339,12 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L23">property <b>loadBalancer</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: aws.lb.LoadBalancer;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>loadBalancer: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#LoadBalancer'>aws.lb.LoadBalancer</a>;</code></pre>
 <h4 class="pdoc-member-header" id="NetworkLoadBalancer-securityGroups">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L25">property <b>securityGroups</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>securityGroups: x.ec2.SecurityGroup[];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>securityGroups: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#SecurityGroup'>x.ec2.SecurityGroup</a>[];</code></pre>
 <h4 class="pdoc-member-header" id="NetworkLoadBalancer-targetGroups">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L29">property <b>targetGroups</b></a>
 </h4>
@@ -3363,7 +3363,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/loadBalancer.ts#L24">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="NetworkLoadBalancerArgs" data-link-title="NetworkLoadBalancerArgs">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L197">
         interface <strong>NetworkLoadBalancerArgs</strong>
@@ -3421,7 +3421,7 @@ LoadBalancer constructor will be hashed and used as the name.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L235">property <b>subnetMappings</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>subnetMappings?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[]&gt; | OutputInstance&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | OutputInstance&lt;LoadBalancerSubnetMapping&gt;[]&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>subnetMappings?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[] | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;LoadBalancerSubnetMapping&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;LoadBalancerSubnetMapping&gt;[]&gt;;</code></pre>
 
 A subnet mapping block as documented below.
 
@@ -3429,7 +3429,7 @@ A subnet mapping block as documented below.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L242">property <b>subnets</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>subnets?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt; | x.lb.LoadBalancerSubnets;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>subnets?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>&gt;[]&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerSubnets'>x.lb.LoadBalancerSubnets</a>;</code></pre>
 
 A list of subnet IDs to attach to the LB. Subnets cannot be updated for Load Balancers of
 type `network`. Changing this value for load balancers of type `network` will force a
@@ -3439,7 +3439,7 @@ recreation of the resource.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L247">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 A mapping of tags to assign to the resource.
 
@@ -3447,7 +3447,7 @@ A mapping of tags to assign to the resource.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L204">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
 unspecified.
@@ -3495,7 +3495,7 @@ for more details.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: mod.LoadBalancerTarget, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>attachTarget(name: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'>string</a></span>, args: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#LoadBalancerTarget'>mod.LoadBalancerTarget</a>, opts: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions'>pulumi.CustomResourceOptions</a>): <a href='#TargetGroupAttachment'>TargetGroupAttachment</a></code></pre>
 
 
 Attaches a target to this target group.  See
@@ -3507,14 +3507,14 @@ for more details.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;x.ecs.ContainerLoadBalancer&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerLoadBalancer(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#ContainerLoadBalancer'>x.ecs.ContainerLoadBalancer</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="NetworkTargetGroup-containerPortMapping">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L73">method <b>containerPortMapping</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.ecs.PortMapping&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>containerPortMapping(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/ecs/#PortMapping'>aws.ecs.PortMapping</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="NetworkTargetGroup-createListener">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L104">method <b>createListener</b></a>
@@ -3546,14 +3546,14 @@ multiple copies of the Pulumi SDK have been loaded into the same process.
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>listenerDefaultAction(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;mod.ListenerDefaultActionArgs&gt;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listenerDefaultAction(): <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#ListenerDefaultActionArgs'>mod.ListenerDefaultActionArgs</a>&gt;</code></pre>
 
 <h4 class="pdoc-member-header" id="NetworkTargetGroup-registerListener">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L94">method <b>registerListener</b></a>
 </h4>
 
 
-<pre class="highlight"><code><span class='kd'>public </span>registerListener(listener: x.lb.Listener): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>registerListener(listener: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#Listener'>x.lb.Listener</a>): <span class='kd'><a href='https://www.typescriptlang.org/docs/handbook/basic-types.html#void'>void</a></span></code></pre>
 
 
 Do not call directly.  Intended for use by [Listener] and [ListenerRule]
@@ -3569,7 +3569,7 @@ Do not call directly.  Intended for use by [Listener] and [ListenerRule]
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L81">property <b>listeners</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>listeners: x.lb.NetworkListener[];</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>listeners: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/lb/#NetworkListener'>x.lb.NetworkListener</a>[];</code></pre>
 <h4 class="pdoc-member-header" id="NetworkTargetGroup-loadBalancer">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L79">property <b>loadBalancer</b></a>
 </h4>
@@ -3579,7 +3579,7 @@ Do not call directly.  Intended for use by [Listener] and [ListenerRule]
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L31">property <b>targetGroup</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>targetGroup: aws.lb.TargetGroup;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>targetGroup: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lb/#TargetGroup'>aws.lb.TargetGroup</a>;</code></pre>
 <h4 class="pdoc-member-header" id="NetworkTargetGroup-urn">
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L78">property <b>urn</b></a>
 </h4>
@@ -3593,7 +3593,7 @@ deployments.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L32">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'>public </span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'>public </span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 <h3 class="pdoc-module-header" id="NetworkTargetGroupArgs" data-link-title="NetworkTargetGroupArgs">
     <a href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L291">
         interface <strong>NetworkTargetGroupArgs</strong>
@@ -3679,7 +3679,7 @@ requests. The range is 30-900 seconds or 0 to disable. The default value is 0 se
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L354">property <b>stickiness</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>stickiness?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TargetGroupStickiness | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TargetGroupStickiness&gt; | OutputInstance&lt;TargetGroupStickiness&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>stickiness?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TargetGroupStickiness | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TargetGroupStickiness&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TargetGroupStickiness&gt;;</code></pre>
 
 A Stickiness block. Stickiness blocks are documented below. `stickiness` is only valid if
 used with Load Balancers of type `Application`
@@ -3688,7 +3688,7 @@ used with Load Balancers of type `Application`
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L359">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 A mapping of tags to assign to the resource.
 
@@ -3712,7 +3712,7 @@ IP addresses.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/network.ts#L296">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc?: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc?: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
 unspecified.
@@ -3869,7 +3869,7 @@ requests. The range is 30-900 seconds or 0 to disable. The default value is 0 se
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L223">property <b>stickiness</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>stickiness?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TargetGroupStickiness | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TargetGroupStickiness&gt; | OutputInstance&lt;TargetGroupStickiness&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>stickiness?: <span class='kd'><a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined'>undefined</a></span> | TargetGroupStickiness | <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise'>Promise</a>&lt;TargetGroupStickiness&gt; | <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance'>OutputInstance</a>&lt;TargetGroupStickiness&gt;;</code></pre>
 
 A Stickiness block. Stickiness blocks are documented below. `stickiness` is only valid if
 used with Load Balancers of type `Application`
@@ -3878,7 +3878,7 @@ used with Load Balancers of type `Application`
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L228">property <b>tags</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;aws.Tags&gt;;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>tags?: <a href='/docs/reference/pkg/nodejs/pulumi/pulumi/#Input'>pulumi.Input</a>&lt;<a href='/docs/reference/pkg/nodejs/pulumi/aws/#Tags'>aws.Tags</a>&gt;;</code></pre>
 
 A mapping of tags to assign to the resource.
 
@@ -3901,7 +3901,7 @@ publicly routable IP addresses.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroup.ts#L175">property <b>vpc</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>vpc: x.ec2.Vpc;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>vpc: <a href='/docs/reference/pkg/nodejs/pulumi/awsx/ec2/#Vpc'>x.ec2.Vpc</a>;</code></pre>
 
 The vpc for this target group.
 
@@ -3924,7 +3924,7 @@ The Availability Zone where the IP address of the target is to be registered.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/lb/targetGroupAttachment.ts#L135">property <b>func</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>func?: aws.lambda.Function;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>func?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/lambda/#Function'>aws.lambda.Function</a>;</code></pre>
 
 Optional function this target group attachment targets.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/rds/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/rds/_index.md
@@ -808,7 +808,7 @@ Applies to: Aurora MySQL
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/rds/metrics.ts#L102">property <b>cluster</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>cluster?: aws.rds.Cluster;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>cluster?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/rds/#Cluster'>aws.rds.Cluster</a>;</code></pre>
 
 Optional [Cluster] to filter down events to.
 
@@ -865,7 +865,7 @@ to [undefined] then the value will be set to the default.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/rds/metrics.ts#L97">property <b>instance</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>instance?: aws.rds.Instance;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>instance?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/rds/#Instance'>aws.rds.Instance</a>;</code></pre>
 
 Optional [Instance] to filter down events to.
 
@@ -907,7 +907,7 @@ If this is provided then [cluster] must be provided as well.
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/rds/metrics.ts#L130">property <b>sourceRegion</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>sourceRegion?: aws.Region;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>sourceRegion?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/#Region'>aws.Region</a>;</code></pre>
 
 This dimension filters the data you request for the specified region only. For example,
 you can aggregate metrics for all instances in the region [us-east-1].

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/s3/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/s3/_index.md
@@ -370,7 +370,7 @@ Valid statistics: Sum
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/s3/metrics.ts#L33">property <b>bucket</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>bucket?: aws.s3.Bucket;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>bucket?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/s3/#Bucket'>aws.s3.Bucket</a>;</code></pre>
 
 Optional bucket to filter metrics down to.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/sns/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/sns/_index.md
@@ -325,7 +325,7 @@ property, then no change will be made.  However, if the property is there by set
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/sns/metrics.ts#L32">property <b>topic</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>topic?: aws.sns.Topic;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>topic?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/sns/#Topic'>aws.sns.Topic</a>;</code></pre>
 
 Optional topic to filter down to.
 

--- a/content/docs/reference/pkg/nodejs/pulumi/awsx/sqs/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/awsx/sqs/_index.md
@@ -288,7 +288,7 @@ to [undefined] then the value will be set to the default (300s).
 <a class="pdoc-child-name" href="https://github.com/pulumi/pulumi-awsx/blob/27592029c654cdf842eaee527e848a4f7ede759a/nodejs/awsx/sqs/metrics.ts#L31">property <b>queue</b></a>
 </h4>
 
-<pre class="highlight"><code><span class='kd'></span>queue?: aws.sqs.Queue;</code></pre>
+<pre class="highlight"><code><span class='kd'></span>queue?: <a href='/docs/reference/pkg/nodejs/pulumi/aws/sqs/#Queue'>aws.sqs.Queue</a>;</code></pre>
 
 Optional [Queue] to filter events down to.
 

--- a/content/docs/troubleshooting/_index.md
+++ b/content/docs/troubleshooting/_index.md
@@ -280,5 +280,5 @@ field once the Ingress resource is ready to route traffic.
 *Traefik*
 
 For the Traefik controller, verify that the `kubernetes.ingressEndpoint` config
-is [set properly](https://docs.traefik.io/configuration/backends/kubernetes/). This option was
+is [set properly](https://docs.traefik.io/providers/kubernetes-ingress/). This option was
 introduced in Traefik 1.7.0.

--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -1188,7 +1188,7 @@ func (e *emitter) typeHyperlink(t *typeDocType) string {
 					link = "/docs/reference/pkg/nodejs/pulumi/pulumi/"
 				} else if e.pkgname == "awsx" && elements[0] == "aws" {
 					link = "/docs/reference/pkg/nodejs/pulumi/aws/"
-				} else if e.pkgname == "awsx" && elements[0] == "x" {
+				} else if e.pkgname == "awsx" && (elements[0] == "x" || elements[0] == "awsx") {
 					link = "/docs/reference/pkg/nodejs/pulumi/awsx/"
 				} else if elements[0] == "inputs" || elements[0] == "inputApi" {
 					link = "/docs/reference/pkg/nodejs/pulumi/" + e.pkgname + "/types/input/"

--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -1115,6 +1115,13 @@ func (e *emitter) createCodeDetails(node *typeDocNode) string {
 	}
 }
 
+// @pulumi/awsx imports types within the same modules using the following.
+// We'll use this mapping to map the local import to the actual top-level exported module.
+var awsxImportModuleMap = map[string]string{
+	"ecs.": "ecs",
+	"mod.": "lb",
+}
+
 // typeHyperlink returns the hyperlink for help text associated with a given type, if available.
 func (e *emitter) typeHyperlink(t *typeDocType) string {
 	// Add a hyperlink for the type if possible.
@@ -1158,10 +1165,19 @@ func (e *emitter) typeHyperlink(t *typeDocType) string {
 				return fmt.Sprintf(
 					"/docs/reference/pkg/nodejs/pulumi/pulumi/asset/#%s", t.Name)
 			case "ComponentResource", "ComponentResourceOptions", "CustomResource", "CustomResourceOptions",
-				"ID", "Input", "Inputs", "InvokeOptions", "Output", "Outputs", "Resource", "ResourceOptions", "URN",
+				"ID", "Input", "Inputs", "InvokeOptions", "Output", "OutputInstance", "Outputs", "Resource", "ResourceOptions", "URN",
 				"ProviderResource":
 				return fmt.Sprintf(
 					"/docs/reference/pkg/nodejs/pulumi/pulumi/#%s", t.Name)
+			}
+
+			if e.pkgname == "awsx" {
+				for prefix, module := range awsxImportModuleMap {
+					if strings.HasPrefix(t.Name, prefix) {
+						name := strings.TrimPrefix(t.Name, prefix)
+						return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/awsx/%s/#%s", module, name)
+					}
+				}
 			}
 
 			// If this is a qualified name, see if it refers to the Pulumi SDK. If so, generate a link.
@@ -1170,6 +1186,10 @@ func (e *emitter) typeHyperlink(t *typeDocType) string {
 			if len(elements) > 1 {
 				if elements[0] == "pulumi" {
 					link = "/docs/reference/pkg/nodejs/pulumi/pulumi/"
+				} else if e.pkgname == "awsx" && elements[0] == "aws" {
+					link = "/docs/reference/pkg/nodejs/pulumi/aws/"
+				} else if e.pkgname == "awsx" && elements[0] == "x" {
+					link = "/docs/reference/pkg/nodejs/pulumi/awsx/"
 				} else if elements[0] == "inputs" || elements[0] == "inputApi" {
 					link = "/docs/reference/pkg/nodejs/pulumi/" + e.pkgname + "/types/input/"
 					// Strip out everything except first and last element.  This is necessary given


### PR DESCRIPTION
Improved linking within the library as well as now linking to `@pulumi/aws` types.

Fixes #1117