### PR TITLE
Update the link in the 'New Version Warning' output.

### DIFF
--- a/content/docs/get-started/install/_index.md
+++ b/content/docs/get-started/install/_index.md
@@ -162,7 +162,7 @@ If a new version of Pulumi is available, the CLI produces the following example 
 warning: A new version of Pulumi is available. To upgrade from version '0.17.26' to '{{< latest-version >}}', run
    $ curl -sSL https://get.pulumi.com | sh
 
-or visit https://pulumi.com/docs/install/ for manual instructions and release notes.
+or visit https://pulumi.com/docs/reference/install/ for manual instructions and release notes.
 ```
 
 {{< skip-version-check >}}


### PR DESCRIPTION
Copied the link URL from https://github.com/pulumi/pulumi/blob/ce5fd4755806ce49a963998ac0c154e9a6a20ab8/pkg/cmd/pulumi/pulumi.go#L371.

The previous link in the example output was incorrect and took the user to a 404.