### PR TITLE
Add option to hide JavaScript from langchooser

### DIFF
--- a/layouts/shortcodes/langchoose.html
+++ b/layouts/shortcodes/langchoose.html
@@ -12,6 +12,8 @@
 {{ range .Params }}
     {{ if eq . "nopreview" }}
         {{ $nopreview = true }}
+    {{ else if eq . "nojavascript" }}
+        {{ $javascript = false }}
     {{ else if eq . "nogo" }}
         {{ $go = false }}
     {{ else if eq . "nodeonly" }}


### PR DESCRIPTION
For the initial resource model docs, I wanted to emit a lang chooser for the examples that just had TypeScript and Python. This adds a `nojavascript` option that enables this.

Note: The way these options are specified to the langchooser is janky and definitely could use some cleaning up. They've sort of grown organically as we've needed to show/hide various languages, have various languages displayed by default, etc. Would love to clean this all up, but that's a larger effort that would involve changing many pages, and the existing API docs generation, so will save that for a future improvement.