### PR TITLE
Adjust styling of deprecation notice.

### DIFF
--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -71,7 +71,10 @@ dl {
             &.property-deprecated {
                 ~ dd {
                     .property-message {
-                        @apply text-yellow-700 py-2 px-4 rounded border border-yellow-600;
+                        @apply bg-orange-200 text-orange-600 my-4 px-5 py-4 rounded text-sm;
+                    }
+                    code {
+                        @apply bg-orange-200;
                     }
                 }
             }


### PR DESCRIPTION
This change makes the deprecation notices in the resource docs closer to the ones in the API docs.  See discussion in issue https://github.com/pulumi/docs/issues/2866.

Before:
![image](https://user-images.githubusercontent.com/41454626/79497254-352e9780-7fdc-11ea-878b-229f51fd9f5c.png)

After:
![image](https://user-images.githubusercontent.com/41454626/79497203-247e2180-7fdc-11ea-821c-6eb9caa062bd.png)
