### PR TITLE
Add CTA to top of EKS blog post as a bounce reducing experiment

### DIFF
--- a/content/blog/aws-eks-managed-nodes-fargate/index.md
+++ b/content/blog/aws-eks-managed-nodes-fargate/index.md
@@ -17,7 +17,7 @@ summary: |
 
 {{% notes %}}
     Looking for information on how to deploy an EKS cluster? Checkout our
-    <a href="{{< relref "/docs/guides/crosswalk/aws/eks" >}}">AWS Elastic Kubernetes Service</a>.
+    <a href="{{< relref "/docs/guides/crosswalk/aws/eks" >}}">AWS Elastic Kubernetes Service</a> documentation.
 {{% /notes %}}
 
 AWS Elastic Kubernetes Service (EKS) provides a range of performance and control for dynamically scaling your Kubernetes clusters, including Managed Node Groups, Fargate, and Manually-Managed Node Groups in EC2. In this post, we'll see how to use each of these compute options, and when to prefer one over the other in order to maximize productivity, flexibility, and control, based on your needs.

--- a/content/blog/aws-eks-managed-nodes-fargate/index.md
+++ b/content/blog/aws-eks-managed-nodes-fargate/index.md
@@ -8,6 +8,17 @@ date: "2019-12-05"
 meta_image: "pulumi-eks-fargate.png"
 ---
 
+<div class="bg-blue-100 border-t-4 border-blue-500 rounded-b text-blue-900 px-4 py-3 shadow-md my-5" role="alert">
+  <div class="flex">
+    <div class="py-1"><svg class="fill-current h-6 w-6 text-teal-500 mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z"/></svg></div>
+    <div>
+      <p class="font-bold mt-1 mb-0">
+        Looking for information on how to deploy an EKS cluster? Checkout our <a href="https://www.pulumi.com/docs/guides/crosswalk/aws/eks/">AWS Elastic Kubernetes Service</a>.
+    </p>
+    </div>
+  </div>
+</div>
+
 AWS Elastic Kubernetes Service (EKS) provides a range of performance and control for dynamically scaling your Kubernetes clusters, including Managed Node Groups, Fargate, and Manually-Managed Node Groups in EC2. In this post, we'll see how to use each of these compute options, and when to prefer one over the other in order to maximize productivity, flexibility, and control, based on your needs.
 
 <!--more-->

--- a/content/blog/aws-eks-managed-nodes-fargate/index.md
+++ b/content/blog/aws-eks-managed-nodes-fargate/index.md
@@ -13,7 +13,7 @@ meta_image: "pulumi-eks-fargate.png"
     <div class="py-1"><svg class="fill-current h-6 w-6 text-teal-500 mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z"/></svg></div>
     <div>
       <p class="font-bold mt-1 mb-0">
-        Looking for information on how to deploy an EKS cluster? Checkout our <a href="https://www.pulumi.com/docs/guides/crosswalk/aws/eks/">AWS Elastic Kubernetes Service</a>.
+        Looking for information on how to deploy an EKS cluster? Checkout our <a href="https://www.pulumi.com/docs/guides/crosswalk/aws/eks/">AWS Elastic Kubernetes Service</a> documentation.
     </p>
     </div>
   </div>

--- a/content/blog/aws-eks-managed-nodes-fargate/index.md
+++ b/content/blog/aws-eks-managed-nodes-fargate/index.md
@@ -6,22 +6,21 @@ tags: ["Pulumi-News", "AWS", "Kubernetes", "EKS"]
 meta_desc: "Pulumi supports simplify the scaling your Elastic Kubernetes Service (EKS) clusters with Managed Node Groups and Fargate."
 date: "2019-12-05"
 meta_image: "pulumi-eks-fargate.png"
+
+summary: |
+    AWS Elastic Kubernetes Service (EKS) provides a range of performance and control for
+    dynamically scaling your Kubernetes clusters, including Managed Node Groups, Fargate, and
+    Manually-Managed Node Groups in EC2. In this post, we'll see how to use each of these
+    compute options, and when to prefer one over the other in order to maximize productivity,
+    flexibility, and control, based on your needs.
 ---
 
-<div class="bg-blue-100 border-t-4 border-blue-500 rounded-b text-blue-900 px-4 py-3 shadow-md my-5" role="alert">
-  <div class="flex">
-    <div class="py-1"><svg class="fill-current h-6 w-6 text-teal-500 mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z"/></svg></div>
-    <div>
-      <p class="font-bold mt-1 mb-0">
-        Looking for information on how to deploy an EKS cluster? Checkout our <a href="https://www.pulumi.com/docs/guides/crosswalk/aws/eks/">AWS Elastic Kubernetes Service</a> documentation.
-    </p>
-    </div>
-  </div>
-</div>
+{{% notes %}}
+    Looking for information on how to deploy an EKS cluster? Checkout our
+    <a href="{{< relref "/docs/guides/crosswalk/aws/eks" >}}">AWS Elastic Kubernetes Service</a>.
+{{% /notes %}}
 
 AWS Elastic Kubernetes Service (EKS) provides a range of performance and control for dynamically scaling your Kubernetes clusters, including Managed Node Groups, Fargate, and Manually-Managed Node Groups in EC2. In this post, we'll see how to use each of these compute options, and when to prefer one over the other in order to maximize productivity, flexibility, and control, based on your needs.
-
-<!--more-->
 
 ## Managing EKS Workers
 


### PR DESCRIPTION
This is a continuation of https://github.com/pulumi/docs/pull/2592. This PR adds a callout at the top of the blog post directing users to our EKS doc with code examples. 

<img width="831" alt="deployEKSCTA" src="https://user-images.githubusercontent.com/15146337/76474069-afee0c80-63b7-11ea-81bc-903583cc5231.png">
