### PR TITLE
Add fallback incase link does not have an href

### DIFF
--- a/assets/js/tracking.js
+++ b/assets/js/tracking.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
 
             // Get the tracking id.
             const dataTrack = elem.attr("data-track");
-            const href = elem.attr("href").replace(/https?:\/\//g, "");
+            const href = (elem.attr("href") || "").replace(/https?:\/\//g, "");
             const trackingDescription = dataTrack ? dataTrack :
                   href.replace(/^#/, "anchor-")
                       .replace(/^\//, "")


### PR DESCRIPTION
This PR fixes a case where links do not have an href attribute that was causing the link tracking scrip to throw an error on some of docs page.

<img width="666" alt="error" src="https://user-images.githubusercontent.com/15146337/72475308-804bcb00-379f-11ea-98ca-02837183e7ac.png">
