### PR TITLE
Specify the options in the langfile shortcode

### DIFF
--- a/components/src/components/chooser/chooser.tsx
+++ b/components/src/components/chooser/chooser.tsx
@@ -219,14 +219,21 @@ export class Chooser {
     private parseOptions() {
         this.currentOptions = [];
 
-        if (this.type && this.options) {
-            try {
-                const keys: string[] = this.options.split(",").map(s => s.trim());
-                this.mapOptions(this.type, keys as ChooserKey[]);
-            }
-            catch (err) {
-                console.error(`Error parsing chooser options "${this.options}"`, err);
-            }
+        if (!this.type) {
+            throw new Error("Chooser attribute `type` is required.");
+        }
+
+        if (!this.options) {
+            throw new Error("Chooser attribute `options` is required.");
+        }
+
+        try {
+            const keys: string[] = this.options.split(",").map(s => s.trim());
+            this.mapOptions(this.type, keys as ChooserKey[]);
+        }
+        catch (err) {
+            console.error(`Error parsing chooser options "${this.options}"`);
+            throw(err);
         }
     }
 

--- a/layouts/shortcodes/langfile.html
+++ b/layouts/shortcodes/langfile.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific filename based on the chosen language. */ -}}
-<pulumi-chooser type="language" option-style="none" class="inline langfile">
+<pulumi-chooser type="language" option-style="none" options="javascript,typescript,python,go,csharp,fsharp,visualbasic" class="inline">
 <pulumi-choosable type="language" value="javascript"><code>index.js</code></pulumi-choosable>
 <pulumi-choosable type="language" value="typescript"><code>index.ts</code></pulumi-choosable>
 <pulumi-choosable type="language" value="python"><code>__main__.py</code></pulumi-choosable>

--- a/layouts/shortcodes/langfile.html
+++ b/layouts/shortcodes/langfile.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific filename based on the chosen language. */ -}}
-<pulumi-chooser type="language" option-style="none" options="javascript,typescript,python,go,csharp,fsharp,visualbasic" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,fsharp,visualbasic" option-style="none" class="inline">
 <pulumi-choosable type="language" value="javascript"><code>index.js</code></pulumi-choosable>
 <pulumi-choosable type="language" value="typescript"><code>index.ts</code></pulumi-choosable>
 <pulumi-choosable type="language" value="python"><code>__main__.py</code></pulumi-choosable>

--- a/layouts/shortcodes/language-int32.html
+++ b/layouts/shortcodes/language-int32.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript">Number</code>
     </pulumi-choosable>

--- a/layouts/shortcodes/language-null.html
+++ b/layouts/shortcodes/language-null.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript">undefined</code>
     </pulumi-choosable>

--- a/layouts/shortcodes/policy-enforcementlevel-advisory.html
+++ b/layouts/shortcodes/policy-enforcementlevel-advisory.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific enforcement level based on the chosen language. */ -}}
-<pulumi-chooser type="language" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python" option-style="none" class="inline">
 <pulumi-choosable type="language" value="javascript"><code>"advisory"</code></pulumi-choosable>
 <pulumi-choosable type="language" value="typescript"><code>"advisory"</code></pulumi-choosable>
 <pulumi-choosable type="language" value="python"><code>EnforcementLevel.ADVISORY</code></pulumi-choosable>

--- a/layouts/shortcodes/policy-enforcementlevel-disabled.html
+++ b/layouts/shortcodes/policy-enforcementlevel-disabled.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific enforcement level based on the chosen language. */ -}}
-<pulumi-chooser type="language" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python" option-style="none" class="inline">
 <pulumi-choosable type="language" value="javascript"><code>"disabled"</code></pulumi-choosable>
 <pulumi-choosable type="language" value="typescript"><code>"disabled"</code></pulumi-choosable>
 <pulumi-choosable type="language" value="python"><code>EnforcementLevel.DISABLED</code></pulumi-choosable>

--- a/layouts/shortcodes/policy-enforcementlevel-mandatory.html
+++ b/layouts/shortcodes/policy-enforcementlevel-mandatory.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific enforcement level based on the chosen language. */ -}}
-<pulumi-chooser type="language" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python" option-style="none" class="inline">
 <pulumi-choosable type="language" value="javascript"><code>"mandatory"</code></pulumi-choosable>
 <pulumi-choosable type="language" value="typescript"><code>"mandatory"</code></pulumi-choosable>
 <pulumi-choosable type="language" value="python"><code>EnforcementLevel.MANDATORY</code></pulumi-choosable>

