### PR TITLE
Add Google Next to events page

### DIFF
--- a/content/events/google-next-san-francisco-2020-04-06/index.md
+++ b/content/events/google-next-san-francisco-2020-04-06/index.md
@@ -1,0 +1,24 @@
+---
+# Name of the event.
+title: "Google Next"
+
+# Events with external registrations should not be indexed
+# and have redirect to the external registration page.
+block_from_external_search: true
+redirect_to: "https://cloud.withgoogle.com/next/sf/"
+
+# Event information
+event:
+    # The type of activities we will be doing at the event.
+    type: ["booth"]
+    # The event address
+    location: "747 Howard St, San Francisco, CA 94103"
+    # The start date of an event. Format YYYY-MM-DD
+    start_date: "2020-04-06"
+    # The end date of an event. Format YYYY-MM-DD
+    end_date: "2020-04-08"
+    # The event description shown on the event list page.
+    description: "You're invited to gather alongside the brightest minds in tech for 3 days of collaboration, innovation, and networking. Experience the energy of Google Cloud Next with IT professionals, developers, executives, and Google experts."
+    # The external registration url for the event list page.
+    registration_url: "https://cloud.withgoogle.com/next/sf/"
+---


### PR DESCRIPTION
As the title states, this PR adds Google Next to our events page.