### PR TITLE
Fix GCP getting-started page for KMS API

### DIFF
--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -14,7 +14,7 @@ aliases: ["/docs/quickstart/gcp/modify-program/"]
 
 Now that we have an instance of our Pulumi program deployed, let's update it to use our own encryption key instead of the default Google-managed one.
 
-> You must enable the Google KMS API for your project on the GCP console before proceeding. You can enable the API by following this link: `https://console.cloud.google.com/security/kms/noaccess?project={your_project_id}`. Be sure to replace the `{your_project_id}` with your actual Google project ID.
+> You must enable the Google KMS API on the GCP console before proceeding. You can enable the API by going to the [KMS API Library](https://console.cloud.google.com/apis/library/cloudkms.googleapis.com) page and clicking 'ENABLE'.
 
 Replace the entire contents of {{< langfile >}} with the following:
 


### PR DESCRIPTION
Fixes: #2426

The ability to enable a KMS API via URL using project_id has been
removed by google. Their official docs now suggest it should be
done on the Console

https://cloud.google.com/apis/docs/getting-started#enabling_apis


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->