### PR TITLE
Add UTM param tracking to form submissions

### DIFF
--- a/assets/js/webinar.js
+++ b/assets/js/webinar.js
@@ -8,6 +8,40 @@ function localizeDateTime(date) {
     return localeDate.toLocaleString(undefined, options);
 }
 
+/**
+ * This function parses the cookie string and returns an object of the current cookies.
+ */
+function parseCookie() {
+    var cookieObject = {};
+    var cookieString = document.cookie;
+    var parsedCookie = cookieString.split(";").map(function(cookie) {
+        var parts = cookie.split("=");
+        cookieObject[parts[0]] = parts[1];
+        return cookie;
+    });
+
+    return cookieObject
+}
+
+/**
+ * This function parses the UTM cookie and returns and object of the cookie.
+ *
+ * @param {string} utmCookieString The value of the '__utmzz' cookie. Values are separated by '|'.
+ */
+function parseUTMCookie(utmCookieString) {
+    var cookie = utmCookieString ? utmCookieString : "";
+    var parts = cookie.split("|");
+    var utmObj = {};
+
+    for (let i = 0; i < parts.length; i++) {
+        var value = parts[i];
+        var valueParts = value.split("=");
+        utmObj[valueParts[0]] = utmObj[1];
+    }
+
+    return parseUTMCookie;
+}
+
 $(function() {
     var webinarListings = $("#webinarListings")[0];
     var webinarDetails = $("#webinarLandingPage")[0];
@@ -43,6 +77,32 @@ $(function() {
                 $("#" + listId).removeClass("hidden");
                 $(this).removeClass("text-gray-500").removeClass("hover:text-blue-800").addClass("text-blue-700");
             });
+        });
+    }
+
+    // Check that the analytics track function is available.
+    var analyticsAvailable = window.analytics && window.analytics.track &&
+                             (typeof window.analytics.track === "function");
+
+    if (webinarDetails && analyticsAvailable) {
+        var form = $(".hbspt-form form");
+
+        // Parse the cookie and grab the UTM cookie values.
+        var cookies = parseCookie();
+        var utmCookie = parseUTMCookie(cookies["__utmzz"]);
+
+        // When the form is submitted build the submissionData object and
+        // fire an event to Segment with the data.
+        form.submit(function() {
+            var submissionData = {
+                formId: form.attr("data-form-id"),
+                email: $(".hbspt-form form input[name='email']").val(),
+                utmCampaign: utmCookie.utmccn || "(not set)",
+                utmSource: utmCookie.utmcsr || "(direct)",
+                utmMedium: utmCookie.utmcmd || "(none)",
+            };
+
+            window.analytics.track("form-submission", submissionData);
         });
     }
 });


### PR DESCRIPTION
Currently, our tracking for form submissions is missing UTM parameter tracking in HubSpot. This PR adds an analytics `track` event so we can track the UTM parameters in Metabase. I played around with a few solutions for this such as having our Lambda as an endpoint, adding hidden form fields and trying to associate the parameters per submission in HubSpot, but this implementation seemed like the best solution for us right now. I know this adds a bit of jQuery and we are trying to move over to `stencil.js`. Hopefully, you can forgive me for this one.

This type of tracking is really important as we venture into paid advertising.

Fixes: https://github.com/pulumi/home/issues/758