### PR TITLE
Remove PREVIEW label from dynamic providers and self-hosted

### DIFF
--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -3187,7 +3187,7 @@ class MyStack
 
 {{< /chooser >}}
 
-#### Dynamic Providers <span class="badge badge-preview">PREVIEW</span> {#dynamicproviders}
+#### Dynamic Providers {#dynamicproviders}
 
 Every {{< pulumi-customresource >}} has a provider associated with it which knows how to `create`, `read`, `update`, and `delete` instances of the custom resource in the backing cloud provider. This provider plugin is defined by implementing the Pulumi Resource Provider gRPC interface. Most resources implement this without you needing to know how.
 

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -305,7 +305,7 @@
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
             <div class="pricing-item">
-                <span class="pricing-item-label"><a data-track="grid-self-hosted" href="{{ relref . "/docs/guides/self-hosted" }}" class="link">Self-Hosting</a> <span class="badge badge-preview">PREVIEW</span></span>
+                <span class="pricing-item-label"><a data-track="grid-self-hosted" href="{{ relref . "/docs/guides/self-hosted" }}" class="link">Self-Hosting</a></span>
                 <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
                 <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
                 <span class="pricing-item-value">Available</span>


### PR DESCRIPTION
These are both now out of preview, fully-documented, and have meaningful large-scale usage.

There are three remaining areas that are still marked as preview:
1. `@pulumi/kubernetesx` package for NodeJS
2. `@pulumi/cloud` package for NodeJS
2. `pulumi_policy` package for Python

Fixes #2924.
