### PR TITLE
Add ppc landing pages

### DIFF
--- a/assets/js/mock-ide-file-selector.js
+++ b/assets/js/mock-ide-file-selector.js
@@ -1,0 +1,36 @@
+$(function() {
+    console.log("file selector starting...");
+    var codeBlockIds = ["terraformComparePython","terraformCompareGo","terraformCompareCSharp","terraformCompareTypeScript"];
+
+    /**
+     *
+     * @param {string} blockId The id of the code block to show.
+     */
+    function displayCodeBlock(blockId) {
+        for(var i = 0; i < codeBlockIds.length; i++) {
+            var codeBlockId = codeBlockIds[i];
+
+            if (codeBlockId === blockId) {
+                $("#" + codeBlockId + " .compare-code-block").removeClass("hidden");
+                $("#" + codeBlockId + " a").removeClass("file-not-active");
+            } else {
+                $("#" + codeBlockId + " .compare-code-block").addClass("hidden");
+                $("#" + codeBlockId + " a").addClass("file-not-active");
+            }
+        }
+    }
+
+    function registerClickHandlers() {
+        for(var i = 0; i < codeBlockIds.length; i ++) {
+            var clickId = "#" + codeBlockIds[i] + " a";
+
+            $(clickId).on("click", function(e) {
+                e.preventDefault();
+                console.log(this.parentElement.id);
+                displayCodeBlock(this.parentElement.id);
+            });
+        }
+    }
+
+    registerClickHandlers();
+})

--- a/assets/sass/_landing_pages.scss
+++ b/assets/sass/_landing_pages.scss
@@ -1,0 +1,30 @@
+.section-landing-pages {
+    nav {
+        @apply hidden;
+    }
+
+    .landing-page-hero {
+        @apply pt-0;
+
+        #get-started {
+            @apply p-0 bg-transparent;
+
+            div:first-child {
+                @apply mt-0;
+                p {
+                    @apply hidden;
+                }
+            }
+
+            div:nth-child(2) {
+                a {
+                    @apply bg-gray-200;
+                }
+            }
+
+            h2 {
+                @apply text-white;
+            }
+        }
+    }
+}

--- a/assets/sass/_landing_pages.scss
+++ b/assets/sass/_landing_pages.scss
@@ -2,29 +2,4 @@
     nav {
         @apply hidden;
     }
-
-    .landing-page-hero {
-        @apply pt-0;
-
-        #get-started {
-            @apply p-0 bg-transparent;
-
-            div:first-child {
-                @apply mt-0;
-                p {
-                    @apply hidden;
-                }
-            }
-
-            div:nth-child(2) {
-                a {
-                    @apply bg-gray-200;
-                }
-            }
-
-            h2 {
-                @apply text-white;
-            }
-        }
-    }
 }

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -191,6 +191,7 @@ main {
 #terraformCompareCodeBlock {
     .lntable {
         border-radius: 0;
+        background-color: #1a202c;
     }
     pre {
         margin-top: 0;
@@ -201,28 +202,38 @@ main {
     }
 
     #terraformComparePython, #terraformCompareGo, #terraformCompareCSharp {
-        @apply hidden;
+        .compare-code-block {
+            @apply hidden;
+        }
         &:target {
-            @apply block;
+            .code-file-nav--item {
+                @apply font-semibold;
+                background-color: #1a202c;
+            }
+            .compare-code-block {
+                @apply block;
+            }
 
             ~ #terraformCompareTypeScript {
-                @apply hidden;
+                .code-file-nav--item {
+                    background-color: #11151e;
+                    @apply font-normal;
+                }
+                .compare-code-block {
+                    @apply hidden;
+                }
             }
         }
     }
 }
 
-.code-file-nav {
-    @apply flex bg-gray-800 rounded-t;
+.code-file-nav--item {
+    @apply inline-block rounded-t py-2 px-4 text-blue-700 text-white font-semibold;
+    background-color: #1a202c;
 
-    &--item {
-        @apply inline-block rounded-t py-2 px-4 text-blue-700 text-white font-semibold;
-        background-color: #1a202c;
-
-        &.file-not-active {
-            background-color: #11151e;
-            @apply font-normal;
-        }
+    &.file-not-active {
+        background-color: #11151e;
+        @apply font-normal;
     }
 }
 

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -188,6 +188,44 @@ main {
     }
 }
 
+#terraformCompareCodeBlock {
+    .lntable {
+        border-radius: 0;
+    }
+    pre {
+        margin-top: 0;
+        margin-bottom: 0;
+        border-radius: 0;
+        padding-left: 5px;
+        padding-right: 5px;
+    }
+
+    #terraformComparePython, #terraformCompareGo, #terraformCompareCSharp {
+        @apply hidden;
+        &:target {
+            @apply block;
+
+            ~ #terraformCompareTypeScript {
+                @apply hidden;
+            }
+        }
+    }
+}
+
+.code-file-nav {
+    @apply flex bg-gray-800 rounded-t;
+
+    &--item {
+        @apply inline-block rounded-t py-2 px-4 text-blue-700 text-white font-semibold;
+        background-color: #1a202c;
+
+        &.file-not-active {
+            background-color: #11151e;
+            @apply font-normal;
+        }
+    }
+}
+
 // This little trick prepends anchor targets with a pseudoelement that the browser picks
 // up as the anchor target, allowing us to position the actual target below the fixed
 // navbar. Only necessary at medium and up.

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -19,6 +19,7 @@
 @import "hero";
 @import "hubspot";
 @import "icons";
+@import "landing_pages";
 @import "no-select";
 @import "on-this-page";
 @import "notes";

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -200,31 +200,6 @@ main {
         padding-left: 5px;
         padding-right: 5px;
     }
