### PR TITLE
Add documentation for Pulumi 1.2 and 1.3 features

### DIFF
--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -372,7 +372,7 @@ vpc, _ := ec2.Vpc(ctx, "vpc", &VpcArgs{}, pulumi.ResourceOpt{Provider: provider}
 ```
 
 ###### `transformations`
-A list of transformations to apply to the resource and all it's children. This can be used to override or modify the inputs to child resources of a component, for example to add other resource options (like `ignoreChanges` or `protect`) or to modify an input property (like adding to `tags` or changing a property which is not configurable via the component directly).  Transformations can also be applied to all resources in a stack using `pulumi.runtime.registerStackTransformation`.  Transformations are passed the resource type, name, input properties resource options and the resource instance itself.  They can optionally return a new set of resource input properties and resource options which will be used to construct the resource.
+A list of transformations to apply to the resource and all of its children. This can be used to override or modify the inputs to child resources of a component, for example to add other resource options (like `ignoreChanges` or `protect`) or to modify an input property (like adding to `tags` or changing a property which is not configurable via the component directly).  Transformations can also be applied to all resources in a stack using `pulumi.runtime.registerStackTransformation`.  Transformations are passed the resource type, name, input properties resource options and the resource instance itself.  They can optionally return a new set of resource input properties and resource options which will be used to construct the resource.
 
 {{< langchoose >}}
 

--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -371,6 +371,57 @@ provider, _ := aws.Provider(ctx, "provider", { region: "us-west-2" });
 vpc, _ := ec2.Vpc(ctx, "vpc", &VpcArgs{}, pulumi.ResourceOpt{Provider: provider});
 ```
 
+###### `transformations`
+A list of transformations to apply to the resource and all it's children. This can be used to override or modify the inputs to child resources of a component, for example to add other resource options (like `ignoreChanges` or `protect`) or to modify an input property (like adding to `tags` or changing a property which is not configurable via the component directly).  Transformations can also be applied to all resources in a stack using `pulumi.runtime.registerStackTransformation`.  Transformations are passed the resource type, name, input properties resource options and the resource instance itself.  They can optionally return a new set of resource input properties and resource options which will be used to construct the resource.
+
+{{< langchoose >}}
+
+```javascript
+const vpc = new MyVpcComponent("vpc", {}, {
+    transformations: [args => {
+        if (args.type === "aws:ec2/vpc:Vpc" || args.type === "aws:ec2/subnet:Subnet") {
+            return {
+                props: args.props,
+                opts: pulumi.mergeOptions(args.opts, { ignoreChanges: ["tags"] })
+            }
+        }
+        return undefined;
+    }],
+});
+```
+
+```typescript
+const vpc = new MyVpcComponent("vpc", {}, {
+    transformations: [args => {
+        if (args.type === "aws:ec2/vpc:Vpc" || args.type === "aws:ec2/subnet:Subnet") {
+            return {
+                props: args.props,
+                opts: pulumi.mergeOptions(args.opts, { ignoreChanges: ["tags"] })
+            }
+        }
+        return undefined;
+    }],
+});
+```
+
+```python
+def transformation(args: ResourceTransformationArgs):
+    if args.type_ == "aws:ec2/vpc:Vpc" or args.type_ == "aws:ec2/subnet:Subnet":
+        return ResourceTransformationResult(
+            props=args.props,
+            opts=ResourceOptions.merge(args.opts, ResourceOptions(
+                ignore_changes=["tags"],
+            )))
+
+vpc = MyVpcComponent("vpc", opts=ResourceOptions(transformations=[transformation]))
+```
+
+```go
+// Transformations is not yet supported in Go.
+//
+// See https://github.com/pulumi/pulumi/issues/1614.
+```
+
 ### Resource names {#names}
 
 Every resource managed by Pulumi has a **logical name** that you specify as an argument to its constructor. For instance, the logical name of this IAM role is `my-role`:

--- a/content/docs/troubleshooting/_index.md
+++ b/content/docs/troubleshooting/_index.md
@@ -24,7 +24,7 @@ issues](https://github.com/pulumi/pulumi/issues/new) and upvoting existing issue
 ## Diagnosing Issues
 
 There are a few tools available to get additional diagnostics on how your Pulumi program is
-behaving.  These can be useful for self-diagnosing issues, and for sharing details of issues as part
+behaving.  These can be useful for self-diagnosing issues, and for sharing details as part
 of issue reports.
 
 ### Verbose Logging
@@ -55,8 +55,8 @@ $ TF_LOG=TRACE pulumi up --logtostderr -v=9 2> out.txt
 
 If you are seeing unexpectedly slow performance, you can gather a trace to understand what
 operations are being performed throughout the deployment and what the long poles are for your
-deployment.  In most cases, this will be the provisioning of one or more resources in your cloud
-provider.  But there may be cases where Pulumi itself is doing work that is limiting the performance
+deployment.  In most cases, the most time consuming operations will be the provisioning of one or more resources in your cloud
+provider, however, there may be cases where Pulumi itself is doing work that is limiting the performance
 of your deployments, and this may indicate an opportunity to further improve the Pulumi deployment
 orchestration engine to get the maximal parallelism and performance possible for your cloud
 deployment.

--- a/content/docs/troubleshooting/_index.md
+++ b/content/docs/troubleshooting/_index.md
@@ -17,6 +17,64 @@ First thing's first, we are always happy to hear from you and will try to help. 
 [join our Community Slack](https://slack.pulumi.com), where our whole team, in addition to a passionate
 community of users, are there to help out. Any and all questions are welcome!
 
+We also encourage everyone to contribute to the [Pulumi open source
+projects](https://github.com/pulumi) by [opening new
+issues](https://github.com/pulumi/pulumi/issues/new) and upvoting existing issues they care about.
+
+## Diagnosing Issues
+
+There are a few tools available to get additional diagnostics on how your Pulumi program is
+behaving.  These can be useful for self-diagnosing issues, and for sharing details of issues as part
+of issue reports.
+
+### Verbose Logging
+
+Verbose logging of the internals of the Pulumi engine and resource providers can be enabled by
+passing the `-v` flag to any `pulumi` CLI command. The `--logtostderr` flag can be added to send
+this verbose logging directly to `stderr` for easier access.  Pulumi emits logs at a variety of log
+levels between `1` and `9`.  
+
+> These logs may include sensitive information that is provided from your execution environment to
+your cloud provider (and which Pulumi may not even itself be aware of) so be careful to audit before
+sharing.
+
+```
+$ pulumi up --logtostderr -v=9 2> out.txt
+```
+
+Individual resource providers may also have additional flags to customize their diagnostic logging.
+For example, for any Pulumi resource providers that expose a Terraform resource provider into
+Pulumi, you can use [`TF_TRACE`](https://www.terraform.io/docs/internals/debugging.html) set to
+`TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`.
+
+```
+$ TF_LOG=TRACE pulumi up --logtostderr -v=9 2> out.txt
+```
+
+### Performance
+
+If you are seeing unexpectedly slow performance, you can gather a trace to understand what
+operations are being performed throughout the deployment and what the long poles are for your
+deployment.  In most cases, this will be the provisioning of one or more resources in your cloud
+provider.  But there may be cases where Pulumi itself is doing work that is limiting the performance
+of your deployments, and this may indicate an opportunity to further improve the Pulumi deployment
+orchestration engine to get the maximal parallelism and performance possible for your cloud
+deployment.
+
+To collect a trace:
+
+```
+$ pulumi up --tracing=file:./up.trace
+```
+
+To view a trace locally using [AppDash](https://github.com/sourcegraph/appdash):
+
+```
+$ PULUMI_DEBUG_COMMANDS=1 pulumi view-trace ~/Downloads/up.trace
+Displaying trace at http://localhost:8008
+```
+
+
 ## Common Problems
 
 This section covers a few problems that can arise when working with Pulumi.


### PR DESCRIPTION
Adds documentation for:
1. The `transformations` resource option
2. The `--trace` flag for capturing performance traces

As part of (2) also expanded the troubleshooting page with more
diagnostics tips.

Fixes #1910.
