### PR TITLE
Fixed broken Route 53 code examples

### DIFF
--- a/content/docs/reference/pkg/nodejs/pulumi/aws/acm/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/aws/acm/_index.md
@@ -314,6 +314,7 @@ const zone = aws.route53.getZone({
     privateZone: false,
 });
 const certValidation = new aws.route53.Record("certValidation", {
+    name: certCertificate.domainValidationOptions[0].resourceRecordName,
     records: [certCertificate.domainValidationOptions[0].resourceRecordValue],
     ttl: 60,
     type: certCertificate.domainValidationOptions[0].resourceRecordType,
@@ -352,18 +353,21 @@ const zoneAlt = aws.route53.getZone({
     privateZone: false,
 });
 const certValidation = new aws.route53.Record("certValidation", {
+    name: certCertificate.domainValidationOptions[0].resourceRecordName,
     records: [certCertificate.domainValidationOptions[0].resourceRecordValue],
     ttl: 60,
     type: certCertificate.domainValidationOptions[0].resourceRecordType,
     zoneId: zone.id,
 });
 const certValidationAlt1 = new aws.route53.Record("certValidationAlt1", {
+    name: certCertificate.domainValidationOptions[1].resourceRecordName,
     records: [certCertificate.domainValidationOptions[1].resourceRecordValue],
     ttl: 60,
     type: certCertificate.domainValidationOptions[1].resourceRecordType,
     zoneId: zone.id,
 });
 const certValidationAlt2 = new aws.route53.Record("certValidationAlt2", {
+    name: certCertificate.domainValidationOptions[2].resourceRecordName,
     records: [certCertificate.domainValidationOptions[2].resourceRecordValue],
     ttl: 60,
     type: certCertificate.domainValidationOptions[2].resourceRecordType,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

The examples in [docs/reference/pkg/nodejs/pulumi/aws/acm/_index.md](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/acm/) for using DNS Validation with Route 53 were incorrect as they were using the wrong name for the record.

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

Fixes #1923 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
