### PR TITLE
Add support for generating resource docs for Kubernetes overlays

### DIFF
--- a/scripts/gen_resource_docs.sh
+++ b/scripts/gen_resource_docs.sh
@@ -63,6 +63,7 @@ generate_docs() {
 
     if [ $provider = "kubernetes" ]; then
         SCHEMA_FILE="../../../pulumi-kubernetes/sdk/schema/schema.json"
+        OVERLAY_SCHEMA_FILE="./overlays/kubernetes/overlays.json"
     else
         SCHEMA_FILE="../../../pulumi-${provider}/provider/cmd/pulumi-resource-${provider}/schema.json"
     fi
@@ -72,7 +73,7 @@ generate_docs() {
 
     echo "Running docs generator from schema for ${provider}..."
     pushd ${TOOL_RESDOCGEN}
-    go run . -logtostderr ${ABSOLUTEPACKDIR}/${provider} ${SCHEMA_FILE} || exit 3
+    go run . -logtostderr "${ABSOLUTEPACKDIR}/${provider}" "${SCHEMA_FILE}" "${OVERLAY_SCHEMA_FILE}" || exit 3
     popd
 
     echo "Done generating resource docs for ${provider}"

--- a/scripts/gen_resource_docs.sh
+++ b/scripts/gen_resource_docs.sh
@@ -66,6 +66,7 @@ generate_docs() {
         OVERLAY_SCHEMA_FILE="./overlays/kubernetes/overlays.json"
     else
         SCHEMA_FILE="../../../pulumi-${provider}/provider/cmd/pulumi-resource-${provider}/schema.json"
+        OVERLAY_SCHEMA_FILE=""
     fi
 
     echo "Removing the ${PACKDIR}/${provider} dir..."

--- a/tools/resourcedocsgen/go.mod
+++ b/tools/resourcedocsgen/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/pkg/v2 v2.0.0-beta.3
+	github.com/pulumi/pulumi/pkg/v2 v2.0.0
 	github.com/pulumi/pulumi/sdk/v2 v2.0.0
 )
 

--- a/tools/resourcedocsgen/main.go
+++ b/tools/resourcedocsgen/main.go
@@ -18,6 +18,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/dotnet"
+	go_gen "github.com/pulumi/pulumi/pkg/v2/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/nodejs"
 	"io/ioutil"
 	"os"
 	"path"
@@ -36,35 +39,134 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 	if len(args) < 2 {
-		fmt.Fprintf(os.Stderr, "error: usage: %s <out-dir> <provider-schema-file>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "error: usage: %s <out-dir> <provider-schema-file> <overlay-schema-file>\n", os.Args[0])
 		os.Exit(1)
 	}
 
 	defer glog.Flush()
 
-	outDir, schemaFile := args[0], args[1]
+	outDir, schemaFile, overlaysSchemaFile := args[0], args[1], args[2]
 
-	b, err := ioutil.ReadFile(schemaFile)
+	schema, err := ioutil.ReadFile(schemaFile)
 	if err != nil {
 		fmt.Printf("error reading schema file from path: %v", err)
 		os.Exit(1)
 	}
 
-	if err := generateDocsFromSchema(outDir, b); err != nil {
+	mainSpec := &pschema.PackageSpec{}
+	if err := json.Unmarshal(schema, mainSpec); err != nil {
+		fmt.Printf("error unmarshalling schema into a PackageSpec: %v", err)
+		os.Exit(1)
+	}
+
+	if overlaysSchemaFile != "" {
+		overlaySpec := &pschema.PackageSpec{}
+		overlaysSchema, err := ioutil.ReadFile(overlaysSchemaFile)
+		if err != nil {
+			fmt.Printf("error reading overlay schema file from path: %v", err)
+			os.Exit(1)
+		}
+		if err := json.Unmarshal(overlaysSchema, overlaySpec); err != nil {
+			fmt.Printf("error unmarshalling overlay schema into a PackageSpec: %v", err)
+			os.Exit(1)
+		}
+
+		mergeOverlaySchemaSpec(mainSpec, overlaySpec)
+	}
+
+	if err := generateDocsFromSchema(outDir, mainSpec); err != nil {
 		fmt.Printf("error generating docs from schema: %v", err)
 		os.Exit(1)
 	}
 }
 
-func generateDocsFromSchema(outDir string, schema []byte) error {
-	spec := &pschema.PackageSpec{}
-	if err := json.Unmarshal(schema, spec); err != nil {
-		return errors.Wrapf(err, "error unmarshalling schema into a PackageSpec: %v", err)
+// mergeOverlaySchemaSpec merges the resources, types and language info from the overlay schema spec
+// into the main package spec.
+func mergeOverlaySchemaSpec(mainSpec *pschema.PackageSpec, overlaySpec *pschema.PackageSpec) error {
+	// Merge the overlay schema spec into the main schema spec.
+	for key, value := range overlaySpec.Types {
+		mainSpec.Types[key] = value
+	}
+	for key, value := range overlaySpec.Resources {
+		mainSpec.Resources[key] = value
+	}
+	for lang, overlayLanguageInfo := range overlaySpec.Language {
+		switch lang {
+		case "go":
+			var mainSchemaPkgInfo go_gen.GoInfo
+			if err := json.Unmarshal(mainSpec.Language[lang], &mainSchemaPkgInfo); err != nil {
+				return errors.Wrap(err, "error un-marshalling Go package info from the main schema spec")
+			}
+
+			var overlaySchemaPkgInfo go_gen.GoInfo
+			if err := json.Unmarshal(overlayLanguageInfo, &overlaySchemaPkgInfo); err != nil {
+				return errors.Wrap(err, "error un-marshalling Go package info from the overlay schema spec")
+			}
+
+			for key, value := range overlaySchemaPkgInfo.ModuleToPackage {
+				mainSchemaPkgInfo.ModuleToPackage[key] = value
+			}
+			for key, value := range overlaySchemaPkgInfo.PackageImportAliases {
+				mainSchemaPkgInfo.PackageImportAliases[key] = value
+			}
+
+			// Override the language info for Go in the main schema spec.
+			b, err := json.Marshal(mainSchemaPkgInfo)
+			if err != nil {
+				return errors.Wrap(err, "error marshalling Go package info")
+			}
+			mainSpec.Language[lang] = json.RawMessage(string(b))
+		case "nodejs":
+			var mainSchemaPkgInfo nodejs.NodePackageInfo
+			if err := json.Unmarshal(mainSpec.Language[lang], &mainSchemaPkgInfo); err != nil {
+				return errors.Wrap(err, "error un-marshalling NodeJS package info from the main schema spec")
+			}
+
+			var overlaySchemaPkgInfo nodejs.NodePackageInfo
+			if err := json.Unmarshal(overlayLanguageInfo, &overlaySchemaPkgInfo); err != nil {
+				return errors.Wrap(err, "error un-marshalling NodeJS package info from the overlay schema spec")
+			}
+
+			for key, value := range overlaySchemaPkgInfo.ModuleToPackage {
+				mainSchemaPkgInfo.ModuleToPackage[key] = value
+			}
+
+			// Override the language info for NodeJS in the main schema spec.
+			b, err := json.Marshal(mainSchemaPkgInfo)
+			if err != nil {
+				return errors.Wrap(err, "error marshalling NodeJS package info")
+			}
+			mainSpec.Language[lang] = json.RawMessage(string(b))
+		case "csharp":
+			var mainSchemaPkgInfo dotnet.CSharpPackageInfo
+			if err := json.Unmarshal(mainSpec.Language[lang], &mainSchemaPkgInfo); err != nil {
+				return errors.Wrap(err, "error un-marshalling C# package info from the main schema spec")
+			}
+
+			var overlaySchemaPkgInfo dotnet.CSharpPackageInfo
+			if err := json.Unmarshal(overlayLanguageInfo, &overlaySchemaPkgInfo); err != nil {
+				return errors.Wrap(err, "error un-marshalling C# package info from overlay schema spec")
+			}
+
+			for key, value := range overlaySchemaPkgInfo.Namespaces {
+				mainSchemaPkgInfo.Namespaces[key] = value
+			}
+			// Override the language info for C# in the main schema spec.
+			b, err := json.Marshal(mainSchemaPkgInfo)
+			if err != nil {
+				return errors.Wrap(err, "error marshalling C# package info")
+			}
+			mainSpec.Language[lang] = json.RawMessage(string(b))
+		}
 	}
 
+	return nil
+}
+
+func generateDocsFromSchema(outDir string, spec *pschema.PackageSpec) error {
 	pulPkg, err := pschema.ImportSpec(*spec)
 	if err != nil {
-		return errors.Wrapf(err, "error importing un-marshalled package spec: %v", err)
+		return errors.Wrapf(err, "error importing package spec: %v", err)
 	}
 
 	files, err := docsgen.GeneratePackage("Pulumi Docs Generator", pulPkg)

--- a/tools/resourcedocsgen/overlays/kubernetes/overlays.json
+++ b/tools/resourcedocsgen/overlays/kubernetes/overlays.json
@@ -66,6 +66,72 @@
                     "description": "Specific version of a chart. Without this, the latest version is fetched."
                 }
             }
+        },
+        "kubernetes:helm/v3:FetchOpts": {
+            "type": "object",
+            "description": "Additional options to customize the fetching of the Helm chart.",
+            "inputProperties": {
+                "caFile": {
+                    "type": "string",
+                    "description": "Verify certificates of HTTPS-enabled servers using this CA bundle."
+                },
+                "certFile": {
+                    "type": "string",
+                    "description": "Identify HTTPS client using this SSL certificate file."
+                },
+                "destination": {
+                    "type": "string",
+                    "description": "Location to write the chart. If this and tardir are specified, tardir is appended to this (default \".\")."
+                },
+                "devel": {
+                    "type": "boolean",
+                    "description": "Use development versions, too. Equivalent to version '>0.0.0-0'. If –version is set, this is ignored."
+                },
+                "home": {
+                    "type": "string",
+                    "description": "Location of your Helm config. Overrides $HELM_HOME (default \"/Users/abc/.helm\")."
+                },
+                "keyFile": {
+                    "type": "string",
+                    "description": "Identify HTTPS client using this SSL key file."
+                },
+                "keyring": {
+                    "type": "string",
+                    "description": "Keyring containing public keys (default “/Users/abc/.gnupg/pubring.gpg”)."
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Chart repository password."
+                },
+                "prov": {
+                    "type": "string",
+                    "description": "Fetch the provenance file, but don’t perform verification."
+                },
+                "repo": {
+                    "type": "string",
+                    "description": "Chart repository url where to locate the requested chart."
+                },
+                "untar": {
+                    "type": "boolean",
+                    "description": "If set to false, will leave the chart as a tarball after downloading."
+                },
+                "untardir": {
+                    "type": "string",
+                    "description": "If untar is specified, this flag specifies the name of the directory into which the chart is expanded (default \".\")."
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Chart repository username."
+                },
+                "verify": {
+                    "type": "string",
+                    "description": "Verify the package against its signature."
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Specific version of a chart. Without this, the latest version is fetched."
+                }
+            }
         }
     },
     "resources": {
@@ -75,13 +141,11 @@
             "properties": {
                 "apiVersion": {
                     "type": "string",
-                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-                    "const": "admissionregistration.k8s.io/v1"
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
                 },
                 "kind": {
                     "type": "string",
-                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-                    "const": "MutatingWebhookConfiguration"
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
                 },
                 "metadata": {
                     "$ref": "#/types/kubernetes:meta/v1:ObjectMeta",
@@ -91,13 +155,11 @@
             "inputProperties": {
                 "apiVersion": {
                     "type": "string",
-                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-                    "const": "admissionregistration.k8s.io/v1"
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
                 },
                 "kind": {
                     "type": "string",
-                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-                    "const": "MutatingWebhookConfiguration"
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
                 },
                 "metadata": {
                     "$ref": "#/types/kubernetes:meta/v1:ObjectMeta",
@@ -124,6 +186,63 @@
                 },
                 "fetchOpts": {
                     "$ref": "#/types/kubernetes:helm/v2:FetchOpts",
+                    "description": "Additional options to customize the fetching of the Helm chart."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The path to the chart directory which contains the `Chart.yaml` file.\n\nRequired if specifying `LocalChartOpts`."
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "The optional namespace to install chart resources into."
+                },
+                "repo": {
+                    "type": "string",
+                    "description": "The repository name of the chart to deploy. Example: \"stable\".\n\nUsed only when specifying options for a remote chart."
+                },
+                "resourcePrefix": {
+                    "type": "string",
+                    "description": "An optional prefix for the auto-generated resource names. Example: A resource created with resourcePrefix=\"foo\" would produce a resource named \"foo-resourceName\"."
+                },
+                "transformations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Optional array of transformations to apply to resources that will be created by this chart prior to creation. Allows customization of the chart behaviour without directly modifying the chart itself."
+                },
+                "values": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Overrides for chart values."
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the chart to deploy. If not provided, the latest version will be deployed."
+                }
+            }
+        },
+        "kubernetes:helm/v3:Chart": {
+            "description": "ConfigFile creates a set of Kubernetes resources from Kubernetes YAML file. If `config.name`\n is not specified, `ConfigFile` assumes the argument `name` is the filename.",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string",
+                    "description": "urn is the stable logical URN used to distinctly address a resource, both before and after deployments."
+                }
+            },
+            "inputProperties": {
+                "chart": {
+                    "type": "string",
+                    "description": "The name of the chart to deploy. If [repo] is provided, this chart name will be prefixed by the repo name. Example: repo: \"stable\", chart: \"nginx-ingress\" -> \"stable/nginx-ingress\" Example: chart: \"stable/nginx-ingress\" -> \"stable/nginx-ingress\"\n\nRequired if specifying `ChartOpts` for a remote chart."
+                },
+                "fetchOpts": {
+                    "$ref": "#/types/kubernetes:helm/v3:FetchOpts",
                     "description": "Additional options to customize the fetching of the Helm chart."
                 },
                 "path": {
@@ -269,21 +388,21 @@
             "moduleToPackage": {
                 "apiextensions.k8s.io": "apiextensions",
                 "helm/v2": "helm/v2",
+                "helm/v3": "helm/v3",
                 "yaml": "yaml"
             },
-            "packageImportAliases": {
-                "github.com/pulumi/pulumi-kubernetes/sdk/go/kubernetes/helm/v2": "helmv2"
-            }
         },
         "nodejs": {
             "moduleToPackage": {
                 "helm/v2": "helm/v2",
+                "helm/v3": "helm/v3",
                 "yaml": "yaml"
             }
         },
         "csharp": {
             "namespaces": {
                 "helm/v2": "Helm.V2",
+                "helm/v3": "Helm.V3",
                 "yaml": "Yaml"
             }
         }

--- a/tools/resourcedocsgen/overlays/kubernetes/overlays.json
+++ b/tools/resourcedocsgen/overlays/kubernetes/overlays.json
@@ -164,6 +164,13 @@
                 "metadata": {
                     "$ref": "#/types/kubernetes:meta/v1:ObjectMeta",
                     "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+                },
+                "others": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "This field is not an actual property. It is used to represent custom property names and their values that can be passed in addition to the other input properties."
                 }
             }
         },
