### PR TITLE
Add event page for 2.0 launch party

### DIFF
--- a/content/events/launch-v2-seattle-2020-04-15/index.md
+++ b/content/events/launch-v2-seattle-2020-04-15/index.md
@@ -34,13 +34,12 @@ event:
 
 ## About the Event
 
-We are very excited to deliver this release to our customers and community and want to invited everyone to come celebrate with us! Meet new Infrastructure as Code enthusiasts and enjoy some drinks and snacks on us.
+The Pulumi team is excited to announce our version 2.0 release for our customers and community and want you to celebrate with us! Meet other DevOps enthusiasts, learn about all of our new features and enjoy some drinks and snacks on us.
 
-Our 2.0 release aligns with two general themes:
+### What’s new in Pulumi 2.0?
 
-* **Best in class productivity**. Pulumi’s foundation of general-purpose languages has already enabled great productivity gains thanks to ecosystems of tools, sharing and reuse, and familiarity. But we have ideas for more. This includes more languages, features that bring deployments closer to the inner development loop like watch mode, more libraries of off-the-shelf patterns and practices, and the ability to test your infrastructure more easily.
-
-* **Belts and suspenders for teams and enterprises**. As we work with more teams and enterprises to deliver demanding many-cloud workloads to public, private, and hybrid clouds — increasingly involving Kubernetes, and often spanning developers and operations teams — we have heard about many features that would maximize Pulumi’s effectiveness and utility. This includes advanced security and compliance capabilities, more organization-wide controls and policies, and more flexible self- and on-premises hosting of the Pulumi service.
+Pulumi 2.0 gives you infrastructure superpowers! This includes best-in-class productivity — now with support for both .NET and Go, multi-language libraries, and testing support.  We're also introducing our new policy as code framework, CrossGuard, which enables you to enforce security rules, compliance guidelines, and cost controls by writing policies in your favorite language.
+You don't have to wait to enjoy many of the new features!  We've already added strong typing to our Python and Go SDKs and made significant improvements to the .NET SDK. Many of you will also notice improved performance of common tasks.
 
 ## Speakers
 

--- a/content/events/launch-v2-seattle-2020-04-15/index.md
+++ b/content/events/launch-v2-seattle-2020-04-15/index.md
@@ -12,7 +12,7 @@ url_slug: "launch-v2-seattle-2020-04-15"
 # Event information
 event:
     # The type of activities we will be doing at the event.
-    type: ["workshop"]
+    type: ["meetup"]
     # The event address
     location: "1810 6th Ave, Seattle, WA 98101"
     # The start date of an event. Format YYYY-MM-DD

--- a/content/events/launch-v2-seattle-2020-04-15/index.md
+++ b/content/events/launch-v2-seattle-2020-04-15/index.md
@@ -1,7 +1,8 @@
 ---
 # Name of the event.
-title: "2.0 Launch Party!"
-meta_desc:  "Join us in celebration of our 2.0 launch! Meet new Infrastructure as Code enthusiasts and enjoy some drinks and snacks on us."
+title: "Pulumi 2.0 Launch Party"
+subtitle: "Join us for tech talks, snacks and drinks in Seattle"
+meta_desc: "Join us in celebration of our 2.0 launch! Meet new Infrastructure as Code enthusiasts and enjoy some drinks and snacks on us."
 
 # The layout of the landing page.
 type: events
@@ -24,7 +25,7 @@ event:
     # This is only displayed on event specific pages.
     time: "5:00PM - 8:00PM (PT)"
     # The event description shown on the event list page.
-    description: "Join the Pulumi community as we celebrate the launch of our 2.0 release. Come enjoy food, drinks, and good company as we discuss selected achievements and features in our newest release."
+    description: "Come help us celebrate the launch of Pulumi 2.0 at The Blind Tiger Speakeasy on April 15.  You’ll get to hear from current Pulumi users, partners and staff while enjoying snacks and drinks on us."
     # The Calendly registrtion url for event specific pages.
     calendly_url: "https://calendly.com/pulumi/v2launch?month=2020-04"
     # The cost of an event.

