### PR TITLE
Move first time notice to the page where pulumi is first run

### DIFF
--- a/content/docs/get-started/aws/configure.md
+++ b/content/docs/get-started/aws/configure.md
@@ -20,6 +20,8 @@ If you have multiple AWS profiles set up, specify a different profile using one 
 * Set `AWS_PROFILE`as an <a href="{{< relref "/docs/intro/cloud-providers/aws/setup#environment-variables" >}}" target="_blank">environment variable</a>, or
 * Run `pulumi config set aws:profile <profilename>`. See <a href="{{< relref "/docs/intro/cloud-providers/aws#configuration" >}}" target="_blank">AWS Configuration</a> for more configuration options.
 
+> If this is your first time running `pulumi new` or most other `pulumi` commands, you will be prompted to log in to the [Pulumi service](https://app.pulumi.com). The [Pulumi CLI]({{< relref "/docs/reference/cli" >}}) works in tandem with the Pulumi service in order to deliver a reliable experience. It is free for individual use, with [additional features available for teams](https://www.pulumi.com/pricing/). Hitting `ENTER` at the prompt opens up a web browser allowing you to either sign in or sign up.
+
 Next, we'll create a new project.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -34,8 +34,6 @@ $ mkdir quickstart && cd quickstart
 $ pulumi new aws-python
 ```
 
-> If this is your first time running `pulumi new` or most other `pulumi` commands, you will be prompted to log in to the [Pulumi service](https://app.pulumi.com). The [Pulumi CLI]({{< relref "/docs/reference/cli" >}}) works in tandem with the Pulumi service in order to deliver a reliable experience. It is free for individual use, with [additional features available for teams](https://www.pulumi.com/pricing/). Hitting `ENTER` at the prompt opens up a web browser allowing you to either sign in or sign up.
-
 After logging in, the CLI will proceed with walking you through creating a new project.
 
 ```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Users are told to run `pulumi` on the config page but logins aren't talked about until the next page. I was confused by this so I thought I'd suggest moving it to the config page.

Might also be useful to put more information about features you get from logging in and if it's possible to use pulumi without logging in.

### Related issues (optional)

No issues. Just feedback from my personal experience going through the walkthrough.