### PR TITLE
Do not show old events on the event list

### DIFF
--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -19,7 +19,7 @@
                 <ul id="event-list" class="list-none md:flex md:flex-wrap pl-0">
                     {{ $events := (where $.Pages "Type" "events") }}
                     {{ range $index, $event := (sort $events ".Params.event.start_date") }}
-                        {{ if eq ((time .Params.event.end_date).After (now.AddDate 0 0 -1)) true}}
+                        {{ if (time .Params.event.end_date).After (now.AddDate 0 0 -1)}}
                             <li class="w-full m-0 p-0" data-event-type='{{ delimit .Params.event.type "," }}'>
                                 <article class="{{ if lt (add $index 1) (len $events) }} pb-16 mb-12 border-b border-gray-300 {{ end }}">
                                     <h3>

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -18,8 +18,7 @@
                 <h2 id="event-list-heading" class="mb-8">All Upcoming Events</h2>
                 <ul id="event-list" class="list-none md:flex md:flex-wrap pl-0">
                     {{ $events := (where $.Pages "Type" "events") }}
-                    {{ $currentEvents := (where $events "{{ (time .Params.event.start_date).After (now.AddDate 0 0 -1) }}" "ne" true ) }}
-                    {{ range $index, $event := (sort $currentEvents ".Params.event.start_date") }}
+                    {{ range $index, $event := (sort $events ".Params.event.start_date") }}
                         {{ if eq ((time .Params.event.end_date).After (now.AddDate 0 0 -1)) true}}
                             <li class="w-full m-0 p-0" data-event-type='{{ delimit .Params.event.type "," }}'>
                                 <article class="{{ if lt (add $index 1) (len $events) }} pb-16 mb-12 border-b border-gray-300 {{ end }}">

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -18,60 +18,63 @@
                 <h2 id="event-list-heading" class="mb-8">All Upcoming Events</h2>
                 <ul id="event-list" class="list-none md:flex md:flex-wrap pl-0">
                     {{ $events := (where $.Pages "Type" "events") }}
-                    {{ range $index, $event := (sort $events ".Params.event.start_date") }}
-                        <li class="w-full m-0 p-0" data-event-type='{{ delimit .Params.event.type "," }}'>
-                            <article class="{{ if lt (add $index 1) (len $events) }} pb-16 mb-12 border-b border-gray-300 {{ end }}">
-                                <h3>
-                                    {{ if .Params.url_slug }}
-                                        <a class="text-2xl" href="/events/{{ .Params.url_slug }}/">
-                                            {{ .Params.title }}
-                                        </a>
-                                    {{ else }}
-                                        <a class="text-2xl flex items-center" href="{{ .Params.event.registration_url }}" target="_blank">
-                                            {{ .Params.title }}
-                                            <i class="text-sm ml-2 fas fa-external-link-alt"></i>
-                                        </a>
-                                    {{ end }}
-                                </h3>
-                                <div>
-                                    <i class="text-gray-800 far fa-calendar inline-block"></i>
-                                    <span class="ml-1 text-sm uppercase">
-                                        {{ if eq .Params.event.start_date .Params.event.end_date }}
-                                            {{ dateFormat "Monday, Jan 2" .Params.event.start_date }}
+                    {{ $currentEvents := (where $events "{{ (time .Params.event.start_date).After (now.AddDate 0 0 -1) }}" "ne" true ) }}
+                    {{ range $index, $event := (sort $currentEvents ".Params.event.start_date") }}
+                        {{ if eq ((time .Params.event.start_date).After (now.AddDate 0 0 -1)) true}}
+                            <li class="w-full m-0 p-0" data-event-type='{{ delimit .Params.event.type "," }}'>
+                                <article class="{{ if lt (add $index 1) (len $events) }} pb-16 mb-12 border-b border-gray-300 {{ end }}">
+                                    <h3>
+                                        {{ if .Params.url_slug }}
+                                            <a class="text-2xl" href="/events/{{ .Params.url_slug }}/">
+                                                {{ .Params.title }}
+                                            </a>
                                         {{ else }}
-                                            {{ dateFormat "Monday, Jan 2" .Params.event.start_date }} - {{ dateFormat "Mon, Jan 2" .Params.event.end_date }}
+                                            <a class="text-2xl flex items-center" href="{{ .Params.event.registration_url }}" target="_blank">
+                                                {{ .Params.title }}
+                                                <i class="text-sm ml-2 fas fa-external-link-alt"></i>
+                                            </a>
                                         {{ end }}
