### PR TITLE
Unlist march 30th workshop

### DIFF
--- a/content/webinars/getting-started-infrastructure-as-code-2020-03-30/index.md
+++ b/content/webinars/getting-started-infrastructure-as-code-2020-03-30/index.md
@@ -13,7 +13,7 @@ pulumi_tv: false
 preview_image: "/images/webinar/getting-started-with-iac-2020-03-30.png"
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/content/webinars/getting-started-infrastructure-as-code-2020-03-30/index.md
+++ b/content/webinars/getting-started-infrastructure-as-code-2020-03-30/index.md
@@ -3,6 +3,8 @@
 title: "Getting Started with Infrastructure as Code"
 meta_desc: "Join us on March 30th, 2020 for a deep dive into Infrastructure as Code concepts with Pulumi engineers Paul Stack and Mikhail Shilkov."
 
+redirect_to: "/webinars/"
+
 # If the video is pre-recorded or live.
 pre_recorded: false
 

--- a/layouts/webinars/list.html
+++ b/layouts/webinars/list.html
@@ -17,7 +17,8 @@
 
 {{ define "main" }}
     {{ $webinars := (where $.Pages "Type" "webinars") }}
-    {{ $non_pulumi_tv_webinars := (where $webinars ".Params.pulumi_tv" false)}}
+    {{ $listed_webinars := (where $webinars ".Params.unlisted" false) }}
+    {{ $non_pulumi_tv_webinars := (where $listed_webinars ".Params.pulumi_tv" false)}}
     <div class="container mx-auto">
         <div class="justify-between py-10 md:py-24 px-5 md:px-20">
             <div class="w-full">
@@ -32,7 +33,7 @@
             <div class="w-full">
                 <h2 id="pulumiTV" class="mb-8">PulumiTV</h2>
                 <ul class="list-none md:flex md:flex-wrap pl-0">
-                    {{ $pulumi_tv_webinars := (where $webinars ".Params.pulumi_tv" true)}}
+                    {{ $pulumi_tv_webinars := (where $listed_webinars ".Params.pulumi_tv" true)}}
                     {{ range (sort $pulumi_tv_webinars ".Params.main.sortable_date" "desc") }}
                         {{ partial "webinar-list-item" . }}
                     {{ end }}


### PR DESCRIPTION
Remove the March 30th workshop from the webinar page. We will relist the webinar once we have a recording.