### PR TITLE
Update the pricing page

### DIFF
--- a/assets/js/price-toggle.js
+++ b/assets/js/price-toggle.js
@@ -1,0 +1,16 @@
+// The first time the DOM is finished loading, wire up billing period listeners.
+$(document).on("rendered", function() {
+    // If there's a billing period element on the page, wire up a change listener
+    // so we can toggle the various pricing elements between annual/monthly.
+    $("#billing-period").each(function (i, e) {
+        e.addEventListener("change", function(ev) {
+            if (ev && ev.target && ev.target.checked) {
+                $(".billing-price-monthly").each(function (i, p) { $(p).hide(); });
+                $(".billing-price-annually").each(function (i, p) { $(p).show(); });
+            } else {
+                $(".billing-price-monthly").each(function (i, p) { $(p).show(); });
+                $(".billing-price-annually").each(function (i, p) { $(p).hide(); });
+            }
+        });
+    });
+});

--- a/assets/sass/_toggle.scss
+++ b/assets/sass/_toggle.scss
@@ -1,0 +1,29 @@
+.form-switch {
+    @apply relative select-none w-12 leading-normal;
+}
+
+.form-switch-checkbox {
+    @apply hidden;
+}
+
+.form-switch-label {
+    @apply block overflow-hidden cursor-pointer bg-gray-300 border-2 border-orange-500 rounded-full h-4 shadow-inner;
+
+    transition: background-color 0.2s ease-in;
+}
+.form-switch-label:before {
+    @apply absolute block bg-white inset-y-0 w-6 border-2 border-orange-500 rounded-full -ml-1;
+    right: 50%;
+    content: "";
+    transition: all 0.2s ease-in;
+}
+
+.form-switch-checkbox:checked + .form-switch-label,
+.form-switch-checkbox:checked + .form-switch-label:before {
+}
+.form-switch-checkbox:checked + .form-switch-label {
+    @apply bg-orange-500 shadow-none;
+}
+.form-switch-checkbox:checked + .form-switch-label:before {
+    @apply right-0;
+}

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -32,6 +32,7 @@
 @import "tables";
 @import "tiles";
 @import "toc";
