### PR TITLE
Add the pricing page back to top nav

### DIFF
--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -3,4 +3,7 @@ title: Pricing
 meta_desc: Pulumi's open source infrastructure as code SDK and enterprise SaaS products together provide plans for teams of all sizes.
 type: page
 layout: pricing
+menu:		
+    header:		
+        weight: 3
 ---

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -5,5 +5,5 @@ type: page
 layout: pricing
 menu:		
     header:		
-        weight: 3
+        weight: 2
 ---


### PR DESCRIPTION
Add the "Pricing" tab back to the top nav.

<img width="1324" alt="image" src="https://user-images.githubusercontent.com/4029847/66099595-4a6e3800-e55c-11e9-9c1f-2daff6b88697.png">

Part of https://github.com/pulumi/home/issues/572.