### PR TITLE
Add testing webinar and go lang meet up talk

### DIFF
--- a/content/webinars/advanced-infrastructure-as-code-2020-04-16/index.md
+++ b/content/webinars/advanced-infrastructure-as-code-2020-04-16/index.md
@@ -49,7 +49,7 @@ main:
     # Duration of the webinar.
     duration: "90 minutes"
     # Datetime of the webinar.
-    datetime: "WED APR 08, 2020 AT 11:30AM CET"
+    datetime: "THU APR 16, 2020 AT 11:00AM PDT"
     # Description of the webinar.
     description: |
         The hardest part of Kubernetes is setting up the infrastructure: clusters, DNS, firewalls, load balancers, IAM, storage, logging, and performance monitoring, often spanning private, public, and hybrid cloud architectures.

--- a/content/webinars/how-to-test-cloud-infrastructure-2020-04-27/index.md
+++ b/content/webinars/how-to-test-cloud-infrastructure-2020-04-27/index.md
@@ -1,0 +1,75 @@
+---
+# Name of the webinar.
+title: "How to Test Cloud Infrastructure with Pulumi"
+meta_desc: "Cumundi CEO, Ringo De Smet will demonstrate how Pulumi’s mocking capabilities make it easy to ensure that cloud resources are provisioned the right way."
+
+# A featured webinar will display first in the list.
+featured: false
+
+# If the video is pre-recorded or live.
+pre_recorded: false
+
+# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+pulumi_tv: false
+
+# The preview image will be shown on the list page.
+preview_image: "/images/webinar/pulumi_tech_talk.jpg"
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page.
+external: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "how-to-test-cloud-infrastructure-2020-04-27"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: "How to Test Cloud Infrastructure with Pulumi"
+    # The image the appears on the right hand side of the hero.
+    image: "/icons/containers.svg"
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "How to Test Cloud Infrastructure with Pulumi"
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2020-04-27T06:30:00-07:00
+    # Duration of the webinar.
+    duration: "30 minutes"
+    # Datetime of the webinar.
+    datetime: "MON APR 27, 2020 AT 6:30AM PDT"
+    # Description of the webinar.
+    description: |
+        Cloud expert and Cumundi CEO, Ringo De Smet will demonstrate how Pulumi’s new mocking capabilities and multi-language support make it easy to use modern test frameworks to ensure that cloud resources are configured and provisioned the right way the first time.
+
+    # The webinar presenters
+    presenters:
+        - name: Ringo De Smet
+          role: CEO, Cumundi
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn:
+        - Use your preferred test framework in your preferred language to test cloud resources.
+        - How to use Pulumi's new mocking capabilities to decrease test execution time.
+
+# The right hand side form section.
+form:
+    # GoToWebinar webinar key. This key allows us to register people for webinars via the
+    # HubSpot form.
+    gotowebinar_key: "6782734805785325070"
+
+    # HubSpot form id.
+    hubspot_form_id: "c7b0879a-9c73-4c15-be51-04b28f80ad85"
+---

--- a/content/webinars/infrastructure-as-code-go-2020-04-14/index.md
+++ b/content/webinars/infrastructure-as-code-go-2020-04-14/index.md
@@ -67,6 +67,6 @@ main:
 
     # A bullet point list containing what the user will learn during the webinar.
     learn:
-        - How to rovision cloud infrastructure in Go.
+        - How to provision cloud infrastructure in Go.
         - How to test cloud infrastructure.
 ---

--- a/content/webinars/infrastructure-as-code-go-2020-04-14/index.md
+++ b/content/webinars/infrastructure-as-code-go-2020-04-14/index.md
@@ -1,0 +1,72 @@
+---
+# Name of the webinar.
+title: "Modern Cloud Infrastructure in Go"
+meta_desc: "Join us Wed, Apr 1, 2020, 6:30 PM where Evan Boyle will go over modern cloud progamming techniques using Pulumi and Go."
+
+# A featured webinar will display first in the list.
+featured: false
+
+# If the video is pre-recorded or live.
+pre_recorded: false
+
+# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+pulumi_tv: false
+
+# The preview image will be shown on the list page.
+preview_image: "/images/webinar/pulumi_tech_talk.jpg"
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page.
+external: true
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "https://www.meetup.com/golang/events/269676725/"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: "Modern Cloud Infrastructure in Go"
+    # The image the appears on the right hand side of the hero.
+    image: "/icons/containers.svg"
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "Modern Cloud Infrastructure in Go"
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2020-04-14T18:00:00.000-07:00
+    # Duration of the webinar.
+    duration: "2 hours"
+    # Datetime of the webinar.
+    datetime: "TUE, APR 14, 2020 AT 6:00PM PDT"
+    # Description of the webinar.
+    description: >
+        Declaratively defining, deploying, and managing infrastructure usually means breaking out of your day to day toolchain and using YAML or some sort of DSL. Learn how to automate modern infrastructure like functions, containers, and Kubernetes using Pulumi and Go. In this talk we'll explore the productivity superpowers that Pulumi brings to infrastructure:
+
+        1. Provisioning - We'll author a serverless application on AWS, exploring Pulumi's familiar imperative approach using Go that still enables declarative state and change management.
+
+        2. Testing - Pulumi's unique approach opens up a lot of options with unit and integration testing and gives you the confidence to move quickly.
+
+        3. Architecture - Programming languages are naturally suited to encapsulation and abstraction. This enables us to represent our architecture in reusable components that can be published and shared across teams and organizations.
+
+    # The webinar presenters
+    presenters:
+        - name: Evan Boyle
+          role: Staff Software Engineer, Pulumi
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn:
+        - How to rovision cloud infrastructure in Go.
+        - How to test cloud infrastructure.
+---

--- a/content/webinars/on-demand-getting-started-with-infrastructure-as-code/index.md
+++ b/content/webinars/on-demand-getting-started-with-infrastructure-as-code/index.md
@@ -47,7 +47,7 @@ hero:
 main:
     # Webinar title.
     title: "Getting Started with Infrastructure as Code"
-    youtube_url: "https://www.youtube.com/embed/k4UpMCWxbMc"
+    youtube_url: "https://www.youtube.com/embed/emv0iMwCkkg"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2020-03-30T11:30:00.000+01:00
     # Duration of the webinar.


### PR DESCRIPTION
As the title states, this PR adds two new webinars to the listing page. One for the launch testing webinar and the other for Evan's Go talk.