### PR TITLE
Hide scroll gutters when they aren't necessary

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -204,9 +204,8 @@ main {
 }
 
 .sticky-sidebar {
-
     @screen lg {
-        @apply sticky self-start overflow-y-scroll;
+        @apply sticky self-start overflow-y-auto;
         max-height: 90vh;
         top: 112px;
     }


### PR DESCRIPTION
This change adjusts the sidebar CSS to show scroll gutters only where necessary.

Before:

![image](https://user-images.githubusercontent.com/274700/74790101-7bc97500-526b-11ea-8008-4b19013f1341.png)

After:

![image](https://user-images.githubusercontent.com/274700/74789962-11b0d000-526b-11ea-959e-cdb6b5da2556.png)

Fixes #2391.