### PR TITLE
Add a case-studies list page

### DIFF
--- a/content/case-studies/_index.md
+++ b/content/case-studies/_index.md
@@ -1,0 +1,9 @@
+---
+title: Case Studies
+description: |
+    See how our customers are using Pulumi to simplify cloud management, improve operations,
+    reduce costs and scale their services.
+meta_desc: |
+    See how our customers are using Pulumi to simplify cloud management, improve operations,
+    reduce costs and scale their services.
+---

--- a/content/case-studies/learning-machine.md
+++ b/content/case-studies/learning-machine.md
@@ -1,10 +1,10 @@
 ---
 title: Learning Machine
-type: page
-layout: case-study
-
+description: |
+    Learning Machine used Pulumi and TypeScript to streamline its DevOps processes
+    and eliminate several hundred thousand lines of configuration code.
 meta_desc: |
-    Learn how Learning Machine used Pulumi and TypeScript to streamline its DevOps processes
+    Learning Machine used Pulumi and TypeScript to streamline its DevOps processes
     and eliminate several hundred thousand lines of configuration code.
 
 customer_name: Learning Machine

--- a/content/case-studies/menta-network.md
+++ b/content/case-studies/menta-network.md
@@ -1,11 +1,12 @@
 ---
 title: Menta Network
-type: page
-layout: case-study
-
+layout: case-studies
+description: |
+    Menta Network used Pulumi and GitLab to build ephemeral environments in Python and
+    helped its customers to get ready for peak traffic.
 meta_desc: |
-    Learn how Menta Network used Pulumi to lower its operating costs by automating the
-    deployment, scale and decommissioning of its cloud infrastructure.
+    Menta Network used Pulumi and GitLab to build ephemeral environments in Python and
+    helped its customers to get ready for peak traffic.
 
 customer_name: Menta Network
 customer_logo: /logos/customers/menta_logo.svg

--- a/content/case-studies/merceded-benz.md
+++ b/content/case-studies/merceded-benz.md
@@ -1,11 +1,11 @@
 ---
 title: Mercedes-Benz Research and Development
-type: page
-layout: case-study
-
+description: |
+    Mercedes-Benz Research and Development used Pulumi to bring their application and
+    infrastructure teams closer together.
 meta_desc: |
-    Learn more about how Mercedes-Benz Research and Development used Pulumi to bring their
-    application and infrastructure teams closer together.
+    Mercedes-Benz Research and Development used Pulumi to bring their application and
+    infrastructure teams closer together.
 
 customer_name: Mercedes-Benz Research and Development
 customer_logo: /logos/customers/mercedes-benz-RDNA_logo.png

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -1,7 +1,5 @@
 ---
-title: Events
-type: events
-layout: events
+title: Upcoming Events
 description: Talks, workshops, and other gatherings to help you connect with the Pulumi community.
 meta_desc: |
     Pulumi events, both online and in-person, bringing the cloud computing community together

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -1,0 +1,41 @@
+{{ define "hero" }}
+    <header class="header-hero header-hero-glow-bottom">
+        <div class="container mx-auto">
+            <div class="mx-auto text-center">
+                <h1 class="m-0">{{ .Title }}</h1>
+                <p class="inline-block max-w-xl mb-0">
+                    {{ .Description }}
+                </p>
+            </div>
+        </div>
+    </header>
+{{ end }}
+
+{{ define "main" }}
+    <div class="container mx-auto max-w-xl md:max-w-4xl py-16 md:py-24 px-8 md:px-0">
+        <ul class="list-none p-0">
+            {{ $items := where (where .Site.Pages "Type" "case-studies") "Kind" "eq" "page" }}
+            {{ range $index, $item := $items }}
+                <li class="m-0 p-0">
+                    <article class="{{ if lt (add $index 1) (len $items) }} pb-16 mb-16 border-b border-gray-300 {{ end }} md:flex items-start">
+                        <div class="mb-8 md:mb-0 md:pt-2 px-8 md:w-1/3">
+                            <img class="md:block w-40 md:w-48 mx-auto" src="{{ .Params.customer_logo }}" alt="{{ .Params.customer_name }} logo">
+                        </div>
+                        <div class="md:w-2/3">
+                            <h2 class="leading-none">
+                                <a class="text-2xl" href="{{ .RelPermalink }}">
+                                    {{ $item.Title }}
+                                </a>
+                            </h2>
+                            <p class="mb-0">
+                                {{ $item.Description }}
+                            </p>
+                        </div>
+                    </article>
+                </li>
+            {{ end }}
+        </ul>
+    </div>
+
+    {{ partial "learnmore-contactus.html" . }}
+{{ end }}

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -3,12 +3,9 @@
         <div class="header-hero-items container mx-auto">
             <div class="header-hero-item text-center w-full py-4">
                 <div class="uppercase text-base text-purple-100 mb-2">Pulumi Case Study</div>
