### PR TITLE
Use relref for links to /kubernetes

### DIFF
--- a/content/blog/how-do-kubernetes-deployments-work-an-adversarial-perspective/index.md
+++ b/content/blog/how-do-kubernetes-deployments-work-an-adversarial-perspective/index.md
@@ -147,5 +147,5 @@ field with the Kubernetes `Watch` API and a bit of terminal UI
 programming, you're most of your way to `kubespy trace deployment`.
 
 If you enjoyed this post, or are curious to see how this lifecycle is
-baked into the Pulumi CLI, please [give us a shot](/kubernetes)!
+baked into the Pulumi CLI, please [give us a shot]({{< relref "/topics/kubernetes" >}})!
 We'd love to hear your feedback.

--- a/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
+++ b/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
@@ -138,7 +138,7 @@ use.
 If you'd like to go deeper on certain topics, here are some additional
 resources to check out:
 
-- [Overview of Pulumi Kubernetes Scenarios](/kubernetes)
+- [Overview of Pulumi Kubernetes Scenarios]({{< relref "/topics/kubernetes" >}})
 - Tutorial: Create a Kubernetes cluster on a cloud provider
   [Amazon EKS]({{< ref "/docs/tutorials/kubernetes/eks" >}}),
   [Google GKE]({{< ref "/docs/tutorials/kubernetes/gke" >}}), or

--- a/content/blog/improving-kubernetes-management-with-pulumis-await-logic/index.md
+++ b/content/blog/improving-kubernetes-management-with-pulumis-await-logic/index.md
@@ -116,7 +116,7 @@ use.
 If you'd like to go deeper on certain topics, here are some additional
 resources to check out:
 
-- [Overview of Pulumi Kubernetes Scenarios](/kubernetes)
+- [Overview of Pulumi Kubernetes Scenarios]({{< relref "/topics/kubernetes" >}})
 - Tutorial: Create a Kubernetes cluster on a cloud provider
   [Amazon EKS]({{< ref "/docs/tutorials/kubernetes/eks" >}}),
   [Google GKE]({{< ref "/docs/tutorials/kubernetes/gke" >}}), or

--- a/content/blog/kubespy-and-the-lifecycle-of-a-kubernetes-pod-in-four-images/index.md
+++ b/content/blog/kubespy-and-the-lifecycle-of-a-kubernetes-pod-in-four-images/index.md
@@ -113,5 +113,5 @@ practices we've accumulated, and describe how we solved the problem of
 repeatable `Pod` deployments in Pulumi.
 
 If you enjoyed this post, or are curious to see how this lifecycle is
-baked into the Pulumi CLI, [give us a shot](/kubernetes)!
+baked into the Pulumi CLI, [give us a shot]({{< relref "/topics/kubernetes" >}})!
 We'd love to have your feedback.

--- a/content/blog/kubespy-trace-a-real-time-view-into-the-heart-of-a-kubernetes-service/index.md
+++ b/content/blog/kubespy-trace-a-real-time-view-into-the-heart-of-a-kubernetes-service/index.md
@@ -63,7 +63,7 @@ One of our major goals in this work was to make deploying an application
 to Kubernetes as simple as possible, by presenting a concise summary of
 this information in the CLI experience. See
 [my tweetstorm](https://twitter.com/hausdorff_space/status/1039940379301179392)
-on the subject, or [try it out](/kubernetes) for
+on the subject, or [try it out]({{< relref "/topics/kubernetes" >}}) for
 yourself!
 
 ![status-rich](./status-rich.gif)
@@ -135,5 +135,5 @@ enough tools to really dig into what is happening when you roll out your
 app.
 
 In the mean time, if you enjoyed this post, or are curious to see how
-this lifecycle is baked into the Pulumi CLI, [give it a spin](/kubernetes)!
+this lifecycle is baked into the Pulumi CLI, [give it a spin]({{< relref "/topics/kubernetes" >}})!
 We'd love to have your feedback.

--- a/content/blog/meet-the-pulumi-team-at-aws-reinvent/index.md
+++ b/content/blog/meet-the-pulumi-team-at-aws-reinvent/index.md
@@ -15,7 +15,7 @@ Whatever the reason, the Pulumi team will be there all week at **Booth
 [AWS and Pulumi]({{< ref "/crosswalk/aws" >}}).
 
 Catch up with us on serverless functions, [containers]({{< ref "/containers" >}}) and
-[Kubernetes](/kubernetes), managed services and
+[Kubernetes]({{< relref "/topics/kubernetes" >}}), managed services and
 any other cloud native infrastructure as code, and see how you can more
 productively manage your AWS cloud resources with general purpose
 programming languages. We can even help you

--- a/content/blog/pulumi-a-better-way-to-kubernetes/index.md
+++ b/content/blog/pulumi-a-better-way-to-kubernetes/index.md
@@ -20,7 +20,7 @@ resources in addition to Kubernetes ones.
 In this post, we will see how [Pulumi](/) can help you
 tame these issues and make Kubernetes more accessible, using familiar
 languages and your favorite tools. It's simply
-[Kubernetes made easy](/kubernetes)!
+[Kubernetes made easy]({{< relref "/topics/kubernetes" >}})!
 <!--more-->
 
 ## Clusters as code

--- a/content/blog/using-helm-and-pulumi-to-define-cloud-native-infrastructure-as-code/index.md
+++ b/content/blog/using-helm-and-pulumi-to-define-cloud-native-infrastructure-as-code/index.md
@@ -116,5 +116,5 @@ the friction caused by multiple deployment tools and models across
 complex architectures.
 
 - Find out more about our [Azure]({{< ref "/azure" >}}) and
-  [Kubernetes](/kubernetes) support
+  [Kubernetes]({{< relref "/topics/kubernetes" >}}) support
 - Join the Slack community at <https://slack.pulumi.com> 


### PR DESCRIPTION
We were previously using `{{< ref "/kubernetes" >}}`, but that recently started failing with errors like:

```
ERROR 2019/11/15 15:39:25 [en] REF_NOT_FOUND: Ref "/kubernetes": "/Users/justin/go/src/github.com/pulumi/docs/content/blog/how-do-kubernetes-deployments-work-an-adversarial-perspective/index.md:150:52": failed to resolve ref: page reference "kubernetes" is ambiguous
ERROR 2019/11/15 15:39:29 [en] REF_NOT_FOUND: Ref "/kubernetes": "/Users/justin/go/src/github.com/pulumi/docs/content/blog/how-do-kubernetes-deployments-work-an-adversarial-perspective/index.md:150:52": failed to resolve ref: page reference "kubernetes" is ambiguous
```

I didn't dig into why it started happening recently, but we weren't referring to the content page correctly. It should be `"/topics/kubernetes.md"` (though, the `.md` isn't necessary) as that's where the content page actually lives (though, it will be emitted at `/kubernetes` when the site is generated since the page has a `url: /kubernetes` front matter property, and Hugo's `relref` will do the right thing and output the URL as `/kubernetes/`).