### PR TITLE
Fix invalid bullet points in `stack init`

### DIFF
--- a/content/docs/reference/cli/pulumi_stack_init.md
+++ b/content/docs/reference/cli/pulumi_stack_init.md
@@ -22,9 +22,11 @@ provider and a stack created using the local or cloud object storage backend wil
 `--secrets-provider` flag.
 
 To use the `passphrase` secrets provider with the pulumi.com backend, use:
+
 * `pulumi stack init --secrets-provider=passphrase`
 
 To use a cloud secrets provider with any backend, use one of the following:
+
 * `pulumi stack init --secrets-provider="awskms://alias/ExampleAlias?region=us-east-1"`
 * `pulumi stack init --secrets-provider="awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1"`
 * `pulumi stack init --secrets-provider="azurekeyvault://mykeyvaultname.vault.azure.net/keys/mykeyname"`


### PR DESCRIPTION
Hi! I'm new to pulumi and started referencing the docs. Just found a part where it seems the bullet points aren't rendered correctly.

Wasn't sure how I can scan for other syntax mistakes, so here's a tiny fix for the `stack init` page.

### Proposed changes

This fixes the issue where the bullet points aren't rendered correctly
by hugo.

**Current(https://www.pulumi.com/docs/reference/cli/pulumi_stack_init/)**
![image](https://user-images.githubusercontent.com/3941889/66262928-c69aa100-e824-11e9-86e0-c6438544a23e.png)

**Fixed**
![image](https://user-images.githubusercontent.com/3941889/66262929-ce5a4580-e824-11e9-90e0-ab305182794d.png)

