### PR TITLE
Remove CE notes in Product and Why Pulumi pages

### DIFF
--- a/layouts/page/product.html
+++ b/layouts/page/product.html
@@ -8,11 +8,6 @@
                     Easily go to production with modern cloud architectures, and break down
                     silos inhibiting innovation within your organization.
                 </p>
-                <p class="my-8" style="font-size: 1rem !important">
-                    <a class="rounded text-orange-400 font-bold underline md:font-normal md:no-underline md:border-2 md:border-orange-400 md:py-1 md:px-2 md:mr-1 hover:text-orange-300 hover:border-orange-300 transition-all"
-                        href="{{ relref . "/pricing#community-edition" }}">Pulumi Community Edition</a>
-                    is free forever for unlimited individual use.
-                </p>
                 <div class="header-hero-actions">
                     <a class="btn btn-lg" href="{{ relref . "/docs/get-started" }}">Get Started</a>
                     <a class="btn btn-lg btn-orange-translucent" href="{{ relref . "/pricing" }}">View Pricing</a>

--- a/layouts/page/why-pulumi.html
+++ b/layouts/page/why-pulumi.html
@@ -8,11 +8,6 @@
                     Pulumi makes you more productive, and enables sharing and reuse of common patterns.
                     A single delivery workflow across any cloud helps developers and operators work better together.
                 </p>
-                <p class="my-8" style="font-size: 1rem !important">
-                    <a class="rounded text-orange-400 font-bold underline md:font-normal md:no-underline md:border-2 md:border-orange-400 md:py-1 md:px-2 md:mr-1 hover:text-orange-300 hover:border-orange-300 transition-all"
-                        href="{{ relref . "/pricing#community-edition" }}">Pulumi Community Edition</a>
-                    is free forever for unlimited individual use.
-                </p>
                 <div class="header-hero-actions">
                     <a class="btn btn-lg" href="{{ relref . "/docs/get-started" }}">
                         Get Started


### PR DESCRIPTION
These lines were added in an attempt to make it clear there's a Community Edition and that it's free, but given the recent changes to the Pricing page, they're arguably no longer be necessary (since the VIEW PRICING buttons now bring you to a very that does make that clear).