### PR TITLE
Add a tooltip component

### DIFF
--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -65,7 +65,18 @@ module.exports = {
 
             // Whitelist custom parent selectors and their children.
             whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/],
-            whitelistPatternsChildren: [/^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/],
+            whitelistPatternsChildren: [
+                /^hs-/,
+                /^highlight$/,
+                /^pagination$/,
+                /^code-/,
+                /^copy-/,
+                /^carousel/,
+
+                // Whitelist our web components along with any of their descendent selectors.
+                /^pulumi-chooser/,
+                /^pulumi-tooltip/
+            ],
 
             // We need to extract the Tailwind screen size selectors (e.g. sm, md, lg)
             // so that we do not strip them out. As long as a class name appears in the HTML

--- a/assets/js/copybutton.js
+++ b/assets/js/copybutton.js
@@ -117,19 +117,20 @@ $(function() {
         return text;
     }
 
+    var tooltipText = "Click to copy";
     var buttonHtml =
-        '<div class="copy-button-container">\n' +
-        '    <button class="copy-button">\n' +
-        '        <i class="far fa-copy copy text-xl" title="Copy code snippet"></i>\n' +
-        '    </button>\n' +
-        '    <span class="copy-button-tooltip">Copied!</span>\n'+
+        '<div class="copy-button-container">' +
+        '    <pulumi-tooltip>' +
+        '        <button class="copy-button"><i class="far fa-copy copy text-xl"></i></button>' +
+        '        <span slot="content">' + tooltipText + '</span>' +
+        '    </pulumi-tooltip>' +
         '</div>';
 
     $(":not(.no-copy) > div.highlight")
         .append(buttonHtml)
         .on("click", "button.copy-button", function() {
             var $b = $(this);
-            var $code = $b.parent().siblings("pre").children("code");
+            var $code = $b.parent().parent().parent().siblings("pre").children("code");
 
             // Get the lang and code.
             var lang = $code.attr("data-lang");
@@ -145,10 +146,19 @@ $(function() {
             $b.blur();
 
             // Show a "Copied!" tooltip for a second.
-            var duration = 1000;
-            var $tooltip = $b.siblings(".copy-button-tooltip").fadeIn();
-            setTimeout(function() {
-                $tooltip.fadeOut();
-            }, duration);
+            var $tooltip = $b.closest("pulumi-tooltip");
+            var $tooltipContent = $tooltip.find("[slot='content']");
+            var tooltipEl = $tooltip.get(0);
+
+            $tooltipContent.text("Copied!");
+            tooltipEl
+                .show()
+                .then(() => {
+                    setTimeout(function() {
+                        tooltipEl
+                            .hide()
+                            .then(() => $tooltipContent.text(tooltipText));
+                    }, 1000);
+                });
         });
 });

--- a/assets/sass/_copy-button.scss
+++ b/assets/sass/_copy-button.scss
@@ -1,4 +1,3 @@
-@import "colors";
 @import "mixins";
 
 .copy-button-container {
@@ -6,6 +5,13 @@
 
     .code-mode-dark & {
         @apply bg-gray-900;
+    }
+
+    // Use a slightly narrower tooltip for these.
+    pulumi-tooltip {
+        .tooltip-content {
+            @apply w-24;
+        }
     }
 }
 
@@ -24,21 +30,5 @@
         &:hover {
             @apply text-gray-500;
         }
-    }
-}
-
-.copy-button-tooltip {
-    @apply absolute hidden text-white text-xs text-center bg-gray-900 rounded p-2 z-0 opacity-75 top-0 right-0 mt-10 -mr-3;
-
-    // Arrow on top of the tooltip.
-    &::after {
-        @apply absolute border-solid;
-
-        content: " ";
-        bottom: 100%;
-        left: 50%;
-        margin-left: -5px;
-        border-width: 5px;
-        border-color: transparent transparent map-get($gray, 900) transparent;
     }
 }

--- a/assets/sass/_toggle.scss
+++ b/assets/sass/_toggle.scss
@@ -7,7 +7,7 @@
 }
 
 .form-switch-label {
-    @apply block overflow-hidden cursor-pointer bg-gray-300 border-2 border-orange-500 rounded-full h-4 shadow-inner;
+    @apply block overflow-hidden cursor-pointer bg-orange-500 border-2 border-orange-500 rounded-full h-4 shadow-inner;
 
     transition: background-color 0.2s ease-in;
 }
