### PR TITLE
Hide new hosting element on mobile

### DIFF
--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -12,7 +12,7 @@
 
 {{ define "main" }}
     <section class="bg-purple-800 pt-12 text-white px-4 justify-center text-center" id="editions">
-        <div class="container mx-auto lg:flex justify-center pb-8">
+        <div class="container mx-auto lg:flex justify-center pb-8 hidden lg:block">
             <div class="lg:w-3/4 pr-1">
                 <div class="container" style="border-bottom: 2px solid #a48bb3">
                     <p class="text-purple-200 text-sm font-bold">


### PR DESCRIPTION
This new element breaks the flow when the tier boxes
wrap in smaller (mobile) UIs. Simply hide them unless
we have a larger format display.
