### PR TITLE
Use next page title as the button in Getting Started

### DIFF
--- a/content/docs/get-started/aws/configure.md
+++ b/content/docs/get-started/aws/configure.md
@@ -1,7 +1,7 @@
 ---
-title: Configure | AWS
-h1: Configure
-linktitle: Configure
+title: Configure Cloud Access | AWS
+h1: Configure Cloud Access
+linktitle: Configure Cloud Access
 meta_desc: This page provides an overview of how to configure an AWS project.
 weight: 4
 menu:

--- a/content/docs/get-started/aws/configure.md
+++ b/content/docs/get-started/aws/configure.md
@@ -1,7 +1,7 @@
 ---
-title: Configure Cloud Access | AWS
-h1: Configure Cloud Access
-linktitle: Configure Cloud Access
+title: Configure AWS | AWS
+h1: Configure AWS
+linktitle: Configure AWS
 meta_desc: This page provides an overview of how to configure an AWS project.
 weight: 4
 menu:

--- a/content/docs/get-started/azure/configure.md
+++ b/content/docs/get-started/azure/configure.md
@@ -1,7 +1,7 @@
 ---
-title: Configure | Azure
-h1: Configure
-linktitle: Configure
+title: Configure Cloud Access | Azure
+h1: Configure Cloud Access
+linktitle: Configure Cloud Access
 meta_desc: This page provides an overview of how to configure an Azure project.
 weight: 4
 menu:

--- a/content/docs/get-started/azure/configure.md
+++ b/content/docs/get-started/azure/configure.md
@@ -1,7 +1,7 @@
 ---
-title: Configure Cloud Access | Azure
-h1: Configure Cloud Access
-linktitle: Configure Cloud Access
+title: Configure Azure | Azure
+h1: Configure Azure
+linktitle: Configure Azure
 meta_desc: This page provides an overview of how to configure an Azure project.
 weight: 4
 menu:

--- a/content/docs/get-started/gcp/configure.md
+++ b/content/docs/get-started/gcp/configure.md
@@ -1,7 +1,7 @@
 ---
-title: Configure | GCP
-h1: Configure
-linktitle: Configure
+title: Configure Cloud Access | GCP
+h1: Configure Cloud Access
+linktitle: Configure Cloud Access
 meta_desc: This page provides an overview of how to configure a Google Cloud (GCP) project.
 weight: 4
 menu:

--- a/content/docs/get-started/gcp/configure.md
+++ b/content/docs/get-started/gcp/configure.md
@@ -1,7 +1,7 @@
 ---
-title: Configure Cloud Access | GCP
-h1: Configure Cloud Access
-linktitle: Configure Cloud Access
+title: Configure GCP | GCP
+h1: Configure GCP
+linktitle: Configure GCP
 meta_desc: This page provides an overview of how to configure a Google Cloud (GCP) project.
 weight: 4
 menu:

--- a/content/docs/get-started/kubernetes/configure.md
+++ b/content/docs/get-started/kubernetes/configure.md
@@ -1,7 +1,7 @@
 ---
-title: Configure Cluster Access | Kubernetes
-h1: Configure Cluster Access
-linktitle: Configure Cluster Access
+title: Configure Kubernetes | Kubernetes
+h1: Configure Kubernetes
+linktitle: Configure Kubernetes
 meta_desc: This page provides an overview of how to configure a Kubernetes project.
 weight: 4
 menu:

--- a/content/docs/get-started/kubernetes/configure.md
+++ b/content/docs/get-started/kubernetes/configure.md
@@ -1,7 +1,7 @@
 ---
-title: Configure | Kubernetes
-h1: Configure
-linktitle: Configure
+title: Configure Cluster Access | Kubernetes
+h1: Configure Cluster Access
+linktitle: Configure Cluster Access
 meta_desc: This page provides an overview of how to configure a Kubernetes project.
 weight: 4
 menu:

--- a/layouts/shortcodes/get-started-stepper.html
+++ b/layouts/shortcodes/get-started-stepper.html
@@ -36,6 +36,6 @@
 {{ end }}
 {{ if ne $step $last }}
     {{ $next := index $pages (add $step 1) }}
-    <a data-track="next-step" class="btn" href="{{ $next.RelPermalink }}">NEXT STEP &gt;</a>
+    <a data-track="next-step" class="btn" href="{{ $next.RelPermalink }}">{{ $next.LinkTitle }} &gt;</a>
 {{ end }}
 </div>


### PR DESCRIPTION
This changes the "NEXT STEP >" button to use the title of the
next page in the flow, like "INSTALL PULUMI >", etc. The theory
is that this is more enticing to click as well as clearly
communicating what comes next.

As part of this, I changed the "CONFIGURE >" step to be a little
clearer; for now, I chose "CONFIGURE CLOUD ACCESS >" for AWS,
Azure, and GCP, and "CONFIGURE CLUSTER ACCESS >" for Kubernetes.