--- a/content/events/launch-v2-seattle-2020-04-15/index.md
+++ b/content/events/launch-v2-seattle-2020-04-15/index.md
@@ -1,0 +1,36 @@
+---
+# Name of the event.
+title: "2.0 Launch Party!"
+meta_desc:  "Join us in celebration of our 2.0 launch! Meet new Infrastructure as Code enthusiasts and enjoy some drinks and snacks on us."
+
+# The layout of the landing page.
+type: events
+
+# The url slug for the even landing page.
+url_slug: "launch-v2-seattle-2020-04-15"
+
+# Event information
+event:
+    # The type of activities we will be doing at the event.
+    type: ["workshop"]
+    # The event address
+    location: "1810 6th Ave, Seattle, WA 98101"
+    # The start date of an event. Format YYYY-MM-DD
+    start_date: "2020-04-15"
+    # The end date of an event. Format YYYY-MM-DD
+    end_date: "2020-04-15"
+    # The start and end time of an event with the time zone.
+    # i.e. 5:30PM - 8:30PM (PT)
+    # This is only displayed on event specific pages.
+    time: "5:00PM - 8:00PM (PT)"
+    # The event description shown on the event list page.
+    description: "Join the Pulumi community as we celebrate the launch of our 2.0 release. Come enjoy food, drinks, and good company as we discuss selected achievements and features in our newest release."
+    # The Calendly registrtion url for event specific pages.
+    calendly_url: "https://calendly.com/pulumi/v2launch?month=2020-04"
+    # The cost of an event.
+    cost: "Free"
+---
+
+## Details
+
+Join us in celebration of our 1.0 launch! Meet new Infrastructure as Code enthusiasts and enjoy some drinks and snacks on us.

--- a/content/events/launch-v2-seattle-2020-04-15/index.md
+++ b/content/events/launch-v2-seattle-2020-04-15/index.md
@@ -38,7 +38,7 @@ The Pulumi team is excited to announce our version 2.0 release for our customers
 
 ### What’s new in Pulumi 2.0?
 
-Pulumi 2.0 gives you infrastructure superpowers! This includes best-in-class productivity — now with support for both .NET and Go, multi-language libraries, and testing support.  We're also introducing our new policy as code framework, CrossGuard, which enables you to enforce security rules, compliance guidelines, and cost controls by writing policies in your favorite language.
+Pulumi 2.0 gives you infrastructure superpowers! This includes best-in-class productivity — now with support for both .NET and Go, multi-language libraries, and testing support.  We're also introducing our new policy-as-code framework, CrossGuard, which enables you to enforce security rules, compliance guidelines, and cost controls by writing policies in your language of choice.
 You don't have to wait to enjoy many of the new features!  We've already added strong typing to our Python and Go SDKs and made significant improvements to the .NET SDK. Many of you will also notice improved performance of common tasks.
 
 ## Speakers

--- a/content/events/launch-v2-seattle-2020-04-15/index.md
+++ b/content/events/launch-v2-seattle-2020-04-15/index.md
@@ -1,7 +1,7 @@
 ---
 # Name of the event.
 title: "Pulumi 2.0 Launch Party"
-subtitle: "Join us for tech talks, snacks and drinks in Seattle"
+subtitle: "Join us for tech talks, snacks, and drinks in Seattle"
 meta_desc: "Join us in celebration of our 2.0 launch! Meet new Infrastructure as Code enthusiasts and enjoy some drinks and snacks on us."
 
 # The layout of the landing page.
@@ -32,6 +32,18 @@ event:
     cost: "Free"
 ---
 
-## Details
+## About the Event
 
-Join us in celebration of our 1.0 launch! Meet new Infrastructure as Code enthusiasts and enjoy some drinks and snacks on us.
+We are very excited to deliver this release to our customers and community and want to invited everyone to come celebrate with us! Meet new Infrastructure as Code enthusiasts and enjoy some drinks and snacks on us.
+
+Our 2.0 release aligns with two general themes:
+
+* **Best in class productivity**. Pulumi’s foundation of general-purpose languages has already enabled great productivity gains thanks to ecosystems of tools, sharing and reuse, and familiarity. But we have ideas for more. This includes more languages, features that bring deployments closer to the inner development loop like watch mode, more libraries of off-the-shelf patterns and practices, and the ability to test your infrastructure more easily.
+
+* **Belts and suspenders for teams and enterprises**. As we work with more teams and enterprises to deliver demanding many-cloud workloads to public, private, and hybrid clouds — increasingly involving Kubernetes, and often spanning developers and operations teams — we have heard about many features that would maximize Pulumi’s effectiveness and utility. This includes advanced security and compliance capabilities, more organization-wide controls and policies, and more flexible self- and on-premises hosting of the Pulumi service.
+
+## Speakers
+
+Speakers to be announced at a later date.
+
+**Food and drinks provided**.


### PR DESCRIPTION
This PR adds a landing page for the 2.0 event. Speakers are currently TBD (I believe) so I added an abstract that describes the two themes outlined in "2.0 Roadmap" blog post. Open to any suggestions for placeholder text in the abstract until we nail down the speakers and agenda for the event.