### PR TITLE
Add landing pages for NYC and London workshops

### DIFF
--- a/content/events/workshop-london-2020-09-23/index.md
+++ b/content/events/workshop-london-2020-09-23/index.md
@@ -1,0 +1,46 @@
+---
+# Name of the event.
+title: "Infrastructure As Code Workshop | London, UK"
+meta_desc: "Join Pulumi at our Infrastructure As Code Workshop in London, UK and learn more about cloud programming, infrastructure as code, and many other topics."
+
+# The layout of the landing page.
+type: events
+
+# The url slug for the even landing page.
+url_slug: "workshop-london-2020-09-23"
+
+# Event information
+event:
+    # The type of activities we will be doing at the event.
+    type: ["workshop"]
+    # The event address
+    location: "70 Wilson Street, London, UK"
+    # The start date of an event. Format YYYY-MM-DD
+    start_date: "2020-09-23"
+    # The end date of an event. Format YYYY-MM-DD
+    end_date: "2020-09-23"
+    # The start and end time of an event with the time zone.
+    # i.e. 5:30PM - 8:30PM (PT)
+    # This is only displayed on event specific pages.
+    time: "5:30PM - 8:30PM (PT)"
+    # The event description shown on the event list page.
+    description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
+    # The Calendly registrtion url for event specific pages.
+    calendly_url: "Registration URL"
+    # The cost of an event.
+    cost: "Free"
+---
+
+### About the Workshop
+
+The hardest part of Kubernetes is setting up the infrastructure: clusters, DNS, firewalls, load balancers, IAM, storage, logging, and performance monitoring, often spanning private, public, and hybrid cloud architectures.
+
+In this workshop, the Pulumi team will show you how to tackle these challenges using Infrastructure as Code (IaC) through a series of hands-on labs. The techniques work for any cloud - Azure, AWS, and GCP. You'll be able to leverage your favorite languages including Python, Go, JavaScript, TypeScript, and C# instead of YAML or domain-specific languages.
+
+After completing this workshop, you'll be up and running with IaC fundamentals, modern application architectures across many clouds, and Kubernetes best-practices that are ready for production environments. You'll also be ready to empower your development teams to be more productive - continuously deploying both their applications and infrastructure.
+
+### Instructors
+
+* Luke Hoban - CTO, Pulumi <a href="https://twitter.com/lukehoban" target="_blank">@lukehoban</a>
+
+**Pizza will be provided.** This event is free thanks to sponsorship from Microsoft.

--- a/content/events/workshop-london-2020-09-23/index.md
+++ b/content/events/workshop-london-2020-09-23/index.md
@@ -26,7 +26,7 @@ event:
     # The event description shown on the event list page.
     description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
     # The Calendly registrtion url for event specific pages.
-    calendly_url: "Registration URL"
+    calendly_url: "https://calendly.com/pulumi/london?month=2020-09"
     # The cost of an event.
     cost: "Free"
 ---

--- a/content/events/workshop-nyc-2020-07-08/index.md
+++ b/content/events/workshop-nyc-2020-07-08/index.md
@@ -24,7 +24,7 @@ event:
     # This is only displayed on event specific pages.
     time: "5:30PM - 8:30PM (PT)"
     # The event description shown on the event list page.
-    description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
+    description: "Join us as we walk through Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
     # The Calendly registrtion url for event specific pages.
     calendly_url: "https://calendly.com/pulumi/nyc?month=2020-07"
     # The cost of an event.

--- a/content/events/workshop-nyc-2020-07-08/index.md
+++ b/content/events/workshop-nyc-2020-07-08/index.md
@@ -1,0 +1,46 @@
+---
+# Name of the event.
+title: "Infrastructure As Code Workshop | New York City, NY"
+meta_desc: "Join Pulumi at our Infrastructure As Code Workshop in New York City and learn more about cloud programming, infrastructure as code, and many other topics."
+
+# The layout of the landing page.
+type: events
+
+# The url slug for the even landing page.
+url_slug: "workshop-nyc-2020-07-08"
+
+# Event information
+event:
+    # The type of activities we will be doing at the event.
+    type: ["workshop"]
+    # The event address
+    location: "11 Times Square, New York, NY 10036"
+    # The start date of an event. Format YYYY-MM-DD
+    start_date: "2020-07-08"
+    # The end date of an event. Format YYYY-MM-DD
+    end_date: "2020-07-08"
+    # The start and end time of an event with the time zone.
+    # i.e. 5:30PM - 8:30PM (PT)
+    # This is only displayed on event specific pages.
+    time: "5:30PM - 8:30PM (PT)"
+    # The event description shown on the event list page.
+    description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
+    # The Calendly registrtion url for event specific pages.
+    calendly_url: "Registration URL"
+    # The cost of an event.
+    cost: "Free"
+---
+
+### About the Workshop
+
+The hardest part of Kubernetes is setting up the infrastructure: clusters, DNS, firewalls, load balancers, IAM, storage, logging, and performance monitoring, often spanning private, public, and hybrid cloud architectures.
+
+In this workshop, the Pulumi team will show you how to tackle these challenges using Infrastructure as Code (IaC) through a series of hands-on labs. The techniques work for any cloud - Azure, AWS, and GCP. You'll be able to leverage your favorite languages including Python, Go, JavaScript, TypeScript, and C# instead of YAML or domain-specific languages.
+
+After completing this workshop, you'll be up and running with IaC fundamentals, modern application architectures across many clouds, and Kubernetes best-practices that are ready for production environments. You'll also be ready to empower your development teams to be more productive - continuously deploying both their applications and infrastructure.
+
+### Instructors
+
+* Luke Hoban - CTO, Pulumi <a href="https://twitter.com/lukehoban" target="_blank">@lukehoban</a>
+
+**Pizza will be provided.** This event is free thanks to sponsorship from Microsoft.

--- a/content/events/workshop-nyc-2020-07-08/index.md
+++ b/content/events/workshop-nyc-2020-07-08/index.md
@@ -26,7 +26,7 @@ event:
     # The event description shown on the event list page.
     description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
     # The Calendly registrtion url for event specific pages.
-    calendly_url: "Registration URL"
+    calendly_url: "https://calendly.com/pulumi/nyc?month=2020-07"
     # The cost of an event.
     cost: "Free"
 ---

--- a/content/events/workshop-redmond-2020-03-12/index.md
+++ b/content/events/workshop-redmond-2020-03-12/index.md
@@ -24,7 +24,7 @@ event:
     # This is only displayed on event specific pages.
     time: "5:30PM - 8:30PM (PT)"
     # The event description shown on the event list page.
-    description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
+    description: "Join us as we walk through Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
     # The calendly registrtion url for event specific pages.
     calendly_url: "https://calendly.com/pulumi/redmond?month=2020-03"
     # The cost of an event.


### PR DESCRIPTION
Just as the title states, this PR adds landing pages for NYC and London workshops.