### PR TITLE
Fix the C# getting started guides

### DIFF
--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -90,25 +90,25 @@ pulumi.export('bucket_name',  bucket.id)
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Pulumi;
-using Pulumi.Aws.Kms;
-using Pulumi.Aws.S3;
+using Aws = Pulumi.Aws;
 
 class Program
 {
-    static Task Main() =>
-        Deployment.Run(() =>
+    static Task Main()
+    {
+        return Deployment.RunAsync(() =>
         {
             // Create a KMS Key for S3 server-side encryption
-            var key = new Kms.Key('my-key');
+            var key = new Aws.Kms.Key("my-key");
 
             // Create an AWS resource (S3 Bucket)
-            var bucket = new S3.Bucket('my-bucket', new S3.BucketArgs
+            var bucket = new Aws.S3.Bucket("my-bucket", new Aws.S3.BucketArgs
             {
-                ServerSideEncryptionConfiguration = new S3.BucketServerSideEncryptionConfigurationArgs
+                ServerSideEncryptionConfiguration = new Aws.S3.Inputs.BucketServerSideEncryptionConfigurationArgs
                 {
-                    Rules = new S3.BucketServerSideEncryptionConfigurationRuleArgs
+                    Rule = new Aws.S3.Inputs.BucketServerSideEncryptionConfigurationRuleArgs
                     {
-                        ApplyServerSideEncryptionByDefault = new S3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs
+                        ApplyServerSideEncryptionByDefault = new Aws.S3.Inputs.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs
                         {
                             SseAlgorithm = "aws:kms",
                             KmsMasterKeyId = key.Id,
@@ -118,8 +118,11 @@ class Program
             });
 
             // Export the name of the bucket
-            return new Dictionary<string, object> { { "bucket_name", bucket.Id } };
+            return new Dictionary<string, object> {
+                { "bucket_name", bucket.Id },
+            };
         });
+    }
 }
 ```
 

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -61,14 +61,18 @@ using Pulumi.Aws.S3;
 
 class Program
 {
-    static Task Main() =>
-        Deployment.Run(() => {
+    static Task Main()
+    {
+        return Deployment.RunAsync(() => {
             // Create an AWS resource (S3 Bucket)
-            var bucket = S3.Bucket('my-bucket');
+            var bucket = new Bucket("my-bucket");
 
             // Export the name of the bucket
-            return new Dictionary<string, object> { { "bucket_name" , bucket.Id } };
+            return new Dictionary<string, object> {
+                { "bucket_name" , bucket.Id },
+            };
         });
+    }
 }
 ```
 

--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -75,13 +75,13 @@ pulumi.export('connection_string', account.primary_connection_string)
 ```csharp
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Pulumi;
-using Pulumi.Azure;
+using Azure = Pulumi.Azure;
 
 class Program
 {
-    static Task Main() =>
-        Deployment.Run(() => {
+    static Task Main()
+    {
+        return Deployment.RunAsync(() => {
             // Create an Azure Resource Group
             var resourceGroup = new Azure.Core.ResourceGroup("resourceGroup");
 
@@ -95,8 +95,11 @@ class Program
             });
 
             // Export the connection string for the storage account
-            return new Dictionary<string, object> { { "connectionString", account.PrimaryConnectionString } };
+            return new Dictionary<string, object> {
+                { "connectionString", account.PrimaryConnectionString },
+            };
         });
+    }
 }
 ```
 

--- a/content/docs/get-started/azure/review-project.md
+++ b/content/docs/get-started/azure/review-project.md
@@ -79,8 +79,9 @@ using Pulumi.Azure;
 
 class Program
 {
-    static Task Main() =>
-        Deployment.Run(() => {
+    static Task Main()
+    {
+        return Deployment.RunAsync(() => {
             // Create an Azure Resource Group
             var resourceGroup = new Azure.Core.ResourceGroup("resourceGroup");
 
@@ -93,8 +94,11 @@ class Program
             });
 
             // Export the connection string for the storage account
-            return new Dictionary<string, object> { { "connectionString", account.PrimaryConnectionString } };
+            return new Dictionary<string, object> {
+                { "connectionString", account.PrimaryConnectionString },
+            };
         });
+    }
 }
 ```
 

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -89,15 +89,16 @@ pulumi.export('bucket_name',  bucket.url)
 ```csharp
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Pulumi;
-using Pulumi.Gcp;
+using Gcp = Pulumi.Gcp;
 
 class Program
 {
-    static Task Main() =>
-        Deployment.Run(() =>
+    static Task Main()
+    {
+        return Deployment.RunAsync(() =>
         {
-            // Let's create a customer managed key and use that for encryption instead of the default Google-managed key.
+            // Let's create a customer managed key and use that for encryption
+            // instead of the default Google-managed key.
             var keyRing = new Gcp.Kms.KeyRing("my-keyring", new Gcp.Kms.KeyRingArgs
             {
                 Location = "global",
@@ -112,15 +113,18 @@ class Program
             // Create a GCP resource (Storage Bucket)
             var bucket = new Gcp.Storage.Bucket("my-bucket", new Gcp.Storage.BucketArgs
             {
-                Encryption = new Gcp.Storage.BucketEncryptionArgs
+                Encryption = new Gcp.Storage.Inputs.BucketEncryptionArgs
                 {
                     DefaultKmsKeyName = cryptoKey.SelfLink,
                 },
             });
 
             // Export the DNS name of the bucket
-            return new Dictionary<string, object> { { "bucketName", bucket.Url } };
+            return new Dictionary<string, object> {
+                { "bucketName", bucket.Url },
+            };
         });
+    }
 }
 ```
 

--- a/content/docs/get-started/gcp/review-project.md
+++ b/content/docs/get-started/gcp/review-project.md
@@ -59,15 +59,19 @@ using Pulumi.Gcp.Storage;
 
 class Program
 {
-    static Task Main() =>
-        Deployment.Run(() =>
+    static Task Main()
+    {
+        return Deployment.RunAsync(() =>
         {
             // Create a GCP resource (Storage Bucket)
             var bucket = new Storage.Bucket("my-bucket");
 
             // Export the DNS name of the bucket
-            return new Dictionary<string, object> { { "bucket_name", bucket.Url } };
+            return new Dictionary<string, object> {
+                { "bucket_name", bucket.Url },
+            };
         });
+    }
 }
 ```
 


### PR DESCRIPTION
These guides didn't actually compiled. I guess the APIs may have
changed since writing them, but there were also syntax issues --
like using single quotes instead of doubles -- and semantic
issues -- like referring to incorrect types given the way the
using statements have been laid out. I've verified these compile.
