### PR TITLE
Use tiles on the Get Started page

### DIFF
--- a/assets/sass/_tiles.scss
+++ b/assets/sass/_tiles.scss
@@ -1,5 +1,5 @@
 .tiles {
-    @apply items-center justify-center;
+    @apply items-center;
 
     @screen md {
         @apply flex;
@@ -7,7 +7,7 @@
 
     .tile {
         @include transition;
-        @apply flex-1 p-8 block rounded shadow border border-gray-300 cursor-pointer;
+        @apply block rounded shadow border border-gray-300 cursor-pointer;
 
         &:hover {
             @apply shadow-md;

--- a/content/docs/get-started/_index.md
+++ b/content/docs/get-started/_index.md
@@ -14,27 +14,35 @@ aliases:
 ---
 
 <div class="flex max-w-2xl">
-    <p class="text-xl leading-loose text-gray-600">
+    <p class="text-xl leading-relaxed text-gray-600">
         Step-by-step guides for creating, deploying, and managing infrastructure with
-        Pulumi on the cloud using your favorite language
+        Pulumi on the cloud using your favorite language.
     </p>
 </div>
 
 ## Choose Your Cloud
 
-<div class="flex flex-col max-w-full md:max-w-lg">
-    <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center" href="{{< relref "aws" >}}">
-        <img class="h-10" src="/logos/tech/aws.svg" alt="AWS">
-    </a>
-    <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center" href="{{< relref "azure" >}}">
-        <img class="h-10" src="/logos/tech/azure.svg" alt="Azure">
-    </a>
-    <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center" href="{{< relref "gcp" >}}">
-        <img class="h-10" src="/logos/tech/gcp.svg" alt="Google Cloud">
-    </a>
-    <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 flex justify-center" href="{{< relref "kubernetes" >}}">
-        <img class="h-10" src="/logos/tech/k8s.svg" alt="Kubernetes">
-    </a>
+<div class="tiles flex-wrap mt-4">
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <a class="tile p-4" href="{{< relref "aws" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
+        </a>
+    </div>
+    <div class="pb-4 md:w-1/2">
+        <a class="tile p-4" href="{{< relref "azure" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
+        </a>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <a class="tile p-4" href="{{< relref "gcp" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
+        </a>
+    </div>
+    <div class="pb-4 md:w-1/2">
+        <a class="tile p-4" href="{{< relref "kubernetes" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
+        </a>
+    </div>
 </div>
 
 See [Cloud Providers]({{< relref "/docs/intro/cloud-providers" >}}) for other clouds.

--- a/content/docs/intro/languages/dotnet.md
+++ b/content/docs/intro/languages/dotnet.md
@@ -22,16 +22,27 @@ Pulumi supports infrastructure as code using any .NET Core language. You can use
 
 The fastest way to get up and running is to choose from one of the following Getting Started guides:
 
-<div class="flex md:flex-row flex-col my-6">
-    <a class="block flex-1 btn bg-transparent border border-solid border-gray-300 hover:bg-gray-200 p-4 mb-4 mr-0 md:mb-0 md:mr-4 flex justify-center" href="{{< relref "../../get-started/aws" >}}">
-        <img class="h-5" src="/logos/tech/aws.svg" alt="AWS">
-    </a>
-    <a class="block flex-1 btn bg-transparent border border-solid border-gray-300 hover:bg-gray-200 p-4 mb-4 mr-0 md:mb-0 md:mr-4 flex justify-center" href="{{< relref "../../get-started/azure" >}}">
-        <img class="h-5" src="/logos/tech/azure.svg" alt="Azure">
-    </a>
-    <a class="block flex-1 btn bg-transparent border border-solid border-gray-300 hover:bg-gray-200 p-4 flex justify-center" href="{{< relref "../../get-started/gcp" >}}">
-        <img class="h-5" src="/logos/tech/gcp.svg" alt="Google Cloud">
-    </a>
+<div class="tiles mt-4">
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
+        </a>
+    </div>
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
+        </a>
+    </div>
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
+        </a>
+    </div>
+    <div class="flex-1 pb-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
+        </a>
+    </div>
 </div>
 
 > The Getting Started guides currently only demonstrate C#. For F# and Visual Basic, please refer to the

--- a/content/docs/intro/languages/go.md
+++ b/content/docs/intro/languages/go.md
@@ -19,15 +19,15 @@ Pulumi supports writing your infrastructure as code using the Go language.
 
 The fastest way to get up and running is to choose from one of the following Getting Started guides:
 
-<div class="flex md:flex-row flex-col my-6">
-    <a class="block flex-1 btn bg-transparent border border-solid border-gray-300 hover:bg-gray-200 p-4 mb-4 mr-0 md:mb-0 md:mr-4 flex justify-center" href="{{< relref "../../get-started/aws" >}}">
-        <img class="h-5" src="/logos/tech/aws.svg" alt="AWS">
+<div class="tiles my-4">
+    <a class="tile flex-1 p-4" href="{{< relref "/docs/get-started/aws" >}}">
+        <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
     </a>
-    <a class="block flex-1 btn bg-transparent border border-solid border-gray-300 hover:bg-gray-200 p-4 mb-4 mr-0 md:mb-0 md:mr-4 flex justify-center" href="{{< relref "../../get-started/azure" >}}">
-        <img class="h-5" src="/logos/tech/azure.svg" alt="Azure">
+    <a class="tile md:mx-4 flex-1 p-4" href="{{< relref "/docs/get-started/azure" >}}">
+        <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
     </a>
-    <a class="block flex-1 btn bg-transparent border border-solid border-gray-300 hover:bg-gray-200 p-4 flex justify-center" href="{{< relref "../../get-started/gcp" >}}">
-        <img class="h-5" src="/logos/tech/gcp.svg" alt="Google Cloud">
+    <a class="tile flex-1 p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+        <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
     </a>
 </div>
 

--- a/content/docs/reference/pkg/_index.md
+++ b/content/docs/reference/pkg/_index.md
@@ -21,13 +21,13 @@ Kubernetes cluster, and building and publishing containers to private registries
 Reference documentation and examples for major cloud providers.
 
 <div class="tiles">
-    <a class="tile" href="{{< relref "/docs/reference/pkg/aws" >}}">
+    <a class="tile flex-1 p-8" href="{{< relref "/docs/reference/pkg/aws" >}}">
         <img class="h-10 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
     </a>
-    <a class="tile md:mx-4 my-4 md:my-0" href="{{< relref "/docs/reference/pkg/azure" >}}">
+    <a class="tile flex-1 p-8 md:mx-4 my-4 md:my-0" href="{{< relref "/docs/reference/pkg/azure" >}}">
         <img class="h-10 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
     </a>
-    <a class="tile" href="{{< relref "/docs/reference/pkg/gcp" >}}">
+    <a class="tile flex-1 p-8" href="{{< relref "/docs/reference/pkg/gcp" >}}">
         <img class="h-10 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
     </a>
 </div>

--- a/layouts/partials/get-started.html
+++ b/layouts/partials/get-started.html
@@ -7,26 +7,29 @@
             </p>
         </div>
     </div>
-    <div class="container mx-auto max-w-5xl">
-        <div class="flex flex-row max-w-full">
-            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 mr-4"
-                href="{{ relref . "/docs/get-started/aws" }}">
-                <img class="h-10" src="/logos/tech/aws.svg" alt="AWS">
-            </a>
-            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 ml-4"
-                href="{{ relref . "/docs/get-started/azure" }}">
-                <img class="h-10" src="/logos/tech/azure.svg" alt="Azure">
-            </a>
-        </div>
-        <div class="flex flex-row max-w-full">
-            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 mr-4"
-                href="{{ relref . "/docs/get-started/gcp" }}">
-                <img class="h-10" src="/logos/tech/gcp.svg" alt="Google Cloud">
-            </a>
-            <a class="btn bg-transparent border border-gray-300 hover:bg-gray-200 p-5 mb-5 flex justify-center w-1/2 ml-4"
-                href="{{ relref . "/docs/get-started/kubernetes" }}">
-                <img class="h-10" src="/logos/tech/k8s.svg" alt="Kubernetes">
-            </a>
+
+    <div class="mx-auto max-w-4xl">
+        <div class="tiles flex-wrap mt-4">
+            <div class="pb-4 md:pr-4 md:w-1/2">
+                <a class="tile p-8" href="{{ relref . "/docs/get-started/aws" }}">
+                    <img class="h-10 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
+                </a>
+            </div>
+            <div class="pb-4 md:w-1/2">
+                <a class="tile p-8" href="{{ relref . "/docs/get-started/azure" }}">
+                    <img class="h-10 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
+                </a>
+            </div>
+            <div class="pb-4 md:pr-4 md:w-1/2">
+                <a class="tile p-8" href="{{ relref . "/docs/get-started/gcp" }}">
+                    <img class="h-10 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
+                </a>
+            </div>
+            <div class="pb-4 md:w-1/2">
+                <a class="tile p-8" href="{{ relref . "/docs/get-started/kubernetes" }}">
+                    <img class="h-10 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
+                </a>
+            </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
On the API Reference page, I recently added some "tiles" for the cloud providers. This PR applies that same treatment for the Choose Your Provider selection on the Get Started page, mainly for consistency.

