### PR TITLE
Fix typo in learning machine case study section on webinar landing pages

### DIFF
--- a/layouts/webinars/single.html
+++ b/layouts/webinars/single.html
@@ -98,7 +98,7 @@
                     <h6 class="text-gray-600 uppercase">Study</h6>
                     <div class="text-xl">How Learning Machine Improved Time to Ship</div>
                     <p class="text-gray-600">
-                        Pulumi helped Learning Machine delivered a more agile, streamlined
+                        Pulumi helped Learning Machine deliver a more agile, streamlined
                         DevOps experience for the benefit of their customers, with
                         significant reductions in code and boilerplate.
                     </p>


### PR DESCRIPTION
As the title states, there was a typo in the webinar landing pages. This PR fixes that typo.

cc// @ericrudder @isaac-pulumi 