### PR TITLE
Exclude download link for Windows v1.10.0

### DIFF
--- a/content/docs/get-started/install/versions.md
+++ b/content/docs/get-started/install/versions.md
@@ -13,12 +13,12 @@ The current stable version of Pulumi is **{{< latest-version >}}**.
         <tr>
             <th scope="col" width="25%">Version</th>
             <th scope="col" width="25%">Date</th>
-            <th scope="col" width="50%">Downloads</th>
+            <th scope="col" colspan="3" width="50%">Downloads</th>
         </tr>
     </thead>
     <tbody>
         {{< changelog-table-row version="1.10.1" date="2020-02-06" >}}
-        {{< changelog-table-row version="1.10.0" date="2020-02-05" >}}
+        {{< changelog-table-row version="1.10.0" date="2020-02-05" exclude="windows" >}}
         {{< changelog-table-row version="1.9.1" date="2020-01-27" >}}
         {{< changelog-table-row version="1.9.0" date="2020-01-22" >}}
         {{< changelog-table-row version="1.8.1" date="2019-12-20" >}}

--- a/layouts/shortcodes/changelog-table-row.html
+++ b/layouts/shortcodes/changelog-table-row.html
@@ -12,14 +12,20 @@
     {{ errorf "invalid number of components for param 'date': %s" .Position }}
 {{ end }}
 
+{{ $exclude := split (.Get "exclude") "," }}
+
 <tr>
     <td><a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#{{ $flatVersion }}-{{ $date }}">{{ $version }}</a></td>
     <td>{{ $date }}</td>
-    <td>
-        <a href="https://get.pulumi.com/releases/sdk/pulumi-v{{ $version }}-linux-x64.tar.gz">Linux</a>
-        |
-        <a href="https://get.pulumi.com/releases/sdk/pulumi-v{{ $version }}-darwin-x64.tar.gz">macOS</a>
-        |
-        <a href="https://get.pulumi.com/releases/sdk/pulumi-v{{ $version }}-windows-x64.zip">Windows</a>
-    </td>
+    <td>{{ template "dl" (dict "exclude" $exclude "version" $version "platform" "linux" "ext" "tar.gz" "display" "Linux") }}</td>
+    <td>{{ template "dl" (dict "exclude" $exclude "version" $version "platform" "darwin" "ext" "tar.gz" "display" "macOS") }}</td>
+    <td>{{ template "dl" (dict "exclude" $exclude "version" $version "platform" "windows" "ext" "zip" "display" "Windows") }}</td>
 </tr>
+
+{{ define "dl" }}
+    {{ if in .exclude .platform }}
+        <span class="text-sm text-gray-500">unavailable</span>
+    {{ else }}
+        <a href="https://get.pulumi.com/releases/sdk/pulumi-v{{ .version }}-{{ .platform }}-x64.{{ .ext }}">{{ .display }}</a>
+    {{ end }}
+{{ end }}

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -28,8 +28,7 @@ check_links() {
         --exclude "https://ksonnet.io/" \
         --exclude "https://www.latlong.net/" \
         --exclude "https://media.amazonwebservices.com/architecturecenter/AWS_ac_ra_web_01.pdf" \
-        --exclude "https://www.packet.com/" \
-        --exclude "https://get.pulumi.com/releases/sdk/pulumi-v1.10.0-windows-x64.zip"
+        --exclude "https://www.packet.com/"
 }
 
 retry() {


### PR DESCRIPTION
## Before

<img width="503" alt="Screen Shot 2020-02-08 at 3 23 30 AM" src="https://user-images.githubusercontent.com/710598/74084277-6ad66380-4a22-11ea-82d3-af1b31100ca1.png">

## After

<img width="558" alt="Screen Shot 2020-02-08 at 3 47 48 AM" src="https://user-images.githubusercontent.com/710598/74084636-cbb36b00-4a25-11ea-9ee3-ebf4fb8beed0.png">

Fixes #2392