### PR TITLE
Display the docs TOC at the bottom of the page on mobile

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -2,20 +2,6 @@
     <div class="container mx-auto px-8 py-8 md:px-0 mt-2">
         <div class="md:flex">
 
-            <div class="md:w-2/12 pl-8 mt-2 md:order-last">
-                <div class="mb-8 md:mb-4">
-                    {{ partial "docs/search.html" . }}
-                </div>
-
-                <div class="ml-2 hidden md:block">
-                    {{ partial "docs/right-nav.html" . }}
-                </div>
-            </div>
-
-            <div class="md:w-3/12 pr-8 mt-2 mb-8 pb-8 border-b-2 border-gray-400 md:border-none md:pb-0 md:mb-0">
-                {{ partial "docs/toc.html" . }}
-            </div>
-
             <div class="md:w-7/12">
                 {{ partial "docs/breadcrumb.html" . }}
 
@@ -24,6 +10,20 @@
                 {{ end }}
 
                 {{ .Content }}
+            </div>
+
+            <div class="md:w-2/12 md:pl-8 mt-2">
+                <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
+                    {{ partial "docs/search.html" . }}
+                </div>
+
+                <div class="ml-2 hidden md:block">
+                    {{ partial "docs/right-nav.html" . }}
+                </div>
+            </div>
+
+            <div class="md:w-3/12 pr-8 mb-2 pt-8 md:order-first md:border-none md:pt-0 md:mt-0">
+                {{ partial "docs/toc.html" . }}
             </div>
         </div>
     </div>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -2,20 +2,6 @@
     <div class="container mx-auto px-8 py-8 md:px-0 mt-2">
         <div class="md:flex">
 
-            <div class="md:w-2/12 pl-8 mt-2 md:order-last">
-                <div class="mb-8 md:mb-4">
-                    {{ partial "docs/search.html" . }}
-                </div>
-
-                <div class="ml-2 hidden md:block">
-                    {{ partial "docs/right-nav.html" . }}
-                </div>
-            </div>
-
-            <div class="md:w-3/12 pr-8 mt-2 mb-8 pb-8 border-b-2 border-gray-400 md:border-none md:pb-0 md:mb-0">
-                {{ partial "docs/toc.html" . }}
-            </div>
-
             <div class="md:w-7/12">
                 {{ partial "docs/breadcrumb.html" . }}
 
@@ -24,6 +10,20 @@
                 {{ end }}
 
                 {{ .Content }}
+            </div>
+
+            <div class="md:w-2/12 md:pl-8 mt-2">
+                <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
+                    {{ partial "docs/search.html" . }}
+                </div>
+
+                <div class="ml-2 hidden md:block">
+                    {{ partial "docs/right-nav.html" . }}
+                </div>
+            </div>
+
+            <div class="md:w-3/12 pr-8 mb-2 pt-8 md:order-first md:border-none md:pt-0 md:mt-0">
+                {{ partial "docs/toc.html" . }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Right now, on small (mobile) displays, we show the TOC at the top of the page. This forces you to scroll down to get to the actual content. Instead, move the TOC to the bottom of the page on mobile so the actual content is front-and-center at the top.

Here's before/after looking at the .NET page.

## Before

<img width="402" alt="Screen Shot 2019-11-07 at 7 48 50 AM" src="https://user-images.githubusercontent.com/710598/68404352-3f965c80-0133-11ea-8035-c4f742adcad7.png">


You have to scroll down to get to the actual content:

<img width="438" alt="Screen Shot 2019-11-07 at 7 49 44 AM" src="https://user-images.githubusercontent.com/710598/68404302-2c838c80-0133-11ea-8748-98165e39a0d1.png">


## After

<img width="405" alt="Screen Shot 2019-11-07 at 7 48 56 AM" src="https://user-images.githubusercontent.com/710598/68404240-15449f00-0133-11ea-882e-47a3cd91fc1b.png">

And then scrolling to the bottom to see the TOC:

<img width="427" alt="Screen Shot 2019-11-07 at 7 49 31 AM" src="https://user-images.githubusercontent.com/710598/68404277-2392bb00-0133-11ea-9328-211695ec02cc.png">

Note: I considered adding a toggle button (like we do for the blog's sidebar) and also moving the breadcrumb to the bottom of the page, but that will require some more rejiggering. I think this is a good enough improvement as-is.