### PR TITLE
Use `relref` instead of `ref`

### DIFF
--- a/content/blog/2018-year-at-a-glance/index.md
+++ b/content/blog/2018-year-at-a-glance/index.md
@@ -16,7 +16,7 @@ Here are some of the exciting things that happened:
 
 **Launching our open source
 community.** After being hard at work for a little over a year,
-[we launched our open source project]({{< ref "/blog/introducing-pulumi-a-cloud-development-platform" >}}),
+[we launched our open source project]({{< relref "/blog/introducing-pulumi-a-cloud-development-platform" >}}),
 with the aim of making it considerably easier and more enjoyable to create and operate
 cloud software. This was a major moment for us. We had previously only shown Pulumi to a few select friends,
 family, and private beta users, and the reception was beyond our wildest expectations. We got passionate +1’s
@@ -27,21 +27,21 @@ open source contributions and passionate community leaders emerging who are help
 helping us to make Pulumi even better.
 
 **Support for major public, private, and hybrid clouds.** We launched with support for the three major public
-clouds, [AWS]({{< ref "/docs/get-started/aws" >}}), [Azure]({{< ref "/docs/get-started/azure" >}}), and
-[Google Cloud]({{< ref "/docs/get-started/gcp" >}}), and have since added capabilities across all
-of them, including adding [serverless]({{< ref "/docs/tutorials/aws/rest-api" >}}),
+clouds, [AWS]({{< relref "/docs/get-started/aws" >}}), [Azure]({{< relref "/docs/get-started/azure" >}}), and
+[Google Cloud]({{< relref "/docs/get-started/gcp" >}}), and have since added capabilities across all
+of them, including adding [serverless]({{< relref "/docs/tutorials/aws/rest-api" >}}),
 [containers](https://github.com/pulumi/examples/blob/master/aws-ts-containers/index.ts), and
 [infrastructure](https://github.com/pulumi/examples/blob/master/aws-js-webserver/index.js)
 productivity libraries -- it is here where we believe Pulumi’s unique approach of using general purpose languages truly
 shines. We immediately had a wave of inbound interest in applying the Pulumi approach to infrastructure as code in other
 areas, and quickly added other providers including OpenStack, VMWare vSphere, Alibaba Cloud, F5 BigIP, and more. In
-September, we unveiled [a native Kubernetes provider]({{< ref "/docs/get-started/kubernetes" >}}) with support for the
+September, we unveiled [a native Kubernetes provider]({{< relref "/docs/get-started/kubernetes" >}}) with support for the
 entire API surface area across all versions, plus an operations tool, [KubeSpy](https://github.com/pulumi/kubespy) --
 both of which continue to lead to significant community growth. Many customers are loving that they can achieve a
 consistent engineering workflow across multi-cloud environments -- often spanning public, private, and/or hybrid clouds.
 
 **Launching our commercial SaaS product.** In October, [we launched our commercial SaaS
-product]({{< ref "/blog/building-a-future-of-cloud-engineering" >}}), with reasonable
+product]({{< relref "/blog/building-a-future-of-cloud-engineering" >}}), with reasonable
 [pricing](https://www.pulumi.com/pricing/) so that teams of all sizes are able to get their code to the cloud
 productively, securely, and collaboratively. If Pulumi is like Git -- a local CLI and SDK -- then the Pulumi SaaS is
 like GitHub -- a hosted service to ensure you can use Pulumi in a team setting. In addition to the Team Edition, which

--- a/content/blog/advanced-typescript-type-ftw/index.md
+++ b/content/blog/advanced-typescript-type-ftw/index.md
@@ -12,8 +12,8 @@ typechecking – making for a more productive inner loop and helping to find err
 how this works for infrastructure as code can be fascinating!
 <!--more-->
 
-A core part of the Pulumi [programming model]({{< ref "/docs/reference" >}}) is that we allow people to express complex
-[dependency data]({{< ref "/docs/intro/concepts/programming-model#outputs" >}}) that may _eventually_ be available.
+A core part of the Pulumi [programming model]({{< relref "/docs/reference" >}}) is that we allow people to express complex
+[dependency data]({{< relref "/docs/intro/concepts/programming-model#outputs" >}}) that may _eventually_ be available.
 Traditional JavaScript programming might expose that as a Promise<T>, but we’ve taken that one step further by introducing
     a type we call:
 

--- a/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
+++ b/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
@@ -34,7 +34,7 @@ it unintentionally penalized certain architectural decisions. The new
 per user model should be more affordable and predictable.
 
 Here is a summary of the resulting options. For full details, [view our
-pricing page]({{< ref "/pricing" >}}).
+pricing page]({{< relref "/pricing" >}}).
 
 <style>
 /* Just use CSS rather than whatever customization the Markdown processor exposes. */
@@ -52,7 +52,7 @@ All editions offer a 14-day free trial, no credit card
 required. If you need a longer trial period, want to discuss potential proof of
 concept projects, or are interested in advanced capabilities, such as
 large numbers of seats, Training, or Support, please [contact
-us]({{< ref "/contact" >}}).
+us]({{< relref "/contact" >}}).
 
 We remain committed to fostering a vibrant open source community while
 also delivering a robust production service that teams of all sizes are
@@ -100,14 +100,14 @@ facilities, including RBAC for advanced policy controls.
 Yes! We designed the editions to make it easy to get started with Team
 Starter, and once you've outgrown it, upgrading to Team Pro is a single
 click away. To upgrade to Enterprise, please [contact
-us]({{< ref "/contact" >}}).
+us]({{< relref "/contact" >}}).
 
 ### I'm an existing customer on a per stack plan -- what do I do?
 
 We are in the process of reaching out to all existing customers to offer
 a switch to one of the new plans. If you haven't heard from us yet,
 please don't hesitate to [drop us a
-line]({{< ref "/contact" >}}). If now isn't the right time to change
+line]({{< relref "/contact" >}}). If now isn't the right time to change
 for your team, however, don't worry — we are happy to honor your
 existing subscription terms.
 
@@ -115,7 +115,7 @@ existing subscription terms.
 
 We are always happy to discuss the best way to ensure Pulumi can work
 for your team. To talk with a leader at the company, please simply [fill
-out the contact us form]({{< ref "/contact" >}}) and we'll be
+out the contact us form]({{< relref "/contact" >}}) and we'll be
 in touch.
 
 ### What payment options do you accept?
@@ -127,4 +127,4 @@ your organization's Settings page.
 
 For annual subscriptions, we also offer invoicing that is payable with
 bank transfer or check. To discuss those options in more detail, please
-[contact us]({{< ref "/contact" >}}).
+[contact us]({{< relref "/contact" >}}).

--- a/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
+++ b/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
@@ -13,17 +13,17 @@ platform.  The response has been overwhelming and we've been hard at
 work responding to your feedback ever since.
 
 Today, we are excited to release [Pulumi 0.15](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0150-2018-08-13) and make
-it [available to download]({{< ref "/docs/get-started/install" >}}).  This release
+it [available to download]({{< relref "/docs/get-started/install" >}}).  This release
 includes improvements across the entire Pulumi development experience.
 Pulumi supports more platforms
