### PR TITLE
Fix "make non-relative relref page reference absolute" warning

### DIFF
--- a/content/blog/aws-serverless-analytics/index.md
+++ b/content/blog/aws-serverless-analytics/index.md
@@ -15,7 +15,7 @@ Whether it’s an IoT installation, a website, or a mobile app, modern software 
 3. How to implement this architecture as code in a reusable library with Pulumi.
 4. How to automate the development loop when writing Pulumi libraries.
 
-If you’d like to follow along, you can clone and run [the reference implementation](https://github.com/pulumi/examples/tree/master/aws-ts-serverless-datawarehouse). If you’re new to Pulumi, you can follow [this guide to get started]({{< relref "/docs/get-started/_index.md" >}}).
+If you’d like to follow along, you can clone and run [the reference implementation](https://github.com/pulumi/examples/tree/master/aws-ts-serverless-datawarehouse). If you’re new to Pulumi, you can follow [this guide to get started]({{< relref "/docs/get-started" >}}).
 
 ## ACME E-Commerce
 
@@ -82,7 +82,7 @@ While our new serverless streaming architecture brings a slew of benefits that e
 
 We want repeatable infrastructure that we can reliably develop, test, and deploy. Creating a single Redshift instance through the console was manageable, but our serverless architecture utilizes multiple instances of five AWS services. Serverless solutions frequently require many more granular resources, and thus the complexity of the infrastructure as code increases, and we need more robust tools to manage this complexity - just like we manage software complexity.
 
-Pulumi takes care of the complexity by bringing software development best practices like abstraction, encapsulation, and modularity to infrastructure. You can use design patterns in your favorite programming language to provision modern cloud infrastructure. [Component Resources]({{< relref "/blog/creating-and-reusing-cloud-components-using-package-managers/index.md" >}}) are our tools for encapsulating low-level cloud infrastructure into Architecture as Code that is shareable across teams.
+Pulumi takes care of the complexity by bringing software development best practices like abstraction, encapsulation, and modularity to infrastructure. You can use design patterns in your favorite programming language to provision modern cloud infrastructure. [Component Resources]({{< relref "/blog/creating-and-reusing-cloud-components-using-package-managers" >}}) are our tools for encapsulating low-level cloud infrastructure into Architecture as Code that is shareable across teams.
 
 With Pulumi the code we write looks very similar to our architecture diagram:
 
@@ -128,7 +128,7 @@ export const clickInputStream = clicksInputStream.name;
 
 In a dozen lines of code, we’ve provisioned two of our desired tables, “clicks” and “impressions”, using our serverless streaming input architecture. It takes care of everything, including implicitly creating an arrival time [partition scheme](https://docs.aws.amazon.com/athena/latest/ug/partitions.html) with the key “inserted_at”. We export our Kinesis input streams as [stack outputs]({{< relref "/docs/intro/concepts/stack#outputs" >}}) that can be referenced in other projects, such as the instrumentation within our ad server or consumer-facing web app.
 
-While on the surface this Pulumi component is described imperatively, it produces a declarative output in the form of a [state file]({{<  relref "docs/intro/concepts/state.md" >}}) that can be managed locally, in an object store like S3, or by the Pulumi Service backend. Running a ‘pulumi up’ shows that we’ve created 45 AWS resources, and lists our stack outputs to the console.
+While on the surface this Pulumi component is described imperatively, it produces a declarative output in the form of a [state file]({{<  relref "/docs/intro/concepts/state" >}}) that can be managed locally, in an object store like S3, or by the Pulumi Service backend. Running a ‘pulumi up’ shows that we’ve created 45 AWS resources, and lists our stack outputs to the console.
 
 ![Pulumi Up Result](./PulumiUpOutput.png)
 
@@ -590,7 +590,7 @@ Here we’ve seen three different ways to use Pulumi to automate and improve the
 
 ACME re-evaluated their analytics architecture and shipped the next-generation serverless streaming solution that can take them to the next click-stop, and well through the next order of magnitude. Along the way, they learned how to reason about streaming data and examined the underlying assumptions about time and completeness of data in their existing system. ACME developed its streaming architecture using Pulumi and learned how to automate and create reproducible developer environments along the way. The outcome isn’t just an instance of the serverless streaming architecture, but a component library that implements best practices. That investment in time is bundled up and shipped in a format that the next generation of incubators at ACME can pick up and run with.
 
-If you’d like to get started delivering best practices in infrastructure across your organization, [get started with Pulumi free today]({{< relref "/docs/get-started/_index.md" >}}). Clone and run [the reference implementation](https://github.com/pulumi/examples/tree/master/aws-ts-serverless-datawarehouse) of the Serverless Data Warehouse to build your own serverless analytics stack.
+If you’d like to get started delivering best practices in infrastructure across your organization, [get started with Pulumi free today]({{< relref "/docs/get-started" >}}). Clone and run [the reference implementation](https://github.com/pulumi/examples/tree/master/aws-ts-serverless-datawarehouse) of the Serverless Data Warehouse to build your own serverless analytics stack.
 
 ## Architectural Caveats
 


### PR DESCRIPTION
Fix the following warning due to the `relref` on line 131:

```
WARN 2020/02/03 07:06:00 make non-relative ref/relref page reference(s) in page %q absolute, e.g. {{< ref "/blog/my-post.md" >}}
```

And clean up some other relref links on the page.