### PR TITLE
Migrate HubSpot forms from a partial to stencil

### DIFF
--- a/components/src/components.d.ts
+++ b/components/src/components.d.ts
@@ -36,6 +36,11 @@ export namespace Components {
   }
   interface PulumiExample {}
   interface PulumiExamples {}
+  interface PulumiHubspotForm {
+    'cssClass': string;
+    'formId': string;
+    'goToWebinarKey': string;
+  }
   interface PulumiRoot {}
   interface PulumiTopButton {}
 }
@@ -67,6 +72,12 @@ declare global {
     new (): HTMLPulumiExamplesElement;
   };
 
+  interface HTMLPulumiHubspotFormElement extends Components.PulumiHubspotForm, HTMLStencilElement {}
+  var HTMLPulumiHubspotFormElement: {
+    prototype: HTMLPulumiHubspotFormElement;
+    new (): HTMLPulumiHubspotFormElement;
+  };
+
   interface HTMLPulumiRootElement extends Components.PulumiRoot, HTMLStencilElement {}
   var HTMLPulumiRootElement: {
     prototype: HTMLPulumiRootElement;
@@ -83,6 +94,7 @@ declare global {
     'pulumi-chooser': HTMLPulumiChooserElement;
     'pulumi-example': HTMLPulumiExampleElement;
     'pulumi-examples': HTMLPulumiExamplesElement;
+    'pulumi-hubspot-form': HTMLPulumiHubspotFormElement;
     'pulumi-root': HTMLPulumiRootElement;
     'pulumi-top-button': HTMLPulumiTopButtonElement;
   }
@@ -105,6 +117,11 @@ declare namespace LocalJSX {
   }
   interface PulumiExample {}
   interface PulumiExamples {}
+  interface PulumiHubspotForm {
+    'cssClass'?: string;
+    'formId'?: string;
+    'goToWebinarKey'?: string;
+  }
   interface PulumiRoot {
     'onRendered'?: (event: CustomEvent<any>) => void;
   }
@@ -115,6 +132,7 @@ declare namespace LocalJSX {
     'pulumi-chooser': PulumiChooser;
     'pulumi-example': PulumiExample;
     'pulumi-examples': PulumiExamples;
+    'pulumi-hubspot-form': PulumiHubspotForm;
     'pulumi-root': PulumiRoot;
     'pulumi-top-button': PulumiTopButton;
   }
@@ -130,6 +148,7 @@ declare module "@stencil/core" {
       'pulumi-chooser': LocalJSX.PulumiChooser & JSXBase.HTMLAttributes<HTMLPulumiChooserElement>;
       'pulumi-example': LocalJSX.PulumiExample & JSXBase.HTMLAttributes<HTMLPulumiExampleElement>;
       'pulumi-examples': LocalJSX.PulumiExamples & JSXBase.HTMLAttributes<HTMLPulumiExamplesElement>;
+      'pulumi-hubspot-form': LocalJSX.PulumiHubspotForm & JSXBase.HTMLAttributes<HTMLPulumiHubspotFormElement>;
       'pulumi-root': LocalJSX.PulumiRoot & JSXBase.HTMLAttributes<HTMLPulumiRootElement>;
       'pulumi-top-button': LocalJSX.PulumiTopButton & JSXBase.HTMLAttributes<HTMLPulumiTopButtonElement>;
     }

--- a/components/src/components.d.ts
+++ b/components/src/components.d.ts
@@ -40,6 +40,11 @@ export namespace Components {
     'cssClass': string;
     'formId': string;
     'goToWebinarKey': string;
+    'hasSubmittedForm': boolean;
+    'hiddenFormButtonClass': string;
+    'hiddenFormButtonText': string;
+    'hiddenFormButtonURL': string;
+    'hideIfSubmitted': boolean;
   }
   interface PulumiRoot {}
   interface PulumiTopButton {}
@@ -121,6 +126,11 @@ declare namespace LocalJSX {
     'cssClass'?: string;
     'formId'?: string;
     'goToWebinarKey'?: string;
+    'hasSubmittedForm'?: boolean;
+    'hiddenFormButtonClass'?: string;
+    'hiddenFormButtonText'?: string;
+    'hiddenFormButtonURL'?: string;
+    'hideIfSubmitted'?: boolean;
   }
   interface PulumiRoot {
     'onRendered'?: (event: CustomEvent<any>) => void;

--- a/components/src/components/hubspot-form/hubspot-form.css
+++ b/components/src/components/hubspot-form/hubspot-form.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/components/src/components/hubspot-form/hubspot-form.e2e.ts
+++ b/components/src/components/hubspot-form/hubspot-form.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('pulumi-hubspot-form', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pulumi-hubspot-form></pulumi-hubspot-form>');
+
+    const element = await page.find('pulumi-hubspot-form');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/components/src/components/hubspot-form/hubspot-form.spec.ts
+++ b/components/src/components/hubspot-form/hubspot-form.spec.ts
@@ -1,0 +1,7 @@
+import { HubspotForm } from './hubspot-form';
+
+describe('pulumi-hubspot-form', () => {
+  it('builds', () => {
+    expect(new HubspotForm()).toBeTruthy();
+  });
+});

--- a/components/src/components/hubspot-form/hubspot-form.tsx
+++ b/components/src/components/hubspot-form/hubspot-form.tsx
@@ -1,0 +1,65 @@
+import { Component, Prop, h } from '@stencil/core';
+// import { Store, Unsubscribe } from "@stencil/redux";
+// import { AppState } from "../../store/state";
+
+interface HubSpotFormOptions {
+  portalId: string;
+  formId: string;
+  css: string;
+  cssClass: string;
+  goToWebinarWebinarKey: string | undefined;
+  target: string;
+}
+
+@Component({
+  tag: 'pulumi-hubspot-form',
+  styleUrl: 'hubspot-form.css',
+})
+export class HubspotForm {
+  formContainerId = "hubSpotInlineForm";
+
+  // The ID of the form in HubSpot.
+  @Prop()
+  formId: string;
+
+  // OPTIONAL: CSS class(es) to assign to the form.
+  @Prop()
+  cssClass: string;
+
+  // OPTIONAL: The key for the GoToWebinar Webinar the form is assciated with. This
+  // value is required to automatically register people in GoToWebinar when the form
+  // is submitted.
+  @Prop()
+  goToWebinarKey: string;
+
+  componentDidLoad() {
+    const hsFormOpts: HubSpotFormOptions = {
+      portalId: "4429525",
+      css: "",
+      formId: this.formId,
+      cssClass: this.cssClass,
+      goToWebinarWebinarKey: this.goToWebinarKey,
+      target: "#" + this.formContainerId,
+    };
+
+    // Create the script element for loading the HubSpot form script.
+    const hsFormScript = document.createElement("script");
+    hsFormScript.src = "https://js.hsforms.net/forms/v2.js";
+    document.body.appendChild(hsFormScript);
+
+    hsFormScript.addEventListener("load", () => {
+      const win = window as any;
+      if (win.hbspt && win.hbspt.forms && typeof win.hbspt.forms.create === "function") {
+        win.hbspt.forms?.create(hsFormOpts);
+      }
+    });
+  }
+
+  render() {
+    return [
+      <div id={this.formContainerId}></div>,
+      <slot></slot>
+    ];
+  }
+
+}

--- a/components/src/components/hubspot-form/hubspot-form.tsx
+++ b/components/src/components/hubspot-form/hubspot-form.tsx
@@ -1,65 +1,167 @@
-import { Component, Prop, h } from '@stencil/core';
-// import { Store, Unsubscribe } from "@stencil/redux";
-// import { AppState } from "../../store/state";
+import { Component, Prop, Listen, h } from '@stencil/core';
+import { Store, Unsubscribe } from "@stencil/redux";
+import { AppState } from "../../store/state";
+import { addSubmittedFormId } from "../../store/actions/form";
 
 interface HubSpotFormOptions {
-  portalId: string;
-  formId: string;
-  css: string;
-  cssClass: string;
-  goToWebinarWebinarKey: string | undefined;
-  target: string;
+    portalId: string;
+    formId: string;
+    css: string;
+    cssClass: string;
+    goToWebinarWebinarKey: string | undefined;
+    target: string;
 }
 
 @Component({
-  tag: 'pulumi-hubspot-form',
-  styleUrl: 'hubspot-form.css',
+    tag: 'pulumi-hubspot-form',
+    styleUrl: 'hubspot-form.css',
 })
 export class HubspotForm {
-  formContainerId = "hubSpotInlineForm";
+    private storeUnsubscribe: Unsubscribe;
 
-  // The ID of the form in HubSpot.
-  @Prop()
-  formId: string;
+    // A handle to the application store.
+    @Prop({ context: "store" })
+    store: Store;
 
-  // OPTIONAL: CSS class(es) to assign to the form.
-  @Prop()
-  cssClass: string;
+    // The ID for the container we will attach the form to.
+    formContainerId = "hubSpotInlineForm";
 
-  // OPTIONAL: The key for the GoToWebinar Webinar the form is assciated with. This
-  // value is required to automatically register people in GoToWebinar when the form
-  // is submitted.
-  @Prop()
-  goToWebinarKey: string;
+    // Check if the form has been loaded.
+    private _isLoaded = false;
 
-  componentDidLoad() {
-    const hsFormOpts: HubSpotFormOptions = {
-      portalId: "4429525",
-      css: "",
-      formId: this.formId,
-      cssClass: this.cssClass,
-      goToWebinarWebinarKey: this.goToWebinarKey,
-      target: "#" + this.formContainerId,
-    };
+    // The ID of the form in HubSpot.
+    @Prop()
+    formId: string;
 
-    // Create the script element for loading the HubSpot form script.
-    const hsFormScript = document.createElement("script");
-    hsFormScript.src = "https://js.hsforms.net/forms/v2.js";
-    document.body.appendChild(hsFormScript);
+    // OPTIONAL: CSS class(es) to assign to the form.
+    @Prop()
+    cssClass: string;
 
-    hsFormScript.addEventListener("load", () => {
-      const win = window as any;
-      if (win.hbspt && win.hbspt.forms && typeof win.hbspt.forms.create === "function") {
-        win.hbspt.forms?.create(hsFormOpts);
-      }
-    });
-  }
+    // OPTIONAL: The key for the GoToWebinar Webinar the form is assciated with. This
+    // value is required to automatically register people in GoToWebinar when the form
+    // is submitted.
+    @Prop()
+    goToWebinarKey: string;
 
-  render() {
-    return [
-      <div id={this.formContainerId}></div>,
-      <slot></slot>
-    ];
-  }
+    // OPTIONAL: If this value is set to true, then the component will render a button
+    // instead of the form.
+    @Prop()
+    hideIfSubmitted: boolean;
 
+    // OPTIONAL: The URL for the button to direct a user to when the form is hidden.
+    @Prop()
+    hiddenFormButtonURL: string;
+
+    // OPTIONAL: The text for the button when the form is hidden.
+    @Prop()
+    hiddenFormButtonText: string;
+
+    // OPTIONAL: The class names for the button when the form is hidden.
+    @Prop()
+    hiddenFormButtonClass: string;
+
+    // Has this form been submitted by the user before.
+    @Prop({ mutable: true })
+    hasSubmittedForm: boolean;
+
+    // Dispatch function for handling submitted forms.
+    addSubmittedFormId: typeof addSubmittedFormId;
+
+    // When the document is rendered, let's check to see if the form we are about
+    // to load has already been submitted and set up our action function.
+    @Listen("rendered", { target: "document" })
+    onRendered(_event: CustomEvent) {
+        this.store.mapDispatchToProps(this, { addSubmittedFormId });
+
+        // If the form is not marked as one to hide, then return.
+        if (!this.hideIfSubmitted) {
+            return;
+        }
+
+        const checkIfSubmittedForm = this.checkIfSubmittedForm.bind(this);
+        this.storeUnsubscribe = this.store.mapStateToProps(this, (state: AppState) => {
+            if (!this._isLoaded) {
+                this._isLoaded = true;
+                return { hasSubmittedForm: checkIfSubmittedForm(state.form.submittedFormIds) };
+            }
+
+            // If this isn't the first load do no change the value of the prop. We only want to display
+            // the button on the user's next visit to the form. Otherwise we will hide any "thank you"
+            // messages HubSpot displays after the submission.
+            return { hasSubmittedForm: this.hasSubmittedForm };
+        });
+    }
+
+    // Add an event listener to listen for a form submission and dispatch
+    // that formId to be added to the user's preferences.
+    @Listen("message", { target: "window" })
+    onMessage(event: MessageEvent) {
+        // Check to make sure we have the right event.
+        if(event.data.type === 'hsFormCallback' && event.data.eventName === 'onFormReady') {
+            // Check that the form exists.
+            const form = document.querySelector("#hubSpotInlineForm form");
+            if (!form) {
+                return;
+            }
+
+            // Add the form id to the the state store in local storage, so if the
+            // user comes back we can hide the form if needed.
+            const handler = this.addSubmittedFormId;
+            const formId = this.formId;
+            form.addEventListener("submit", function() {
+                handler(formId);
+            });
+        }
+    }
+
+    // Once the component has loaded we will attach the form
+    // to the form container, if neccessary.
+    componentDidLoad() {
+        const hsFormOpts: HubSpotFormOptions = {
+            portalId: "4429525",
+            css: "",
+            formId: this.formId,
+            cssClass: this.cssClass,
+            goToWebinarWebinarKey: this.goToWebinarKey,
+            target: "#" + this.formContainerId,
+        };
+
+        // Create the script element for loading the HubSpot form script.
+        const hsFormScript = document.createElement("script");
+        hsFormScript.src = "https://js.hsforms.net/forms/v2.js";
+        document.body.appendChild(hsFormScript);
+
+        // Once the script loads create the HubSpot form.
+        hsFormScript.addEventListener("load", () => {
+            const win = window as any;
+            if (win.hbspt && win.hbspt.forms && typeof win.hbspt.forms.create === "function") {
+                win.hbspt.forms.create(hsFormOpts);
+            }
+        });
+    }
+
+    componentDidUnload() {
+        if (this.storeUnsubscribe) {
+            this.storeUnsubscribe();
+        }
+    }
+
+    renderWatchNowButton() {
+        return [
+            <a data-track={this.hiddenFormButtonText} class={this.hiddenFormButtonClass} href={this.hiddenFormButtonURL}>
+                { this.hiddenFormButtonText }
+            </a>
+        ];
+    }
+
+    render() {
+        return [
+            this.hasSubmittedForm ? this.renderWatchNowButton() : <div id={this.formContainerId}></div>,
+            <slot></slot>
+        ];
+    }
+
+    private checkIfSubmittedForm(formIds: string[]): boolean {
+        return formIds.indexOf(this.formId) > -1;
+    }
 }

--- a/components/src/store/actions/form.ts
+++ b/components/src/store/actions/form.ts
@@ -1,0 +1,15 @@
+import { TypeKeys } from "./index";
+
+export interface AddSubmittedFormId {
+    type: TypeKeys.ADD_SUBMITTED_FORM_ID;
+    key: string;
+}
+
+// Add a HubSpot formId to submitted forms list.
+export const addSubmittedFormId = (formId: string) => (dispatch, _getState) => {
+    const action: AddSubmittedFormId = {
+        type: TypeKeys.ADD_SUBMITTED_FORM_ID,
+        key: formId,
+    };
+    dispatch(action);
+};

--- a/components/src/store/actions/index.ts
+++ b/components/src/store/actions/index.ts
@@ -1,10 +1,12 @@
 import { SetLanguage, SetK8sLanguage, SetOS, SetCloud } from "./preferences";
+import { AddSubmittedFormId } from "./form";
 
 export enum TypeKeys {
     SET_LANGUAGE = "SET_LANGUAGE",
     SET_K8S_LANGUAGE = "SET_K8S_LANGUAGE",
     SET_OS = "SET_OS",
-    SET_CLOUD = "SET_CLOUD"
+    SET_CLOUD = "SET_CLOUD",
+    ADD_SUBMITTED_FORM_ID = "ADD_SUBMITTED_FORM_ID",
 }
 
-export type ActionTypes = SetLanguage | SetK8sLanguage | SetOS | SetCloud;
+export type ActionTypes = SetLanguage | SetK8sLanguage | SetOS | SetCloud | AddSubmittedFormId;

--- a/components/src/store/index.ts
+++ b/components/src/store/index.ts
@@ -5,9 +5,10 @@ import thunk from "redux-thunk";
 
 import { AppState } from "./state";
 import { preferences } from "./reducers/preferences";
+import { form } from "./reducers/form";
 
 export const rootReducer = combineReducers({
-    preferences
+    preferences, form
 });
 
 // The Redux store. See https://redux.js.org/ for general information about Redux and

--- a/components/src/store/reducers/form.ts
+++ b/components/src/store/reducers/form.ts
@@ -1,0 +1,29 @@
+import { ActionTypes, TypeKeys } from "../actions/index";
+import { FormState } from "../../store/state";
+
+// Define the default values of form state.
+const getInitialState = (): FormState => {
+    return {
+        submittedFormIds: [],
+    };
+};
+
+// The preferences reducer. Note that it does not mutate state, but rather always returns a fresh copy.
+// https://redux.js.org/basics/reducers/
+export const form = (currentState = getInitialState(), action: ActionTypes): FormState => {
+
+    switch (action.type) {
+        case TypeKeys.ADD_SUBMITTED_FORM_ID:
+            const formId = action.key;
+
+            // Check to see if the user has submitted the form before. If not,
+            // add the formId.
+            if (currentState.submittedFormIds.indexOf(formId) === -1) {
+                currentState.submittedFormIds.push(action.key);
+            }
+
+            return currentState;
+        default:
+            return currentState;
+    }
+};

--- a/components/src/store/state.d.ts
+++ b/components/src/store/state.d.ts
@@ -9,6 +9,11 @@ export interface PreferencesState {
     cloud: CloudKey,
 }
 
+export interface FormState {
+    submittedFormIds: string[];
+}
+
 export interface AppState {
-    preferences: PreferencesState
+    preferences: PreferencesState;
+    form: FormState;
 }

--- a/layouts/partials/form-section.html
+++ b/layouts/partials/form-section.html
@@ -29,7 +29,7 @@
                     <h3 class="text-center">{{ .form.headline }}</h3>
                     <div class="mx-auto flex justify-center">
                         <div class="hs-form hs-form-fg-dark font-normal">
-                            {{ partial "hubspot-form.html" (dict "hubspotFormID" .form.hubspot_form_id "classNames" .form.class_names) }}
+                            <pulumi-hubspot-form form-id="{{ .form.hubspot_form_id }}" css-class="{{ .form.class_names }}"></pulumi-hubspot-form>
                         </div>
                     </div>
                 </div>
@@ -41,7 +41,7 @@
         <h3 class="text-center">{{ .form.headline }}</h3>
         <div class="mx-auto flex justify-center">
             <div class="hs-form hs-form-fg-dark font-normal">
-                {{ partial "hubspot-form.html" (dict "hubspotFormID" .form.hubspot_form_id "classNames" .form.class_names) }}
+                <pulumi-hubspot-form form-id="{{ .form.hubspot_form_id }}" css-class="{{ .form.class_names }}"></pulumi-hubspot-form>
             </div>
         </div>
     </div>

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -2,7 +2,7 @@
     <div class="container mx-auto">
         <div class="flex justify-center flex-col md:flex-row text-center">
             <h4 class="text-gray-100 md:mr-8 mt-2">Sign up for our newsletter</h4>
-            {{ partial "hubspot-form.html" (dict "hubspotFormID" "027b4c6d-9b73-4ad8-b149-3c8b07fff608" "classNames" "newsletter") }}
+            <pulumi-hubspot-form form-id="027b4c6d-9b73-4ad8-b149-3c8b07fff608" css-class="newsletter"></pulumi-hubspot-form>
         </div>
     </div>
 </section>

--- a/layouts/webinars/single.html
+++ b/layouts/webinars/single.html
@@ -62,8 +62,7 @@
                         {{ $formHeader := (cond (eq .Params.pre_recorded true) "Watch The Recording Now" "Register Here") }}
                         {{ with .Params.form }}
                             <h3 class="text-orange">{{ $formHeader }}</h3>
-
-                            {{ partial "hubspot-form.html" (dict "hubspotFormID" .hubspot_form_id "goToWebinarKey" .gotowebinar_key) }}
+                            <pulumi-hubspot-form form-id="{{ .hubspot_form_id }}" go-to-webinar-key="{{ .gotowebinar_key }}"></pulumi-hubspot-form>
                         {{ end }}
                     {{ end }}
                 </div>


### PR DESCRIPTION
This PR migrates our HubSpot forms from being loaded through a partial to being loaded through a stencil.js component. This will help set up the work for a cleaner "On Demand" video experience, as we will be tracking if the user has submitted the form or not. So users should in theory only need to submit an "On Demand" form once and then always be shown the video on subsequent visits to the page.