### PR TITLE
Remove synchronous invoke from GKE example

### DIFF
--- a/content/docs/tutorials/kubernetes/gke.md
+++ b/content/docs/tutorials/kubernetes/gke.md
@@ -80,7 +80,7 @@ In this tutorial, we'll launch a new Managed Kubernetes cluster in Google Kubern
     const name = "helloworld";
 
     // Create a GKE cluster
-    const engineVersion = gcp.container.getEngineVersions().latestMasterVersion;
+    const engineVersion = gcp.container.getEngineVersions().then(v => v.latestMasterVersion);
     const cluster = new gcp.container.Cluster(name, {
         initialNodeCount: 2,
         minMasterVersion: engineVersion,


### PR DESCRIPTION
### Proposed changes

The GKE cluster tutorial uses a now-invalid way of trying to access the engine versions, and is unusable. This change fixes the example with `.then(…)`.

### Related issues

This is in line with https://github.com/pulumi/docs/pull/2791 and https://github.com/pulumi/examples/pull/669.