### PR TITLE
Add a "share this post" section to blogs

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -39,8 +39,10 @@
                 </article>
             </div>
 
-            <div class="md:w-2/12 pl-8">
-                <!-- Right sidebar, unused. -->
+            <div class="md:w-3/12 md:pl-8 mt-16">
+                <div class="sticky-sidebar">
+                    {{ partial "blog/right-nav.html" . }}
+                </div>
             </div>
         </div>
     </div>

--- a/layouts/partials/blog/right-nav.html
+++ b/layouts/partials/blog/right-nav.html
@@ -6,12 +6,12 @@
                     class="mr-2"
                     href="https://twitter.com/intent/tweet?text={{ $.Page.Title }}&tw_p=tweetbutton&url={{ $.Page.Permalink }}"
                     target="_blank">
-                <i class="fab fa-twitter text-gray-500 hover:text-blue-700 text-xl"></i>
+                <i class="fab fa-twitter text-blue-500 hover:text-blue-700 text-xl"></i>
             </a>
             <a data-track="share-linkedin"
                     href="https://www.linkedin.com/sharing/share-offsite/?url={{ $.Page.Permalink }}"
                     target="_blank">
-                <i class="fab fa-linkedin text-gray-500 hover:text-blue-700 text-xl"></i>
+                <i class="fab fa-linkedin text-blue-500 hover:text-blue-700 text-xl"></i>
             </a>
         </li>
     </ul>

--- a/layouts/partials/blog/right-nav.html
+++ b/layouts/partials/blog/right-nav.html
@@ -3,6 +3,7 @@
     <ul class="p-0 list-none">
         <li>
             <a data-track="share-twitter"
+                    class="mr-2"
                     href="https://twitter.com/intent/tweet?text={{ $.Page.Title }}&tw_p=tweetbutton&url={{ $.Page.Permalink }}"
                     target="_blank">
                 <i class="fab fa-twitter text-gray-500 hover:text-blue-700 text-xl"></i>

--- a/layouts/partials/blog/right-nav.html
+++ b/layouts/partials/blog/right-nav.html
@@ -1,0 +1,17 @@
+{{ with .File }}
+    <p class="text-gray-500 text-xs">Share this post</p>
+    <ul class="p-0 list-none">
+        <li>
+            <a data-track="share-twitter"
+                    href="https://twitter.com/intent/tweet?text={{ $.Page.Title }}&tw_p=tweetbutton&url={{ $.Page.Permalink }}"
+                    target="_blank">
+                <i class="fab fa-twitter text-gray-500 hover:text-blue-700 text-xl"></i>
+            </a>
+            <a data-track="share-linkedin"
+                    href="https://www.linkedin.com/sharing/share-offsite/?url={{ $.Page.Permalink }}"
+                    target="_blank">
+                <i class="fab fa-linkedin text-gray-500 hover:text-blue-700 text-xl"></i>
+            </a>
+        </li>
+    </ul>
+{{ end }}


### PR DESCRIPTION
This change adds a Twitter and LinkedIn sharing button to the right
hand nav for blogs. It's sticky so we don't need to choose between
top/bottom and I tried to keep the font sizes small and colors subdued
so as not to distract from the actual post content itself.

Fixes pulumi/docs#3065.
