### PR TITLE
Add link tracking script and apply it home page links

### DIFF
--- a/assets/js/tracking.js
+++ b/assets/js/tracking.js
@@ -1,0 +1,54 @@
+/*
+ * Function for registering tracking to a link. To add tracking to a link you
+ * need to have an "id" attritube on the <a> element and the "track-click" attribute.
+ *
+ *   - ex. <a id="get-started-no-yaml" class="btn" href="/docs/get-started" track-click>GET STARTED</a>
+ */
+$(document).ready(function() {
+    // Check if the analytics object and track function are available. If they are
+    // not we do not even want to attempt to track anything.
+    if (window && window.analytics && typeof window.analytics.track === "function") {
+
+        // Find all the links with a "track-click" attribute.
+        const links = $("a[track-click]");
+
+        // Get the current date/time so we can track time from page load to user click.
+        const now = new Date().getTime();
+
+        function registerTracker(element) {
+            // Create the tracking object.
+            const trackingData = {
+                // The id of the element.
+                element_id: $(element).attr("id"),
+                // The destination url of the link.
+                destinationPath: $(element).attr("href"),
+                // The current path.
+                url: window.location.pathname,
+                // The Google Analytic Event Values. These values are pushed into GA
+                // specifically. More info: https://support.google.com/analytics/answer/1033068#Anatomy
+                category: "User Interaction",
+                label: $(element).attr("id"),
+            }
+
+            // Register a listener to the link to send data to Segment
+            // when it has been clicked.
+            $(element).on("click", function(e) {
+                // The value is the time in seconds from page load to user action.
+                trackingData.value = ((new Date().getTime()) - now) / 1000;
+                window.analytics.track("link-click", trackingData);
+            });
+        }
+
+        // Loop over the array of elements to register the click listeners.
+        for (var i = 0; i < links.length; i++) {
+            registerTracker(links[i]);
+        }
+
+        // Remove the event listeners when we navigate to a new page.
+        $(window).on("unload", function() {
+            for (var i = 0; i < links.length; i++) {
+                $(link[i]).off("click");
+            }
+        });
+    }
+});

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,13 +11,13 @@
                 {{ .Params.subhead | markdownify }}
             </p>
             <div class="mt-6">
-                <a href="{{ relref . "/docs/get-started" }}" class="btn bg-purple-300 hover:bg-purple-200 border-none px-8 py-4 transition-all text-sm rounded-full uppercase shadow-lg" title="Create your first project with Pulumi">
+                <a id="home-hero-cta" href="{{ relref . "/docs/get-started" }}" class="btn bg-purple-300 hover:bg-purple-200 border-none px-8 py-4 transition-all text-sm rounded-full uppercase shadow-lg" title="Create your first project with Pulumi" track-click>
                     Get Started
                 </a>
             </div>
             <div class="mt-8 text-sm text-purple-100">
-                Pulumi is <a class="text-white hover:underline" href="{{ relref . "/pricing#community-edition" }}">free</a>
-                and <a class="text-white hover:underline" href="https://github.com/pulumi/pulumi" target="_blank">open source</a>.
+                Pulumi is <a id="home-hero-pricing" class="text-white hover:underline" href="{{ relref . "/pricing#community-edition" }}" track-click>free</a>
+                and <a id="home-hero-github" class="text-white hover:underline" href="https://github.com/pulumi/pulumi" target="_blank" track-click>open source</a>.
             </div>
         </div>
     </header>
@@ -39,7 +39,7 @@
                     {{ (index .Params.ctas 0) | markdownify }}
                 </div>
                 <div class="inline-flex items-center">
-                    <a class="btn group w-40 md:ml-4 text-left pl-6 py-3 rounded-lg" href="{{ relref . "/docs/get-started" }}" title="Create your first project with Pulumi">
+                    <a id="carousel-get-started" class="btn group w-40 md:ml-4 text-left pl-6 py-3 rounded-lg" href="{{ relref . "/docs/get-started" }}" title="Create your first project with Pulumi" track-click>
                         <span>Get Started</span>
                         <span class="pl-1 group-hover:pl-2 transition-all">&rarr;</span>
                     </a>
@@ -108,33 +108,33 @@
     <section class="mb-16 px-4 md:px-0">
         <div class="container mx-auto">
             <div class="lg:flex items-center justify-center my-4">
-                <a href="https://www.tableau.com/" target="_blank">
+                <a id="tableau-logo" href="https://www.tableau.com/" target="_blank" track-click>
                     <img class="mx-auto lg:mx-8 h-12 mx-8" src="/logos/customers/tableau_logo.png" alt="Tableau Software" title="Tableau Software">
                 </a>
