### PR TITLE
Update gcp getting started to be smooth like butter

### DIFF
--- a/content/docs/get-started/gcp/deploy-changes.md
+++ b/content/docs/get-started/gcp/deploy-changes.md
@@ -21,23 +21,20 @@ $ pulumi up
 Pulumi computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
+$ pulumi up
 Previewing update (dev):
-
-     Type                   Name            Plan       Info
-     pulumi:pulumi:Stack    quickstart-dev
- +   ├─ gcp:kms:KeyRing     my-keyring      create
- +   ├─ gcp:kms:CryptoKey   my-cryptokey    create
- ~   └─ gcp:storage:Bucket  my-bucket       update     [diff: +encryption]
-
+     Type                   Name               Plan       Info
+     pulumi:pulumi:Stack    quickstart-dev             
+ ~   └─ gcp:storage:Bucket  my-bucket          update     [diff: ~labels]
+ 
 Outputs:
-  ~ bucketName: "gs://my-bucket-62f8bc7" => output<string>
+  ~ bucketName: "gs://my-bucket-d8d30a1" => output<string>
 
 Resources:
-    + 2 to create
     ~ 1 to update
-    3 changes. 1 unchanged
+    1 unchanged
 
-Do you want to perform this update?
+Do you want to perform this update?  [Use arrows to move, enter to select, type to filter]
   yes
 > no
   details
@@ -50,20 +47,16 @@ Choosing `yes` will proceed with the update.
 ```
 Do you want to perform this update? yes
 Updating (dev):
-
-     Type                   Name            Status      Info
-     pulumi:pulumi:Stack    gcp-bucket-dev
- +   ├─ gcp:kms:KeyRing     my-keyring      created
- +   ├─ gcp:kms:CryptoKey   my-cryptokey    created
- ~   └─ gcp:storage:Bucket  my-bucket       updated     [diff: +encryption]
-
+     Type                   Name               Status      Info
+     pulumi:pulumi:Stack    quickstart-dev              
+ ~   └─ gcp:storage:Bucket  my-bucket          updated     [diff: ~labels]
+ 
 Outputs:
-    bucketName: "gs://my-bucket-62f8bc7"
+    bucketName: "gs://my-bucket-d8d30a1"
 
 Resources:
-    + 2 created
     ~ 1 updated
-    3 changes. 1 unchanged
+    1 unchanged
 
 Duration: 4s
 ```

--- a/content/docs/get-started/gcp/deploy-changes.md
+++ b/content/docs/get-started/gcp/deploy-changes.md
@@ -24,9 +24,9 @@ Pulumi computes the minimally disruptive change to achieve the desired state des
 $ pulumi up
 Previewing update (dev):
      Type                   Name               Plan       Info
-     pulumi:pulumi:Stack    quickstart-dev             
+     pulumi:pulumi:Stack    quickstart-dev
  ~   └─ gcp:storage:Bucket  my-bucket          update     [diff: ~labels]
- 
+
 Outputs:
   ~ bucketName: "gs://my-bucket-d8d30a1" => output<string>
 
@@ -48,9 +48,9 @@ Choosing `yes` will proceed with the update.
 Do you want to perform this update? yes
 Updating (dev):
      Type                   Name               Status      Info
-     pulumi:pulumi:Stack    quickstart-dev              
+     pulumi:pulumi:Stack    quickstart-dev
  ~   └─ gcp:storage:Bucket  my-bucket          updated     [diff: ~labels]
- 
+
 Outputs:
     bucketName: "gs://my-bucket-d8d30a1"
 

--- a/content/docs/get-started/gcp/deploy-stack.md
+++ b/content/docs/get-started/gcp/deploy-stack.md
@@ -24,9 +24,9 @@ This command instructs Pulumi to determine the resources needed to create the st
 $ pulumi up
 Previewing update (dev):
      Type                   Name               Plan       Info
-     pulumi:pulumi:Stack    quickstart-dev             
+     pulumi:pulumi:Stack    quickstart-dev
  ~   └─ gcp:storage:Bucket  my-bucket          update     [diff: ~labels]
- 
+
 Outputs:
   ~ bucketName: "gs://my-bucket-d8d30a1" => output<string>
 

--- a/content/docs/get-started/gcp/deploy-stack.md
+++ b/content/docs/get-started/gcp/deploy-stack.md
@@ -23,16 +23,12 @@ This command instructs Pulumi to determine the resources needed to create the st
 ```
 $ pulumi up
 Previewing update (dev):
-     Type                   Name               Plan       Info
-     pulumi:pulumi:Stack    quickstart-dev
- ~   └─ gcp:storage:Bucket  my-bucket          update     [diff: ~labels]
-
-Outputs:
-  ~ bucketName: "gs://my-bucket-d8d30a1" => output<string>
+     Type                   Name       Plan
+ +   pulumi:pulumi:Stack    quickstart-dev  create
+ +   └─ gcp:storage:Bucket  my-bucket  create
 
 Resources:
-    ~ 1 to update
-    1 unchanged
+    + 2 to create
 
 Do you want to perform this update?  [Use arrows to move, enter to select, type to filter]
   yes

--- a/content/docs/get-started/gcp/deploy-stack.md
+++ b/content/docs/get-started/gcp/deploy-stack.md
@@ -21,16 +21,20 @@ $ pulumi up
 This command instructs Pulumi to determine the resources needed to create the stack. First, a preview is shown of the changes that will be made:
 
 ```
