### PR TITLE
Set tab-size to four spaces for code sampes

### DIFF
--- a/assets/sass/_code.scss
+++ b/assets/sass/_code.scss
@@ -38,6 +38,10 @@ pre {
     .code-max-h & {
         @apply border-none my-0;
     }
+
+    // For code samples that contain tabs (e.g., Go), limit them to four spaces, to make
+    // better use of horizontal space.
+    tab-size: 4;
 }
 
 .code-max-h {


### PR DESCRIPTION
This change overrides the `tab-size` setting for code samples (from 8 spaces to 4) to make better use of horizontal real estate.