### PR TITLE
Move Go steps to pages with tabs

### DIFF
--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -14,16 +14,6 @@ aliases: ["/docs/quickstart/aws/deploy-changes/"]
 
 Now let's deploy our changes.
 
-{{% lang go %}}
-Recompile your project so the changes are picked up:
-
-```bash
-$ go build $(basename $(pwd))
-```
-
-Now, deploy them:
-{{% /lang %}}
-
 ```bash
 $ pulumi up
 ```

--- a/content/docs/get-started/aws/deploy-stack.md
+++ b/content/docs/get-started/aws/deploy-stack.md
@@ -14,18 +14,6 @@ aliases: ["/docs/quickstart/aws/deploy-stack/"]
 
 Let's go ahead and deploy the stack:
 
-{{% lang go %}}
-Because Go is a compiled language, you first need to compile it:
-
-```bash
-$ go build $(basename $(pwd))
-```
-
-This instructs Go to create a binary whose name is the same as your directory. It needs to match your project name.
-
-Next, we will ask Pulumi to run it and deploy the stack:
-{{% /lang %}}
-
 ```bash
 $ pulumi up
 ```

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -170,6 +170,15 @@ class Program
 
 Our program now creates a KMS key and enables server-side encryption on the S3 bucket using the KMS key.
 
+{{% lang go %}}
+Recompile your project so the changes are picked up:
+
+```bash
+$ go build $(basename $(pwd))
+```
+
+{{% /lang %}}
+
 Next, we'll deploy the changes.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -128,6 +128,13 @@ For Go, before we can deploy the stack, you will need to initialize your project
 $ go mod init
 ```
 
+Because Go is a compiled language, you also need to compile it:
+
+```bash
+$ go build $(basename $(pwd))
+```
+
+This instructs Go to create a binary whose name is the same as your directory. It needs to match your project name.
 {{% /lang %}}
 
 Next, we'll deploy the stack.

--- a/content/docs/get-started/azure/deploy-changes.md
+++ b/content/docs/get-started/azure/deploy-changes.md
@@ -14,16 +14,6 @@ aliases: ["/docs/quickstart/azure/deploy-changes/"]
 
 Now let's deploy our changes.
 
-{{% lang go %}}
-Recompile your project so the changes are picked up:
-
-```bash
-$ go build $(basename $(pwd))
-```
-
-Now, deploy them:
-{{% /lang %}}
-
 ```bash
 $ pulumi up
 ```

--- a/content/docs/get-started/azure/deploy-stack.md
+++ b/content/docs/get-started/azure/deploy-stack.md
@@ -14,18 +14,6 @@ aliases: ["/docs/quickstart/azure/deploy-stack/"]
 
 Let's go ahead and deploy the stack:
 
-{{% lang go %}}
-Because Go is a compiled language, you first need to compile it:
-
-```bash
-$ go build $(basename $(pwd))
-```
-
-This instructs Go to create a binary whose name is the same as your directory. It needs to match your project name.
-
-Next, we will ask Pulumi to run it and deploy the stack:
-{{% /lang %}}
-
 ```bash
 $ pulumi up
 ```

--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -144,6 +144,15 @@ class Program
 }
 ```
 
+{{% lang go %}}
+Recompile your project so the changes are picked up:
+
+```bash
+$ go build $(basename $(pwd))
+```
+
+{{% /lang %}}
+
 Next, we'll deploy the changes.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/azure/review-project.md
+++ b/content/docs/get-started/azure/review-project.md
@@ -169,6 +169,13 @@ For Go, before we can deploy the stack, you will need to initialize your project
 $ go mod init
 ```
 
+Because Go is a compiled language, you first need to compile it:
+
+```bash
+$ go build $(basename $(pwd))
+```
+
+This instructs Go to create a binary whose name is the same as your directory. It needs to match your project name.
 {{% /lang %}}
 
 Next, we'll deploy the stack.

--- a/content/docs/get-started/gcp/deploy-changes.md
+++ b/content/docs/get-started/gcp/deploy-changes.md
@@ -14,16 +14,6 @@ aliases: ["/docs/quickstart/gcp/deploy-changes/"]
 
 Now let's deploy our changes.
 
-{{% lang go %}}
-Recompile your project so the changes are picked up:
-
-```bash
-$ go build $(basename $(pwd))
-```
-
-Now, deploy them:
-{{% /lang %}}
-
 ```bash
 $ pulumi up
 ```

--- a/content/docs/get-started/gcp/deploy-stack.md
+++ b/content/docs/get-started/gcp/deploy-stack.md
@@ -14,18 +14,6 @@ aliases: ["/docs/quickstart/gcp/deploy-stack/"]
 
 Let's go ahead and deploy the stack:
 
-{{% lang go %}}
-Because Go is a compiled language, you first need to compile it:
-
-```bash
-$ go build $(basename $(pwd))
-```
-
-This instructs Go to create a binary whose name is the same as your directory. It needs to match your project name.
-
-Next, we will ask Pulumi to run it and deploy the stack:
-{{% /lang %}}
-
 ```bash
 $ pulumi up
 ```

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -175,6 +175,15 @@ class Program
 }
 ```
 
+{{% lang go %}}
+Recompile your project so the changes are picked up:
+
+```bash
+$ go build $(basename $(pwd))
+```
+
+{{% /lang %}}
+
 Next, we'll deploy the changes.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/review-project.md
+++ b/content/docs/get-started/gcp/review-project.md
@@ -127,6 +127,13 @@ For Go, before we can deploy the stack, you will need to initialize your project
 $ go mod init
 ```
 
+Because Go is a compiled language, you first need to compile it:
+
+```bash
+$ go build $(basename $(pwd))
+```
+
+This instructs Go to create a binary whose name is the same as your directory. It needs to match your project name.
 {{% /lang %}}
 
 Next, we'll deploy the stack.


### PR DESCRIPTION
Because our language chooser doesn't show/hide language
elements for pages without tabs, some Go steps are hidden.
We tried to make that logic apply even when tabs aren't present,
but that had unintented consequences for regular content like
blogs. So, just move those steps to pages with tabs on them.