+$ pulumi up
 Previewing update (dev):
-
-     Type                   Name            Plan
- +   pulumi:pulumi:Stack    quickstart-dev  create
- +   └─ gcp:storage:Bucket  my-bucket       create
+     Type                   Name               Plan       Info
+     pulumi:pulumi:Stack    quickstart-dev             
+ ~   └─ gcp:storage:Bucket  my-bucket          update     [diff: ~labels]
+ 
+Outputs:
+  ~ bucketName: "gs://my-bucket-d8d30a1" => output<string>
 
 Resources:
-    + 2 to create
+    ~ 1 to update
+    1 unchanged
 
-Do you want to perform this update?
+Do you want to perform this update?  [Use arrows to move, enter to select, type to filter]
   yes
 > no
   details

--- a/content/docs/get-started/gcp/destroy-stack.md
+++ b/content/docs/get-started/gcp/destroy-stack.md
@@ -24,29 +24,29 @@ You'll be prompted to make sure you really want to delete these resources.
 
 ```
 Previewing destroy (dev):
+     Type                   Name       Plan
+ -   pulumi:pulumi:Stack    quickstart-dev  delete
+ -   └─ gcp:storage:Bucket  my-bucket  delete
 
-     Type                   Name            Plan
- -   pulumi:pulumi:Stack    gcp-bucket-dev  delete
- -   ├─ gcp:storage:Bucket  my-bucket       delete
- -   ├─ gcp:kms:CryptoKey   my-cryptokey    delete
- -   └─ gcp:kms:KeyRing     my-keyring      delete
+Outputs:
+  - BucketName: "gs://my-bucket-b93323e"
 
 Resources:
-    - 4 to delete
+    - 2 to delete
 
 Do you want to perform this destroy? yes
 Destroying (dev):
+     Type                   Name       Status
+ -   pulumi:pulumi:Stack    quickstart-dev  deleted
+ -   └─ gcp:storage:Bucket  my-bucket  deleted
 
-     Type                   Name            Status
- -   pulumi:pulumi:Stack    gcp-bucket-dev  deleted
- -   ├─ gcp:storage:Bucket  my-bucket       deleted
- -   ├─ gcp:kms:CryptoKey   my-cryptokey    deleted
- -   └─ gcp:kms:KeyRing     my-keyring      deleted
+Outputs:
+  - BucketName: "gs://my-bucket-b93323e"
 
 Resources:
-    - 4 deleted
+    - 2 deleted
 
-Duration: 3s
+Duration: 2s
 ```
 
 To delete the stack itself, run [`pulumi stack rm`]({{< relref "/docs/reference/cli/pulumi_stack_rm" >}}).

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -43,7 +43,7 @@ import * as gcp from "@pulumi/gcp";
 
 // Create a GCP resource (Storage Bucket)
 const bucket = new gcp.storage.Bucket("my-bucket", {
-    labels: { "environment": "dev" } 
+    labels: { "environment": "dev" }
 });
 
 // Export the DNS name of the bucket

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -100,32 +100,18 @@ func main() {
 
 ```csharp
 using Pulumi;
-using Gcp = Pulumi.Gcp;
+using Pulumi.Gcp.Storage;
 
 class MyStack : Stack
 {
     public MyStack()
     {
-        // Let's create a customer managed key and use that for encryption
-        // instead of the default Google-managed key.
-        var keyRing = new Gcp.Kms.KeyRing("my-keyring", new Gcp.Kms.KeyRingArgs
-        {
-            Location = "global",
-        });
-
-        var cryptoKey = new Gcp.Kms.CryptoKey("my-cryptokey", new Gcp.Kms.CryptoKeyArgs
-        {
-            KeyRing = keyRing.SelfLink,
-            RotationPeriod = "100000s",
-        });
-
         // Create a GCP resource (Storage Bucket)
-        var bucket = new Gcp.Storage.Bucket("my-bucket", new Gcp.Storage.BucketArgs
-        {
-            Encryption = new Gcp.Storage.Inputs.BucketEncryptionArgs
+        var bucket = new Bucket("my-bucket", new BucketArgs{
+            Labels =
             {
-                DefaultKmsKeyName = cryptoKey.SelfLink,
-            },
+                { "environment", "dev" }
+            }
         });
 
         // Export the DNS name of the bucket

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -55,17 +55,11 @@ export const bucketName = bucket.url;
 
 ```python
 import pulumi
-from pulumi_gcp import storage, kms
+from pulumi_gcp import storage
 
-# Create a KMS KeyRing and CryptoKey to use with the Bucket
-keyRing = kms.KeyRing('my-keyring', location='global')
-cryptoKey = kms.CryptoKey('my-cryptokey',
-                          key_ring=keyRing.self_link,
-                          rotation_period="100000s")
-
-# Create a GCP resource (Storage Bucket) with customer-managed encryption key
+# Create a GCP resource (Storage Bucket)
 bucket = storage.Bucket('my-bucket',
-                        encryption={'defaultKmsKeyName': cryptoKey.self_link})
+    labels={'environemnt': "dev"})
 
 # Export the DNS name of the bucket
 pulumi.export('bucket_name',  bucket.url)

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -25,21 +25,9 @@ Replace the entire contents of {{< langfile >}} with the following:
 const pulumi = require("@pulumi/pulumi");
 const gcp = require("@pulumi/gcp");
 
