### PR TITLE
Remove unnecessary CLI note from configure step

### DIFF
--- a/content/docs/get-started/aws/configure.md
+++ b/content/docs/get-started/aws/configure.md
@@ -16,10 +16,7 @@ aliases: ["/docs/quickstart/aws/configure/"]
 If you have multiple AWS profiles set up, specify a different profile using one of the following ways:
 
 * Set `AWS_PROFILE`as an <a href="{{< relref "/docs/intro/cloud-providers/aws/setup#environment-variables" >}}" target="_blank">environment variable</a>, or
-* Run `pulumi config set aws:profile <profilename>`. See <a href="{{< relref "/docs/intro/cloud-providers/aws#configuration" >}}" target="_blank">AWS Configuration</a> for more configuration options.
-
-{{< cli-note >}}
-
+* After creating your project in the next step, run `pulumi config set aws:profile <profilename>`. See <a href="{{< relref "/docs/intro/cloud-providers/aws#configuration" >}}" target="_blank">AWS Configuration</a> for more configuration options.
 
 Next, we'll create a new project.
 

--- a/content/docs/get-started/azure/configure.md
+++ b/content/docs/get-started/azure/configure.md
@@ -13,8 +13,6 @@ aliases: ["/docs/quickstart/azure/configure/"]
 
 <a href="{{< relref "/docs/intro/cloud-providers/azure/setup.md" >}}" target="_blank">Configure Azure</a> so the Pulumi CLI can connect to Azure. If you have previously configured the <a href="https://docs.microsoft.com/en-us/cli/azure/" target="_blank">Azure CLI</a>, `az`, Pulumi will respect and use your configuration settings.
 
-{{< cli-note >}}
-
 Next, we'll create a new project.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/configure.md
+++ b/content/docs/get-started/gcp/configure.md
@@ -13,8 +13,6 @@ aliases: ["/docs/quickstart/gcp/configure/"]
 
 <a href="{{< relref "/docs/intro/cloud-providers/gcp/setup.md" >}}" target="_blank">Configure Google Cloud</a> so the Pulumi CLI can connect to Google Cloud. If you have previously configured the <a href="https://cloud.google.com/sdk/gcloud/" target="_blank">Google Cloud CLI</a>, `gcloud`, Pulumi will respect and use your configuration settings.
 
-{{< cli-note >}}
-
 Next, we'll create a new project.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/kubernetes/configure.md
+++ b/content/docs/get-started/kubernetes/configure.md
@@ -13,8 +13,6 @@ aliases: ["/docs/quickstart/kubernetes/configure/"]
 
 <a href="{{< relref "/docs/intro/cloud-providers/kubernetes/setup.md" >}}" target="_blank">Configure Kubernetes</a> so the Pulumi CLI can connect to a Kubernetes cluster. If you have previously configured the <a href="https://kubernetes.io/docs/reference/kubectl/overview/" target="_blank">kubectl CLI</a>, `kubectl`, Pulumi will respect and use your configuration settings.
 
-{{< cli-note >}}
-
 Next, we'll create a new project.
 
 {{< get-started-stepper >}}


### PR DESCRIPTION
Presumably this was added because some of the more detailed instructions in the linked pages mention using `pulumi config`, but those commands should happen after running `pulumi new`, and at that point the user would have already been prompted about logging-in. So there's no need to include this note.

Fixes #1947