### PR TITLE
Prevent header and carousel ide from overflowing page container

### DIFF
--- a/assets/sass/_carousel.scss
+++ b/assets/sass/_carousel.scss
@@ -1,37 +1,24 @@
 .homepage-carousel--container {
-	overflow: hidden;
-	.carousel-text--container {
-		height: 520px;
-		@media (min-width: 769px) and (max-width: 1030px) {
-			height: 365px;
-		}
-		@media (min-width: 600px) and (max-width: 768px) {
-			height: 440px;
-		}
-	}
-	@media (max-width: 1030px) {
-		max-width: 1023px;
-		padding: 0 25px;
-	}
-	@media (max-width: 1030px) {
-		.carousel-content--container {
-			display: flex;
-			flex-direction: column;
-			.carousel-text--container, .carousel-media--container {
-				width: 100%;
-			}
-			.carousel-text--container {
-				@include order(9999);
-			}
-			.carousel-media--container {
-				@include order(-9999);
-			}
-		}
+	@apply max-w-5xl;
+	@screen md {
+		max-width: 1280px;
 	}
 	@media (max-width: 390px) {
-		padding: 0;
+		@apply p-0;
 		.carousel-ide {
-			font-size: 11px;
+			@include font-size(11px);
+		}
+	}
+	.carousel-text--container {
+		height: 520px;
+		@screen sm {
+			height: 440px;
+		}
+		@screen md {
+			height: 365px;
+		}
+		@screen lg {
+			height: 520px;
 		}
 	}
 	.home-carousel-ide--popup-group {
@@ -43,12 +30,12 @@
 			.ide-popup--container {
 				width: 292px;
 			}
-			@media (min-width: 1030px) and (max-width: 1280px) {
+			@screen md {
+				top: 38px;
+			}
+			@screen lg {
 				top: 25px;
 				left: 115px;
-			}
-			@media (min-width: 769px) and (max-width: 1029px) {
-				top: 38px;
 			}
 			@media (max-width: 768px) {
 				top: 40px;
@@ -72,18 +59,18 @@
 	.home-carousel-cli--text-container {
 		height: 400px;
 		@media (max-width: 500px) {
-			font-size: 10px;
+			@include font-size(10px);
 		}
 		@media (max-width: 430px) {
-			font-size: 8px;
+			@include font-size(8px);
 		}
 	}
 	.home-carousel--console-content {
 		@media (max-width: 480px) {
-			font-size: 9px;
+			@include font-size(9px);
 		}
 		@media (max-width: 380px) {
-			font-size: 8px;
+			@include font-size(8px);
 		}
 	}
 }

--- a/assets/sass/_carousel.scss
+++ b/assets/sass/_carousel.scss
@@ -1,21 +1,89 @@
 .homepage-carousel--container {
 	overflow: hidden;
+	.carousel-text--container {
+		height: 520px;
+		@media (min-width: 769px) and (max-width: 1030px) {
+			height: 365px;
+		}
+		@media (min-width: 600px) and (max-width: 768px) {
+			height: 440px;
+		}
+	}
 	@media (max-width: 1030px) {
 		max-width: 1023px;
 		padding: 0 25px;
 	}
 	@media (max-width: 1030px) {
 		.carousel-content--container {
+			display: flex;
 			flex-direction: column;
-
 			.carousel-text--container, .carousel-media--container {
 				width: 100%;
 			}
+			.carousel-text--container {
+				@include order(9999);
+			}
+			.carousel-media--container {
+				@include order(-9999);
+			}
 		}
 	}
-	@media (max-width: 530px) {
-		.carousel-text--container {
-			margin-bottom: 15px;
+	@media (max-width: 390px) {
+		padding: 0;
+		.carousel-ide {
+			font-size: 11px;
+		}
+	}
+	.home-carousel-ide--popup-group {
+		top: -6px;
+		left: 188px;
+		.home-carousel-ide--details-popup {
+			top: 40px;
+			left: 198px;
+			.ide-popup--container {
+				width: 292px;
+			}
+			@media (min-width: 1030px) and (max-width: 1280px) {
+				top: 25px;
+				left: 115px;
+			}
+			@media (min-width: 769px) and (max-width: 1029px) {
+				top: 38px;
+			}
+			@media (max-width: 768px) {
+				top: 40px;
+				left: -70px;
+			}
+			@media (max-width: 630px) {
+				left: 55px;
+			}
+			@media (max-width: 450px) {
+				left: 5px;
+				.ide-popup--container {
+					width: 260px;
+				}
+			}
+		}
+		@media (max-width: 630px) {
+			top: -2px;
+			left: 0;
+		}
+	}
+	.home-carousel-cli--text-container {
+		height: 400px;
+		@media (max-width: 500px) {
+			font-size: 10px;
+		}
+		@media (max-width: 430px) {
+			font-size: 8px;
+		}
+	}
+	.home-carousel--console-content {
+		@media (max-width: 480px) {
+			font-size: 9px;
+		}
+		@media (max-width: 380px) {
+			font-size: 8px;
 		}
 	}
 }

--- a/assets/sass/_carousel.scss
+++ b/assets/sass/_carousel.scss
@@ -1,0 +1,21 @@
+.homepage-carousel--container {
+	overflow: hidden;
+	@media (max-width: 1030px) {
+		max-width: 1023px;
+		padding: 0 25px;
+	}
+	@media (max-width: 1030px) {
+		.carousel-content--container {
+			flex-direction: column;
+
+			.carousel-text--container, .carousel-media--container {
+				width: 100%;
+			}
+		}
+	}
+	@media (max-width: 530px) {
+		.carousel-text--container {
+			margin-bottom: 15px;
+		}
+	}
+}

--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -1,3 +1,8 @@
+@function calculateRem($size) {
+	$remSize: $size / 16px;
+	@return #{$remSize}rem;
+}
+
 @mixin transition($scope: all, $duration: 100ms, $fn: linear) {
     transition: $scope $duration $fn;
 }
@@ -6,10 +11,7 @@
     background-image: radial-gradient($radius at $center-x $center-y, $from-color, $to-color);
 }
 
-@mixin order($number) {
-	-webkit-box-ordinal-group: $number;
-	-moz-box-ordinal-group: $number;
-	-ms-flex-order: $number;
-	-webkit-order: $number;
-	order: $number;
+@mixin font-size($size) {
+	font-size: $size;
+	font-size: calculateRem($size);
 }

--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -5,3 +5,11 @@
 @mixin bg-gradient($from-color, $to-color, $radius, $center-x: 50%, $center-y: 50%) {
     background-image: radial-gradient($radius at $center-x $center-y, $from-color, $to-color);
 }
+
+@mixin order($number) {
+	-webkit-box-ordinal-group: $number;
+	-moz-box-ordinal-group: $number;
+	-ms-flex-order: $number;
+	-webkit-order: $number;
+	order: $number;
+}

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -10,6 +10,7 @@
 @import "badges";
 @import "breadcrumb";
 @import "buttons";
+@import "carousel";
 @import "chooser";
 @import "code";
 @import "copy-button";

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,7 +25,7 @@
 
 {{ define "main" }}
     <section class="pb-16 px-4 md:px-0" style="background: linear-gradient(#ffffff 50%, #f5fbff 100%);">
-        <div class="container mx-auto text-center">
+        <div class="container mx-auto text-center homepage-carousel--container">
 
             <!-- Carousel -->
             {{ partial "carousel" . }}

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -15,10 +15,10 @@
     </div>
 </div>
 
-<div class="sm:flex md:flex items-start carousel-content--container">
+<div class="flex flex-col px-6 items-start overflow-hidden md:mx-auto lg:flex-row lg:px-5 carousel-content--container">
 
     <!-- Left side -->
-    <div class="text-left md:w-2/5 relative carousel-text--container">
+    <div class="text-left order-last w-full relative lg:w-2/5 lg:order-none carousel-text--container">
         <div class="carousel-item-description opacity-0 transition-all absolute md:pr-10">
 
             <div class="text-4xl text-purple-700 leading-snug mt-6 mr-8" style="text-shadow: 0px 0px 12px #e2e8f0;">
@@ -188,7 +188,7 @@
     </div>
 
     <!-- Right side -->
-    <div id="carousel" class="md:w-3/5 carousel-media--container">
+    <div id="carousel" class="order-first w-full lg:w-3/5 lg:order-none carousel-media--container">
 
         <div class="relative p-10" style="height: 440px;">
 

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -15,10 +15,10 @@
     </div>
 </div>
 
-<div class="md:flex items-start carousel-content--container">
+<div class="sm:flex md:flex items-start carousel-content--container">
 
     <!-- Left side -->
-    <div class="text-left md:w-2/5 relative carousel-text--container" style="height: 520px;">
+    <div class="text-left md:w-2/5 relative carousel-text--container">
         <div class="carousel-item-description opacity-0 transition-all absolute md:pr-10">
 
             <div class="text-4xl text-purple-700 leading-snug mt-6 mr-8" style="text-shadow: 0px 0px 12px #e2e8f0;">
@@ -190,7 +190,7 @@
     <!-- Right side -->
     <div id="carousel" class="md:w-3/5 carousel-media--container">
 
-        <div class="relative p-10" style="height: 520px;">
+        <div class="relative p-10" style="height: 440px;">
 
             <!-- IDE -->
             <div class="carousel-item opacity-1 absolute top-0 right-0 left-0 transition-all-200 text-xs shadow-xl">

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -15,10 +15,10 @@
     </div>
 </div>
 
-<div class="md:flex items-start">
+<div class="md:flex items-start carousel-content--container">
 
     <!-- Left side -->
-    <div class="text-left md:w-1/2 relative" style="height: 520px;">
+    <div class="text-left md:w-2/5 relative carousel-text--container" style="height: 520px;">
         <div class="carousel-item-description opacity-0 transition-all absolute md:pr-10">
 
             <div class="text-4xl text-purple-700 leading-snug mt-6 mr-8" style="text-shadow: 0px 0px 12px #e2e8f0;">
@@ -188,7 +188,7 @@
     </div>
 
     <!-- Right side -->
-    <div id="carousel" class="md:w-1/2">
+    <div id="carousel" class="md:w-3/5 carousel-media--container">
 
         <div class="relative p-10" style="height: 520px;">
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,7 +15,7 @@
     <nav class="nav-main bg-purple-700 py-6 px-4 lg:px-0 border-t border-purple-500">
         <div class="container mx-auto">
             <header class="flex items-center justify-between flex-wrap md:flex-no-wrap">
-                <div class="flex items-center flex-shrink-0 text-white lg:mr-6">
+                <div class="flex items-center flex-shrink-0 text-white md:mx-1 lg:mr-6">
                     <a class="block" href="/">
                         <img class="h-10 block" src="/images/logo/logo-inv.svg" alt="Pulumi logo">
                     </a>
@@ -31,7 +31,7 @@
                     {{ range $.Site.Menus.header }}
                         <li class="whitespace-no-wrap">
                             {{ $active := hasPrefix $.RelPermalink .URL }}
-                            <a href="{{ .URL }}" data-submenu="{{ .Identifier }}" class="block py-2 px-4 md:px-0 md:py-0 md:px-4 md:py-2 my-2 md:my-0 lg:mx-4 rounded {{ if $active }}bg-purple-400 hover:bg-purple-400{{ else }}hover:bg-purple-500{{ end }}">
+                            <a href="{{ .URL }}" data-submenu="{{ .Identifier }}" class="block py-2 px-4 md:px-0 md:py-0 md:px-2 md:py-2 my-2 md:my-0 lg:mx-2 xl:mx-4 rounded {{ if $active }}bg-purple-400 hover:bg-purple-400{{ else }}hover:bg-purple-500{{ end }}">
                                 {{ .Name }}
                             </a>
                         </li>

--- a/layouts/partials/home/cli.html
+++ b/layouts/partials/home/cli.html
@@ -6,7 +6,7 @@
             <div class="bg-green-600 rounded-full h-3 w-3"></div>
         </div>
     </div>
-    <div class="bg-gray-900 rounded-b text-gray-100 font-mono p-4 overflow-x-scroll md:overflow-x-visible" style="height: 400px;">
+    <div class="bg-gray-900 rounded-b text-gray-100 font-mono p-4 overflow-x-scroll md:overflow-x-visible home-carousel-cli--text-container">
         <span class="text-green-400">&rarr;</span>
         <span class="line typed">
             <span>pulumi up</span>

--- a/layouts/partials/home/console.html
+++ b/layouts/partials/home/console.html
@@ -43,7 +43,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="bg-gray-900 rounded mt-4 text-xs px-4 py-2 font-mono">
+                    <div class="bg-gray-900 rounded mt-4 text-xs px-4 py-2 font-mono home-carousel--console-content">
                         <small>
                             <div class="text-purple-200 my-2">Changes:</div>
                             <div><pre class="overflow-x-hidden bg-transparent border-none p-0 m-0 text-blue-500">    Type                 Name                Status</pre></div>
@@ -66,7 +66,7 @@
                         <li class="my-0 mx-3 px-2 py-3 border-b-2 border-purple-500"><span>Resources</span></li>
                     </ul>
                 </div>
-                <div class="py-4 px-4 text-xs">
+                <div class="py-4 px-4 text-xs home-carousel--console-content">
                     <div class="bg-white p-4 rounded shadow">
                         <div class="flex items-center font-mono border-b border-gray-200 pb-5 mb-5">
                             <div class="w-6"><i class="fas fa-cloud text-purple-600"></i></div>

--- a/layouts/partials/home/ide.html
+++ b/layouts/partials/home/ide.html
@@ -1,4 +1,4 @@
-<div id="carousel-ide" class="text-left">
+<div id="carousel-ide" class="text-left carousel-ide">
     <div class="bg-gray-400 rounded-t border-r-2 border-gray-500">
         <div class="flex p-2">
             <div class="bg-red-600 rounded-full h-3 w-3"></div>
@@ -43,34 +43,36 @@
                     </div>
                 </div>
                 <div class="relative" style="top: -6px; left: 188px;">
-                    <div class="menu opacity-0 absolute">
-                        <div class="bg-gray-800 p-1 text-white border border-gray-600 w-64 shadow">
-                            <div class="row bg-gray-600 px-2">AccountPublicAccessBlock</div>
-                            <div class="row px-2">Bucket</div>
-                            <div class="row px-2">BucketEventSubscription</div>
-                            <div class="row px-2">BucketMetric</div>
-                            <div class="row px-2">BucketNotification</div>
-                            <div class="row px-2">BucketObject</div>
+                    <div class="relative">
+                        <div class="menu opacity-0 absolute">
+                            <div class="bg-gray-800 p-1 text-white border border-gray-600 w-64 shadow">
+                                <div class="row bg-gray-600 px-2">AccountPublicAccessBlock</div>
+                                <div class="row px-2">Bucket</div>
+                                <div class="row px-2">BucketEventSubscription</div>
+                                <div class="row px-2">BucketMetric</div>
+                                <div class="row px-2">BucketNotification</div>
+                                <div class="row px-2">BucketObject</div>
+                            </div>
                         </div>
-                    </div>
-                    <div class="menu opacity-0 absolute" data-delay="1200" style="top: 14px;left: 198px;">
-                        <div class="bg-gray-800 p-1 shadow text-white border border-gray-600 whitespace-normal" style="width: 292px;">
-                            <div class="font-sans">
-                                <div class="mb-2">Create a Bucket resource with the given unique name, arguments, and options.</div>
-                                <div>
-                                    <span class="text-blue-400">@param</span>
-                                    <span class="font-mono bg-gray-800 text-orange-200">name</span>
-                                    <span>The <em>unique</em> name of the resource.</span>
-                                </div>
-                                <div>
-                                    <span class="text-blue-400">@param</span>
-                                    <span class="font-mono bg-gray-800 text-orange-200">args</span>
-                                    <span>The arguments to use to populate this resource's properties.</span>
-                                </div>
-                                <div>
-                                    <span class="text-blue-400">@param</span>
-                                    <span class="font-mono bg-gray-800 text-orange-200">opts</span>
-                                    <span>A bag of options that control this resource's behavior.</span>
+                        <div class="menu opacity-0 absolute" data-delay="1200" style="top: 14px;left: 198px;">
+                            <div class="bg-gray-800 p-1 shadow text-white border border-gray-600 whitespace-normal" style="width: 292px;">
+                                <div class="font-sans">
+                                    <div class="mb-2">Create a Bucket resource with the given unique name, arguments, and options.</div>
+                                    <div>
+                                        <span class="text-blue-400">@param</span>
+                                        <span class="font-mono bg-gray-800 text-orange-200">name</span>
+                                        <span>The <em>unique</em> name of the resource.</span>
+                                    </div>
+                                    <div>
+                                        <span class="text-blue-400">@param</span>
+                                        <span class="font-mono bg-gray-800 text-orange-200">args</span>
+                                        <span>The arguments to use to populate this resource's properties.</span>
+                                    </div>
+                                    <div>
+                                        <span class="text-blue-400">@param</span>
+                                        <span class="font-mono bg-gray-800 text-orange-200">opts</span>
+                                        <span>A bag of options that control this resource's behavior.</span>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/layouts/partials/home/ide.html
+++ b/layouts/partials/home/ide.html
@@ -42,7 +42,7 @@
                         <span class="text-green-300"><span>aws</span><span class="text-white">.</span><span class="text-green-300">s3</span><span class="text-white">.</span></span>
                     </div>
                 </div>
-                <div class="relative" style="top: -6px; left: 188px;">
+                <div class="relative home-carousel-ide--popup-group">
                     <div class="relative">
                         <div class="menu opacity-0 absolute">
                             <div class="bg-gray-800 p-1 text-white border border-gray-600 w-64 shadow">
@@ -54,8 +54,8 @@
                                 <div class="row px-2">BucketObject</div>
                             </div>
                         </div>
-                        <div class="menu opacity-0 absolute" data-delay="1200" style="top: 14px;left: 198px;">
-                            <div class="bg-gray-800 p-1 shadow text-white border border-gray-600 whitespace-normal" style="width: 292px;">
+                        <div class="menu opacity-0 absolute home-carousel-ide--details-popup" data-delay="1200">
+                            <div class="bg-gray-800 p-1 shadow text-white border border-gray-600 whitespace-normal ide-popup--container">
                                 <div class="font-sans">
                                     <div class="mb-2">Create a Bucket resource with the given unique name, arguments, and options.</div>
                                     <div>


### PR DESCRIPTION
The IDE in the home page carousel was causing a white gap to appear on the right side of the site when the screen was smaller than ~1300px in width. The header was also spilling over the page container.

<img width="1065" alt="ideGap" src="https://user-images.githubusercontent.com/15146337/68322511-5a57cb00-0078-11ea-9af5-d6a699cdd4e8.png">
<img width="364" alt="whitegap" src="https://user-images.githubusercontent.com/15146337/68784380-4fa9b280-05f1-11ea-83a8-b05c0c404580.png">


This also includes some alignment and responsive fixes for the actual carousel elements. Some of the "popups" and text were getting cut off and/or lost their alignment as the screen got smaller. I also flipped the text and media of the carousel section when the screen gets smaller to avoid content jumping around as much when the carousel changes.

