### PR TITLE
Allow s3:ListBucket access for account users

### DIFF
--- a/infrastructure/Pulumi.production.yaml
+++ b/infrastructure/Pulumi.production.yaml
@@ -1,7 +1,6 @@
 config:
   aws:region: us-west-2
   www.pulumi.com:certificateArn: arn:aws:acm:us-east-1:058607598222:certificate/a3f72a2b-e715-4639-b126-1e4efc0b634b
-  www.pulumi.com:principalAccount: 058607598222
   www.pulumi.com:pathToWebsiteContents: ../public
   www.pulumi.com:targetDomain: www-production.pulumi.com
   www.pulumi.com:websiteDomain: www-prod.pulumi.com

--- a/infrastructure/Pulumi.production.yaml
+++ b/infrastructure/Pulumi.production.yaml
@@ -1,6 +1,7 @@
 config:
   aws:region: us-west-2
   www.pulumi.com:certificateArn: arn:aws:acm:us-east-1:058607598222:certificate/a3f72a2b-e715-4639-b126-1e4efc0b634b
+  www.pulumi.com:principalAccount: 058607598222
   www.pulumi.com:pathToWebsiteContents: ../public
   www.pulumi.com:targetDomain: www-production.pulumi.com
   www.pulumi.com:websiteDomain: www-prod.pulumi.com

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -52,7 +52,7 @@ const websiteBucket = new aws.s3.Bucket(
     },
 );
 
-// The website bucket needs to have the "public-read" ACL so their contents can be read by
+// The website bucket needs to have the "public-read" ACL so its contents can be read by
 // CloudFront and served. But we deny the s3:ListBucket permission to anyone but account
 // users to prevent unintended disclosure of the bucket's contents.
 const policy = new aws.s3.BucketPolicy("website-bucket-policy", {

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -26,8 +26,6 @@ const config = {
     certificateArn: stackConfig.require("certificateArn"),
     // redirectDomain is the domain to use for any redirects.
     redirectDomain: stackConfig.get("redirectDomain") || undefined,
-    // principalAccount is the AWS account used for managing this stack.
-    principalAccount: stackConfig.require("principalAccount"),
 };
 
 // redirectDomain is the domain to use when redirecting.
@@ -67,7 +65,7 @@ const policy = new aws.s3.BucketPolicy("website-bucket-policy", {
                 Resource: arn,
                 Condition: {
                     StringNotEquals: {
-                        "aws:PrincipalAccount": config.principalAccount,
+                        "aws:PrincipalAccount": aws.getCallerIdentity().accountId,
                     },
                 },
             },


### PR DESCRIPTION
This PR removes the (now empty) S3 bucket that served the website prior to #2368, and applies a `ListBucket` policy to the current bucket that denies public list access, but grants it to members of the AWS account that manages the stack.