### PR TITLE
Allow for restricting max-height on code blocks

### DIFF
--- a/assets/config/tailwind.config.js
+++ b/assets/config/tailwind.config.js
@@ -73,9 +73,7 @@ const green = {
 
 module.exports = {
     theme: {
-
         extend: {
-
             fontFamily: {
                 display: [
                     "Ubuntu",
@@ -87,7 +85,6 @@ module.exports = {
                 ],
             },
         },
-
         colors: {
             white,
             black,
@@ -100,6 +97,12 @@ module.exports = {
             green,
             transparent,
         },
+        maxHeight: {
+            '25': '25vh',
+            '50': '50vh',
+            '75': '75vh',
+            '100': '100vh',
+        }
     },
 
     variants: {

--- a/assets/js/copybutton.js
+++ b/assets/js/copybutton.js
@@ -72,7 +72,6 @@ $(function() {
         '</div>';
 
     $(":not(.no-copy) > div.highlight")
-        .addClass("relative")
         .append(buttonHtml)
         .on("click", "button.copy-button", function() {
             var $b = $(this);
@@ -97,5 +96,5 @@ $(function() {
             setTimeout(function() {
                 $tooltip.fadeOut();
             }, duration);
-        })
+        });
 });

--- a/assets/sass/_code.scss
+++ b/assets/sass/_code.scss
@@ -4,8 +4,12 @@ code {
     @apply bg-gray-100 rounded py-1 px-2 text-sm break-words;
 }
 
+pre, .code-max-h {
+    @apply rounded border border-gray-200 my-4;
+}
+
 pre {
-    @apply bg-gray-100 py-4 px-5 pr-8 rounded border border-gray-200 scrolling-auto overflow-x-auto my-4 leading-normal;
+    @apply bg-gray-100 py-4 px-5 pr-8 scrolling-auto overflow-x-auto leading-normal;
 
     .code-mode-dark & {
         @apply bg-gray-900 border-none shadow-md;
@@ -29,6 +33,26 @@ pre {
 
     code {
         @apply break-normal;
+    }
+
+    .code-max-h & {
+        @apply border-none my-0;
+    }
+}
+
+.code-max-h {
+    @apply relative;
+
+    > [class*="max-h-"] {
+        @apply overflow-y-auto;
+    }
+}
+
+:not(.no-copy) > .highlight {
+    @apply relative;
+
+    .code-max-h & {
+        @apply static;
     }
 }
 

--- a/assets/sass/_copy-button.scss
+++ b/assets/sass/_copy-button.scss
@@ -2,7 +2,7 @@
 @import "mixins";
 
 .copy-button-container {
-    @apply absolute top-0 right-0 mt-px mr-px p-1 pt-2 pr-2 rounded bg-gray-100;
+    @apply absolute top-0 right-0 mt-px mr-px pt-1 pb-0 pt-2 pr-2 rounded bg-gray-100;
 
     .code-mode-dark & {
         @apply bg-gray-900;


### PR DESCRIPTION
Fixes #1969. Example usage:

```
<div class="code-max-h">
    <div class="max-h-50"> <!-- as % of viewport height: we have -25, -50, -75 and -100) -->
        some beautiful code
    </div>
</div>
```

I'd hoped to be able to do this with a single div (say, `code-max-h max-h-25`), but the need to keep the copy buttons absolutely positioned required a containing div, alas. 

![](http://cnunciato-dropshare.s3.amazonaws.com/Screen-Recording-2019-11-27-08-51-47.gif)