--- a/layouts/shortcodes/policy-reportviolation.html
+++ b/layouts/shortcodes/policy-reportviolation.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific enforcement level based on the chosen language. */ -}}
-<pulumi-chooser type="language" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python" option-style="none" class="inline">
 <pulumi-choosable type="language" value="javascript"><code>reportViolation</code></pulumi-choosable>
 <pulumi-choosable type="language" value="typescript"><code>reportViolation</code></pulumi-choosable>
 <pulumi-choosable type="language" value="python"><code>report_violation</code></pulumi-choosable>

--- a/layouts/shortcodes/policy-validateresource.html
+++ b/layouts/shortcodes/policy-validateresource.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific enforcement level based on the chosen language. */ -}}
-<pulumi-chooser type="language" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python" option-style="none" class="inline">
 <pulumi-choosable type="language" value="javascript"><code>validateResource</code></pulumi-choosable>
 <pulumi-choosable type="language" value="typescript"><code>validateResource</code></pulumi-choosable>
 <pulumi-choosable type="language" value="python"><code>validate</code></pulumi-choosable>

--- a/layouts/shortcodes/pulumi-all.html
+++ b/layouts/shortcodes/pulumi-all.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#all">all</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-apply.html
+++ b/layouts/shortcodes/pulumi-apply.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" values="javascript,typescript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#OutputInstance-apply">apply</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-componentresource-registeroutputs.html
+++ b/layouts/shortcodes/pulumi-componentresource-registeroutputs.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript,typescript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResource-registerOutputs">registerOutputs</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-componentresource.html
+++ b/layouts/shortcodes/pulumi-componentresource.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#ComponentResource">ComponentResource</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-config-get.html
+++ b/layouts/shortcodes/pulumi-config-get.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config-get">Config.get</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-config-getnumber.html
+++ b/layouts/shortcodes/pulumi-config-getnumber.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config-getNumber">Config.getNumber</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-config-getobject.html
+++ b/layouts/shortcodes/pulumi-config-getobject.html
@@ -1,5 +1,4 @@
-
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config-getObject">Config.getObject</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-config-getsecret.html
+++ b/layouts/shortcodes/pulumi-config-getsecret.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config-getSecret">Config.getSecret</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-config-require.html
+++ b/layouts/shortcodes/pulumi-config-require.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config-require">Config.require</a></code></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-config-requiresecret.html
+++ b/layouts/shortcodes/pulumi-config-requiresecret.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config-requireSecret">Config.requireSecret</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-config.html
+++ b/layouts/shortcodes/pulumi-config.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config">Config</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-customresource.html
+++ b/layouts/shortcodes/pulumi-customresource.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResource">CustomResource</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-getproject.html
+++ b/layouts/shortcodes/pulumi-getproject.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#getProject">getProject</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-getstack.html
+++ b/layouts/shortcodes/pulumi-getstack.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#getStack">getStack</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-input-nohref.html
+++ b/layouts/shortcodes/pulumi-input-nohref.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript">Input</code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-input.html
+++ b/layouts/shortcodes/pulumi-input.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#Input">Input</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-log.html
+++ b/layouts/shortcodes/pulumi-log.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/log/">pulumi.log.debug/info/warn/error</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-output-nohref.html
+++ b/layouts/shortcodes/pulumi-output-nohref.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript">Output</code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-output.html
+++ b/layouts/shortcodes/pulumi-output.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#Output">Output</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-resource.html
+++ b/layouts/shortcodes/pulumi-resource.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#Resource">Resource</a></code>
     </pulumi-choosable>

--- a/layouts/shortcodes/pulumi-secret-new.html
+++ b/layouts/shortcodes/pulumi-secret-new.html
@@ -1,4 +1,4 @@
-<pulumi-chooser option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#secret">secret</a></code>
     </pulumi-choosable>


### PR DESCRIPTION
These [should be specified](https://github.com/pulumi/docs/tree/master/components#usage), but it looks like I never did that. 🤦

Also removes an unused CSS class.

Fixes #2909.

---

Updated to apply this change to all shortcodes, and to throw when either `type` or `options` is missing.