### PR TITLE
fix missing go stack reference docs

### DIFF
--- a/content/docs/intro/concepts/organizing-stacks-projects.md
+++ b/content/docs/intro/concepts/organizing-stacks-projects.md
@@ -124,9 +124,7 @@ pulumi.export("kubeConfig", ... a cluster's output property ...)
 {{% choosable language go %}}
 
 ```go
-// StackReference is not supported in Go currently.
-//
-// See https://github.com/pulumi/pulumi/issues/1614.
+ctx.Export("kubeConfig", /*...a cluster's output property...*/)
 ```
 
 {{% /choosable %}}
@@ -197,9 +195,21 @@ service = core.v1.Service(..., ResourceOptions(provider=provider))
 {{% choosable language go %}}
 
 ```go
-// StackReference is not supported in Go currently.
-//
-// See https://github.com/pulumi/pulumi/issues/1614.
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+    org := cfg.Require("org")
+		slug := fmt.Sprintf("%v/%v/%v", org, ctx.Project(), ctx.Stack())
+		stackRef, err := pulumi.NewStackReference(ctx, slug, nil)
+  }
+
+  kubeConfig := stackRef.GetOutput(pulumi.String("kubeConfig"))
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/intro/concepts/organizing-stacks-projects.md
+++ b/content/docs/intro/concepts/organizing-stacks-projects.md
@@ -203,12 +203,13 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-    org := cfg.Require("org")
-		slug := fmt.Sprintf("%v/%v/%v", org, ctx.Project(), ctx.Stack())
-		stackRef, err := pulumi.NewStackReference(ctx, slug, nil)
-  }
+		slug := fmt.Sprintf("acmecorp/%v/%v", ctx.Project(), ctx.Stack())
+    stackRef, err := pulumi.NewStackReference(ctx, slug, nil)
 
-  kubeConfig := stackRef.GetOutput(pulumi.String("kubeConfig"))
+    kubeConfig := stackRef.GetOutput(pulumi.String("kubeConfig"))
+    // ...
+    return nil
+  }
 }
 ```
 

--- a/content/docs/intro/concepts/organizing-stacks-projects.md
+++ b/content/docs/intro/concepts/organizing-stacks-projects.md
@@ -202,8 +202,8 @@ import (
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		slug := fmt.Sprintf("acmecorp/%v/%v", ctx.Project(), ctx.Stack())
+  pulumi.Run(func(ctx *pulumi.Context) error {
+    slug := fmt.Sprintf("acmecorp/%v/%v", ctx.Project(), ctx.Stack())
     stackRef, err := pulumi.NewStackReference(ctx, slug, nil)
 
     kubeConfig := stackRef.GetOutput(pulumi.String("kubeConfig"))

--- a/content/docs/intro/concepts/organizing-stacks-projects.md
+++ b/content/docs/intro/concepts/organizing-stacks-projects.md
@@ -196,9 +196,9 @@ service = core.v1.Service(..., ResourceOptions(provider=provider))
 
 ```go
 import (
-	"fmt"
+  "fmt"
 
-	"github.com/pulumi/pulumi/sdk/go/pulumi"
+  "github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
 func main() {


### PR DESCRIPTION
Looks like we missed two language choosers (stack references). 

I did a global search for `https://github.com/pulumi/pulumi/issues/1614` and the only other references were for dynamic providers and the 2.0 roadmap blog post so this should be it. 