### PR TITLE
remove plugin installation instructions from go getting started docs

### DIFF
--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -43,9 +43,6 @@ $ pulumi new aws-python
 {{% choosable language go %}}
 
 ```bash
-# install the pulumi aws plugin
-# check for the release version here https://github.com/pulumi/pulumi-aws/releases
-$ pulumi plugin install resource aws 1.29.0
 # from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new aws-go

--- a/content/docs/get-started/azure/create-project.md
+++ b/content/docs/get-started/azure/create-project.md
@@ -51,9 +51,6 @@ $ pulumi new azure-csharp
 {{% choosable language go %}}
 
 ```bash
-# install the pulumi azure plugin
-# check for the release version here https://github.com/pulumi/pulumi-azure/releases
-$ pulumi plugin install resource azure 2.3.1
 # from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new azure-go

--- a/content/docs/get-started/gcp/create-project.md
+++ b/content/docs/get-started/gcp/create-project.md
@@ -43,9 +43,6 @@ $ pulumi new gcp-python
 {{% choosable language go %}}
 
 ```bash
-# install the pulumi gcp plugin
-# check for the release version here https://github.com/pulumi/pulumi-gcp/releases
-$ pulumi plugin install resource gcp 2.11.1
 # from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new gcp-go


### PR DESCRIPTION
Removing these instructions now that we do this automatically via https://github.com/pulumi/pulumi/pull/4297

We should wait to merge this until that change is in an official release. 