### PR TITLE
Remove search-data from sitemap

### DIFF
--- a/content/docs/search-data.md
+++ b/content/docs/search-data.md
@@ -2,4 +2,5 @@
 layout: "search-data"
 outputs: ["json"]
 noindex: true
+private: true
 ---


### PR DESCRIPTION
This page is never published (it's used to generate the search index, and is deleted before publishing), so it should not be included in the site map.

https://github.com/pulumi/docs/blob/7096328b6b0ab93b6571e76929ae3e0b669b77f9/layouts/_default/sitemap.xml#L4

Fixes #1821