### PR TITLE
~languages: add link to go page

### DIFF
--- a/content/docs/intro/languages/_index.md
+++ b/content/docs/intro/languages/_index.md
@@ -21,7 +21,7 @@ The following language runtimes are currently supported by Pulumi:
 * [Node.js]({{< relref "javascript" >}}) - JavaScript, TypeScript, or any other Node.js compatible language
 * [Python]({{< relref "python" >}}) - Python 3.6 or greater
 * [.NET Core]({{< relref "dotnet" >}}) <span class="badge badge-preview">PREVIEW</span> - C#, F#, and Visual Basic on .NET Core 3.1 or greater
-* Go <span class="badge badge-preview">PREVIEW</span> - statically compiled Go binaries (*documentation coming soon*)
+* [Go]({{< relref "go" >}}) <span class="badge badge-preview">PREVIEW</span> - statically compiled Go binaries (*documentation coming soon*)
 
 If your favorite language isn't listed, it may be on its way soon. Pulumi is [open
 source](https://github.com/pulumi/pulumi), and it is possible [to add your own


### PR DESCRIPTION
Adds link to the go language page like the other languages already had.