### PR TITLE
Suppress wrapping of header-submenu items

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -133,7 +133,7 @@
                     </div>
                     <div class="w-1/4 px-12 border-r border-purple-500 text-purple-100 text-sm">
                         <h3 class="no-anchor text-white">Any Code</h3>
-                        <ul class="p-0 leading-loose">
+                        <ul class="p-0 leading-loose whitespace-no-wrap">
                             <li>
                                 <a data-track="header-subnav-serverless" class="text-orange-500 font-bold hover:text-orange-400 hover:mr-1 transition-all" href="{{ relref . "/topics/serverless" }}">Serverless</a>
                                 <span>&rarr;</span>
@@ -154,7 +154,7 @@
                     </div>
                     <div class="w-1/4 pl-12 text-purple-100 text-sm">
                         <h3 class="no-anchor text-white">Any Cloud</h3>
-                        <ul class="p-0 leading-loose">
+                        <ul class="p-0 leading-loose whitespace-no-wrap">
                             <li>
                                 <a data-track="header-subnav-aws" class="text-orange-500 font-bold hover:text-orange-400 hover:mr-1 transition-all" href="{{ relref . "/partner/aws" }}">AWS</a>
                                 <span>&rarr;</span>


### PR DESCRIPTION
Before:

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/274700/74776026-ac011b80-524b-11ea-9d89-799fa1f44990.png">

After:

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/274700/74775998-9ee42c80-524b-11ea-9dec-31e48327bf64.png">

Fixes #2355.
