### PR TITLE
Add section about front matter title values

### DIFF
--- a/BLOGGING.md
+++ b/BLOGGING.md
@@ -37,6 +37,19 @@ and browse the site locally, you're ready to move on to the next section.
 
    Feel free to adjust the title, authors (more on this below) and tags as appropriate. To change the post's URL, simply rename the folder containing `_index.md`; changing the folder name to `my-awesome-post`, for example, would result in a post ultimately published at https://www.pulumi.com/blog/my-awesome-post.
 
+   **Important**
+
+   The `title` will populate the `<title>` tag of the page, the `<h1>`, and the display value if it is linked to internally. This field has a strict 60 character limit because of SEO related limitations. If you would like to have a longer display title (i.e. the `<h1>` tag) then you will need to specify it by adding `h1: Whatever title you would like` to the front matter. If you would like to display different text on internal links than what the `title` value is, you can also specify a `linktitle` value. Both the `h1` and `linktitle` values can be of any length. Below is an example of this:
+
+   ```
+   ---
+   title: This a Page Title
+   h1: This is the H1 for the page
+   linktitle: This is the link text
+   ...
+   ---
+   ```
+
    **Keep in mind that only posts dated prior to "now" (meaning the moment the build process begins) and _not_ marked as `draft`s will published to production.** The development server renders both future and draft content (so you can work on scheduled posts in advance), but the build process does not; see below for details on scheduling posts for future publishing.
 
 2. If you don't already have a [TOML](https://github.com/toml-lang/toml) file [in the `team` directory](https://github.com/pulumi/docs/tree/master/data/team/team) of the repo, create one now. For Pulumi employees, that file should look something like this:
@@ -145,7 +158,7 @@ For this reason, leaving the `draft` property `true` until you're actually ready
 - [ ] As mentioned, use the Hugo blog-post generator instead of copying another post: ```hugo new --kind blog-post blog/my-new-post```
 - [ ] Drafts will not be published, so either set `draft: false` or or delete it.
 - [ ] Spell and grammar check. Consider using a service such as [Grammarly](http://grammarly.com).
-- [ ] Check for a break `<!--more-->` after the first paragraph, and ensure that your post's introduction looks right on the blog home page. 
+- [ ] Check for a break `<!--more-->` after the first paragraph, and ensure that your post's introduction looks right on the blog home page.
 - [ ] Check that your meta_image appears properly on the blog home page. Do not use animated GIFs for preview images.
 - [ ] Preview locally. Check formatting, links, and images for appearance.
 - [ ] Use the [Twitter card validator](https://cards-dev.twitter.com/validator) to check the how the blog appears in a tweet (use the preview provided in the PR).


### PR DESCRIPTION
This PR adds as a section about the front matter of a blog page and how to use custom values for the `title`, `h1` and `linktitle`.
