### PR TITLE
Address horizontal overflows

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,11 +27,11 @@
                     </button>
                 </div>
 
-                <ul class="nav-header-items hidden w-full flex-grow md:flex md:items-center md:w-auto text-white text-sm md:text-xs lg:text-sm uppercase pt-4 md:pt-0">
+                <ul class="nav-header-items hidden w-full flex-grow md:flex md:items-center md:w-auto text-white text-sm md:text-xs lg:text-sm md:ml-4 uppercase pt-4 md:pt-0">
                     {{ range $.Site.Menus.header }}
                         <li class="whitespace-no-wrap">
                             {{ $active := hasPrefix $.RelPermalink .URL }}
-                            <a href="{{ .URL }}" data-submenu="{{ .Identifier }}" class="block py-2 px-4 md:px-0 md:py-0 md:px-4 md:py-2 my-2 md:my-0 lg:mx-4 rounded {{ if $active }}bg-purple-400 hover:bg-purple-400{{ else }}hover:bg-purple-500{{ end }}">
+                            <a href="{{ .URL }}" data-submenu="{{ .Identifier }}" class="block px-4 py-2 my-2 md:px-2 md:my-0 lg:mx-4 rounded {{ if $active }}bg-purple-400 hover:bg-purple-400{{ else }}hover:bg-purple-500{{ end }}">
                                 {{ .Name }}
                             </a>
                         </li>

--- a/layouts/partials/home/cli.html
+++ b/layouts/partials/home/cli.html
@@ -6,7 +6,7 @@
             <div class="bg-green-600 rounded-full h-3 w-3"></div>
         </div>
     </div>
-    <div class="bg-gray-900 rounded-b text-gray-100 font-mono p-4 overflow-x-scroll md:overflow-x-visible" style="height: 400px;">
+    <div class="bg-gray-900 rounded-b text-gray-100 font-mono p-4 overflow-x-hidden" style="height: 400px;">
         <span class="text-green-400">&rarr;</span>
         <span class="line typed">
             <span>pulumi up</span>

--- a/layouts/partials/home/console.html
+++ b/layouts/partials/home/console.html
@@ -1,4 +1,4 @@
-<div id="carousel-console" class="text-left text-base relative bg-gray-100">
+<div id="carousel-console" class="text-left text-base relative bg-gray-100 text-gray-700">
     <div class="bg-gray-400 rounded-t border-r-2 border-gray-500">
         <div class="flex p-2">
             <div class="bg-red-600 rounded-full h-3 w-3"></div>

--- a/layouts/partials/home/ide.html
+++ b/layouts/partials/home/ide.html
@@ -6,7 +6,7 @@
             <div class="bg-green-600 rounded-full h-3 w-3"></div>
         </div>
     </div>
-    <div class="bg-gray-900 rounded-b text-gray-100 font-mono overflow-x-hidden lg:overflow-x-visible relative" style="height: 400px;">
+    <div class="bg-gray-900 rounded-b text-gray-100 font-mono overflow-x-hidden relative" style="height: 400px;">
         <div class="flex items-center h-8">
             <div class="bg-gray-900 h-8 w-40 px-4 flex items-center">
                 <div class="bg-orange-300 rounded-full h-1 w-1"></div>
@@ -44,7 +44,7 @@
                 </div>
                 <div class="relative" style="top: -6px; left: 188px;">
                     <div class="menu opacity-0 absolute">
-                        <div class="bg-gray-800 p-1 text-white border border-gray-600 w-64 shadow">
+                        <div class="bg-gray-800 p-1 text-white border border-gray-600 w-56 shadow">
                             <div class="row bg-gray-600 px-2">AccountPublicAccessBlock</div>
                             <div class="row px-2">Bucket</div>
                             <div class="row px-2">BucketEventSubscription</div>
@@ -53,24 +53,24 @@
                             <div class="row px-2">BucketObject</div>
                         </div>
                     </div>
-                    <div class="menu opacity-0 absolute" data-delay="1200" style="top: 14px;left: 198px;">
-                        <div class="bg-gray-800 p-1 shadow text-white border border-gray-600 whitespace-normal" style="width: 292px;">
+                    <div class="menu opacity-0 absolute" data-delay="1200" style="top: 14px; left: 138px;">
+                        <div class="bg-gray-800 p-1 shadow text-white border border-gray-600 whitespace-normal" style="width: 242px;">
                             <div class="font-sans">
-                                <div class="mb-2">Create a Bucket resource with the given unique name, arguments, and options.</div>
+                                <div class="mb-2">Create a Bucket resource with the given name, arguments, and options.</div>
                                 <div>
                                     <span class="text-blue-400">@param</span>
                                     <span class="font-mono bg-gray-800 text-orange-200">name</span>
-                                    <span>The <em>unique</em> name of the resource.</span>
+                                    <span>The name of the resource.</span>
                                 </div>
                                 <div>
                                     <span class="text-blue-400">@param</span>
                                     <span class="font-mono bg-gray-800 text-orange-200">args</span>
-                                    <span>The arguments to use to populate this resource's properties.</span>
+                                    <span>The arguments for this resource's properties.</span>
                                 </div>
                                 <div>
                                     <span class="text-blue-400">@param</span>
                                     <span class="font-mono bg-gray-800 text-orange-200">opts</span>
-                                    <span>A bag of options that control this resource's behavior.</span>
+                                    <span>A bag of options for this resource's behavior.</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
This change addresses some overflow issues on medium-sized screens by:

* Reducing the widths and left-offsets of the "select boxes" in the carousel IDE
* Always hiding overflows
* Adjusting the spacing between top-level navigation items 

Also fixes a bug that caused some of the text elements in the carousel console to be white (so not visible) instead of the intended grey.

## Before

![](https://cl.ly/a10f2a128c80/Screen%252520Recording%2525202019-12-23%252520at%25252002.40%252520PM.gif)

## After

![](https://cl.ly/50365d218a1a/Screen%252520Recording%2525202019-12-23%252520at%25252002.42%252520PM.gif)