### PR TITLE
Removed canceled events

### DIFF
--- a/archetypes/event/index.md
+++ b/archetypes/event/index.md
@@ -2,6 +2,9 @@
 # Name of the event.
 title: "Name of the Event"
 
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
 # Events with external registrations should not be indexed
 # and have redirect to the external registration page.
 block_from_external_search: true

--- a/archetypes/workshop/index.md
+++ b/archetypes/workshop/index.md
@@ -3,6 +3,9 @@
 title: "Name of the Event"
 meta_desc: "Search Description"
 
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
 # The layout of the landing page.
 type: events
 

--- a/content/events/conference-kubecon-eu-2020-03-31/index.md
+++ b/content/events/conference-kubecon-eu-2020-03-31/index.md
@@ -2,6 +2,9 @@
 # Name of the event.
 title: "KubeCon EU"
 
+# Events with unlisted as true will not be shown on the event list
+unlisted: true
+
 # Events with external registrations should not be indexed
 # and have redirect to the external registration page.
 block_from_external_search: true

--- a/content/events/workshop-amsterdam-2020-03-30/index.md
+++ b/content/events/workshop-amsterdam-2020-03-30/index.md
@@ -3,6 +3,9 @@
 title: "KubeCon EU Pre-day Workshop"
 meta_desc: "Join Pulumi at our Infrastructure As Code Workshop at KubeCon EU and learn more about cloud programming, infrastructure as code, and many other topics."
 
+# Events with unlisted as true will not be shown on the event list
+unlisted: true
+
 # The layout of the landing page.
 type: events
 

--- a/content/events/workshop-redmond-2020-03-12/index.md
+++ b/content/events/workshop-redmond-2020-03-12/index.md
@@ -4,6 +4,9 @@ title: "Infrastructure As Code Workshop | Redmond, WA"
 subtitle: "Azure Infrastructure as Code using C#"
 meta_desc: "Join Pulumi at our Infrastructure As Code Workshop in Redmond, WA and learn more about cloud programming, infrastructure as code, and many other topics."
 
+# Events with unlisted as true will not be shown on the event list
+unlisted: true
+
 # The layout of the landing page.
 type: events
 

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -19,7 +19,7 @@
                 <ul id="event-list" class="list-none md:flex md:flex-wrap pl-0">
                     {{ $events := (where $.Pages "Type" "events") }}
                     {{ range $index, $event := (sort $events ".Params.event.start_date") }}
-                        {{ if (time .Params.event.end_date).After (now.AddDate 0 0 -1)}}
+                        {{ if and ((time .Params.event.end_date).After (now.AddDate 0 0 -1)) (ne .Params.unlisted true)}}
                             <li class="w-full m-0 p-0" data-event-type='{{ delimit .Params.event.type "," }}'>
                                 <article class="{{ if lt (add $index 1) (len $events) }} pb-16 mb-12 border-b border-gray-300 {{ end }}">
                                     <h3>


### PR DESCRIPTION
This PR adds an `unlisted` flag to events. This is so we can hide events that have been canceled.