### PR TITLE
[tools/resourcedocsgen] Pass the version to resourcedocsgen tool

### DIFF
--- a/tools/resourcedocsgen/go.sum
+++ b/tools/resourcedocsgen/go.sum
@@ -343,6 +343,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 h1:G04eS0JkAIVZfaJLjla9dNxkJCPiKIGZlw9AfOhzOD0=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/tools/resourcedocsgen/main.go
+++ b/tools/resourcedocsgen/main.go
@@ -38,14 +38,14 @@ func main() {
 	// Grab the args.
 	flag.Parse()
 	args := flag.Args()
-	if len(args) < 2 {
-		fmt.Fprintf(os.Stderr, "error: usage: %s <out-dir> <provider-schema-file> [overlay-schema-file]>\n", os.Args[0])
+	if len(args) < 3 {
+		fmt.Fprintf(os.Stderr, "error: usage: %s <out-dir> <provider-schema-file> <version> [overlay-schema-file]>\n", os.Args[0])
 		os.Exit(1)
 	}
 
 	defer glog.Flush()
 
-	outDir, schemaFile, overlaysSchemaFile := args[0], args[1], args[2]
+	outDir, schemaFile, version, overlaysSchemaFile := args[0], args[1], args[2], args[3]
 
 	schema, err := ioutil.ReadFile(schemaFile)
 	if err != nil {
@@ -58,6 +58,7 @@ func main() {
 		glog.Infof("error unmarshalling schema into a PackageSpec: %v", err)
 		os.Exit(1)
 	}
+	mainSpec.Version = version
 
 	if overlaysSchemaFile != "" {
 		overlaySpec := &pschema.PackageSpec{}


### PR DESCRIPTION
### Proposed changes

This PR updates the `resourcedocsgen` tool to accept a version param. Since I was touching the `gen_resource_docs.sh`, I have also updated it to check if a `schema.json` file exists before generating the schema, which fixes #3378.

### Unreleased product version (optional)

N/A

### Related issues (optional)

Fixes #3386
Fixes #3378