### PR TITLE
Revert to using Git SHAs in docs templates

### DIFF
--- a/tools/tscdocgen/main.go
+++ b/tools/tscdocgen/main.go
@@ -201,10 +201,7 @@ func emitMarkdownDocs(srcdir, pkgname string, doc *typeDocNode, outdir, outdatad
 	// want to revisit this and make the logic here more sophisticated and general purpose someday.
 	pkg := doc.Name
 
-	// The Git commit sha is emitted as a front matter parameter (`git_sha`) on each markdown page, so we use Hugo's
-	// built-in `param` shortcode to look it up. This reduces the size of diffs when updating API docs because the Git
-	// commit sha will only change in one place at the top of the page, rather than throughout.
-	repoURL := getRepoURL(pkgRepoDir, "{{< param git_sha >}}")
+	repoURL := getRepoURL(pkgRepoDir, gitSha)
 
 	// The kubernetes package requires some special handling since the structure differs from
 	// the tf-generated providers.


### PR DESCRIPTION
Looks like the cause of the increase in build failures on this repo is the use of the `param` shortcode that was introduced in [this commit](https://github.com/pulumi/docs/commit/3bd3ac68097b95300d0d4eadb050a98179c270bd), which looks up the `git_sha` and swaps it into the page at build-time. (There's nothing wrong with that shortcode per se; it's just that we're making around 150K calls to it now, up a good deal more than when it was added, and the increased overhead seem to have built up gradually over time.) This reduces site build time to around 12 minutes, and the overall memory usage by about half in local development. It'll make diffs of the Node.js docs quite a bit noisier, since the SHAs will once again be baked into the templates, but PRs and builds should become more stable.

Likely still not quite as fast it it could be, and we'll still want to upgrade Hugo (which I tried, and which didn't help with this issue) and start thinking about ways to split up the site to allow for continued growth, but this should get us out of the woods and keep things green for a while.

For reference, [here's the branch I've been working with](https://github.com/pulumi/docs/actions?query=workflow%3A%22Build+site+with+Hugo%22+branch%3Acnunciato%2Fparam-test) to test this. 

(Note that this particular PR and those that follow it will continue to fail until the Node.js docs are regenerated based on this change.)

Fixes #3109  🤞 