### PR TITLE
[tools/resourcedocsgen] Type properties are just properties and not classified as input or output

### DIFF
--- a/tools/resourcedocsgen/overlays/kubernetes/overlays.json
+++ b/tools/resourcedocsgen/overlays/kubernetes/overlays.json
@@ -4,7 +4,7 @@
         "kubernetes:helm/v2:FetchOpts": {
             "type": "object",
             "description": "Additional options to customize the fetching of the Helm chart.",
-            "inputProperties": {
+            "properties": {
                 "caFile": {
                     "type": "string",
                     "description": "Verify certificates of HTTPS-enabled servers using this CA bundle."
@@ -70,7 +70,7 @@
         "kubernetes:helm/v3:FetchOpts": {
             "type": "object",
             "description": "Additional options to customize the fetching of the Helm chart.",
-            "inputProperties": {
+            "properties": {
                 "caFile": {
                     "type": "string",
                     "description": "Verify certificates of HTTPS-enabled servers using this CA bundle."


### PR DESCRIPTION
This PR just updates the k8s overlays schema in `/overlays/kubernetes/overlays.json` to have the correct attribute name according to the json schema used by Pulumi schema.