-
-    #terraformComparePython, #terraformCompareGo, #terraformCompareCSharp {
-        .compare-code-block {
-            @apply hidden;
-        }
-        &:target {
-            .code-file-nav--item {
-                @apply font-semibold;
-                background-color: #1a202c;
-            }
-            .compare-code-block {
-                @apply block;
-            }
-
-            ~ #terraformCompareTypeScript {
-                .code-file-nav--item {
-                    background-color: #11151e;
-                    @apply font-normal;
-                }
-                .compare-code-block {
-                    @apply hidden;
-                }
-            }
-        }
-    }
 }
 
 .code-file-nav--item {

--- a/content/landing-pages/_index.md
+++ b/content/landing-pages/_index.md
@@ -1,0 +1,5 @@
+---
+private: true
+title: Landing Pages
+meta_desc: A collection of pages on cloud resources and concepts and how Pulumi compares to other tools.
+---

--- a/content/landing-pages/terraform.md
+++ b/content/landing-pages/terraform.md
@@ -62,7 +62,7 @@ quotes:
 contact_us_form:
     section_id: contact
     hubspot_form_id: 8ffce4b8-9eb1-4c9d-804b-2d9054806aa2
-    headline: Want more information?
+    headline: Request Demo
     quote:
         title: Learn how top engineering teams are using Pulumi to manage and provision infrastructure in any cloud.
         name: Harrison Heck

--- a/content/landing-pages/terraform.md
+++ b/content/landing-pages/terraform.md
@@ -6,8 +6,8 @@ type: page
 layout: ppc-landing
 
 hero:
-    title: Modern Languages. Modern Infrastructure.
-    body: |
+    title: Modern Languages. Modern Infrastructures.
+    body: >
         Terraform uses a proprietary DSL called HCL to describe and provision infrastructure resources.
 
         In Pulumi, you describe infrastructure using familiar languages and tools, providing productivity gains,

--- a/content/landing-pages/terraform.md
+++ b/content/landing-pages/terraform.md
@@ -1,0 +1,74 @@
+---
+title: Modern Infrastructure as Code | Real Languages, Any Cloud
+meta_desc: Stop using a proprietary DSL to describe infrastructure and start describing infrastructure using real programming languages and familiar tools.
+url: /terraform/real-code
+type: page
+layout: ppc-landing
+
+hero:
+    title: Modern Languages. Modern Infrastructure.
+    body: |
+        Terraform uses a proprietary DSL called HCL to describe and provision infrastructure resources.
+
+        In Pulumi, you describe infrastructure using familiar languages and tools, providing productivity gains,
+        better abstraction and reuse, and developer approachability — while still supporting robust infrastructure
+        as code provisioning across many clouds.
+
+quotes:
+    - name: Dinesh Ramamurthy
+      title: Engineering Manager, Mercedes-Benz Research and Development North America
+      logo: mercedes-benz-RDNA_logo.png
+      body: >
+        I needed a solution that cut across silos and gave our developers a tool they could use
+        themselves to provision infrastructure to suit their own immediate needs. The way Pulumi
+        solves the multi-cloud problem is exactly what I was looking for.
+
+    - name: Harrison Heck
+      title: Head of DevOps, Linio
+      logo: linio_logo.png
+      body: >
+        As the largest eCommerce platform in Latin America, our infrastructure has to be highly
+        stable, well documented and agile. With Pulumi, we're able to develop new infrastructure,
+        change existing infrastructure and more with greater speed and reliability than we've ever
+        had before.
+
+    - name: Josh Imhoff
+      title: Site Reliability Engineer, Cockroach Labs
+      logo: cockroach-labs_logo.png
+      body: >
+        We are building a distributed-database-as-a-service product that runs on Kubernetes clusters
+        across multiple public clouds including GCP, AWS and others. Pulumi's declarative model,
+        the support for real programming languages, and the uniform workflow on any cloud
+        make our SRE team much more efficient.
+
+    - name: Beyang Liu
+      title: CTO, Sourcegraph
+      logo: sourcegraph_logo.png
+      body: >
+        Sourcegraph uses Kubernetes heavily and Pulumi is a great tool that lets us work efficiently
+        with Kubernetes and support a rich set of configuration options for our customers' diverse
+        set of scaling, deployment, and end-user needs. Pulumi's infrastructure as code model makes
+        working on this stuff a joy.
+
+    - name: Pankaj Dhingra
+      title: Senior Director of Cloud Engineering, Tableau Software
+      avatar: tableau_logo.png
+      body: >
+        Our team was looking for an end-to-end solution to tame the complexity of Kubernetes on AWS
+        and ensure we adhere to AWS best practices. Pulumi has equipped our team to scale far better:
+        our delivery is now automated and we can now deliver new features with much faster turn-around.
+        Pulumi is key to our team's productivity.
+
+contact_us_form:
+    section_id: contact
+    hubspot_form_id: 8ffce4b8-9eb1-4c9d-804b-2d9054806aa2
+    headline: Want more information?
+    quote:
+        title: Learn how top engineering teams are using Pulumi to manage and provision infrastructure in any cloud.
+        name: Harrison Heck
+        name_title: Head of DevOps, Linio
+        content: |
+            As the largest eCommerce platform in Latin America, our infrastructure has to be highly stable, well
+            documented and agile. With Pulumi, we're able to develop new infrastructure, change existing infrastructure
+            and more with greater speed and reliability than we've ever had before.
+---

--- a/layouts/page/ppc-landing.html
+++ b/layouts/page/ppc-landing.html
@@ -3,139 +3,19 @@
         <div class="w-full mb-5 p-10">
             <img src="/images/logo/logo-inv.svg" alt="Pulumi Logo" class="h-16 block" />
         </div>
-        <div class="header-hero-items container mx-auto">
-            <div class="header-hero-item">
+        <div class="container mx-auto">
+            <div class="block w-full">
                 <h1>{{ .Params.hero.title }}</h1>
                 {{ .Params.hero.body | markdownify }}
             </div>
-            <div class="header-hero-item">
-                    {{ partial "get-started.html" . }}
-
+            <div>
+                    {{ partial "terraform-code-compare.html" . }}
             </div>
         </div>
     </header>
 {{ end }}
 
 {{ define "main" }}
-
-    <!-- Customer logos -->
-    <section class="mb-16 px-4">
-        <div class="container mx-auto">
-            <div class="lg:flex items-center justify-center my-4">
-                <a data-track="customer-logo" href="https://www.tableau.com/" target="_blank">
-                    <img class="mx-auto lg:mx-8 h-12 mx-8" src="/logos/customers/tableau_logo.png" alt="Tableau Software" title="Tableau Software">
-                </a>
-                <a data-track="customer-logo" href="https://mbrdna.com/" target="_blank">
-                    <img class="mx-auto lg:mx-8 mt-8 mb-4 lg:my-0 h-12 mx-8" src="/logos/customers/mercedes-benz-RDNA_logo.png" title="Mercedes-Benz Research and Development" alt="Mercedes-Benz Research and Development">
-                </a>
-                <a data-track="customer-logo" href="https://www.mindbodyonline.com/" target="_blank">
-                    <img class="mx-auto lg:mx-8 h-16 mx-8" src="/logos/customers/mindbody_logo.svg" alt="MindBody" title="MindBody">
-                </a>
-                <a data-track="customer-logo" href="https://www.nih.gov/" target="_blank">
-                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-10 mx-8" src="/logos/customers/nih.png" alt="National Institutes of Health" title="National Institutes of Health">
-                </a>
-            </div>
-            <div class="lg:flex items-center justify-center my-4">
-                <a data-track="customer-logo" href="https://www.linio.com/" target="_blank">
-                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/linio_logo.png" alt="Linio" title="Linio">
-                </a>
-                <a data-track="customer-logo" href="https://www.cockroachlabs.com/" target="_blank">
-                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/cockroach-labs_logo.png" alt="Cockroach Labs" title="Cockroach Labs">
-                </a>
-                <a data-track="customer-logo" href="https://www.sourcegraph.com/" target="_blank">
-                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-6 mx-8" src="/logos/customers/sourcegraph_logo.png" alt="Sourcegraph" title="Sourcegraph">
-                </a>
-                <a data-track="customer-logo" href="https://www.snopes.com/" target="_blank">
-                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-10 mx-8" src="/logos/customers/snopes_logo.png" alt="Snopes" title="Snopes">
-                </a>
-                <a data-track="customer-logo" href="https://www.lemonade.com/" target="_blank">
-                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-8 mx-8" src="/logos/customers/lemonade.svg" alt="Lemonade" title="Lemonade">
-                </a>
-            </div>
-        </div>
-    </section>
-
-    <section id="code" class="bg-gray-200 py-16 px-4">
-        <div class="container mx-auto">
-            <div class="md:flex my-8">
-                <div class="md:w-1/2 md:mr-4">
-                    <h2>Take advantage of real coding features with Pulumi</h2>
-                    <p>
-                        Pulumi provides a more expressive and efficient way to define cloud resources:
-                    </p>
-                    <ul>
-                        <li>Use variable loops, not copy/paste</li>
-                        <li>Use any Node libaries (or Python/Go)</li>
-                        <li>On-the-fly error checking</li>
-                        <li>Freeform code instead of complex interpolations</li>
-                    </ul>
-                    <p>
-                        <a href="https://github.com/pulumi/examples">Find many other examples here</a>.
-                    </p>
-                </div>
-                <div class="md:w-1/2 md:ml:4">
-
-                    <!-- Example 1 -->
-                    {{ $code := `import * as aws from "@pulumi/aws";
-import { readFileSync, readdirSync } from "fs";
-import { join as pathjoin } from "path";
-
-const bucket = new aws.s3.Bucket("mybucket");
-
-const folder = "./files";
-let files = readdirSync(folder);
-for (let file of files) {
-    const object = new aws.s3.BucketObject(file, {
-        bucket: bucket,
-        content: readFileSync(pathjoin(folder, file)).toString("utf8")
-    });
-}
-
-export const bucketname = bucket.id;` }}
-
-                    {{ partial "code" (dict "code" $code "lang" "js" "mode" "dark") }}
-
-                    <!-- Example 2 -->
-                    {{ $code := `resource "aws_s3_bucket" "mybucket" {
-    bucket_prefix = "mybucket"
-}
-
-resource "aws_s3_bucket_object" "data_txt" {
-    key        = "data.txt"
-    bucket     = "${aws_s3_bucket.mybucket.id}"
-    source     = "./files/data.txt"
-}
-
-resource "aws_s3_bucket_object" "index_html" {
-    key        = "index.html"
-    bucket     = "${aws_s3_bucket.mybucket.id}"
-    source     = "./files/index.html"
-}
-
-resource "aws_s3_bucket_object" "index_js" {
-    key        = "index.js"
-    bucket     = "${aws_s3_bucket.mybucket.id}"
-    source     = "./files/index.js"
-}
-
-resource "aws_s3_bucket_object" "main.css" {
-    key        = "main.css"
-    bucket     = "${aws_s3_bucket.mybucket.id}"
-    source     = "./files/main.css"
-}
-
-resource "aws_s3_bucket_object" "favicon.ico" {
-    key        = "favicon.ico"
-    bucket     = "${aws_s3_bucket.mybucket.id}"
-    source     = "./files/favicon.ico"
-}` }}
-
-                        {{ partial "code" (dict "code" $code "lang" "plain" "mode" "dark") }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
 
     <!-- Testimonials -->
     <section class="py-16 px-4" style="background: url(/images/home/waves-blue.svg) repeat-x; background-position: top left;">
@@ -190,6 +70,43 @@ resource "aws_s3_bucket_object" "favicon.ico" {
                         </div>
                     </div>
                 </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Customer logos -->
+    <section class="mb-16 px-4">
+        <div class="container mx-auto">
+            <div class="lg:flex items-center justify-center my-4">
+                <a data-track="customer-logo" href="https://www.tableau.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 h-12 mx-8" src="/logos/customers/tableau_logo.png" alt="Tableau Software" title="Tableau Software">
+                </a>
+                <a data-track="customer-logo" href="https://mbrdna.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 mt-8 mb-4 lg:my-0 h-12 mx-8" src="/logos/customers/mercedes-benz-RDNA_logo.png" title="Mercedes-Benz Research and Development" alt="Mercedes-Benz Research and Development">
+                </a>
+                <a data-track="customer-logo" href="https://www.mindbodyonline.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 h-16 mx-8" src="/logos/customers/mindbody_logo.svg" alt="MindBody" title="MindBody">
+                </a>
+                <a data-track="customer-logo" href="https://www.nih.gov/" target="_blank">
+                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-10 mx-8" src="/logos/customers/nih.png" alt="National Institutes of Health" title="National Institutes of Health">
+                </a>
+            </div>
+            <div class="lg:flex items-center justify-center my-4">
+                <a data-track="customer-logo" href="https://www.linio.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/linio_logo.png" alt="Linio" title="Linio">
+                </a>
+                <a data-track="customer-logo" href="https://www.cockroachlabs.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/cockroach-labs_logo.png" alt="Cockroach Labs" title="Cockroach Labs">
+                </a>
+                <a data-track="customer-logo" href="https://www.sourcegraph.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-6 mx-8" src="/logos/customers/sourcegraph_logo.png" alt="Sourcegraph" title="Sourcegraph">
+                </a>
+                <a data-track="customer-logo" href="https://www.snopes.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-10 mx-8" src="/logos/customers/snopes_logo.png" alt="Snopes" title="Snopes">
+                </a>
+                <a data-track="customer-logo" href="https://www.lemonade.com/" target="_blank">
+                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-8 mx-8" src="/logos/customers/lemonade.svg" alt="Lemonade" title="Lemonade">
+                </a>
             </div>
         </div>
     </section>

--- a/layouts/page/ppc-landing.html
+++ b/layouts/page/ppc-landing.html
@@ -1,0 +1,198 @@
+{{ define "hero" }}
+    <header class="header-hero header-hero-glow landing-page-hero">
+        <div class="w-full mb-5 p-10">
+            <img src="/images/logo/logo-inv.svg" alt="Pulumi Logo" class="h-16 block" />
+        </div>
+        <div class="header-hero-items container mx-auto">
+            <div class="header-hero-item">
+                <h1>{{ .Params.hero.title }}</h1>
+                {{ .Params.hero.body | markdownify }}
+            </div>
+            <div class="header-hero-item">
+                    {{ partial "get-started.html" . }}
+
+            </div>
+        </div>
+    </header>
+{{ end }}
+
+{{ define "main" }}
+
+    <!-- Customer logos -->
+    <section class="mb-16 px-4">
+        <div class="container mx-auto">
+            <div class="lg:flex items-center justify-center my-4">
+                <a data-track="customer-logo" href="https://www.tableau.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 h-12 mx-8" src="/logos/customers/tableau_logo.png" alt="Tableau Software" title="Tableau Software">
+                </a>
+                <a data-track="customer-logo" href="https://mbrdna.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 mt-8 mb-4 lg:my-0 h-12 mx-8" src="/logos/customers/mercedes-benz-RDNA_logo.png" title="Mercedes-Benz Research and Development" alt="Mercedes-Benz Research and Development">
+                </a>
+                <a data-track="customer-logo" href="https://www.mindbodyonline.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 h-16 mx-8" src="/logos/customers/mindbody_logo.svg" alt="MindBody" title="MindBody">
+                </a>
+                <a data-track="customer-logo" href="https://www.nih.gov/" target="_blank">
+                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-10 mx-8" src="/logos/customers/nih.png" alt="National Institutes of Health" title="National Institutes of Health">
+                </a>
+            </div>
+            <div class="lg:flex items-center justify-center my-4">
+                <a data-track="customer-logo" href="https://www.linio.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/linio_logo.png" alt="Linio" title="Linio">
+                </a>
+                <a data-track="customer-logo" href="https://www.cockroachlabs.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/cockroach-labs_logo.png" alt="Cockroach Labs" title="Cockroach Labs">
+                </a>
+                <a data-track="customer-logo" href="https://www.sourcegraph.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-6 mx-8" src="/logos/customers/sourcegraph_logo.png" alt="Sourcegraph" title="Sourcegraph">
+                </a>
+                <a data-track="customer-logo" href="https://www.snopes.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-10 mx-8" src="/logos/customers/snopes_logo.png" alt="Snopes" title="Snopes">
+                </a>
+                <a data-track="customer-logo" href="https://www.lemonade.com/" target="_blank">
+                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-8 mx-8" src="/logos/customers/lemonade.svg" alt="Lemonade" title="Lemonade">
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <section id="code" class="bg-gray-200 py-16 px-4">
+        <div class="container mx-auto">
+            <div class="md:flex my-8">
+                <div class="md:w-1/2 md:mr-4">
+                    <h2>Take advantage of real coding features with Pulumi</h2>
+                    <p>
+                        Pulumi provides a more expressive and efficient way to define cloud resources:
+                    </p>
+                    <ul>
+                        <li>Use variable loops, not copy/paste</li>
+                        <li>Use any Node libaries (or Python/Go)</li>
+                        <li>On-the-fly error checking</li>
+                        <li>Freeform code instead of complex interpolations</li>
+                    </ul>
+                    <p>
+                        <a href="https://github.com/pulumi/examples">Find many other examples here</a>.
+                    </p>
+                </div>
+                <div class="md:w-1/2 md:ml:4">
+
+                    <!-- Example 1 -->
+                    {{ $code := `import * as aws from "@pulumi/aws";
+import { readFileSync, readdirSync } from "fs";
+import { join as pathjoin } from "path";
+
+const bucket = new aws.s3.Bucket("mybucket");
+
+const folder = "./files";
+let files = readdirSync(folder);
+for (let file of files) {
+    const object = new aws.s3.BucketObject(file, {
+        bucket: bucket,
+        content: readFileSync(pathjoin(folder, file)).toString("utf8")
+    });
+}
+
+export const bucketname = bucket.id;` }}
+
+                    {{ partial "code" (dict "code" $code "lang" "js" "mode" "dark") }}
+
+                    <!-- Example 2 -->
+                    {{ $code := `resource "aws_s3_bucket" "mybucket" {
+    bucket_prefix = "mybucket"
+}
+
+resource "aws_s3_bucket_object" "data_txt" {
+    key        = "data.txt"
+    bucket     = "${aws_s3_bucket.mybucket.id}"
+    source     = "./files/data.txt"
+}
+
+resource "aws_s3_bucket_object" "index_html" {
+    key        = "index.html"
+    bucket     = "${aws_s3_bucket.mybucket.id}"
+    source     = "./files/index.html"
+}
+
+resource "aws_s3_bucket_object" "index_js" {
+    key        = "index.js"
+    bucket     = "${aws_s3_bucket.mybucket.id}"
+    source     = "./files/index.js"
+}
+
+resource "aws_s3_bucket_object" "main.css" {
+    key        = "main.css"
+    bucket     = "${aws_s3_bucket.mybucket.id}"
+    source     = "./files/main.css"
+}
+
+resource "aws_s3_bucket_object" "favicon.ico" {
+    key        = "favicon.ico"
+    bucket     = "${aws_s3_bucket.mybucket.id}"
+    source     = "./files/favicon.ico"
+}` }}
+
+                        {{ partial "code" (dict "code" $code "lang" "plain" "mode" "dark") }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Testimonials -->
+    <section class="py-16 px-4" style="background: url(/images/home/waves-blue.svg) repeat-x; background-position: top left;">
+        <h2 class="text-center mb-10">See What Our Customers Have to Say</h2>
+        <div>
+            <div class="container mx-auto md:flex items-start">
+                <div class="md:w-1/3 mx-auto bg-white py-8 px-10 text-sm rounded rounded-lg shadow-lg border border-gray-300 relative">
+                    <i class="fa fa-quote-left text-gray-200 absolute top-0 left-0 ml-4 mt-4 text-5xl z-0"></i>
+                    <p class="leading-loose mt-0 z-10 relative text-gray-800">
+                        {{ (index .Params.quotes 0).body }}
+                    </p>
+                    <div class="leading-relaxed flex items-start">
+                        <div>
+                            <div class="text-blue-700 font-semibold">
+                                {{ (index .Params.quotes 0).name }}
+                            </div>
+                            <div class="text-blue-500">
+                                {{ (index .Params.quotes 0).title }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="md:w-1/3 md:mx-8 my-8 md:my-0 bg-white py-8 px-10 text-sm rounded rounded-lg shadow-lg border border-gray-300 relative">
+                    <i class="fa fa-quote-left text-gray-200 absolute top-0 left-0 ml-4 mt-4 text-5xl z-0"></i>
+                    <p class="leading-loose mt-0 z-10 relative text-gray-800">
+                        {{ (index .Params.quotes 1).body }}
+                    </p>
+                    <div class="leading-relaxed flex items-start">
+                        <div>
+                            <div class="text-blue-700 font-semibold">
+                                {{ (index .Params.quotes 1).name }}
+                            </div>
+                            <div class="text-blue-500">
+                                {{ (index .Params.quotes 1).title }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="md:w-1/3 bg-white py-8 px-10 text-sm rounded rounded-lg shadow-lg border border-gray-300 relative shadow-lg">
+                    <i class="fa fa-quote-left text-gray-200 absolute top-0 left-0 ml-4 mt-4 text-5xl z-0"></i>
+                    <p class="leading-loose mt-0 z-10 relative text-gray-800">
+                        {{ (index .Params.quotes 2).body }}
+                    </p>
+                    <div class="leading-relaxed flex items-start">
+                        <div>
+                            <div class="text-blue-700 font-semibold">
+                                {{ (index .Params.quotes 2).name }}
+                            </div>
+                            <div class="text-blue-500">
+                                {{ (index .Params.quotes 2).title }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+{{ end }}

--- a/layouts/page/ppc-landing.html
+++ b/layouts/page/ppc-landing.html
@@ -1,5 +1,5 @@
 {{ define "hero" }}
-    <header class="header-hero header-hero-glow landing-page-hero">
+    <header class="header-hero header-hero-glow landing-page-hero pt-0">
         <div class="w-full mb-5 p-10">
             <img src="/images/logo/logo-inv.svg" alt="Pulumi Logo" class="h-16 block" />
         </div>
@@ -8,6 +8,7 @@
                 <h1>{{ .Params.hero.title }}</h1>
                 <p>{{ .Params.hero.body | markdownify }}</p>
                 <a href="#contact" class="btn">REQUEST DEMO</a>
+                <a href="{{ relref . "/docs/get-started" }}" class="btn btn-orange">GET STARTED</a>
             </div>
             <div>
                 {{ partial "terraform-code-compare.html" . }}

--- a/layouts/page/ppc-landing.html
+++ b/layouts/page/ppc-landing.html
@@ -6,16 +6,140 @@
         <div class="container mx-auto">
             <div class="block w-full">
                 <h1>{{ .Params.hero.title }}</h1>
-                {{ .Params.hero.body | markdownify }}
+                <p>{{ .Params.hero.body | markdownify }}</p>
+                <a href="#contact" class="btn">REQUEST DEMO</a>
             </div>
             <div>
-                    {{ partial "terraform-code-compare.html" . }}
+                {{ partial "terraform-code-compare.html" . }}
             </div>
         </div>
     </header>
 {{ end }}
 
 {{ define "main" }}
+
+    <!-- Customer logos -->
+    <section class="mb-16 px-4">
+        <div class="container mx-auto">
+            <div class="lg:flex items-center justify-center my-4">
+                <a data-track="customer-logo" href="https://www.tableau.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 h-12 mx-8" src="/logos/customers/tableau_logo.png" alt="Tableau Software" title="Tableau Software">
+                </a>
+                <a data-track="customer-logo" href="https://mbrdna.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 mt-8 mb-4 lg:my-0 h-12 mx-8" src="/logos/customers/mercedes-benz-RDNA_logo.png" title="Mercedes-Benz Research and Development" alt="Mercedes-Benz Research and Development">
+                </a>
+                <a data-track="customer-logo" href="https://www.mindbodyonline.com/" target="_blank">
+                    <img class="mx-auto lg:mx-8 h-16 mx-8" src="/logos/customers/mindbody_logo.svg" alt="MindBody" title="MindBody">
+                </a>
+                <a data-track="customer-logo" href="https://www.nih.gov/" target="_blank">
+                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-10 mx-8" src="/logos/customers/nih.png" alt="National Institutes of Health" title="National Institutes of Health">
+                </a>
+            </div>
+            <div class="lg:flex items-center justify-center my-4">
+                <a data-track="customer-logo" href="https://www.linio.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/linio_logo.png" alt="Linio" title="Linio">
+                </a>
+                <a data-track="customer-logo" href="https://www.cockroachlabs.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/cockroach-labs_logo.png" alt="Cockroach Labs" title="Cockroach Labs">
+                </a>
+                <a data-track="customer-logo" href="https://www.sourcegraph.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-6 mx-8" src="/logos/customers/sourcegraph_logo.png" alt="Sourcegraph" title="Sourcegraph">
+                </a>
+                <a data-track="customer-logo" href="https://www.snopes.com/" target="_blank">
+                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-10 mx-8" src="/logos/customers/snopes_logo.png" alt="Snopes" title="Snopes">
+                </a>
+                <a data-track="customer-logo" href="https://www.lemonade.com/" target="_blank">
+                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-8 mx-8" src="/logos/customers/lemonade.svg" alt="Lemonade" title="Lemonade">
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Programming Model -->
+    <section>
+        <div class="flex container mx-auto py-10">
+            <div class="w-6/12 px-10">
+                <p class="text-3xl font-bold">Programs</p>
+                <p>Pulumi programs are written in general-purpose programming languages, including JavaScript,
+                    TypeScript, Python, Go or any .NET language such as C#, F#, or VB. You use the language’s
+                    native tools and libraries, including Pulumi’s own packages containing infrastructure resource types.
+                    Although you use general-purpose languages, Pulumi is still a declarative infrastructure as code tool.
+                </p>
+                <p>
+                    After writing a program, you run the Pulumi CLI command pulumi up, which executes the program and determines
+                    the desired infrastructure state for all resources declared. The CLI will show you a preview of changes to be made,
+                    including all new resources to be created and existing resources to update or destroy. After confirming, Pulumi will
+                    carry out the changes.
+                </p>
+            </div>
+            <div class="w-6/12 px-10">
+                <img src="/images/docs/reference/engine-block-diagram.png" alt="Pulumi engine and providers" />
+            </div>
+        </div>
+    </section>
+
+    <!-- Terraform Backend -->
+    {{ $terraformBackendCode := `import * as pulumi from "@pulumi/pulumi";
+import * as terraform from "@pulumi/terraform";
+
+const config = new pulumi.Config();
+const tfeToken = config.requireSecret("tfeToken");
+
+const networkState = new terraform.state.RemoteStateReference("network", {
+    backendType: "remote",
+    token: tfeToken,
+    organization: "acme",
+    workspaces: {
+        name: "production-network"
+    },
+});` }}
+    <section>
+        <div class="flex container mx-auto py-10">
+            <div class="w-6/12 px-10">
+                {{ partial "code" (dict "code" $terraformBackendCode "lang" "typescript" "mode" "dark") }}
+            </div>
+            <div class="w-6/12 px-10">
+                <p class="text-3xl font-bold">Using Pulumi and Terraform Side-by-Side</p>
+                <p>
+                    Pulumi supports consuming local or remote Terraform state from your Pulumi programs.
+                    This helps with incremental adoption, whereby you continue managing a subset of your
+                    infrastructure with Terraform, while you incrementally move to Pulumi.
+                </p>
+                <p>
+                    For instance, say you would like to keep your VPC and low level network definitions written in
+                    Terraform so as to avoid any disruption, or maybe because some of the team would like to stay on
+                    Terraform for now. Using the state reference support described above, you can author higher level
+                    infrastructure in Pulumi that consumes the Terraform-provisioned VPC information (like the VPC ID, Subnet IDs, etc),
+                    making co-existence easy to automate.
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Programming Model -->
+    <section>
+        <div class="flex container mx-auto py-10">
+            <div class="w-6/12 px-10">
+                <p class="text-3xl font-bold">Less Code. More Productivity.</p>
+                <p>
+                    By simplifying configuration with Pulumi, Amazon ECS, AWS Fargate and AWS Lambda,
+                    Learning Machine not only realized a 50x reduction in the amount of configuration that
+                    they had to manage but were also able to add new customers faster. Before the project,
+                    provisioning a new customer could take up to 3 weeks due to the complexity of configuration
+                    while their new approach reduced provisioning time to one hour.
+                </p>
+                <p>
+                    The impact of serverless capabilities was also transformative for the Learning Machine business.
+                    Pulumi enabled a rapid shift to Amazon ECS, AWS Fargate and AWS Lambda — the net effect of which
+                    was a 67% reduction in AWS charges. This enabled the team to spend less time focused on maintaining
+                    existing infrastructure and more time deploying new applications on AWS and adding new customers.
+                </p>
+            </div>
+            <div class="w-6/12 px-10">
+                <img src="/images/whitepaper/cloud-native-infrastructure/graph5.png" alt="Pulumi productivity" />
+            </div>
+        </div>
+    </section>
 
     <!-- Testimonials -->
     <section class="py-16 px-4" style="background: url(/images/home/waves-blue.svg) repeat-x; background-position: top left;">
@@ -70,43 +194,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Customer logos -->
-    <section class="mb-16 px-4">
-        <div class="container mx-auto">
-            <div class="lg:flex items-center justify-center my-4">
-                <a data-track="customer-logo" href="https://www.tableau.com/" target="_blank">
-                    <img class="mx-auto lg:mx-8 h-12 mx-8" src="/logos/customers/tableau_logo.png" alt="Tableau Software" title="Tableau Software">
-                </a>
-                <a data-track="customer-logo" href="https://mbrdna.com/" target="_blank">
-                    <img class="mx-auto lg:mx-8 mt-8 mb-4 lg:my-0 h-12 mx-8" src="/logos/customers/mercedes-benz-RDNA_logo.png" title="Mercedes-Benz Research and Development" alt="Mercedes-Benz Research and Development">
-                </a>
-                <a data-track="customer-logo" href="https://www.mindbodyonline.com/" target="_blank">
-                    <img class="mx-auto lg:mx-8 h-16 mx-8" src="/logos/customers/mindbody_logo.svg" alt="MindBody" title="MindBody">
-                </a>
-                <a data-track="customer-logo" href="https://www.nih.gov/" target="_blank">
-                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-10 mx-8" src="/logos/customers/nih.png" alt="National Institutes of Health" title="National Institutes of Health">
-                </a>
-            </div>
-            <div class="lg:flex items-center justify-center my-4">
-                <a data-track="customer-logo" href="https://www.linio.com/" target="_blank">
-                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/linio_logo.png" alt="Linio" title="Linio">
-                </a>
-                <a data-track="customer-logo" href="https://www.cockroachlabs.com/" target="_blank">
-                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-8 mx-8" src="/logos/customers/cockroach-labs_logo.png" alt="Cockroach Labs" title="Cockroach Labs">
-                </a>
-                <a data-track="customer-logo" href="https://www.sourcegraph.com/" target="_blank">
-                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-6 mx-8" src="/logos/customers/sourcegraph_logo.png" alt="Sourcegraph" title="Sourcegraph">
-                </a>
-                <a data-track="customer-logo" href="https://www.snopes.com/" target="_blank">
-                    <img class="mx-auto my-8 md:my-0 lg:mx-8 h-10 mx-8" src="/logos/customers/snopes_logo.png" alt="Snopes" title="Snopes">
-                </a>
-                <a data-track="customer-logo" href="https://www.lemonade.com/" target="_blank">
-                    <img class="mx-auto mt-6 md:mt-0 lg:mx-8 h-8 mx-8" src="/logos/customers/lemonade.svg" alt="Lemonade" title="Lemonade">
-                </a>
             </div>
         </div>
     </section>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -14,6 +14,7 @@
 {{ $s = $s | append (resources.Get "js/tracking.js") }}
 {{ $s = $s | append (resources.Get "js/docs-feedback.js") }}
 {{ $s = $s | append (resources.Get "js/event-filtering.js") }}
+{{ $s = $s | append (resources.Get "js/mock-ide-file-selector.js") }}
 
 <!-- We use the `clipboard-polyfill` npm package. If it hasn't been installed, show a friendlier error message. -->
 {{ $clipboardFile := "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js" }}

--- a/layouts/partials/terraform-code-compare.html
+++ b/layouts/partials/terraform-code-compare.html
@@ -157,8 +157,9 @@ class Program
 
 <div id="terraformCompareCodeBlock" class="flex mt-10">
     <div class="w-5/12">
-        <ul class="bg-gray-800 pt-3 rounded-t">
-            <li class="-mb-px mr-1 mt-1">
+        {{ partial "chrome.html" . }}
+        <ul class="bg-gray-800">
+            <li class="-mb-px mr-1">
                 <span class="code-file-nav--item">main.tf</span>
             </li>
         </ul>
@@ -168,29 +169,32 @@ class Program
         <i class="fas fa-arrow-right text-6xl block mb-20 mt-10"></i>
         <i class="fas fa-arrow-right text-6xl block mb-20"></i>
     </div>
-    <div class="flex w-6/12 relative bg-gray-800 pt-3 rounded-t h-32">
-        <div id="terraformComparePython">
-            <a class="code-file-nav--item file-not-active" href="#terraformComparePython">__main__.py</a>
-            <div class="compare-code-block w-full absolute left-0">
-                {{ partial "code" (dict "code" $pythonCodeBlock "lang" "python" "mode" "dark" "opts" "linenos=true") }}
+    <div class="w-6/12">
+        {{ partial "chrome.html" . }}
+        <div class="flex relative bg-gray-800 h-32">
+            <div id="terraformComparePython">
+                <a class="code-file-nav--item file-not-active" href="#">__main__.py</a>
+                <div class="compare-code-block w-full absolute left-0 hidden">
+                    {{ partial "code" (dict "code" $pythonCodeBlock "lang" "python" "mode" "dark" "opts" "linenos=true") }}
+                </div>
             </div>
-        </div>
-        <div id="terraformCompareGo">
-            <a class="code-file-nav--item file-not-active" href="#terraformCompareGo">main.go</a>
-            <div class="compare-code-block w-full absolute left-0">
-                {{ partial "code" (dict "code" $goCodeBlock "lang" "go" "mode" "dark" "opts" "linenos=true") }}
+            <div id="terraformCompareGo">
+                <a class="code-file-nav--item file-not-active" href="#">main.go</a>
+                <div class="compare-code-block w-full absolute left-0 hidden">
+                    {{ partial "code" (dict "code" $goCodeBlock "lang" "go" "mode" "dark" "opts" "linenos=true") }}
+                </div>
             </div>
-        </div>
-        <div id="terraformCompareCSharp">
-            <a class="code-file-nav--item file-not-active" href="#terraformCompareCSharp">Program.cs</a>
-            <div class="compare-code-block w-full absolute left-0">
-                {{ partial "code" (dict "code" $cSharpCodeBlock "lang" "csharp" "mode" "dark" "opts" "linenos=true") }}
+            <div id="terraformCompareCSharp">
+                <a class="code-file-nav--item file-not-active" href="#">Program.cs</a>
+                <div class="compare-code-block w-full absolute left-0 hidden">
+                    {{ partial "code" (dict "code" $cSharpCodeBlock "lang" "csharp" "mode" "dark" "opts" "linenos=true") }}
+                </div>
             </div>
-        </div>
-        <div id="terraformCompareTypeScript" class="order-first">
-            <a class="code-file-nav--item" href="#terraformCompareTypeScript">index.ts</a>
-            <div class="compare-code-block w-full absolute">
-                {{ partial "code" (dict "code" $typeScriptCodeBlock "lang" "typescript" "mode" "dark" "opts" "linenos=true") }}
+            <div id="terraformCompareTypeScript" class="order-first">
+                <a class="code-file-nav--item" href="#">index.ts</a>
+                <div class="compare-code-block w-full absolute">
+                    {{ partial "code" (dict "code" $typeScriptCodeBlock "lang" "typescript" "mode" "dark" "opts" "linenos=true") }}
+                </div>
             </div>
         </div>
     </div>

--- a/layouts/partials/terraform-code-compare.html
+++ b/layouts/partials/terraform-code-compare.html
@@ -77,15 +77,87 @@ for (let file of files) {
 
 export const bucketname = bucket.id;` }}
 
-{{ $pythonCodeBlock := ``}}
+{{ $pythonCodeBlock := `import os
 
-{{ $goCodeBlock := ``}}
+from pulumi import export, FileAsset
+from pulumi_aws import s3
 
-{{ $cSharpCodeBlock := ``}}
+bucket = s3.Bucket('my-bucket')
+
+for file in os.listdir('files'):
+    filepath = os.path.join(content_dir, file)
+    mime_type, _ = mimetypes.guess_type(filepath)
+    s3.BucketObject(file,
+        bucket=bucket.id,
+        source=FileAsset(filepath),
+        content_type=mime_type)
+
+pulumi.export('bucket_name',  bucket.id)`}}
+
+{{ $goCodeBlock := `package main
+
+import (
+    "io/ioutil"
+    "github.com/pulumi/pulumi-aws/sdk/go/aws/s3"
+    "github.com/pulumi/pulumi/sdk/go/pulumi"
+)
+
+func main() {
+    pulumi.Run(func(ctx *pulumi.Context) error {
+        bucket, err := s3.NewBucket(ctx, "my-bucket", nil)
+        if err != nil {
+            return err
+        }
+
+        files, err := ioutil.ReadDir("./")
+        if err != nil {
+            return err
+        }
+
+        for _, item := range files {
+            name := item.Name()
+            if _, err := s3.NewBucketObject(ctx, name, &s3.BucketObjectArgs{
+                Bucket:      siteBucket.ID(),
+                Source:      pulumi.NewFileAsset(filepath.Join(siteDir, name)),
+                ContentType: pulumi.String(mime.TypeByExtension(path.Ext(name))),
+            }); err != nil {
+                return err
+            }
+        }
+
+        ctx.Export("bucketName", bucket.ID())
+        return nil
+    })
+}`}}
+
+{{ $cSharpCodeBlock := `using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pulumi;
+using Pulumi.Aws.S3;
+
+class Program
+{
+    static Task Main()
+    {
+        return Deployment.RunAsync(() => {
+            var bucket = new Bucket("my-bucket");
+
+            string[] files = Directory.GetFiles("./files");
+            foreach (string fileName in fileEntries)
+            {
+                // ...upload the files to the bucket
+            }
+
+            return new Dictionary<string, object> {
+                { "bucket_name" , bucket.Id },
+            };
+        });
+    }
+}`}}
 
 <div id="terraformCompareCodeBlock" class="flex mt-10">
     <div class="w-5/12">
-        <ul class="code-file-nav">
+        <ul class="bg-gray-800 pt-3 rounded-t">
             <li class="-mb-px mr-1 mt-1">
                 <span class="code-file-nav--item">main.tf</span>
             </li>
@@ -95,34 +167,31 @@ export const bucketname = bucket.id;` }}
     <div class="w-1/12 text-center">
         <i class="fas fa-arrow-right text-6xl block mb-20 mt-10"></i>
         <i class="fas fa-arrow-right text-6xl block mb-20"></i>
-        <i class="fas fa-arrow-right text-6xl block mb-20"></i>
     </div>
-    <div class="w-6/12">
-        <ul class="code-file-nav">
-            <li class="-mb-px mr-1 mt-1">
-                <a class="code-file-nav--item" href="#terraformCompareTypeScript">index.ts</a>
-            </li>
-            <li class="-mb-px mr-1 mt-1">
-                <a class="code-file-nav--item file-not-active" href="#terraformComparePython">__main__.py</a>
-            </li>
-            <li class="-mb-px mr-1 mt-1">
-                <a class="code-file-nav--item file-not-active" href="#terraformCompareGo">main.go</a>
-            </li>
-            <li class="-mb-px mr-1 mt-1">
-                <a class="code-file-nav--item file-not-active" href="#terraformCompareCSharp">Program.cs</a>
-            </li>
-        </ul>
+    <div class="flex w-6/12 relative bg-gray-800 pt-3 rounded-t h-32">
         <div id="terraformComparePython">
-            {{ partial "code" (dict "code" $pythonCodeBlock "lang" "ts" "mode" "dark" "opts" "linenos=true") }}
+            <a class="code-file-nav--item file-not-active" href="#terraformComparePython">__main__.py</a>
+            <div class="compare-code-block w-full absolute left-0">
+                {{ partial "code" (dict "code" $pythonCodeBlock "lang" "python" "mode" "dark" "opts" "linenos=true") }}
+            </div>
         </div>
         <div id="terraformCompareGo">
-            {{ partial "code" (dict "code" $goCodeBlock "lang" "ts" "mode" "dark" "opts" "linenos=true") }}
+            <a class="code-file-nav--item file-not-active" href="#terraformCompareGo">main.go</a>
+            <div class="compare-code-block w-full absolute left-0">
+                {{ partial "code" (dict "code" $goCodeBlock "lang" "go" "mode" "dark" "opts" "linenos=true") }}
+            </div>
         </div>
         <div id="terraformCompareCSharp">
-            {{ partial "code" (dict "code" $cSharpCodeBlock "lang" "ts" "mode" "dark" "opts" "linenos=true") }}
+            <a class="code-file-nav--item file-not-active" href="#terraformCompareCSharp">Program.cs</a>
+            <div class="compare-code-block w-full absolute left-0">
+                {{ partial "code" (dict "code" $cSharpCodeBlock "lang" "csharp" "mode" "dark" "opts" "linenos=true") }}
+            </div>
         </div>
-        <div id="terraformCompareTypeScript">
-            {{ partial "code" (dict "code" $typeScriptCodeBlock "lang" "ts" "mode" "dark" "opts" "linenos=true") }}
+        <div id="terraformCompareTypeScript" class="order-first">
+            <a class="code-file-nav--item" href="#terraformCompareTypeScript">index.ts</a>
+            <div class="compare-code-block w-full absolute">
+                {{ partial "code" (dict "code" $typeScriptCodeBlock "lang" "typescript" "mode" "dark" "opts" "linenos=true") }}
+            </div>
         </div>
     </div>
 </div>

--- a/layouts/partials/terraform-code-compare.html
+++ b/layouts/partials/terraform-code-compare.html
@@ -1,0 +1,128 @@
+{{ $terraformCodeBlock := `resource "aws_s3_bucket" "mybucket" {
+    bucket_prefix = "mybucket"
+}
+
+data "archive_file" "lambda_zip" {
+    type        = "zip"
+    output_path = "lambda.zip"
+
+    source {
+    filename = "index.js"
+    content = < {
+    console.log(JSON.stringify(ev))
+}
+EOF
+    }
+}
+
+data "aws_iam_policy_document" "lambda-assume-role-policy" {
+    statement {
+        actions = ["sts:AssumeRole"]
+
+        principals {
+            type        = "Service"
+            identifiers = ["lambda.amazonaws.com"]
+        }
+    }
+}
+
+resource "aws_iam_role" "lambda" {
+    assume_role_policy = "${data.aws_iam_policy_document.lambda-assume-role-policy.json}"
+}
+
+resource "aws_lambda_function" "my_lambda" {
+    filename = "${data.archive_file.lambda_zip.output_path}"
+    source_code_hash = "${data.archive_file.lambda_zip.output_base64sha256}"
+    function_name = "my_lambda"
+    role = "${aws_iam_role.lambda.arn}"
+    handler = "index.handler"
+    runtime = "nodejs8.10"
+}
+
+resource "aws_lambda_permission" "allow_bucket" {
+    statement_id  = "AllowExecutionFromS3Bucket"
+    action        = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.my_lambda.arn}"
+    principal     = "s3.amazonaws.com"
+    source_arn    = "${aws_s3_bucket.mybucket.arn}"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+    bucket = "${aws_s3_bucket.mybucket.id}"
+
+    lambda_function {
+        lambda_function_arn = "${aws_lambda_function.my_lambda.arn}"
+        events              = ["s3:ObjectCreated:*"]
+    }
+}
+
+output "bucket_name" {
+    value = "${aws_s3_bucket.mybucket.id}"
+}`}}
+
+{{ $typeScriptCodeBlock := `import * as aws from "@pulumi/aws";
+import { readFileSync, readdirSync } from "fs";
+import { join as pathjoin } from "path";
+
+const bucket = new aws.s3.Bucket("mybucket");
+
+const folder = "./files";
+let files = readdirSync(folder);
+for (let file of files) {
+    const object = new aws.s3.BucketObject(file, {
+        bucket: bucket,
+        content: readFileSync(pathjoin(folder, file)).toString("utf8")
+    });
+}
+
+export const bucketname = bucket.id;` }}
+
+{{ $pythonCodeBlock := ``}}
+
+{{ $goCodeBlock := ``}}
+
+{{ $cSharpCodeBlock := ``}}
+
+<div id="terraformCompareCodeBlock" class="flex mt-10">
+    <div class="w-5/12">
+        <ul class="code-file-nav">
+            <li class="-mb-px mr-1 mt-1">
+                <span class="code-file-nav--item">main.tf</span>
+            </li>
+        </ul>
+        {{ partial "code" (dict "code" $terraformCodeBlock "lang" "plain" "mode" "dark" "opts" "linenos=true") }}
+    </div>
+    <div class="w-1/12 text-center">
+        <i class="fas fa-arrow-right text-6xl block mb-20 mt-10"></i>
+        <i class="fas fa-arrow-right text-6xl block mb-20"></i>
+        <i class="fas fa-arrow-right text-6xl block mb-20"></i>
+    </div>
+    <div class="w-6/12">
+        <ul class="code-file-nav">
+            <li class="-mb-px mr-1 mt-1">
+                <a class="code-file-nav--item" href="#terraformCompareTypeScript">index.ts</a>
+            </li>
+            <li class="-mb-px mr-1 mt-1">
+                <a class="code-file-nav--item file-not-active" href="#terraformComparePython">__main__.py</a>
+            </li>
+            <li class="-mb-px mr-1 mt-1">
+                <a class="code-file-nav--item file-not-active" href="#terraformCompareGo">main.go</a>
+            </li>
+            <li class="-mb-px mr-1 mt-1">
+                <a class="code-file-nav--item file-not-active" href="#terraformCompareCSharp">Program.cs</a>
+            </li>
+        </ul>
+        <div id="terraformComparePython">
+            {{ partial "code" (dict "code" $pythonCodeBlock "lang" "ts" "mode" "dark" "opts" "linenos=true") }}
+        </div>
+        <div id="terraformCompareGo">
+            {{ partial "code" (dict "code" $goCodeBlock "lang" "ts" "mode" "dark" "opts" "linenos=true") }}
+        </div>
+        <div id="terraformCompareCSharp">
+            {{ partial "code" (dict "code" $cSharpCodeBlock "lang" "ts" "mode" "dark" "opts" "linenos=true") }}
+        </div>
+        <div id="terraformCompareTypeScript">
+            {{ partial "code" (dict "code" $typeScriptCodeBlock "lang" "ts" "mode" "dark" "opts" "linenos=true") }}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This PR adds the framework and first ppc landing page for our site. You will notice the header and footer have been hidden for these pages. We want to keep any who clicks on an ad focused on the goal of the page. Including additional navigation can confuse users and lead them to become distracted. The other important thing to note are the logos and customer quotes. They provide social proof for us, which is helpful when trying to convert users. They can see that actual companies use our product.