### PR TITLE
Extend the cache TTLs of bundled assets

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -149,6 +149,7 @@ const websiteLogsBucket = new aws.s3.Bucket(
 const fiveMinutes = 60 * 5;
 const oneHour = fiveMinutes * 12;
 const oneWeek = oneHour * 24 * 7;
+const oneYear = oneWeek * 52;
 
 const baseCacheBehavior = {
     targetOriginId: websiteBucket.arn,
@@ -224,20 +225,20 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         {
             ...baseCacheBehavior,
             pathPattern: "/css/styles.*.css",
-            defaultTtl: oneWeek,
-            maxTtl: oneWeek,
+            defaultTtl: oneYear,
+            maxTtl: oneYear,
         },
         {
             ...baseCacheBehavior,
             pathPattern: "/js/bundle.min.*.js",
-            defaultTtl: oneWeek,
-            maxTtl: oneWeek,
+            defaultTtl: oneYear,
+            maxTtl: oneYear,
         },
         {
             ...baseCacheBehavior,
             pathPattern: "/js/search.min.*.js",
-            defaultTtl: oneWeek,
-            maxTtl: oneWeek,
+            defaultTtl: oneYear,
+            maxTtl: oneYear,
         },
         {
             ...baseCacheBehavior,


### PR DESCRIPTION
This change extends the CloudFront default and max TTLs of our generated CSS and JS bundles to one year. It's one way to address #2256, the other being a more explicit approach that would fetch previously built bundles (say, those younger than some period of time) and save them explicitly to the `public` folder, so they get added to build archives as part of the normal process.

I feel good about trying this approach first, though, since it doesn't really require any code, and it _should_, except in really rare situations, get the job done. @justinvp wondering what you think, though. 

Fixes #2256.