### PR TITLE
Add support for deploying with S3 sync

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:alpine
+
+RUN pip install --no-cache-dir awscli
+COPY sync.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/sync.sh"]

--- a/infrastructure/Pulumi.production.yaml
+++ b/infrastructure/Pulumi.production.yaml
@@ -3,4 +3,5 @@ config:
   www.pulumi.com:certificateArn: arn:aws:acm:us-east-1:058607598222:certificate/a3f72a2b-e715-4639-b126-1e4efc0b634b
   www.pulumi.com:pathToWebsiteContents: ../public
   www.pulumi.com:targetDomain: www-production.pulumi.com
+  www.pulumi.com:websiteDomain: www-prod.pulumi.com
   www.pulumi.com:redirectDomain: www.pulumi.com

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -50,6 +50,25 @@ const contentBucket = new aws.s3.Bucket(
     },
 );
 
+// contentBucket needs to have the "public-read" ACL so its contents can be ready by CloudFront and
+// served. But we deny the s3:ListBucket permission to prevent unintended disclosure of the bucket's
+// contents.
+const denyListPolicyState: aws.s3.BucketPolicyArgs = {
+    bucket: contentBucket.bucket,
+    policy: contentBucket.arn.apply((arn: string) => JSON.stringify({
+        Version: "2008-10-17",
+        Statement: [
+            {
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:ListBucket",
+                Resource: arn,
+            },
+        ],
+    })),
+};
+const denyListPolicy = new aws.s3.BucketPolicy("deny-list", denyListPolicyState);
+
 // websiteBucket stores the static content to be served via the CDN.
 const websiteBucket = new aws.s3.Bucket(
     "website-bucket",

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -4,12 +4,16 @@
         "lint": "tslint --project tsconfig.json"
     },
     "devDependencies": {
+        "@types/glob": "^7.1.1",
         "@types/mime": "^2.0.1",
         "@types/node": "^12.7.2",
+        "@types/tar": "^4.0.3",
+        "@types/tmp": "^0.1.0",
         "tslint": "^5.19.0"
     },
     "dependencies": {
         "@pulumi/aws": "^0.18.27",
+        "@pulumi/awsx": "^0.19.1",
         "@pulumi/pulumi": "^0.17.28",
         "mime": "^2.4.4"
     }

--- a/infrastructure/sync.sh
+++ b/infrastructure/sync.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# S3 URL of the website tarball.
+site_archive="$1"
+
+# S3 URL of the destination website bucket (e.g., the one hosting www.pulumi.com).
+site_bucket="$2"
+
+# Download the archive from the archive bucket and unpack it into a local folder.
+echo "Downloading $site_archive..."
+aws s3 cp $site_archive .
+mkdir site_contents
+tar -xzvf $(basename "$site_archive") -C site_contents
+
+# Upload the JS and CSS bundles first.
+cd site_contents
+
+for file in $(find css -name "styles.*.css") ; do
+    aws s3 cp "$file" "$site_bucket/$file" --acl public-read
+done
+
+for file in $(find js -name "bundle.min.*.js") ; do
+    aws s3 cp "$file" "$site_bucket/$file"  --acl public-read
+done
+
+cd ..
+
+# Synchronize the remaining contents of the local folder and site bucket, deleting
+# whatever files exist remotely but not locally.
+echo "Synchronizing to $site_bucket..."
+aws s3 sync site_contents "$site_bucket" --acl public-read --delete
+
+# Set the content-type of latest-version explicitly. (Otherwise, it'll be set as binary/octet-stream.)
+aws s3 cp "site_contents/latest-version" "$site_bucket/latest-version" \
+    --content-type "text/plain" --acl public-read --metadata-directive REPLACE
+
+echo "Done!"

--- a/infrastructure/yarn.lock
+++ b/infrastructure/yarn.lock
@@ -83,6 +83,37 @@
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
+"@pulumi/aws@^1.0.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-1.19.0.tgz#9485b569dcc7e12bf8068b13ede3388e91c289ef"
+  integrity sha512-oEZIGqMGI4TsUlm/8om2hAF/50xAtBcPCXxemJVxxnKEQIRm9EWon3paonDtewug4EvVZja09dgmyUZerPyxfw==
+  dependencies:
+    "@pulumi/pulumi" "^1.0.0"
+    aws-sdk "^2.0.0"
+    builtin-modules "3.0.0"
+    mime "^2.0.0"
+    read-package-tree "^5.2.1"
+    resolve "^1.7.1"
+
+"@pulumi/awsx@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/awsx/-/awsx-0.19.1.tgz#ac1fd98b19f15b0a14b489b98b46aa9f68fcdd32"
+  integrity sha512-74YloUq+nciJOPHFJ8ImdZ40IxyQYpQnXzlHln+H2H7Rafg1Uw4IgS6Ee2Ogwf0rJ3aJ9J25DVcJTRnzupWDsA==
+  dependencies:
+    "@pulumi/aws" "^1.0.0"
+    "@pulumi/docker" "^1.0.0"
+    "@pulumi/pulumi" "^1.0.0"
+    "@types/aws-lambda" "^8.10.23"
+    mime "^2.0.0"
+
+"@pulumi/docker@^1.0.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-1.2.0.tgz#bd04fb84bb6a8fd68ec0cdfcf742e6ccbd914af6"
+  integrity sha512-OJ4un0XC/VkPimtD7tDnnChWQ162tgiZ100C4Etga1GVFoxm6U1Zhqjq0ENi8llNA0B9Kz41GIUfRF8XdXEV9Q==
+  dependencies:
+    "@pulumi/pulumi" "^1.0.0"
+    semver "^5.4.0"
+
 "@pulumi/pulumi@^0.17.27", "@pulumi/pulumi@^0.17.28":
   version "0.17.28"
   resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.17.28.tgz#26f27c0075685b98647263565bfe8bb12adc0542"
