### PR TITLE
Fix compile errors in CSharp quickstarts.

### DIFF
--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -75,6 +75,7 @@ pulumi.export('connection_string', account.primary_connection_string)
 ```csharp
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Pulumi;
 using Azure = Pulumi.Azure;
 
 class Program

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -89,6 +89,7 @@ pulumi.export('bucket_name',  bucket.url)
 ```csharp
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Pulumi;
 using Gcp = Pulumi.Gcp;
 
 class Program


### PR DESCRIPTION
I verified the other quickstarts - AWS compiles successfully, Kubernetes doesn't have dotnet suppport yet.