### PR TITLE
Update import paths for go getting started

### DIFF
--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -104,38 +104,38 @@ pulumi.export('bucket_name',  bucket.id)
 package main
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/go/aws/kms"
-	"github.com/pulumi/pulumi-aws/sdk/go/aws/s3"
-	"github.com/pulumi/pulumi/sdk/go/pulumi"
+    "github.com/pulumi/pulumi-aws/sdk/v2/go/aws/kms"
+    "github.com/pulumi/pulumi-aws/sdk/v2/go/aws/s3"
+    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		// Create a KMS Key for S3 server-side encryption
-		key, err := kms.NewKey(ctx, "my-key", nil)
-		if err != nil {
-			return err
-		}
+    pulumi.Run(func(ctx *pulumi.Context) error {
+        // Create a KMS Key for S3 server-side encryption
+        key, err := kms.NewKey(ctx, "my-key", nil)
+        if err != nil {
+            return err
+        }
 
-		// Create an AWS resource (S3 Bucket)
-		bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
-			ServerSideEncryptionConfiguration: s3.BucketServerSideEncryptionConfigurationArgs{
-				Rule: s3.BucketServerSideEncryptionConfigurationRuleArgs{
-					ApplyServerSideEncryptionByDefault: s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs{
-						SseAlgorithm:   pulumi.StringInput(pulumi.String("aws:kms")),
-						KmsMasterKeyId: key.ID(),
-					},
-				},
-			},
-		})
-		if err != nil {
-			return err
-		}
+        // Create an AWS resource (S3 Bucket)
+        bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
+            ServerSideEncryptionConfiguration: s3.BucketServerSideEncryptionConfigurationArgs{
+                Rule: s3.BucketServerSideEncryptionConfigurationRuleArgs{
+                    ApplyServerSideEncryptionByDefault: s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs{
+                        SseAlgorithm:   pulumi.StringInput(pulumi.String("aws:kms")),
+                        KmsMasterKeyId: key.ID(),
+                    },
+                },
+            },
+        })
+        if err != nil {
+            return err
+        }
 
-		// Export the name of the bucket
-		ctx.Export("bucketName", bucket.ID())
-		return nil
-	})
+        // Export the name of the bucket
+        ctx.Export("bucketName", bucket.ID())
+        return nil
+    })
 }
 ```
 

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -81,8 +81,8 @@ pulumi.export('bucket_name',  bucket.id)
 package main
 
 import (
-    "github.com/pulumi/pulumi-aws/sdk/go/aws/s3"
-    "github.com/pulumi/pulumi/sdk/go/pulumi"
+    "github.com/pulumi/pulumi-aws/sdk/v2/go/aws/s3"
+    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
 func main() {

--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -94,38 +94,38 @@ pulumi.export('connection_string', account.primary_connection_string)
 package main
 
 import (
-	"github.com/pulumi/pulumi-azure/sdk/v2/go/azure/core"
-	"github.com/pulumi/pulumi-azure/sdk/v2/go/azure/storage"
-	"github.com/pulumi/pulumi/sdk/go/pulumi"
+    "github.com/pulumi/pulumi-azure/sdk/v3/go/azure/core"
+    "github.com/pulumi/pulumi-azure/sdk/v3/go/azure/storage"
+    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		// Create an Azure Resource Group
-		resourceGroup, err := core.NewResourceGroup(ctx, "resourceGroup", &core.ResourceGroupArgs{
-			Location: pulumi.String("WestUS"),
-		})
-		if err != nil {
-			return err
-		}
+    pulumi.Run(func(ctx *pulumi.Context) error {
+        // Create an Azure Resource Group
+        resourceGroup, err := core.NewResourceGroup(ctx, "resourceGroup", &core.ResourceGroupArgs{
+            Location: pulumi.String("WestUS"),
+        })
+        if err != nil {
+            return err
+        }
 
-		// Create an Azure resource (Storage Account)
-		account, err := storage.NewAccount(ctx, "storage", &storage.AccountArgs{
-			ResourceGroupName:      resourceGroup.Name,
-			AccountTier:            pulumi.String("Standard"),
-			AccountReplicationType: pulumi.String("LRS"),
-			Tags: pulumi.StringMap{
-				"Environment": pulumi.String("Dev"),
-			},
-		})
-		if err != nil {
-			return err
-		}
+        // Create an Azure resource (Storage Account)
+        account, err := storage.NewAccount(ctx, "storage", &storage.AccountArgs{
+            ResourceGroupName:      resourceGroup.Name,
+            AccountTier:            pulumi.String("Standard"),
+            AccountReplicationType: pulumi.String("LRS"),
+            Tags: pulumi.StringMap{
+                "Environment": pulumi.String("Dev"),
+            },
+        })
+        if err != nil {
+            return err
+        }
 
-		// Export the connection string for the storage account
-		ctx.Export("connectionString", account.PrimaryConnectionString)
-		return nil
-	})
+        // Export the connection string for the storage account
+        ctx.Export("connectionString", account.PrimaryConnectionString)
+        return nil
+    })
 }
 ```
 

