### PR TITLE
Add confirmation page for workshops

### DIFF
--- a/content/confirmation/_index.md
+++ b/content/confirmation/_index.md
@@ -1,6 +1,6 @@
 ---
 private: true
 title: Confirmation
-meta_desc: This page is provides confirmation about register for a Pulumi event, webinar, or workshop.
+meta_desc: This page provides confirmation after registering for a Pulumi event, webinar, or workshop.
 block_external_search_index: true
 ---

--- a/content/confirmation/_index.md
+++ b/content/confirmation/_index.md
@@ -1,0 +1,6 @@
+---
+private: true
+title: Confirmation
+meta_desc: This page is provides confirmation about register for a Pulumi event, webinar, or workshop.
+block_external_search_index: true
+---

--- a/content/confirmation/_index.md
+++ b/content/confirmation/_index.md
@@ -1,6 +1,3 @@
 ---
-private: true
-title: Confirmation
-meta_desc: This page provides confirmation after registering for a Pulumi event, webinar, or workshop.
-block_external_search_index: true
+redirect_to: /
 ---

--- a/content/confirmation/workshop.md
+++ b/content/confirmation/workshop.md
@@ -1,9 +1,8 @@
 ---
 title: Thank You | Workshop
-meta_desc: This page is provides confirmation about register for a Pulumi workshop.
+meta_desc: This page provides confirmation after registering for a Pulumi workshop.
 type: page
 layout: confirmation
-url: /confirmation/workshop
 
 confirmation_text: Thank you for signing up for a Pulumi workshop! You'll receive a confirmation email shortly.  While you're here, see how easy it is to get started using Pulumi below.
 

--- a/content/confirmation/workshop.md
+++ b/content/confirmation/workshop.md
@@ -1,0 +1,22 @@
+---
+title: Thank You | Workshop
+meta_desc: This page is provides confirmation about register for a Pulumi workshop.
+type: page
+layout: confirmation
+url: /confirmation/workshop
+
+confirmation_text: Thank you for signing up for a Pulumi workshop! You'll receive a confirmation email shortly.  While you're here, see how easy it is to get started using Pulumi below.
+
+contact_us_form:
+    section_id: contact
+    hubspot_form_id: 8381e562-5fdf-4736-bb10-86096705e4ee
+    headline: Contact Us
+    quote:
+        title: Learn how top engineering teams are using Pulumi to manage and provision infrastructure in any cloud.
+        name: Harrison Heck
+        name_title: Head of DevOps, Linio
+        content: |
+            As the largest eCommerce platform in Latin America, our infrastructure has to be highly stable, well
+            documented and agile. With Pulumi, we're able to develop new infrastructure, change existing infrastructure
+            and more with greater speed and reliability than we've ever had before.
+---

--- a/layouts/page/confirmation.html
+++ b/layouts/page/confirmation.html
@@ -1,0 +1,15 @@
+{{ define "hero" }}
+<header class="header-hero">
+    <div class="container mx-auto">
+        <div class="mx-auto text-center">
+            <p class="text-4xl">{{ .Params.confirmation_text }}</p>
+        </div>
+    </div>
+</header>
+{{ end }}
+
+{{ define "main" }}
+    {{ partial "get-started.html" . }}
+
+    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+{{ end }}


### PR DESCRIPTION
This PR adds a confirmation page for workshop sign-ups. We are going to use Calendly to handle the registrations, and after a person registers on Calendly they will be redirected to this page. Eventually, we will want to have confirmation pages for other events, and using this layout we should just need to create another markdown file and define the front matter values.