### PR TITLE
Add target selector to purgecss whitelist

### DIFF
--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -37,7 +37,7 @@ module.exports = {
             ],
 
             // Whitelist specific classes that were being removed.
-            whitelist: ["supported-cicd-platforms", ":not", "md:max-w-lg", "blink", "typing", "char"],
+            whitelist: ["supported-cicd-platforms", ":not", ":target", "md:max-w-lg", "blink", "typing", "char"],
 
             // Whitelist custom parent selectors and their children.
             whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/],


### PR DESCRIPTION
This PR fixes a regression from PurgeCSS where the CSS code that was preventing the navbar from overlapping with anchor links was being removed. This adds the `:target` selector to the whitelist.