@@ -22,7 +22,7 @@
 .form-switch-checkbox:checked + .form-switch-label:before {
 }
 .form-switch-checkbox:checked + .form-switch-label {
-    @apply bg-orange-500 shadow-none;
+    @apply shadow-none;
 }
 .form-switch-checkbox:checked + .form-switch-label:before {
     @apply right-0;

--- a/assets/sass/_tooltip.scss
+++ b/assets/sass/_tooltip.scss
@@ -1,0 +1,34 @@
+@import "colors";
+@import "mixins";
+
+pulumi-tooltip {
+    @apply relative;
+
+    .tooltip-content {
+        @apply absolute block opacity-0 w-48 py-2 mb-2 px-3 bg-gray-700 rounded shadow font-body font-normal text-center text-xs text-white leading-normal z-50;
+        @include transition();
+
+        // Position the tooltip above the target, centered.
+        bottom: 108%;
+        transform: translateX(-50%);
+        left: 50%;
+
+        // Draw the caret below the tooltip.
+        &:after {
+            @apply block bg-gray-700 -mb-3 mt-1 h-2 w-2 text-center mx-auto;
+            transform: rotate(45deg);
+            content: " ";
+        }
+    }
+
+    .tooltip-target {
+        @apply cursor-pointer;
+
+        &.active {
+            + .tooltip-content {
+                opacity: 0.98;
+                bottom: 100%;
+            }
+        }
+    }
+}

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -34,6 +34,7 @@
 @import "tiles";
 @import "toc";
 @import "toggle";
+@import "tooltip";
 
 h1, h2, h3, h4, h5, h6 {
     @apply font-display text-gray-700 mb-2;
@@ -224,32 +225,6 @@ main {
             max-width: 1600px;
         }
     }
-}
-
-.tooltip {
-    @apply absolute;
-}
-
-.tooltip .tooltip-text {
-    @apply absolute text-white hidden text-xs text-center font-normal bg-gray-700 rounded p-2 z-0 bottom-0 right-0 opacity-75 mb-8 w-64;
-    margin-right: -7rem;
-
-    // Arrow on the bottom of the tooltip.
-    &::after {
-        @apply absolute border-solid;
-
-        content: " ";
-        top: 100%;
-        left: 50%;
-        margin-left: -5px;
-        border-width: 5px;
-        border-color: map-get($gray, 700) transparent transparent transparent;
-    }
-
-}
-
-.tooltip:hover .tooltip-text {
-    @apply block;
 }
 
 .resource-deprecated {

--- a/components/README.md
+++ b/components/README.md
@@ -146,48 +146,6 @@ its own, in which case it'll simply honor whatever's in the global store.
         ...
 ```
 
-### pulumi-tooltip
-
-This component can be used to show an accessible tooltip over an element. You can provide
-it with text or markup using the named `content` [slot](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot).
-Markup outside of that slot will be treated as the tooltip's corresponding target.
-
-#### Usage
-
-In markup:
-
-```
-<pulumi-tooltip>
-    <i class="fas fa-question-circle"></i>
-    <span slot="content">
-        You hovered over the icon!
-    </span>
-</pulumi-tooltip>
-```
-
-Programmatically:
-
-```
-<pulumi-tooltip id="my-tooltip">
-    <i class="fas fa-question-circle"></i>
-    <span slot="content">
-        You called the show() method!
-    </span>
-</pulumi-tooltip>
-
-<script>
-    var tooltip = document.querySelector("#my-tooltip");
-
-    tooltip
-        .show()
-        .then(function() { console.log("The tooltip is visible."); });
-
-    tooltip
-        .hide()
-        .then(function() { console.log("The tooltip is not visible."); });
-</script>
-```
-
 #### Shortcodes (and some gotchas)
 
 In Markdown files, you can express these choosers either as HTML alone or with
@@ -265,6 +223,51 @@ A few things to note:
     </pulumi-chooser>
     computer. Nice!
 </p>
+```
+
+### pulumi-tooltip
+
+This component shows a tooltip bubble over its children on mouseover (or touch). The
+content of the bubble is specified using the `content`
+[slot](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot).
+
+The component also exposes `show()` and `hide()` methods for programmatic control over the
+bubble's visibility.
+
+#### Usage
+
+##### HTML
+
+```
+<pulumi-tooltip>
+    <i class="fas fa-question-circle"></i>
+    <span slot="content">
+        You hovered over the icon!
+    </span>
+</pulumi-tooltip>
+```
+
+##### JavaScript
+
+```
+<pulumi-tooltip id="my-tooltip">
+    <i class="fas fa-question-circle"></i>
+    <span slot="content">
+        You called the show() method!
+    </span>
+</pulumi-tooltip>
+
+<script>
+    var tooltip = document.querySelector("#my-tooltip");
+
+    tooltip
+        .show()
+        .then(function() { console.log("The tooltip is visible."); });
+
+    tooltip
+        .hide()
+        .then(function() { console.log("The tooltip is not visible."); });
+</script>
 ```
 
 ## Questions?

--- a/components/README.md
+++ b/components/README.md
@@ -146,6 +146,48 @@ its own, in which case it'll simply honor whatever's in the global store.
         ...
 ```
 
+### pulumi-tooltip
+
+This component can be used to show an accessible tooltip over an element. You can provide
+it with text or markup using the named `content` [slot](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot).
+Markup outside of that slot will be treated as the tooltip's corresponding target.
+
+#### Usage
+
+In markup:
+
+```
+<pulumi-tooltip>
+    <i class="fas fa-question-circle"></i>
+    <span slot="content">
+        You hovered over the icon!
+    </span>
+</pulumi-tooltip>
+```
+
+Programmatically:
+
+```
+<pulumi-tooltip id="my-tooltip">
+    <i class="fas fa-question-circle"></i>
+    <span slot="content">
+        You called the show() method!
+    </span>
+</pulumi-tooltip>
+
+<script>
+    var tooltip = document.querySelector("#my-tooltip");
+
+    tooltip
+        .show()
+        .then(function() { console.log("The tooltip is visible."); });
+
+    tooltip
+        .hide()
+        .then(function() { console.log("The tooltip is not visible."); });
+</script>
+```
+
 #### Shortcodes (and some gotchas)
 
 In Markdown files, you can express these choosers either as HTML alone or with

--- a/components/package.json
+++ b/components/package.json
@@ -22,9 +22,11 @@
     "@stencil/core": "^1.8.8",
     "@stencil/redux": "^0.1.2",
     "@stencil/sass": "^1.1.1",
+    "@types/uuid": "^8.0.0",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
+    "uuid": "^8.1.0",
     "workbox-build": "4.3.1"
   },
   "devDependencies": {

--- a/components/src/components.d.ts
+++ b/components/src/components.d.ts
@@ -37,6 +37,10 @@ export namespace Components {
   interface PulumiExample {}
   interface PulumiExamples {}
   interface PulumiRoot {}
+  interface PulumiTooltip {
+    'hide': () => Promise<unknown>;
+    'show': () => Promise<unknown>;
+  }
   interface PulumiTopButton {}
 }
 
@@ -73,6 +77,12 @@ declare global {
     new (): HTMLPulumiRootElement;
   };
 
+  interface HTMLPulumiTooltipElement extends Components.PulumiTooltip, HTMLStencilElement {}
+  var HTMLPulumiTooltipElement: {
+    prototype: HTMLPulumiTooltipElement;
+    new (): HTMLPulumiTooltipElement;
+  };
+
   interface HTMLPulumiTopButtonElement extends Components.PulumiTopButton, HTMLStencilElement {}
   var HTMLPulumiTopButtonElement: {
     prototype: HTMLPulumiTopButtonElement;
@@ -84,6 +94,7 @@ declare global {
     'pulumi-example': HTMLPulumiExampleElement;
     'pulumi-examples': HTMLPulumiExamplesElement;
     'pulumi-root': HTMLPulumiRootElement;
+    'pulumi-tooltip': HTMLPulumiTooltipElement;
     'pulumi-top-button': HTMLPulumiTopButtonElement;
   }
 }
@@ -108,6 +119,7 @@ declare namespace LocalJSX {
   interface PulumiRoot {
     'onRendered'?: (event: CustomEvent<any>) => void;
   }
+  interface PulumiTooltip {}
   interface PulumiTopButton {}
 
   interface IntrinsicElements {
@@ -116,6 +128,7 @@ declare namespace LocalJSX {
     'pulumi-example': PulumiExample;
     'pulumi-examples': PulumiExamples;
     'pulumi-root': PulumiRoot;
+    'pulumi-tooltip': PulumiTooltip;
     'pulumi-top-button': PulumiTopButton;
   }
 }
@@ -131,6 +144,7 @@ declare module "@stencil/core" {
       'pulumi-example': LocalJSX.PulumiExample & JSXBase.HTMLAttributes<HTMLPulumiExampleElement>;
       'pulumi-examples': LocalJSX.PulumiExamples & JSXBase.HTMLAttributes<HTMLPulumiExamplesElement>;
       'pulumi-root': LocalJSX.PulumiRoot & JSXBase.HTMLAttributes<HTMLPulumiRootElement>;
+      'pulumi-tooltip': LocalJSX.PulumiTooltip & JSXBase.HTMLAttributes<HTMLPulumiTooltipElement>;
       'pulumi-top-button': LocalJSX.PulumiTopButton & JSXBase.HTMLAttributes<HTMLPulumiTopButtonElement>;
     }
   }

--- a/components/src/components/tooltip/tooltip.e2e.ts
+++ b/components/src/components/tooltip/tooltip.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from "@stencil/core/testing";
+
+describe("pulumi-tooltip", () => {
+    it("renders", async () => {
+        const page = await newE2EPage();
+        await page.setContent("<pulumi-tooltip></pulumi-tooltip>");
+
+        const element = await page.find("pulumi-tooltip");
+        expect(element).toHaveClass("hydrated");
+    });
+});

--- a/components/src/components/tooltip/tooltip.spec.ts
+++ b/components/src/components/tooltip/tooltip.spec.ts
@@ -1,0 +1,7 @@
+import { Tooltip } from "./tooltip";
+
+describe("pulumi-tooltip", () => {
+    it("builds", () => {
+        expect(new Tooltip()).toBeTruthy();
+    });
+});

--- a/components/src/components/tooltip/tooltip.tsx
+++ b/components/src/components/tooltip/tooltip.tsx
@@ -1,0 +1,82 @@
+import { Component, Element, Host, h, Method, State } from '@stencil/core';
+import { getUUID } from "../../util/util";
+
+/**
+ * The ToolTip component shows a tooltip bubble above another element when you hover over
+ * (or, on mobile tap on) it. Use the named `content` slot for supplying the markup to
+ * show in the bubble.
+ *
+ * Usage:
+
+ * <pulumi-tooltip>
+ *     <i class="fas fa-question-circle"></i>
+ *     <span slot="content">
+ *         You hovered over (or tapped on) the thing!
+ *     </span>
+ * </pulumi-tooltip>
+ */
+@Component({
+    tag: "pulumi-tooltip",
+    shadow: false,
+})
+export class Tooltip {
+
+    @Element()
+    el: HTMLElement;
+
+    // The id property is just a unique identifier that binds the tooltip to the control
+    // it relates to, for better accessibility.
+    @State()
+    id: string;
+
+    // Whether the tooltip is currently visible.
+    @State()
+    active: boolean;
+
+    // Show the tooltip.
+    @Method()
+    async show() {
+        return new Promise(resolve => {
+            this.active = true;
+
+            // Wait 100 to allow for the fade-in transition to complete.
+            setTimeout(() => resolve(), 100);
+        });
+    }
+
+    // Hide the tooltip.
+    @Method()
+    async hide() {
+        return new Promise(resolve => {
+            this.active = false;
+
+            // Wait 100 to allow for the fade-out transition to complete.
+            setTimeout(() => resolve(), 100);
+        });
+    }
+
+    componentDidLoad() {
+        this.id = getUUID();
+        this.active = false;
+
+        // Toggle the tooltip when the target element is hovered or tapped.
+        const target = this.el.querySelector(".tooltip-target");
+        target.addEventListener("mouseover", () => this.active = true);
+        target.addEventListener("mouseout", () => this.active = false);
+        target.addEventListener("touchstart", () => this.active = true);
+        target.addEventListener("touchend", () => this.active = false);
+    }
+
+    render() {
+        return (
+            <Host role="tooltip">
+                <span class={`tooltip-target ${ this.active ? "active" : "" }`} aria-labelledby={ this.id }>
+                    <slot></slot>
+                </span>
+                <span id={ this.id } class="tooltip-content" role="tooltip">
+                    <slot name="content"></slot>
+                </span>
+            </Host>
+        );
+    }
+}

--- a/components/src/components/tooltip/tooltip.tsx
+++ b/components/src/components/tooltip/tooltip.tsx
@@ -39,7 +39,7 @@ export class Tooltip {
         return new Promise(resolve => {
             this.active = true;
 
-            // Wait 100 to allow for the fade-in transition to complete.
+            // Wait 100ms to allow for the fade-in transition to complete.
             setTimeout(() => resolve(), 100);
         });
     }
@@ -50,7 +50,7 @@ export class Tooltip {
         return new Promise(resolve => {
             this.active = false;
 
-            // Wait 100 to allow for the fade-out transition to complete.
+            // Wait 100ms to allow for the fade-out transition to complete.
             setTimeout(() => resolve(), 100);
         });
     }
@@ -69,7 +69,7 @@ export class Tooltip {
 
     render() {
         return (
-            <Host role="tooltip">
+            <Host>
                 <span class={`tooltip-target ${ this.active ? "active" : "" }`} aria-labelledby={ this.id }>
                     <slot></slot>
                 </span>

--- a/components/src/util/util.ts
+++ b/components/src/util/util.ts
@@ -1,3 +1,4 @@
+import * as uuid from "uuid";
 
 // Extracts a query string variable from the browser's location.
 export function getQueryVariable(paramKey) :string {
@@ -12,4 +13,8 @@ export function getQueryVariable(paramKey) :string {
         }
     })
     return paramVal;
+}
+
+export function getUUID() {
+    return uuid.v4();
 }

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -420,6 +420,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/uuid@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.0.0.tgz#165aae4819ad2174a17476dbe66feebd549556c0"
+  integrity sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -3426,6 +3431,11 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
+  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -25,12 +25,14 @@
                 <div class="container" style="border-bottom: 2px solid #a48bb3">
                     <p class="text-purple-200 text-sm font-bold">
                         CLOUD-HOSTED
-                        <span class="tooltip">
-                            <span class="tooltip-text">
-                                Easy hosting in the cloud so that state
-                                management is automatically reliable and secure.
-                            </span>
-                            <i class="w-8 fas fa-question-circle text-purple-500"></i>
+                        <span>
+                            <pulumi-tooltip>
+                                <i class="w-8 fas fa-question-circle text-purple-500"></i>
+                                <span slot="content">
+                                    Easy hosting in the cloud so that state management is
+                                    automatically reliable and secure.
+                                </span>
+                            </pulumi-tooltip>
                         </span>
                     </p>
                 </div>
@@ -40,12 +42,14 @@
                     <p class="text-purple-200 text-sm font-bold">
                         CLOUD- or SELF-HOSTED
                         <span class="tooltip">
-                            <span class="tooltip-text">
-                                Get the convenience of cloud hosting with built-in
-                                reliability and security, or host your own server for
-                                ultimate customization and control.
-                            </span>
-                            <i class="w-8 fas fa-question-circle text-purple-500"></i>
+                            <pulumi-tooltip>
+                                <i class="w-8 fas fa-question-circle text-purple-500"></i>
+                                <span slot="content">
+                                    Get the convenience of cloud hosting with built-in
+                                    reliability and security, or host your own server for
+                                    ultimate customization and control.
+                                </span>
+                            </pulumi-tooltip>
                         </span>
                     </p>
                 </div>
@@ -163,20 +167,17 @@
                             <i class="w-8 text-center fas fa-user-friends text-orange-500"></i>
                             <span class="flex-1">
                                 Up to <strong>25</strong> team members
-                                <span class="tooltip pl-1">
-                                    <span class="tooltip-text">
+                                <pulumi-tooltip>
+                                    <i class="fas fa-question-circle text-gray-500"></i>
+                                    <span slot="content">
                                         Starts at
-                                        <span class="billing-price-annually">$225/mo</span>
-                                        <span class="billing-price-monthly hidden">$270/mo</span>
-                                        for your first three team members.
-                                        After you reach three, each additional
-                                        team member is
-                                        <span class="billing-price-annually">$75/mo</span>
-                                        <span class="billing-price-monthly hidden">$90/mo</span>
-                                        .
+                                        <span class="billing-price-annually">$225</span>
+                                        <span class="billing-price-monthly hidden">$270</span>
+                                        for your first three team members. After you reach three, each additional team member is
+                                        <span class="billing-price-annually">$75.</span>
+                                        <span class="billing-price-monthly hidden">$90.</span>
                                     </span>
-                                    <i class="w-8 fas fa-question-circle text-gray-500"></i>
-                                </span>
+                                </pulumi-tooltip>
                             </span>
                         </li>
                         <li class="flex items-center">


### PR DESCRIPTION
This change adds a tooltip component that shows a little bubble when you hover over an element. In this PR, it's being used to replace the tooltips used on the Pricing page and for copy buttons.

Usage:

```
<pulumi-tooltip>
    <i class="fas fa-question-circle"></i>
    <span slot="content">
        You hovered over the thing!
    </span>
</pulumi-tooltip>
```

![tooltips mov](https://user-images.githubusercontent.com/274700/83206077-00e2e680-a105-11ea-90f9-9bac1c7c2668.gif)

This is the first part of #2855. (The component needs to be added before the docs that use it are incorporated.)

