### PR TITLE
Unscramble the cloud providers ToC

### DIFF
--- a/content/docs/intro/cloud-providers/aiven/_index.md
+++ b/content/docs/intro/cloud-providers/aiven/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-aiven
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/aiven.svg" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/alicloud/_index.md
+++ b/content/docs/intro/cloud-providers/alicloud/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-alicloud
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/alicloud.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/azure/_index.md
+++ b/content/docs/intro/cloud-providers/azure/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-azure
-    weight: 2
+    weight: 1
 
 aliases: ["/docs/reference/clouds/azure/"]
 ---

--- a/content/docs/intro/cloud-providers/cloudamqp/_index.md
+++ b/content/docs/intro/cloud-providers/cloudamqp/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-cloudamqp
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/cloudamqp.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/cloudflare/_index.md
+++ b/content/docs/intro/cloud-providers/cloudflare/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-cloudflare
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/cloudflare.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/consul/_index.md
+++ b/content/docs/intro/cloud-providers/consul/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-consul
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/consul.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/datadog/_index.md
+++ b/content/docs/intro/cloud-providers/datadog/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-datadog
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/datadog.svg" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/digitalocean/_index.md
+++ b/content/docs/intro/cloud-providers/digitalocean/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-digitalocean
-    weight: 5
+    weight: 2
 
 aliases: ["/docs/reference/clouds/digitalocean/"]
 ---

--- a/content/docs/intro/cloud-providers/dnsimple/_index.md
+++ b/content/docs/intro/cloud-providers/dnsimple/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-dnsimple
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/dnsimple.svg" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/docker/_index.md
+++ b/content/docs/intro/cloud-providers/docker/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-docker
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/docker.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/f5bigip/_index.md
+++ b/content/docs/intro/cloud-providers/f5bigip/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-f5bigip
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/f5bigip.svg" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/fastly/_index.md
+++ b/content/docs/intro/cloud-providers/fastly/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-fastly
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/fastly.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/gcp/_index.md
+++ b/content/docs/intro/cloud-providers/gcp/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-gcp
-    weight: 3
+    weight: 1
 
 aliases: ["/docs/reference/clouds/gcp/"]
 ---

--- a/content/docs/intro/cloud-providers/gitlab/_index.md
+++ b/content/docs/intro/cloud-providers/gitlab/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-gitlab
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/gitlab.svg" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/kafka/_index.md
+++ b/content/docs/intro/cloud-providers/kafka/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-kafka
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/kafka.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/kubernetes/_index.md
+++ b/content/docs/intro/cloud-providers/kubernetes/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-kubernetes
-    weight: 4
+    weight: 1
 
 aliases: ["/docs/reference/clouds/kubernetes/"]
 ---

--- a/content/docs/intro/cloud-providers/mailgun/_index.md
+++ b/content/docs/intro/cloud-providers/mailgun/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-mailgun
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/mailgun.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/mysql/_index.md
+++ b/content/docs/intro/cloud-providers/mysql/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-mysql
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/mysql.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/newrelic/_index.md
+++ b/content/docs/intro/cloud-providers/newrelic/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-newrelic
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/newrelic.svg" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/okta/_index.md
+++ b/content/docs/intro/cloud-providers/okta/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-okta
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/okta.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/openstack/_index.md
+++ b/content/docs/intro/cloud-providers/openstack/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-openstack
-    weight: 5
+    weight: 2
 
 aliases: ["/docs/reference/clouds/openstack/"]
 ---

--- a/content/docs/intro/cloud-providers/postgresql/_index.md
+++ b/content/docs/intro/cloud-providers/postgresql/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-postgresql
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/postgresql.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/rabbitmq/_index.md
+++ b/content/docs/intro/cloud-providers/rabbitmq/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-rabbitmq
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/rabbitmq.svg" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/rancher2/_index.md
+++ b/content/docs/intro/cloud-providers/rancher2/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-rancher2
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/rancher.svg" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/random/_index.md
+++ b/content/docs/intro/cloud-providers/random/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-random
-    weight: 5
+    weight: 2
 ---
 
 The Random provider for Pulumi can be used to help introduce random values when dealing with Pulumi resources.

--- a/content/docs/intro/cloud-providers/signalfx/_index.md
+++ b/content/docs/intro/cloud-providers/signalfx/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-signalfx
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/signalfx.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/spotinst/_index.md
+++ b/content/docs/intro/cloud-providers/spotinst/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-spotinst
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/spotinst.png" align="right" class="h-16 px-8 pb-4">

--- a/content/docs/intro/cloud-providers/tls/_index.md
+++ b/content/docs/intro/cloud-providers/tls/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-tls
-    weight: 5
+    weight: 2
 ---
 
 The TLS provider for Pulumi can be used to help to create TLS keys and certitifcate for use with Pulumi resources.

--- a/content/docs/intro/cloud-providers/vault/_index.md
+++ b/content/docs/intro/cloud-providers/vault/_index.md
@@ -5,7 +5,7 @@ menu:
   intro:
     parent: cloud-providers
     identifier: clouds-vault
-    weight: 5
+    weight: 2
 ---
 
 <img src="/logos/tech/vault.png" align="right" class="h-16 px-8 pb-4">


### PR DESCRIPTION
I noticed that the ordering on the left-hand navigation for the
cloud providers section got scrambled at some point. I suspect we
just weren't watching the "weight" specifiers closely as we added
some of them (if it is intentional, it wasn't apparent to me).

I've changed this to have two clumps of cloud providers:

* First, the "primary four" -- AWS, Azure, GCP, and Kubernetes --
  that sorts at the very top (in alphabetical order).

* Second, the rest.

I gave them the same weights and let the ToC rendering logic
alphabetize rather than needing to maintain them by hand, which
would get quite tedious.