### PR TITLE
Remove the link-checking step from PR and push jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: true
 branches:
   only:
   - master
-  - staging
 before_install:
 # Download and install required tools.
 # Limit to one push build per branch.

--- a/Makefile
+++ b/Makefile
@@ -55,34 +55,22 @@ validate:
 travis_push::
 	$(MAKE) banner
 	$(MAKE) ensure
-ifeq ($(TRAVIS_BRANCH),staging)
-	HUGO_ENVIRONMENT=staging $(MAKE) build
-	$(MAKE) validate
-	./scripts/run-pulumi.sh update staging
-else ifeq ($(TRAVIS_BRANCH),master)
+ifeq ($(TRAVIS_BRANCH),master)
 	HUGO_ENVIRONMENT=production $(MAKE) build
-	$(MAKE) validate
 	./scripts/run-pulumi.sh update production
 else
 	$(MAKE) build
-	$(MAKE) validate
 endif
 
 .PHONY: travis_pull_request
 travis_pull_request::
 	$(MAKE) banner
 	$(MAKE) ensure
-ifeq ($(TRAVIS_BRANCH),staging)
-	HUGO_ENVIRONMENT=staging $(MAKE) build
-	$(MAKE) validate
-	./scripts/run-pulumi.sh preview staging
-else ifeq ($(TRAVIS_BRANCH),master)
+ifeq ($(TRAVIS_BRANCH),master)
 	HUGO_ENVIRONMENT=production $(MAKE) build
-	$(MAKE) validate
 	./scripts/run-pulumi.sh preview production
 else
 	$(MAKE) build
-	$(MAKE) validate
 endif
 
 .PHONY: travis_cron


### PR DESCRIPTION
This change removes the `validate` task from `pull_request` and `push` jobs. 

I've set up a [Travis Cron job](https://docs.travis-ci.com/user/cron-jobs/) to run daily, which based on our .travis.yml file will run `make travis_cron` (invoking the `validate` target and running the link-checking script), and should alert us in the #builds channel whenever that fails. (It doesn't look like we can control _when_ that job runs, though, and `daily` appears to be as granular as we can get, so if this doesn't give us enough control, we could also just run it elsewhere.)

This also removes the checks for the `staging` branch, which I believe is no longer in use.