### PR TITLE
Make a CSS selector more specific

### DIFF
--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -72,9 +72,10 @@ dl {
                 ~ dd {
                     .property-message {
                         @apply bg-orange-200 text-orange-600 my-4 px-5 py-4 rounded text-sm;
-                    }
-                    code {
-                        @apply bg-orange-200;
+
+                        code {
+                            @apply bg-orange-200;
+                        }
                     }
                 }
             }

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -91,12 +91,5 @@ dl {
                 vertical-align: middle;
             }
         }
-
-        dd {
-            code {
-                @apply bg-white px-0;
-            }
-        }
     }
-
 }


### PR DESCRIPTION
We want this to match within `property-message` elements, but leave others alone.

Fixes #3091.