### PR TITLE
Define CDN aliases explicitly

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -300,6 +300,19 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     },
 };
 
+// domainAliases is a list of CNAMEs that accompany the CloudFront distribution. Any
+// domain name to be used to access the website must be listed here.
+const domainAliases = [];
+// websiteDomain is the A record for the website bucket associated with the website.
+domainAliases.push(config.websiteDomain);
+// targetDomain is the A record associated with the bucket populated by Pulumi. It may be
+// removed that bucket is removed.
+domainAliases.push(config.targetDomain);
+// redirectDomain is the domain to use for fully-qualified 301 redirects.
+if (config.redirectDomain) {
+     domainAliases.push(config.redirectDomain);
+}
+
 // NOTE: Sometimes updating the CloudFront distribution will fail with:
 // "PreconditionFailed: The request failed because it didn't meet the preconditions in one or more
 // request-header fields."
@@ -312,11 +325,7 @@ const cdn = new aws.cloudfront.Distribution(
     {
         protect: true,
         dependsOn: [ websiteBucket, websiteLogsBucket ],
-        aliases:  [
-            config.websiteDomain,
-            config.targetDomain,
-            config.redirectDomain || "",    // redirectDomain may be undefined.
-        ].filter(domain => domain !== ""),
+        aliases:  domainAliases,
     });
 
 // crawlDirectory recursive crawls the provided directory, applying the provided function

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -187,12 +187,27 @@ const baseCacheBehavior = {
     maxTtl: fiveMinutes,
 };
 
+// domainAliases is a list of CNAMEs that accompany the CloudFront distribution. Any
+// domain name to be used to access the website must be listed here.
+const domainAliases = [];
+// websiteDomain is the A record for the website bucket associated with the website.
+domainAliases.push(config.websiteDomain);
+// targetDomain is the A record associated with the bucket populated by Pulumi. It may be
+// removed once that bucket is removed.
+domainAliases.push(config.targetDomain);
+// redirectDomain is the domain to use for fully-qualified 301 redirects.
+if (config.redirectDomain) {
+     domainAliases.push(config.redirectDomain);
+}
+
 // distributionArgs configures the CloudFront distribution. Relevant documentation:
 // https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html
 // https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudfront
 const distributionArgs: aws.cloudfront.DistributionArgs = {
     enabled: true,
+
+    aliases: domainAliases,
 
     // We only specify one origin for this distribution: the S3 content bucket.
     origins: [
@@ -300,19 +315,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     },
 };
 
-// domainAliases is a list of CNAMEs that accompany the CloudFront distribution. Any
-// domain name to be used to access the website must be listed here.
-const domainAliases = [];
-// websiteDomain is the A record for the website bucket associated with the website.
-domainAliases.push(config.websiteDomain);
-// targetDomain is the A record associated with the bucket populated by Pulumi. It may be
-// removed that bucket is removed.
-domainAliases.push(config.targetDomain);
-// redirectDomain is the domain to use for fully-qualified 301 redirects.
-if (config.redirectDomain) {
-     domainAliases.push(config.redirectDomain);
-}
-
 // NOTE: Sometimes updating the CloudFront distribution will fail with:
 // "PreconditionFailed: The request failed because it didn't meet the preconditions in one or more
 // request-header fields."
@@ -325,8 +327,8 @@ const cdn = new aws.cloudfront.Distribution(
     {
         protect: true,
         dependsOn: [ websiteBucket, websiteLogsBucket ],
-        aliases:  domainAliases,
-    });
+    }
+);
 
 // crawlDirectory recursive crawls the provided directory, applying the provided function
 // to every file it contains. Doesn't handle cycles from symlinks.

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -312,6 +312,11 @@ const cdn = new aws.cloudfront.Distribution(
     {
         protect: true,
         dependsOn: [ websiteBucket, websiteLogsBucket ],
+        aliases:  [
+            config.websiteDomain,
+            config.targetDomain,
+            config.redirectDomain || "",    // redirectDomain may be undefined.
+        ].filter(domain => domain !== ""),
     });
 
 // crawlDirectory recursive crawls the provided directory, applying the provided function


### PR DESCRIPTION
The brief website outage we experienced this morning occurred because the CloudFront distribution aliases in use with www.pulumi.com had not been declared in the Pulumi program that defines that distribution. (They'd been keyed into the AWS Console by hand as part of the GREAT WEBSITE MIGRATION last year.) Since some of the properties of the distribution were modified today in #2351, when that commit's update ran, it cleared out the list of aliases in AWS, rendering the website temporarily inaccessible. This PR adds those aliases to the program explicitly to prevent that from occurring in the future.

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 

Note that as of now, because the most immediate fix for today's outage was to specify those values by hand _again_, the CloudFront distribution's [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) and aliases list are once again out of sync, **so another manual `pulumi refresh` will need to be performed before this change is merged** (or another outage will occur).  

