### PR TITLE
Hide form and delist April 9th workshop from list

### DIFF
--- a/content/webinars/infrastructure-as-code-workshop-2020-04-09/index.md
+++ b/content/webinars/infrastructure-as-code-workshop-2020-04-09/index.md
@@ -18,7 +18,7 @@ pulumi_tv: false
 preview_image: "/images/webinar/pulumi_workshop.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.


### PR DESCRIPTION
This PR hides the April 9th workshop from on the webinar listing page and replaces the form with a message informing the user the recording will be available soon.