### PR TITLE
Added Go example for transformations

### DIFF
--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -1013,7 +1013,7 @@ var vpc = new MyVpcComponent("vpc", new ResourceOptions
 });
 ```
 
-Transformations can also be applied in bulk to many resources in a stack by using the `pulumi.runtime.registerStackTransformation` or `ctx.RegisterStackTransformation` function.
+Transformations can also be applied in bulk to many resources in a stack by using the `registerStackTransformation` function.
 
 ##### Resource Getter Functions {#resource-get}
 

--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -975,9 +975,17 @@ vpc = MyVpcComponent("vpc", opts=ResourceOptions(transformations=[transformation
 ```
 
 ```go
-// Transformations are not yet supported in Go.
-//
-// See https://github.com/pulumi/pulumi/issues/1614.
+transformation := func(args *pulumi.ResourceTransformationArgs) *pulumi.ResourceTransformationResult {
+    if args.Type == "aws:ec2/vpc:Vpc" || args.Type == "aws:ec2/subnet:Subnet" {
+        return &pulumi.ResourceTransformationResult{
+            Props: args.Props,
+            Opts:  append(args.Opts, pulumi.IgnoreChanges([]string{"tags"}))
+        }
+    }
+    return nil
+}
+
+vpc := MyVpcComponent("vpc", pulumi.Transformations([]pulumi.ResourceTransformation{transformation}))
 ```
 
 ```csharp
@@ -1005,7 +1013,7 @@ var vpc = new MyVpcComponent("vpc", new ResourceOptions
 });
 ```
 
-Transformations can also be applied in bulk to many resources in a stack by using the `pulumi.runtime.registerStackTransformation` function.
+Transformations can also be applied in bulk to many resources in a stack by using the `pulumi.runtime.registerStackTransformation` or `ctx.RegisterStackTransformation` function.
 
 ##### Resource Getter Functions {#resource-get}
 


### PR DESCRIPTION
Added an example for Go transformations. 

I wasn't sure how best to express the `pulumi.runtime.registerStackTransformation` equivalent for Go, so I tacked it onto the end of the paragraph. Another option would be to add `...then applies the same transformation to all future resources in the stack:` to the previous paragraph and include each language's `registerStackTransformation` with its example.