### PR TITLE
Update dates for london event; add note to top of page w/ link to webinars

### DIFF
--- a/content/events/devopscon-london-2020-04-21/index.md
+++ b/content/events/devopscon-london-2020-04-21/index.md
@@ -14,9 +14,9 @@ event:
     # The event address
     location: "239 Vauxhall Bridge Rd, Pimlico, London SW1V 1EQ, United Kingdom"
     # The start date of an event. Format YYYY-MM-DD
-    start_date: "2020-04-21"
+    start_date: "2020-08-31"
     # The end date of an event. Format YYYY-MM-DD
-    end_date: "2020-04-24"
+    end_date: "2020-09-03"
     # The event description shown on the event list page.
     description: "The Conference for Continuous Delivery, DevOps, Microservices, Containers, Cloud and Lean Business."
     # The external registration url for the event list page.

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -13,14 +13,12 @@
 
 {{ define "main" }}
     <div class="container mx-auto">
-        <div class="w-10/12 mx-auto mt-10 note note-info" role="alert">
-            <p class="text-lg">
+        <div class="note note-info w-11/12 mx-auto mt-10" role="alert">
+            <p class="text-base">
                 <i class="fas fa-info-circle pr-2"></i>
-                The demand for Pulumi content and education continues to grow and, even in
-                the face of restricted travel, we will ramp it up further. Although many events
-                worldwide we’d planned to sponsor or otherwise participate in have been canceled,
-                we have shifted to working with customers through digital channels wherever we can.
-                Checkout our <a href="{{ relref . "/webinars" }}"><b>upcoming webinars</b></a>.
+                In light of recent events and restricted travel, we’ve had to cancel many of our events planned for
+                the first half of this year. To keep up with demand, we’ve scheduled a series of free remote tutorials, tech talks
+                and workshops — check out our <a href="{{ relref . "/webinars" }}"><strong>upcoming sessions and on-demand content</strong></a>.
             </p>
         </div>
         <div class="flex justify-between py-10 md:py-24 md:pt-5 px-5 md:px-20">

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -13,7 +13,17 @@
 
 {{ define "main" }}
     <div class="container mx-auto">
-        <div class="flex justify-between py-10 md:py-24 px-5 md:px-20">
+        <div class="w-10/12 mx-auto mt-10 note note-info" role="alert">
+            <p class="text-lg">
+                <i class="fas fa-info-circle pr-2"></i>
+                The demand for Pulumi content and education continues to grow and, even in
+                the face of restricted travel, we will ramp it up further. Although many events
+                worldwide we’d planned to sponsor or otherwise participate in have been canceled,
+                we have shifted to working with customers through digital channels wherever we can.
+                Checkout our <a href="{{ relref . "/webinars" }}"><b>upcoming webinars</b></a>.
+            </p>
+        </div>
+        <div class="flex justify-between py-10 md:py-24 md:pt-5 px-5 md:px-20">
             <div class="w-full md:w-8/12">
                 <h2 id="event-list-heading" class="mb-8">All Upcoming Events</h2>
                 <ul id="event-list" class="list-none md:flex md:flex-wrap pl-0">


### PR DESCRIPTION
This PR updates the dates for DevOpsCon London and adds a note to the top of the events page linking to our new webinar pages.