### PR TITLE
Tweak PurgeCSS to include some missing CSS selectors

### DIFF
--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -29,10 +29,10 @@ module.exports = {
                 // Look for CSS classes in our markdown content. We use `glob` explicitly here so we can ignore the
                 // files for the API docs in ./content/docs/reference/pkg/**/* because it includes a large number of
                 // files that significantly impacts build time (~25 seconds vs. many minutes). Instead, we'll only look
-                // for CSS classes in a single package (the Pulumi SDK package) for nodejs and python, which should
-                // include all classes used in the docs for any other package.
+                // for CSS classes in a subset of packages for NodeJS and Python, which should be representative of all
+                // the other packages.
                 ...require("glob").sync("./content/**/*.md", { ignore: "./content/docs/reference/pkg/**/*" }),
-                "./content/docs/reference/pkg/nodejs/pulumi/pulumi/**/*.md",
+                "./content/docs/reference/pkg/nodejs/pulumi/aws/**/*.md",
                 "./content/docs/reference/pkg/python/pulumi/**/*.md",
             ],
 


### PR DESCRIPTION
I noticed the CSS for styling a data source "symbol" was missing in the `@pulumi/aws` NodeJS API docs: https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/#data-sources-1

The reason it's missing is because we only look or classes in the `@pulumi/pulumi` package, and that package doesn't have any data sources. To fix, just swap looking at `@pulumi/aws` rather than `@pulumi/pulumi`.

## Before

<img width="714" alt="Screen Shot 2020-02-19 at 8 30 44 PM" src="https://user-images.githubusercontent.com/710598/74901159-cffd5380-5356-11ea-9ccd-a3ce18483adc.png">

## After

<img width="704" alt="Screen Shot 2020-02-19 at 8 30 52 PM" src="https://user-images.githubusercontent.com/710598/74901176-d5f33480-5356-11ea-920a-a9b4c83c7bd7.png">
