### PR TITLE
Fix: mention using stable ids in import documentation

### DIFF
--- a/content/blog/adopting-existing-cloud-resources-into-pulumi/index.md
+++ b/content/blog/adopting-existing-cloud-resources-into-pulumi/index.md
@@ -61,6 +61,8 @@ Because the `import` is provided in code, it can be configured in several differ
 
 Import can be used for a wide variety of adoption scenarios, from importing a single resource to migrating an entire stack from an existing tool like Terraform.  You can even automate an entire migration process across dozens of instances of infrastructure deployment.  For small numbers of resources, you can just paste in individual resource IDs.  For larger conversions, you can create a mapping of cloud resource ids (in JSON, CSV, or any other format) and load that into your Pulumi program with something like `import: idMapping[name]`.  If you are importing or migrating dozens of stacks, you can even select between which of these mappings to use via a Pulumi config setting.
 
+When you intent on keeping the `import: <id>` property after initial import, it is important to use the same id as the resource has externally. For example, if you have a `gcp.Firewall` and you use "allow-ssh" as the import id, this will lead to continuous `import-replacements` if you keep the import id after the initial import into the checkpoint file. Use the full id as used by the provider: `projects/<myproject>/global/firewalls/allow-ssh`.
+
 ### Walkthrough of Adopting Existing Infrastructure to Pulumi
 
 To see one of these scenarios in action end-to-end, let's walk through the process of deploying some "existing" infrastructure outside of Pulumi, and then adopting it under management of a Pulumi program.  You can also check out the video below which walks through the same scenario.

--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -330,7 +330,9 @@ var res = new MyResource("res", new MyResourceArgs { prop = "new-value" }, new R
 
 ##### `import`
 
-The ID of an existing resource to import for Pulumi to manage. When set, Pulumi will read the current state of the resource with the given ID from the backing provider &ndash; AWS, Azure, GCP, or Kubernetes for example. The inputs to the resource's constructor must not differ from this state or the import will fail. Once a resource has been imported, this property should be unset.
+The ID of an existing resource to import for Pulumi to manage. When set, Pulumi will read the current state of the resource with the given ID from the backing provider &ndash; AWS, Azure, GCP, or Kubernetes for example. The inputs to the resource's constructor must not differ from this state or the import will fail.
+
+Either make sure the import id exactly matches the id after importing, or remove the property after importing. Failing to do so will cause the resource to be continuously imported for "import-replacement", which leads to unnecessary deletes & recreates and is problematic for protected resources. When keeping the imports, you can for example use (with GCP Firewalls) `projects/<myproject>/global/firewalls/<name>` as id, instead of just `<name>`.
 
 {{< langchoose csharp >}}
 


### PR DESCRIPTION
When we were actively adopting Pulumi in our infrastructure we had multiple employees with local checkpoint files that were all experimenting with adapting resources. Adding and removing imports is cumbersome, so ideally we would like to leave the imports in-place but could not get that to work: each time an already imported resource was processed it would be import-replaced. After some accidental find we discovered why: the id we specified was a short version of the full id as known at the provider. Therefore, the id of the resource downloaded by the `import` directive 'changed' after downloading to the fully qualified one (`projects/myproject/global/firewall/allow-ssh`) causing the import to re-run for each consecutive `pulumi up` execution.

As mentioned only in this commit message: https://github.com/pulumi/pulumi/commit/e1a52693dc79c6316c0001cf8781401bb26c1305
there are 4 'modes' of importing.

We were hitting case 3, instead of 4.

Note that we added a global setting to disable all import directives, once we had imported all resources. However, until all individual resources successfully imported, we were now able to leave the import directives in-place.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
- Mention using fully qualified ids in adoptation blog and programming model docs.

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)
#2893 #1662 by @pgavlin
and mentioning @lukehoban who wrote the adaptation blog

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
