### PR TITLE
PaC doc updates for Pulumi 1.5.2

### DIFF
--- a/content/docs/get-started/policy-as-code/authoring-a-policy-pack.md
+++ b/content/docs/get-started/policy-as-code/authoring-a-policy-pack.md
@@ -9,16 +9,22 @@ menu:
 ---
 {{% pac-preview %}}
 
+1. Verify your version of the Pulumi CLI
+
+    ```sh
+    $ pulumi version # should be v1.5.2 or later
+    ```
+
 1. Create a directory for your new Policy Pack, and change into it.
 
     ```sh
     $ mkdir policypack && cd policypack
     ```
 
-1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_DEBUG_COMMANDS=true` as an environment variable or simply pre-append it to your commands as shown. (Note: Pulumi 1.4.1 or later is required to use `pulumi policy new` command.)
+1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_EXPERIMENTAL=true` as an environment variable or simply pre-append it to your commands as shown.
 
     ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy new aws-typescript
+    $ PULUMI_EXPERIMENTAL=true pulumi policy new aws-typescript
     Created Policy Pack!
     Installing dependencies...
     ...
@@ -26,10 +32,10 @@ menu:
 
     Your new Policy Pack is ready to go! ✨
 
-    Once you're done editing your Policy Pack, run `pulumi policy publish <org-name>/<policy-pack-name>` to publish the pack.
+    Once you're done editing your Policy Pack, run `pulumi policy publish [org-name]` to publish the pack.
     ```
 
-2. Tweak the Policy Pack in the `index.ts` file as desired. The existing policy in the template (which is annotated below) mandates that an AWS S3 bucket not have public read or write permissions enabled. Each Policy must have a unique name, an enforcement level, and a validation function. Here we use `validateTypedResource` that allows us to validate S3 Bucket resources.
+1. Tweak the Policy Pack in the `index.ts` file as desired. The existing policy in the template (which is annotated below) mandates that an AWS S3 bucket not have public read or write permissions enabled. Each Policy must have a unique name, an enforcement level, and a validation function. Here we use `validateTypedResource` that allows us to validate S3 Bucket resources.
 
     ```typescript
     // Create a new Policy Pack.
@@ -74,13 +80,13 @@ Policy Packs can be tested on a user’s local workstation to facilitate rapid d
     In the Pulumi project's directory run:
 
     ```sh
-    PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack <path-to-policy-pack-directory>
+    $ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack <path-to-policy-pack-directory>
     ```
 
     If the stack is in compliance, we expect the output to simply tell us which Policy Packs were run.
 
     {{< highlight sh >}}
-$ PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack policy-pack-typescript
+$ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack policy-pack-typescript
 Previewing update (dev):
 
      Type                 Name          Plan
@@ -105,7 +111,7 @@ Permalink:
 1. We then run the `pulumi preview` command again and this time get an error message indicating we failed the preview because of a policy violation.
 
     {{< highlight sh >}}
-$ PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack ~/policy-pack-typescript
+$ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack ~/policy-pack-typescript
 Previewing update (dev):
 
      Type                 Name          Plan       Info

--- a/content/docs/get-started/policy-as-code/enforcing-a-policy-pack.md
+++ b/content/docs/get-started/policy-as-code/enforcing-a-policy-pack.md
@@ -14,32 +14,34 @@ Once you’ve validated the behavior of your policies, an organization administr
 1. From within the Policy Pack directory, run the following command to publish your pack:
 
     ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy publish <org-name>/<policy-pack-name>
+    $ PULUMI_EXPERIMENTAL=true pulumi policy publish [org-name]
     ```
+
+    The `[org-name]` is optional. If not specified, the pack will be published to your user account.
 
     The `<policy-pack-name>` is the name you’d like to see used to reference the pack in the Pulumi Console.
 
     The output will tell you what version of the Policy Pack you just published. The Pulumi service provides a monotonic version number for Policy Packs.
 
     ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy publish pulumi/policy-pack-typescript
+    $ PULUMI_EXPERIMENTAL=true pulumi policy publish myorg
     Obtaining policy metadata from policy plugin
     Compressing policy pack
     Uploading policy pack to Pulumi service
-    Publishing as policy-pack-typescript
+    Publishing policy-pack-typescript to myorg
     Published as version 1
     ```
 
 1. You can apply this Policy Pack to your organization’s default Policy Group by running:
 
     ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy apply <organization>/<policy-pack-name> <version>
+    $ PULUMI_EXPERIMENTAL=true pulumi policy apply <org-name>/<policy-pack-name> <version>
     ```
 
     For example, to apply the Policy Pack created in the previous step:
 
     ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy apply pulumi/policy-pack-typescript 1
+    $ PULUMI_EXPERIMENTAL=true pulumi policy apply pulumi/policy-pack-typescript 1
     ```
 
     The CLI can only be used to apply the Policy Pack to your default Policy Group. If you would like to add the Policy Pack to a different Policy Group, you can do so via the Pulumi Console.


### PR DESCRIPTION
Let's just recommend using 1.5.2. And while `PULUMI_DEBUG_COMMANDS` still works, let's recommend the preferred `PULUMI_EXPERIMENTAL` be used instead.