### PR TITLE
Add check for required Hugo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ lint_markdown:
 .PHONY: serve
 serve:
 	@echo -e "\033[0;32mSERVE:\033[0m"
+	./scripts/check-hugo-version.sh
 	yarn lint-markdown --no-error
 	yarn --cwd components run build
 	$(MAKE) copy_static_prebuilt

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ banner:
 ensure:
 	yarn install
 	yarn --cwd components install
+	./scripts/check-hugo-version.sh
 
 .PHONY: ensure_tools
 ensure_tools:

--- a/scripts/check-hugo-version.sh
+++ b/scripts/check-hugo-version.sh
@@ -9,6 +9,11 @@
 
 set -o nounset -o errexit -o pipefail
 
+>/dev/null 2>/dev/null which hugo || {
+    echo "ERROR: Can't find hugo. Do you have hugo installed?"
+    exit 1
+}
+
 readonly REQUIRED_HUGO_VERSION="v0.55.4"
 
 HUGO_VERSION=$(hugo version)

--- a/scripts/check-hugo-version.sh
+++ b/scripts/check-hugo-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Check the currently installed version of Hugo is the specific
+# one required.
+#
+# Recent versions of Hugo have bugs in the markdown renderer (Blackfriday) that prevents fenced
+# code from rendering correctly in lists when a language is specified. See README.md for more
+# details.
+
+set -o nounset -o errexit -o pipefail
+
+readonly REQUIRED_HUGO_VERSION="v0.55.4"
+
+HUGO_VERSION=$(hugo version)
+if [[ ${HUGO_VERSION} != *"${REQUIRED_HUGO_VERSION}"* ]]; then
+    echo "ERROR: Running incorrect version of hugo detected. See README.md for more information."
+    echo "    Installed: ${HUGO_VERSION}"
+    echo "    Required : ${REQUIRED_HUGO_VERSION}"
+    exit 1
+fi

--- a/scripts/run-hugo-build.sh
+++ b/scripts/run-hugo-build.sh
@@ -1,9 +1,13 @@
 # Start a heartbeat process to write data to STDOUT even if there is a long
 # delay in updates from the Hugo build process. This keeps Travis from assuming our
 # jobs have hung. (Ping every min, stop beating after an hour.)
+set -e
+
 ./scripts/emit-heartbeat.sh 60 3600 &
 HEARTBEAT_PID=$!
 echo "Started hearbeat process on PID ${HEARTBEAT_PID}"
+
+./scripts/check-hugo-version.sh
 
 stop_heartbeat() {
     kill -9 ${HEARTBEAT_PID} || echo "Error killing heartbeat process."


### PR DESCRIPTION
Add a check that you are running Hugo v0.55.4, as required to properly render the site's HTML. If you are on a newer version of Hugo, the build will complete successfully but fail to render HTML in the correct format.

We just so happen to install the right version of Hugo in CI, but adding a check will save developer time by failing fast. (It's likely this will break some developers local flow, since depending on what parts of the site you are editing, you might not notice any problems running a newer version of Hugo.) But it's probably better to just add this check.