### PR TITLE
add entries for two recent releases

### DIFF
--- a/content/docs/get-started/install/versions.md
+++ b/content/docs/get-started/install/versions.md
@@ -17,6 +17,8 @@ The current stable version of Pulumi is **{{< latest-version >}}**.
         </tr>
     </thead>
     <tbody>
+        {{< changelog-table-row version="1.8.1" date="2019-12-20" >}}
+        {{< changelog-table-row version="1.8.0" date="2019-12-19" >}}
         {{< changelog-table-row version="1.7.1" date="2019-12-14" >}}
         {{< changelog-table-row version="1.7.0" date="2019-12-11" >}}
         {{< changelog-table-row version="1.6.1" date="2019-11-26" >}}


### PR DESCRIPTION
The website's Available Versions page does not list the two most recent releases. I believe this PR will fix this.

https://www.pulumi.com/docs/get-started/install/versions/
