### PR TITLE
Pass the minify option to the Hugo build

### DIFF
--- a/.github/workflows/pulumify.yml
+++ b/.github/workflows/pulumify.yml
@@ -1,0 +1,16 @@
+name: Pulumify
+on: [pull_request, delete]
+jobs:
+  updateLivePreview:
+    name: Update Live Preview
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker://pulumi/pulumify:v0.1.2
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        PULUMIFY_BUILD: make ensure && hugo --minify --buildFuture -e $GITHUB_SHA
+        PULUMIFY_ROOT: public
+        PULUMIFY_ORGANIZATION: pulumi

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ generate:
 build:
 	@echo -e "\033[0;32mBUILD ($(HUGO_ENVIRONMENT)):\033[0m"
 	yarn lint-markdown
-	hugo
+	hugo --minify
 	node ./scripts/build-search-index.js < ./public/docs/search-data/index.json > ./public/docs/search-index.json
 	rm -rf ./public/docs/search-data
 


### PR DESCRIPTION
This change adds the `--minify` option to the Hugo build command, which trims superfluous whitespace and markup (using https://github.com/tdewolff/minify), reducing the size of the build by about 20% (and individual page sizes by about the same): 

```
$du -sh public_master public_minified
544M	public_master
433M	public_minified
```

This also lets us re-enable Pulumify, since the resulting build is now well below the 512MB limit.

We should do some manual browser testing to make sure this doesn't break anything important, and cc @zchase as well, in case this could affect anything SEO-related.

Fixes #2344 (if not necessarily permanently). 