### PR TITLE
Optimization for SEO

### DIFF
--- a/content/docs/intro/cloud-providers/azure/_index.md
+++ b/content/docs/intro/cloud-providers/azure/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Azure
-meta_desc: This page provides an overview of the Azure Provider for Pulumi.
+title: Azure Provider
+meta_desc: The Azure provider for Pulumi can be used to provision any of the cloud resources available in Azure via Azure Resource Manager (ARM).
 menu:
   intro:
     parent: cloud-providers
@@ -45,7 +45,7 @@ const resourceGroupName = new azure.core.ResourceGroup("my-group", {
 });
 ```
 
-You can find additional examples of using Azure in [the Pulumi examples repo](https://github.com/pulumi/examples).
+Above is one example of an Azure resource group using Pulumi. You can find additional examples in [the Pulumi examples repo](https://github.com/pulumi/examples).
 
 ## Libraries
 
@@ -72,3 +72,5 @@ The Azure provider accepts the following configuration settings.  These can be p
 * `subscriptionId`: (Optional) The subscription ID to use. It can also be sourced from the `ARM_SUBSCRIPTION_ID` environment variable.
 * `tenantId`: (Optional) The tenant ID to use. It can also be sourced from the `ARM_TENANT_ID` environment variable.
 * `useMsi`: (Optional) Set to true to authenticate using managed service identity. It can also be sourced from the `ARM_USE_MSI` environment variable.
+
+For Pulumi Azure support and troubleshooting, click the links in the sidebar on the left of the page.


### PR DESCRIPTION
@cnunciato this page is already quite well optimized; the main changes are to get the primary focus KW in the metadata ("Azure provider"). "Azure resource group" and "Azure support" are secondary keywords that we are trying to tackle, so if I mislabeled the example by calling it a resource group, hopefully there's a way to fix that while still keeping the keyword.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