-                                    </span>
-                                </div>
-                                <div>
-                                    <i class="text-gray-800 fas fa-map-marker-alt"></i>
-                                    <span class="ml-1 text-sm uppercase">
-                                        {{ .Params.event.location }}
-                                    </span>
-                                </div>
-                                <p class="my-4">
-                                    {{ .Params.event.description }}
-                                </p>
-                                <div class="flex mt-2">
-                                    <div class="w-full">
-                                        <div class="event-tags">
-                                            {{ if in .Params.event.type "workshop" }}
-                                                <span class="badge bg-orange-400 text-white">Workshop</span>
+                                    </h3>
+                                    <div>
+                                        <i class="text-gray-800 far fa-calendar inline-block"></i>
+                                        <span class="ml-1 text-sm uppercase">
+                                            {{ if eq .Params.event.start_date .Params.event.end_date }}
+                                                {{ dateFormat "Monday, Jan 2" .Params.event.start_date }}
+                                            {{ else }}
+                                                {{ dateFormat "Monday, Jan 2" .Params.event.start_date }} - {{ dateFormat "Mon, Jan 2" .Params.event.end_date }}
                                             {{ end }}
-                                            {{ if in .Params.event.type "talk" }}
-                                                <span class="badge bg-orange-400 text-white">Talk</span>
-                                            {{ end }}
-                                            {{ if in .Params.event.type "booth" }}
-                                                <span class="badge bg-orange-400 text-white">Booth</span>
-                                            {{ end }}
-                                            {{ if in .Params.event.type "meetup" }}
-                                                <span class="badge bg-orange-400 text-white">MeetUp</span>
-                                            {{ end }}
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <i class="text-gray-800 fas fa-map-marker-alt"></i>
+                                        <span class="ml-1 text-sm uppercase">
+                                            {{ .Params.event.location }}
+                                        </span>
+                                    </div>
+                                    <p class="my-4">
+                                        {{ .Params.event.description }}
+                                    </p>
+                                    <div class="flex mt-2">
+                                        <div class="w-full">
+                                            <div class="event-tags">
+                                                {{ if in .Params.event.type "workshop" }}
+                                                    <span class="badge bg-orange-400 text-white">Workshop</span>
+                                                {{ end }}
+                                                {{ if in .Params.event.type "talk" }}
+                                                    <span class="badge bg-orange-400 text-white">Talk</span>
+                                                {{ end }}
+                                                {{ if in .Params.event.type "booth" }}
+                                                    <span class="badge bg-orange-400 text-white">Booth</span>
+                                                {{ end }}
+                                                {{ if in .Params.event.type "meetup" }}
+                                                    <span class="badge bg-orange-400 text-white">MeetUp</span>
+                                                {{ end }}
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                            </article>
-                        </li>
+                                </article>
+                            </li>
+                        {{ end }}
                     {{ end }}
                 </ul>
             </div>

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -20,7 +20,7 @@
                     {{ $events := (where $.Pages "Type" "events") }}
                     {{ $currentEvents := (where $events "{{ (time .Params.event.start_date).After (now.AddDate 0 0 -1) }}" "ne" true ) }}
                     {{ range $index, $event := (sort $currentEvents ".Params.event.start_date") }}
-                        {{ if eq ((time .Params.event.start_date).After (now.AddDate 0 0 -1)) true}}
+                        {{ if eq ((time .Params.event.end_date).After (now.AddDate 0 0 -1)) true}}
                             <li class="w-full m-0 p-0" data-event-type='{{ delimit .Params.event.type "," }}'>
                                 <article class="{{ if lt (add $index 1) (len $events) }} pb-16 mb-12 border-b border-gray-300 {{ end }}">
                                     <h3>


### PR DESCRIPTION
This PR adds support for hiding old events from the event list. I also removed the old event pages. 

The best way to handle old events is for us to delete the pages after the event ends but this PR adds an `if...` statement to check if the event end date is after yesterday. If we check against `now` our events will be unlisted a day early. So I made the decision to check against the previous day to ensure the event will be listed through the entirety of the event duration.