### PR TITLE
Fix typo in devops belfast image

### DIFF
--- a/content/webinars/devops-belfast-2020-05-19/index.md
+++ b/content/webinars/devops-belfast-2020-05-19/index.md
@@ -13,7 +13,7 @@ pre_recorded: false
 pulumi_tv: false
 
 # The preview image will be shown on the list page.
-preview_image: "/images/webinar/pulumi_tech_talk.png"
+preview_image: "/images/webinar/pulumi_tech_talk.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: false


### PR DESCRIPTION
As the title states, it fixes a typo in the image file for the DevOps Belfast webinar.