### PR TITLE
Fix Hugo `REF_NOT_FOUND` errors

### DIFF
--- a/content/docs/intro/languages/dotnet.md
+++ b/content/docs/intro/languages/dotnet.md
@@ -167,7 +167,7 @@ $ mkdir myproject && cd myproject
 $ pulumi new csharp
 ```
 
-This will create a `Pulumi.yaml` [project file]({{< relref "project" >}}) containing some minimal metadata about your project (including a name and description which you may wish to change), an `Infra.csproj` file that holds references used by the project, and a `Program.cs` file, containing your program. The `.csproj` file can be named more appropriately depending upon the project. The name of the directory is used as the project name in `Pulumi.yaml`.
+This will create a `Pulumi.yaml` [project file]({{< relref "../concepts/project" >}}) containing some minimal metadata about your project (including a name and description which you may wish to change), an `Infra.csproj` file that holds references used by the project, and a `Program.cs` file, containing your program. The `.csproj` file can be named more appropriately depending upon the project. The name of the directory is used as the project name in `Pulumi.yaml`.
 
 To deploy your infrastructure run `pulumi up` and the Pulumi engine automatically runs `dotnet build` as part of the deployment. Pulumi will perform the operations needed to deploy the infrastructure you have declared.
 
@@ -186,7 +186,7 @@ $ mkdir myproject && cd myproject
 $ pulumi new fsharp
 ```
 
-This will create a `Pulumi.yaml` [project file]({{< relref "project" >}}) containing some minimal metadata about your project (including a name and description which you may wish to change), an `Infra.fsproj` file that holds references used by the project, and a `Program.fs` file, containing your program. The `.fsproj` file can be named more appropriately depending upon the project. The name of the directory is used as the project name in `Pulumi.yaml`.
+This will create a `Pulumi.yaml` [project file]({{< relref "../concepts/project" >}}) containing some minimal metadata about your project (including a name and description which you may wish to change), an `Infra.fsproj` file that holds references used by the project, and a `Program.fs` file, containing your program. The `.fsproj` file can be named more appropriately depending upon the project. The name of the directory is used as the project name in `Pulumi.yaml`.
 
 To deploy your infrastructure run `pulumi up` and the Pulumi engine automatically runs `dotnet build` as part of the deployment. Pulumi will perform the operations needed to deploy the infrastructure you have declared.
 
@@ -205,7 +205,7 @@ $ mkdir myproject && cd myproject
 $ pulumi new visualbasic
 ```
 
-This will create a `Pulumi.yaml` [project file]({{< relref "project" >}}) containing some minimal metadata about your project (including a name and description which you may wish to change), an `Infra.vbproj` file that holds references used by the project, and a `Program.vb` file, containing your program. The `.vbproj` file can be named more appropriately depending upon the project. The name of the directory is used as the project name in `Pulumi.yaml`.
+This will create a `Pulumi.yaml` [project file]({{< relref "../concepts/project" >}}) containing some minimal metadata about your project (including a name and description which you may wish to change), an `Infra.vbproj` file that holds references used by the project, and a `Program.vb` file, containing your program. The `.vbproj` file can be named more appropriately depending upon the project. The name of the directory is used as the project name in `Pulumi.yaml`.
 
 To deploy your infrastructure run `pulumi up` and the Pulumi engine automatically runs `dotnet build` as part of the deployment. Pulumi will perform the operations needed to deploy the infrastructure you have declared.
 

--- a/content/docs/intro/languages/go.md
+++ b/content/docs/intro/languages/go.md
@@ -43,7 +43,7 @@ $ mkdir myproject && cd myproject
 $ pulumi new go
 ```
 
-This will create a `Pulumi.yaml` [project file]({{< relref "project" >}}) containing some minimal metadata about your project (including a name and description which you may wish to change) and a `main.go` file containing your program. The name of the directory is used as the project name in `Pulumi.yaml`. Use your favorite Go dependency manager (such as Go's built-in modules system, by running `go mod init` in your project's directory).
+This will create a `Pulumi.yaml` [project file]({{< relref "../concepts/project" >}}) containing some minimal metadata about your project (including a name and description which you may wish to change) and a `main.go` file containing your program. The name of the directory is used as the project name in `Pulumi.yaml`. Use your favorite Go dependency manager (such as Go's built-in modules system, by running `go mod init` in your project's directory).
 
 To deploy your infrastructure, first build your Go program: `go build -o $(basename $(pwd))`. Then run `pulumi up` and Pulumi will perform the operations needed to deploy the infrastructure you have declared.
 

--- a/content/docs/intro/languages/javascript.md
+++ b/content/docs/intro/languages/javascript.md
@@ -29,7 +29,7 @@ $ mkdir myproject && cd myproject
 $ pulumi new javascript
 ```
 
-This will create a `Pulumi.yaml` [project file]({{< relref "project" >}}), a `package.json` file for dependencies, and an `index.js` file, containing your program. The name of the directory is used as the project name in `Pulumi.yaml`.
+This will create a `Pulumi.yaml` [project file]({{< relref "../concepts/project" >}}), a `package.json` file for dependencies, and an `index.js` file, containing your program. The name of the directory is used as the project name in `Pulumi.yaml`.
 
 ## TypeScript
 


### PR DESCRIPTION
We have a few relref links to "project", which currently work, but when running the prototype API doc gen for AWS, it's generating project.md files elsewhere in the site which causes Hugo to start failing for these links with `REF_NOT_FOUND: Ref "project"`. This fixes these refs to point to the right location so that they're no longer ambiguous.

```
ERROR 2020/02/24 15:12:09 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/dotnet.md:1:1": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:09 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/dotnet.md:1:1": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:09 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/dotnet.md:1:1": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:14 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/go.md:46:49": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:15 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/javascript.md:32:49": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:32 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/dotnet.md:1:1": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:32 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/dotnet.md:1:1": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:32 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/dotnet.md:1:1": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:35 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/go.md:46:49": failed to resolve ref: page reference "project" is ambiguous
ERROR 2020/02/24 15:12:35 [en] REF_NOT_FOUND: Ref "project": "/Users/justin/go/src/github.com/pulumi/docs/content/docs/intro/languages/javascript.md:32:49": failed to resolve ref: page reference "project" is ambiguous
```