### PR TITLE
use a RelPermalink for the CSS ref

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -98,7 +98,7 @@
         {{ $toCSS := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" true) }}
         {{ $postCSS := (dict "config" "assets/config/postcss.config.js") }}
         {{ $styles := resources.Get "sass/styles.scss" | resources.ToCSS $toCSS | resources.PostCSS $postCSS | resources.Fingerprint }}
-        <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
+        <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
     {{ else }}
         {{ errorf "%q does not exist. Run `make ensure` to install required dependencies." $postCSSCLIFile }}
     {{ end }}


### PR DESCRIPTION
The `link` reference to the CSS bundle should be relative (as it is with the JS bundle), so that it loads properly in subdomains.