### PR TITLE
Only run autoprefixer, cssnano and purgecss for production builds

### DIFF
--- a/.github/workflows/pulumify.yml
+++ b/.github/workflows/pulumify.yml
@@ -11,6 +11,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-        PULUMIFY_BUILD: make ensure && hugo --minify --buildFuture -e $GITHUB_SHA
+        NODE_ENV: production
+        PULUMIFY_BUILD: NODE_ENV=production make ensure && NODE_ENV=production hugo --minify --buildFuture -e $GITHUB_SHA
         PULUMIFY_ROOT: public
         PULUMIFY_ORGANIZATION: pulumi

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ generate:
 build:
 	@echo -e "\033[0;32mBUILD ($(HUGO_ENVIRONMENT)):\033[0m"
 	yarn lint-markdown
-	hugo --minify
+	NODE_ENV=production hugo --minify
 	node ./scripts/build-search-index.js < ./public/docs/search-data/index.json > ./public/docs/search-index.json
 	rm -rf ./public/docs/search-data
 
@@ -62,7 +62,7 @@ travis_push::
 	$(MAKE) banner
 	$(MAKE) ensure
 ifeq ($(TRAVIS_BRANCH),master)
-	HUGO_ENVIRONMENT=production $(MAKE) build
+	$(MAKE) build
 	./scripts/run-pulumi.sh update production
 else
 	$(MAKE) build
@@ -73,7 +73,7 @@ travis_pull_request::
 	$(MAKE) banner
 	$(MAKE) ensure
 ifeq ($(TRAVIS_BRANCH),master)
-	HUGO_ENVIRONMENT=production $(MAKE) build
+	$(MAKE) build
 	./scripts/run-pulumi.sh preview production
 else
 	$(MAKE) build

--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -3,6 +3,11 @@
  * build process for our Sass files, since we run the resulting CSS through PostCSS
  * at the end to do more transformations.
  */
+
+// Note whether we're in "production" mode, so we can avoid doing post-processing and
+// optimization during development.
+const isProduction = process.env.NODE_ENV === "production";
+
 module.exports = {
     plugins: [
         // TailwindCSS
@@ -10,23 +15,37 @@ module.exports = {
 
         // Apply vendor prefixes for CSS features that aren't
         // fully supported yet.
-        require("autoprefixer")({
+        isProduction ? require("autoprefixer")({
             overrideBrowserslist: [
                 "last 2 versions"
             ]
-        }),
+        }) : null,
 
-        // PurgeCSS to remove unused classes for better page speed.
+        // Remove whitespace, comments and other safe things.
+        // https://cssnano.co/guides/getting-started/
+        isProduction ? require("cssnano")({
+            preset: [
+                "default",
+                {
+                    discardComments: {
+                        removeAll: true,
+                    },
+                },
+            ],
+        }) : null,
+
+        // Use PurgeCSS to remove unused classes for better page speed.
         // Docs: https://purgecss.com/plugins/postcss.html
-        require("@fullhuman/postcss-purgecss")({
+        isProduction ? require("@fullhuman/postcss-purgecss")({
             // Specify the paths to all of the template files in your project
             content: [
+                // All layout files.
                 "./layouts/**/*.html",
 
                 // Some of our scripts reference CSS classes.
                 "./assets/js/**/*.js",
 
-                // Look for CSS classes in our markdown content. We use `glob` explicitly here so we can ignore the
+                // Look for CSS classes in our Markdown content. We use `glob` explicitly here so we can ignore the
                 // files for the API docs in ./content/docs/reference/pkg/**/* because it includes a large number of
                 // files that significantly impacts build time (~25 seconds vs. many minutes). Instead, we'll only look
                 // for CSS classes in a subset of packages for NodeJS and Python, which should be representative of all
@@ -45,14 +64,9 @@ module.exports = {
 
             // We need to extract the Tailwind screen size selectors (e.g. sm, md, lg)
             // so that we do not strip them out. As long as a class name appears in the HTML
-            // in its entirety, Purgecss will not remove it.
+            // in its entirety, PurgeCSS will not remove it.
             // Ex. https://tailwindcss.com/docs/controlling-file-size/#writing-purgeable-html
             defaultExtractor: content => content.match(/[\w-/:]*[\w-/:]/g) || [],
-        }),
-
-        // Minify the CSS even further. (It works!)
-        require('cssnano')({
-            preset: 'default',
-        })
-    ]
+        }) : null,
+    ],
 };

--- a/package.json
+++ b/package.json
@@ -6,17 +6,15 @@
     "lint-links": "node ./scripts/link_linter.js"
   },
   "dependencies": {
-    "broken-link-checker": "^0.7.8",
-    "clipboard-polyfill": "^2.8.1",
-    "typedoc": "^0.15.3"
-  },
-  "devDependencies": {
     "@fullhuman/postcss-purgecss": "^2.0.6",
     "autoprefixer": "^9.6.0",
+    "broken-link-checker": "^0.7.8",
+    "clipboard-polyfill": "^2.8.1",
     "cssnano": "^4.1.10",
     "js-yaml": "^3.13.1",
     "markdownlint": "^0.17.2",
     "postcss-cli": "^6.1.3",
-    "tailwindcss": "^1.0.4"
+    "tailwindcss": "^1.0.4",
+    "typedoc": "^0.15.3"
   }
 }


### PR DESCRIPTION
This change limits the use of Autoprefixer, CSSNano and PurgeCSS to full/production builds only, to make the development loop (significantly!) quicker. 

Note that for the Pulumify action, we need to set NODE_ENV at the individual build-command level because [Pulumify excludes ambient environment variables](https://github.com/pulumi/actions-pulumify/blob/0781e889546d5cce5efcb3eec289894fb043e841/infra/pulumify#L82-L85). 