### PR TITLE
Add 03/18/2020 edition of PulumiTV

### DIFF
--- a/assets/sass/_hubspot.scss
+++ b/assets/sass/_hubspot.scss
@@ -18,6 +18,11 @@
             width: 100% !important;
         }
 
+        .legal-consent-container .hs-form-booleancheckbox-display .hs-input {
+            width: auto !important;
+            margin-top: 4px;
+        }
+
         .hs-form-required {
             @apply ml-1 text-red-500;
         }

--- a/content/webinars/aws-lambda-api-gateway/index.md
+++ b/content/webinars/aws-lambda-api-gateway/index.md
@@ -1,16 +1,16 @@
 ---
 # Name of the webinar.
-title: "Name of the Webinar"
+title: "API Gateway for an AWS Lambda"
 meta_desc: "Search Description"
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
-pulumi_tv: false
+pulumi_tv: true
 
 # The preview image will be shown on the list page.
-preview_image: ""
+preview_image: "https://img.youtube.com/vi/yYWqcgs6FlA/hqdefault.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: false
@@ -28,41 +28,35 @@ external: false
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.
-url_slug: "{{ .Name }}"
+url_slug: "aws-lambda-api-gateway"
 
 # The content of the hero section.
 hero:
     # The title text in the hero. This also serves as the pages H1.
-    title: ""
+    title: "API Gateway for an AWS Lambda"
     # The image the appears on the right hand side of the hero.
     image: "/icons/containers.svg"
 
 # Content for the left hand side section of the page.
 main:
     # Webinar title.
-    title: ""
+    title: "API Gateway for an AWS Lambda"
     # URL for embedding a URL for ungated webinars.
-    youtube_url: ""
+    youtube_url: "https://www.youtube.com/embed/yYWqcgs6FlA"
     # Datetime of the webinar.
     datetime: 2019-02-05 10:00:00 -07:00
     # Description of the webinar.
-    description: ""
+    description: |
+        For our Inaugural Episode, we’ll show you how to set up an API Gateway for an AWS Lambda function in 30 minutes. You’ll learn how to wire this up to a domain name and secure it using an API key for authorization. Finally, we’ll show you how to store the API key in a secrets manager.
 
     # The webinar presenters
     presenters:
-        - name: ""
-          role: ""
+        - name: Lee Zen
+          role: VP of Engineering, Pulumi
 
     # A bullet point list containing what the user will learn during the webinar.
     learn:
-        - ""
-
-# The right hand side form section.
-form:
-    # GoToWebinar webinar key. This key allows us to register people for webinars via the
-    # HubSpot form.
-    gotowebinar_key: ""
-
-    # HubSpot form id.
-    hubspot_form_id: ""
+        - How to set up an API Gateway for an AWS Lambda.
+        - How to use an API key for authorization.
+        - How to store an API key in a secrets manager.
 ---

--- a/content/webinars/aws-lambda-api-gateway/index.md
+++ b/content/webinars/aws-lambda-api-gateway/index.md
@@ -1,7 +1,7 @@
 ---
 # Name of the webinar.
 title: "API Gateway for an AWS Lambda"
-meta_desc: "Search Description"
+meta_desc: "In this week's edition of Modern Infrastructure as Code Wednesday, we’ll show you how to set up an API Gateway for an AWS Lambda function in 30 minutes."
 
 # If the video is pre-recorded or live.
 pre_recorded: true


### PR DESCRIPTION
This PR adds the 03/18/2020 edition of PulumiTV to the webinar listing page. I also snuck in a CSS fix for the alignment of the form checkbox as it is a bit off.