### PR TITLE
Fix Python `.all` example

### DIFF
--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -1625,7 +1625,7 @@ let url: Output<string> = pulumi.all([hostname, port]).
 ```
 
 ```python
-url = Output.all([hostname, port]).apply(lambda l: f"http://{l[0]}:{l[1]}/")
+url = Output.all(hostname, port).apply(lambda l: f"http://{l[0]}:{l[1]}/")
 ```
 
 ```go


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

The `.all` example in ["Working with Outputs and Strings"](https://www.pulumi.com/docs/intro/concepts/programming-model/#outputs-and-strings) is broken.

The [Python function](https://github.com/pulumi/pulumi/blob/d9acfc3190fc911c7b68498dd1a7399075f3de90/sdk/python/lib/pulumi/output.py#L303) takes `*args`, which doesn't work when you pass in an array directly.

(the other example on the page is correct).