### PR TITLE
Add AWSGuard guide and various PaC-related tweaks

### DIFF
--- a/content/docs/get-started/policy-as-code/_index.md
+++ b/content/docs/get-started/policy-as-code/_index.md
@@ -8,7 +8,7 @@ menu:
 ---
 {{% crossguard-preview %}}
 
-Pulumi CrossGuards a product that provides gated deployments via Policy as Code.
+Pulumi CrossGuard is a product that provides gated deployments via Policy as Code.
 
 Often organizations want to empower developers to manage their infrastructure yet are concerned about giving them full access. CrossGuard allows administrators to provide autonomy to their developers while ensuring compliance to defined organization policies.
 

--- a/content/docs/get-started/policy-as-code/authoring-a-policy-pack.md
+++ b/content/docs/get-started/policy-as-code/authoring-a-policy-pack.md
@@ -5,14 +5,18 @@ weight: 1
 menu:
   getstarted:
     parent: pac
-    identifier: pac-authoring-a-policy-pack
 ---
 {{% crossguard-preview %}}
 
-1. Verify your version of the Pulumi CLI
+1. Install prerequisites.
+
+   - [Install Pulumi]({{< relref "/docs/get-started/install" >}})
+   - [Install Node.js version 8 or later](https://nodejs.org/en/download/)
+
+1. Verify your version of Pulumi.
 
     ```sh
-    $ pulumi version # should be v1.5.2 or later
+    $ pulumi version # should be v1.6.1 or later
     ```
 
 1. Create a directory for your new Policy Pack, and change into it.
@@ -21,19 +25,52 @@ menu:
     $ mkdir policypack && cd policypack
     ```
 
-1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_DEBUG_COMMANDS=true` as an environment variable or simply pre-append it to your commands as shown.
+1. Run the `pulumi policy new` command. Since Policy as Code is a beta feature, you will need to set `PULUMI_EXPERIMENTAL=true` as an environment variable or simply pre-append it to your commands as shown.
 
-    ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy new aws-typescript
-    Created Policy Pack!
-    Installing dependencies...
-    ...
-    Finished installing dependencies
+    {{< oschoose >}}
 
-    Your new Policy Pack is ready to go! ✨
+    <div class="os-prologue-macos"></div>
+    <div class="mt-4">
+{{% md %}}
+On macOS, you can run `export PULUMI_EXPERIMENTAL=true` or simply prepend it to your commands as shown.
 
-    Once you're done editing your Policy Pack, run `pulumi policy publish [org-name]` to publish the pack.
-    ```
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy new aws-typescript
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-linux"></div>
+    <div class="mt-4">
+{{% md %}}
+On Linux, you can run `export PULUMI_EXPERIMENTAL=true` or simply prepend it to your commands as shown.
+
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy new aws-typescript
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-windows"></div>
+    <div class="mt-4">
+{{% md %}}
+On Windows, you must first set the environment variable before running the command.
+
+**Windows cmd.exe**
+
+```bat
+set PULUMI_EXPERIMENTAL=true
+pulumi policy new aws-typescript
+```
+
+**Windows PowerShell**
+
+```powershell
+$env:PULUMI_EXPERIMENTAL = 'true'
+pulumi policy new aws-typescript
+```
+{{% /md %}}
+    </div>
 
 1. Tweak the Policy Pack in the `index.ts` file as desired. The existing policy in the template (which is annotated below) mandates that an AWS S3 bucket not have public read or write permissions enabled. Each Policy must have a unique name, an enforcement level, and a validation function. Here we use `validateTypedResource` that allows us to validate S3 Bucket resources.
 
@@ -79,14 +116,48 @@ Policy Packs can be tested on a user’s local workstation to facilitate rapid d
 
     In the Pulumi project's directory run:
 
-    ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack <path-to-policy-pack-directory>
-    ```
+    {{< oschoose >}}
+
+    <div class="os-prologue-macos"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack <path-to-policy-pack-directory>
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-linux"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack <path-to-policy-pack-directory>
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-windows"></div>
+    <div class="mt-4">
+{{% md %}}
+**Windows cmd.exe**
+
+```bat
+set PULUMI_EXPERIMENTAL=true
+pulumi preview --policy-pack <path-to-policy-pack-directory>
+```
+
+**Windows PowerShell**
+
+```powershell
+$env:PULUMI_EXPERIMENTAL = 'true'
+pulumi preview --policy-pack <path-to-policy-pack-directory>
+```
+{{% /md %}}
+    </div>
 
     If the stack is in compliance, we expect the output to simply tell us which Policy Packs were run.
 
     {{< highlight sh >}}
-$ PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack policy-pack-typescript
 Previewing update (dev):
 
      Type                 Name          Plan
@@ -95,9 +166,6 @@ Previewing update (dev):
 
 Resources:
     + 2 to create
-
-Permalink:
-...
 {{< /highlight >}}
 
 1. We can then edit the stack code to specify the ACL to be public-read.
@@ -111,7 +179,6 @@ Permalink:
 1. We then run the `pulumi preview` command again and this time get an error message indicating we failed the preview because of a policy violation.
 
     {{< highlight sh >}}
-$ PULUMI_DEBUG_COMMANDS=true pulumi preview --policy-pack ~/policy-pack-typescript
 Previewing update (dev):
 
      Type                 Name          Plan       Info
@@ -125,9 +192,6 @@ Diagnostics:
   aws:s3:Bucket (my-bucket):
     mandatory: [s3-no-public-read] Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.
     You cannot set public-read or public-read-write on an S3 bucket. Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html
-
-Permalink:
-...
 {{< /highlight >}}
 
 Now that your Policy Pack is ready to go, let's enforce the pack across your organization.

--- a/content/docs/get-started/policy-as-code/enforcing-a-policy-pack.md
+++ b/content/docs/get-started/policy-as-code/enforcing-a-policy-pack.md
@@ -5,7 +5,6 @@ weight: 2
 menu:
   getstarted:
     parent: pac
-    identifier: pac-enforcing-a-policy-pack
 ---
 {{% crossguard-preview %}}
 
@@ -13,18 +12,50 @@ Once you’ve validated the behavior of your policies, an organization administr
 
 1. From within the Policy Pack directory, run the following command to publish your pack:
 
-    ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy publish [org-name]
-    ```
+    {{< oschoose >}}
+
+    <div class="os-prologue-macos"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy publish [org-name]
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-linux"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy publish [org-name]
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-windows"></div>
+    <div class="mt-4">
+{{% md %}}
+**Windows cmd.exe**
+
+```bat
+set PULUMI_EXPERIMENTAL=true
+pulumi policy publish [org-name]
+```
+
+**Windows PowerShell**
+
+```powershell
+$env:PULUMI_EXPERIMENTAL = 'true'
+pulumi policy publish [org-name]
+```
+{{% /md %}}
+    </div>
 
     The `[org-name]` is optional. If not specified, the pack will be published to your user account.
 
-    The `<policy-pack-name>` is the name you’d like to see used to reference the pack in the Pulumi Console.
-
     The output will tell you what version of the Policy Pack you just published. The Pulumi service provides a monotonic version number for Policy Packs.
 
-    ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy publish myorg
+    ```
     Obtaining policy metadata from policy plugin
     Compressing policy pack
     Uploading policy pack to Pulumi service
@@ -34,15 +65,85 @@ Once you’ve validated the behavior of your policies, an organization administr
 
 1. You can apply this Policy Pack to your organization’s default Policy Group by running:
 
-    ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy apply <org-name>/<policy-pack-name> <version>
-    ```
+    {{< oschoose >}}
+
+    <div class="os-prologue-macos"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy apply <org-name>/<policy-pack-name> <version>
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-linux"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy apply <org-name>/<policy-pack-name> <version>
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-windows"></div>
+    <div class="mt-4">
+{{% md %}}
+**Windows cmd.exe**
+
+```bat
+set PULUMI_EXPERIMENTAL=true
+pulumi policy apply <org-name>/<policy-pack-name> <version>
+```
+
+**Windows PowerShell**
+
+```powershell
+$env:PULUMI_EXPERIMENTAL = 'true'
+pulumi policy apply <org-name>/<policy-pack-name> <version>
+```
+{{% /md %}}
+    </div>
 
     For example, to apply the Policy Pack created in the previous step:
 
-    ```sh
-    $ PULUMI_DEBUG_COMMANDS=true pulumi policy apply pulumi/policy-pack-typescript 1
-    ```
+    {{< oschoose >}}
+
+    <div class="os-prologue-macos"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy apply pulumi/policy-pack-typescript 1
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-linux"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy apply pulumi/policy-pack-typescript 1
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-windows"></div>
+    <div class="mt-4">
+{{% md %}}
+**Windows cmd.exe**
+
+```bat
+set PULUMI_EXPERIMENTAL=true
+pulumi policy apply pulumi/policy-pack-typescript 1
+```
+
+**Windows PowerShell**
+
+```powershell
+$env:PULUMI_EXPERIMENTAL = 'true'
+pulumi policy apply pulumi/policy-pack-typescript 1
+```
+{{% /md %}}
+    </div>
 
     The CLI can only be used to apply the Policy Pack to your default Policy Group. If you would like to add the Policy Pack to a different Policy Group, you can do so via the Pulumi Console.
 

--- a/content/docs/guides/crossguard/_index.md
+++ b/content/docs/guides/crossguard/_index.md
@@ -18,6 +18,10 @@ Using CrossGuard, organization administrators can apply these rules to particula
 To get started with Pulumi CrossGuard, [download and install Pulumi]({{< relref "/docs/get-started/install" >}}). Afterwards,
 try the [Getting Started tutorial]({{< relref "/docs/get-started/policy-as-code" >}}).
 
+## Pulumi CrossGuard policies for AWS (AWSGuard)
+
+In addition to being able to implement your own CrossGuard policies, we've also created a set of policies that codifies best practices for AWS that you can adopt and use in a Policy Pack. AWSGuard is a configurable library that you can use to enforce best practices for your own Pulumi stacks or organization. [Learn more and get started with AWSGuard]({{< relref "./awsguard" >}}).
+
 ## Examples
 
 If you're looking for some example Policy Packs, take a look at these:

--- a/content/docs/guides/crossguard/awsguard.md
+++ b/content/docs/guides/crossguard/awsguard.md
@@ -11,9 +11,9 @@ menu:
 
 ## Overview
 
-AWSGuard codifies best practices for AWS. This is a configurable library that you can use to enforce these best practices for your own Pulumi stacks or organization.
+[AWSGuard](https://github.com/pulumi/pulumi-policy-aws) codifies best practices for AWS. It is an [open source](https://github.com/pulumi/pulumi-policy-aws) library that you can configure and use to enforce these best practices for your own Pulumi stacks or organization.
 
-For more information on Pulumi's Policy as Code solution, visit our [docs](https://www.pulumi.com/docs/get-started/policy-as-code/).
+For more information on Pulumi's Policy as Code solution, visit our [docs]({{< relref "/docs/get-started/policy-as-code" >}}).
 
 ## Trying AWSGuard
 
@@ -32,7 +32,7 @@ pulumi version # should be v1.6.1 or later
 
 ### Authoring a Policy Pack that uses AWSGuard policies
 
-To use AWSGuard policies, you must create a Policy Pack that references the `@pulumi/awsguard` npm package and in the implementation of the Policy Pack, create a new instance of the `AwsGuard` class.
+To use AWSGuard policies, you must create a Policy Pack that references the `@pulumi/awsguard` npm package and creates a new instance of the `AwsGuard` class.
 
 1. Create a directory for your new Policy Pack, and change into it.
 

--- a/content/docs/guides/crossguard/awsguard.md
+++ b/content/docs/guides/crossguard/awsguard.md
@@ -1,0 +1,251 @@
+---
+title: Pulumi CrossGuard policies for AWS (AWSGuard)
+linktitle: AWSGuard
+
+menu:
+  userguides:
+    parent: crossguard
+    weight: 2
+---
+{{% crossguard-preview %}}
+
+## Overview
+
+AWSGuard codifies best practices for AWS. This is a configurable library that you can use to enforce these best practices for your own Pulumi stacks or organization.
+
+For more information on Pulumi's Policy as Code solution, visit our [docs](https://www.pulumi.com/docs/get-started/policy-as-code/).
+
+## Trying AWSGuard
+
+In this guide, we'll show you how to create a Policy Pack that configures and uses the policies available in AWSGuard.
+
+### Prerequisites
+
+- [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+- [Install Node.js version 8 or later](https://nodejs.org/en/download/)
+
+### Verify your version of the Pulumi CLI
+
+```sh
+pulumi version # should be v1.6.1 or later
+```
+
+### Authoring a Policy Pack that uses AWSGuard policies
+
+To use AWSGuard policies, you must create a Policy Pack that references the `@pulumi/awsguard` npm package and in the implementation of the Policy Pack, create a new instance of the `AwsGuard` class.
+
+1. Create a directory for your new Policy Pack, and change into it.
+
+    ```sh
+    mkdir awsguard && cd awsguard
+    ```
+
+1. Run the `pulumi policy new` command. Since Policy as Code is in preview, you will need to set `PULUMI_EXPERIMENTAL=true` as an environment variable.
+
+    {{< oschoose >}}
+
+    <div class="os-prologue-macos"></div>
+    <div class="mt-4">
+{{% md %}}
+On macOS, you can run `export PULUMI_EXPERIMENTAL=true` or simply prepend it to your commands as shown.
+
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy new awsguard-typescript
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-linux"></div>
+    <div class="mt-4">
+{{% md %}}
+On Linux, you can run `export PULUMI_EXPERIMENTAL=true` or simply prepend it to your commands as shown.
+
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi policy new awsguard-typescript
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-windows"></div>
+    <div class="mt-4">
+{{% md %}}
+On Windows, you must first set the environment variable before running the command.
+
+**Windows cmd.exe**
+
+```bat
+set PULUMI_EXPERIMENTAL=true
+pulumi policy new awsguard-typescript
+```
+
+**Windows PowerShell**
+
+```powershell
+$env:PULUMI_EXPERIMENTAL = 'true'
+pulumi policy new awsguard-typescript
+```
+{{% /md %}}
+    </div>
+
+1. Tweak the code in the `index.ts` file as desired. The default implementation provided by the `awsguard-typescript` template simply creates a new instance of `AwsGuard` with all policies set to have an enforcement level of advisory.
+
+    ```typescript
+    new AwsGuard({ all: "advisory" });
+    ```
+
+    From here, you can change the enforcement level for all policies or configure individual policies.
+
+    For example:
+
+    To make all policies mandatory rather than advisory:
+
+    ```typescript
+    new AwsGuard({ all: "mandatory" });
+    ```
+
+    To make all policies mandatory, but change certain policies to be advisory:
+
+    ```typescript
+    new AwsGuard({
+        all: "mandatory",
+        ec2InstanceNoPublicIP: "advisory",
+        elbAccessLoggingEnabled: "advisory",
+    });
+    ```
+
+    To disable a particular policy:
+
+    ```typescript
+    new AwsGuard({
+        ec2InstanceNoPublicIP: "disabled",
+    });
+    ```
+
+    To disable all policies except ones explicitly enabled:
+
+    ```typescript
+    new AwsGuard({
+        all: "disabled",
+        ec2InstanceNoPublicIP: "mandatory",
+        elbAccessLoggingEnabled: "mandatory",
+    });
+    ```
+
+    To specify additional configuration for policies that support it:
+
+    ```typescript
+    new AwsGuard({
+        ec2VolumeInUseCheck: { checkDeletion: false },
+        encryptedVolumes: { enforcementLevel: "mandatory", kmsId: "id" },
+        redshiftClusterMaintenanceSettingsCheck: { preferredMaintenanceWindow: "Mon:09:30-Mon:10:00" },
+        acmCheckCertificateExpiration: { maxDaysUntilExpiration: 10 },
+    });
+    ```
+
+### Test the new Policy Pack
+
+Policy Packs can be tested on a user's local workstation to facilitate rapid development and testing of policies.
+
+1. Run `npm install` in the Policy Pack directory.
+
+1. Use the `--policy-pack` flag with `pulumi preview` or `pulumi up` to specify the path to the directory containing your Policy Pack when previewing/updating a Pulumi program.
+
+    If you don’t have a Pulumi program readily available, you can create a new project for testing by running `pulumi new aws-typescript` in an empty directory. This AWS example will create an S3 bucket, which is perfect for testing our Policy.
+
+    In the Pulumi project's directory run:
+
+    {{< oschoose >}}
+
+    <div class="os-prologue-macos"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack <path-to-policy-pack-directory>
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-linux"></div>
+    <div class="mt-4">
+{{% md %}}
+```sh
+$ PULUMI_EXPERIMENTAL=true pulumi preview --policy-pack <path-to-policy-pack-directory>
+```
+{{% /md %}}
+    </div>
+
+    <div class="os-prologue-windows"></div>
+    <div class="mt-4">
+{{% md %}}
+**Windows cmd.exe**
+
+```bat
+set PULUMI_EXPERIMENTAL=true
+pulumi preview --policy-pack <path-to-policy-pack-directory>
+```
+
+**Windows PowerShell**
+
+```powershell
+$env:PULUMI_EXPERIMENTAL = 'true'
+pulumi preview --policy-pack <path-to-policy-pack-directory>
+```
+{{% /md %}}
+    </div>
+
+    If the stack is not in compliance, the policy violation will be displayed. Since the enforcement level for all policies are set to advisory, a warning is shown for any resources that are not in compliance with the AWSGuard policies. In this case, logging must be defined for S3 buckets.
+
+    {{< highlight sh >}}
+Previewing update (dev):
+
+    Type                 Name           Plan       Info
++   pulumi:pulumi:Stack  test-dev       create
++   └─ aws:s3:Bucket     my-bucket      create     1 warning
+
+Diagnostics:
+aws:s3:Bucket (my-bucket):
+    advisory: [s3-bucket-logging-enabled] Checks whether logging is enabled for your S3 buckets.
+    Bucket logging must be defined.
+
+Resources:
+    + 2 to create
+{{< /highlight >}}
+
+1. If you had wanted the preview to fail for any policy violations, the Policy Pack can be modified to configure all policies to be mandatory.
+
+    ```typescript
+    new AwsGuard({ all: "mandatory" });
+    ```
+
+1. Running the `pulumi preview` command again will now fail the preview operation.
+
+    {{< highlight sh >}}
+Previewing update (dev):
+
+    Type                 Name           Plan       Info
++   pulumi:pulumi:Stack  test-dev       create     1 error
++   └─ aws:s3:Bucket     my-bucket      create     1 error
+
+Diagnostics:
+pulumi:pulumi:Stack (test-dev):
+    error: preview failed
+
+aws:s3:Bucket (my-bucket):
+    mandatory: [s3-bucket-logging-enabled] Checks whether logging is enabled for your S3 buckets.
+    Bucket logging must be defined.
+{{< /highlight >}}
+
+1. If you do not want to enforce this particular policy, you can modify the Policy Pack to disable it.
+
+    ```typescript
+    new AwsGuard({
+        all: "mandatory",
+        s3BucketLoggingEnabled: "disabled",
+    });
+    ```
+
+## Next Steps
+
+Once you've validated the behavior of the AWSGuard policies you've configured in your Policy Pack, an organization administrator can publish the Policy Pack to the Pulumi Console to be enforced across your organization. To learn more see [Enforcing a Policy Pack Across an Organization]({{< relref "/docs/get-started/policy-as-code/enforcing-a-policy-pack" >}}).
+
+Now that you've seen how to configure and use AWSGuard policies, you may want to write your own policies. See the [Getting Started tutorial]({{< relref "/docs/get-started/policy-as-code" >}}) to get started.

--- a/content/docs/guides/crossguard/awsguard.md
+++ b/content/docs/guides/crossguard/awsguard.md
@@ -1,11 +1,11 @@
 ---
 title: Pulumi CrossGuard policies for AWS (AWSGuard)
 linktitle: AWSGuard
+weight: 2
 
 menu:
   userguides:
     parent: crossguard
-    weight: 2
 ---
 {{% crossguard-preview %}}
 

--- a/content/docs/guides/crossguard/best-practices.md
+++ b/content/docs/guides/crossguard/best-practices.md
@@ -1,11 +1,11 @@
 ---
 title: Best Practices for Writing Policy Packs
 linktitle: Best Practices
+weight: 3
 
 menu:
   userguides:
     parent: crossguard
-    weight: 3
 ---
 {{% crossguard-preview %}}
 

--- a/content/docs/guides/crossguard/best-practices.md
+++ b/content/docs/guides/crossguard/best-practices.md
@@ -5,7 +5,7 @@ linktitle: Best Practices
 menu:
   userguides:
     parent: crossguard
-    identifier: crossguard-best-practices
+    weight: 3
 ---
 {{% crossguard-preview %}}
 

--- a/content/docs/guides/crossguard/core-concepts.md
+++ b/content/docs/guides/crossguard/core-concepts.md
@@ -1,11 +1,11 @@
 ---
 title: Core Concepts
 linktitle: Core Concepts
+weight: 1
 
 menu:
   userguides:
     parent: crossguard
-    weight: 1
 ---
 {{% crossguard-preview %}}
 

--- a/content/docs/guides/crossguard/core-concepts.md
+++ b/content/docs/guides/crossguard/core-concepts.md
@@ -5,7 +5,7 @@ linktitle: Core Concepts
 menu:
   userguides:
     parent: crossguard
-    identifier: crossguard-core-concepts
+    weight: 1
 ---
 {{% crossguard-preview %}}
 

--- a/content/docs/guides/crossguard/faq.md
+++ b/content/docs/guides/crossguard/faq.md
@@ -1,11 +1,11 @@
 ---
 title: Frequently Asked Questions
 linktitle: Frequently Asked Questions
+weight: 4
 
 menu:
   userguides:
     parent: crossguard
-    weight: 4
 ---
 {{% crossguard-preview %}}
 

--- a/content/docs/guides/crossguard/faq.md
+++ b/content/docs/guides/crossguard/faq.md
@@ -5,7 +5,7 @@ linktitle: Frequently Asked Questions
 menu:
   userguides:
     parent: crossguard
-    identifier: crossguard-faq
+    weight: 4
 ---
 {{% crossguard-preview %}}
 

--- a/layouts/shortcodes/crossguard-preview.html
+++ b/layouts/shortcodes/crossguard-preview.html
@@ -2,7 +2,7 @@
     <p>
         <i class="fas fa-info-circle pr-2"></i>
         CrossGuard is a beta feature and is subject to breaking changes. The open
-        source `--policy-pack` flag is free and available for all to use. A preview of CrossGuard
+        source <code>--policy-pack</code> flag is free and available for all to use. A preview of CrossGuard
         is also available in the Pulumi Console, which enables you to enforce policies across an
         organization. To get access, submit a request <a href="{{ relref . "/contact" }}">here</a>.
     </p>


### PR DESCRIPTION
Adds a page that guides getting started using AWSGuard. Also updates the commands throughout to show how to set `PULUMI_EXPERIMENTAL` correctly on the various OSes (using the OS chooser tabs). And some minor other tweaks.