### PR TITLE
Adjust tags styling for consistency

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -132,6 +132,26 @@ main {
     @apply text-blue-700;
 }
 
+.tag {
+    @apply text-sm lowercase border border-gray-200 rounded py-1 px-2 mr-1 transition-all;
+
+    &.tag-blog {
+        @apply bg-white text-blue-600;
+
+        &:hover {
+            @apply border-blue-600;
+        }
+
+        &.active {
+            @apply border-blue-600 bg-blue-600 text-white;
+
+            &:hover {
+                @apply text-white;
+            }
+        }
+    }
+}
+
 .transition-all {
     @include transition(all);
 

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -22,9 +22,8 @@
                         <ul class="m-0 p-0">
                             {{ range $tag := .Params.tags }}
                             <li class="mt-0 inline-flex">
-                                {{ $classes := "bg-white border border-gray-200 text-blue-600 text-sm lowercase hover:border-blue-600" }}
-                                <a class="px-2 py-1 mr-1 rounded transition-all {{ $classes }}" href="/blog/tag/{{ $tag | urlize }}/">
-                                    {{ $tag }}
+                                <a class="tag tag-blog" href="/blog/tag/{{ $tag | urlize }}/">
+                                    {{ $tag | urlize }}
                                 </a>
                             </li>
                             {{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -21,9 +21,9 @@
                         {{ if .Params.tags }}
                         <ul class="m-0 p-0">
                             {{ range $tag := .Params.tags }}
-                            <li class="inline-flex">
-                                {{ $classes := "bg-white border border-gray-200 text-blue-600 hover:border-blue-600" }}
-                                <a class="px-2 text-s rounded transition-all {{ $classes }}" href="/blog/tag/{{ $tag | urlize }}/">
+                            <li class="mt-0 inline-flex">
+                                {{ $classes := "bg-white border border-gray-200 text-blue-600 text-sm lowercase hover:border-blue-600" }}
+                                <a class="px-2 py-1 mr-1 rounded transition-all {{ $classes }}" href="/blog/tag/{{ $tag | urlize }}/">
                                     {{ $tag }}
                                 </a>
                             </li>

--- a/layouts/partials/blog/sidebar.html
+++ b/layouts/partials/blog/sidebar.html
@@ -26,16 +26,11 @@
         </div>
 
         <ul class="list-none p-0 mb-4 inline-flex flex-wrap text-xs">
-            {{ $title := .Title | lower }}
             {{ range $tag, $_ := .Site.Taxonomies.tags }}
                 {{ if $tag }}
                     <li>
-                        {{ $classes := "bg-white border border-gray-200 text-blue-600 hover:border-blue-600" }}
-                        {{ if eq $tag $title }}
-                            {{ $classes = "border-blue-600 bg-blue-600 text-white hover:text-white" }}
-                        {{ end }}
-                        <a class="px-2 py-1 mr-1 rounded transition-all {{ $classes }}" href="{{ .Page.Permalink }}">
-                            {{ $tag }}
+                        <a class="tag tag-blog text-xs {{ if eq (lower $tag) (urlize ((lower $.Title))) }} active {{ end }}" href="{{ .Page.Permalink }}">
+                            {{ $tag | urlize }}
                         </a>
                     </li>
                 {{ end }}


### PR DESCRIPTION
Just a little thing I've noticed that I figured I'd fix up. (In the sidebar, they're lowercased, so this does the same, and reduces the text size slightly as well.)

![](https://cl.ly/c3607f348ed8/Screen%252520Recording%2525202019-12-06%252520at%25252011.55%252520AM.gif)