### PR TITLE
Exclude broken link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ test:
 		--exclude "https://www.googleapis.com/" \
 		--exclude "https://us-central1-/" \
 		--exclude "https://www.mysql.com/" \
-		--exclude "https://ksonnet.io/"
+		--exclude "https://ksonnet.io/" \
+		--exclude "https://www.latlong.net/"
 
 .PHONY: validate
 validate:


### PR DESCRIPTION
https://www.latlong.net/ is down (assuming it's just temporary). Since this link comes from a tutorial generated from an example, the simple fix is to just exclude it for now.