### PR TITLE
Updated dependsOn syntax for python code to add resource in list

### DIFF
--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -241,7 +241,7 @@ let res2 = new MyResource("res2", {}, { dependsOn: [res1] });
 
 ```python
 res1 = MyResource("res1");
-res2 = MyResource("res2", opts=ResourceOptions(depends_on=res1));
+res2 = MyResource("res2", opts=ResourceOptions(depends_on=[res1]));
 ```
 
 ```go


### PR DESCRIPTION
### Proposed changes
Example give on dependsOn feature for Python code was wrong. It needs to be list or resources rather than a single resource. This PR corrects that.  

### Unreleased product version (optional)

### Related issues (optional)
