### PR TITLE
De-dupe title tags in the API reference docs

### DIFF
--- a/tools/pydocgen/pydocgen/__init__.py
+++ b/tools/pydocgen/pydocgen/__init__.py
@@ -79,6 +79,7 @@ class CreateMarkdownInput(NamedTuple):
     The CreateMarkdownInput is the input to create_markdown_file.
     """
     title: str
+    title_tag: str
     linktitle: str
     """
     Sphinx output file, to be used as the source of data to derive a Markdown file. It is technically
@@ -268,6 +269,7 @@ def transform_sphinx_output_to_markdown(ctx: Context):
         # If this thing has submodules, provider_sphinx_output is a directory and it exists.
         if path.exists(provider_sphinx_output):
             create_markdown_input = CreateMarkdownInput(title=f"Package {provider.package_name}",
+                                                        title_tag=f"Package {provider.package_name}",
                                                         linktitle=provider.package_name,
                                                         file=f"{provider_sphinx_output}.fjson",
                                                         out_file=path.join(provider_path, "_index.md"))
@@ -287,12 +289,14 @@ def transform_sphinx_output_to_markdown(ctx: Context):
                     module_path = create_dir(provider_path, module_name)
 
                 create_markdown_input = CreateMarkdownInput(title=f"Module {module_name}",
+                                                            title_tag=f"Module {module_name} | Package {provider.package_name}",
                                                             linktitle=module_name,
                                                             file=file,
                                                             out_file=path.join(module_path, "_index.md"))
                 create_markdown_file(create_markdown_input)
         else:
             create_markdown_input = CreateMarkdownInput(title=f"Package {provider.package_name}",
+                                                        title_tag=f"Package {provider.package_name}",
                                                         linktitle=provider.package_name,
                                                         file=f"{provider_sphinx_output}.fjson",
                                                         out_file=path.join(provider_path, "_index.md"))
@@ -321,6 +325,7 @@ def create_markdown_file(input: CreateMarkdownInput):
         # First, write some empty front-matter at the beginning of the file.
         f.write("---\n")
         f.write(f"title: {input.title}\n")
+        f.write(f"title_tag: {input.title_tag}\n")
         f.write(f"linktitle: {input.linktitle}\n")
         f.write(f"notitle: true\n")
         f.write("---\n\n")

--- a/tools/pydocgen/pydocgen/__init__.py
+++ b/tools/pydocgen/pydocgen/__init__.py
@@ -325,7 +325,7 @@ def create_markdown_file(input: CreateMarkdownInput):
         # First, write some empty front-matter at the beginning of the file.
         f.write("---\n")
         f.write(f"title: {input.title}\n")
-        f.write(f"title_tag: {input.title_tag}\n")
+        f.write(f"title_tag: {input.title_tag} | Python SDK\n")
         f.write(f"linktitle: {input.linktitle}\n")
         f.write(f"notitle: true\n")
         f.write("---\n\n")

--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -389,6 +389,7 @@ func (e *emitter) emitMarkdownModule(name string, mod *module, root bool) error 
 
 	// First a title and some additional package header info, for the root module.
 	var title string
+	var titleTag string
 	var linktitle string
 	var pkg string
 	var pkgvar string
@@ -396,12 +397,14 @@ func (e *emitter) emitMarkdownModule(name string, mod *module, root bool) error 
 
 	if root {
 		title = fmt.Sprintf("Package %s", e.pkg)
+		titleTag = fmt.Sprintf("Package %s", e.pkg)
 		linktitle = e.pkg
 		pkg = e.pkg
 		pkgvar = camelCase(e.pkg[strings.IndexRune(e.pkg, '/')+1:])
 		readme = filepath.Join(e.srcdir, "README.md")
 	} else {
 		title = fmt.Sprintf("Module %s", name)
+		titleTag = fmt.Sprintf("%s | Package %s", title, e.pkg)
 		readme = filepath.Join(e.srcdir, name, "README.md")
 		linktitle = name
 		if slix := strings.IndexRune(linktitle, '/'); slix != -1 {
@@ -507,6 +510,7 @@ func (e *emitter) emitMarkdownModule(name string, mod *module, root bool) error 
 	// To generate the code, simply render the source Mustache template, using the right set of arguments.
 	if err = indexTemplate.FRender(f, map[string]interface{}{
 		"Title":                     title,
+		"TitleTag":                  titleTag,
 		"LinkTitle":                 linktitle,
 		"MetaDescription":           metaDescription,
 		"RepoURL":                   e.repoURL,

--- a/tools/tscdocgen/templates/nodejs.tmpl
+++ b/tools/tscdocgen/templates/nodejs.tmpl
@@ -1,6 +1,6 @@
 ---
 title: "{{Title}}"
-title_tag: "{{TitleTag}}"
+title_tag: "{{TitleTag}} | Node.js SDK"
 linktitle: "{{LinkTitle}}"
 meta_desc: "{{MetaDescription}}"
 ---

--- a/tools/tscdocgen/templates/nodejs.tmpl
+++ b/tools/tscdocgen/templates/nodejs.tmpl
@@ -1,5 +1,6 @@
 ---
 title: "{{Title}}"
+title_tag: "{{TitleTag}}"
 linktitle: "{{LinkTitle}}"
 meta_desc: "{{MetaDescription}}"
 ---


### PR DESCRIPTION
This change adds `title_tag` attributes to the API doc templates in order to disambiguate them in search-engine listings. 

I stopped short of including a full run of the docs, here, but was able to generate then successfully. Their diffs end up looking like this, for example:

![](https://cl.ly/e818cf8d8909/Screen%252520Recording%2525202019-12-06%252520at%25252010.13%252520AM.gif)

Fixes #2106.