### PR TITLE
Add PurgeCSS to remove unused CSS classes from page loads

### DIFF
--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -21,9 +21,9 @@ module.exports = {
             // Specify the paths to all of the template files in your project
             content: [ "./layouts/**/*.html" ],
             // Whitelist HubSpot specific classes so they don't get removed.
-            whitelist: ["supported-cicd-platforms"],
-            whitelistPatterns: [/^hs-/, /^highlight$/],
-            whitelistPatternsChildren: [/^hs-/, /^highlight$/],
+            whitelist: ["supported-cicd-platforms", ":not"],
+            whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/,  /^copy-/],
+            whitelistPatternsChildren: [/^hs-/, /^highlight$/, /^pagination$/, /^code-/,  /^copy-/],
             // Extract the default tailwind classes.
             defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || [],
         }),

--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -20,7 +20,19 @@ module.exports = {
         // Docs: https://purgecss.com/plugins/postcss.html
         require("@fullhuman/postcss-purgecss")({
             // Specify the paths to all of the template files in your project
-            content: [ "./layouts/**/*.html" ],
+            content: [
+                "./layouts/**/*.html",
+                // Some of our scripts reference CSS classes.
+                "./assets/js/**/*.js",
+                // Look for CSS classes in our markdown content. We use `glob` explicitly here so we can ignore the
+                // files for the API docs in ./content/docs/reference/pkg/**/* because it includes a large number of
+                // files that significantly impacts build time (~25 seconds vs. many minutes). Instead, we'll only look
+                // for CSS classes in a single package (the Pulumi SDK package) for nodejs and python, which should
+                // include all classes used in the docs for any other package.
+                ...require("glob").sync("./content/**/*.md", { ignore: "./content/docs/reference/pkg/**/*" }),
+                "./content/docs/reference/pkg/nodejs/pulumi/pulumi/**/*.md",
+                "./content/docs/reference/pkg/python/pulumi/**/*.md",
+            ],
             // Whitelist HubSpot specific classes so they don't get removed.
             whitelist: ["supported-cicd-platforms", ":not", "md:max-w-lg", "blink", "typing", "char"],
             whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/],
@@ -29,7 +41,7 @@ module.exports = {
             // so that we do not strip them out. As long as a class name appears in the HTML
             // in its entirety, Purgecss will not remove it.
             // Ex. https://tailwindcss.com/docs/controlling-file-size/#writing-purgeable-html
-            defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || [],
+            defaultExtractor: content => content.match(/[\w-/:]*[\w-/:]/g) || [],
         }),
 
         // Minify the CSS even further. (It works!)

--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -22,8 +22,10 @@ module.exports = {
             // Specify the paths to all of the template files in your project
             content: [
                 "./layouts/**/*.html",
+
                 // Some of our scripts reference CSS classes.
                 "./assets/js/**/*.js",
+
                 // Look for CSS classes in our markdown content. We use `glob` explicitly here so we can ignore the
                 // files for the API docs in ./content/docs/reference/pkg/**/* because it includes a large number of
                 // files that significantly impacts build time (~25 seconds vs. many minutes). Instead, we'll only look
@@ -33,10 +35,14 @@ module.exports = {
                 "./content/docs/reference/pkg/nodejs/pulumi/pulumi/**/*.md",
                 "./content/docs/reference/pkg/python/pulumi/**/*.md",
             ],
-            // Whitelist HubSpot specific classes so they don't get removed.
+
+            // Whitelist specific classes that were being removed.
             whitelist: ["supported-cicd-platforms", ":not", "md:max-w-lg", "blink", "typing", "char"],
+
+            // Whitelist custom parent selectors and their children.
             whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/],
             whitelistPatternsChildren: [/^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/],
+
             // We need to extract the Tailwind screen size selectors (e.g. sm, md, lg)
             // so that we do not strip them out. As long as a class name appears in the HTML
             // in its entirety, Purgecss will not remove it.

--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -16,6 +16,18 @@ module.exports = {
             ]
         }),
 
