### PR TITLE
[tools/pydocgen] Update generate_python_docs script to not prefix the core Pulumi SDK

### DIFF
--- a/scripts/generate_python_docs.sh
+++ b/scripts/generate_python_docs.sh
@@ -67,7 +67,11 @@ else
     # Install the Python package and run the pydocgen tool for just the provider that
     # was requested.
     echo "Building Python docs for ${REPO_OVERRIDE}..."
-    PACKAGE="pulumi_${REPO_OVERRIDE}"
+    if [ "${REPO_OVERRIDE}" = "pulumi" ]; then
+      PACKAGE="${REPO_OVERRIDE}"
+    else
+      PACKAGE="pulumi_${REPO_OVERRIDE}"
+    fi
     pipenv run pip install "${PACKAGE}"
     pipenv run python -m pydocgen "../../content/docs/reference/pkg" "${PACKAGE}"
 fi

--- a/scripts/generate_python_docs.sh
+++ b/scripts/generate_python_docs.sh
@@ -67,10 +67,9 @@ else
     # Install the Python package and run the pydocgen tool for just the provider that
     # was requested.
     echo "Building Python docs for ${REPO_OVERRIDE}..."
-    if [ "${REPO_OVERRIDE}" = "pulumi" ]; then
-      PACKAGE="${REPO_OVERRIDE}"
-    else
-      PACKAGE="pulumi_${REPO_OVERRIDE}"
+    PACKAGE="pulumi"
+    if [ "${REPO_OVERRIDE}" != "pulumi" ]; then
+        PACKAGE="pulumi_${REPO_OVERRIDE}"
     fi
     pipenv run pip install "${PACKAGE}"
     pipenv run python -m pydocgen "../../content/docs/reference/pkg" "${PACKAGE}"

--- a/tools/pydocgen/pydocgen/__init__.py
+++ b/tools/pydocgen/pydocgen/__init__.py
@@ -106,7 +106,8 @@ def read_input(input_file: str, package_override: str = "") -> Input:
         providers = []
         if package_override != "":
             provider = [obj for obj in input_dict.get("providers") if obj["package_name"] == package_override]
-            providers.append(Provider(**provider[0]))
+            if len(provider) > 0:
+                providers.append(Provider(**provider[0]))
         else:
             for provider in input_dict.get("providers") or []:
                 providers.append(Provider(**provider))


### PR DESCRIPTION
### Proposed changes

The `generate_python_docs.sh` script allows one to override the repo/package for which we want to build Python docs. As part of that it installs the latest Python package for that Pulumi package from `pip`, however, the script was incorrectly prefix the core `pulumi` package with a `pulumi_`. So this PR fixes that.

The issue was reported to me by @stack72.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A
