### PR TITLE
Add some pre-deployment sanity checks

### DIFF
--- a/infrastructure/sync.sh
+++ b/infrastructure/sync.sh
@@ -22,14 +22,13 @@ aws s3 cp $site_archive .
 mkdir site_contents
 tar -xzvf $(basename "$site_archive") -C site_contents
 
-# Perform a couple of sanity checks to make sure the unpacked archive looks like a proper
-# website docroot (e.g., one composed of at least a thousand index.html files, including
-# one at the root).
-if [ -z "$(ls -al site_contents/index.html)" ]; then
+# Verify index.html exists in the root.
+if [ ! -f "site_contents/index.html" ]; then
     echo "Missing root index.html. See the archive extraction log above for details."
     exit 1
 fi
 
+# Verify we have at least 1000 index.html files in total across the site.
 if [ ! "$(find site_contents -type f | grep index.html | wc -l)" -ge 1000 ]; then
     echo "Page-count check failed. See the archive extraction log above for details."
     exit 1

--- a/infrastructure/sync.sh
+++ b/infrastructure/sync.sh
@@ -6,11 +6,34 @@ site_archive="$1"
 # S3 URL of the destination website bucket (e.g., the one hosting www.pulumi.com).
 site_bucket="$2"
 
+if [ -z "$site_archive" ]; then
+    echo "Missing argument: site_archive"
+    exit 1
+fi
+
+if [ -z "$site_bucket" ]; then
+    echo "Missing argument: site_bucket"
+    exit 1
+fi
+
 # Download the archive from the archive bucket and unpack it into a local folder.
 echo "Downloading $site_archive..."
 aws s3 cp $site_archive .
 mkdir site_contents
 tar -xzvf $(basename "$site_archive") -C site_contents
+
+# Perform a couple of sanity checks to make sure the unpacked archive looks like a proper
+# website docroot (e.g., one composed of at least a thousand index.html files, including
+# one at the root).
+if [ -z "$(ls -al site_contents/index.html)" ]; then
+    echo "Missing root index.html. See the archive extraction log above for details."
+    exit 1
+fi
+
+if [ ! "$(find site_contents -type f | grep index.html | wc -l)" -ge 1000 ]; then
+    echo "Page-count check failed. See the archive extraction log above for details."
+    exit 1
+fi
 
 # Upload the JS and CSS bundles first.
 cd site_contents


### PR DESCRIPTION
This change adds a couple of quick checks to the deployment script before it runs s3 sync, just to ensure we don't do anything too destructive by accident. It looks first for an index.html file at the docroot, then for at least a thousand HTML files in the archive payload, exiting if either of those checks fails.