@@ -103,10 +134,62 @@
     typescript "^3.0.0"
     upath "^1.1.0"
 
+"@pulumi/pulumi@^1.0.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-1.9.1.tgz#1957c915f2f81e36c7c7554d0b1243210cd1f8d7"
+  integrity sha512-jcBDGxKDzzG54ngaOojj6PmkViW2i6sLuwvqMf7sZgsRnn+Z6AsknJqbJhQroHrOEaHZeSo8w0cFnxg6vTWujw==
+  dependencies:
+    "@pulumi/query" "^0.3.0"
+    deasync "^0.1.15"
+    google-protobuf "^3.5.0"
+    grpc "1.24.2"
+    minimist "^1.2.0"
+    normalize-package-data "^2.4.0"
+    protobufjs "^6.8.6"
+    read-package-tree "^5.3.1"
+    require-from-string "^2.0.1"
+    semver "^6.1.0"
+    source-map-support "^0.4.16"
+    ts-node "8.5.4"
+    typescript "~3.7.3"
+    upath "^1.1.0"
+
 "@pulumi/query@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
+
+"@types/aws-lambda@^8.10.23":
+  version "8.10.40"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.40.tgz#d60b912a9425f74f60c57667a8c6b99d58df4ada"
+  integrity sha512-D0hOUw2y6in/cPWv0JMMCBnO3Hc/DNeLi8QQ1wymwk9Eixh6IFgVnCGJnUHefjxKEAVxL7z6LKBsFUrIjKygRg==
+
+"@types/bytebuffer@^5.0.40":
+  version "5.0.40"
+  resolved "https://registry.yarnpkg.com/@types/bytebuffer/-/bytebuffer-5.0.40.tgz#d6faac40dcfb09cd856cdc4c01d3690ba536d3ee"
+  integrity sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==
+  dependencies:
+    "@types/long" "*"
+    "@types/node" "*"
+
+"@types/events@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
+  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/glob@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/long@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
 "@types/long@^4.0.0":
   version "4.0.0"
@@ -118,6 +201,23 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
   integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
 
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+
+"@types/minipass@*":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minipass/-/minipass-2.2.0.tgz#51ad404e8eb1fa961f75ec61205796807b6f9651"
+  integrity sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*":
+  version "13.5.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.2.tgz#3de53b55fd39efc428a901a0f6db31f761cfa131"
+  integrity sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA==
+
 "@types/node@^10.1.0":
   version "10.14.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.19.tgz#f52742c7834a815dedf66edfc8a51547e2a67342"
@@ -127,6 +227,19 @@
   version "12.7.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.8.tgz#cb1bf6800238898bc2ff6ffa5702c3cadd350708"
   integrity sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==
+
+"@types/tar@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.3.tgz#e2cce0b8ff4f285293243f5971bd7199176ac489"
+  integrity sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==
+  dependencies:
+    "@types/minipass" "*"
+    "@types/node" "*"
+
+"@types/tmp@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
+  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
 abbrev@1:
   version "1.1.1"
@@ -162,6 +275,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.2.tgz#e70c90579e02c63d80e3ad4e31d8bfdb8bd50064"
+  integrity sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -501,6 +619,18 @@ grpc@1.21.1:
     node-pre-gyp "^0.13.0"
     protobufjs "^5.0.3"
 
+grpc@1.24.2:
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.24.2.tgz#76d047bfa7b05b607cbbe3abb99065dcefe0c099"
+  integrity sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==
+  dependencies:
+    "@types/bytebuffer" "^5.0.40"
+    lodash.camelcase "^4.3.0"
+    lodash.clone "^4.5.0"
+    nan "^2.13.2"
+    node-pre-gyp "^0.14.0"
+    protobufjs "^5.0.3"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -757,6 +887,22 @@ node-pre-gyp@^0.13.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-pre-gyp@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
+  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -1016,7 +1162,7 @@ sax@>=0.6.0, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -1163,7 +1309,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-tar@^4:
+tar@^4, tar@^4.4.2:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -1175,6 +1321,17 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+ts-node@8.5.4:
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.4.tgz#a152add11fa19c221d0b48962c210cf467262ab2"
+  integrity sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
 
 ts-node@^7.0.0:
   version "7.0.1"
@@ -1221,10 +1378,15 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-typescript@^3.0.0, typescript@^3.5.3:
+typescript@^3.0.0:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+
+typescript@~3.7.3:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 upath@^1.1.0:
   version "1.2.0"
@@ -1329,3 +1491,8 @@ yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
   integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
+
+yn@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
This change represents the first of two steps in migrating to using`aws s3 sync` to manage deployments of the website. It is completely additive (new bucket, event handler and associated infrastructure) so it can be merged safely without disrupting the current deployment.