### PR TITLE
Change language delimiter for anchor tags

### DIFF
--- a/components/src/components/root/root.tsx
+++ b/components/src/components/root/root.tsx
@@ -55,7 +55,7 @@ export class Root {
         // both are present because the anchor will not work otherwise.
         const anchorTag = window.location.hash;
         if (anchorTag) {
-            const language = anchorTag.split("~")
+            const language = anchorTag.split("_")
                 .slice(-1)
                 .find(lang => ["typescript", "javascript", "csharp", "go", "python"].includes(lang));
             if (language) {


### PR DESCRIPTION
Updating to delimit on underscore. This will assume the last occurrence of the split to be the language choice.