### PR TITLE
Don't use markdown format in reference links

### DIFF
--- a/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
+++ b/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
@@ -21,11 +21,8 @@ WebSockets, HTTP/2, AWS WAF (web application firewall) integration,
 integrated access logs, and health checks.
 
 The [AWS ALB Ingress controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller)
-is a Kubernetes
-[SIG-AWS](https://github.com/kubernetes/community/tree/master/sig-aws)
-subproject - it was the second sub-project added to
-[SIG-AWS](https://github.com/kubernetes/community/tree/master/sig-aws)
-after the [aws-authenticator subproject](https://github.com/kubernetes-sigs/aws-iam-authenticator).
+is a Kubernetes SIG-AWS subproject - it was the second sub-project added to
+SIG-AWS after the [aws-authenticator subproject](https://github.com/kubernetes-sigs/aws-iam-authenticator).
 The ALB Ingress controller triggers the creation of an ALB and the
 necessary supporting AWS resources whenever a Kubernetes user declares
 an Ingress resource on the cluster.

--- a/content/blog/multicloud-app/index.md
+++ b/content/blog/multicloud-app/index.md
@@ -111,8 +111,10 @@ demo this post in an episode of the [Kubernetes Community Meeting](https://kuber
 
 {{< youtube "EyW2m5Xa_BQ?rel=0&start=67" >}}
 
-[multicloud-example]: [https://github.com/pulumi/examples/tree/master/kubernetes-ts-multicloud](https://github.com/pulumi/examples/tree/master/kubernetes-ts-multicloud)
+<!-- markdownlint-disable url -->
+[multicloud-example]: https://github.com/pulumi/examples/tree/master/kubernetes-ts-multicloud
 [levi-blackstone]: {{< relref "/authors/levi-blackstone" >}}
-[pulumi-kubernetes]: [https://github.com/pulumi/pulumi-kubernetes](https://github.com/pulumi/pulumi-kubernetes)
-[client-go]: [https://github.com/kubernetes/client-go](https://github.com/kubernetes/client-go)
+[pulumi-kubernetes]: https://github.com/pulumi/pulumi-kubernetes
+[client-go]: https://github.com/kubernetes/client-go
 [crosswalk-aws]: {{< relref "/docs/guides/crosswalk/aws" >}}
+<!-- markdownlint-enable url -->


### PR DESCRIPTION
This PR fixes a formatting issue on reference links that caused the broken link checker to check the markdown link, which caused a few false broken links to be thrown. It also removes a dead link that was throwing an error as well.

<img width="1223" alt="brokenLink" src="https://user-images.githubusercontent.com/15146337/71149986-fda60f00-21e4-11ea-9682-f5d28b830a81.png">
