### PR TITLE
Apply cache-control settings for asset bundles

### DIFF
--- a/infrastructure/sync.sh
+++ b/infrastructure/sync.sh
@@ -34,15 +34,16 @@ if [ ! "$(find site_contents -type f | grep index.html | wc -l)" -ge 1000 ]; the
     exit 1
 fi
 
-# Upload the JS and CSS bundles first.
+# Upload the JS and CSS bundles first, applying cache-control headers that match our
+# CloudFront settings (to cache these objects for one year).
 cd site_contents
 
 for file in $(find css -name "styles.*.css") ; do
-    aws s3 cp "$file" "$site_bucket/$file" --acl public-read
+    aws s3 cp "$file" "$site_bucket/$file" --acl public-read --cache-control "public, max-age=31536000" --metadata-directive REPLACE
 done
 
 for file in $(find js -name "bundle.min.*.js") ; do
-    aws s3 cp "$file" "$site_bucket/$file"  --acl public-read
+    aws s3 cp "$file" "$site_bucket/$file"  --acl public-read --cache-control "public, max-age=31536000" --metadata-directive REPLACE
 done
 
 cd ..


### PR DESCRIPTION
This change sets cache-control headers for our asset bundles to instruct browsers to cache them for one year, which matches our CDN distribution settings.

![image](https://user-images.githubusercontent.com/274700/74368698-03554680-4d89-11ea-8154-18c75e46f330.png)

Fixes #2436. 