### PR TITLE
Handle failures to write state to localStorage

### DIFF
--- a/components/src/store/index.ts
+++ b/components/src/store/index.ts
@@ -27,7 +27,14 @@ export const configureStore = () => {
     // Serialize to localStorage.
     store.subscribe(() => {
         const state = store.getState();
-        localStorage.setItem("pulumi_state", JSON.stringify(state));
+
+        // localStorage.setItem can fail when the user's settings prevent it or when the
+        // the browser's storage limit has been exceeded.
+        try {
+            localStorage.setItem("pulumi_state", JSON.stringify(state));
+        } catch (e) {
+            console.error("Failed to save pulumi_state:", e);
+        }
     });
 
     return store;


### PR DESCRIPTION
This change just adds a try/catch around the attempt to serialize the user's browsing preferences (like language selection) to localStorage between pageviews. 

Now when this fails (which can happen when the write would exceed the amount of available space, as determined by the user's personal settings or the browser's maximum), we'll just log to the console, but the selection should still take effect within the scope of the page. (Issue was reported in Community Slack.)

![](http://cnunciato-dropshare.s3.amazonaws.com/Screen-Recording-2020-03-31-17-48-03.gif)