### PR TITLE
Fix the `installing Pulumi` anchor link.

### DIFF
--- a/content/docs/get-started/install/_index.md
+++ b/content/docs/get-started/install/_index.md
@@ -15,7 +15,7 @@ NOTE: To update this page with a new binary release, do the following:
 - Update `content/docs/get-started/install/versions.md`
 -->
 
-This page contains detailed instructions for [installing Pulumi](#install-pulumi) on your machine. For links to detailed release notes, see the [Available Versions]({{< relref "versions" >}}) page.
+This page contains detailed instructions for [installing Pulumi](#installing-pulumi) on your machine. For links to detailed release notes, see the [Available Versions]({{< relref "versions" >}}) page.
 
 {{< get-started-note >}}
 


### PR DESCRIPTION
The `installing Pulumi` anchor link is currently broken, this fixes it.