### PR TITLE
Fix Python stack dependency example

### DIFF
--- a/content/docs/intro/concepts/organizing-stacks-projects.md
+++ b/content/docs/intro/concepts/organizing-stacks-projects.md
@@ -155,7 +155,7 @@ from pulumi_kubernetes import Provider, core
 
 env = get_stack()
 infra = StackReference(f"acmecorp/infra/{env}")
-provider = Provider("k8s", { "kubeconfig": infra.get_output("kubeConfig") })
+provider = Provider("k8s", kubeconfig=infra.get_output("kubeConfig"))
 service = core.v1.Service(..., ResourceOptions(provider=provider))
 ```
 


### PR DESCRIPTION
Fix the Python example for setting kubeconfig in the introduction to organizing stacks

https://github.com/pulumi/docs/issues/2012