### PR TITLE
Fix examples, they were using "record" instead of "records".

### DIFF
--- a/content/docs/reference/pkg/azure/dns/caarecord.md
+++ b/content/docs/reference/pkg/azure/dns/caarecord.md
@@ -38,7 +38,7 @@ example_caa_record = azure.dns.CaaRecord("exampleCaaRecord",
     zone_name=example_zone.name,
     resource_group_name=example_resource_group.name,
     ttl=300,
-    record=[
+    records=[
         {
             "flags": 0,
             "tag": "issue",
@@ -77,7 +77,7 @@ const exampleCaaRecord = new azure.dns.CaaRecord("exampleCaaRecord", {
     zoneName: exampleZone.name,
     resourceGroupName: exampleResourceGroup.name,
     ttl: 300,
-    record: [
+    records: [
         {
             flags: 0,
             tag: "issue",

--- a/content/docs/reference/pkg/azure/dns/mxrecord.md
+++ b/content/docs/reference/pkg/azure/dns/mxrecord.md
@@ -38,7 +38,7 @@ example_mx_record = azure.dns.MxRecord("exampleMxRecord",
     zone_name=example_zone.name,
     resource_group_name=example_resource_group.name,
     ttl=300,
-    record=[
+    records=[
         {
             "preference": 10,
             "exchange": "mail1.contoso.com",
@@ -65,7 +65,7 @@ const exampleMxRecord = new azure.dns.MxRecord("exampleMxRecord", {
     zoneName: exampleZone.name,
     resourceGroupName: exampleResourceGroup.name,
     ttl: 300,
-    record: [
+    records: [
         {
             preference: 10,
             exchange: "mail1.contoso.com",

--- a/content/docs/reference/pkg/azure/dns/srvrecord.md
+++ b/content/docs/reference/pkg/azure/dns/srvrecord.md
@@ -38,7 +38,7 @@ example_srv_record = azure.dns.SrvRecord("exampleSrvRecord",
     zone_name=example_zone.name,
     resource_group_name=example_resource_group.name,
     ttl=300,
-    record=[{
+    records=[{
         "priority": 1,
         "weight": 5,
         "port": 8080,
@@ -61,7 +61,7 @@ const exampleSrvRecord = new azure.dns.SrvRecord("exampleSrvRecord", {
     zoneName: exampleZone.name,
     resourceGroupName: exampleResourceGroup.name,
     ttl: 300,
-    record: [{
+    records: [{
         priority: 1,
         weight: 5,
         port: 8080,

--- a/content/docs/reference/pkg/azure/dns/txtrecord.md
+++ b/content/docs/reference/pkg/azure/dns/txtrecord.md
@@ -38,7 +38,7 @@ example_txt_record = azure.dns.TxtRecord("exampleTxtRecord",
     zone_name=example_zone.name,
     resource_group_name=example_resource_group.name,
     ttl=300,
-    record=[
+    records=[
         {
             "value": "google-site-authenticator",
         },
@@ -63,7 +63,7 @@ const exampleTxtRecord = new azure.dns.TxtRecord("exampleTxtRecord", {
     zoneName: exampleZone.name,
     resourceGroupName: exampleResourceGroup.name,
     ttl: 300,
-    record: [
+    records: [
         {
             value: "google-site-authenticator",
         },

--- a/content/docs/reference/pkg/azure/privatedns/mxrecord.md
+++ b/content/docs/reference/pkg/azure/privatedns/mxrecord.md
@@ -38,7 +38,7 @@ example_mx_record = azure.privatedns.MxRecord("exampleMxRecord",
     resource_group_name=example_resource_group.name,
     zone_name=example_zone.name,
     ttl=300,
-    record=[
+    records=[
         {
             "preference": 10,
             "exchange": "mx1.contoso.com",
@@ -65,7 +65,7 @@ const exampleMxRecord = new azure.privatedns.MxRecord("exampleMxRecord", {
     resourceGroupName: exampleResourceGroup.name,
     zoneName: exampleZone.name,
     ttl: 300,
-    record: [
+    records: [
         {
             preference: 10,
             exchange: "mx1.contoso.com",

--- a/content/docs/reference/pkg/azure/privatedns/srvrecord.md
+++ b/content/docs/reference/pkg/azure/privatedns/srvrecord.md
@@ -38,7 +38,7 @@ test_srv_record = azure.privatedns.SRVRecord("testSRVRecord",
     resource_group_name=azurerm_resource_group["test"]["name"],
     zone_name=test_zone.name,
     ttl=300,
-    record=[
+    records=[
         {
             "priority": 1,
             "weight": 5,
@@ -69,7 +69,7 @@ const testSRVRecord = new azure.privatedns.SRVRecord("testSRVRecord", {
     resourceGroupName: azurerm_resource_group.test.name,
     zoneName: testZone.name,
     ttl: 300,
-    record: [
+    records: [
         {
             priority: 1,
             weight: 5,

--- a/content/docs/reference/pkg/azure/privatedns/txtrecord.md
+++ b/content/docs/reference/pkg/azure/privatedns/txtrecord.md
@@ -38,7 +38,7 @@ test_txt_record = azure.privatedns.TxtRecord("testTxtRecord",
     resource_group_name=azurerm_resource_group["test"]["name"],
     zone_name=test_zone.name,
     ttl=300,
-    record=[{
+    records=[{
         "value": "v=spf1 mx ~all",
     }])
 ```
@@ -55,7 +55,7 @@ const testTxtRecord = new azure.privatedns.TxtRecord("testTxtRecord", {
     resourceGroupName: azurerm_resource_group.test.name,
     zoneName: testZone.name,
     ttl: 300,
-    record: [{
+    records: [{
         value: "v=spf1 mx ~all",
     }],
 });


### PR DESCRIPTION
### Proposed changes

Fix examples related to Azure DNS, they were using `resource` instead of `resources`.
