### PR TITLE
Update intro paragraph to not include references to provision concurr…

### DIFF
--- a/content/blog/aws-lambda-provisioned-concurrency-no-cold-starts/index.md
+++ b/content/blog/aws-lambda-provisioned-concurrency-no-cold-starts/index.md
@@ -7,8 +7,7 @@ authors: ["mikhail-shilkov"]
 tags: ["AWS", "Serverless"]
 ---
 
-AWS recently [announced](https://aws.amazon.com/blogs/aws/new-provisioned-concurrency-for-lambda-functions/) the launch of **Provisioned Concurrency**, a new feature of AWS Lambda that intends to solve the problem of cold starts. In this article, we take another look at the problem of latency-critical serverless applications, and how the new feature impacts the status-quo.
-<!--more-->
+AWS Lambda cold starts (the time it takes for AWS to assign a worker to a request) are a major frustration point of many serverless programmers. In this article, we will take a look at the problem of latency-critical serverless applications, and how [Provisioned Concurrency](https://aws.amazon.com/blogs/aws/new-provisioned-concurrency-for-lambda-functions/) impacts the status-quo.
 
 ## Concurrency Model of AWS Lambda
 


### PR DESCRIPTION
Relevant Issue: https://github.com/pulumi/docs/pull/2621

This post ranks well for us and has a high bounce rate. To hopefully mitigate the bounce rate I updated the intro paragraph to be less about Provisioned Concurrency be a new feature and tried to lead in more with the problem it solves. 