### PR TITLE
Make the docs sidebars sticky

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -23,21 +23,50 @@ function generateOnThisPage() {
     var $ul = $(".on-this-page > ul");
     if ($ul) {
         var found = false;
+        var headings = [];
+
         $("h2, h3").each(function () {
             var $el = $(this);
             var id = $el.attr("id");
             var text = $el.text();
             var linkTitle = $el.data("link-title");
             var tag = $el.prop("tagName").toLowerCase();
+
             if (id && text) {
                 found = true;
-                $ul.append("<li class='" + tag + "'><a href='#" + id + "'>" + (linkTitle || text) + "</a></li>");
+                var li = $("<li class='" + tag + "'><a href='#" + id + "'>" + (linkTitle || text) + "</a></li>");
+                $ul.append(li);
+
+                // Capture associated heading and list-item elements, so we can mark list
+                // items active when they become visible.
+                headings.push({
+                    element: $el,
+                    listItem: li,
+                });
             }
         });
 
         // It's hidden by default. If we added links to the list, show it.
         if (found) {
             $(".on-this-page").show();
+
+            // Highlight the first heading whose offset from top is greater than the current scroll
+            // position, to best indicate your location within the page hierarchy.
+            function setActiveItem() {
+                var active;
+                for (var heading of headings) {
+                    if (!active && heading.element.offset().top >= window.scrollY) {
+                        active = heading;
+                    }
+                    heading.listItem.toggleClass("font-bold", heading === active);
+                }
+            }
+
+            $(window).on("scroll", function() {
+                setActiveItem();
+            });
+
+            setActiveItem();
         }
     }
 }

--- a/assets/sass/_on-this-page.scss
+++ b/assets/sass/_on-this-page.scss
@@ -1,5 +1,5 @@
 .on-this-page {
-    @apply mt-2 py-6 hidden;
+    @apply mt-2 pt-6 pb-8 hidden;
 
     h4 {
         @apply text-gray-600 uppercase tracking-wide font-bold text-sm;

--- a/assets/sass/_toc.scss
+++ b/assets/sass/_toc.scss
@@ -1,5 +1,5 @@
 .toc {
-    @apply text-blue-800;
+    @apply text-blue-800 pb-8;
 
     a {
         &:hover {

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -187,4 +187,13 @@ main {
     }
 }
 
+.sticky-sidebar {
+
+    @screen lg {
+        @apply sticky self-start overflow-y-scroll;
+        max-height: 90vh;
+        top: 112px;
+    }
+}
+
 @tailwind utilities;

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -15,21 +15,25 @@
             </div>
 
             <div class="md:w-2/12 md:pl-8 mt-2">
-                <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
-                    {{ partial "docs/search.html" . }}
-                </div>
+                <div class="sticky-sidebar">
+                    <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
+                        {{ partial "docs/search.html" . }}
+                    </div>
 
-                <div class="ml-2 hidden md:block">
-                    {{ partial "docs/right-nav.html" . }}
-                </div>
+                    <div class="ml-2 hidden md:block">
+                        {{ partial "docs/right-nav.html" . }}
+                    </div>
 
-                <div>
-                    {{ partial "docs/feedback.html" . }}
+                    <div>
+                        {{ partial "docs/feedback.html" . }}
+                    </div>
                 </div>
             </div>
 
             <div class="md:w-3/12 pr-8 mb-2 pt-8 md:order-first md:border-none md:pt-0 md:mt-0">
-                {{ partial "docs/toc.html" . }}
+                <div class="sticky-sidebar">
+                    {{ partial "docs/toc.html" . }}
+                </div>
             </div>
         </div>
     </div>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -15,21 +15,25 @@
             </div>
 
             <div class="md:w-2/12 md:pl-8 mt-2">
-                <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
-                    {{ partial "docs/search.html" . }}
-                </div>
+                <div class="sticky-sidebar">
+                    <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
+                        {{ partial "docs/search.html" . }}
+                    </div>
 
-                <div class="ml-2 hidden md:block">
-                    {{ partial "docs/right-nav.html" . }}
-                </div>
+                    <div class="ml-2 hidden md:block">
+                        {{ partial "docs/right-nav.html" . }}
+                    </div>
 
-                <div>
-                    {{ partial "docs/feedback.html" . }}
+                    <div>
+                        {{ partial "docs/feedback.html" . }}
+                    </div>
                 </div>
             </div>
 
             <div class="md:w-3/12 pr-8 mb-2 pt-8 md:order-first md:border-none md:pt-0 md:mt-0">
-                {{ partial "docs/toc.html" . }}
+                <div class="sticky-sidebar">
+                    {{ partial "docs/toc.html" . }}
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This change applies sticky positioning and independent scrolling to the left- and right-hand sidebars in docs layouts, and highlights the on-the-page item that represents where you are in the overall page hierarchy.

![](https://cl.ly/7db5fb0e1b2c/Screen%252520Recording%2525202020-02-05%252520at%25252012.39%252520PM.gif)

Fixes #1900.