### PR TITLE
Exclude kubernetes-the-prod-way repo for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ test:
 		--exclude "https://www.mysql.com/" \
 		--exclude "https://ksonnet.io/" \
 		--exclude "https://www.latlong.net/" \
-		--exclude "https://media.amazonwebservices.com/architecturecenter/AWS_ac_ra_web_01.pdf"
+		--exclude "https://media.amazonwebservices.com/architecturecenter/AWS_ac_ra_web_01.pdf" \
+		--exclude "https://github.com/pulumi/kubernetes-the-prod-way/"
 
 .PHONY: validate
 validate:


### PR DESCRIPTION
The repo is going through some major restructuring this milestone, so we'll disable broken links in the old content for now until after the restructure.