-([Kubernetes]({{< ref "/docs/get-started/kubernetes" >}}) and
-[OpenStack]({{< ref "/docs/intro/cloud-providers/openstack" >}})), is faster
+([Kubernetes]({{< relref "/docs/get-started/kubernetes" >}}) and
+[OpenStack]({{< relref "/docs/intro/cloud-providers/openstack" >}})), is faster
 (Parallelism, simpler (native
 TypeScript support), richer
 (serverless frameworks for Azure and
 GCP),  and is more deeply
 integrated into the application lifecycle
-([GitHub App for CI/CD integration]({{< ref "/docs/guides/continuous-delivery/github-app" >}})).
+([GitHub App for CI/CD integration]({{< relref "/docs/guides/continuous-delivery/github-app" >}})).
 
 In this post, we'll take a quick tour of these new features. Stay tuned
 for follow up blog posts to dive deeper into individual topics.
@@ -86,8 +86,8 @@ const kibana = new helm.v2.Chart("kibana", {
 ```
 
 Check out the [Kubernetes
-overview]({{< ref "/docs/get-started/kubernetes" >}}) docs, the [API
-documentation]({{< ref "/docs/reference/pkg/nodejs/pulumi/kubernetes" >}})
+overview]({{< relref "/docs/get-started/kubernetes" >}}) docs, the [API
+documentation]({{< relref "/docs/reference/pkg/nodejs/pulumi/kubernetes" >}})
 and the [pulumi-kubernetes](https://github.com/pulumi/pulumi-kubernetes)
 GitHub project for additional details.
 
@@ -194,7 +194,7 @@ const instance = new os.compute.Instance("test", {
 exports.instanceIP = instance.accessIpV4;
 ```
 
-Check out the [API documentation]({{< ref "/docs/reference/pkg/nodejs/pulumi/openstack" >}})
+Check out the [API documentation]({{< relref "/docs/reference/pkg/nodejs/pulumi/openstack" >}})
 and the [pulumi-openstack](https://github.com/pulumi/pulumi-openstack)
 GitHub project for additional details. Huge thanks to Fraser for his
 work on this!
@@ -241,7 +241,7 @@ export let url = f.function.httpsTriggerUrl;
 
 ## GitHub App for CI/CD Integration
 
-Pulumi already works with [your favorite CI/CD systems]({{< ref "/docs/guides/continuous-delivery" >}})
+Pulumi already works with [your favorite CI/CD systems]({{< relref "/docs/guides/continuous-delivery" >}})
 to accomplish automated
 and continuous deployments of cloud infrastructure and applications.
 This is how Pulumi deploys and manages our own infrastructure that runs
@@ -263,14 +263,14 @@ infrastructure changes.
 The Pulumi GitHub App is still in preview as we work to support more CI
 systems and extend its capabilities. For information on how to install
 it and configure it with your CI system, please [read the
-documentation]({{< ref "/docs/guides/continuous-delivery/github-app" >}}).
+documentation]({{< relref "/docs/guides/continuous-delivery/github-app" >}}).
 
 ## Summary
 
 We're excited about all the new features in this release and the new
 scenarios they enable for the Pulumi community . If you are new to
 Pulumi, [download the tools and get started
-today]({{< ref "/docs/get-started" >}}), or [join us in Slack](https://slack.pulumi.com). A big thanks to all the users and
+today]({{< relref "/docs/get-started" >}}), or [join us in Slack](https://slack.pulumi.com). A big thanks to all the users and
 contributors who have helped shape this release -- we can't wait to see
 what you build next !
 

--- a/content/blog/announcing-support-for-email-based-identities/index.md
+++ b/content/blog/announcing-support-for-email-based-identities/index.md
@@ -26,7 +26,7 @@ ready to go.
 ## Quickstart
 
 Get started quickly by creating a new [template-based project](https://app.pulumi.com/site/new-project).
-This creates a project, and a [stack]({{< ref "/docs/intro/concepts/stack" >}}) ready to be used by the Pulumi CLI.
+This creates a project, and a [stack]({{< relref "/docs/intro/concepts/stack" >}}) ready to be used by the Pulumi CLI.
 The wizard also shows you the commands you need to run in the CLI.
 
 Haven't setup your CLI for a specific cloud yet? Check out this docs page on how to do that.
@@ -36,4 +36,4 @@ Haven't setup your CLI for a specific cloud yet? Check out this docs page on how
 Once you've deployed your first stack, the next step is up to you. You can refer to our documentation on integrating Pulumi into your CI/CD pipeline, setting up chat-ops workflows via Webhooks, or taking your Kubernetes solutions to the next level!
 
 We'd love to hear what you're up to. Say 👋 in the [Pulumi Community Slack](https://slack.pulumi.com/)
-or [drop us a line]({{< ref "/contact" >}}).
+or [drop us a line]({{< relref "/contact" >}}).

--- a/content/blog/aws-cloudwatch-made-easy-with-pulumi-infrastructure-as-code/index.md
+++ b/content/blog/aws-cloudwatch-made-easy-with-pulumi-infrastructure-as-code/index.md
@@ -13,7 +13,7 @@ and visualizations directly inside your Pulumi application.
 As cloud applications tend to be long-lived, we think it's vital that it
 be possible to get regular insights on the performance of the
 application at all times. Using
-[Crosswalk for AWS]({{< ref "/docs/guides/crosswalk/aws" >}}) Pulumi applications
+[Crosswalk for AWS]({{< relref "/docs/guides/crosswalk/aws" >}}) Pulumi applications
 allow you to easily define and visualize the appropriate
 [metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html)
 that show the health of your services, create
@@ -91,10 +91,10 @@ two resources. That's very simple to do:
 
 Then, we want to get information about how long these functions are
 taking. With Pulumi's
-[Crosswalk]({{< ref "/docs/guides/crosswalk/aws" >}}) APIs it's simple
+[Crosswalk]({{< relref "/docs/guides/crosswalk/aws" >}}) APIs it's simple
 to get at this information. Inside all the main "Crosswalk for AWS"
 modules are exposed
-[Metrics]({{< ref "/docs/reference/pkg/nodejs/pulumi/awsx/cloudwatch#Metric" >}})
+[Metrics]({{< relref "/docs/reference/pkg/nodejs/pulumi/awsx/cloudwatch#Metric" >}})
 for almost anything you might ever need. In this case, we want to know
 how long those Functions are taking so we can get that information as
 follows:
@@ -166,4 +166,4 @@ content:
 
 1. [Pulumi Crosswalk for AWS Announcement]({{< relref "introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws" >}})
 2. [Mapbox IOT-as-Code with Pulumi Crosswalk for AWS]({{< relref "mapbox-iot-as-code-with-pulumi-crosswalk-for-aws" >}})
-3. [Pulumi Crosswalk for AWS Documentation]({{< ref "/docs/guides/crosswalk/aws" >}})
+3. [Pulumi Crosswalk for AWS Documentation]({{< relref "/docs/guides/crosswalk/aws" >}})

--- a/content/blog/build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws/index.md
+++ b/content/blog/build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws/index.md
@@ -47,7 +47,7 @@ If you're on Windows, run this:
     SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
 
 You'll deploy this app to your own AWS account, so follow the steps
-to [configure your AWS account]({{< ref "/docs/intro/cloud-providers/aws/setup.md" >}}).
+to [configure your AWS account]({{< relref "/docs/intro/cloud-providers/aws/setup.md" >}}).
 
 Make sure you have [Node.js](https://nodejs.org/en/download/) installed,
 with a version of 6.10.x or later.

--- a/content/blog/building-a-future-of-cloud-engineering/index.md
+++ b/content/blog/building-a-future-of-cloud-engineering/index.md
@@ -129,7 +129,7 @@ vSphere and OpenStack. Our delivery platform works great with your
 favorite CI systems. Expect to see continued growth in all of these
 areas, in addition to new clouds, languages, and integrations.
 
-Today we launched [the Team Edition]({{< ref "/pricing" >}}) for our
+Today we launched [the Team Edition]({{< relref "/pricing" >}}) for our
 SaaS delivery platform. This includes many features that you, the
 community, told us you need to better operationalize Pulumi within your
 teams. We already have many happy customers using these features
@@ -137,17 +137,17 @@ successfully for organizations big and small. Expect to see a steady
 stream of improvements, in addition to Enterprise Edition capabilities
 for the largest of organizations needing on-premises, advanced security,
 and custom identity. Please always [let us
-know]({{< ref "/contact" >}}) how we can better meet your
+know]({{< relref "/contact" >}}) how we can better meet your
 needs.
 
 This new round of funding will allow us to strengthen our commitment to
 open source and community, increase our R&D velocity, and also scale our
 business to enable organizations of all sizes to successfully achieve
 cloud engineering within their teams. We are [hiring in all areas of the
-company]({{< ref "/careers" >}}) as we enter this next exciting
+company]({{< relref "/careers" >}}) as we enter this next exciting
 chapter of the company.
 
-[Download Pulumi]({{< ref "/docs/get-started/install" >}}) -- we
+[Download Pulumi]({{< relref "/docs/get-started/install" >}}) -- we
 can't wait to see all the great things you build next with Pulumi!
 
 Joe & Eric

--- a/content/blog/building-and-publishing-docker-images-to-a-private-amazon-ecr-repository/index.md
+++ b/content/blog/building-and-publishing-docker-images-to-a-private-amazon-ecr-repository/index.md
@@ -20,7 +20,7 @@ need to operate your own container repositories or worry about scaling
 the underlying infrastructure. ECR hosts your images in a highly
 available and scalable architecture, allowing you to reliably deploy
 containers for your applications. In this article, we'll see how
-[Pulumi Crosswalk for AWS]({{< ref "/crosswalk/aws" >}}) lets you use
+[Pulumi Crosswalk for AWS]({{< relref "/crosswalk/aws" >}}) lets you use
 infrastructure as code to easily build, publish, and pull from private
 ECR repositories.
 <!--more-->
@@ -200,7 +200,7 @@ manually going and cleaning up the stale garbage in the future.
 
 ## Next Steps
 
-We've shown how [Pulumi Crosswalk for AWS]({{< ref "/crosswalk/aws" >}})
+We've shown how [Pulumi Crosswalk for AWS]({{< relref "/crosswalk/aws" >}})
 can create a tight developer inner
 loop for building, publishing, and consuming Docker images, using
 private ECR repositories, while keeping all your ECS or EKS services and
@@ -213,10 +213,10 @@ sync.
 Pulumi is open source and free to use. For more information on Getting
 Started, check out:
 
-1. [AWS QuickStart]({{< ref "/docs/get-started/aws" >}})
+1. [AWS QuickStart]({{< relref "/docs/get-started/aws" >}})
 2. [Pulumi Crosswalk for AWS Announcement]({{< relref "introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws" >}})
 3. [Mapbox IOT-as-Code with Pulumi Crosswalk for AWS]({{< relref "mapbox-iot-as-code-with-pulumi-crosswalk-for-aws" >}})
-4. [Pulumi Crosswalk for AWS Documentation for ECS, EKS, ELB, and more]({{< ref "/docs/guides/crosswalk/aws" >}})
+4. [Pulumi Crosswalk for AWS Documentation for ECS, EKS, ELB, and more]({{< relref "/docs/guides/crosswalk/aws" >}})
 
 We think there's no easier way to do containers in a tight inner
 development loop, and we hope you agree!

--- a/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
+++ b/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
@@ -81,6 +81,6 @@ We hope you like these helpers. If you're keen to get stuck in:
 - [Join the Slack conversation](https://slack.pulumi.com) - it's
   heating up in there.
 - Try out the [many examples we have](https://app.pulumi.com), and
-  [dive into the docs]({{< ref "/docs/reference" >}}).
+  [dive into the docs]({{< relref "/docs/reference" >}}).
 - [Submit new templates as PRs](https://github.com/pulumi/templates) -
   contribution == [t-shirts at least](https://info.pulumi.com/community/give-me-a-tshirt).

--- a/content/blog/building-your-first-serverless-app-using-only-javascript/index.md
+++ b/content/blog/building-your-first-serverless-app-using-only-javascript/index.md
@@ -28,7 +28,7 @@ need for building cloud applications. Better than that, you can even
 
 ## Our first serverless app in 5 lines of JavaScript
 
-After [installing the Pulumi CLI]({{< ref "/docs/get-started/install" >}}), just run
+After [installing the Pulumi CLI]({{< relref "/docs/get-started/install" >}}), just run
 the following to create a new app:
 
     mkdir firstapp && cd firstapp
@@ -80,7 +80,7 @@ This approach avoided significant amounts of configuration (YAML, or
 point-and-click). Pulumi also supports containers (including
 Kubernetes), managed services, infrastructure and everything else in
 between that you might need for building cloud applications.
-[Get started with Pulumi]({{< ref "/docs/get-started" >}}).
+[Get started with Pulumi]({{< relref "/docs/get-started" >}}).
 
 ## Why JavaScript for serverless programming?
 
@@ -135,6 +135,6 @@ To learn more take a look at more tutorials and example code:
 - Our origin story: [Hello, Pulumi!](http://joeduffyblog.com/2018/06/18/hello-pulumi/)
 - Tutorial: [Deploying Containers with Pulumi]({{< relref "deploying-production-ready-containers-with-pulumi" >}})
 - Tutorial: [Build a video thumbnailer using AWS Lambda, Fargate, and S3 in JavaScript]({{< relref "build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws" >}})
-- [Pulumi Quickstart]({{< ref "/docs/get-started" >}})
+- [Pulumi Quickstart]({{< relref "/docs/get-started" >}})
 - [Pulumi Community Slack](https://slack.pulumi.com)
 - [Pulumi Examples on GitHub](https://github.com/pulumi/examples)

--- a/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
+++ b/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
@@ -17,7 +17,7 @@ infrastructure is just a few steps away for you and your teams.
 To make it easy to use Pulumi with Azure, we are announcing an
 open-source task extension for Azure Pipelines! The task extension will
 manage the installation of the Pulumi CLI, and run the [Pulumi
-commands]({{< ref "/docs/reference/cli" >}}) you specify against
+commands]({{< relref "/docs/reference/cli" >}}) you specify against
 your stack.
 
 You can install the task extension directly from the [Visual Studio
@@ -33,7 +33,7 @@ To use the Pulumi task extension in Azure Pipelines, there are two
 options. The
 full [example](https://github.com/pulumi/pulumi-az-pipelines-task/tree/master/examples) is
 in the source repo. For contrast, without this task extension,
-[here's]({{< ref "/docs/guides/continuous-delivery/azure-devops#using-scripts-manual-approach" >}}) how
+[here's]({{< relref "/docs/guides/continuous-delivery/azure-devops#using-scripts-manual-approach" >}}) how
 you would achieve the same, but with scripts.
 
 ## OPTION 1: Using the Classic Editor Console
@@ -82,7 +82,7 @@ easily integrate Pulumi into your CI/CD pipeline, and take advantage of previews
 changes in pull requests, push-to-deploy, and ultimately removing the friction for your DevOps.
 
 As always, we'd love to hear what you think. Say 👋 in the [Pulumi Community Slack](https://slack.pulumi.com)
-or [drop us a line]({{< ref "/contact" >}}).
+or [drop us a line]({{< relref "/contact" >}}).
 
 Want to learn more? Check out [this post from Mikhail Shilkov]({{< relref "level-up-your-azure-platform-as-a-service-applications-with-pulumi" >}})
 for a detailed look at deploying applications on Azure with Pulumi.

--- a/content/blog/cloud-native-infrastructure-with-kubernetes-and-pulumi/index.md
+++ b/content/blog/cloud-native-infrastructure-with-kubernetes-and-pulumi/index.md
@@ -20,7 +20,7 @@ a way to create, deploy, and manage Kubernetes applications using your
 favorite programming languages.
 that works across AWS, Azure, Google Cloud, OpenStack, and other clouds,
 now to Kubernetes and cloud native architectures. You can
-[dive right in here]({{< ref "/docs/get-started/kubernetes" >}}) and
+[dive right in here]({{< relref "/docs/get-started/kubernetes" >}}) and
 look at some
 [powerful things Pulumi enables here]({{< relref "program-kubernetes-with-11-cloud-native-pulumi-pearls" >}}).
 <!--more-->
@@ -126,14 +126,14 @@ entry for using Kubernetes with real components and reuse.
 We can't wait to hear what you think. To learn more or give it a try,
 please check out these resources:
 
-- [EKS Quickstart]({{< ref "/docs/tutorials/kubernetes/eks" >}})
-- [GKE Quickstart]({{< ref "/docs/tutorials/kubernetes/gke" >}})
-- [AKS Quickstart]({{< ref "/docs/tutorials/kubernetes/aks" >}})
+- [EKS Quickstart]({{< relref "/docs/tutorials/kubernetes/eks" >}})
+- [GKE Quickstart]({{< relref "/docs/tutorials/kubernetes/gke" >}})
+- [AKS Quickstart]({{< relref "/docs/tutorials/kubernetes/aks" >}})
 
 These two tutorials will walk you through your first Pulumi for Kubernetes project:
 
-- [Tutorial: Deploy a Stateless Nginx Application]({{< ref "/docs/tutorials/kubernetes/stateless-app" >}})
-- [Tutorial: Deploy a Load-Balanced Guestbook App with Redis and Nginx]({{< ref "/docs/tutorials/kubernetes/guestbook" >}})
+- [Tutorial: Deploy a Stateless Nginx Application]({{< relref "/docs/tutorials/kubernetes/stateless-app" >}})
+- [Tutorial: Deploy a Load-Balanced Guestbook App with Redis and Nginx]({{< relref "/docs/tutorials/kubernetes/guestbook" >}})
 
 [Program Kubernetes with 11 Pearls]({{< relref "program-kubernetes-with-11-cloud-native-pulumi-pearls" >}}):
 a companion blog post with 11 exciting examples.

--- a/content/blog/code-deploy-and-manage-a-serverless-rest-api-on-aws-with-pulumi/index.md
+++ b/content/blog/code-deploy-and-manage-a-serverless-rest-api-on-aws-with-pulumi/index.md
@@ -54,7 +54,7 @@ If you're on Windows, run this:
     SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
 
 You'll deploy this app to your own AWS account, so follow the steps to
-[configure your AWS account]({{< ref "/docs/get-started/aws" >}}).
+[configure your AWS account]({{< relref "/docs/get-started/aws" >}}).
 
 Make sure you have [Node.js](https://nodejs.org/en/download/) installed,
 with a version of 6.10.x or later.

--- a/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
+++ b/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
@@ -79,7 +79,7 @@ in addition to our favorite IDEs and tools.
 After committing our changes, Pulumi takes it from there. Deployments
 can be previewed, diffed, and are recorded so that you'll always know
 who changed what, when, and why -- all very "Git-like." Pulumi's
-[GitHub App]({{< ref "/docs/guides/continuous-delivery/github-app" >}})
+[GitHub App]({{< relref "/docs/guides/continuous-delivery/github-app" >}})
 adds to this and enables "GitOps" so that teams can propose, approve,
 and promote code from "staging" to "production" using pull requests
 (more on that below).
@@ -96,7 +96,7 @@ all of this up and running. Let's see how!
 ## Getting Up and Running
 
 The full sequence of steps is available in our [GitHub Actions Getting
-Started Guide]({{< ref "/docs/guides/continuous-delivery/github-actions" >}}).
+Started Guide]({{< relref "/docs/guides/continuous-delivery/github-actions" >}}).
 
 In summary, using GitHub Actions with Pulumi is as easy as [signing up
 for Pulumi](https://app.pulumi.com/) (if you haven't already), creating
@@ -135,7 +135,7 @@ it's so easy!
 
 If you are going to use this setup in a real team setting, you'll
 probably also want to use Pulumi's GitHub App. Simply by
-[installing it into your repo]({{< ref "/docs/guides/continuous-delivery/github-app" >}}),
+[installing it into your repo]({{< relref "/docs/guides/continuous-delivery/github-app" >}}),
 and combined with the above, you'll instantly get improved GitHub Checks API
 integration and, more importantly, context added by the Pulumi bot to
 your Pull Requests about what a deployment will do before it's even
@@ -152,8 +152,8 @@ There is so much more fun to have, and we're just getting started. Look
 for more in the weeks to come. In the meantime, here are some follow up
 links in case you want to learn more about GitHub Actions and Pulumi:
 
-- To learn more, [install Pulumi]({{< ref "/docs/get-started/install" >}}) and then
-  check out our [Getting Started guide]({{< ref "/docs/get-started" >}}).
+- To learn more, [install Pulumi]({{< relref "/docs/get-started/install" >}}) and then
+  check out our [Getting Started guide]({{< relref "/docs/get-started" >}}).
 - In addition to [the keynote
   video](https://www.youtube.com/watch?v=59SxB2uY9E0), we have two
   other videos that you might enjoy watching to learn more:
@@ -173,7 +173,7 @@ about it is that *it's fun* in the same way programming is fun.
 
 If you're not yet in the GitHub Actions private beta, but want to try
 Pulumi, head on over to our
-[Pulumi Getting Started guide]({{< ref "/docs/get-started" >}}). You'll be running CLI commands,
+[Pulumi Getting Started guide]({{< relref "/docs/get-started" >}}). You'll be running CLI commands,
 but we think that can be a lot of fun too!
 
 We want to thank our GitHub partners for the bold and innovative work

--- a/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
+++ b/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
@@ -19,7 +19,7 @@ Pulumi libraries for [Azure](https://github.com/pulumi/pulumi-azure) and
 
 - An account on [https://app.pulumi.com](https://app.pulumi.com/) with
   an organization.
-- The latest `pulumi` CLI. Installation instructions are [here]({{< ref "/docs/get-started/install" >}}).
+- The latest `pulumi` CLI. Installation instructions are [here]({{< relref "/docs/get-started/install" >}}).
 - A bare repository. Set the remote URL to be your GitLab project.
 
 ## Concepts in Pulumi
@@ -31,8 +31,8 @@ organization. This can be a specific GitHub, GitLab or Atlassian
 organization or your solo organization. Inside each organization, users
 create Pulumi projects and stacks.
 
-Pulumi [projects]({{< ref "/docs/intro/concepts/project" >}})
-and [stacks]({{< ref "/docs/intro/concepts/stack" >}})
+Pulumi [projects]({{< relref "/docs/intro/concepts/project" >}})
+and [stacks]({{< relref "/docs/intro/concepts/stack" >}})
 are flexible to accommodate the diverse needs across teams, applications,
 and infrastructure scenarios. Just like Git repos that work with varying
 approaches Pulumi projects and stacks allow you to organize your code
@@ -55,14 +55,14 @@ suited in a production setup giving users more flexibility and
 boundaries between their teams. We will use this structure in our
 example below. For more information on Pulumi projects and stacks,
 please refer to our documentation
-[here]({{< ref "/docs/intro/concepts/organizing-stacks-projects" >}}).
+[here]({{< relref "/docs/intro/concepts/organizing-stacks-projects" >}}).
 
 ### Use Tags to group Pulumi Stacks as Environments:
 
 - Pulumi Stacks have associated metadata in the form of key/value
     tags.
 - You can assign custom tags to stacks (when logged into the
-  [Pulumi Service backend]({{< ref "/docs/intro/concepts/state" >}}) to customize how
+  [Pulumi Service backend]({{< relref "/docs/intro/concepts/state" >}}) to customize how
   stacks are listed in the [Pulumi Console](https://app.pulumi.com/).
     - In our example below we have two environments _prod_ and _dev_.
     - To group stacks by environment we assign custom tags
@@ -71,7 +71,7 @@ please refer to our documentation
     - In the Pulumi Console, you'll be able to group stacks by
         tag: `environment:dev` and tag: `environment:prod`.
 
-Please read more about managing [stack tags in Pulumi]({{< ref "/docs/intro/concepts/stack#stack-tags" >}}).
+Please read more about managing [stack tags in Pulumi]({{< relref "/docs/intro/concepts/stack#stack-tags" >}}).
 
 ![Stack tags](./image-4.png)
 

--- a/content/blog/create-aks-clusters-with-monitoring-and-logging-with-pulumi-azure-open-source-sdks/index.md
+++ b/content/blog/create-aks-clusters-with-monitoring-and-logging-with-pulumi-azure-open-source-sdks/index.md
@@ -17,9 +17,9 @@ write this as a simple example using Pulumi SDKs.
 
 ## Prerequisites
 
-1. [Install `pulumi` CLI]({{< ref "/docs/get-started/install" >}})
-    and set up your [*Azure credentials*]({{< ref "/docs/get-started/azure" >}})
-2. Initialize a new [Pulumi project]({{< ref "/docs/intro/concepts/project" >}}) from available
+1. [Install `pulumi` CLI]({{< relref "/docs/get-started/install" >}})
+    and set up your [*Azure credentials*]({{< relref "/docs/get-started/azure" >}})
+2. Initialize a new [Pulumi project]({{< relref "/docs/intro/concepts/project" >}}) from available
     templates. We use **`****`azure-typescript`****`** template here to
     install all dependencies and save the configuration.
 

--- a/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
+++ b/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
@@ -83,7 +83,7 @@ become just a few lines of very simple, understandable code.
 ## Reusing Infrastructure as Code
 
 To use this new package, head on over to a Pulumi program, or
-[create a new one]({{< ref "/docs/get-started" >}})
+[create a new one]({{< relref "/docs/get-started" >}})
 (for instance, with `pulumi new aws-typescript`).
 Then just add a reference like any other dependency:
 
@@ -210,7 +210,7 @@ richer visualization in the [pulumi.com](http://pulumi.com) console:
 ![pulumi app graph](./pulumi-resource-visualization.png)
 
 If you want to learn more about components, see the
-[documentation]({{< ref "/docs/reference/pkg/nodejs/pulumi/pulumi" >}}).
+[documentation]({{< relref "/docs/reference/pkg/nodejs/pulumi/pulumi" >}}).
 
 ## Package Everything!
 

--- a/content/blog/data-science-on-demand-spinning-up-a-wallaroo-cluster-is-easy-with-pulumi/index.md
+++ b/content/blog/data-science-on-demand-spinning-up-a-wallaroo-cluster-is-easy-with-pulumi/index.md
@@ -75,7 +75,7 @@ Let's jump into it!
 
 First of all, if you'd like to follow along (and spend some money
 provisioning EC2 servers), please
-[download and set up Pulumi]({{< ref "/docs/get-started/install" >}}).
+[download and set up Pulumi]({{< relref "/docs/get-started/install" >}}).
 
 Next, [clone the wallaroo blog examples repo](https://github.com/WallarooLabs/wallaroo_blog_examples) and
 navigate to `provisioned-classifier`. If you followed along with the

--- a/content/blog/day-2-kubernetes-migrating-eks-nodegroups-with-zero-downtime/index.md
+++ b/content/blog/day-2-kubernetes-migrating-eks-nodegroups-with-zero-downtime/index.md
@@ -149,7 +149,7 @@ load testing and decommissioning of the original node group.
 ## Learn More
 
 If you'd like to learn about Pulumi and how to manage your
-infrastructure and Kubernetes through code, [get started today]({{< ref "/docs/get-started" >}}). Pulumi is open source and free to
+infrastructure and Kubernetes through code, [get started today]({{< relref "/docs/get-started" >}}). Pulumi is open source and free to
 use.
 
 For further examples on how to use Pulumi to create Kubernetes
@@ -164,7 +164,7 @@ join our [Community Slack](https://slack.pulumi.com/) channel if you have
 any questions, need support, or just want to say hello.
 
 If you'd like to chat with our team, or get hands-on assistance with
-migrating your existing configuration code to Pulumi, please don't hesitate to [drop us a line]({{< ref "/contact" >}}).
+migrating your existing configuration code to Pulumi, please don't hesitate to [drop us a line]({{< relref "/contact" >}}).
 
 [eks-amis]: https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
 [ingress-nginx]: https://github.com/kubernetes/ingress-nginx

--- a/content/blog/delivering-cloud-native-infrastructure-as-code-a-pulumi-white-paper/index.md
+++ b/content/blog/delivering-cloud-native-infrastructure-as-code-a-pulumi-white-paper/index.md
@@ -26,7 +26,7 @@ technology generation, and even by cloud vendor, and so deny the full
 potential of cloud native application delivery.
 
 In our latest white paper,
-[Delivering Cloud Native Infrastructure as Code]({{< ref "/why-pulumi/delivering-cloud-native-infrastructure-as-code" >}}),
+[Delivering Cloud Native Infrastructure as Code]({{< relref "/why-pulumi/delivering-cloud-native-infrastructure-as-code" >}}),
 we make the case for a consistent programming model for the cloud and examine:
 
 - How the cloud has already evolved three times as it increasingly
@@ -40,7 +40,7 @@ we make the case for a consistent programming model for the cloud and examine:
   development and operations functions, and does not satisfy the need
   for increasing delivery speed in the cloud.
 
-You can read the paper in full [here]({{< ref "/why-pulumi/delivering-cloud-native-infrastructure-as-code" >}}),
+You can read the paper in full [here]({{< relref "/why-pulumi/delivering-cloud-native-infrastructure-as-code" >}}),
 or download a copy [here](./Pulumi-Delivering-CNI-as-Code.pdf).
 
 Let us know what you think!

--- a/content/blog/deploying-production-ready-containers-with-pulumi/index.md
+++ b/content/blog/deploying-production-ready-containers-with-pulumi/index.md
@@ -34,7 +34,7 @@ If you're on Windows, run this:
     SET "PATH=%PATH%;%USERPROFILE%.pulumiin"
 
 You'll deploy this app to your own AWS account, so follow the steps to
-[configure your AWS account]({{< ref "/docs/intro/cloud-providers/aws/setup.md" >}}).
+[configure your AWS account]({{< relref "/docs/intro/cloud-providers/aws/setup.md" >}}).
 
 Make sure you have [Node.js](https://nodejs.org/en/download/) installed,
 with a version of 6.10.x or later.

--- a/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
+++ b/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
@@ -20,11 +20,11 @@ package](https://github.com/pulumi/pulumi-eks). Let's see how.
 ![Pulumi making EKS Easy](./easy-eks.png)
 
 To get started, download the free and open source
-[Pulumi SDK]({{< ref "/docs/get-started/install" >}}). The SDK includes
+[Pulumi SDK]({{< relref "/docs/get-started/install" >}}). The SDK includes
 the CLI we'll be using below, and requires AWS credentials to access
 your AWS account and provision resources. If you already have the AWS
 CLI installed and configured, you're already all set to go. Otherwise,
-[check out the docs here]({{< ref "/docs/intro/cloud-providers/aws/setup.md" >}})
+[check out the docs here]({{< relref "/docs/intro/cloud-providers/aws/setup.md" >}})
 to set things up.
 
 From here, there are two ways to proceed:
@@ -181,7 +181,7 @@ this stack. The stack exports are also published in this same dashboard,
 so that key outputs from a deployment are easily available and can be
 shared with other users in your organization, like your kubeconfig.
 
-[Additional management features]({{< ref "/product" >}}), including
+[Additional management features]({{< relref "/product" >}}), including
 RBAC, CI/CD integrations, and rich resource graph visualization, are
 also available via the [Pulumi app](https://app.pulumi.com),
 including Team and Enterprise Editions for production teams of all
@@ -192,10 +192,10 @@ sizes.
 We've seen how Pulumi takes care of the heavy lifting with AWS EKS so
 you don't have to. You can use Pulumi to easily deploy new clusters,
 managed AWS resources, and then deploy Kubernetes apps to it. Support is
-also available for Azure AKS, [Google GKE]({{< ref "/docs/tutorials/kubernetes/gke" >}}),
+also available for Azure AKS, [Google GKE]({{< relref "/docs/tutorials/kubernetes/gke" >}}),
 and custom clusters (including Minikube), using the same workflow and approach.
 
 For more information:
 
-- [Get started with Pulumi and Kubernetes]({{< ref "/docs/get-started/kubernetes" >}})
-- [Get started with Pulumi and AWS]({{< ref "/docs/get-started/aws" >}})
+- [Get started with Pulumi and Kubernetes]({{< relref "/docs/get-started/kubernetes" >}})
+- [Get started with Pulumi and AWS]({{< relref "/docs/get-started/aws" >}})

--- a/content/blog/easy-serverless-apps-and-infrastructure-real-events-real-code/index.md
+++ b/content/blog/easy-serverless-apps-and-infrastructure-real-events-real-code/index.md
@@ -167,7 +167,7 @@ Note also that the `CallbackFunction` class -- the powerful abstraction
 behind all of this -- is exported, and offers some knobs,
 in case you want to do things like reuse existing IAM roles rather than
 creating new ones.
-See the [`pulumi/aws/lambda` documentation]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/lambda" >}}) for details.
+See the [`pulumi/aws/lambda` documentation]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/lambda" >}}) for details.
 For instance, say we want to increase the RAM available to our function from 128MB to 256MB:
 
 ```typescript
@@ -245,7 +245,7 @@ bucket name, so we use an environment variable. This highlights both the
 benefits and drawbacks to programming at this level -- we need to know
 how to configure all of these ancillary resources, but as a result,
 the
-[entire power of Lambda is at our fingertips]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/lambda#Function" >}}).
+[entire power of Lambda is at our fingertips]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/lambda#Function" >}}).
 
 Notice that we've pointed to our application logic inside of `./app`.
 Pulumi will create the zipfile for you. If we instead wanted to use a
@@ -258,7 +258,7 @@ zipfile we've already packaged, just change `code` as follows:
 ```
 
 Using Pulumi's
-[`Asset` and `Archive` classes]({{< ref "/docs/reference/pkg/nodejs/pulumi/pulumi/asset" >}}),
+[`Asset` and `Archive` classes]({{< relref "/docs/reference/pkg/nodejs/pulumi/pulumi/asset" >}}),
 we can fetch code from anywhere -- even the network.
 
 Although managing your functions manually isn't quite as magical, it is
@@ -288,7 +288,7 @@ We've given the function's ID, `zipTpsReports-19d51dc`, which allows
 Pulumi to locate it in your account and reuse it. This can make it easy
 to incrementally adopt Pulumi one piece at a time, collaborate between
 teams, or stitch together resources
-[managed by different stacks]({{< ref "/docs/intro/concepts/organizing-stacks-projects" >}}).
+[managed by different stacks]({{< relref "/docs/intro/concepts/organizing-stacks-projects" >}}).
 
 ## More About Functions
 
@@ -358,12 +358,12 @@ pace.
 Lastly, it's possible to use Pulumi stacks to actually break apart your
 cloud resources and functions into independently deployable pieces. This
 allows teams to leverage features
-like [RBAC]({{< ref "/docs/intro/console/collaboration" >}}).
+like [RBAC]({{< relref "/docs/intro/console/collaboration" >}}).
 For instance, it's common for the DevOps team to manage the physical
 cloud resources like queues, topics, and buckets, while the development
 team authors and manages the serverless functions attached to them. Read
 more about
-this [here]({{< ref "/docs/intro/concepts/organizing-stacks-projects" >}}).
+this [here]({{< relref "/docs/intro/concepts/organizing-stacks-projects" >}}).
 
 ## More About Event Sources
 
@@ -376,10 +376,10 @@ The simplest answer here is to create a new resource in your Pulumi
 program using `new`, as we saw above. Because Pulumi is an
 infrastructure as code platform, any resources in any cloud are
 available --
-[AWS]({{< ref "/docs/get-started/aws" >}}),
-[Azure]({{< ref "/docs/get-started/azure" >}}),
-[GCP]({{< ref "/docs/get-started/gcp" >}}),
-[Kubernetes]({{< ref "/docs/get-started/kubernetes" >}}), etc. When
+[AWS]({{< relref "/docs/get-started/aws" >}}),
+[Azure]({{< relref "/docs/get-started/azure" >}}),
+[GCP]({{< relref "/docs/get-started/gcp" >}}),
+[Kubernetes]({{< relref "/docs/get-started/kubernetes" >}}), etc. When
 you `new` one up, Pulumi understands how to provision and manage it.
 
 We saw simple examples of this earlier:
@@ -441,26 +441,26 @@ exposed in the AWS package:
 
 - [`apigateway.x.API`](https://github.com/pulumi/examples/tree/master/aws-ts-apigateway):
   create serverless APIs using an Express.js style
-- [`cloudwatch.onSchedule`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch#onSchedule" >}}):
+- [`cloudwatch.onSchedule`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch#onSchedule" >}}):
   fire a CloudWatch event on a particular schedule, e.g. a cron
   expression
-- [`cloudwatch.Event.onEvent`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch#EventRule-onEvent" >}}):
+- [`cloudwatch.Event.onEvent`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch#EventRule-onEvent" >}}):
   fire an event when a particular CloudWatch event occurs
-- [`cloudwatch.LogGroup.onEvent`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch#LogGroup-onEvent" >}}):
+- [`cloudwatch.LogGroup.onEvent`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/cloudwatch#LogGroup-onEvent" >}}):
   fire an event when a CloudWatch logs event occurs
-- [`dynamodb.Table.onEvent`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/dynamodb#Table-onEvent" >}}):
+- [`dynamodb.Table.onEvent`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/dynamodb#Table-onEvent" >}}):
   fire events for DynamoDB insert, modify, or remove operations
-- [`kinesis.Stream.onEvent`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/kinesis#Stream-onEvent" >}}):
+- [`kinesis.Stream.onEvent`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/kinesis#Stream-onEvent" >}}):
   fire Kinesis Stream events at particular times or batch sizes
-- [`s3.Bucket.onObjectCreated`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/s3#Bucket-onObjectCreated" >}}):
+- [`s3.Bucket.onObjectCreated`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/s3#Bucket-onObjectCreated" >}}):
   trigger a function anytime an object is created in an S3 Bucket
-- [`s3.Bucket.onObjectRemoved`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/s3#Bucket-onObjectRemoved" >}}):
+- [`s3.Bucket.onObjectRemoved`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/s3#Bucket-onObjectRemoved" >}}):
   trigger a function anytime an object is removed from an S3 Bucket
-- [`s3.Bucket.onEvent`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/s3#Bucket-onEvent" >}}):
+- [`s3.Bucket.onEvent`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/s3#Bucket-onEvent" >}}):
   trigger a function for a wide range of S3 Bucket events
-- [`sns.Topic.onEvent`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/sns#Topic-onEvent" >}}):
+- [`sns.Topic.onEvent`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/sns#Topic-onEvent" >}}):
   fire SNS Topic events when new messages arrive
-- [`sqs.Queue.onEvent`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/sqs#Queue-onEvent" >}}):
+- [`sqs.Queue.onEvent`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/sqs#Queue-onEvent" >}}):
   fire SQS Queue events when new messages are enqueued (or on DLQ
   events, etc)
 

--- a/content/blog/from-terraform-to-infrastructure-as-software/index.md
+++ b/content/blog/from-terraform-to-infrastructure-as-software/index.md
@@ -232,7 +232,7 @@ translation automatically for you. This is a great place to get started
 to leverage languages better.
 
 The first step is to create a Pulumi project.
-[Download Pulumi here]({{< ref "/docs/get-started/install" >}}), and then run:
+[Download Pulumi here]({{< relref "/docs/get-started/install" >}}), and then run:
 
 ```
 $ pulumi new aws-typescript

--- a/content/blog/get-started-with-docker-on-aws-fargate-using-pulumi/index.md
+++ b/content/blog/get-started-with-docker-on-aws-fargate-using-pulumi/index.md
@@ -82,7 +82,7 @@ export const url = web.endpoint.hostname;
 ## Step 1. Create a Cluster
 
 The opening stanza imports Pulumi's
-[open source AWSX NPM package]({{< ref "/docs/reference/pkg/nodejs/pulumi/awsx" >}}), `@pulumi/awsx`. It
+[open source AWSX NPM package]({{< relref "/docs/reference/pkg/nodejs/pulumi/awsx" >}}), `@pulumi/awsx`. It
 contains high level AWS best practices and patterns, and leverages real
 languages to eliminate boilerplate YAML templating:
 
@@ -233,7 +233,7 @@ Pulumi's "everything is code" approach means deploying everything can be
 done with a CLI command, unlocking the power of the entire Docker
 platform with a great inner development loop, that works from the
 desktop all the way to production. This entire flow can be
-[easily integrated into your favorite CI/CD pipeline]({{< ref "/docs/guides/continuous-delivery" >}}),
+[easily integrated into your favorite CI/CD pipeline]({{< relref "/docs/guides/continuous-delivery" >}}),
 including GitOps workflows.
 
 If we want to augment our service with other AWS resources -- like S3
@@ -247,4 +247,4 @@ but also Azure and GCP cloud providers, in addition to Kubernetes!
 Want to go deeper?
 
 - [Check out this example on GitHub](https://github.com/pulumi/examples/tree/master/aws-ts-hello-fargate)
-- [Get Started with your favorite cloud and scenario now]({{< ref "/docs/get-started" >}})
+- [Get Started with your favorite cloud and scenario now]({{< relref "/docs/get-started" >}})

--- a/content/blog/happy-birthday-to-pulumi-open-source/index.md
+++ b/content/blog/happy-birthday-to-pulumi-open-source/index.md
@@ -17,29 +17,29 @@ Here are some highlights we've added in partnership with the community
 since launching:
 
 - Over 100 [examples](https://github.com/pulumi/examples),
-    [tutorials]({{< ref "/docs/tutorials" >}}), and a brand new
-    [Getting Started guide]({{< ref "/docs/get-started" >}}).
+    [tutorials]({{< relref "/docs/tutorials" >}}), and a brand new
+    [Getting Started guide]({{< relref "/docs/get-started" >}}).
 - [A native Kubernetes provider with 100% Kubernetes API/version coverage.]({{< relref "pulumi-a-better-way-to-kubernetes" >}})
 - A steady stream of improvements across
-    [AWS]({{< ref "/docs/get-started/aws" >}}),
-    [Azure]({{< ref "/docs/get-started/azure" >}}), and
-    [Google Cloud]({{< ref "/docs/get-started/gcp" >}}) providers.
+    [AWS]({{< relref "/docs/get-started/aws" >}}),
+    [Azure]({{< relref "/docs/get-started/azure" >}}), and
+    [Google Cloud]({{< relref "/docs/get-started/gcp" >}}) providers.
 - [Pulumi Crosswalk for AWS, a framework with built-in AWS infrastructure best practices.]({{< relref "/crosswalk/aws" >}})
 - Over 20 additional providers, including
     [CloudFlare](https://github.com/pulumi/pulumi-cloudflare),
     [Digital Ocean](https://github.com/pulumi/pulumi-digitalocean), and
     [MySQL]({{< relref "managing-your-mysql-databases-with-pulumi" >}}).
-- Brought our [Python 3 SDK]({{< ref "/docs/reference/pkg/python" >}})
+- Brought our [Python 3 SDK]({{< relref "/docs/reference/pkg/python" >}})
     to parity with our
-    [Node.js-based JavaScript and TypeScript SDKs]({{< ref "/docs/reference/pkg/nodejs" >}}).
+    [Node.js-based JavaScript and TypeScript SDKs]({{< relref "/docs/reference/pkg/nodejs" >}}).
 - [Team and Enterprise SaaS editions for teams managing infrastructure in production.](https://www.pulumi.com/pricing)
-- [GitHub, GitLab, Atlassian, and SAML/SSO identity providers.]({{< ref "/docs/intro/console/accounts-and-organizations/organizations" >}})
-- [CI/CD integrations with GitHub, GitLab, Codefresh, CircleCI, major clouds, and more.]({{< ref "/docs/guides/continuous-delivery" >}})
+- [GitHub, GitLab, Atlassian, and SAML/SSO identity providers.]({{< relref "/docs/intro/console/accounts-and-organizations/organizations" >}})
+- [CI/CD integrations with GitHub, GitLab, Codefresh, CircleCI, major clouds, and more.]({{< relref "/docs/guides/continuous-delivery" >}})
 - [Pluggable secrets management and transitive state encryption.]({{< relref "managing-secrets-with-pulumi" >}})
-- [Pluggable state backends for AWS S3, Azure Blob Store, and Google Cloud Store.]({{< ref "/docs/intro/concepts/state" >}})
+- [Pluggable state backends for AWS S3, Azure Blob Store, and Google Cloud Store.]({{< relref "/docs/intro/concepts/state" >}})
 - [Tools for managing complex, multi-stack environments, including Terraform integration.]({{< relref "using-terraform-remote-state-with-pulumi" >}})
 - Numerous engine reliability and performance improvements, including parallelism.
-- [75 blogs, increasingly focused on end to end solutions we see working with customers.]({{< ref "/blog" >}})
+- [75 blogs, increasingly focused on end to end solutions we see working with customers.]({{< relref "/blog" >}})
 
 In addition to the steady stream of product improvements, the community
 has grown fast:

--- a/content/blog/how-to-deploy-jenkins-to-kubernetes-with-pulumi/index.md
+++ b/content/blog/how-to-deploy-jenkins-to-kubernetes-with-pulumi/index.md
@@ -43,8 +43,8 @@ code as an included class.
 ## Running the App
 
 Follow the steps in
-[Pulumi Installation and Setup]({{< ref "/docs/get-started/install" >}}) and
-[Configuring Pulumi Kubernetes]({{< ref "/docs/get-started/kubernetes" >}})
+[Pulumi Installation and Setup]({{< relref "/docs/get-started/install" >}}) and
+[Configuring Pulumi Kubernetes]({{< relref "/docs/get-started/kubernetes" >}})
 to get setup with Pulumi and Kubernetes.
 
 > *Note*: The code in this repo assumes you are deploying to a cluster
@@ -165,5 +165,5 @@ and comprehension for building cloud stacks.
 Find out more:
 
 - Get the [example code on GitHub](https://github.com/pulumi/examples/tree/master/kubernetes-ts-jenkins)
-- Read the docs on [Kubernetes]({{< ref "/docs/reference/pkg/nodejs/pulumi/kubernetes" >}})
-- See the tutorial on [building components]({{< ref "/docs/tutorials/aws/s3-folder-component" >}})
+- Read the docs on [Kubernetes]({{< relref "/docs/reference/pkg/nodejs/pulumi/kubernetes" >}})
+- See the tutorial on [building components]({{< relref "/docs/tutorials/aws/s3-folder-component" >}})

--- a/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
+++ b/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
@@ -132,7 +132,7 @@ Another fun example is
 ## Learn More
 
 If you'd like to learn about Pulumi and how to manage your
-infrastructure and Kubernetes through code, [click here to get started today]({{< ref "/docs/get-started" >}}). Pulumi is open source and free to
+infrastructure and Kubernetes through code, [click here to get started today]({{< relref "/docs/get-started" >}}). Pulumi is open source and free to
 use.
 
 If you'd like to go deeper on certain topics, here are some additional
@@ -140,12 +140,12 @@ resources to check out:
 
 - [Overview of Pulumi Kubernetes Scenarios]({{< relref "/topics/kubernetes" >}})
 - Tutorial: Create a Kubernetes cluster on a cloud provider
-  [Amazon EKS]({{< ref "/docs/tutorials/kubernetes/eks" >}}),
-  [Google GKE]({{< ref "/docs/tutorials/kubernetes/gke" >}}), or
+  [Amazon EKS]({{< relref "/docs/tutorials/kubernetes/eks" >}}),
+  [Google GKE]({{< relref "/docs/tutorials/kubernetes/gke" >}}), or
   [Azure AKS](https://github.com/pulumi/examples/tree/master/azure-ts-aks-mean)
-- Tutorial: [Operate and deploy to a Kubernetes cluster]({{< ref "/docs/tutorials/kubernetes/exposed-deployment" >}})
-- Docs: [Pulumi docs]({{< ref "/docs/reference" >}}), including an
-  [overview of the programming model]({{< ref "/docs/intro/concepts/programming-model" >}})
+- Tutorial: [Operate and deploy to a Kubernetes cluster]({{< relref "/docs/tutorials/kubernetes/exposed-deployment" >}})
+- Docs: [Pulumi docs]({{< relref "/docs/reference" >}}), including an
+  [overview of the programming model]({{< relref "/docs/intro/concepts/programming-model" >}})
 - Video: In February, we were honored to have Joe Beda
 [show where Pulumi fits in on his TGIK livestream](https://www.youtube.com/watch?v=ILMK65YVSKw),
 highlighting how to use your favorite language and consistent workflows to create,
@@ -161,4 +161,4 @@ any questions, need support, or just want to say hello.
 
 If you'd like to chat with our team, or get hands-on assistance with
 migrating your existing configuration code (including ksonnet programs)
-to Pulumi, please don't hesitate to [drop us a line]({{< ref "/contact" >}}).
+to Pulumi, please don't hesitate to [drop us a line]({{< relref "/contact" >}}).

--- a/content/blog/improving-kubernetes-management-with-pulumis-await-logic/index.md
+++ b/content/blog/improving-kubernetes-management-with-pulumis-await-logic/index.md
@@ -29,7 +29,7 @@ We've
 how Pulumi [**tracks the status**]({{< relref "kubespy-trace-a-real-time-view-into-the-heart-of-a-kubernetes-service" >}})
 of Kubernetes resources to provide fine-grained status messages for both
 your [**infrastructure and applications**]({{< relref "how-do-kubernetes-deployments-work-an-adversarial-perspective" >}}).
-Pulumi [**uses a resource graph**]({{< ref "/docs/intro/concepts/how-pulumi-works" >}})
+Pulumi [**uses a resource graph**]({{< relref "/docs/intro/concepts/how-pulumi-works" >}})
 for orchestration, dependency management, differential updates, and
 cascading rollouts.
 
@@ -48,7 +48,7 @@ Pulumi's sophisticated await logic helps customers with a couple use
 cases:
 
 1) Visualize fine-grained, live, single-view status updates for all of
-the Kubernetes cluster resources belonging to a [**Pulumi stack**]({{< ref "/docs/intro/concepts/stack" >}}). Most applications
+the Kubernetes cluster resources belonging to a [**Pulumi stack**]({{< relref "/docs/intro/concepts/stack" >}}). Most applications
 deployed to Kubernetes have a variety of interacting components,
 including Pods, Deployments, Secrets, Persistent Volumes, Config Maps,
 Ingress and more. Rather than requiring multiple commands like
@@ -60,7 +60,7 @@ stacks of cloud resources, simplifying the process of adding new
 applications, or sharing responsibilities between teams.
 
 2) Reliably integrate with
-[**CI/CD systems**]({{< ref "/docs/guides/continuous-delivery" >}}) for infrastructure and
+[**CI/CD systems**]({{< relref "/docs/guides/continuous-delivery" >}}) for infrastructure and
 application deployments without requiring hardcoded timeouts, or
 scripting kubectl and parsing the resulting JSON/YAML to detect errors.
 If errors are encountered, Pulumi automatically surfaces the relevant
@@ -109,7 +109,7 @@ interesting edge cases!
 
 If you'd like to learn about Pulumi and how to manage your
 infrastructure and Kubernetes through code,
-[click here to get started today]({{< ref "/docs/get-started" >}}). Pulumi is open source and free to
+[click here to get started today]({{< relref "/docs/get-started" >}}). Pulumi is open source and free to
 use.
 
 If you'd like to go deeper on certain topics, here are some additional
@@ -117,12 +117,12 @@ resources to check out:
 
 - [Overview of Pulumi Kubernetes Scenarios]({{< relref "/topics/kubernetes" >}})
 - Tutorial: Create a Kubernetes cluster on a cloud provider
-  [Amazon EKS]({{< ref "/docs/tutorials/kubernetes/eks" >}}),
-  [Google GKE]({{< ref "/docs/tutorials/kubernetes/gke" >}}), or
+  [Amazon EKS]({{< relref "/docs/tutorials/kubernetes/eks" >}}),
+  [Google GKE]({{< relref "/docs/tutorials/kubernetes/gke" >}}), or
   [Azure AKS](https://github.com/pulumi/examples/tree/master/azure-ts-aks-mean)
-- Tutorial: [Operate and deploy to a Kubernetes cluster]({{< ref "/docs/tutorials/kubernetes/exposed-deployment" >}})
-- Docs: [Pulumi docs]({{< ref "/docs/reference" >}}), including an
-  [overview of the programming model]({{< ref "/docs/intro/concepts/programming-model" >}})
+- Tutorial: [Operate and deploy to a Kubernetes cluster]({{< relref "/docs/tutorials/kubernetes/exposed-deployment" >}})
+- Docs: [Pulumi docs]({{< relref "/docs/reference" >}}), including an
+  [overview of the programming model]({{< relref "/docs/intro/concepts/programming-model" >}})
 - Video: [Watch Joe Beda take Pulumi for a spin in last week's TGIK](https://www.youtube.com/watch?v=ILMK65YVSKw)
 
 As always, you can check out our code
@@ -134,4 +134,4 @@ any questions, need support, or just want to say hello.
 
 If you'd like to chat with our team, or get hands-on assistance with
 migrating your existing configuration code (including ksonnet programs)
-to Pulumi, please don't hesitate [to drop us a line]({{< ref "/contact" >}}).
+to Pulumi, please don't hesitate [to drop us a line]({{< relref "/contact" >}}).

--- a/content/blog/introducing-kx/index.md
+++ b/content/blog/introducing-kx/index.md
@@ -75,7 +75,7 @@ let us know what you think!
 
 If you'd like to learn about Pulumi and how to manage your
 infrastructure and Kubernetes through code,
-[click here to get started today]({{< ref "/docs/get-started" >}}). Pulumi is open
+[click here to get started today]({{< relref "/docs/get-started" >}}). Pulumi is open
 source and free to use.
 
 As always, you can check out our code on

--- a/content/blog/introducing-pulumi-a-cloud-development-platform/index.md
+++ b/content/blog/introducing-pulumi-a-cloud-development-platform/index.md
@@ -31,7 +31,7 @@ best practices within teams and the community.
 
 We started on Pulumi a little over a year ago, have built an incredible
 team, and I'm thrilled to announce its availability.  Download or learn
-more [here]({{< ref "/docs" >}}), or read more background on Pulumi's
+more [here]({{< relref "/docs" >}}), or read more background on Pulumi's
 motivation and world-view **[over on my personal blog](http://joeduffyblog.com/2018/06/18/hello-pulumi)**.
 
 The team can't wait to see all the incredible things you will build

--- a/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
+++ b/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
@@ -19,7 +19,7 @@ of minutes or hours. And AWS building block services frequently leave
 you to re-implement (and re-discover) best-practices instead of
 providing these as smart defaults.
 
-[Pulumi Crosswalk for AWS]({{< ref "/crosswalk/aws" >}}) is a
+[Pulumi Crosswalk for AWS]({{< relref "/crosswalk/aws" >}}) is a
 new open source library of infrastructure-as-code components that make
 it easier to get from zero to production on AWS, easier to adopt AWS
 best practices by default, and easier to evolve your AWS infrastructure
@@ -55,7 +55,7 @@ enterprise application to cloud-native infrastructure, or delivering a
 new service as part of an established cloud application, Crosswalk for
 AWS provides the easiest way to get from zero to production, and to then
 evolve with your projects' needs. You can
-[get started with Crosswalk for AWS]({{< ref "/docs/guides/crosswalk/aws" >}}) today!
+[get started with Crosswalk for AWS]({{< relref "/docs/guides/crosswalk/aws" >}}) today!
 
 > *Note:* Crosswalk for AWS projects are authored using the Pulumi
 > infrastructure-as-code tools. Pulumi allows you to define your
@@ -95,10 +95,10 @@ By building on top of great AWS building blocks like Lambda, API
 Gateway, IAM and more, we avoid needing to worry about infrastructure,
 pay nearly zero fixed costs, and gain the ability to iterate quickly.
 With just a few more lines of code, we can
-[wire up to our own domain]({{< ref "/docs/guides/crosswalk/aws/api-gateway#configuring-api-gateway-custom-domains-and-ssl-using-route53-and-acm" >}}),
-[add authorization]({{< ref "/docs/guides/crosswalk/aws/api-gateway#controlling-and-managing-access-to-apis" >}}),
-[provision a database]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/dynamodb#Table" >}}),
-or [chain together a more complex event-driven application]({{< ref "/docs/guides/crosswalk/aws/lambda#available-aws-services-with-event-sources" >}}).
+[wire up to our own domain]({{< relref "/docs/guides/crosswalk/aws/api-gateway#configuring-api-gateway-custom-domains-and-ssl-using-route53-and-acm" >}}),
+[add authorization]({{< relref "/docs/guides/crosswalk/aws/api-gateway#controlling-and-managing-access-to-apis" >}}),
+[provision a database]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/dynamodb#Table" >}}),
+or [chain together a more complex event-driven application]({{< relref "/docs/guides/crosswalk/aws/lambda#available-aws-services-with-event-sources" >}}).
 
 ### Containers (ECS, Fargate)
 
@@ -136,9 +136,9 @@ export const url = web.endpoint.hostname;
 Using ECS, Fargate, ECR and ELB, we get a robust production-ready
 container deployment - horizontally scaled out, load-balanced, and
 integrated with a private image repository. With just a few more lines
-of code, we can [add autoscaling]({{< ref "/docs/guides/crosswalk/aws/ecs#creating-an-auto-scaling-group-for-ecs-cluster-instances" >}}),
-[customize our ECS cluster]({{< ref "/docs/guides/crosswalk/aws/ecs#explicitly-creating-ecs-clusters-for-ec2-or-fargate" >}}),
-or [wire through advanced container configuration]({{< ref "/docs/guides/crosswalk/aws/ecs#ecs-tasks-containers-and-services" >}})
+of code, we can [add autoscaling]({{< relref "/docs/guides/crosswalk/aws/ecs#creating-an-auto-scaling-group-for-ecs-cluster-instances" >}}),
+[customize our ECS cluster]({{< relref "/docs/guides/crosswalk/aws/ecs#explicitly-creating-ecs-clusters-for-ec2-or-fargate" >}}),
+or [wire through advanced container configuration]({{< relref "/docs/guides/crosswalk/aws/ecs#ecs-tasks-containers-and-services" >}})
 (volumes, environment variables, and more).
 
 ### Networking (VPC)
@@ -167,9 +167,9 @@ design patterns based on [AWS guidance and documentation](https://docs.aws.amazo
 By building in simple defaults for routing, subnet structure, NATs and
 multi-AZ you can get started quickly without having to re-discover these
 best practices. And as your needs grow, you can deeply customize and
-evolve your VPC structure - [defining custom CIDR blocks]({{< ref "/docs/guides/crosswalk/aws/vpc#configuring-cidr-blocks-for-a-vpc" >}}),
-[customizing Internet and NAT Gateways]({{< ref "/docs/guides/crosswalk/aws/vpc#configuring-internet-and-nat-gateways-for-subnets-in-a-vpc" >}})
-or [additional additional private subnets]({{< ref "/docs/guides/crosswalk/aws/vpc#configuring-subnets-for-a-vpc" >}}).
+evolve your VPC structure - [defining custom CIDR blocks]({{< relref "/docs/guides/crosswalk/aws/vpc#configuring-cidr-blocks-for-a-vpc" >}}),
+[customizing Internet and NAT Gateways]({{< relref "/docs/guides/crosswalk/aws/vpc#configuring-internet-and-nat-gateways-for-subnets-in-a-vpc" >}})
+or [additional additional private subnets]({{< relref "/docs/guides/crosswalk/aws/vpc#configuring-subnets-for-a-vpc" >}}).
 
 ### Kubernetes (EKS)
 
@@ -203,9 +203,9 @@ export const kubeconfig = cluster.kubeconfig;
 Building on EKS we get all the benefits of managed Kubernetes paired
 with the platform capabilities of AWS. With Crosswalk for AWS, we can
 get started quickly, and then evolve to take advantage of all of these
-platform features, like [customized node groups]({{< ref "/docs/guides/crosswalk/aws/eks#configuring-your-eks-cluster-s-worker-nodes-and-node-groups" >}}),
-[private networking]({{< ref "/docs/guides/crosswalk/aws/eks#configuring-your-eks-cluster-s-networking" >}}),
-and even [deploying Kubernetes YAML and Helm charts]({{< ref "/docs/guides/crosswalk/aws/eks#deploying-existing-kubernetes-yaml-config-to-your-eks-cluster" >}})
+platform features, like [customized node groups]({{< relref "/docs/guides/crosswalk/aws/eks#configuring-your-eks-cluster-s-worker-nodes-and-node-groups" >}}),
+[private networking]({{< relref "/docs/guides/crosswalk/aws/eks#configuring-your-eks-cluster-s-networking" >}}),
+and even [deploying Kubernetes YAML and Helm charts]({{< relref "/docs/guides/crosswalk/aws/eks#deploying-existing-kubernetes-yaml-config-to-your-eks-cluster" >}})
 to our cluster.
 
 ### Monitoring (CloudWatch)
@@ -244,9 +244,9 @@ export const dashboardUrl =
 With CloudWatch being deeply integrated into all AWS services, we can
 easily build up robust logging, alerting and dashboarding solutions
 across our AWS infrastructure. With just a few more lines of code we can
-[get logs for our functions and containers]({{< ref "/docs/guides/crosswalk/aws/cloudwatch#configuring-cloudwatch-logging" >}}),
-[create alarms when we cross critical thresholds]({{< ref "/docs/guides/crosswalk/aws/cloudwatch#creating-cloudwatch-alarms" >}}),
-and [create rich dashboard layouts]({{< ref "/docs/guides/crosswalk/aws/cloudwatch#defining-cloudwatch-dashboards-in-code" >}})
+[get logs for our functions and containers]({{< relref "/docs/guides/crosswalk/aws/cloudwatch#configuring-cloudwatch-logging" >}}),
+[create alarms when we cross critical thresholds]({{< relref "/docs/guides/crosswalk/aws/cloudwatch#creating-cloudwatch-alarms" >}}),
+and [create rich dashboard layouts]({{< relref "/docs/guides/crosswalk/aws/cloudwatch#defining-cloudwatch-dashboards-in-code" >}})
 all of which will version along with our infrastructure!
 
 ## Early Feedback
@@ -304,7 +304,7 @@ at <https://www.pulumi.com/crosswalk/aws>.
 
 For more on Crosswalk for AWS see:
 
-- [Pulumi Crosswalk for AWS documentation]({{< ref "/crosswalk/aws" >}})
+- [Pulumi Crosswalk for AWS documentation]({{< relref "/crosswalk/aws" >}})
 - [Get Started with Docker on AWS Fargate using Pulumi]({{< relref "get-started-with-docker-on-aws-fargate-using-pulumi" >}})
 - [Easy Serverless Apps and Infrastructure -- Real Events, Real Code]({{< relref "easy-serverless-apps-and-infrastructure-real-events-real-code" >}})
 - [Easily Create and Manage AWS EKS Kubernetes Clusters with Pulumi]({{< relref "easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi" >}})

--- a/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
+++ b/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
@@ -47,10 +47,10 @@ packages.
 
 ## Step 1: Initialize Pulumi project and stack
 
-[Install pulumi CLI]({{< ref "/docs/get-started" >}})
-and set up your [AWS credentials]({{< ref "/docs/get-started/aws" >}}).
-Initialize a new [Pulumi project]({{< ref "/docs/intro/concepts/project" >}})
-and [Pulumi stack]({{< ref "/docs/reference/cli/pulumi_stack" >}}) from
+[Install pulumi CLI]({{< relref "/docs/get-started" >}})
+and set up your [AWS credentials]({{< relref "/docs/get-started/aws" >}}).
+Initialize a new [Pulumi project]({{< relref "/docs/intro/concepts/project" >}})
+and [Pulumi stack]({{< relref "/docs/reference/cli/pulumi_stack" >}}) from
 available programming [language
 templates](https://github.com/pulumi/templates). We will use the
 `aws-typescript` template here and install all library
@@ -399,4 +399,4 @@ product platform, check out the following resources:
 
 - [Pulumi Crosswalk for AWS Announcement]({{< relref "introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws" >}})
 - [Mapbox IOT-as-Code with Pulumi Crosswalk for AWS]({{< relref "mapbox-iot-as-code-with-pulumi-crosswalk-for-aws" >}})
-- [Pulumi Crosswalk for AWS Documentation for ECS, EKS, ELB, and more]({{< ref "/docs/guides/crosswalk/aws" >}})
+- [Pulumi Crosswalk for AWS Documentation for ECS, EKS, ELB, and more]({{< relref "/docs/guides/crosswalk/aws" >}})

--- a/content/blog/lambdas-as-lambdas-the-magic-of-simple-serverless-functions/index.md
+++ b/content/blog/lambdas-as-lambdas-the-magic-of-simple-serverless-functions/index.md
@@ -102,8 +102,8 @@ application code that runs as a function.
 First, we're just defining two simple resources: 1) an `s3.Bucket`,
 where we expect new video files to be uploaded to, and 2) a
 `cloud.Topic` that will inform interested parties when new videos are
-uploaded. (The full surface area of AWS is available in [the aws package]({{< ref "/docs/get-started/aws" >}}), and
-[the cloud package]({{< ref "/docs/tutorials/cloudfx" >}}) offers
+uploaded. (The full surface area of AWS is available in [the aws package]({{< relref "/docs/get-started/aws" >}}), and
+[the cloud package]({{< relref "/docs/tutorials/cloudfx" >}}) offers
 multi-cloud abstractions that work at a higher level of abstraction.)
 Right after defining the resources, we start creating our first FaaS
 resources. `videoBucket` has an `onObjectCreated` event subscription

--- a/content/blog/level-up-your-azure-platform-as-a-service-applications-with-pulumi/index.md
+++ b/content/blog/level-up-your-azure-platform-as-a-service-applications-with-pulumi/index.md
@@ -101,7 +101,7 @@ definition, and deployment pipeline in [Pulumi Examples repository](https://git
 
 The Pulumi development experience is powered by the
 [Pulumi CLI]({{< relref "/docs/reference/cli" >}}). After
-[installing the CLI]({{< ref "/docs/get-started/install" >}}), I jump into an empty
+[installing the CLI]({{< relref "/docs/get-started/install" >}}), I jump into an empty
 `infra` folder and run `pulumi new azure-typescript` accepting all the
 default answers. The CLI bootstraps a skeleton of a TypeScript NodeJS
 application. The code looks like this:
@@ -139,7 +139,7 @@ that such an application will run in multiple environments: production,
 staging, development, and so on.
 
 Pulumi comes with a handy concept of
-[stacks]({{< ref "/docs/intro/concepts/stack" >}})--- isolated,
+[stacks]({{< relref "/docs/intro/concepts/stack" >}})--- isolated,
 independently configurable instances of a Pulumi program. A separate
 stack can be designated for each deployment environment.
 
@@ -263,7 +263,7 @@ I'm using Azure SQL Database service.
 Setting up a SQL Server requires a couple of parameter values that might
 change between execution environments, for instance, a username and a
 password for the connection string. Pulumi provides
-[a way to configure]({{< ref "/docs/intro/concepts/config" >}}) the program's
+[a way to configure]({{< relref "/docs/intro/concepts/config" >}}) the program's
 parameters per stack.
 
 The configuration itself will happen in my CI/CD pipeline. For now, I
@@ -454,9 +454,9 @@ language.
 
 You can get going with these resources:
 
-- [Getting Started with Pulumi]({{< ref "/docs/get-started" >}})
-- [Setup Pulumi to work with Azure]({{< ref "/docs/get-started/azure" >}})
-- [Walkthroughs and Examples]({{< ref "/docs/get-started/azure" >}})
+- [Getting Started with Pulumi]({{< relref "/docs/get-started" >}})
+- [Setup Pulumi to work with Azure]({{< relref "/docs/get-started/azure" >}})
+- [Walkthroughs and Examples]({{< relref "/docs/get-started/azure" >}})
 
 Pulumi enables developers to define cloud infrastructure using general
 purpose programming languages. Pulumi works with multiple cloud

--- a/content/blog/managing-f5-big-ip-systems-with-pulumi/index.md
+++ b/content/blog/managing-f5-big-ip-systems-with-pulumi/index.md
@@ -207,6 +207,6 @@ applications.
 To start managing your F5 BIG-IP systems with real programming
 languages, please check out the following links:
 
-- [Node.js documentation]({{< ref "/docs/reference/pkg/nodejs/pulumi/f5bigip" >}})
-- [Python documentation]({{< ref "/docs/reference/pkg/python/pulumi_f5bigip" >}})
+- [Node.js documentation]({{< relref "/docs/reference/pkg/nodejs/pulumi/f5bigip" >}})
+- [Python documentation]({{< relref "/docs/reference/pkg/python/pulumi_f5bigip" >}})
 - [F5 BIG-IP Example using Pulumi](https://github.com/pulumi/examples/tree/master/f5bigip-ts-ltm-pool)

--- a/content/blog/managing-your-mysql-databases-with-pulumi/index.md
+++ b/content/blog/managing-your-mysql-databases-with-pulumi/index.md
@@ -16,7 +16,7 @@ AWS, Azure and GCP. In addition to this, Pulumi recently added support for manag
 instances themselves to manage permissions, create databases, and other common tasks.
 
 In this post, we’ll walk through a quick tutorial of how to use this new
-[Pulumi MySQL provider]({{< ref "/docs/reference/pkg/nodejs/pulumi/mysql" >}}) to manage existing
+[Pulumi MySQL provider]({{< relref "/docs/reference/pkg/nodejs/pulumi/mysql" >}}) to manage existing
 and new MySQL databases.
 <!--more-->
 
@@ -160,7 +160,7 @@ $ pulumi up
 Wrapping Up
 Pulumi allows you to manage your MySQL cloud instances in AWS, Azure, and GCP, as well as manage MySQL databases,
 users and more. Together, this enables end-to-end provisioning of your application’s database infrastructure.
-Read more about the [Pulumi MySQL provider]({{< ref "/docs/reference/pkg/nodejs/pulumi/mysql" >}}).
+Read more about the [Pulumi MySQL provider]({{< relref "/docs/reference/pkg/nodejs/pulumi/mysql" >}}).
 
 We’ve only shown a little bit of what Pulumi can do. If you need any help, feel free to create an issue
 [on GitHub](https://github.com/pulumi/) or join the [Pulumi Community Slack](https://slack.pulumi.com) channel.

--- a/content/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws/index.md
+++ b/content/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws/index.md
@@ -35,9 +35,9 @@ Also refer to this blog of the [Race across America](https://blog.mapbox.com/tea
 showcased live during the webinar tomorrow.
 <!--more-->
 
-**Prerequisites:** [Install Pulumi]({{< ref "/docs/get-started/install" >}});
+**Prerequisites:** [Install Pulumi]({{< relref "/docs/get-started/install" >}});
 [Install Node.js version 8 or later](https://nodejs.org/en/download/) and
-[Setup AWS]({{< ref "/docs/get-started/aws" >}})
+[Setup AWS]({{< relref "/docs/get-started/aws" >}})
 
 The diagram represents how Mapbox's solution design on AWS services is
 built with Pulumi AWS and AWSX libraries in Javascript. Data is ingested

--- a/content/blog/meet-the-pulumi-team-at-aws-reinvent/index.md
+++ b/content/blog/meet-the-pulumi-team-at-aws-reinvent/index.md
@@ -7,19 +7,19 @@ tags: ["Pulumi-News"]
 ---
 
 Heading to AWS re:Invent? Concerned about how you'll manage to get
-[that much YAML]({{< ref "/cloudformation" >}}) into your carry
+[that much YAML]({{< relref "/cloudformation" >}}) into your carry
 on bag? Or maybe you just like purple.
 
 Whatever the reason, the Pulumi team will be there all week at **Booth
 316, Startup Central, Aria Quad, **and we'd love to chat with you about
-[AWS and Pulumi]({{< ref "/crosswalk/aws" >}}).
+[AWS and Pulumi]({{< relref "/crosswalk/aws" >}}).
 
-Catch up with us on serverless functions, [containers]({{< ref "/containers" >}}) and
+Catch up with us on serverless functions, [containers]({{< relref "/containers" >}}) and
 [Kubernetes]({{< relref "/topics/kubernetes" >}}), managed services and
 any other cloud native infrastructure as code, and see how you can more
 productively manage your AWS cloud resources with general purpose
 programming languages. We can even help you
-[migrate your CloudFormation to Pulumi]({{< ref "/cloudformation" >}}).
+[migrate your CloudFormation to Pulumi]({{< relref "/cloudformation" >}}).
 
 If you want to grab a specific time to talk through your needs,
 [then use this link](https://info.pulumi.com/meetings/team-pulumi/aws-reinvent-catchup),

--- a/content/blog/persisting-kubernetes-workloads-with-amazon-efscsi-volumes-using-pulumi-sdks/index.md
+++ b/content/blog/persisting-kubernetes-workloads-with-amazon-efscsi-volumes-using-pulumi-sdks/index.md
@@ -16,7 +16,7 @@ In this blog, we will work through an example that shows how to use AWS EFS CSI 
 
 ## Step 1: Initialize Pulumi Project and Stack for your organization:
 
-[Install Pulumi CLI]({{< ref "/docs/get-started" >}}) and set up your [AWS credentials]({{< ref "/docs/get-started/aws" >}}). Initialize a new [Pulumi project]({{< ref "/docs/intro/concepts/project" >}}) from available templates. We use `aws-typescript` template here to install all library dependencies.
+[Install Pulumi CLI]({{< relref "/docs/get-started" >}}) and set up your [AWS credentials]({{< relref "/docs/get-started/aws" >}}). Initialize a new [Pulumi project]({{< relref "/docs/intro/concepts/project" >}}) from available templates. We use `aws-typescript` template here to install all library dependencies.
 
 We will work with two Pulumi stacks in this example, one for the Amazon EKS cluster and AWS EFS CSI components caled k8sinfra. The other for the application and its storage class, persistent volume and persistent volume claim called app. The AWS EFS CSI (Container Storage Interface) is based on the initial [AWS EFS CSI Driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver/) work done by Kubernetes SIG-AWS.
 

--- a/content/blog/program-kubernetes-with-11-cloud-native-pulumi-pearls/index.md
+++ b/content/blog/program-kubernetes-with-11-cloud-native-pulumi-pearls/index.md
@@ -73,7 +73,7 @@ resources in code.
 
 [
 [Code](https://github.com/pulumi/examples/tree/master/kubernetes-ts-nginx) |
-[Tutorial]({{< ref "/docs/tutorials/kubernetes/stateless-app" >}}) ]
+[Tutorial]({{< relref "/docs/tutorials/kubernetes/stateless-app" >}}) ]
 
 Let's begin by seeing what defining Kubernetes applications in a real
 language looks like. The full Kubernetes API is available, just in code
@@ -138,7 +138,7 @@ some more compelling reasons why this is so great.
 
 We've all seen [the canonical Kubernetes guestbook application](https://kubernetes.io/docs/tutorials/stateless-application/guestbook/)
 that uses PHP, Nginx, and Redis. We have
-[the same tutorial written in Pulumi]({{< ref "/docs/tutorials/kubernetes/guestbook" >}}).
+[the same tutorial written in Pulumi]({{< relref "/docs/tutorials/kubernetes/guestbook" >}}).
 But the basic conversion from YAML to TypeScript leaves something to be
 desired; namely, it's equally as verbose, feels a little too "low level"
 for an application definition, and misses opportunities to reduce
@@ -685,7 +685,7 @@ resource graph. In this example, we've changed our container image from
 The ability to look at previews before making an update ensures mistakes
 don't get made and that deployments don't have unanticipated impacts.
 There is even a
-[Pulumi GitHub App]({{< ref "/docs/guides/continuous-delivery/github-app" >}})
+[Pulumi GitHub App]({{< relref "/docs/guides/continuous-delivery/github-app" >}})
 that will show such diffs inside of pull requests before they've been
 deployed, so you know the impact of configuration changes before code
 even makes its way to master.
@@ -827,7 +827,7 @@ these goodies ready to go, are thrilled to ship, and we look forward to
 hearing about your ideas and scenarios about where to take things from
 here.
 
-To get started, head over to the [Pulumi Quickstart]({{< ref "/docs/get-started" >}}),
+To get started, head over to the [Pulumi Quickstart]({{< relref "/docs/get-started" >}}),
 meet us over on GitHub where all the goodies are open source <https://github.com/pulumi/pulumi>, and/or join our
 [Pulumi Community Slack](https://slack.pulumi.com). We can't wait to hear
 from you. Happy hacking!

--- a/content/blog/program-the-cloud-with-12-pulumi-pearls/index.md
+++ b/content/blog/program-the-cloud-with-12-pulumi-pearls/index.md
@@ -18,7 +18,7 @@ in short order.
 
 If you want to follow along and try some of this out, Pulumi is
 [open source on GitHub](https://github.com/pulumi/pulumi), free to download
-and use, and [the quickstart]({{< ref "/docs/get-started" >}}) will acquaint you with the CLI. Most of
+and use, and [the quickstart]({{< relref "/docs/get-started" >}}) will acquaint you with the CLI. Most of
 the examples are directly runnable and available in [our examples repo](https://github.com/pulumi/examples), and are just a
 `pulumi up` away, unlike other approaches that
 require you to point-and-click around in your cloud's console, and/or

--- a/content/blog/programming-the-cloud-with-python/index.md
+++ b/content/blog/programming-the-cloud-with-python/index.md
@@ -134,7 +134,7 @@ If you'd like to try the above example out for yourself, we've put the [full cod
 Full instructions for installing Pulumi and deploying your own static website on S3 are in the `README`.
 Don't take our word for it, though! We'd love for you to check it out and see for yourself how
 great it is to reclaim the “code” in “infrastructure as code”. If you want to know more about
-Pulumi and the things it can do for you, check out our [Getting Started]({{< ref "/docs/get-started" >}}) page and our Documentation for more information.
+Pulumi and the things it can do for you, check out our [Getting Started]({{< relref "/docs/get-started" >}}) page and our Documentation for more information.
 
 Python is the language of automation today and the future. Pulumi is the infrastructure as
 code automation tool of the future. Using them both together is an incredible way to automate a

--- a/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
+++ b/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
@@ -287,7 +287,7 @@ enable developers to get their code production ready faster.
 
 Get going with these resources:
 
-- [Getting Started]({{< ref "/docs/get-started" >}})
+- [Getting Started]({{< relref "/docs/get-started" >}})
 - [Serverless REST API on AWS](https://github.com/pulumi/examples/tree/master/aws-ts-apigateway)
 
 To learn more about using Pulumi and Lambda authorizers

--- a/content/blog/provisioning-and-managing-cloud-infrastructure-with-pulumi/index.md
+++ b/content/blog/provisioning-and-managing-cloud-infrastructure-with-pulumi/index.md
@@ -15,9 +15,9 @@ But, did you know that you can manage any cloud resource in AWS, Azure, or Googl
 <!--more-->
 
 You can use the
-[@pulumi/aws]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws" >}}),
-[@pulumi/azure]({{< ref "/docs/reference/pkg/nodejs/pulumi/azure" >}}),
-or [@pulumi/gcp]({{< ref "/docs/reference/pkg/nodejs/pulumi/gcp" >}})
+[@pulumi/aws]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws" >}}),
+[@pulumi/azure]({{< relref "/docs/reference/pkg/nodejs/pulumi/azure" >}}),
+or [@pulumi/gcp]({{< relref "/docs/reference/pkg/nodejs/pulumi/gcp" >}})
 libraries to manage cloud resources. Using these libraries, you can
 directly manage the properties of any cloud resource.
 
@@ -108,11 +108,11 @@ just a few lines of JavaScript:
 
 These are just a few examples of the AWS resources you can manage in
 Pulumi. You can provision
-[Athena databases]({{< ref "/docs/aws/athena" >}}),
-[DynamoDB tables]({{< ref "/docs/aws/dynamodb" >}}),
-[IAM users, roles, groups, and role policies]({{< ref "/docs/aws/iam" >}}),
-[Kinesis streams]({{< ref "/docs/aws/kinesis" >}}), and more.
+[Athena databases]({{< relref "/docs/aws/athena" >}}),
+[DynamoDB tables]({{< relref "/docs/aws/dynamodb" >}}),
+[IAM users, roles, groups, and role policies]({{< relref "/docs/aws/iam" >}}),
+[Kinesis streams]({{< relref "/docs/aws/kinesis" >}}), and more.
 
 To learn more, take a look at the
-[@pulumi/aws reference documentation]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws" >}})
+[@pulumi/aws reference documentation]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws" >}})
 and the [sample code that provisions a variety of infrastructure resources](https://github.com/pulumi/examples/blob/master/aws-ts-resources/index.ts).

--- a/content/blog/pulumi-a-better-way-to-kubernetes/index.md
+++ b/content/blog/pulumi-a-better-way-to-kubernetes/index.md
@@ -115,8 +115,8 @@ integrate with CI/CD systems. How do you know when your application is
 ready? Common workflows involve [scripting kubectl calls](https://kubernetes.io/docs/reference/kubectl/conventions/#using-kubectl-in-reusable-scripts)
 and parsing JSON output in Bash. This approach is brittle, and the
 process is a little different for every Kubernetes resource type.
-Pulumi's [state reconciliation model]({{< ref "/docs/intro/concepts/how-pulumi-works" >}}) is a
-[natural fit for CI/CD systems]({{< ref "/docs/guides/continuous-delivery" >}}): review changes with a
+Pulumi's [state reconciliation model]({{< relref "/docs/intro/concepts/how-pulumi-works" >}}) is a
+[natural fit for CI/CD systems]({{< relref "/docs/guides/continuous-delivery" >}}): review changes with a
 preview, and then proceed with confidence once an update succeeds. This
 is great for GitOps and [ChatOps]({{< relref "getting-to-chatops-with-pulumi-webhooks" >}})
 workflows. You don't have to be an expert on the inner workings of
@@ -136,7 +136,7 @@ scenarios.
 
 If you'd like to learn about Pulumi and how to manage your
 infrastructure and Kubernetes through code,
-[click here to get started today]({{< ref "/docs/get-started" >}}). Pulumi is open source and free to
+[click here to get started today]({{< relref "/docs/get-started" >}}). Pulumi is open source and free to
 use.
 
 As always, you can check out our code on
@@ -148,4 +148,4 @@ any questions, need support, or just want to say hello.
 
 If you'd like to chat with our team, or get hands-on assistance with
 migrating your existing configuration code (including ksonnet programs)
-to Pulumi, [please don't hesitate to drop us a line]({{< ref "/contact" >}}).
+to Pulumi, [please don't hesitate to drop us a line]({{< relref "/contact" >}}).

--- a/content/blog/pulumi-and-docker-development-to-production/index.md
+++ b/content/blog/pulumi-and-docker-development-to-production/index.md
@@ -25,7 +25,7 @@ development and production!
 
 In addition to the number of cloud and infrastructure providers that
 Pulumi supports, Pulumi also supports
-[defining Docker resources]({{< ref "/docs/reference/pkg/nodejs/pulumi/docker" >}})
+[defining Docker resources]({{< relref "/docs/reference/pkg/nodejs/pulumi/docker" >}})
 in code. Let's look at this code snippet of Pulumi TypeScript code:
 
     // This program encodes a complete application: a container running Redis Commander,
@@ -178,13 +178,13 @@ tools we already use for software engineering:
 
 1. Abstraction, encapsulation, and code reuse for infrastructure and
    applications
-2. [Testing]({{< ref "/blog/testing-your-infrastructure-as-code-with-pulumi" >}}),
+2. [Testing]({{< relref "/blog/testing-your-infrastructure-as-code-with-pulumi" >}}),
    both unit and integration
 3. IDEs and tools for detecting errors extremely early in a developer's
    inner loop, instead of at deployment time
 
 Pulumi is open source, free to use, and works today with
-[a variety of clouds]({{< ref "/docs/intro/cloud-providers" >}}) and bring a little more
+[a variety of clouds]({{< relref "/docs/intro/cloud-providers" >}}) and bring a little more
 software and less code into your infrastructure! If you'd like to see
 more about this particular code demo,
 [check out my DockerCon EU 2018 talk](https://www.youtube.com/watch?v=EbsE4p3uCu0)

--- a/content/blog/pulumi-and-epsagon-define-deploy-and-monitor-serverless-applications/index.md
+++ b/content/blog/pulumi-and-epsagon-define-deploy-and-monitor-serverless-applications/index.md
@@ -108,5 +108,5 @@ it easy to author and deploy these kinds of architectures, and Epsagon
 makes it easy to monitor them. Users get an application-centric view
 across their full serverless application infrastructure.
 
-Checkout the quickstart guides for [Pulumi]({{< ref "/docs/get-started" >}})
+Checkout the quickstart guides for [Pulumi]({{< relref "/docs/get-started" >}})
 and [Epsagon](https://docs.epsagon.com/#/quick-start-guide) now!

--- a/content/blog/pulumi-heart-google-cloud-platform/index.md
+++ b/content/blog/pulumi-heart-google-cloud-platform/index.md
@@ -96,7 +96,7 @@ will it proceed (with a full audit history):
     ...
 
 Learn more about working with Pulumi and Google Cloud infrastructure in
-this [GCE Web Server]({{< ref "/docs/tutorials/gcp/gce-webserver" >}})
+this [GCE Web Server]({{< relref "/docs/tutorials/gcp/gce-webserver" >}})
 tutorial.
 
 ## Working with Kubernetes and Google Container Engine (GKE)
@@ -160,7 +160,7 @@ k8s_cluster = Cluster('gke-cluster',
 ```
 
 Learn more about using Pulumi with Kubernetes and GKE in this
-[Hello GKE]({{< ref "/docs/tutorials/kubernetes/gke" >}}) tutorial.
+[Hello GKE]({{< relref "/docs/tutorials/kubernetes/gke" >}}) tutorial.
 
 ## Super Simple Serverless with Google Cloud Functions
 
@@ -230,7 +230,7 @@ you can see and approve infrastructure changes before they happen:
 ![Pulumi in a Pull Request](./pulumi_pr.png)
 
 Learn more about integrating Pulumi with CI/CD in our
-[continuous delivery]({{< ref "/docs/guides/continuous-delivery" >}}) documentation.
+[continuous delivery]({{< relref "/docs/guides/continuous-delivery" >}}) documentation.
 
 ## Managing Deployment with the Pulumi Console
 
@@ -263,9 +263,9 @@ Pulumi is free and open source. You can get started with Pulumi today.
 Here are a few resources to learn more about working with Pulumi and
 GCP:
 
-- [Google Cloud Platform Getting Started Guide]({{< ref "/docs/get-started/gcp" >}})
-- [GKE Tutorial]({{< ref "/docs/tutorials/kubernetes/gke" >}})
-- [GCE Tutorial]({{< ref "/docs/tutorials/gcp/gce-webserver" >}})
+- [Google Cloud Platform Getting Started Guide]({{< relref "/docs/get-started/gcp" >}})
+- [GKE Tutorial]({{< relref "/docs/tutorials/kubernetes/gke" >}})
+- [GCE Tutorial]({{< relref "/docs/tutorials/gcp/gce-webserver" >}})
 - Example: [Serverless Slackbot with Cloud Functions in JavaScript](https://github.com/pulumi/examples/tree/master/gcp-ts-slackbot)
 - Example: [GKE + Kubernetes Pod Deployment in Python](https://github.com/pulumi/examples/tree/master/gcp-py-gke)
 - [Pulumi Community Slack](https://slack.pulumi.com/)

--- a/content/blog/pulumi-now-supports-atlassian-identity/index.md
+++ b/content/blog/pulumi-now-supports-atlassian-identity/index.md
@@ -52,20 +52,20 @@ Team-backed organization, you can invite the same members to collaborate
 on Pulumi.
 
 This allows you to set permissions on
-[Stacks]({{< ref "/docs/intro/concepts/stack" >}}) owned by your
+[Stacks]({{< relref "/docs/intro/concepts/stack" >}}) owned by your
 organization. You can learn more about
-[Teams & Collaboration]({{< ref "/docs/intro/console/collaboration" >}})
+[Teams & Collaboration]({{< relref "/docs/intro/console/collaboration" >}})
 in the Pulumi and how those permissions get applied too.
 
 ## CI Integration
 
 Did you also know that the Pulumi CLI can be used in most, if not all,
 CI/CD workflows? Check out our
-[documentation]({{< ref "/docs/guides/continuous-delivery" >}}) for integrating
+[documentation]({{< relref "/docs/guides/continuous-delivery" >}}) for integrating
 with several popular CI/CD systems. Get up and running with Pulumi in CI
-on [GitLab]({{< ref "/docs/guides/continuous-delivery/gitlab-ci" >}}),
-[Travis]({{< ref "/docs/guides/continuous-delivery/travis" >}}),
-[Azure DevOps]({{< ref "/docs/guides/continuous-delivery/azure-devops" >}}) and more.
+on [GitLab]({{< relref "/docs/guides/continuous-delivery/gitlab-ci" >}}),
+[Travis]({{< relref "/docs/guides/continuous-delivery/travis" >}}),
+[Azure DevOps]({{< relref "/docs/guides/continuous-delivery/azure-devops" >}}) and more.
 Don't see docs for a particular CI system? Let us know or better yet
 file an issue [here](https://github.com/pulumi/docs/issues).
 

--- a/content/blog/reusable-cicd-components-with-circleci-orbs-for-pulumi/index.md
+++ b/content/blog/reusable-cicd-components-with-circleci-orbs-for-pulumi/index.md
@@ -75,7 +75,7 @@ that happened during a CircleCI workflow.
 
 Also, if you are using CircleCI with GitHub, you can consider installing
 the
-[Pulumi GitHub application]({{< ref "/docs/guides/continuous-delivery/github-app" >}}. The Pulumi
+[Pulumi GitHub application]({{< relref "/docs/guides/continuous-delivery/github-app" >}}. The Pulumi
 GitHub app will surface the results of any previews or updates from your
 CI/CD on the source GitHub pull request. It's always good to know if a
 pull request is going to lead to changes to your cloud infrastructure!
@@ -85,7 +85,7 @@ Deployment" part of CI/CD workflows, and with the release of CircleCIs
 Orbs, it's just that much easier.
 
 Having trouble? Questions? Join our [community Slack](https://slack.pulumi.com/)
-or [drop us a line]({{< ref "/contact" >}}).
+or [drop us a line]({{< relref "/contact" >}}).
 
 Links:
 

--- a/content/blog/running-a-serverles-nodejs-http-server-on-aws-and-azure/index.md
+++ b/content/blog/running-a-serverles-nodejs-http-server-on-aws-and-azure/index.md
@@ -127,7 +127,7 @@ with a simpler approach for these cloud ecosystems. To further this
 goal, we've created a new API called
 [cloud.HttpServer](https://github.com/pulumi/pulumi-cloud/blob/master/api/httpServer.ts).
 `HttpServer` is a Pulumi
-[Resource]({{< ref "/docs/intro/concepts/programming-model#resources" >}}),
+[Resource]({{< relref "/docs/intro/concepts/programming-model#resources" >}}),
 but is designed to work well with the existing large middleware
 ecosystem out there. And critically, the same HttpServer API can be
 implemented consistently on AWS, Azure and GCP - so you can write once
@@ -242,6 +242,6 @@ the cloud at runtime! That magic, along with powerful components like
 the new HttpServer API can help make cloud applications dramatically
 simpler to write and maintain. Happy coding!
 
-You can dig in to [serverless coding with Pulumi here]({{< ref "/docs/tutorials/cloudfx/rest-api" >}}),
+You can dig in to [serverless coding with Pulumi here]({{< relref "/docs/tutorials/cloudfx/rest-api" >}}),
 and join us on Wednesday 3rd October at 11am PDT to hear more about
 [serverless programming with Pulumi on our YouTube live stream](https://www.youtube.com/watch?v=k8ceyQuJiVM).

--- a/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
+++ b/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
@@ -95,7 +95,7 @@ containers run in. That includes control over the precise numbers of
 servers, AMIs they are running, and their auto-scaling policies.
 
 To use an EC2 backed cluster, you will need to
-[create a cluster and configure the EC2 launch and autoscaling configurations]({{< ref "/docs/guides/crosswalk/aws/ecs#creating-an-auto-scaling-group-for-ecs-cluster-instances" >}}),
+[create a cluster and configure the EC2 launch and autoscaling configurations]({{< relref "/docs/guides/crosswalk/aws/ecs#creating-an-auto-scaling-group-for-ecs-cluster-instances" >}}),
 and then simply use the awsx.ecs.EC2Service class to create your service
 instead. Other than these differences, the resulting code would look
 very similar to Option 1 - ECS Fargate above.
@@ -123,9 +123,9 @@ compute, and storage.
 [Kubernetes](https://kubernetes.io) is an open standard for running
 containers across a variety of public and private cloud environments.
 Most public cloud vendors now offer an EKS-like managed offering,
-including [Azure (AKS)]({{< ref "/docs/tutorials/kubernetes/aks" >}}),
-[Google Cloud (GKE)]({{< ref "/docs/tutorials/kubernetes/gke" >}}),
-and [Digital Ocean]({{< ref "/docs/reference/pkg/nodejs/pulumi/digitalocean#KubernetesCluster" >}}),
+including [Azure (AKS)]({{< relref "/docs/tutorials/kubernetes/aks" >}}),
+[Google Cloud (GKE)]({{< relref "/docs/tutorials/kubernetes/gke" >}}),
+and [Digital Ocean]({{< relref "/docs/reference/pkg/nodejs/pulumi/digitalocean#KubernetesCluster" >}}),
 and the availability of on-premises private cloud configurations enables
 hybrid cloud for large organizations. Kubernetes in inherently more
 complicated to operate than the equivalent ECS solutions mentioned
@@ -195,7 +195,7 @@ more about Pulumi's support for Kubernetes, [go here]({{< relref "pulumi-a-bette
 
 ## Private ECR Container Registries
 
-In all of these cases, [Amazon Elastic Container Registry (ECR)]({{< ref "/docs/guides/crosswalk/aws/ecr" >}})
+In all of these cases, [Amazon Elastic Container Registry (ECR)]({{< relref "/docs/guides/crosswalk/aws/ecr" >}})
 lets you publish
 Docker container images to a privately hosted repository inside your AWS
 account. The benefit of this is that images are stored within your AWS
@@ -214,14 +214,14 @@ and CloudWatch. It's possible to use any of these services without
 Pulumi, but there are [many benefits to Pulumi's infrastructure as code](https://www.pulumi.com/why-pulumi/).
 
 In short, to get your containers up on AWS, in an easy yet
-production-ready way, [get started for free with Pulumi for AWS today]({{< ref "/docs/get-started/aws" >}})!
+production-ready way, [get started for free with Pulumi for AWS today]({{< relref "/docs/get-started/aws" >}})!
 
 After getting started, here are some additional resources to go deeper
 on specific topics:
 
-- [Getting Started with ECS]({{< ref "/docs/guides/crosswalk/aws/ecs" >}})
-- [Getting Started with EKS]({{< ref "/docs/guides/crosswalk/aws/eks" >}})
-- [Getting Started with ECR]({{< ref "/docs/guides/crosswalk/aws/ecr" >}})
-    - [Using ECR from ECS Fargate or EC2]({{< ref "/docs/guides/crosswalk/aws/ecs#building-and-publishing-docker-images-automatically" >}})
-    - [Using ECR from EKS]({{< ref "/docs/guides/crosswalk/aws/eks#using-an-ecr-container-image-from-an-eks-kubernetes-deployment" >}})
+- [Getting Started with ECS]({{< relref "/docs/guides/crosswalk/aws/ecs" >}})
+- [Getting Started with EKS]({{< relref "/docs/guides/crosswalk/aws/eks" >}})
+- [Getting Started with ECR]({{< relref "/docs/guides/crosswalk/aws/ecr" >}})
+    - [Using ECR from ECS Fargate or EC2]({{< relref "/docs/guides/crosswalk/aws/ecs#building-and-publishing-docker-images-automatically" >}})
+    - [Using ECR from EKS]({{< relref "/docs/guides/crosswalk/aws/eks#using-an-ecr-container-image-from-an-eks-kubernetes-deployment" >}})
     - [Building and Publishing Docker Images to a Private Amazon ECR Repository]({{< relref "building-and-publishing-docker-images-to-a-private-amazon-ecr-repository" >}})

--- a/content/blog/simple-reproducible-kubernetes-deployments/index.md
+++ b/content/blog/simple-reproducible-kubernetes-deployments/index.md
@@ -291,7 +291,7 @@ actually making any changes. And because Pulumi is always tracking old
 states, rollback afterwards is easy also.
 
 This CLI workflow is great for the dev inner loop, however
-[the Pulumi GitHub App]({{< ref "/docs/guides/continuous-delivery/github-app" >}}) also integrates
+[the Pulumi GitHub App]({{< relref "/docs/guides/continuous-delivery/github-app" >}}) also integrates
 these previews and diffs with your CI/CD system, by enlightening your
 GitHub Pull Requests with potential update impacts, while your team
 still has a chance to discuss changes inside the usual PR workflow,
@@ -304,7 +304,7 @@ real code, instead of YAML, and you've gotten a taste of the `pulumi up`
 deployment workflow, especially compared to `kubectl`.
 
 **Try it out now** by heading over to our
-[Getting Started page]({{< ref "/docs/get-started" >}}).
+[Getting Started page]({{< relref "/docs/get-started" >}}).
 
 We are just getting started. In the coming weeks we will be sharing more
 around other deployment scenarios, including A/B traffic splitting,

--- a/content/blog/simple-serverless-programming-with-google-cloud-functions-and-pulumi/index.md
+++ b/content/blog/simple-serverless-programming-with-google-cloud-functions-and-pulumi/index.md
@@ -176,11 +176,11 @@ takes care of that you would normally be responsible for. This includes:
     Function when it finally is triggered.
 8. Figuring out a safe and secure way to encode and access secrets for
     your Cloud Function. Here, we can use Pulumi's
-    [Config Secrets]({{< ref "/docs/intro/concepts/config#secrets" >}}) to safely
+    [Config Secrets]({{< relref "/docs/intro/concepts/config#secrets" >}}) to safely
     encrypt and manage secrets for your Cloud Function code.
 
 Not to mention that by doing all of that, you can achieve continuous deployment
-[Pulumi and Google Cloud Build]({{< ref "/docs/guides/continuous-delivery/google-cloud-build" >}}).
+[Pulumi and Google Cloud Build]({{< relref "/docs/guides/continuous-delivery/google-cloud-build" >}}).
 
 ## Updating Your Google Functions Code
 
@@ -227,7 +227,7 @@ create, update, and maintain.
 
 To check things out, get started today:
 
-- [Get Started with Pulumi on GCP]({{< ref "/docs/get-started/gcp" >}})
+- [Get Started with Pulumi on GCP]({{< relref "/docs/get-started/gcp" >}})
 - [Deploy a Minimal Google Cloud Function Application](https://github.com/pulumi/examples/tree/master/gcp-ts-functions)
 
 PS: If you're interested in how Pulumi manages to take a

--- a/content/blog/simplified-outputs-in-pulumi-0.17.0/index.md
+++ b/content/blog/simplified-outputs-in-pulumi-0.17.0/index.md
@@ -10,7 +10,7 @@ meta_image: "comp-list.png"
 Pulumi allows cloud developers to use programming languages like
 JavaScript, TypeScript and Python to define and deploy cloud
 infrastructure and applications. To do this, Pulumi exposes a notion of
-[Outputs]({{< ref "/docs/intro/concepts/programming-model#outputs" >}})
+[Outputs]({{< relref "/docs/intro/concepts/programming-model#outputs" >}})
 that track how the outputs of one cloud resource are used and
 transformed as part of creating another cloud resource.
 

--- a/content/blog/simplify-kubernetes-rbac-in-amazon-eks-with-open-source-pulumi-packages/index.md
+++ b/content/blog/simplify-kubernetes-rbac-in-amazon-eks-with-open-source-pulumi-packages/index.md
@@ -44,11 +44,11 @@ Here are a few highlights:
 
 ## Prerequisites to work with Pulumi
 
-[Install `pulumi` CLI]({{< ref "/docs/get-started/install" >}}) and
+[Install `pulumi` CLI]({{< relref "/docs/get-started/install" >}}) and
 set up your
-[AWS credentials]({{< ref "/docs/get-started/aws" >}}).
+[AWS credentials]({{< relref "/docs/get-started/aws" >}}).
 Initialize a new
-[Pulumi project]({{< ref "/docs/intro/concepts/project" >}}) from available
+[Pulumi project]({{< relref "/docs/intro/concepts/project" >}}) from available
 templates. We use `aws-typescript template` here to install all
 dependencies and save the configuration.
 
@@ -547,4 +547,4 @@ simple, comprehensive,
 non-sequential and part of your everyday programming experience. You can find the [complete pulumi code for our example](https://gist.github.com/d-nishi/a4e54dfc973ea047ec46c8deb5193f4e) and try it out yourself.
 
 Pulumi is open source and free to use. For more examples, visit our GitHub examples page
-[here](https://github.com/pulumi/examples). To learn more about Pulumi and how to manage Kubernetes through code, have a look at our ["Get Started with Kubernetes" guide]({{< ref "/docs/get-started/kubernetes" >}}).
+[here](https://github.com/pulumi/examples). To learn more about Pulumi and how to manage Kubernetes through code, have a look at our ["Get Started with Kubernetes" guide]({{< relref "/docs/get-started/kubernetes" >}}).

--- a/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
+++ b/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
@@ -545,29 +545,29 @@ domains.
 Pulumi supports your existing CI systems. Here are a few of those
 supported:
 
-- [AWS Code Services]({{< ref "/docs/guides/continuous-delivery/aws-code-services" >}})
-- [Azure DevOps]({{< ref "/docs/guides/continuous-delivery/azure-devops" >}})
-- [CircleCI]({{< ref "/docs/guides/continuous-delivery/circleci" >}})
-- [GitHub Actions]({{< ref "/docs/guides/continuous-delivery/github-actions" >}})
-- [GitLab CI]({{< ref "/docs/guides/continuous-delivery/gitlab-ci" >}})
-- [Google Cloud Build]({{< ref "/docs/guides/continuous-delivery/google-cloud-build" >}})
-- [Travis]({{< ref "/docs/guides/continuous-delivery/travis" >}})
+- [AWS Code Services]({{< relref "/docs/guides/continuous-delivery/aws-code-services" >}})
+- [Azure DevOps]({{< relref "/docs/guides/continuous-delivery/azure-devops" >}})
+- [CircleCI]({{< relref "/docs/guides/continuous-delivery/circleci" >}})
+- [GitHub Actions]({{< relref "/docs/guides/continuous-delivery/github-actions" >}})
+- [GitLab CI]({{< relref "/docs/guides/continuous-delivery/gitlab-ci" >}})
+- [Google Cloud Build]({{< relref "/docs/guides/continuous-delivery/google-cloud-build" >}})
+- [Travis]({{< relref "/docs/guides/continuous-delivery/travis" >}})
 
 Please refer to the
-[Continuous Delivery documentation]({{< ref "/docs/guides/continuous-delivery" >}})) for a more
+[Continuous Delivery documentation]({{< relref "/docs/guides/continuous-delivery" >}})) for a more
 comprehensive guide.
 
 ## Ephemeral Environments
 
 A very powerful capability this unlocks is the ability to spin up
 ephemeral environments solely for purposes of acceptance testing.
-Pulumi's concept of [projects and stacks]({{< ref "/docs/intro/concepts/organizing-stacks-projects" >}}) is
+Pulumi's concept of [projects and stacks]({{< relref "/docs/intro/concepts/organizing-stacks-projects" >}}) is
 designed to make it very easy to stand up entirely isolated and
 independent environments, and to tear them down, all in either a few
 easy CLI gestures, or by using the integration testing framework.
 
 If you are using GitHub, Pulumi offers a
-[GitHub App]({{< ref "/docs/guides/continuous-delivery/github-app" >}}) that helps to glue
+[GitHub App]({{< relref "/docs/guides/continuous-delivery/github-app" >}}) that helps to glue
 together your Pull Request workflow with this sort of acceptance testing
 run inside of your CI pipelines. Simply install the App into your GitHub
 repos, and Pulumi in your CI, and your Pull Requests will light up with
@@ -589,4 +589,4 @@ runtime testing. It's easy to run these on demand and harness them in
 your CI system of choice.
 
 Pulumi is open source, free to use, and works with your favorite
-languages and clouds -- [give it a try today]({{< ref "/docs" >}})!
+languages and clouds -- [give it a try today]({{< relref "/docs" >}})!

--- a/content/blog/unified-logs-with-pulumi-logs/index.md
+++ b/content/blog/unified-logs-with-pulumi-logs/index.md
@@ -177,7 +177,7 @@ to have access to these logs at the click of a button - and this is
 something we're also excited to enable in the near future.
 
 You can take `pulumi` for a spin today by checking out the
-[Getting Started Guide]({{< ref "/docs/get-started" >}}) guide or some of the
+[Getting Started Guide]({{< relref "/docs/get-started" >}}) guide or some of the
 [Pulumi Examples](https://github.com/pulumi/examples) on GitHub. Then join us in the
 [Pulumi Community Slack](https://slack.pulumi.com) to chat about where
 you want to see us go (and where you'd like to help out!) with

--- a/content/blog/upcoming-aws-pulumi-webinar-on-feb-5/index.md
+++ b/content/blog/upcoming-aws-pulumi-webinar-on-feb-5/index.md
@@ -7,11 +7,11 @@ meta_desc: "In February, Pulumi & Learning Machine hosted a webinar with AWS Far
 meta_image: code-comparison.png
 ---
 
-Pulumi is hosting [a webinar with AWS Fargate]({{< ref "/webinar/aws-fargate-and-pulumi" >}}) **on
+Pulumi is hosting [a webinar with AWS Fargate]({{< relref "/webinar/aws-fargate-and-pulumi" >}}) **on
 February 5th, 10AM PST** (register
 [here](https://pages.awscloud.com/acq_NAMER_IPC-Pulumi-February-2019-Registration-Page.html?sc_channel=el&sc_campaign=ContainersPulumiFebruary2019&sc_country=US&sc_geo=NAMER&sc_category=mult&sc_outcome=acq%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20&trk=Partner_Website_Landing_Page)).
 We'll be chatting about how to implement cloud native infrastructure
-across your organization using [AWS and Pulumi]({{< ref "/crosswalk/aws" >}}): general purpose programming
+across your organization using [AWS and Pulumi]({{< relref "/crosswalk/aws" >}}): general purpose programming
 languages to deliver everything from VMs to Kubernetes to Serverless.
 <!--more-->
 

--- a/content/blog/using-helm-and-pulumi-to-define-cloud-native-infrastructure-as-code/index.md
+++ b/content/blog/using-helm-and-pulumi-to-define-cloud-native-infrastructure-as-code/index.md
@@ -116,6 +116,6 @@ can make the best use of existing tools such as Helm, and also reduce
 the friction caused by multiple deployment tools and models across
 complex architectures.
 
-- Find out more about our [Azure]({{< ref "/azure" >}}) and
+- Find out more about our [Azure]({{< relref "/azure" >}}) and
   [Kubernetes]({{< relref "/topics/kubernetes" >}}) support
 - Join the Slack community at <https://slack.pulumi.com>

--- a/content/blog/using-terraform-remote-state-with-pulumi/index.md
+++ b/content/blog/using-terraform-remote-state-with-pulumi/index.md
@@ -19,19 +19,19 @@ by different teams. For example, it's common to see an application team
 deploying into a VPC owned and managed by a network operations team.
 
 Pulumi supports
-[this kind of workflow]({{< ref "/docs/intro/concepts/organizing-stacks-projects#inter-stack-dependencies" >}})
-natively using the [`StackReference`]({{< ref "/docs/reference/pkg/nodejs/pulumi/pulumi#StackReference" >}})
+[this kind of workflow]({{< relref "/docs/intro/concepts/organizing-stacks-projects#inter-stack-dependencies" >}})
+natively using the [`StackReference`]({{< relref "/docs/reference/pkg/nodejs/pulumi/pulumi#StackReference" >}})
 type from the Pulumi SDK. Integration with the most popular
 cloud-specific tools have been supported by Pulumi since the earliest
 days:
 
-- The [`aws.cloudformation.getStack()`]({{< ref "/docs/reference/pkg/nodejs/pulumi/aws/cloudformation#getStack" >}})
+- The [`aws.cloudformation.getStack()`]({{< relref "/docs/reference/pkg/nodejs/pulumi/aws/cloudformation#getStack" >}})
   function can be used to obtain the outputs from a CloudFormation
   Stack.
 
-- The [`get`]({{< ref "/docs/reference/pkg/nodejs/pulumi/azure/core#TemplateDeployment-get" >}})
+- The [`get`]({{< relref "/docs/reference/pkg/nodejs/pulumi/azure/core#TemplateDeployment-get" >}})
   method of the
-  [`azure.core.TemplateDeployment`]({{< ref "/docs/reference/pkg/nodejs/pulumi/azure/core#TemplateDeployment" >}})
+  [`azure.core.TemplateDeployment`]({{< relref "/docs/reference/pkg/nodejs/pulumi/azure/core#TemplateDeployment" >}})
   class can be used to obtain the outputs of an ARM Template Deployment.
 
 We recently added similar support for reading the outputs of a Terraform
@@ -174,10 +174,10 @@ environments. Resources which were provisioned by CloudFormation, ARM or
 Terraform can remain in place, while still allowing those values to be
 dynamically consumed by a Pulumi program.
 
-Pulumi is free and open-source, and you can [get started today]({{< ref "/docs/get-started" >}}).
+Pulumi is free and open-source, and you can [get started today]({{< relref "/docs/get-started" >}}).
 To learn more about migrating
 from Terraform to Pulumi, check out
 [From Terraform to Infrastructure as Software]({{< relref "from-terraform-to-infrastructure-as-software" >}})
-and the [Terraform comparison documentation]({{< ref "/docs/intro/vs/terraform" >}}), or join us in
+and the [Terraform comparison documentation]({{< relref "/docs/intro/vs/terraform" >}}), or join us in
 the [Pulumi Community Slack](https://slack.pulumi.com/) to discuss with
 the Pulumi community.

--- a/content/blog/welcoming-gitlab-users-to-pulumi/index.md
+++ b/content/blog/welcoming-gitlab-users-to-pulumi/index.md
@@ -56,8 +56,8 @@ would collaborate on a project on GitLab.
 
 ## Running Pulumi on GitLab
 
-Pulumi can be run in [many CI/CD environments]({{< ref "/docs/guides/continuous-delivery" >}}). Pulumi can be easily
-integrated in your [CI pipeline on GitLab]({{< ref "/docs/guides/continuous-delivery/gitlab-ci" >}}), too.
+Pulumi can be run in [many CI/CD environments]({{< relref "/docs/guides/continuous-delivery" >}}). Pulumi can be easily
+integrated in your [CI pipeline on GitLab]({{< relref "/docs/guides/continuous-delivery/gitlab-ci" >}}), too.
 
 ## Deep-linking to your GitLab projects, branches and commits
 
@@ -91,9 +91,9 @@ to sign-in.
 Yes. Signing-in with a GitLab account will create a new account. That
 means, your stacks and activity will stay with the other account. You
 can migrate them by performing a
-[`pulumi stack export`]({{< ref "/docs/reference/cli/pulumi_stack_export" >}})
+[`pulumi stack export`]({{< relref "/docs/reference/cli/pulumi_stack_export" >}})
 from your source stack and then importing it using
-[`pulumi stack import`]({{< ref "/docs/reference/cli/pulumi_stack_import" >}})
+[`pulumi stack import`]({{< relref "/docs/reference/cli/pulumi_stack_import" >}})
 in a new stack in your GitLab-based account.
 
 If you would like to add your GitLab identity to your _existing_ Pulumi account, you can

--- a/content/docs/guides/continuous-delivery/github-app.md
+++ b/content/docs/guides/continuous-delivery/github-app.md
@@ -61,12 +61,12 @@ system will have its results reported back to GitHub.
 Pulumi supports a wide array of CI/CD systems, and the Pulumi GitHub App should pick up your changes
 automatically. For instructions for specific CI services, see one of our existing guides:
 
-* [AWS Code Services]({{< ref "/docs/guides/continuous-delivery/aws-code-services.md" >}})
-* [Azure DevOps]({{< ref "/docs/guides/continuous-delivery/azure-devops.md" >}})
-* [CircleCI]({{< ref "/docs/guides/continuous-delivery/circleci.md" >}})
-* [GitHub Actions]({{< ref "/docs/guides/continuous-delivery/github-actions.md" >}})
-* [GitLab CI]({{< ref "/docs/guides/continuous-delivery/gitlab-ci.md" >}})
-* [Travis]({{< ref "/docs/guides/continuous-delivery/travis.md" >}})
+* [AWS Code Services]({{< relref "/docs/guides/continuous-delivery/aws-code-services.md" >}})
+* [Azure DevOps]({{< relref "/docs/guides/continuous-delivery/azure-devops.md" >}})
+* [CircleCI]({{< relref "/docs/guides/continuous-delivery/circleci.md" >}})
+* [GitHub Actions]({{< relref "/docs/guides/continuous-delivery/github-actions.md" >}})
+* [GitLab CI]({{< relref "/docs/guides/continuous-delivery/gitlab-ci.md" >}})
+* [Travis]({{< relref "/docs/guides/continuous-delivery/travis.md" >}})
 
 If you are using a system we don't support yet, please [file an issue](https://github.com/pulumi/pulumi/issues/new)
 so we can add it.

--- a/content/docs/guides/continuous-delivery/gitlab-ci.md
+++ b/content/docs/guides/continuous-delivery/gitlab-ci.md
@@ -38,7 +38,7 @@ The source code for the stack is in a repository in GitLab and uses `TypeScript`
 You may choose a naming convention that best suits your organization.
 
 Alternatively, you can also run `pulumi new [template]` to create a template project.
-Learn more [here]({{< ref "/docs/reference/cli/pulumi_new.md" >}}).
+Learn more [here]({{< relref "/docs/reference/cli/pulumi_new.md" >}}).
 
 ## GitLab CI Runners
 

--- a/content/docs/guides/continuous-delivery/jenkins.md
+++ b/content/docs/guides/continuous-delivery/jenkins.md
@@ -39,7 +39,7 @@ The source code for the stack is in a repository in GitHub and uses TypeScript a
 You may choose a naming convention that best suits your organization.
 
 Alternatively, you can also run `pulumi new [template]` to create a template project.
-Learn more [here]({{< ref "/docs/reference/cli/pulumi_new.md" >}}).
+Learn more [here]({{< relref "/docs/reference/cli/pulumi_new.md" >}}).
 
 ## PULUMI_ACCESS_TOKEN
 

--- a/content/docs/guides/crosswalk/aws/lambda.md
+++ b/content/docs/guides/crosswalk/aws/lambda.md
@@ -96,7 +96,7 @@ defined -- or even use functions that already exist, and simply glue them togeth
 Because Pulumi provisions and manages resources, updating your functions after creating them is easy. Just edit your
 code, run `pulumi up`, and Pulumi will diff and compute the minimal set of changes it can make to upgrade your code,
 without any downtime required. This is as easy to do by hand as it is in
-[CI/CD]({{< ref "/docs/guides/continuous-delivery" >}}).
+[CI/CD]({{< relref "/docs/guides/continuous-delivery" >}}).
 
 ### Register an Event Handler Using a Magic Lambda Function
 

--- a/content/docs/guides/saml/_index.md
+++ b/content/docs/guides/saml/_index.md
@@ -12,7 +12,7 @@ aliases:
 - /docs/console/accounts/saml/
 ---
 
-The [Pulumi Console](https://app.pulumi.com) can be configured to work with any SAML 2.0 identity provider. SAML support requires Pulumi Enterprise Edition. To learn more about the capabilities of the Enterprise Edition, refer to the [pricing page]({{< ref "/pricing" >}}).
+The [Pulumi Console](https://app.pulumi.com) can be configured to work with any SAML 2.0 identity provider. SAML support requires Pulumi Enterprise Edition. To learn more about the capabilities of the Enterprise Edition, refer to the [pricing page]({{< relref "/pricing" >}}).
 
 ## Single Sign-On (SSO)
 

--- a/content/docs/intro/concepts/organizing-stacks-projects.md
+++ b/content/docs/intro/concepts/organizing-stacks-projects.md
@@ -192,7 +192,7 @@ structure enables seamless continuous deployment.
 
 In this model, there is a rough correspondence between a Git repo and a Pulumi project, and a Git branch and
 its associated Pulumi stack. Please read more about
-[how these mapping are maintained here]({{< ref "/docs/guides/continuous-delivery" >}}).
+[how these mapping are maintained here]({{< relref "/docs/guides/continuous-delivery" >}}).
 
 ## Tagging Stacks
 

--- a/content/docs/intro/console/accounts-and-organizations/editions.md
+++ b/content/docs/intro/console/accounts-and-organizations/editions.md
@@ -32,7 +32,7 @@ scale,
 with advanced or custom needs.
 
 For more information about the specific differences and capabilities offered for the
-Pulumi Team and Enterprise editions, refer to the [pricing page]({{< ref "/pricing" >}}).
+Pulumi Team and Enterprise editions, refer to the [pricing page]({{< relref "/pricing" >}}).
 
 To create a new Pulumi organization with a new edition, see [Creating a New
 Organization]({{< relref "organizations#creating-a-new-organization" >}}).

--- a/content/docs/intro/console/extensions/pulumi-button.md
+++ b/content/docs/intro/console/extensions/pulumi-button.md
@@ -23,7 +23,7 @@ To create a "Deploy with Pulumi" button:
 The Pulumi button works with project templates hosted in public GitHub repositories or gists. A template is a Pulumi project that has the required `Pulumi.yaml` file describing the project. The project template can be in the root of the GitHub repository, or within a subdirectory. Multiple projects can be hosted within subdirectories of a single repository.
 
 The `Pulumi.yaml` file can optionally contain a `template` section, which typically includes a `config` section for specifying required config values for the project. Each config value can have a `description` and a `default` value. Config values can also have a `secret` property, which can be set to `true` to indicate that it is a
-[secret]({{< ref "/docs/intro/concepts/config.md#secrets" >}}).
+[secret]({{< relref "/docs/intro/concepts/config.md#secrets" >}}).
 
 ```yaml
 name: my-aws-project

--- a/content/docs/reference/cli/_index.md
+++ b/content/docs/reference/cli/_index.md
@@ -12,7 +12,7 @@ aliases: [/docs/reference/commands/]
 Pulumi is controlled primarily using the command line interface (CLI). It works in conjunction with the Pulumi service
 to deploy changes to your cloud apps and infrastructure.  It keeps a history of who updated what in your team and when.
 This CLI has been designed for great inner loop productivity, in addition to
-[continuous integration and delivery]({{< ref "/docs/guides/continuous-delivery" >}}) scenarios.
+[continuous integration and delivery]({{< relref "/docs/guides/continuous-delivery" >}}) scenarios.
 
 ## Installation
 


### PR DESCRIPTION
Changes usage of `ref` (fully qualified URL) to `relref` (relative URL), as there's no need for these to be fully qualified and we generally use `relref` throughout.