### PR TITLE
Declare assets as dependencies of web pages

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -4,6 +4,7 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
 import * as fs from "fs";
+import * as glob from "glob";
 import * as mime from "mime";
 import * as path from "path";
 
@@ -226,22 +227,6 @@ const cdn = new aws.cloudfront.Distribution(
         dependsOn: [ contentBucket, logsBucket ],
     });
 
-// crawlDirectory recursive crawls the provided directory, applying the provided function
-// to every file it contains. Doesn't handle cycles from symlinks.
-function crawlDirectory(dir: string, f: (_: string) => void) {
-    const files = fs.readdirSync(dir);
-    for (const file of files) {
-        const filePath = `${dir}/${file}`;
-        const stat = fs.statSync(filePath);
-        if (stat.isDirectory()) {
-            crawlDirectory(filePath, f);
-        }
-        if (stat.isFile()) {
-            f(filePath);
-        }
-    }
-}
-
 // Some files do not get the correct mime/type inferred from the mime package, and we
 // need to set our own.
 function getMimeType(filePath: string): string | undefined {
@@ -257,47 +242,121 @@ function getMimeType(filePath: string): string | undefined {
 // Sync the contents of the source directory with the S3 bucket, which will in-turn show up on the CDN.
 const webContentsRootPath = path.join(process.cwd(), config.pathToWebsiteContents);
 console.log("Syncing contents from local disk at", webContentsRootPath);
-crawlDirectory(
-    webContentsRootPath,
-    (filePath: string) => {
-        const relativeFilePath = filePath.replace(webContentsRootPath + "/", "");
 
-        const baseArgs = {
-            acl: "public-read",
-            key: relativeFilePath,
-            bucket: contentBucket,
-        };
+// Certain files, like JavaScript and CSS files produced during the build, must exist
+// before the website's HTML files can use them (otherwise, pages won't render properly,
+// or may be unusable), and others, like fonts and images, would be nice to have there in
+// advance, too. Extensions listed here are used for identifying files that should exist
+// on S3 before any HTML pages are updated to reference them.
+const assetTypes = [
+    "js",
+    "css",
+    "png",
+    "jpg",
+    "gif",
+    "svg",
+    "pdf",
+    "eot",
+    "ttf",
+    "woff",
+    "woff2",
+];
 
-        // Create a new S3 object for most files, but HTML files that contain a redirect
-        // just create a stubbed out S3 object with the right metadata so they return a
-        // 301 redirect (instead of serving the HTML with a meta-redirect). This ensures
-        // the right HTTP code response is returned for search engines, as well as
-        // enables better support for URL anchors.
-        const redirect = getMetaRefreshRedirect(filePath);
-        if (!redirect) {
-            const contentFile = new aws.s3.BucketObject(
-                relativeFilePath,
-                {
-                    ...baseArgs,
-                    source: new pulumi.asset.FileAsset(filePath),
-                    contentType: getMimeType(filePath) || undefined,
-                },
-                {
-                    parent: contentBucket,
-                });
-        } else {
-            const s3Redirect = new aws.s3.BucketObject(
-                relativeFilePath,
-                {
-                    ...baseArgs,
-                    source: new pulumi.asset.FileAsset("/dev/null"), // Empty file.
-                    websiteRedirect: translateRedirect(filePath, redirect),
-                },
-                {
-                    parent: contentBucket,
-                });
-        }
+// Keep track of the asset paths we encounter and the resources we create from them, so we
+// can declare the necessary dependency relationships.
+const assetPaths: string[] = [];
+const assetResources: aws.s3.BucketObject[] = [];
+
+// Find all files matching the patterns above, creating a new BucketObject for each one.
+// These objects are declared first in order to pass them conditionally as dependencies
+// below.
+assetTypes.forEach(pattern => {
+    glob.sync(`${webContentsRootPath}/**/*.${pattern}`).forEach(assetPath => {
+
+        // Remember the asset path, so we can ignore it later.
+        assetPaths.push(assetPath);
+
+        // Turn the full (local) path into a relative path, so we can use it for an S3 object key.
+        const relativeAssetPath = assetPath.replace(webContentsRootPath + "/", "");
+
+        // Create a resource object with the asset.
+        const assetResource = new aws.s3.BucketObject(
+            relativeAssetPath,
+            {
+                acl: "public-read",
+                key: relativeAssetPath,
+                source: new pulumi.asset.FileAsset(assetPath),
+                contentType: getMimeType(assetPath) || undefined,
+                bucket: contentBucket,
+            },
+            {
+                parent: contentBucket,
+            },
+        );
+
+        // Add the bucket resource to the list of asset dependencies.
+        assetResources.push(assetResource);
     });
+});
+
+// Now create bucket objects for everything else, bypassing anything created already.
+glob.sync(`${webContentsRootPath}/**/*`).forEach(filePath => {
+
+    // Ignore directories.
+    if (fs.lstatSync(filePath).isDirectory()) {
+        return;
+    }
+
+    // Ignore previously encountered asset paths, since they'll already have been declared.
+    if (assetPaths.includes(filePath)) {
+        return;
+    }
+
+    const relativeFilePath = filePath.replace(webContentsRootPath + "/", "");
+    const baseArgs = {
+        acl: "public-read",
+        key: relativeFilePath,
+        bucket: contentBucket,
+    };
+
+    // Create a new S3 object for most files, but HTML files that contain a redirect
+    // just create a stubbed out S3 object with the right metadata so they return a
+    // 301 redirect (instead of serving the HTML with a meta-redirect). This ensures
+    // the right HTTP code response is returned for search engines, as well as
+    // enables better support for URL anchors.
+    const redirect = getMetaRefreshRedirect(filePath);
+    if (!redirect) {
+        const contentType = getMimeType(filePath) || undefined;
+        console.log(contentType);
+
+        const contentFile = new aws.s3.BucketObject(
+            relativeFilePath,
+            {
+                ...baseArgs,
+                source: new pulumi.asset.FileAsset(filePath),
+                contentType,
+            },
+            {
+                parent: contentBucket,
+
+                // Only HTML files need depend on asset files.
+                dependsOn: contentType === "text/html" ? assetResources : undefined,
+            },
+        );
+    } else {
+        const s3Redirect = new aws.s3.BucketObject(
+            relativeFilePath,
+            {
+                ...baseArgs,
+                source: new pulumi.asset.FileAsset("/dev/null"), // Empty file.
+                websiteRedirect: translateRedirect(filePath, redirect),
+            },
+            {
+                parent: contentBucket,
+            },
+        );
+    }
+});
 
 // Returns the redirect URL if filePath is an HTML file that contains a meta refresh tag, otherwise undefined.
 function getMetaRefreshRedirect(filePath: string): string | undefined {

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -4,6 +4,7 @@
         "lint": "tslint --project tsconfig.json"
     },
     "devDependencies": {
+        "@types/glob": "^7.1.1",
         "@types/mime": "^2.0.1",
         "@types/node": "^12.7.2",
         "tslint": "^5.19.0"
@@ -11,7 +12,6 @@
     "dependencies": {
         "@pulumi/aws": "^0.18.27",
         "@pulumi/pulumi": "^0.17.28",
-        "@types/glob": "^7.1.1",
         "glob": "^7.1.6",
         "mime": "^2.4.4"
     }

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -11,6 +11,8 @@
     "dependencies": {
         "@pulumi/aws": "^0.18.27",
         "@pulumi/pulumi": "^0.17.28",
+        "@types/glob": "^7.1.1",
+        "glob": "^7.1.6",
         "mime": "^2.4.4"
     }
 }

--- a/infrastructure/yarn.lock
+++ b/infrastructure/yarn.lock
@@ -108,6 +108,20 @@
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
 
+"@types/events@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
+  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/glob@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -117,6 +131,16 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
   integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+
+"@types/node@*":
+  version "13.1.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.8.tgz#1d590429fe8187a02707720ecf38a6fe46ce294b"
+  integrity sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==
 
 "@types/node@^10.1.0":
   version "10.14.19"
@@ -472,6 +496,18 @@ glob@^7.0.5, glob@^7.1.1, glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1221,7 +1257,7 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-typescript@^3.0.0, typescript@^3.5.3:
+typescript@^3.0.0:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==


### PR DESCRIPTION
This change adds a bit of logic to the infrastructure app to declare assets (like CSS and JS files and others) as dependencies on HTML files, so the site doesn't break momentarily during deployment.

Fixes #1687. 