### PR TITLE
Preserve client-side redirects during deployments

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -420,57 +420,65 @@ async function createAliasRecord(
 // If the current run is an update (i.e., not a preview), zip up the contents of the
 // website directory and upload the archive to S3.
 if (!pulumi.runtime.isDryRun()) {
+    archiveBucket.id.apply(bucketID => {
 
-    pulumi.all([ archiveBucket.id, websiteBucket.id ]).apply(async ([ archiveBucketId, websiteBucketId ]) => {
-        const s3 = new aws.sdk.S3();
+        // Wait for the update to complete before running the code to upload the archive,
+        // to ensure the task that handles it is the one most recently deployed.
+        process.on("beforeExit", async (code) => {
+            if (code === 0 /* success */) {
+                const s3 = new aws.sdk.S3();
 
-        // For each Hugo-generated redirect, write the relative path and destination URL
-        // to a text file to be processed later in the sync step.
-        const redirectPaths = new Map<string, string>();
-        glob.sync(`${webContentsRootPath}/**/*.html`).map(filePath => {
-            const relativeFilePath = filePath.replace(webContentsRootPath + "/", "");
-            const redirect = getMetaRefreshRedirect(filePath);
+                // For each Hugo-generated redirect, write the relative path and destination URL
+                // to a text file to be processed later in the sync step.
+                const redirectPaths = new Map<string, string>();
+                glob.sync(`${webContentsRootPath}/**/*.html`).map(filePath => {
+                    const relativeFilePath = filePath.replace(webContentsRootPath + "/", "");
+                    const redirect = getMetaRefreshRedirect(filePath);
 
-            if (redirect) {
-                redirectPaths.set(relativeFilePath, translateRedirect(filePath, redirect));
+                    if (redirect) {
+                        redirectPaths.set(relativeFilePath, translateRedirect(filePath, redirect));
+                    }
+                });
+
+                fs.writeFileSync(
+                    `${webContentsRootPath}/redirects.txt`,
+                    Array.from(redirectPaths, ([k, v]) => `${k}|${v}`).join("\n") + "\n",
+                );
+
+                // Tar up the files in the `public` directory.
+                const archivePath = tmp.fileSync({ postfix: ".tgz" }).name;
+                tar.c(
+                    {
+                        gzip: true,
+                        sync: true,
+                        file: archivePath,
+                        C: config.pathToWebsiteContents,
+                        portable: true,
+                    },
+                    fs.readdirSync(config.pathToWebsiteContents),
+                );
+
+                // Upload the archive.
+                const result = await s3.putObject({
+                    Bucket: bucketID,
+                    Key: path.basename(archivePath),
+                    Body: fs.readFileSync(archivePath),
+                })
+                .promise();
+
+                console.log(`Website archive ${archivePath} was uploaded.`);
+
+                // Properly exit.
+                process.exit(code);
             }
         });
-
-        fs.writeFileSync(
-            `${webContentsRootPath}/redirects.txt`,
-            Array.from(redirectPaths, ([k, v]) => `${k}|${v}`).join("\n") + "\n",
-        );
-
-        // Tar up the files in the `public` directory.
-        const archivePath = tmp.fileSync({ postfix: ".tgz" }).name;
-        tar.c(
-            {
-                gzip: true,
-                sync: true,
-                // Exclude redirects.
-                filter: (filePath, stat) => !redirectPaths.has(filePath),
-                file: archivePath,
-                C: config.pathToWebsiteContents,
-                portable: true,
-            },
-            fs.readdirSync(config.pathToWebsiteContents),
-        );
-
-        // Upload the archive.
-        const result = await s3.putObject({
-            Bucket: archiveBucketId,
-            Key: path.basename(archivePath),
-            Body: fs.readFileSync(archivePath),
-        })
-        .promise();
-
-        console.log(`Website archive ${archivePath} was uploaded.`);
     });
 }
 
 const aRecord = createAliasRecord(config.targetDomain, cdn);
 const aliasRecord = createAliasRecord(config.websiteDomain, cdn);
 
+export const archiveBucketUri = archiveBucket.bucket.apply(b => `s3://${b}`);
 export const websiteBucketUri = websiteBucket.bucket.apply(b => `s3://${b}`);
 export const websiteBucketWebsiteDomain = websiteBucket.websiteDomain;
 export const websiteBucketWebsiteEndpoint = websiteBucket.websiteEndpoint;


### PR DESCRIPTION
The `s3 sync` script now responsible for pushing files into the production bucket deletes files that don't exist in the source directory, which, since we exclude client-side (HTML) redirects from the archives we generate from Hugo builds, is causing redirects to disappear between the `s3 sync` step and the `s3api` loop that follows it (to apply applying them as s3 metadata), resulting in temporary 404s. This change leaves the client-side redirects in place during that process in order to prevent anyone from actually encountering a 404.