### PR TITLE
Update banner to promote 2.0 launch webinar

### DIFF
--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,9 +1,10 @@
 <div class="mx-auto mb-12">
-    <a href="{{ relref . "/webinars/pulumi-update-2020-04-29" }}"
-       class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex">
-        <span class="flex rounded-full bg-orange-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New</span>
-        <span class="text-left flex-auto text-white text-sm md:text-base leading-normal">Join Pulumi CEO, Joe Duffy and Corey Quinn for a
-            fun walk-through of Pulumi 2.0 new features and capabilities.</span>
-        <i class="fill-current fas fa-chevron-right text-xs opacity-75 ml-2 mr-1"></i>
-    </a>
-</div>
+        <a href="{{ relref . "/webinars/pulumi-update-2020-04-29" }}"
+           class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex">
+            <span class="flex rounded-full bg-orange-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New</span>
+            <span class="text-left flex-auto text-white text-sm md:text-base leading-normal">
+                Join us on April 29 for a fun walk-through of the latest Pulumi features and capabilities.
+            </span>
+            <i class="fill-current fas fa-chevron-right text-xs opacity-75 ml-2 mr-1"></i>
+        </a>
+    </div>

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,11 +1,9 @@
-<!--
 <div class="mx-auto mb-12">
-    <a href="{{ relref . "/blog/pulumi-2-0-roadmap" }}"
+    <a href="{{ relref . "/webinars/pulumi-update-2020-04-29" }}"
        class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex">
         <span class="flex rounded-full bg-orange-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New</span>
-        <span class="text-left flex-auto text-white text-sm md:text-base leading-normal">Announcing the Pulumi 2.0
-            roadmap! Policy as code, better .NET and Go, and more.</span>
+        <span class="text-left flex-auto text-white text-sm md:text-base leading-normal">Join Pulumi CEO, Joe Duffy and Corey Quinn for a
+            fun walk-through of Pulumi 2.0 new features and capabilities.</span>
         <i class="fill-current fas fa-chevron-right text-xs opacity-75 ml-2 mr-1"></i>
     </a>
 </div>
--->

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -3,7 +3,7 @@
            class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex">
             <span class="flex rounded-full bg-orange-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New</span>
             <span class="text-left flex-auto text-white text-sm md:text-base leading-normal">
-                Join us on April 29 for a fun walk-through of the latest Pulumi features and capabilities.
+                Join us on April 29 for a fun walk-through of the latest Pulumi features and capabilities with Corey Quinn.
             </span>
             <i class="fill-current fas fa-chevron-right text-xs opacity-75 ml-2 mr-1"></i>
         </a>


### PR DESCRIPTION
Due to the HackerNews post reaching the first page, we want to promote our 2.0 launch webinar to these visitors. This PR adds a banner to promote the webinar.