### PR TITLE
Fix typo on unload listener

### DIFF
--- a/assets/js/tracking.js
+++ b/assets/js/tracking.js
@@ -69,7 +69,7 @@ $(document).ready(function() {
         // Remove the event listeners when we navigate to a new page.
         $(window).on("unload", function() {
             for (var i = 0; i < links.length; i++) {
-                $(link[i]).off("click");
+                $(links[i]).off("click");
             }
         });
     }


### PR DESCRIPTION
This PR fixes a typo in the tracking script during the `unload` call.