--- a/content/docs/get-started/azure/review-project.md
+++ b/content/docs/get-started/azure/review-project.md
@@ -96,35 +96,35 @@ pulumi.export('connection_string', account.primary_connection_string)
 package main
 
 import (
-	"github.com/pulumi/pulumi-azure/sdk/v2/go/azure/core"
-	"github.com/pulumi/pulumi-azure/sdk/v2/go/azure/storage"
-	"github.com/pulumi/pulumi/sdk/go/pulumi"
+    "github.com/pulumi/pulumi-azure/sdk/v3/go/azure/core"
+    "github.com/pulumi/pulumi-azure/sdk/v3/go/azure/storage"
+    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		// Create an Azure Resource Group
-		resourceGroup, err := core.NewResourceGroup(ctx, "resourceGroup", &core.ResourceGroupArgs{
-			Location: pulumi.String("WestUS"),
-		})
-		if err != nil {
-			return err
-		}
+    pulumi.Run(func(ctx *pulumi.Context) error {
+        // Create an Azure Resource Group
+        resourceGroup, err := core.NewResourceGroup(ctx, "resourceGroup", &core.ResourceGroupArgs{
+            Location: pulumi.String("WestUS"),
+        })
+        if err != nil {
+            return err
+        }
 
-		// Create an Azure resource (Storage Account)
-		account, err := storage.NewAccount(ctx, "storage", &storage.AccountArgs{
-			ResourceGroupName:      resourceGroup.Name,
-			AccountTier:            pulumi.String("Standard"),
-			AccountReplicationType: pulumi.String("LRS"),
-		})
-		if err != nil {
-			return err
-		}
+        // Create an Azure resource (Storage Account)
+        account, err := storage.NewAccount(ctx, "storage", &storage.AccountArgs{
+            ResourceGroupName:      resourceGroup.Name,
+            AccountTier:            pulumi.String("Standard"),
+            AccountReplicationType: pulumi.String("LRS"),
+        })
+        if err != nil {
+            return err
+        }
 
-		// Export the connection string for the storage account
-		ctx.Export("connectionString", account.PrimaryConnectionString)
-		return nil
-	})
+        // Export the connection string for the storage account
+        ctx.Export("connectionString", account.PrimaryConnectionString)
+        return nil
+    })
 }
 ```
 

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -104,42 +104,42 @@ pulumi.export('bucket_name',  bucket.url)
 package main
 
 import (
-	"github.com/pulumi/pulumi-gcp/sdk/v2/go/gcp/kms"
-	"github.com/pulumi/pulumi-gcp/sdk/v2/go/gcp/storage"
-	"github.com/pulumi/pulumi/sdk/go/pulumi"
+    "github.com/pulumi/pulumi-gcp/sdk/v3/go/gcp/kms"
+    "github.com/pulumi/pulumi-gcp/sdk/v3/go/gcp/storage"
+    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		// Create a KMS KeyRing and CryptoKey to use with the Bucket
-		keyRing, err := kms.NewKeyRing(ctx, "my-keyring", &kms.KeyRingArgs{
-			Location: pulumi.String("global"),
-		})
-		if err != nil {
-			return err
-		}
-		cryptoKey, err := kms.NewCryptoKey(ctx, "my-cryptokey", &kms.CryptoKeyArgs{
-			KeyRing:        keyRing.SelfLink,
-			RotationPeriod: pulumi.String("100000s"),
-		})
-		if err != nil {
-			return err
-		}
+    pulumi.Run(func(ctx *pulumi.Context) error {
+        // Create a KMS KeyRing and CryptoKey to use with the Bucket
+        keyRing, err := kms.NewKeyRing(ctx, "my-keyring", &kms.KeyRingArgs{
+            Location: pulumi.String("global"),
+        })
+        if err != nil {
+            return err
+        }
+        cryptoKey, err := kms.NewCryptoKey(ctx, "my-cryptokey", &kms.CryptoKeyArgs{
+            KeyRing:        keyRing.SelfLink,
+            RotationPeriod: pulumi.String("100000s"),
+        })
+        if err != nil {
+            return err
+        }
 
-		// Create a GCP resource (Storage Bucket) with customer-managed encryption key
-		bucket, err := storage.NewBucket(ctx, "my-bucket", &storage.BucketArgs{
-			Encryption: storage.BucketEncryptionArgs{
-				DefaultKmsKeyName: cryptoKey.SelfLink,
-			},
-		})
-		if err != nil {
-			return err
-		}
+        // Create a GCP resource (Storage Bucket) with customer-managed encryption key
+        bucket, err := storage.NewBucket(ctx, "my-bucket", &storage.BucketArgs{
+            Encryption: storage.BucketEncryptionArgs{
+                DefaultKmsKeyName: cryptoKey.SelfLink,
+            },
+        })
+        if err != nil {
+            return err
+        }
 
-		// Export the DNS name of the bucket
-		ctx.Export("bucketName", bucket.Url)
-		return nil
-	})
+        // Export the DNS name of the bucket
+        ctx.Export("bucketName", bucket.Url)
+        return nil
+    })
 }
 ```
 