-                <a href="https://mbrdna.com/" target="_blank">
+                <a href="https://mbrdna.com/" target="_blank" track-click>
                     <img class="mx-auto lg:mx-8 mt-8 mb-4 lg:my-0 h-12 mx-8" src="/logos/customers/mercedes-benz-RDNA_logo.png" title="Mercedes-Benz Research and Development" alt="Mercedes-Benz Research and Development">
                 </a>
-                <a href="https://www.mindbodyonline.com/" target="_blank">
+                <a href="https://www.mindbodyonline.com/" target="_blank" track-click>
                     <img class="mx-auto lg:mx-8 h-16 mx-8" src="/logos/customers/mindbody_logo.svg" alt="MindBody" title="MindBody">
                 </a>
-                <a href="https://www.nih.gov/" target="_blank">
+                <a href="https://www.nih.gov/" target="_blank" track-click>
                     <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-10 mx-8" src="/logos/customers/nih.png" alt="National Institutes of Health" title="National Institutes of Health">
                 </a>
             </div>
-            <div class="lg:flex items-center justify-center my-4">
+            <div class="lg:flex items-center justify-center my-4" track-click>
                 <a href="https://www.linio.com/" target="_blank">
                     <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/linio_logo.png" alt="Linio" title="Linio">
                 </a>
-                <a href="https://www.cockroachlabs.com/" target="_blank">
+                <a id="cockroach-labs-logo" href="https://www.cockroachlabs.com/" target="_blank" track-click>
                     <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/cockroach-labs_logo.png" alt="Cockroach Labs" title="Cockroach Labs">
                 </a>
-                <a href="https://www.sourcegraph.com/" target="_blank">
+                <a id="sourcegraph-logo" href="https://www.sourcegraph.com/" target="_blank" track-click>
                     <img class="mx-auto my-8 md:my-0 lg:mx-8 h-6 mx-8" src="/logos/customers/sourcegraph_logo.png" alt="Sourcegraph" title="Sourcegraph">
                 </a>
-                <a href="https://www.snopes.com/" target="_blank">
+                <a id="snopes-logo" href="https://www.snopes.com/" target="_blank" track-click>
                     <img class="mx-auto my-8 md:my-0 lg:mx-8 h-10 mx-8" src="/logos/customers/snopes_logo.png" alt="Snopes" title="Snopes">
                 </a>
-                <a href="https://www.lemonade.com/" target="_blank">
+                <a id="lemonade-logo" href="https://www.lemonade.com/" target="_blank" track-click>
                     <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-8 mx-8" src="/logos/customers/lemonade.svg" alt="Lemonade" title="Lemonade">
                 </a>
             </div>
@@ -151,7 +151,7 @@
                     {{ (index .Params.articles 0).label }}
                 </div>
                 <h3 class="mt-2">
-                    <a class="text-blue-700 hover:text-blue-500" href="{{ relref . (index .Params.articles 0).url }}">
+                    <a id="article-{{ (index .Params.articles 0).title }}" class="text-blue-700 hover:text-blue-500" href="{{ relref . (index .Params.articles 0).url }}" track-click>
                         {{ (index .Params.articles 0).title }}
                     </a>
                 </h3>
@@ -159,7 +159,7 @@
                     {{ (index .Params.articles 0).summary | markdownify }}
                 </p>
                 <p class="text-blue-500">
-                    <a href="{{ relref . (index .Params.articles 0).url }}" class="hover:mr-1 transition-all">Read on</a> &rarr;
+                    <a id="article-{{ (index .Params.articles 0).title }}-read-on" href="{{ relref . (index .Params.articles 0).url }}" class="hover:mr-1 transition-all" track-click>Read on</a> &rarr;
                 </p>
             </article>
             <article class="md:w-1/3 md:mx-8 my-12 md:my-0 py-12 md:py-0 border-t border-b border-gray-200 md:border-none">
@@ -167,7 +167,7 @@
                     {{ (index .Params.articles 1).label }}
                 </div>
                 <h3 class="mt-2">
-                    <a class="text-blue-700 hover:text-blue-500" href="{{ relref . (index .Params.articles 1).url }}">
+                    <a id="article-{{ (index .Params.articles 1).title }}" class="text-blue-700 hover:text-blue-500" href="{{ relref . (index .Params.articles 1).url }}" track-click>
                         {{ (index .Params.articles 1).title }}
                     </a>
                 </h3>
