### PR TITLE
update go aws getting started docs

### DIFF
--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -40,6 +40,7 @@ $ pulumi new aws-python
 <div class="language-prologue-go"></div>
 
 ```bash
+# from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new aws-go
 ```

--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -42,7 +42,7 @@ $ pulumi new aws-python
 ```bash
 # install the pulumi aws plugin
 # check for the release version here https://github.com/pulumi/pulumi-aws/releases
-$ pulumi plugin install resource aws 1.22.0 
+$ pulumi plugin install resource aws 1.22.0
 # from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new aws-go

--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -40,6 +40,9 @@ $ pulumi new aws-python
 <div class="language-prologue-go"></div>
 
 ```bash
+# install the pulumi aws plugin
+# check for the release version here https://github.com/pulumi/pulumi-aws/releases
+$ pulumi plugin install resource aws 1.22.0 
 # from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new aws-go

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -93,38 +93,38 @@ pulumi.export('bucket_name',  bucket.id)
 package main
 
 import (
-    "github.com/pulumi/pulumi-aws/sdk/go/aws/kms"
-    "github.com/pulumi/pulumi-aws/sdk/go/aws/s3"
-    "github.com/pulumi/pulumi/sdk/go/pulumi"
+	"github.com/pulumi/pulumi-aws/sdk/go/aws/kms"
+	"github.com/pulumi/pulumi-aws/sdk/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
 func main() {
-    pulumi.Run(func(ctx *pulumi.Context) error {
-        // Create a KMS Key for S3 server-side encryption
-        key, err := kms.NewKey(ctx, "my-key", nil)
-        if err != nil {
-            return err
-        }
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Create a KMS Key for S3 server-side encryption
+		key, err := kms.NewKey(ctx, "my-key", nil)
+		if err != nil {
+			return err
+		}
 
-        // Create an AWS resource (S3 Bucket)
-        bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
-            ServerSideEncryptionConfiguration: map[string]interface{}{
-                "rule": map[string]interface{}{
-                    "applyServerSideEncryptionByDefault": map[string]interface{}{
-                        "sseAlgorithm":   "aws:kms",
-                        "kmsMasterKeyId": key.ID(),
-                    },
-                },
-            },
-        })
-        if err != nil {
-            return err
-        }
+		// Create an AWS resource (S3 Bucket)
+		bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
+			ServerSideEncryptionConfiguration: s3.BucketServerSideEncryptionConfigurationArgs{
+				Rule: s3.BucketServerSideEncryptionConfigurationRuleArgs{
+					ApplyServerSideEncryptionByDefault: s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs{
+						SseAlgorithm:   pulumi.StringInput(pulumi.String("aws:kms")),
+						KmsMasterKeyId: key.ID(),
+					},
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
 
-        // Export the name of the bucket
-        ctx.Export("bucketName", bucket.ID())
-        return nil
-    })
+		// Export the name of the bucket
+		ctx.Export("bucketName", bucket.ID())
+		return nil
+	})
 }
 ```
 
@@ -171,10 +171,10 @@ class Program
 Our program now creates a KMS key and enables server-side encryption on the S3 bucket using the KMS key.
 
 {{% lang go %}}
-Recompile your project so the changes are picked up:
+We'll need to run `dep ensure` to pick up the new dependencies:
 
 ```bash
-$ go build $(basename $(pwd))
+$ dep ensure
 ```
 
 {{% /lang %}}

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -127,6 +127,7 @@ For Go, before we can deploy the stack, you will need to initialize your project
 ```bash
 $ dep ensure
 ```
+{{% /lang %}}
 
 Next, we'll deploy the stack.
 

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -122,20 +122,11 @@ $ pip3 install -r requirements.txt
 {{% /lang %}}
 
 {{% lang go %}}
-For Go, before we can deploy the stack, you will need to initialize your project's dependencies. Any dependency manager can be used, including Go's built-in module system:
+For Go, before we can deploy the stack, you will need to initialize your project's dependencies. Pulumi templates currently use `dep`:
 
 ```bash
-$ go mod init
+$ dep ensure
 ```
-
-Because Go is a compiled language, you also need to compile it:
-
-```bash
-$ go build $(basename $(pwd))
-```
-
-This instructs Go to create a binary whose name is the same as your directory. It needs to match your project name.
-{{% /lang %}}
 
 Next, we'll deploy the stack.
 

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -127,6 +127,7 @@ For Go, before we can deploy the stack, you will need to initialize your project
 ```bash
 $ dep ensure
 ```
+
 {{% /lang %}}
 
 Next, we'll deploy the stack.

--- a/layouts/shortcodes/install-go.html
+++ b/layouts/shortcodes/install-go.html
@@ -1,3 +1,4 @@
 <p class="mt-4">
-    Install <strong><a href="https://golang.org/doc/install" target="_blank">Go</a></strong>.
+    Install <strong><a href="https://golang.org/doc/install" target="_blank">Go</a></strong>. <br/>
+    Install <strong><a href="https://golang.github.io/dep/docs/installation.html" target="_blank">dep</a></strong>.
 </p>


### PR DESCRIPTION
Ran through the getting started and found some issues. With these changes, users should be able to successfully run through the getting started in go. Fixes:

1. Add installation of `dep` to the setup guide. Hopefully, this goes away if we can find a solution to https://github.com/pulumi/pulumi/issues/3817
2. Make sure we run `dep ensure` any time we add a new dependency. This really shouldn't be necessary and is a crappy user experience. During the 'modify program` step, if you don't run dep ensure after adding the KMS import you get an error: 
```
main.go:4:2: cannot find package "github.com/pulumi/pulumi-aws/sdk/go/aws/kms" in any of:
    	/Users/evanboyle/go/src/go_qs_2/vendor/github.com/pulumi/pulumi-aws/sdk/go/aws/kms (vendor tree)
    	/usr/local/Cellar/go/1.13.8/libexec/src/github.com/pulumi/pulumi-aws/sdk/go/aws/kms (from $GOROOT)
    	/Users/evanboyle/go/src/github.com/pulumi/pulumi-aws/sdk/go/aws/kms (from $GOPATH)
```
3. Remove any references to building artifacts. This is no longer necessary with the `go run` work in https://github.com/pulumi/pulumi/issues/3486
4. Fix the modify program code.
5. Add instructions for plugin installation

contributes to https://github.com/pulumi/docs/issues/2311