+        // PurgeCSS to remove unused classes for better page speed.
+        require("@fullhuman/postcss-purgecss")({
+            // Specify the paths to all of the template files in your project
+            content: [ "./layouts/**/*.html" ],
+            // Whitelist HubSpot specific classes so they don't get removed.
+            whitelist: ["supported-cicd-platforms"],
+            whitelistPatterns: [/^hs-/, /^highlight$/],
+            whitelistPatternsChildren: [/^hs-/, /^highlight$/],
+            // Extract the default tailwind classes.
+            defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || [],
+        }),
+
         // Minify the CSS even further. (It works!)
         require('cssnano')({
             preset: 'default',

--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -17,14 +17,18 @@ module.exports = {
         }),
 
         // PurgeCSS to remove unused classes for better page speed.
+        // Docs: https://purgecss.com/plugins/postcss.html
         require("@fullhuman/postcss-purgecss")({
             // Specify the paths to all of the template files in your project
             content: [ "./layouts/**/*.html" ],
             // Whitelist HubSpot specific classes so they don't get removed.
-            whitelist: ["supported-cicd-platforms", ":not"],
-            whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/,  /^copy-/],
-            whitelistPatternsChildren: [/^hs-/, /^highlight$/, /^pagination$/, /^code-/,  /^copy-/],
-            // Extract the default tailwind classes.
+            whitelist: ["supported-cicd-platforms", ":not", "md:max-w-lg", "blink", "typing", "char"],
+            whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/],
+            whitelistPatternsChildren: [/^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/],
+            // We need to extract the Tailwind screen size selectors (e.g. sm, md, lg)
+            // so that we do not strip them out. As long as a class name appears in the HTML
+            // in its entirety, Purgecss will not remove it.
+            // Ex. https://tailwindcss.com/docs/controlling-file-size/#writing-purgeable-html
             defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || [],
         }),
 

--- a/layouts/partials/home/ide.html
+++ b/layouts/partials/home/ide.html
@@ -1,4 +1,4 @@
-<div id="carousel-ide" class="text-left">
+<div id="carousel-ide" class="text-left carousel-ide">
     <div class="bg-gray-400 rounded-t border-r-2 border-gray-500">
         <div class="flex p-2">
             <div class="bg-red-600 rounded-full h-3 w-3"></div>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typedoc": "^0.15.3"
   },
   "devDependencies": {
+    "@fullhuman/postcss-purgecss": "^2.0.6",
     "autoprefixer": "^9.6.0",
     "cssnano": "^4.1.10",
     "js-yaml": "^3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@fullhuman/postcss-purgecss@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.0.6.tgz#55612eda275e6a86a8d4a03e9deb58b2e95dd6f1"
+  integrity sha512-RgD05Yd1VFudo1H1b2inb+10AS1mexp1edHfdoJvoeKaoMVoi/9DWrbWOpIrDmKq1CO82oQrb5wf4V64oaNkKQ==
+  dependencies:
+    postcss "7.0.26"
+    purgecss "^2.0.6"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -549,6 +557,11 @@ combined-stream2@^1.0.2:
     bluebird "^2.8.1"
     debug "^2.1.1"
     stream-length "^1.0.1"
+
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@~2.20.0:
   version "2.20.0"
@@ -2663,7 +2676,7 @@ postcss-selector-parser@^5.0.0, postcss-selector-parser@^5.0.0-rc.4:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.0:
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
   integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
@@ -2695,6 +2708,15 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
+
+postcss@7.0.26:
+  version "7.0.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
+  integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
 
 postcss@^6.0.9:
   version "6.0.23"
@@ -2756,6 +2778,16 @@ punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+purgecss@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-2.0.6.tgz#fc0a03f9533448635309af5979b094aab57ff361"
+  integrity sha512-Xab72ykpWtg+j/dTphz9HCrychRNbMebNBrI+pOU0mC7mG5OlwRksEEpNAdOLb1jg9oRHDDu6Exe+nlM9ZLp5Q==
+  dependencies:
+    commander "^4.0.0"
+    glob "^7.0.0"
+    postcss "7.0.26"
+    postcss-selector-parser "^6.0.2"
 
 q@^1.1.2:
   version "1.5.1"


### PR DESCRIPTION
This PR adds PurgeCSS as a plugin to our already existing PostCSS process. PurgeCSS removed unused CSS classes, which cuts the CSS file load in about half. A lot of third party classes and some of our custom CSS are excluded by default so I had to add custom whitelisting rules to include them.

Relevant issue: https://github.com/pulumi/docs/issues/2378