-// Let's create a customer managed key and use that for encryption instead of the default Google-managed key.
-const keyRing = new gcp.kms.KeyRing("my-keyring", {
-    location: "global",
-});
-
-const cryptoKey = new gcp.kms.CryptoKey("my-cryptokey", {
-    keyRing: keyRing.selfLink,
-    rotationPeriod: "100000s",
-});
-
 // Create a GCP resource (Storage Bucket)
 const bucket = new gcp.storage.Bucket("my-bucket", {
-    encryption: {
-        defaultKmsKeyName: cryptoKey.selfLink,
-    }
+    labels: { "environment": "dev" }
 });
 
 // Export the DNS name of the bucket
@@ -53,21 +41,9 @@ exports.bucketName = bucket.url;
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
 
-// Let's create a customer managed key and use that for encryption instead of the default Google-managed key.
-const keyRing = new gcp.kms.KeyRing("my-keyring", {
-    location: "global",
-});
-
-const cryptoKey = new gcp.kms.CryptoKey("my-cryptokey", {
-    keyRing: keyRing.selfLink,
-    rotationPeriod: "100000s",
-});
-
 // Create a GCP resource (Storage Bucket)
 const bucket = new gcp.storage.Bucket("my-bucket", {
-    encryption: {
-        defaultKmsKeyName: cryptoKey.selfLink,
-    }
+    labels: { "environment": "dev" } 
 });
 
 // Export the DNS name of the bucket

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -12,9 +12,7 @@ menu:
 aliases: ["/docs/quickstart/gcp/modify-program/"]
 ---
 
-Now that we have an instance of our Pulumi program deployed, let's update it to use our own encryption key instead of the default Google-managed one.
-
-> You must enable the Google KMS API on the GCP console before proceeding. You can enable the API by going to the [KMS API Library](https://console.cloud.google.com/apis/library/cloudkms.googleapis.com) page and clicking 'ENABLE'.
+Now that we have an instance of our Pulumi program deployed, let's add some labels to it.
 
 Replace the entire contents of {{< langfile >}} with the following:
 
@@ -104,32 +102,16 @@ pulumi.export('bucket_name',  bucket.url)
 package main
 
 import (
-    "github.com/pulumi/pulumi-gcp/sdk/v3/go/gcp/kms"
     "github.com/pulumi/pulumi-gcp/sdk/v3/go/gcp/storage"
     "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
 func main() {
     pulumi.Run(func(ctx *pulumi.Context) error {
-        // Create a KMS KeyRing and CryptoKey to use with the Bucket
-        keyRing, err := kms.NewKeyRing(ctx, "my-keyring", &kms.KeyRingArgs{
-            Location: pulumi.String("global"),
-        })
-        if err != nil {
-            return err
-        }
-        cryptoKey, err := kms.NewCryptoKey(ctx, "my-cryptokey", &kms.CryptoKeyArgs{
-            KeyRing:        keyRing.SelfLink,
-            RotationPeriod: pulumi.String("100000s"),
-        })
-        if err != nil {
-            return err
-        }
-
-        // Create a GCP resource (Storage Bucket) with customer-managed encryption key
+        // Create a GCP resource (Storage Bucket)
         bucket, err := storage.NewBucket(ctx, "my-bucket", &storage.BucketArgs{
-            Encryption: storage.BucketEncryptionArgs{
-                DefaultKmsKeyName: cryptoKey.SelfLink,
+            Labels: pulumi.StringMap{
+                "environment": pulumi.String("dev"),
             },
         })
         if err != nil {


### PR DESCRIPTION
fixes https://github.com/pulumi/docs/issues/2958

Right now GCP getting started requires updating account privileges to be successful. This should not be necessary. Updating this example to sidestep this problem in a similar way to Azure https://github.com/pulumi/docs/pull/2964

Tested all of these changes manually. 