### PR TITLE
Only offset anchors at medium and up

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -138,15 +138,17 @@ main {
 
 // This little trick prepends anchor targets with a pseudoelement that the browser picks
 // up as the anchor target, allowing us to position the actual target below the fixed
-// navbar.
-:target {
-    &::before {
-        content: " ";
-        display: block;
+// navbar. Only necessary at medium and up.
+@screen md {
+    :target {
+        &::before {
+            content: " ";
+            display: block;
 
-        // 106px is the navbar height (90px) plus a 16px offset for some vertical padding.
-        height: 106px;
-        margin-top: -106px;
+            // 106px is the navbar height (90px) plus a 16px offset for some vertical padding.
+            height: 106px;
+            margin-top: -106px;
+        }
     }
 }
 


### PR DESCRIPTION
Since we don't fix the navbar on mobile, we can let the browser do what it does by default there.