@@ -390,7 +397,7 @@
                 "helm/v2": "helm/v2",
                 "helm/v3": "helm/v3",
                 "yaml": "yaml"
-            },
+            }
         },
         "nodejs": {
             "moduleToPackage": {

--- a/tools/resourcedocsgen/overlays/kubernetes/overlays.json
+++ b/tools/resourcedocsgen/overlays/kubernetes/overlays.json
@@ -1,0 +1,291 @@
+{
+    "name": "kubernetes",
+    "types": {
+        "kubernetes:helm/v2:FetchOpts": {
+            "type": "object",
+            "description": "Additional options to customize the fetching of the Helm chart.",
+            "inputProperties": {
+                "caFile": {
+                    "type": "string",
+                    "description": "Verify certificates of HTTPS-enabled servers using this CA bundle."
+                },
+                "certFile": {
+                    "type": "string",
+                    "description": "Identify HTTPS client using this SSL certificate file."
+                },
+                "destination": {
+                    "type": "string",
+                    "description": "Location to write the chart. If this and tardir are specified, tardir is appended to this (default \".\")."
+                },
+                "devel": {
+                    "type": "boolean",
+                    "description": "Use development versions, too. Equivalent to version '>0.0.0-0'. If –version is set, this is ignored."
+                },
+                "home": {
+                    "type": "string",
+                    "description": "Location of your Helm config. Overrides $HELM_HOME (default \"/Users/abc/.helm\")."
+                },
+                "keyFile": {
+                    "type": "string",
+                    "description": "Identify HTTPS client using this SSL key file."
+                },
+                "keyring": {
+                    "type": "string",
+                    "description": "Keyring containing public keys (default “/Users/abc/.gnupg/pubring.gpg”)."
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Chart repository password."
+                },
+                "prov": {
+                    "type": "string",
+                    "description": "Fetch the provenance file, but don’t perform verification."
+                },
+                "repo": {
+                    "type": "string",
+                    "description": "Chart repository url where to locate the requested chart."
+                },
+                "untar": {
+                    "type": "boolean",
+                    "description": "If set to false, will leave the chart as a tarball after downloading."
+                },
+                "untardir": {
+                    "type": "string",
+                    "description": "If untar is specified, this flag specifies the name of the directory into which the chart is expanded (default \".\")."
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Chart repository username."
+                },
+                "verify": {
+                    "type": "string",
+                    "description": "Verify the package against its signature."
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Specific version of a chart. Without this, the latest version is fetched."
+                }
+            }
+        }
+    },
+    "resources": {
+        "kubernetes:apiextensions.k8s.io:CustomResource": {
+            "description": "CustomResource represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResource`, passing the\n `ServiceMonitor` resource definition as an argument.",
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "const": "admissionregistration.k8s.io/v1"
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "const": "MutatingWebhookConfiguration"
+                },
+                "metadata": {
+                    "$ref": "#/types/kubernetes:meta/v1:ObjectMeta",
+                    "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+                }
+            },
+            "inputProperties": {
+                "apiVersion": {
+                    "type": "string",
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "const": "admissionregistration.k8s.io/v1"
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "const": "MutatingWebhookConfiguration"
+                },
+                "metadata": {
+                    "$ref": "#/types/kubernetes:meta/v1:ObjectMeta",
+                    "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+                }
+            }
+        },
+        "kubernetes:helm/v2:Chart": {
+            "description": "ConfigFile creates a set of Kubernetes resources from Kubernetes YAML file. If `config.name`\n is not specified, `ConfigFile` assumes the argument `name` is the filename.",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string",
+                    "description": "urn is the stable logical URN used to distinctly address a resource, both before and after deployments."
+                }
+            },
+            "inputProperties": {
+                "chart": {
+                    "type": "string",
+                    "description": "The name of the chart to deploy. If [repo] is provided, this chart name will be prefixed by the repo name. Example: repo: \"stable\", chart: \"nginx-ingress\" -> \"stable/nginx-ingress\" Example: chart: \"stable/nginx-ingress\" -> \"stable/nginx-ingress\"\n\nRequired if specifying `ChartOpts` for a remote chart."
+                },
+                "fetchOpts": {
+                    "$ref": "#/types/kubernetes:helm/v2:FetchOpts",
+                    "description": "Additional options to customize the fetching of the Helm chart."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The path to the chart directory which contains the `Chart.yaml` file.\n\nRequired if specifying `LocalChartOpts`."
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "The optional namespace to install chart resources into."
+                },
+                "repo": {
+                    "type": "string",
+                    "description": "The repository name of the chart to deploy. Example: \"stable\".\n\nUsed only when specifying options for a remote chart."
+                },
+                "resourcePrefix": {
+                    "type": "string",
+                    "description": "An optional prefix for the auto-generated resource names. Example: A resource created with resourcePrefix=\"foo\" would produce a resource named \"foo-resourceName\"."
+                },
+                "transformations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Optional array of transformations to apply to resources that will be created by this chart prior to creation. Allows customization of the chart behaviour without directly modifying the chart itself."
+                },
+                "values": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Overrides for chart values."
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the chart to deploy. If not provided, the latest version will be deployed."
+                }
+            }
+        },
+        "kubernetes:yaml:ConfigFile": {
+            "description": "ConfigFile creates a set of Kubernetes resources from Kubernetes YAML file. If `config.name` is not specified, `ConfigFile` assumes the argument `name` is the filename.",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string",
+                    "description": "urn is the stable logical URN used to distinctly address a resource, both before and after deployments."
+                }
+            },
+            "inputProperties": {
+                "file": {
+                    "type": "string",
+                    "description": "Path or a URL that uniquely identifies a file."
+                },
+                "resourcePrefix": {
+                    "type": "string",
+                    "description": "An optional prefix for the auto-generated resource names. Example: A resource created with resourcePrefix=\"foo\" would produce a resource named \"foo-resourceName\"."
+                },
+                "transformations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "A set of transformations to apply to Kubernetes resource definitions before registering with engine."
+                }
+            }
+        },
+        "kubernetes:yaml:ConfigGroup": {
+            "description": "ConfigGroup creates a set of Kubernetes resources from Kubernetes YAML text. The YAML text\n may be supplied using any of the following `ConfigGroupOpts`:\n\n\n1. Using a filename or a list of filenames:\n\ta. `{files: \"foo.yaml\"}`\n\tb. `{files: [\"foo.yaml\", \"bar.yaml\"]}`\n2. Using a file pattern or a list of file patterns:\n\ta. `{files: \"*.yaml\"}`\n\tb. `{files: [\"foo/*.yaml\", \"bar/*.yaml\"]}`\n3. Using a literal string containing YAML, or a list of such strings:\n\ta. `{yaml: \"(LITERAL YAML HERE)\"}`\n\tb. `{yaml: [\"(LITERAL YAML HERE)\", \"(MORE YAML)\"]}`\n4. Any combination of files, patterns, or YAML strings:\n\ta. `{files: \"foo.yaml\", yaml: \"(LITERAL YAML HERE)\"}`",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string",
+                    "description": "urn is the stable logical URN used to distinctly address a resource, both before and after deployments."
+                }
+            },
+            "inputProperties": {
+                "files": {
+                    "description": "Set of paths or a URLs that uniquely identify files.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "Path or a URL that uniquely identifies a file."
+                },
+                "objs": {
+                    "description": "Objects representing Kubernetes resources.",
+                    "oneOf": [
+                        {
+                            "$ref": "pulumi.json#/Any"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "pulumi.json#/Any"
+                            }
+                        }
+                    ],
+                    "description": "Path or a URL that uniquely identifies a file."
+                },
+                "resourcePrefix": {
+                    "type": "string",
+                    "description": "An optional prefix for the auto-generated resource names. Example: A resource created with resourcePrefix=\"foo\" would produce a resource named \"foo-resourceName\"."
+                },
+                "transformations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "A set of transformations to apply to Kubernetes resource definitions before registering with engine."
+                },
+                "yaml": {
+                    "description": "YAML text containing Kubernetes resource definitions.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "Path or a URL that uniquely identifies a file."
+                }
+            }
+        }
+    },
+    "language": {
+        "go": {
+            "moduleToPackage": {
+                "apiextensions.k8s.io": "apiextensions",
+                "helm/v2": "helm/v2",
+                "yaml": "yaml"
+            },
+            "packageImportAliases": {
+                "github.com/pulumi/pulumi-kubernetes/sdk/go/kubernetes/helm/v2": "helmv2"
+            }
+        },
+        "nodejs": {
+            "moduleToPackage": {
+                "helm/v2": "helm/v2",
+                "yaml": "yaml"
+            }
+        },
+        "csharp": {
+            "namespaces": {
+                "helm/v2": "Helm.V2",
+                "yaml": "Yaml"
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Proposed changes

This PR updates the resourcedocsgen tool, which is a driver of the resource docs generator, to merge an overlay schema for k8s with the main schema before kicking-off the resource docs generator with it.

The only thing I am unsure of how to workaround is the `transformation` property. One thought I had was to perhaps specify something in the description for that property that showed how to specify its value perhaps?

### Unreleased product version (optional)

N/A

### Related issues (optional)

Related to pulumi/pulumi#4406.
