### PR TITLE
Update python k8s quickstart

### DIFF
--- a/content/docs/get-started/kubernetes/modify-program.md
+++ b/content/docs/get-started/kubernetes/modify-program.md
@@ -104,6 +104,9 @@ export const ip = isMinikube
 {{% choosable language python %}}
 
 ```python
+"""
+Creating a Kubernetes Deployment
+"""
 import pulumi
 from pulumi_kubernetes.apps.v1 import Deployment
 from pulumi_kubernetes.core.v1 import Service
@@ -140,10 +143,15 @@ frontend = Service(
     })
 
 # When "done", this will print the public IP.
+result = None
 if is_minikube:
-    pulumi.export("ip", frontend.spec.apply(lambda v: v["cluster_ip"] if "cluster_ip" in v else None))
+    result = frontend.spec.apply(lambda v: v["cluster_ip"] if "cluster_ip" in v else None)
 else:
-    pulumi.export("ip", frontend.status.apply(lambda v: v["load_balancer"]["ingress"][0]["ip"] if "load_balancer" in v else None))
+    ingress = frontend.status.apply(lambda v: v["load_balancer"]["ingress"][0] if "load_balancer" in v else None)
+    if ingress is not None:
+        result = ingress.apply(lambda v: v["ip"] if "ip" in v else v["hostname"])
+
+pulumi.export("ip", result)
 ```
 
 {{% /choosable %}}

--- a/content/docs/get-started/kubernetes/review-project.md
+++ b/content/docs/get-started/kubernetes/review-project.md
@@ -71,6 +71,9 @@ export const name = deployment.metadata.name;
 {{% choosable language python %}}
 
 ```python
+"""
+Creating a Kubernetes Deployment
+"""
 import pulumi
 from pulumi_kubernetes.apps.v1 import Deployment
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This example didn't work for Docker Desktop k8s,
because the LoadBalancer endpoint is in the
`hostname` field rather than `ip`.
<!--Give us a brief description of what you've done and what it solves. -->

