### PR TITLE
Switch London registration to eventbrite

### DIFF
--- a/content/events/workshop-london-2020-09-23/index.md
+++ b/content/events/workshop-london-2020-09-23/index.md
@@ -27,7 +27,8 @@ event:
     # The event description shown on the event list page.
     description: "Join us as we walkthrough Infrastructure as Code concepts via a series of hands-on labs. Topics covered include IaC fundamentals, in addition to application architectures and how to use IaC to create, update, and manage them."
     # The Calendly registrtion url for event specific pages.
-    calendly_url: "https://calendly.com/pulumi/london?month=2020-09"
+    eventbrite_url: "https://www.eventbrite.com/e/infrastructure-as-code-with-pulumi-tickets-97322563407"
+    eventbrite_id: "97322563407"
     # The cost of an event.
     cost: "Free"
 ---


### PR DESCRIPTION
This PR switches the London Workshop to use Eventbrite as the registration provider.