### PR TITLE
Fix the spacing between plan names on the pricing page

### DIFF
--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -271,10 +271,10 @@
                 <div class="flex items-center text-xs md:text-base">
                     <div class="w-1/4"></div>
                     <div class="w-1/4 font-display text-center text-gray-200 uppercase py-2 md:py-4">
-                        Team <br class="block md:hidden"> Starter
+                        Team <span class="block mx-0 md:inline md:mr-1"></span> Starter
                     </div>
                     <div class="w-1/4 font-display text-center text-gray-200 uppercase py-2 md:py-4">
-                        Team <br class="block md:hidden"> Pro
+                        Team <span class="block mx-0 md:inline md:mr-1"></span> Pro
                     </div>
                     <div class="w-1/4 font-display text-center text-gray-200 uppercase py-2 md:py-4">
                         Enterprise
@@ -285,11 +285,13 @@
             <div class="pricing-item">
                 <span class="pricing-item-label">Annual Price</span>
                 <span class="pricing-item-value">
-                    <span class="text-sm text-gray-700"><span class="font-bold">$50/mo</span></span>
+                    <span class="text-sm font-bold">$50/mo</span>
                 </span>
                 <span class="pricing-item-value">
-                    <span class="text-sm text-gray-700"><span class="font-bold">$75 per user/mo</span></span><br>
-                    <span class="text-xs text-purple-300 pl-2">
+                    <div>
+                        <span class="text-sm font-bold">$75 per user/mo</span>
+                    </div>
+                    <span class="text-xs text-purple-300">
                         Starts at $225/month for 3 users
                     </span>
                 </span>
@@ -298,11 +300,13 @@
             <div class="pricing-item">
                 <span class="pricing-item-label">Monthly Price</span>
                 <span class="pricing-item-value">
-                    <span class="text-sm text-gray-700"><span class="font-bold">$60/mo</span></span>
+                    <span class="text-sm font-bold">$60/mo</span>
                 </span>
                 <span class="pricing-item-value">
-                    <span class="text-sm text-gray-700"><span class="font-bold">$90 per user/mo</span></span><br>
-                    <span class="text-xs text-purple-300 pl-2">
+                    <div>
+                        <span class="text-sm font-bold">$90 per user/mo</span>
+                    </div>
+                    <span class="text-xs text-purple-300">
                         Starts at $270/month for 3 users
                     </span>
                 </span>


### PR DESCRIPTION
The minification we added with #2455 stripped out the spacing between Team Starter and Team Pro on the pricing page at desktop width:

![image](https://user-images.githubusercontent.com/274700/82580609-30fa1a80-9b44-11ea-91da-51d99a934293.png)

This change fixes that up, and also removes a bit of redundant markup that I happened to notice while I was in there.

![pricing mov](https://user-images.githubusercontent.com/274700/82580869-a0700a00-9b44-11ea-9028-ee1113f0e7a0.gif)


 