### PR TITLE
update go aws/gcp/azure getting started to use go modules

### DIFF
--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -45,7 +45,7 @@ $ pulumi new aws-python
 ```bash
 # install the pulumi aws plugin
 # check for the release version here https://github.com/pulumi/pulumi-aws/releases
-$ pulumi plugin install resource aws 1.22.0
+$ pulumi plugin install resource aws 1.29.0
 # from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new aws-go

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -186,15 +186,6 @@ class Program
 
 Our program now creates a KMS key and enables server-side encryption on the S3 bucket using the KMS key.
 
-{{% choosable language go %}}
-We'll need to run `dep ensure` to pick up the new dependencies:
-
-```bash
-$ dep ensure
-```
-
-{{% /choosable %}}
-
 Next, we'll deploy the changes.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -130,16 +130,6 @@ This Pulumi program creates an S3 bucket and exports the name of the bucket.
 
 {{% /choosable %}}
 
-{{% choosable language go %}}
-
-For Go, before we can deploy the stack, you will need to initialize your project's dependencies. Pulumi templates currently use `dep`:
-
-```bash
-$ dep ensure
-```
-
-{{% /choosable %}}
-
 Next, we'll deploy the stack.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/azure/create-project.md
+++ b/content/docs/get-started/azure/create-project.md
@@ -53,7 +53,7 @@ $ pulumi new azure-csharp
 ```bash
 # install the pulumi azure plugin
 # check for the release version here https://github.com/pulumi/pulumi-azure/releases
-$ pulumi plugin install resource azure 1.14.0
+$ pulumi plugin install resource azure 2.3.1
 # from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new azure-go

--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -90,8 +90,8 @@ pulumi.export('connection_string', account.primary_connection_string)
 package main
 
 import (
-	"github.com/pulumi/pulumi-azure/sdk/go/azure/core"
-	"github.com/pulumi/pulumi-azure/sdk/go/azure/storage"
+	"github.com/pulumi/pulumi-azure/sdk/v2/go/azure/core"
+	"github.com/pulumi/pulumi-azure/sdk/v2/go/azure/storage"
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 

--- a/content/docs/get-started/azure/review-project.md
+++ b/content/docs/get-started/azure/review-project.md
@@ -89,8 +89,8 @@ pulumi.export('connection_string', account.primary_connection_string)
 package main
 
 import (
-	"github.com/pulumi/pulumi-azure/sdk/go/azure/core"
-	"github.com/pulumi/pulumi-azure/sdk/go/azure/storage"
+	"github.com/pulumi/pulumi-azure/sdk/v2/go/azure/core"
+	"github.com/pulumi/pulumi-azure/sdk/v2/go/azure/storage"
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
@@ -164,15 +164,6 @@ This Pulumi program creates an Azure resource group and storage account and expo
 {{% choosable language python %}}
 
 {{< python-venv >}}
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-For Go, before we can deploy the stack, you will need to initialize your project's dependencies. Pulumi templates currently use `dep`:
-
-```bash
-$ dep ensure
-```
 
 {{% /choosable %}}
 

--- a/content/docs/get-started/gcp/create-project.md
+++ b/content/docs/get-started/gcp/create-project.md
@@ -45,7 +45,7 @@ $ pulumi new gcp-python
 ```bash
 # install the pulumi gcp plugin
 # check for the release version here https://github.com/pulumi/pulumi-gcp/releases
-$ pulumi plugin install resource gcp 2.6.0
+$ pulumi plugin install resource gcp 2.11.1
 # from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new gcp-go

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -104,8 +104,8 @@ pulumi.export('bucket_name',  bucket.url)
 package main
 
 import (
-	"github.com/pulumi/pulumi-gcp/sdk/go/gcp/kms"
-	"github.com/pulumi/pulumi-gcp/sdk/go/gcp/storage"
+	"github.com/pulumi/pulumi-gcp/sdk/v2/go/gcp/kms"
+	"github.com/pulumi/pulumi-gcp/sdk/v2/go/gcp/storage"
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
@@ -187,15 +187,6 @@ class Program
         });
     }
 }
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-We'll need to run `dep ensure` to pick up the new dependencies:
-
-```bash
-$ dep ensure
 ```
 
 {{% /choosable %}}

--- a/content/docs/get-started/gcp/review-project.md
+++ b/content/docs/get-started/gcp/review-project.md
@@ -69,7 +69,7 @@ pulumi.export('bucket_name',  bucket.url)
 package main
 
 import (
-	"github.com/pulumi/pulumi-gcp/sdk/go/gcp/storage"
+	"github.com/pulumi/pulumi-gcp/sdk/v2/go/gcp/storage"
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
@@ -122,15 +122,6 @@ This Pulumi program creates a storage bucket and exports the bucket URL.
 {{% choosable language python %}}
 
 {{< python-venv >}}
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-For Go, before we can deploy the stack, you will need to initialize your project's dependencies. Pulumi templates currently use `dep`:
-
-```bash
-$ dep ensure
-```
 
 {{% /choosable %}}
 

--- a/layouts/shortcodes/install-go.html
+++ b/layouts/shortcodes/install-go.html
@@ -1,4 +1,3 @@
 <p class="mt-4">
     Install <strong><a href="https://golang.org/doc/install" target="_blank">Go</a></strong>. <br/>
-    Install <strong><a href="https://golang.github.io/dep/docs/installation.html" target="_blank">dep</a></strong>.
 </p>


### PR DESCRIPTION
This change removes the dep installation as a pre-req, and removes and `dep ensure` steps. In addition import paths for the new gcp and azure modules were updated. 