### PR TITLE
Fix logo stretch on Safari

### DIFF
--- a/layouts/crosswalk/kubernetes.html
+++ b/layouts/crosswalk/kubernetes.html
@@ -63,7 +63,7 @@
     <section id="case-study" class="bg-gray-200 py-16 px-4 md:px-0">
         <div class="container mx-auto text-center px-4 md:px-0">
             <div class="flex justify-center mb-4">
-                <img class="md:max-w-sm" src="/logos/customers/credijusto_logo.png" alt="Credijusto">
+                <img class="h-20" src="/logos/customers/credijusto_logo.png" alt="Credijusto">
             </div>
             <blockquote class="border-orange-500 italic text-gray-800 mb-8 max-w-5xl mx-auto">
                 Pulumi enables our teams to deploy, scale and manage Kubernetes clusters in a


### PR DESCRIPTION
### Before

Large screen

<img width="1745" alt="Screen Shot 2019-11-14 at 8 13 51 AM" src="https://user-images.githubusercontent.com/710598/68874832-b2b14d00-06b6-11ea-8af4-538dfc5187d9.png">

Small screen (mobile)

<img width="499" alt="Screen Shot 2019-11-14 at 8 14 25 AM" src="https://user-images.githubusercontent.com/710598/68874877-c78de080-06b6-11ea-8f77-286e4862914f.png">

### After

Large screen

<img width="1637" alt="Screen Shot 2019-11-14 at 8 15 11 AM" src="https://user-images.githubusercontent.com/710598/68874950-e2605500-06b6-11ea-8409-cafc40dba661.png">

Small screen (mobile)

<img width="502" alt="Screen Shot 2019-11-14 at 8 14 47 AM" src="https://user-images.githubusercontent.com/710598/68874914-d379a280-06b6-11ea-9cfd-bdb23308f0b3.png">
