### PR TITLE
Fix error in AWS IoT TopicRule example.

### DIFF
--- a/content/docs/reference/pkg/nodejs/pulumi/aws/iot/_index.md
+++ b/content/docs/reference/pkg/nodejs/pulumi/aws/iot/_index.md
@@ -970,6 +970,7 @@ const role = new aws.iam.Role("role", {
 `,
 });
 const rule = new aws.iot.TopicRule("rule", {
+    name: "rule",
     description: "Example rule",
     enabled: true,
     sns: {


### PR DESCRIPTION
AWS IoT TopicRule example in documentation does not currently work. `name` property must be set. Otherwise, it will fail with the following:

```
Diagnostics:
  aws:iot:TopicRule (rule):
    error: aws:iot/topicRule:TopicRule resource 'rule' has a problem: Name must match the pattern ^[a-zA-Z0-9_]+$
```

### Proposed changes

Add the name field :upside_down_face: 

