### PR TITLE
Remove old webinars from listing page and update redirect for April 9th workshop

### DIFF
--- a/content/webinars/advanced-infrastructure-as-code-2020-04-16/index.md
+++ b/content/webinars/advanced-infrastructure-as-code-2020-04-16/index.md
@@ -52,9 +52,7 @@ main:
     datetime: "THU APR 16, 2020 AT 11:00AM PDT"
     # Description of the webinar.
     description: |
-        The hardest part of Kubernetes is setting up the infrastructure: clusters, DNS, firewalls, load balancers, IAM, storage, logging, and performance monitoring, often spanning private, public, and hybrid cloud architectures.
-
-        In this workshop, Luke Hoban and the Pulumi team will show you how to tackle these challenges using Infrastructure as Code (IaC) through a series of hands-on labs. The techniques work for any cloud - Azure, AWS, and GCP. You’ll be able to leverage your favorite languages including Python, Go, JavaScript, TypeScript, and C# instead of YAML or domain-specific languages.
+        This workshop will cover advanced infrastructure as code topics including using and authoring components, multi-stack architectures and testing - as well as how to apply infrastructure as code to Kubernetes - both for provisioning managed Kubernetes clusters and deploying Kubernetes applications and services on top of existing clusters.
 
         After completing this workshop, you’ll be up and running with IaC fundamentals, modern application architectures across many clouds, and Kubernetes best-practices that are ready for production environments. You’ll also be ready to empower your development teams to be more productive - continuously deploying both their applications and infrastructure.
 

--- a/content/webinars/getting-started-with-infrastructure-as-code/index.md
+++ b/content/webinars/getting-started-with-infrastructure-as-code/index.md
@@ -3,6 +3,9 @@
 title: "Getting Started with Infrastructure as Code"
 meta_desc: "In this hands-on workshop, the Pulumi team will show you how to stand up basic services using Infrastructure as Code (IaC) through a series of hands-on labs."
 
+aliases:
+  - /webinars/getting-started-with-infrastrcuture-as-code
+
 # A featured webinar will display first in the list.
 featured: true
 
@@ -60,10 +63,12 @@ main:
 
     # The webinar presenters
     presenters:
-        - name: Paul Stack
+        - name: Luke Hoban
+          role: CTO, Pulumi
+        - name: Mike Metral
           role: Software Engineer, Pulumi
-        - name: Mikhail Shilkov
-          role: Software Engineer, Pulumi
+        - name: Cameron Stokes
+          role: Customer Engineer, Pulumi
 
     # A bullet point list containing what the user will learn during the webinar.
     learn:

--- a/content/webinars/infrastructure-as-code-go-2020-04-14/index.md
+++ b/content/webinars/infrastructure-as-code-go-2020-04-14/index.md
@@ -16,7 +16,7 @@ pulumi_tv: false
 preview_image: "/images/webinar/pulumi_tech_talk.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/content/webinars/infrastructure-as-code-workshop-2020-04-09/index.md
+++ b/content/webinars/infrastructure-as-code-workshop-2020-04-09/index.md
@@ -7,6 +7,7 @@ meta_desc: "In this workshop, Luke Hoban shows you the easy way to start using I
 featured: false
 
 aliases: [ "/events/workshop-san-francisco-2020-04-09" ]
+redirect_to: "/webinars/getting-started-with-infrastructure-as-code/"
 
 # If the video is pre-recorded or live.
 pre_recorded: false

--- a/content/webinars/manage-any-cloud-dotnet-2020-04-13/index.md
+++ b/content/webinars/manage-any-cloud-dotnet-2020-04-13/index.md
@@ -20,7 +20,7 @@ pulumi_tv: false
 preview_image: "/images/webinar/pulumi_tech_talk.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.


### PR DESCRIPTION
This PR adds the`unlist` to webinars that already happened this week. It also adds a redirect for the April 9th workshop to the landing page for the On-Demand recording of the workshop.