### PR TITLE
Add <h1> tag to Blog tags template

### DIFF
--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -11,7 +11,7 @@
                 {{ $paginator := .Paginate .Data.Pages.ByDate.Reverse }}
 
                 <header>
-                    <h3 class="no-anchor">Posts Tagged {{ .Data.Term }}</h3>
+                    <h1 class="no-anchor">Posts Tagged {{ .Data.Term }}</h1>
                 </header>
 
                 {{ range $paginator.Pages }}


### PR DESCRIPTION
Saw "Missing or Invalid H1" from the list of Mozzarellas SEO recommendations. One class of error was that the "tags" pages for the block don't include an `<h1>` element on them. This PR fixes that.

This makes a small change in the display, so we could update the CSS to make the "Posts tagged with X" less noticeable, like it was before. But I'm inclined to err on the side of using the unmodified `<h1>` tag, so that it looks the same for the `<h1>` we included the author's page too.

https://www.pulumi.com/blog/tag/typescript/

Current:
<img width="769" alt="image" src="https://user-images.githubusercontent.com/4029847/66724106-64b6da00-edd6-11e9-97e8-c12669717097.png">

With change:
<img width="764" alt="image" src="https://user-images.githubusercontent.com/4029847/66724108-7ac49a80-edd6-11e9-9156-f24dbe59be58.png">

