### PR TITLE
Add support for eventbrite registration modal

### DIFF
--- a/content/events/workshop-amsterdam-2020-03-30/index.md
+++ b/content/events/workshop-amsterdam-2020-03-30/index.md
@@ -25,8 +25,9 @@ event:
     time: "11:30AM - 4:00pm (CET)"
     # The event description shown on the event list page.
     description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
-    # The calendly registrtion url for event specific pages.
-    calendly_url: "https://calendly.com/pulumi/kubecon?month=2020-03"
+    # The eventbrite registrtion url for event specific pages.
+    eventbrite_url: "https://www.eventbrite.com/e/infrastructure-as-code-with-pulumi-tickets-95941386269"
+    eventbrite_id: "95941386269"
     # The cost of an event.
     cost: "€99"
 ---

--- a/content/events/workshop-amsterdam-2020-03-30/index.md
+++ b/content/events/workshop-amsterdam-2020-03-30/index.md
@@ -25,7 +25,7 @@ event:
     time: "11:30AM - 4:00pm (CET)"
     # The event description shown on the event list page.
     description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
-    # The eventbrite registrtion url for event specific pages.
+    # The Eventbrite registration URL for the event.
     eventbrite_url: "https://www.eventbrite.com/e/infrastructure-as-code-with-pulumi-tickets-95941386269"
     eventbrite_id: "95941386269"
     # The cost of an event.

--- a/content/events/workshop-redmond-2020-03-12/index.md
+++ b/content/events/workshop-redmond-2020-03-12/index.md
@@ -34,9 +34,9 @@ event:
 
 ### About the Workshop
 
-The hardest part of Kubernetes is setting up the infrastructure: clusters, DNS, firewalls, load balancers, IAM, storage, logging, and performance monitoring, often spanning private, public, and hybrid cloud architectures.
+The hardest part of taking your application to the cloud is configuring the infrastructure: clusters, DNS, firewalls, load balancers, IAM, storage, logging, and performance monitoring, often spanning private, public, and hybrid cloud architectures.
 
-In this workshop, the Pulumi team will show you how to tackle these challenges using Infrastructure as Code (IaC) through a series of hands-on labs. The techniques work for any cloud - Azure, AWS, and GCP. You'll be able to leverage your favorite languages including Python, Go, JavaScript, TypeScript, and C# instead of YAML or domain-specific languages.
+In this workshop, the Pulumi team will show you how to tackle these challenges using Infrastructure as Code (IaC) through a series of hands-on labs. We’ll demonstrate how easy it is to get started with IaC using C# and Azure, however, the techniques work for any cloud - Azure, AWS, and GCP. You’ll be able to leverage your favorite languages including Python, Go, JavaScript, TypeScript, and C# instead of YAML or domain-specific languages.
 
 After completing this workshop, you'll be up and running with IaC fundamentals, modern application architectures across many clouds, and Kubernetes best-practices that are ready for production environments. You'll also be ready to empower your development teams to be more productive - continuously deploying both their applications and infrastructure.
 

--- a/content/events/workshop-redmond-2020-03-12/index.md
+++ b/content/events/workshop-redmond-2020-03-12/index.md
@@ -1,6 +1,7 @@
 ---
 # Name of the event.
 title: "Infrastructure As Code Workshop | Redmond, WA"
+subtitle: "Azure Infrastructure as Code using C#"
 meta_desc: "Join Pulumi at our Infrastructure As Code Workshop in Redmond, WA and learn more about cloud programming, infrastructure as code, and many other topics."
 
 # The layout of the landing page.

--- a/content/events/workshop-san-francisco-2020-04-09/index.md
+++ b/content/events/workshop-san-francisco-2020-04-09/index.md
@@ -1,6 +1,7 @@
 ---
 # Name of the event.
 title: "Infrastructure As Code Workshop | San Francisco, CA"
+subtitle: "Azure Infrastructure as Code using C#"
 meta_desc: "Join Pulumi at our Infrastructure As Code Workshop in San Francisco, CA and learn more about cloud programming, infrastructure as code, and many other topics."
 
 # The layout of the landing page.

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -55,7 +55,7 @@
                             <button id="eventbrite-widget-modal-trigger-{{ .Params.event.eventbrite_id }}" type="button" class="btn bg-orange-500 border-2 border-orange-600 hover:bg-orange-600 hover:border-orange-600">Buy Tickets</button>
                             <noscript></a>Buy Tickets on Eventbrite</noscript>
                             <script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
-                            <script type="text/javascript">
+                            <script>
                                 if (window && window.EBWidgets && (typeof window.EBWidgets.createWidget === "function")) {
                                     window.EBWidgets.createWidget({
                                         widgetType: "checkout",

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -44,7 +44,7 @@
 
                             <!-- Calendly link widget begin -->
                             <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">
-                            <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>
+                            <script src="https://assets.calendly.com/assets/external/widget.js"></script>
                             <a href="#" class="btn bg-orange-500 border-2 border-orange-600 hover:bg-orange-600 hover:border-orange-600" onclick="Calendly.initPopupWidget({url: '{{ .Params.event.calendly_url }}&hide_event_type_details=1'});return false;">Register Now</a>
                             <!-- Calendly link widget end -->
 

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -63,7 +63,7 @@
                                         modal: true,
                                         modalTriggerElementId: "eventbrite-widget-modal-trigger-{{ .Params.event.eventbrite_id }}",
                                         onOrderComplete: function() {
-                                            window.location = "/confirmation/workshop/"
+                                            window.location = "{{ relref . "/confirmation/workshop" }}";
                                         }
                                     });
                                 }

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -65,7 +65,7 @@
                                     eventId: "{{ .Params.event.eventbrite_id }}",
                                     modal: true,
                                     modalTriggerElementId: "eventbrite-widget-modal-trigger-{{ .Params.event.eventbrite_id }}",
