### PR TITLE
Add a note to old testing blog posts

### DIFF
--- a/content/blog/cumundi-guest-post/index.md
+++ b/content/blog/cumundi-guest-post/index.md
@@ -6,7 +6,7 @@ meta_image: cumundi-pulumi.png
 authors:
     - ringo-de-smet
 tags:
-    - Test Driven Developmnet
+    - Test Driven Development
 ---
 
 **Guest Article:** [Ringo De Smet](https://www.linkedin.com/in/ringodesmet/), Founder of [Cumundi](https://www.cumundi.cloud), standardizes on Pulumi for writing infrastructure as reusable code libraries for his customers. Pulumi enables him to rapidly iterate through the build-test-release cycle of these building blocks.

--- a/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
+++ b/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
@@ -7,11 +7,10 @@ meta_desc: "Leverage Pulumi for your core acceptance test workflow and unlock ne
 meta_image: "InfraTesting.png"
 ---
 
-<div class="note note-warning" role="alert">
-    <p>
-        Some parts of this blog post are out-of-date. Please refer to our <b><a href="https://www.pulumi.com/docs/guides/testing/">Testing Guide</a></b> for updated overview and tutorials.
-    </p>
-</div>
+{{% notes type="warning" %}}
+    Some parts of this blog post are out-of-date. Please refer to our
+    <a href="{{< relref "/docs/guides/testing" >}}">Testing Guide</a> for updated overview and tutorials.
+{{% /notes %}}
 
 Using Pulumi and general purpose languages for infrastructure as code
 comes with many benefits: leveraging existing skills and knowledge,

--- a/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
+++ b/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
@@ -9,7 +9,7 @@ meta_image: "InfraTesting.png"
 
 {{% notes type="warning" %}}
     Some parts of this blog post are out-of-date. Please refer to our
-    <a href="{{< relref "/docs/guides/testing" >}}">Testing Guide</a> for updated overview and tutorials.
+    <a href="{{< relref "/docs/guides/testing" >}}">Testing Guide</a> for the updated overview and tutorials.
 {{% /notes %}}
 
 Using Pulumi and general purpose languages for infrastructure as code

--- a/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
+++ b/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
@@ -7,6 +7,12 @@ meta_desc: "Leverage Pulumi for your core acceptance test workflow and unlock ne
 meta_image: "InfraTesting.png"
 ---
 
+<div class="note note-warning" role="alert">
+    <p>
+        Some parts of this blog post are out-of-date. Please refer to our <b><a href="https://www.pulumi.com/docs/guides/testing/">Testing Guide</a></b> for updated overview and tutorials.
+    </p>
+</div>
+
 Using Pulumi and general purpose languages for infrastructure as code
 comes with many benefits: leveraging existing skills and knowledge,
 eliminating boilerplate through abstraction, and using the same

--- a/content/blog/unit-test-infrastructure/index.md
+++ b/content/blog/unit-test-infrastructure/index.md
@@ -6,7 +6,7 @@ meta_image: tdd.png
 authors:
     - sophia-parafina
 tags:
-    - unit testing
+    - testing
     - test driven development
 ---
 

--- a/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
+++ b/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
@@ -7,11 +7,10 @@ meta_desc: "This post shows how to use Node.js, the Mocha test framework, and th
 meta_image: "meta.png"
 ---
 
-<div class="note note-warning" role="alert">
-    <p>
-        Some parts of this blog post are out-of-date. Please refer to our <b><a href="https://www.pulumi.com/docs/guides/testing/">Testing Guide</a></b> for updated overview and tutorials.
-    </p>
-</div>
+{{% notes type="warning" %}}
+    Some parts of this blog post are out-of-date. Please refer to our
+    <a href="{{< relref "/docs/guides/testing" >}}">Testing Guide</a> for updated overview and tutorials.
+{{% /notes %}}
 
 Testing your infrastructure using familiar tools like Node.js's Mocha
 framework allows you to ensure configuration is correct before provisioning,

--- a/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
+++ b/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
@@ -9,7 +9,7 @@ meta_image: "meta.png"
 
 {{% notes type="warning" %}}
     Some parts of this blog post are out-of-date. Please refer to our
-    <a href="{{< relref "/docs/guides/testing" >}}">Testing Guide</a> for updated overview and tutorials.
+    <a href="{{< relref "/docs/guides/testing" >}}">Testing Guide</a> for the updated overview and tutorials.
 {{% /notes %}}
 
 Testing your infrastructure using familiar tools like Node.js's Mocha

--- a/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
+++ b/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
@@ -7,6 +7,11 @@ meta_desc: "This post shows how to use Node.js, the Mocha test framework, and th
 meta_image: "meta.png"
 ---
 
+<div class="note note-warning" role="alert">
+    <p>
+        Some parts of this blog post are out-of-date. Please refer to our <b><a href="https://www.pulumi.com/docs/guides/testing/">Testing Guide</a></b> for updated overview and tutorials.
+    </p>
+</div>
 
 Testing your infrastructure using familiar tools like Node.js's Mocha
 framework allows you to ensure configuration is correct before provisioning,

--- a/layouts/shortcodes/notes.html
+++ b/layouts/shortcodes/notes.html
@@ -1,6 +1,9 @@
-<div class="note note-info" role="alert">
+{{ $warning := eq (.Get "type") "warning" }}
+{{ $class := cond $warning "warning" "info" }}
+{{ $icon := cond $warning "exclamation-triangle" "info-circle" }}
+<div class="note note-{{ $class }}" role="alert">
     <p>
-        <i class="fas fa-info-circle pr-2"></i>
+        <i class="fas fa-{{ $icon }} pr-2"></i>
         {{ .Inner }}
     </p>
 </div>


### PR DESCRIPTION
Point to our testing guide from the old blog posts.
Reconcile some tags to make sure the new unit testing blog shows up first on the `testing` tag.