### PR TITLE
Add an exclusion for https://www.latlong.net/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ test:
 		--exclude "https://www.googleapis.com/" \
 		--exclude "https://us-central1-/" \
 		--exclude "https://www.mysql.com/" \
-		--exclude "https://ksonnet.io/"
+		--exclude "https://ksonnet.io/" \
+		--exclude "https://www.latlong.net/"
 
 .PHONY: validate
 validate:


### PR DESCRIPTION
Site is down and blocking merges.