### PR TITLE
Add a /crossguard short-link

### DIFF
--- a/content/crossguard/_index.md
+++ b/content/crossguard/_index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: "/docs/guides/crossguard"
+---


### PR DESCRIPTION
This link is just an alias to the CrossGuard user guide, but
makes it a little easier to link to from slides, videos, etc.