@@ -175,7 +175,7 @@
                     {{ (index .Params.articles 1).summary | markdownify }}
                 </p>
                 <p class="text-blue-500">
-                    <a href="{{ relref . (index .Params.articles 1).url }}" class="hover:mr-1 transition-all">Read on</a> &rarr;
+                    <a id="article-{{ (index .Params.articles 1).title }}-read-on" href="{{ relref . (index .Params.articles 1).url }}" class="hover:mr-1 transition-all" track-click>Read on</a> &rarr;
                 </p>
             </article>
             <article class="md:w-1/3">
@@ -183,7 +183,7 @@
                     {{ (index .Params.articles 2).label }}
                 </div>
                 <h3 class="mt-2">
-                    <a class="text-blue-700 hover:text-blue-500" href="{{ relref . (index .Params.articles 2).url }}">
+                    <a id="article-{{ (index .Params.articles 2).title }}" class="text-blue-700 hover:text-blue-500" href="{{ relref . (index .Params.articles 2).url }}" track-click>
                         {{ (index .Params.articles 2).title }}
                     </a>
                 </h3>
@@ -191,7 +191,7 @@
                     {{ (index .Params.articles 2).summary | markdownify }}
                 </p>
                 <p class="text-blue-500">
-                    <a href="{{ relref . (index .Params.articles 2).url }}" class="hover:mr-1 transition-all">Read on</a> &rarr;
+                    <a id="article-{{ (index .Params.articles 2).title }}-read-on" href="{{ relref . (index .Params.articles 2).url }}" class="hover:mr-1 transition-all" track-click>Read on</a> &rarr;
                 </p>
             </article>
         </div>
@@ -221,7 +221,7 @@
                 </p>
             </div>
             <div class="inline-flex items-center md:ml-10">
-                <a class="btn group w-40 text-left pl-6 py-3 rounded-lg" href="{{ relref . "/docs/get-started" }}" title="Create your first project with Pulumi">
+                <a id="home-get-started-bottom" class="btn group w-40 text-left pl-6 py-3 rounded-lg" href="{{ relref . "/docs/get-started" }}" title="Create your first project with Pulumi" track-click>
                     <span>Get Started</span>
                     <span class="pl-1 group-hover:pl-2 transition-all">&rarr;</span>
                 </a>

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,12 +1,12 @@
 <div class="mx-auto mb-2">
-    <a href="{{ relref . "/docs/intro/languages/dotnet" }}" class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex">
+    <a id="dotnet-banner" href="{{ relref . "/docs/intro/languages/dotnet" }}" class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex" track-click>
         <span class="flex rounded-full bg-blue-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New</span>
         <span class="text-left flex-auto text-white text-sm md:text-base leading-normal">Announcing support for .NET! Write infrastructure in C#, F#, or VB.NET.</span>
         <i class="fill-current fas fa-chevron-right text-xs opacity-75 ml-2 mr-1"></i>
     </a>
 </div>
 <div class="mx-auto mb-12">
-    <a href="{{ relref . "/crosswalk/kubernetes" }}" class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex">
+    <a id="k8s-crosswalk-banner" href="{{ relref . "/crosswalk/kubernetes" }}" class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex" track-click>
         <span class="flex rounded-full bg-orange-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New</span>
         <span class="text-left flex-auto text-white text-sm md:text-base leading-normal">Announcing Pulumi Crosswalk for Kubernetes! Production-ready Kubernetes for teams.</span>
         <i class="fill-current fas fa-chevron-right text-xs opacity-75 ml-2 mr-1"></i>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -11,6 +11,7 @@
 {{ $s = $s | append (resources.Get "js/carousel.js") }}
 {{ $s = $s | append (resources.Get "js/chooser.js") }}
 {{ $s = $s | append (resources.Get "js/noselect.js") }}
+{{ $s = $s | append (resources.Get "js/tracking.js") }}
 
 <!-- We use the `clipboard-polyfill` npm package. If it hasn't been installed, show a friendlier error message. -->
 {{ $clipboardFile := "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js" }}


### PR DESCRIPTION
This PR adds click tracking to links on our home page. The `tracking.js` script will look for all `<a>` elements with a `track-link` attribute and send link click data to Segment when those links are clicked. Right now tracking is dependent on the `track-click` attribute being set and the `id` on the element being set. When expand the tracking we will just capture all `<a>` elements, though we will have to determine a good fallback for when `id` isn't present on an element. Maybe use the DOM path instead? 