### PR TITLE
Add log line to redirect command

### DIFF
--- a/infrastructure/sync.sh
+++ b/infrastructure/sync.sh
@@ -35,6 +35,7 @@ aws s3 sync site_contents "$site_bucket" --acl public-read --delete
 # code response is returned for search engines and enables better support for URL anchors.
 IFS="|"
 while read key location; do
+    echo "Redirect $key to $location (${site_bucket:5})"
     aws s3api put-object --key "$key" --website-redirect-location "$location" --bucket "${site_bucket:5}" --acl public-read
 done < site_contents/redirects.txt
 


### PR DESCRIPTION
Redirects don't appear to be getting set as expected in the new website bucket, so this change adds a log line to clarify what's actually happening.