### PR TITLE
Fix HubSpot form styling

### DIFF
--- a/assets/sass/_hubspot.scss
+++ b/assets/sass/_hubspot.scss
@@ -14,7 +14,7 @@
         }
 
         .hs-input {
-            @apply block;
+            @apply block text-gray-700;
             width: 100% !important;
         }
 

--- a/layouts/migrate/terraform.html
+++ b/layouts/migrate/terraform.html
@@ -41,7 +41,9 @@
             </div>
             <div class="header-hero-item">
                 <h2 class="text-gray-300">Need help converting?</h2>
-                {{ partial "hubspot-form.html" (dict "hubspotFormID" "123cfbdb-9ce4-4d33-a9b7-c30302463d7a") }}
+                <div class="hs-form hs-form-fg-light">
+                    {{ partial "hubspot-form.html" (dict "hubspotFormID" "123cfbdb-9ce4-4d33-a9b7-c30302463d7a") }}
+                </div>
             </div>
         </div>
     </header>


### PR DESCRIPTION
This change applies an explicit font color for form fields, rather than allowing it to be inherited (which results in some form fields being non-visible).