### PR TITLE
Fix some links to new resource docs

### DIFF
--- a/content/blog/adopting-existing-cloud-resources-into-pulumi/index.md
+++ b/content/blog/adopting-existing-cloud-resources-into-pulumi/index.md
@@ -24,15 +24,15 @@ We'll review referencing existing resources, and then dive deeper into how you c
 
 For referencing existing resources, Pulumi offers several tools.
 
-* The `.get` methods available on every resource let you [get all the details for a resource]({{< relref "/docs/reference/pkg/aws/ec2/vpc#look-up-an-existing-vpc-resource" >}}) from the cloud provider based just on its `id`.
+* The `.get` methods available on every resource let you [get all the details for a resource]({{< relref "/docs/reference/pkg/aws/ec2/vpc#look-up" >}}) from the cloud provider based just on its `id`.
 * The `StackReference` resource lets you reference outputs of another stack for use as inputs to a stack, which is very useful for [organizing projects and stacks]({{< relref "/docs/intro/concepts/organizing-stacks-projects" >}}).
-* [`terraform.state.RemoteStateReference()`]({{< relref "/blog/using-terraform-remote-state-with-pulumi" >}}), [`aws.cloudformation.getStack()`]({{< relref "/docs/reference/pkg/aws/cloudformation/getstack" >}}) and [`azure.core.TemplateDeployment.get()`]({{< relref "/docs/reference/pkg/azure/core/templatedeployment#look-up-an-existing-templatedeployment-resource" >}}) let you reference outputs from existing Terraform, CloudFormation and ARM deployments respectively.
+* [`terraform.state.RemoteStateReference()`]({{< relref "/blog/using-terraform-remote-state-with-pulumi" >}}), [`aws.cloudformation.getStack()`]({{< relref "/docs/reference/pkg/aws/cloudformation/getstack" >}}) and [`azure.core.TemplateDeployment.get()`]({{< relref "/docs/reference/pkg/azure/core/templatedeployment#look-up" >}}) let you reference outputs from existing Terraform, CloudFormation and ARM deployments respectively.
 
 Together, these make it easy to reference existing infrastructure regardless of how it was provisioned.
 
 ## Adopting Existing Resources
 
-For adopting existing resources, Pulumi offers the [`import`]({{< relref "/docs/reference/pkg/azure/core/templatedeployment#look-up-an-existing-templatedeployment-resource" >}}) resource option to request that a resource defined in your Pulumi program adopt an existing resource in the cloud provider instead of creating a new one.  In keeping with its focus on infrastructure as *code*, Pulumi lets you specify this `import` behavior inside the Pulumi code for your infrastructure deployment, instead of outside of it in some manual workflow.  In its simplest form, it looks like this:
+For adopting existing resources, Pulumi offers the [`import`]({{< relref "/docs/reference/pkg/azure/core/templatedeployment#look-up" >}}) resource option to request that a resource defined in your Pulumi program adopt an existing resource in the cloud provider instead of creating a new one.  In keeping with its focus on infrastructure as *code*, Pulumi lets you specify this `import` behavior inside the Pulumi code for your infrastructure deployment, instead of outside of it in some manual workflow.  In its simplest form, it looks like this:
 
 ```ts
 const myVpc = new aws.ec2.Vpc("my-vpc", {

--- a/content/blog/aws-eks-managed-nodes-fargate/index.md
+++ b/content/blog/aws-eks-managed-nodes-fargate/index.md
@@ -291,7 +291,7 @@ This can be provisioned with a single `pulumi up`, just like before, but instead
 
 Note that it's possible to mix node groups. So, if you need precise control over some groups, but not others, feel free to call `createNodeGroup` and `createManagedNodeGroup` interspersed with one another. The EKS package knows what to do.
 
-For a full list of properties you can configure on your Managed Node Groups, please refer to the [`createManagedNodeGroup` API docs]({{< relref "/docs/reference/pkg/aws/eks/nodegroup#create-a-nodegroup-resource" >}}). There are fewer options available than manually managed node groups, such as inability to supply kubelet arguments, for instance. We are giving up some control in exchange for simplicity. For complete information about EKS Managed Node Groups, [see AWS's own product documentation](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html).
+For a full list of properties you can configure on your Managed Node Groups, please refer to the [`createManagedNodeGroup` API docs]({{< relref "/docs/reference/pkg/aws/eks/nodegroup#create" >}}). There are fewer options available than manually managed node groups, such as inability to supply kubelet arguments, for instance. We are giving up some control in exchange for simplicity. For complete information about EKS Managed Node Groups, [see AWS's own product documentation](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html).
 
 ## Let Fargate Manage It All
 

--- a/content/docs/guides/crosswalk/aws/ecs.md
+++ b/content/docs/guides/crosswalk/aws/ecs.md
@@ -191,7 +191,7 @@ const nginx = new awsx.ecs.FargateService("nginx", {
 });
 ```
 
-Notice that we are using a method from a different package, [`aws.ecs.Cluster.get`]({{< relref "/docs/reference/pkg/aws/ecs/cluster#look-up-an-existing-cluster-resource" >}}), to look up our existing cluster by its ID and then creating an `awsx.ecs.Cluster` out of it. The former is the raw resource description, while the latter is the object type required to work with the Pulumi Crosswalk for AWS ECS APIs.
+Notice that we are using a method from a different package, [`aws.ecs.Cluster.get`]({{< relref "/docs/reference/pkg/aws/ecs/cluster#look-up" >}}), to look up our existing cluster by its ID and then creating an `awsx.ecs.Cluster` out of it. The former is the raw resource description, while the latter is the object type required to work with the Pulumi Crosswalk for AWS ECS APIs.
 
 ## ECS Tasks, Containers, and Services
 

--- a/content/docs/intro/cloud-providers/kubernetes/setup.md
+++ b/content/docs/intro/cloud-providers/kubernetes/setup.md
@@ -12,7 +12,7 @@ aliases: ["/docs/reference/clouds/kubernetes/setup/"]
 [aks-tutorial]: {{< relref "/docs/tutorials/kubernetes/aks" >}}
 [Heptio AWS quickstart]: https://aws.amazon.com/quickstart/architecture/heptio-kubernetes/
 [provider-args]: {{< relref "/docs/reference/pkg/kubernetes/provider" >}}
-[provider-kubeconfig]: {{< relref "/docs/reference/pkg/kubernetes/provider#resource-arguments" >}}
+[provider-kubeconfig]: {{< relref "/docs/reference/pkg/kubernetes/provider#inputs" >}}
 [kubeconfig]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 [install]: {{< relref "/docs/get-started/install" >}}
 [nodejs]: https://nodejs.org/en/


### PR DESCRIPTION
We recently changed some of the anchor ids on the resource docs. This updates links to use the new anchors.

We should wait to merge this until after all the resource docs have been regenerated.