--- a/content/docs/get-started/gcp/review-project.md
+++ b/content/docs/get-started/gcp/review-project.md
@@ -76,22 +76,22 @@ pulumi.export('bucket_name',  bucket.url)
 package main
 
 import (
-	"github.com/pulumi/pulumi-gcp/sdk/v2/go/gcp/storage"
-	"github.com/pulumi/pulumi/sdk/go/pulumi"
+    "github.com/pulumi/pulumi-gcp/sdk/v3/go/gcp/storage"
+    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		// Create a GCP resource (Storage Bucket)
-		bucket, err := storage.NewBucket(ctx, "my-bucket", nil)
-		if err != nil {
-			return err
-		}
+    pulumi.Run(func(ctx *pulumi.Context) error {
+        // Create a GCP resource (Storage Bucket)
+        bucket, err := storage.NewBucket(ctx, "my-bucket", nil)
+        if err != nil {
+            return err
+        }
 
-		// Export the DNS name of the bucket
-		ctx.Export("bucketName", bucket.Url)
-		return nil
-	})
+        // Export the DNS name of the bucket
+        ctx.Export("bucketName", bucket.Url)
+        return nil
+    })
 }
 ```
 


### PR DESCRIPTION
Tabs have been converted to spaces due to rendering issues. 

There are two outstanding issues, but those will be tackled in other PRs:
1. no getting started for go+kube
2. gcp examples need to be updated to use "labels" instead of keyring due to permissions issues