### PR TITLE
Add events page links to header/footer navs

### DIFF
--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -1,9 +1,14 @@
 ---
-title: Upcoming Events
+title: Events
 type: events
 layout: events
 description: Talks, workshops, and other gatherings to help you connect with the Pulumi community.
 meta_desc: |
     Pulumi events, both online and in-person, bringing the cloud computing community together
     to connect, collaborate, and learn new techniques and best practices.
+
+menu:
+    header:
+        weight: 3
+        identifier: events
 ---

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -6,9 +6,4 @@ description: Talks, workshops, and other gatherings to help you connect with the
 meta_desc: |
     Pulumi events, both online and in-person, bringing the cloud computing community together
     to connect, collaborate, and learn new techniques and best practices.
-
-menu:
-    header:
-        weight: 3
-        identifier: events
 ---

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -2,7 +2,7 @@
     <header class="header-hero header-hero-glow-bottom">
         <div class="container mx-auto">
             <div class="mx-auto text-center">
-                <h1>{{ .Title }}</h1>
+                <h1>Upcoming Events</h1>
                 <p>
                     {{ .Description }}
                 </p>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -41,6 +41,7 @@
                         <li class="mb-4"><a data-track="footer-careers" href="{{ relref . "/careers" }}">Careers</a></li>
                         <li class="mb-4"><a data-track="footer-brand" href="{{ relref . "/brand" }}">Brand</a></li>
                         <li class="mb-4"><a data-track="footer-security" href="{{ relref . "/security" }}">Security</a></li>
+                        <li class="mb-4"><a data-track="footer-events" href="{{ relref . "/events" }}">Upcoming Events</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
As the title says, this PR adds links to the event list page in the header and footer.

https://github.com/pulumi/docs/issues/2416