### PR TITLE
WIP: Fiddle with an examples shortcode

### DIFF
--- a/components/src/components.d.ts
+++ b/components/src/components.d.ts
@@ -27,6 +27,8 @@ export namespace Components {
     'selection': ChooserKey;
     'type': ChooserType;
   }
+  interface PulumiExample {}
+  interface PulumiExamples {}
   interface PulumiRoot {}
 }
 
@@ -45,6 +47,18 @@ declare global {
     new (): HTMLPulumiChooserElement;
   };
 
+  interface HTMLPulumiExampleElement extends Components.PulumiExample, HTMLStencilElement {}
+  var HTMLPulumiExampleElement: {
+    prototype: HTMLPulumiExampleElement;
+    new (): HTMLPulumiExampleElement;
+  };
+
+  interface HTMLPulumiExamplesElement extends Components.PulumiExamples, HTMLStencilElement {}
+  var HTMLPulumiExamplesElement: {
+    prototype: HTMLPulumiExamplesElement;
+    new (): HTMLPulumiExamplesElement;
+  };
+
   interface HTMLPulumiRootElement extends Components.PulumiRoot, HTMLStencilElement {}
   var HTMLPulumiRootElement: {
     prototype: HTMLPulumiRootElement;
@@ -53,6 +67,8 @@ declare global {
   interface HTMLElementTagNameMap {
     'pulumi-choosable': HTMLPulumiChoosableElement;
     'pulumi-chooser': HTMLPulumiChooserElement;
+    'pulumi-example': HTMLPulumiExampleElement;
+    'pulumi-examples': HTMLPulumiExamplesElement;
     'pulumi-root': HTMLPulumiRootElement;
   }
 }
@@ -68,6 +84,8 @@ declare namespace LocalJSX {
     'selection'?: ChooserKey;
     'type'?: ChooserType;
   }
+  interface PulumiExample {}
+  interface PulumiExamples {}
   interface PulumiRoot {
     'onRendered'?: (event: CustomEvent<any>) => void;
   }
@@ -75,6 +93,8 @@ declare namespace LocalJSX {
   interface IntrinsicElements {
     'pulumi-choosable': PulumiChoosable;
     'pulumi-chooser': PulumiChooser;
+    'pulumi-example': PulumiExample;
+    'pulumi-examples': PulumiExamples;
     'pulumi-root': PulumiRoot;
   }
 }
@@ -87,6 +107,8 @@ declare module "@stencil/core" {
     interface IntrinsicElements {
       'pulumi-choosable': LocalJSX.PulumiChoosable & JSXBase.HTMLAttributes<HTMLPulumiChoosableElement>;
       'pulumi-chooser': LocalJSX.PulumiChooser & JSXBase.HTMLAttributes<HTMLPulumiChooserElement>;
+      'pulumi-example': LocalJSX.PulumiExample & JSXBase.HTMLAttributes<HTMLPulumiExampleElement>;
+      'pulumi-examples': LocalJSX.PulumiExamples & JSXBase.HTMLAttributes<HTMLPulumiExamplesElement>;
       'pulumi-root': LocalJSX.PulumiRoot & JSXBase.HTMLAttributes<HTMLPulumiRootElement>;
     }
   }

--- a/components/src/components/example/example.e2e.ts
+++ b/components/src/components/example/example.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('pulumi-example', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pulumi-example></pulumi-example>');
+
+    const element = await page.find('pulumi-example');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/components/src/components/example/example.scss
+++ b/components/src/components/example/example.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/components/src/components/example/example.spec.ts
+++ b/components/src/components/example/example.spec.ts
@@ -1,0 +1,7 @@
+import { Example } from './example';
+
+describe('pulumi-example', () => {
+  it('builds', () => {
+    expect(new Example()).toBeTruthy();
+  });
+});

--- a/components/src/components/example/example.tsx
+++ b/components/src/components/example/example.tsx
@@ -1,0 +1,17 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+    tag: "pulumi-example",
+    styleUrl: "example.scss",
+    shadow: false
+})
+export class Example {
+
+    render() {
+        return (
+            <Host>
+                <slot></slot>
+            </Host>
+        );
+    }
+}

--- a/components/src/components/examples/examples.e2e.ts
+++ b/components/src/components/examples/examples.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('pulumi-examples', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pulumi-examples></pulumi-examples>');
+
+    const element = await page.find('pulumi-examples');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/components/src/components/examples/examples.scss
+++ b/components/src/components/examples/examples.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/components/src/components/examples/examples.spec.ts
+++ b/components/src/components/examples/examples.spec.ts
@@ -1,0 +1,7 @@
+import { Examples } from './examples';
+
+describe('pulumi-examples', () => {
+  it('builds', () => {
+    expect(new Examples()).toBeTruthy();
+  });
+});

--- a/components/src/components/examples/examples.tsx
+++ b/components/src/components/examples/examples.tsx
@@ -1,0 +1,29 @@
+import { Component, Element, Host, h } from "@stencil/core";
+
+@Component({
+    tag: "pulumi-examples",
+    styleUrl: "examples.scss",
+    shadow: false
+})
+export class Examples {
+
+    @Element()
+    el: HTMLElement;
+
+    children: Element[];
+
+    componentWillLoad() {
+        this.children = Array.from(this.el.children);
+        this.el.innerHTML = "";
+    }
+
+    render() {
+        return (
+            <Host>
+                {
+                    this.children.map(c => <pulumi-example innerHTML={c.outerHTML}></pulumi-example>)
+                }
+            </Host>
+        );
+    }
+}

--- a/content/docs/get-started/aws/install-pulumi.md
+++ b/content/docs/get-started/aws/install-pulumi.md
@@ -12,6 +12,22 @@ menu:
 aliases: ["/docs/quickstart/aws/install-pulumi/"]
 ---
 
+{{% examples %}}
+
+```typescript
+import foo from "bar";
+```
+
+```typescript
+import bar from "baz";
+```
+
+```typescript
+import qux from "quux";
+```
+
+{{% /examples %}}
+
 {{< install-pulumi >}}
 
 Next, we'll install the required language runtime.

--- a/layouts/shortcodes/examples.html
+++ b/layouts/shortcodes/examples.html
@@ -1,0 +1,5 @@
+<div>
+<pulumi-examples>
+{{ .Inner | markdownify }}
+</pulumi-examples>
+</div>


### PR DESCRIPTION
This PR adds an `examples` shortcode for rendering Pulumi examples. The usage would work something like this:

```
    {{% examples %}}
    ```typescript
    import foo from "bar";
    ```

    ```typescript
    import bar from "baz";
    ```

    ```typescript
    import qux from "quux";
    ```
    {{% /examples %}}
```

.. and the rendered markup would look something like:

![image](https://user-images.githubusercontent.com/274700/76789882-01f9ae00-677b-11ea-9e51-76d255f85d2b.png)