### PR TITLE
Don't emit empty modules

### DIFF
--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -443,7 +443,7 @@ func (e *emitter) emitMarkdownModule(name string, mod *module, gitSha string, ro
 		Link string
 	}
 	for modname, module := range mod.Modules {
-		if len(module.Exports) == 0 && len(module.Modules) == 0 {
+		if module.IsEmpty() {
 			continue
 		}
 
@@ -537,7 +537,7 @@ func (e *emitter) emitMarkdownModule(name string, mod *module, gitSha string, ro
 
 	// Next up: generate all submodules underneath this one.
 	for sub, module := range mod.Modules {
-		if len(module.Exports) == 0 && len(module.Modules) == 0 {
+		if module.IsEmpty() {
 			continue
 		}
 		if err = e.emitMarkdownModule(sub, module, gitSha, false); err != nil {
@@ -830,6 +830,20 @@ func newModule(name string) *module {
 		Exports: make(map[string]*typeDocNode),
 		Modules: make(map[string]*module),
 	}
+}
+
+// IsEmpty returns true if the module does not have any exports, or all of its
+// submodules are empty.
+func (m *module) IsEmpty() bool {
+	if len(m.Exports) > 0 {
+		return false
+	}
+	for _, module := range m.Modules {
+		if !module.IsEmpty() {
+			return false
+		}
+	}
+	return true
 }
 
 // Merge another module into this one, in place, by mutating it.


### PR DESCRIPTION
Part of removing internal APIs from docs. For example, see https://github.com/pulumi/pulumi/pull/3809 (and the example diff https://github.com/pulumi/docs/compare/justin/internal).

Once this is merged, the next time we release `@pulumi/pulumi` and update its docs, these empty modules will no longer be emitted. (I will then make a subsequent change that actually deletes the files for the modules that are no longer are being updated as part of the doc gen.)