### PR TITLE
Revert back to PULUMI_DEBUG_COMMANDS for PaC commands

### DIFF
--- a/content/docs/get-started/policy-as-code/authoring-a-policy-pack.md
+++ b/content/docs/get-started/policy-as-code/authoring-a-policy-pack.md
@@ -21,10 +21,10 @@ menu:
     $ mkdir policypack && cd policypack
     ```
 
-1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_EXPERIMENTAL=true` as an environment variable or simply pre-append it to your commands as shown.
+1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_DEBUG_COMMANDS=true` as an environment variable or simply pre-append it to your commands as shown.
 
     ```sh
-    $ PULUMI_EXPERIMENTAL=true pulumi policy new aws-typescript
+    $ PULUMI_DEBUG_COMMANDS=true pulumi policy new aws-typescript
     Created Policy Pack!
     Installing dependencies...
     ...
@@ -80,13 +80,13 @@ Policy Packs can be tested on a user’s local workstation to facilitate rapid d
     In the Pulumi project's directory run:
 
     ```sh
-    $ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack <path-to-policy-pack-directory>
+    $ PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack <path-to-policy-pack-directory>
     ```
 
     If the stack is in compliance, we expect the output to simply tell us which Policy Packs were run.
 
     {{< highlight sh >}}
-$ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack policy-pack-typescript
+$ PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack policy-pack-typescript
 Previewing update (dev):
 
      Type                 Name          Plan
@@ -111,7 +111,7 @@ Permalink:
 1. We then run the `pulumi preview` command again and this time get an error message indicating we failed the preview because of a policy violation.
 
     {{< highlight sh >}}
-$ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack ~/policy-pack-typescript
+$ PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack ~/policy-pack-typescript
 Previewing update (dev):
 
      Type                 Name          Plan       Info

--- a/content/docs/get-started/policy-as-code/enforcing-a-policy-pack.md
+++ b/content/docs/get-started/policy-as-code/enforcing-a-policy-pack.md
@@ -14,7 +14,7 @@ Once you’ve validated the behavior of your policies, an organization administr
 1. From within the Policy Pack directory, run the following command to publish your pack:
 
     ```sh
-    $ PULUMI_EXPERIMENTAL=true pulumi policy publish [org-name]
+    $ PULUMI_DEBUG_COMMANDS=true pulumi policy publish [org-name]
     ```
 
     The `[org-name]` is optional. If not specified, the pack will be published to your user account.
@@ -24,7 +24,7 @@ Once you’ve validated the behavior of your policies, an organization administr
     The output will tell you what version of the Policy Pack you just published. The Pulumi service provides a monotonic version number for Policy Packs.
 
     ```sh
-    $ PULUMI_EXPERIMENTAL=true pulumi policy publish myorg
+    $ PULUMI_DEBUG_COMMANDS=true pulumi policy publish myorg
     Obtaining policy metadata from policy plugin
     Compressing policy pack
     Uploading policy pack to Pulumi service
@@ -35,13 +35,13 @@ Once you’ve validated the behavior of your policies, an organization administr
 1. You can apply this Policy Pack to your organization’s default Policy Group by running:
 
     ```sh
-    $ PULUMI_EXPERIMENTAL=true pulumi policy apply <org-name>/<policy-pack-name> <version>
+    $ PULUMI_DEBUG_COMMANDS=true pulumi policy apply <org-name>/<policy-pack-name> <version>
     ```
 
     For example, to apply the Policy Pack created in the previous step:
 
     ```sh
-    $ PULUMI_EXPERIMENTAL=true pulumi policy apply pulumi/policy-pack-typescript 1
+    $ PULUMI_DEBUG_COMMANDS=true pulumi policy apply pulumi/policy-pack-typescript 1
     ```
 
     The CLI can only be used to apply the Policy Pack to your default Policy Group. If you would like to add the Policy Pack to a different Policy Group, you can do so via the Pulumi Console.


### PR DESCRIPTION
We missed updating the `--policy-pack` flag to work with `PULUMI_EXPERIMENTAL`, so just go back to showing `PULUMI_DEBUG_COMMANDS` for now.