### PR TITLE
Don't duplicate supported CI list

### DIFF
--- a/content/docs/guides/continuous-delivery/_index.md
+++ b/content/docs/guides/continuous-delivery/_index.md
@@ -16,7 +16,7 @@ Pulumi's approach to infrastructure as code is great for continuous delivery, be
 cloud resources. This means updates to your cloud infrastructure can be reviewed, validated, and tested using the same
 process that you have today. For example, doing code reviews via Pull Requests, running code through linters or static
 analysis tools, and running unit and integration tests as appropriate. It all "just works" for your cloud
-infrasturcture the same way it would for your application code.
+infrastructure the same way it would for your application code.
 
 Pulumi can easily integrate into any CI/CD system. If yours isn't listed below, see our guide for using Pulumi
 within a [generic CI/CD system]({{< relref "other.md" >}}).

--- a/content/docs/guides/continuous-delivery/github-app.md
+++ b/content/docs/guides/continuous-delivery/github-app.md
@@ -55,29 +55,12 @@ other Pulumi-managed resources.
 
 ## CI Integration
 
+The Pulumi GitHub application will work with any CI/CD system. See our
+[Continuous Delivery]({{< relref "/docs/guides/continuous-delivery" >}}) guide for information on how to
+integration Pulumi with whatever system you.
+
 Once installed in your organization, any `pulumi preview` or `pulumi up` that is run in your CI
 system will have its results reported back to GitHub.
-
-Pulumi supports a wide array of CI/CD systems, and the Pulumi GitHub App should pick up your changes
-automatically. For instructions for specific CI services, see one of our existing guides:
-
-* [AWS Code Services]({{< relref "/docs/guides/continuous-delivery/aws-code-services.md" >}})
-* [Azure DevOps]({{< relref "/docs/guides/continuous-delivery/azure-devops.md" >}})
-* [CircleCI]({{< relref "/docs/guides/continuous-delivery/circleci.md" >}})
-* [GitHub Actions]({{< relref "/docs/guides/continuous-delivery/github-actions.md" >}})
-* [GitLab CI]({{< relref "/docs/guides/continuous-delivery/gitlab-ci.md" >}})
-* [Travis]({{< relref "/docs/guides/continuous-delivery/travis.md" >}})
-
-If you are using a system we don't support yet, please [file an issue](https://github.com/pulumi/pulumi/issues/new)
-so we can add it.
-
-By setting a few environment variables, you can ensure that any stack updates from your CI/CD environment will be
-associated with your GitHub Pull Request.
-
-* `PULUMI_CI_SYSTEM`. The name of whatever CI/CD system you are using. e.g. "Deploytron-9000".
-* `PULUMI_CI_PULL_REQUEST_SHA` (optional). If your CI/CD system is deploying from a different git commit than the
-  GitHub PR, such as the resulting merge commit, then set the `PULUMI_CI_PULL_REQUEST_SHA` to the origional
-  commit SHA, matching what is found on the Pull Request.
 
 ## GitHub UI
 


### PR DESCRIPTION
Currently we duplicate the list of supported CI/CD systems on the Pulumi GitHub App page. This is out of date, and will be a pain to maintain anyways.

So instead I just removed the table and just linked it to our Continuous Delivery guide, which contains all the relevant information.

Current:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/4029847/71599536-11fcdc80-2b00-11ea-9ad6-d674fa4c6580.png">

New:
<img width="781" alt="image" src="https://user-images.githubusercontent.com/4029847/71599545-204af880-2b00-11ea-8ae4-6a0a2a87b3ce.png">

Fixes #3610