-                <h1 class="m-0">
+                <h1 class="mt-0 mb-4">
                     {{ .Title }}
                 </h1>
-                <p>
-                    {{ .Params.description }}
-                </p>
             </div>
         </div>
     </header>

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -18,9 +18,9 @@
                 <h2 id="event-list-heading" class="mb-8">All Upcoming Events</h2>
                 <ul id="event-list" class="list-none md:flex md:flex-wrap pl-0">
                     {{ $events := (where $.Pages "Type" "events") }}
-                    {{ range (sort $events ".Params.event.start_date") }}
+                    {{ range $index, $event := (sort $events ".Params.event.start_date") }}
                         <li class="w-full m-0 p-0" data-event-type='{{ delimit .Params.event.type "," }}'>
-                            <article class="pb-16 mb-12 border-b border-gray-300">
+                            <article class="{{ if lt (add $index 1) (len $events) }} pb-16 mb-12 border-b border-gray-300 {{ end }}">
                                 <h3>
                                     {{ if .Params.url_slug }}
                                         <a class="text-2xl" href="/events/{{ .Params.url_slug }}/">
@@ -83,4 +83,6 @@
             </div>
         </div>
     </div>
+
+    {{ partial "learnmore-contactus.html" . }}
 {{ end }}

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -51,4 +51,6 @@
             </div>
         </div>
     </div>
+
+    {{ partial "learnmore-contactus.html" . }}
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -28,20 +28,22 @@
                         <li class="mb-4"><a data-track="footer-aws" href="{{ relref . "/partner/aws" }}">AWS</a></li>
                         <li class="mb-4"><a data-track="footer-azure" href="{{ relref . "/partner/azure" }}">Azure</a></li>
                         <li class="mb-4"><a data-track="footer-gcp" href="{{ relref . "/partner/gcp" }}">Google Cloud</a></li>
-                    </ul>
-                    <ul class="my-4 text-white w-1/2 md:w-3/12">
                         <li class="mb-4"><a href="{{ relref . "/topics/containers" }}">Containers</a></li>
                         <li class="mb-4"><a href="{{ relref . "/topics/serverless" }}">Serverless</a></li>
                         <li class="mb-4"><a href="{{ relref . "/topics/kubernetes" }}">Kubernetes</a></li>
+                    </ul>
+                    <ul class="my-4 text-white w-1/2 md:w-3/12">
+                        <li class="mb-4"><a data-track="footer-events" href="{{ relref . "/events" }}">Upcoming Events</a></li>
+                        <li class="mb-4"><a data-track="footer-events" href="{{ relref . "/case-studies" }}">Case Studies</a></li>
+                        <li class="mb-4"><a data-track="footer-events" href="{{ relref . "/awards" }}">Awards &amp; Recognitions</a></li>
+                        <li class="mb-4"><a data-track="footer-brand" href="{{ relref . "/brand" }}">Brand Resources</a></li>
+                        <li class="mb-4"><a data-track="footer-security" href="{{ relref . "/security" }}">Security</a></li>
                     </ul>
                     <ul class="my-4 text-white w-1/2 md:w-3/12">
                         <li class="mb-4"><a data-track="footer-about-us" href="{{ relref . "/about" }}">About Us</a></li>
                         <li class="mb-4"><a data-track="footer-contact-us" href="{{ relref . "/contact" }}">Contact Us</a></li>
                         <li class="mb-4"><a data-track="footer-support" href="{{ relref . "/support" }}">Support</a></li>
                         <li class="mb-4"><a data-track="footer-careers" href="{{ relref . "/careers" }}">Careers</a></li>
-                        <li class="mb-4"><a data-track="footer-brand" href="{{ relref . "/brand" }}">Brand</a></li>
-                        <li class="mb-4"><a data-track="footer-security" href="{{ relref . "/security" }}">Security</a></li>
-                        <li class="mb-4"><a data-track="footer-events" href="{{ relref . "/events" }}">Upcoming Events</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #2418. Also shuffles the links in the footer a bit to make room for this one, and adds the `learnmore-contactus` partial to both the events and case-studies pages, just to give folks somewhere to go next.