### PR TITLE
Fix broken link in dotnet preview blog

### DIFF
--- a/content/blog/dotnet-preview/index.md
+++ b/content/blog/dotnet-preview/index.md
@@ -132,7 +132,7 @@ $ pulumi stack rm --yes
 
 In this post, we've shown how to use Pulumi to deploy a modern application to Azure. The example code performs a number of tasks.
 
-First, we created a [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#resource-groups), a [storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy-lrs), and an [application service plan](https://docs.microsoft.com/en-us/azure/app-service/overview-hosting-plans) for our application:
+First, we created a [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-groups), a [storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy-lrs), and an [application service plan](https://docs.microsoft.com/en-us/azure/app-service/overview-hosting-plans) for our application:
 
 ```csharp
 var resourceGroup = new ResourceGroup("appservice-rg");


### PR DESCRIPTION
### Proposed changes

This fixes a broken link in the dotnet preview blog. It looks like Microsoft has recently restructured some of their documentation urls. Please double check that it is indeed the right place to linking to.

Old link: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#resource-groups
New Link: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-groups