### PR TITLE
Use definite assignment assertions with dynamic provider example

### DIFF
--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -2647,8 +2647,8 @@ class MyResourceProvider extends pulumi.dynamic.ResourceProvider {
 }
 
 export class MyResource extends pulumi.dynamic.Resource {
-    public readonly myStringOutput: pulumi.Output<string>;
-    public readonly myNumberOutput: pulumi.Output<number>;
+    public readonly myStringOutput!: pulumi.Output<string>;
+    public readonly myNumberOutput!: pulumi.Output<number>;
 
     constructor(name: string, props: MyResourceInputs, opts?: pulumi.CustomResourceOptions) {
         super(myprovider, name, { myStringOutput: undefined, myNumberOutput: undefined, ...props }, opts);


### PR DESCRIPTION
As of TypeScript 2.7, [strict property initialization](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#strict-class-initialization) is enabled by default (typically), which means TypeScript won't realize properties of dynamic resources will be initialized. We use a definite assignment assertion to relay to TypeScript that these will indeed be initialized.