### PR TITLE
Allow for wider docs layouts for screens that can use it

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -211,4 +211,13 @@ main {
     }
 }
 
+.container {
+    // Allow wider containers for screens that have room for them.
+    &.container-wide {
+        @media (min-width: 1600px) {
+            max-width: 1600px;
+        }
+    }
+}
+
 @tailwind utilities;

--- a/layouts/docs/aws-list.html
+++ b/layouts/docs/aws-list.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8">
+    <div class="container container-wide mx-auto px-4 py-8 mt-2">
         <div class="md:flex">
 
-            <div class="md:w-2/12 pl-8 mt-2 md:order-last">
+            <div class="md:w-3/12 pl-8 mt-2 md:order-last">
                 <div class="mb-8 md:mb-4">
                     {{ partial "docs/search.html" . }}
                 </div>
@@ -20,7 +20,7 @@
                 {{ partial "docs/toc.html" . }}
             </div>
 
-            <div class="md:w-7/12">
+            <div class="md:w-6/12">
                 <h1>{{ .Title }}</h1>
 
                 <p>

--- a/layouts/docs/aws-single.html
+++ b/layouts/docs/aws-single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8">
+    <div class="container mx-auto px-4 lg:px-0 py-8 mt-2">
         <div class="md:flex">
 
             <div class="md:w-2/12 pl-8 mt-2 md:order-last">

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8 mt-2">
+    <div class="container container-wide mx-auto px-4 py-8 mt-2">
         <div class="md:flex">
 
-            <div class="md:w-7/12">
+            <div class="md:w-6/12 md:px-4">
                 {{ partial "docs/breadcrumb.html" . }}
 
                 {{ if and (.Params.h1) (not .Params.notitle) }}
@@ -14,7 +14,7 @@
                 {{ .Content }}
             </div>
 
-            <div class="md:w-2/12 md:pl-8 mt-2">
+            <div class="md:w-3/12 md:pl-8">
                 <div class="sticky-sidebar">
                     <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
                         {{ partial "docs/search.html" . }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8 mt-2">
+    <div class="container container-wide mx-auto px-4 lg:px-0 py-8 mt-2">
         <div class="md:flex">
 
-            <div class="md:w-7/12">
+            <div class="md:w-6/12">
                 {{ partial "docs/breadcrumb.html" . }}
 
                 {{ if and (.Params.h1) (not .Params.notitle) }}
@@ -14,7 +14,7 @@
                 {{ .Content }}
             </div>
 
-            <div class="md:w-2/12 md:pl-8 mt-2">
+            <div class="md:w-3/12 md:pl-8 mt-2">
                 <div class="sticky-sidebar">
                     <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
                         {{ partial "docs/search.html" . }}


### PR DESCRIPTION
This change allows for more use of horizontal real estate in the Docs section, for screens that can support it. (Specifically, if you're on a screen that's wider than 1600px, the main-content container will max out at 1600px, which adds some breathing room, but still keeps the center column at a readable width -- albeit probably at the upper edge of it.) 

![](http://cnunciato-dropshare.s3.amazonaws.com/Screen-Recording-2020-02-27-12-00-16.gif)
