### PR TITLE
Correct an unmatched shortcode

### DIFF
--- a/tools/tscdocgen/templates/nodejs.tmpl
+++ b/tools/tscdocgen/templates/nodejs.tmpl
@@ -35,7 +35,7 @@ import * as {{PackageVar}} from "{{Package}}";
 
 {{=<% %>=}}
 {{% /choosable %}}
-{{% /chooser %}}
+{{< /chooser >}}
 <%={{ }}=%>
 
 {{/Package}}


### PR DESCRIPTION
This won't make much of an actual difference, but I happened to notice it, so figured it should be corrected. (The opening tag uses `<>` delimiters, rather than `%%`.) [More info in the Hugo docs](152366).