### PR TITLE
Use relref in 2.0 roadmap blog post

### DIFF
--- a/content/blog/pulumi-2-0-roadmap/index.md
+++ b/content/blog/pulumi-2-0-roadmap/index.md
@@ -10,7 +10,7 @@ meta_image: "pulumi-1-0.png"
 
 Today we've published [Pulumi's 2.0 roadmap](https://github.com/pulumi/pulumi/issues/3591). 2.0 is the next major phase in Pulumi's journey, and will include better productivity through languages, libraries, and tools, in addition to advanced features for teams in production. And, though we are excited to share our own thoughts, more than anything else, we'd love to hear your feedback to help make sure it's right.
 
-Since [releasing Pulumi 1.0 in September](/blog/pulumi-1-0), we have heard loud and clear that you appreciate the commitment to compatibility, as well as the completeness and stability of the platform, and we have been hard at work making sure we honor those promises.
+Since [releasing Pulumi 1.0 in September]({{< relref "/blog/pulumi-1-0" >}}), we have heard loud and clear that you appreciate the commitment to compatibility, as well as the completeness and stability of the platform, and we have been hard at work making sure we honor those promises.
 
 As we look to 2.0, we are aiming to help you be more successful with modern cloud architectures, by implementing features that we've heard are missing or could be better, as well as doing better at the fundamentals. Although this is a "2.0" release, we do not plan any major breaking changes, so that we can continue honoring our promise to provide a stable platform to you.
 
@@ -44,11 +44,11 @@ Today we have released preview support for a new policy as code offering that we
 
 You can write custom policies, or use off-the-shelf policies authored by the community, including our preview [AWS pack](https://github.com/pulumi/pulumi-policy-aws) and [Open Policy Agent (OPA) integration](https://github.com/pulumi/pulumi-policy-opa). Just as you can share your own infrastructure creations using your language's package manager, you can share your policies too.
 
-CrossGuard is 100% open source, enabled by `pulumi up`'s new `--policy-pack` flag, and advanced organization-wide controls are available in the Team and Enterprise Editions. To learn more, [read the CrossGuard user guide](/docs/guides/crossguard); or, to dive straight in, try out [the getting started tutorial](/docs/get-started/crossguard).
+CrossGuard is 100% open source, enabled by `pulumi up`'s new `--policy-pack` flag, and advanced organization-wide controls are available in the Team and Enterprise Editions. To learn more, [read the CrossGuard user guide]({{< relref "/docs/guides/crossguard" >}}); or, to dive straight in, try out [the getting started tutorial]({{< relref "/docs/get-started/crossguard" >}}).
 
 ### Testing
 
-[We've blogged previously about how to test your infrastructure](/blog/unit-testing-infrastructure-in-nodejs-and-mocha/). However, we hear all the time about new scenarios and ways in which Pulumi could do a better job here, including removing many of the rough edges currently hit when testing Pulumi code.
+[We've blogged previously about how to test your infrastructure]({{< relref "/blog/unit-testing-infrastructure-in-nodejs-and-mocha" >}}). However, we hear all the time about new scenarios and ways in which Pulumi could do a better job here, including removing many of the rough edges currently hit when testing Pulumi code.
 
 Pulumi 2.0 will support a spectrum of testing scenarios, including unit testing, integration testing, and post-deployment runtime validation. The addition of CrossGuard also means you can validate your infrastructure configuration integrated into your existing CI/CD processes. As part of the 2.0 release, we will be publishing comprehensive guides and tutorials for testing your infrastructure.
 
@@ -62,9 +62,9 @@ To give watch mode a try, simply run `pulumi watch`. Or, to see a demo of watch 
 
 ### Self-Host and On-Premises
 
-Although we've worked hard to make the Pulumi service easy and affordable to use by default, we understand that some customers can't depend on a multi-tenanted SaaS website for their infrastructure deployments. For these customers, Pulumi already offers [custom state hosting](/docs/intro/concepts/state/) in AWS S3, Azure Blob Storage, GCP Cloud Storage, or even as a manually managed JSON file. However, by hosting the state this way, you lose out on what makes the Pulumi service so great: identity, teams, RBAC, policies, webhooks, and more.
+Although we've worked hard to make the Pulumi service easy and affordable to use by default, we understand that some customers can't depend on a multi-tenanted SaaS website for their infrastructure deployments. For these customers, Pulumi already offers [custom state hosting]({{< relref "/docs/intro/concepts/state" >}}) in AWS S3, Azure Blob Storage, GCP Cloud Storage, or even as a manually managed JSON file. However, by hosting the state this way, you lose out on what makes the Pulumi service so great: identity, teams, RBAC, policies, webhooks, and more.
 
-Today we are releasing preview support for the self-hosted Pulumi service. This gives you the full capabilities of the Pulumi Enterprise SaaS, while also giving you the flexibility to run it anywhere. Self-hosted Pulumi Enterprise can run on-premises behind your firewall on a VM or in Kubernetes, in your AWS, Azure, or GCP account &mdash; virtually anywhere that can run VMs or containers. For more information, see the [tutorial about how to configure self-hosted Pulumi Enterprise](/docs/guides/self-hosted), or [contact us for pricing information and a demo](/contact).
+Today we are releasing preview support for the self-hosted Pulumi service. This gives you the full capabilities of the Pulumi Enterprise SaaS, while also giving you the flexibility to run it anywhere. Self-hosted Pulumi Enterprise can run on-premises behind your firewall on a VM or in Kubernetes, in your AWS, Azure, or GCP account &mdash; virtually anywhere that can run VMs or containers. For more information, see the [tutorial about how to configure self-hosted Pulumi Enterprise]({{< relref "/docs/guides/self-hosted" >}}), or [contact us for pricing information and a demo]({{< relref "/contact" >}}).
 
 ### A Lot More ...
 
@@ -74,7 +74,7 @@ This is just a sampling of what's already ready to try out. Expect a lot more, i
 
 Pulumi 1.0 gave us a solid foundation of modern infrastructure as code. As we see the things you are building with Pulumi, we understand that challenges don't stop at infrastructure provisioning. Pulumi is also about the applications themselves, as modern cloud architectures demand infrastructure and applications to coexist in harmony and unique ways that Pulumi enables.
 
-In addition to many great features, Pulumi 2.0 will also further advance the [Pulumi Crosswalk family of offerings](/docs/guides/crosswalk) to bring more of these modern application architecture patterns to your fingertips. This includes support for additional languages beyond JavaScript and TypeScript, improved documentation, interactive tutorials, and more extensive libraries of patterns and practices.
+In addition to many great features, Pulumi 2.0 will also further advance the [Pulumi Crosswalk family of offerings]({{< relref "/docs/guides/crosswalk" >}}) to bring more of these modern application architecture patterns to your fingertips. This includes support for additional languages beyond JavaScript and TypeScript, improved documentation, interactive tutorials, and more extensive libraries of patterns and practices.
 
 ## Two Asks
 


### PR DESCRIPTION
Protects agains moving pages around in the future, and ensures all generated links have trailing slashes (avoids intermediate redirect S3 hops).