### PR TITLE
Add a newline at the end of the redirects file

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -494,7 +494,7 @@ if (!pulumi.runtime.isDryRun()) {
 
         fs.writeFileSync(
             `${webContentsRootPath}/redirects.txt`,
-            Array.from(redirectPaths, ([k, v]) => `${k}|${v}`).join("\n"),
+            Array.from(redirectPaths, ([k, v]) => `${k}|${v}`).join("\n") + "\n",
         );
 
         // Tar up the files in the `public` directory.


### PR DESCRIPTION
The last line of the redirects file isn't being processed because it doesn't end in a newline. This fixes that.