+@import "toggle";
 
 h1, h2, h3, h4, h5, h6 {
     @apply font-display text-gray-700 mb-2;

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -1,8 +1,8 @@
 {{ define "hero" }}
     <header class="header-hero">
         <div class="container mx-auto text-center flex-col max-w-2xl">
-            <h1>Pulumi for every team and individual.</h1>
-            <p>
+            <h1>Plans for every team and individual.</h1>
+            <p class="text-gray-400">
                 Whether you're using open source, our free Community Edition, or using
                 Pulumi in your team or entire organization, we have a solution for you.
             </p>
@@ -12,7 +12,7 @@
 
 {{ define "main" }}
     <section class="bg-purple-800 pt-12 text-white px-4 justify-center text-center" id="editions">
-        <div class="container mx-auto lg:flex justify-center pb-8 hidden lg:block">
+        <div class="container mx-auto lg:flex justify-center pb-4 hidden lg:block">
             <div class="lg:w-3/4 pr-1">
                 <div class="container" style="border-bottom: 2px solid #a48bb3">
                     <p class="text-purple-200 text-sm font-bold">
@@ -43,20 +43,33 @@
                 </div>
             </div>
         </div>
+        <div class="container mx-auto lg:flex justify-center pb-2 hidden lg:block">
+            <div class="mb-2">
+                <label class="text-xs text-purple-100 pr-2" for="billing-period">Monthly</label>
+                <div class="form-switch inline-block align-middle">
+                    <input type="checkbox" name="billing-period" id="billing-period" checked class="form-switch-checkbox" />
+                    <label class="form-switch-label" for="billing-period"></label>
+                </div>
+                <label class="text-xs text-purple-100 pl-2" for="billing-period">Annually</label>
+            </div>
+        </div>
         <div class="container mx-auto lg:flex justify-center">
             <div class="bg-white rounded py-8 px-8 lg:w-1/4 mb-4 lg:mb-0" id="community-edition">
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">COMMUNITY</div>
                     <div class="text-black font-display font-bold text-3xl">$0</div>
-                    <div class="text-sm">&nbsp;</div>
                     <p class="text-sm text-gray-700">
                         The basics of Pulumi infrastructure as code
                         for unlimited individual use.
                     </p>
                     <ul class="list-none mt-0 mb-auto mx-auto justify-center text-left text-sm text-gray-700 px-0">
                         <li class="flex items-center">
+                            <i class="w-8 text-center fas fa-user-friends text-blue-500"></i>
+                            <span class="flex-1"><strong>1</strong> team member</span>
+                        </li>
+                        <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-blue-500"></i>
-                            <span class="flex-1">Any cloud</span>
+                            <span class="flex-1">Any cloud and language</span>
                         </li>
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-blue-500"></i>
@@ -68,19 +81,11 @@
                         </li>
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-blue-500"></i>
-                            <span class="flex-1">Deployment history</span>
-                        </li>
-                        <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-check-square text-blue-500"></i>
                             <span class="flex-1">Secrets management</span>
                         </li>
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-blue-500"></i>
                             <span class="flex-1">CI/CD integrations</span>
-                        </li>
-                        <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-heart text-blue-500"></i>
-                            <span class="flex-1">Free forever</span>
                         </li>
                     </ul>
                     <a data-track="community" class="text-center btn btn-lg btn-blue mx-auto mt-8 py-4 px-6" href="{{ relref . "/docs/get-started" }}">Get Started</a>
@@ -89,23 +94,26 @@
             <div class="bg-white rounded py-8 px-8 lg:mx-5 lg:w-1/4 lg:mr-3 mb-4 lg:mb-0" id="team-edition">
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">TEAM STARTER</div>
-                    <div class="text-black font-display font-bold text-3xl">$50</div>
-                    <div class="text-sm text-gray-700 font-bold">per month, 3 users included</div>
+                    <div class="text-black font-display font-bold text-3xl">
+                        <span class="billing-price-annually">$50</span>
+                        <span class="billing-price-monthly hidden">$60</span>
+                        <span class="text-sm text-gray-700 font-bold">/mo</span>
+                    </div>
                     <p class="text-sm text-gray-700">
                         For teams just starting to collaborate on shared projects.
                     </p>
                     <ul class="list-none mt-0 mb-auto mx-auto justify-center text-left text-sm text-gray-700 px-0">
                         <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-arrow-left text-blue-500"></i>
+                            <i class="w-8 text-center fas fa-user-friends text-orange-500"></i>
+                            <span class="flex-1"><strong>3</strong> team members</span>
+                        </li>
+                        <li class="flex items-center">
+                            <i class="w-8 text-center fas fa-arrow-left text-orange-500"></i>
                             <span class="flex-1">Everything in Community</span>
                         </li>
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-orange-500"></i>
-                            <span class="flex-1">Includes 3 users</span>
-                        </li>
-                        <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-check-square text-orange-500"></i>
-                            <span class="flex-1">1 <a data-track="team-starter" href="{{ relref . "/docs/intro/console/accounts-and-organizations/organizations" }}">organization</a></span>
+                            <span class="flex-1">1 organization</span>
                         </li>
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-orange-500"></i>
@@ -119,32 +127,40 @@
                             <i class="w-8 text-center fas fa-check-square text-orange-500"></i>
                             <span class="flex-1">Team activity dashboard</span>
                         </li>
-                        <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-heart text-orange-500"></i>
-                            <span class="flex-1">Try it free for 14 days</span>
-                        </li>
                     </ul>
                     <a data-track="team-starter" class="text-center btn btn-lg btn-orange mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
-                        Start Your Free Trial
+                        Start 14-Day Free Trial
                     </a>
                 </div>
             </div>
             <div class="bg-white rounded py-8 px-8 lg:mx-5 lg:ml-2 lg:w-1/4 mb-4 lg:mb-0">
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">TEAM PRO</div>
-                    <div class="text-black font-display font-bold text-3xl">$75</div>
-                    <div class="text-sm text-gray-700 font-bold">per user/month</div>
+                    <div class="text-black font-display font-bold text-3xl">
+                        <span class="billing-price-annually">$225</span>
+                        <span class="billing-price-monthly hidden">$270</span>
+                        <span class="text-sm text-gray-700 font-bold">/mo</span>
+                    </div>
                     <p class="text-sm text-gray-700">
                         For medium to large teams with many people and projects.
                     </p>
                     <ul class="list-none mt-0 mb-auto mx-auto justify-center text-left text-sm text-gray-700 px-0">
                         <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-arrow-left text-orange-500"></i>
-                            <span class="flex-1">Everything in Team Starter</span>
+                            <i class="w-8 text-center fas fa-user-friends text-orange-500"></i>
+                            <span class="flex-1">
+                                <strong>3-25</strong> team members
+                                <span class="tooltip pl-1">
+                                    <span class="tooltip-text">
+                                        The first 3 team members are included, and additional
+                                        users are available for $75/mo each.
+                                    </span>
+                                    <i class="w-8 fas fa-question-circle text-gray-500"></i>
+                                </span>
+                            </span>
                         </li>
                         <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-check-square text-orange-500"></i>
-                            <span class="flex-1">Up to 25 users</span>
+                            <i class="w-8 text-center fas fa-arrow-left text-orange-500"></i>
+                            <span class="flex-1">Everything in Team Starter</span>
                         </li>
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-orange-500"></i>
@@ -162,13 +178,9 @@
                             <i class="w-8 text-center fas fa-check-square text-orange-500"></i>
                             <span class="flex-1">12×5 support available</span>
                         </li>
-                        <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-heart text-orange-500"></i>
-                            <span class="flex-1">Try it free for 14 days</span>
-                        </li>
                     </ul>
                     <a data-track="team-pro" class="text-center btn btn-lg btn-orange mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
-                        Start Your Free Trial
+                        Start 14-Day Free Trial
                     </a>
                 </div>
             </div>
@@ -176,26 +188,34 @@
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">ENTERPRISE</div>
                     <div class="text-black font-display font-bold text-3xl">Custom</div>
-                    <div class="text-sm">&nbsp;</div>
                     <p class="text-sm text-gray-700">
                         For organizations with advanced security and deployment needs.
                     </p>
                     <ul class="list-none mt-0 mb-auto mx-auto justify-center text-left text-sm text-gray-700 px-0">
                         <li class="flex items-center">
+                            <i class="w-8 text-center fas fa-user-friends text-purple-500"></i>
+                            <span class="flex-1">
+                                <strong>10+</strong> team members
+                                <span class="tooltip pl-1">
+                                    <span class="tooltip-text">
+                                        The first 10 team members are included, and additional
+                                        users are available with custom pricing.
+                                    </span>
+                                    <i class="w-8 fas fa-question-circle text-gray-500"></i>
+                                </span>
+                            </span>
+                        </li>
+                        <li class="flex items-center">
                             <i class="w-8 text-center fas fa-arrow-left text-purple-500"></i>
                             <span class="flex-1">Everything in Team Pro</span>
                         </li>
                         <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-infinity text-purple-500"></i>
-                            <span class="flex-1">Unlimited users</span>
+                            <i class="w-8 text-center fas fa-check-square text-purple-500"></i>
+                            <span class="flex-1">SAML/SSO</span>
                         </li>
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-purple-500"></i>
                             <span class="flex-1">Organization policies</span>
-                        </li>
-                        <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-check-square text-purple-500"></i>
-                            <span class="flex-1">SAML/SSO</span>
                         </li>
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-purple-500"></i>
@@ -204,10 +224,6 @@
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-check-square text-purple-500"></i>
                             <span class="flex-1">24×7 support available</span>
-                        </li>
-                        <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-heart text-purple-500"></i>
-                            <span class="flex-1">Custom trials available</span>
                         </li>
                     </ul>
                     <a data-track="enterprise" class="text-center btn btn-lg btn-purple mx-auto mt-8 py-4 px-6" href="#contact">Contact Us</a>
@@ -258,20 +274,20 @@
 
             <div class="pricing-item">
                 <span class="pricing-item-label">Price</span>
-                <span class="pricing-item-value">$50/mo</span>
-                <span class="pricing-item-value">Starting at $225/mo</span>
+                <span class="pricing-item-value">$50/mo (annual) / $60/mo (monthly)</span>
+                <span class="pricing-item-value">$225/mo (annual) / $270/mo (monthly)</span>
                 <span class="pricing-item-value">Custom (<a data-track="grid-pricing" class="link" href="#contact">Contact Us</a>)</span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label">Team Members</span>
-                <span class="pricing-item-value">3 Included</span>
-                <span class="pricing-item-value">Up to 25 (Minimum 3)</span>
-                <span class="pricing-item-value">Unlimited (Minimum 10)</span>
+                <span class="pricing-item-value">3</span>
+                <span class="pricing-item-value">3-25</span>
+                <span class="pricing-item-value">10+</span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label">Extra Team Members</span>
                 <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
-                <span class="pricing-item-value">$75/user/mo</span>
+                <span class="pricing-item-value">$75/mo (annual) / $90/mo (monthly)</span>
                 <span class="pricing-item-value">Custom (<a data-track="grid-team-members" class="link" href="#contact">Contact Us</a>)</span>
             </div>
             <div class="pricing-item">

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -350,7 +350,7 @@
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
             <div class="pricing-item">
-                <span class="pricing-item-label"><a data-track="grid-self-hosted" href="{{ relref . "/docs/guides/self-hosted" }}" class="link">Self-Hosting</a> <span class="badge badge-preview">PREVIEW</span></span>
+                <span class="pricing-item-label"><a data-track="grid-self-hosted" href="{{ relref . "/docs/guides/self-hosted" }}" class="link">Self-Hosting</a></span>
                 <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
                 <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
                 <span class="pricing-item-value">Available</span>

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -2,10 +2,12 @@
     <header class="header-hero">
         <div class="container mx-auto text-center flex-col max-w-2xl">
             <h1>Plans for every team and individual.</h1>
-            <p class="text-gray-400">
-                Whether you're using open source, our free Community Edition, or using
-                Pulumi in your team or entire organization, we have a solution for you.
+            <p class="text-gray-400 mb-8">
+                Try any edition risk-free for 14-days. No credit card required.
             </p>
+            <a data-track="team-starter" class="text-center btn btn-lg btn-blue mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
+                Start Free Trial
+            </a>
         </div>
     </header>
 {{ end }}
@@ -129,7 +131,7 @@
                         </li>
                     </ul>
                     <a data-track="team-starter" class="text-center btn btn-lg btn-orange mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
-                        Start 14-Day Free Trial
+                        Buy Now
                     </a>
                 </div>
             </div>
@@ -180,7 +182,7 @@
                         </li>
                     </ul>
                     <a data-track="team-pro" class="text-center btn btn-lg btn-orange mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
-                        Start 14-Day Free Trial
+                        Buy Now
                     </a>
                 </div>
             </div>

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -1,7 +1,7 @@
 {{ define "hero" }}
     <header class="header-hero">
         <div class="container mx-auto text-center flex-col max-w-2xl">
-            <h1>Plans for every team and individual.</h1>
+            <h1>Pulumi for every team and individual.</h1>
             <p class="text-gray-400 mb-8">
                 Try any edition risk-free for 14-days. No credit card required.
             </p>
@@ -60,8 +60,9 @@
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">COMMUNITY</div>
                     <div class="text-black font-display font-bold text-3xl">$0</div>
+                    <div class="text-sm text-gray-700 font-bold">&nbsp;</div>
                     <p class="text-sm text-gray-700">
-                        The basics of Pulumi infrastructure as code
+                        The basics of infrastructure as code
                         for unlimited individual use.
                     </p>
                     <ul class="list-none mt-0 mb-auto mx-auto justify-center text-left text-sm text-gray-700 px-0">
@@ -99,10 +100,10 @@
                     <div class="text-black font-display font-bold text-3xl">
                         <span class="billing-price-annually">$50</span>
                         <span class="billing-price-monthly hidden">$60</span>
-                        <span class="text-sm text-gray-700 font-bold">/mo</span>
                     </div>
+                    <div class="text-sm text-gray-700 font-bold">per month, 3 users included</div>
                     <p class="text-sm text-gray-700">
-                        For teams just starting to collaborate on shared projects.
+                        For teams working together on shared projects.
                     </p>
                     <ul class="list-none mt-0 mb-auto mx-auto justify-center text-left text-sm text-gray-700 px-0">
                         <li class="flex items-center">
@@ -131,7 +132,7 @@
                         </li>
                     </ul>
                     <a data-track="team-starter" class="text-center btn btn-lg btn-orange mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
-                        Buy Now
+                        Get Started
                     </a>
                 </div>
             </div>
@@ -139,10 +140,10 @@
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">TEAM PRO</div>
                     <div class="text-black font-display font-bold text-3xl">
-                        <span class="billing-price-annually">$225</span>
-                        <span class="billing-price-monthly hidden">$270</span>
-                        <span class="text-sm text-gray-700 font-bold">/mo</span>
+                        <span class="billing-price-annually">$75</span>
+                        <span class="billing-price-monthly hidden">$90</span>
                     </div>
+                    <div class="text-sm text-gray-700 font-bold">per user/month</div>
                     <p class="text-sm text-gray-700">
                         For medium to large teams with many people and projects.
                     </p>
@@ -151,13 +152,6 @@
                             <i class="w-8 text-center fas fa-user-friends text-orange-500"></i>
                             <span class="flex-1">
                                 <strong>3-25</strong> team members
-                                <span class="tooltip pl-1">
-                                    <span class="tooltip-text">
-                                        The first 3 team members are included, and additional
-                                        users are available for $75/mo each.
-                                    </span>
-                                    <i class="w-8 fas fa-question-circle text-gray-500"></i>
-                                </span>
                             </span>
                         </li>
                         <li class="flex items-center">
@@ -182,7 +176,7 @@
                         </li>
                     </ul>
                     <a data-track="team-pro" class="text-center btn btn-lg btn-orange mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
-                        Buy Now
+                        Get Started
                     </a>
                 </div>
             </div>
@@ -190,6 +184,7 @@
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">ENTERPRISE</div>
                     <div class="text-black font-display font-bold text-3xl">Custom</div>
+                    <div class="text-sm text-gray-700 font-bold">&nbsp;</div>
                     <p class="text-sm text-gray-700">
                         For organizations with advanced security and deployment needs.
                     </p>
@@ -198,13 +193,6 @@
                             <i class="w-8 text-center fas fa-user-friends text-purple-500"></i>
                             <span class="flex-1">
                                 <strong>10+</strong> team members
-                                <span class="tooltip pl-1">
-                                    <span class="tooltip-text">
-                                        The first 10 team members are included, and additional
-                                        users are available with custom pricing.
-                                    </span>
-                                    <i class="w-8 fas fa-question-circle text-gray-500"></i>
-                                </span>
                             </span>
                         </li>
                         <li class="flex items-center">

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -2,12 +2,18 @@
     <header class="header-hero">
         <div class="container mx-auto text-center flex-col max-w-2xl">
             <h1>Pulumi for every team and individual.</h1>
-            <p class="text-gray-400 mb-8">
+            <p class="text-gray-300 mb-8">
                 Try any edition risk-free for 14-days. No credit card required.
             </p>
             <a data-track="team-starter" class="text-center btn btn-lg btn-blue mx-auto mt-8 py-4 px-6" href="https://app.pulumi.com/site/organizations/add">
                 Start Free Trial
             </a>
+            <div class="mt-8 text-sm text-purple-200">
+                Pulumi
+                <a class="text-purple-100 hover:underline" href="{{ relref . "/docs/get-started" }}">open source</a> and
+                <a class="text-purple-100 hover:underline" href="{{ relref . "/pricing#community-edition" }}">Community Edition</a>
+                are free forever.
+            </div>
         </div>
     </header>
 {{ end }}
@@ -156,7 +162,7 @@
                         <li class="flex items-center">
                             <i class="w-8 text-center fas fa-user-friends text-orange-500"></i>
                             <span class="flex-1">
-                                <strong>3-25</strong> team members
+                                Up to <strong>25</strong> team members
                                 <span class="tooltip pl-1">
                                     <span class="tooltip-text">
                                         Starts at
@@ -208,9 +214,9 @@
                     </p>
                     <ul class="list-none mt-0 mb-auto mx-auto justify-center text-left text-sm text-gray-700 px-0">
                         <li class="flex items-center">
-                            <i class="w-8 text-center fas fa-user-friends text-purple-500"></i>
+                            <i class="w-8 text-center fas fa-infinity text-purple-500"></i>
                             <span class="flex-1">
-                                <strong>10+</strong> team members
+                                <strong>Unlimited</strong> team members
                             </span>
                         </li>
                         <li class="flex items-center">

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -60,7 +60,6 @@
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">COMMUNITY</div>
                     <div class="text-black font-display font-bold text-3xl">$0</div>
-                    <div class="text-sm text-gray-700 font-bold">&nbsp;</div>
                     <p class="text-sm text-gray-700">
                         The basics of infrastructure as code
                         for unlimited individual use.
@@ -98,10 +97,13 @@
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">TEAM STARTER</div>
                     <div class="text-black font-display font-bold text-3xl">
-                        <span class="billing-price-annually">$50</span>
-                        <span class="billing-price-monthly hidden">$60</span>
+                        <span class="billing-price-annually">
+                            $50 <span class="text-sm text-gray-700 font-bold">/mo</span>
+                        </span>
+                        <span class="billing-price-monthly hidden">
+                            $60 <span class="text-sm text-gray-700 font-bold">/mo</span>
+                        </span>
                     </div>
-                    <div class="text-sm text-gray-700 font-bold">per month, 3 users included</div>
                     <p class="text-sm text-gray-700">
                         For teams working together on shared projects.
                     </p>
@@ -140,10 +142,13 @@
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">TEAM PRO</div>
                     <div class="text-black font-display font-bold text-3xl">
-                        <span class="billing-price-annually">$75</span>
-                        <span class="billing-price-monthly hidden">$90</span>
+                        <span class="billing-price-annually">
+                            $75 <span class="text-sm text-gray-700 font-bold"> per user/mo</span>
+                        </span>
+                        <span class="billing-price-monthly hidden">
+                            $90 <span class="text-sm text-gray-700 font-bold"> per user/mo</span>
+                        </span>
                     </div>
-                    <div class="text-sm text-gray-700 font-bold">per user/month</div>
                     <p class="text-sm text-gray-700">
                         For medium to large teams with many people and projects.
                     </p>
@@ -152,6 +157,20 @@
                             <i class="w-8 text-center fas fa-user-friends text-orange-500"></i>
                             <span class="flex-1">
                                 <strong>3-25</strong> team members
+                                <span class="tooltip pl-1">
+                                    <span class="tooltip-text">
+                                        Starts at
+                                        <span class="billing-price-annually">$225/mo</span>
+                                        <span class="billing-price-monthly hidden">$270/mo</span>
+                                        for your first three team members.
+                                        After you reach three, each additional
+                                        team member is
+                                        <span class="billing-price-annually">$75/mo</span>
+                                        <span class="billing-price-monthly hidden">$90/mo</span>
+                                        .
+                                    </span>
+                                    <i class="w-8 fas fa-question-circle text-gray-500"></i>
+                                </span>
                             </span>
                         </li>
                         <li class="flex items-center">
@@ -184,7 +203,6 @@
                 <div class="text-center flex flex-col justify-between h-full">
                     <div class="text-lg text-purple-500 font-bold">ENTERPRISE</div>
                     <div class="text-black font-display font-bold text-3xl">Custom</div>
-                    <div class="text-sm text-gray-700 font-bold">&nbsp;</div>
                     <p class="text-sm text-gray-700">
                         For organizations with advanced security and deployment needs.
                     </p>
@@ -258,27 +276,42 @@
                 </div>
             </div>
 
+            <div class="pricing-item">
+                <span class="pricing-item-label">Annual Price</span>
+                <span class="pricing-item-value">
+                    <span class="text-sm text-gray-700"><span class="font-bold">$50/mo</span></span>
+                </span>
+                <span class="pricing-item-value">
+                    <span class="text-sm text-gray-700"><span class="font-bold">$75 per user/mo</span></span><br>
+                    <span class="text-xs text-purple-300 pl-2">
+                        Starts at $225/month for 3 users
+                    </span>
+                </span>
+                <span class="pricing-item-value"><a data-track="grid-pricing" class="link" href="#contact">Contact Sales</a></span>
+            </div>
+            <div class="pricing-item">
+                <span class="pricing-item-label">Monthly Price</span>
+                <span class="pricing-item-value">
+                    <span class="text-sm text-gray-700"><span class="font-bold">$60/mo</span></span>
+                </span>
+                <span class="pricing-item-value">
+                    <span class="text-sm text-gray-700"><span class="font-bold">$90 per user/mo</span></span><br>
+                    <span class="text-xs text-purple-300 pl-2">
+                        Starts at $275/month for 3 users
+                    </span>
+                </span>
+                <span class="pricing-item-value"><a data-track="grid-pricing" class="link" href="#contact">Contact Sales</a></span>
+            </div>
+
             <div class="pricing-item-heading">
                 Fundamentals
             </div>
 
             <div class="pricing-item">
-                <span class="pricing-item-label">Price</span>
-                <span class="pricing-item-value">$50/mo (annual) / $60/mo (monthly)</span>
-                <span class="pricing-item-value">$225/mo (annual) / $270/mo (monthly)</span>
-                <span class="pricing-item-value">Custom (<a data-track="grid-pricing" class="link" href="#contact">Contact Us</a>)</span>
-            </div>
-            <div class="pricing-item">
                 <span class="pricing-item-label">Team Members</span>
                 <span class="pricing-item-value">3</span>
                 <span class="pricing-item-value">3-25</span>
                 <span class="pricing-item-value">10+</span>
-            </div>
-            <div class="pricing-item">
-                <span class="pricing-item-label">Extra Team Members</span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
-                <span class="pricing-item-value">$75/mo (annual) / $90/mo (monthly)</span>
-                <span class="pricing-item-value">Custom (<a data-track="grid-team-members" class="link" href="#contact">Contact Us</a>)</span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label"><a data-track="grid-organizations" href="{{ relref . "/docs/intro/console/accounts-and-organizations/organizations" }}" class="link">Organizations</a></span>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -10,6 +10,7 @@
 {{ $s = $s | append (resources.Get "js/nav.js") }}
 {{ $s = $s | append (resources.Get "js/carousel.js") }}
 {{ $s = $s | append (resources.Get "js/chooser.js") }}
+{{ $s = $s | append (resources.Get "js/price-toggle.js") }}
 {{ $s = $s | append (resources.Get "js/noselect.js") }}
 {{ $s = $s | append (resources.Get "js/tracking.js") }}
 {{ $s = $s | append (resources.Get "js/docs-feedback.js") }}


### PR DESCRIPTION
This change clarifies a few aspects of our pricing page:

* Add a "START TRIAL" button at the very top and make it
   clear that we offer 14-day free trials of all editions.

* Add a billing cycle chooser to switch between Monthly and
  Annually (the default) prices.

* Move the user count to the top of each box, and bold the
  numbers, to make them stand out as clearly different.

* Add tooltips to explain the concept of $225/270 min buy-in
   for Team Pro. Also add better explanation to the details below.

* Trim the bulleted list -- it's gotten quite lengthy. That
  includes removing the "free" and "trial" points, since this
  information is already represented in other areas (headers,
  buttons, etc).