-                                    onOrderComplete: exampleCallback
+                                    onOrderComplete: goToThankYouPage
                                 });
                             </script>
 

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -40,11 +40,36 @@
                         <span>{{ .Params.event.cost }}</span>
                     </div>
                     <div class="my-8">
-                        <!-- Calendly link widget begin -->
-                        <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">
-                        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>
-                        <a href="#" class="btn bg-orange-500 border-2 border-orange-600 hover:bg-orange-600 hover:border-orange-600" onclick="Calendly.initPopupWidget({url: '{{ .Params.event.calendly_url }}&hide_event_type_details=1'});return false;">Register Now</a>
-                        <!-- Calendly link widget end -->
+                        {{ if .Params.event.calendly_url }}
+
+                            <!-- Calendly link widget begin -->
+                            <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">
+                            <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>
+                            <a href="#" class="btn bg-orange-500 border-2 border-orange-600 hover:bg-orange-600 hover:border-orange-600" onclick="Calendly.initPopupWidget({url: '{{ .Params.event.calendly_url }}&hide_event_type_details=1'});return false;">Register Now</a>
+                            <!-- Calendly link widget end -->
+
+                        {{ else if .Params.event.eventbrite_url }}
+
+                            <!-- Noscript content for added SEO -->
+                            <noscript><a href="{{ .Params.event.eventbrite_url }}" rel="noopener noreferrer" target="_blank"></noscript>
+                            <!-- You can customize this button any way you like -->
+                            <button id="eventbrite-widget-modal-trigger-{{ .Params.event.eventbrite_id }}" type="button" class="btn bg-orange-500 border-2 border-orange-600 hover:bg-orange-600 hover:border-orange-600">Buy Tickets</button>
+                            <noscript></a>Buy Tickets on Eventbrite</noscript>
+                            <script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
+                            <script type="text/javascript">
+                                var goToThankYouPage = function() {
+                                    window.location = "/confirmation/workshop/"
+                                };
+                                window.EBWidgets.createWidget({
+                                    widgetType: "checkout",
+                                    eventId: "{{ .Params.event.eventbrite_id }}",
+                                    modal: true,
+                                    modalTriggerElementId: "eventbrite-widget-modal-trigger-{{ .Params.event.eventbrite_id }}",
+                                    onOrderComplete: exampleCallback
+                                });
+                            </script>
+
+                        {{ end }}
                     </div>
                 </div>
                 {{ .Content }}

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -52,21 +52,21 @@
 
                             <!-- Noscript content for added SEO -->
                             <noscript><a href="{{ .Params.event.eventbrite_url }}" rel="noopener noreferrer" target="_blank"></noscript>
-                            <!-- You can customize this button any way you like -->
                             <button id="eventbrite-widget-modal-trigger-{{ .Params.event.eventbrite_id }}" type="button" class="btn bg-orange-500 border-2 border-orange-600 hover:bg-orange-600 hover:border-orange-600">Buy Tickets</button>
                             <noscript></a>Buy Tickets on Eventbrite</noscript>
                             <script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
                             <script type="text/javascript">
-                                var goToThankYouPage = function() {
-                                    window.location = "/confirmation/workshop/"
-                                };
-                                window.EBWidgets.createWidget({
-                                    widgetType: "checkout",
-                                    eventId: "{{ .Params.event.eventbrite_id }}",
-                                    modal: true,
-                                    modalTriggerElementId: "eventbrite-widget-modal-trigger-{{ .Params.event.eventbrite_id }}",
-                                    onOrderComplete: goToThankYouPage
-                                });
+                                if (window && window.EBWidgets && (typeof window.EBWidgets.createWidget === "function")) {
+                                    window.EBWidgets.createWidget({
+                                        widgetType: "checkout",
+                                        eventId: "{{ .Params.event.eventbrite_id }}",
+                                        modal: true,
+                                        modalTriggerElementId: "eventbrite-widget-modal-trigger-{{ .Params.event.eventbrite_id }}",
+                                        onOrderComplete: function() {
+                                            window.location = "/confirmation/workshop/"
+                                        }
+                                    });
+                                }
                             </script>
 
                         {{ end }}

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -3,7 +3,11 @@
         <div class="container mx-auto">
             <div class="mx-auto text-center">
                 <h1>{{ .Title }}</h1>
-                <p class="text-2xl">Infrastructure as code with Pulumi</p>
+                {{ if .Params.subtitle }}
+                    <p class="text-2xl">{{ .Params.subtitle }}</p>
+                {{ else }}
+                    <p class="text-2xl">Infrastructure as code with Pulumi</p>
+                {{ end }}
             </div>
         </div>
     </header>


### PR DESCRIPTION
@isaac-pulumi requested we move the Amsterdam workshop to register through Eventbrite instead of Calendly. This PR adds support for using an Eventbrite embedded modal for registration.

Unfortunately for the modal to show up on the site https needs to be enabled. If you use `ngrok` you can test this locally, otherwise, you will get redirected to an eventbrite page from the live preview.

https://jsonhilder.github.io/blog/ngrok-hugo/