### PR TITLE
Removed an extra semi-colon in "Authoring a new Component" C# example

### DIFF
--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -1573,7 +1573,7 @@ func NewMyComponent(ctx *pulumi.Context, name string, opts ...pulumi.ResourceOpt
 class MyComponent : Pulumi.ComponentResource
 {
     public MyComponent(string name, ComponentResourceOptions opts)
-        : base("pkg:index:MyComponent", name, opts);
+        : base("pkg:index:MyComponent", name, opts)
     {
         // initialization logic.
 


### PR DESCRIPTION
### Proposed changes

Removed an extra semi-colon in "Authoring a new Component" C# example

### Unreleased product version (optional)

None

### Related issues (optional)

No known issues.
