### PR TITLE
Fix TOC active selection of "API Reference"

### DIFF
--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -4,8 +4,6 @@ menu:
   reference:
     name: Overview
     weight: 1
-
-toc_nochildren: true
 ---
 
 This section includes all reference documentation for Pulumi.

--- a/content/docs/troubleshooting/_index.md
+++ b/content/docs/troubleshooting/_index.md
@@ -5,8 +5,6 @@ menu:
     weight: 1
 
 aliases: ["/docs/reference/troubleshooting/"]
-
-toc_nochildren: true
 ---
 
 Pulumi tries very hard to ensure that your infrastructure is always in a known and predictable state.

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -34,7 +34,7 @@
         {{ $toggle_state := "toggle" }}
         {{ $sidenav_selected := "" }}
 
-        {{ if or (eq $page.RelPermalink .URL) (and (not .HasChildren) (hasPrefix $page.RelPermalink .URL) $page.Params.toc_nochildren) }}
+        {{ if or (eq $page.RelPermalink .URL) (and (not .HasChildren) (hasPrefix $page.RelPermalink .URL) (ne .Name "Overview") (ne .Name "Troubleshooting")) }}
             {{ $toggle_state = "toggleVisible" }}
             {{ $sidenav_selected = "active" }}
         {{ else if hasPrefix $page.RelPermalink .URL }}


### PR DESCRIPTION
When viewing an API doc page, the "API Reference" TOC item was no longer selected. Fix by reverting back to the way I was allowing this previously.