### PR TITLE
Increase page generation timeout

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -13,7 +13,7 @@ enableRobotsTXT = true
 # Some of our API docs pages are very large with many shortcodes, which can take
 # a while to generate (especially in CI), so we raise the limit from the default
 # 10 seconds to avoid timeouts when generating the site.
-timeout = 30000
+timeout = 120000
 
 [outputFormats.RSS]
     baseName = "rss"


### PR DESCRIPTION
This should help avoid the "timed out initializing value. This is most likely a circular loop in a shortcode" errors we've been seeing.