### PR TITLE
Hide tooltip content before showing it

### DIFF
--- a/assets/sass/_tooltip.scss
+++ b/assets/sass/_tooltip.scss
@@ -31,4 +31,16 @@ pulumi-tooltip {
             }
         }
     }
+
+    // To prevent a flash of unstyled/understyled slotted content, we hide that content until
+    // it's rendered as a child of the tooltip component.
+    [slot="content"] {
+        @apply hidden;
+    }
+
+    .tooltip-content {
+        [slot="content"] {
+            display: unset;
+        }
+    }
 }


### PR DESCRIPTION
This fixes a minor visual bug that shows the tooltip text briefly before hiding it, due to the way the content's being reparented during component rendering. Before & after:

![flash mov](https://user-images.githubusercontent.com/274700/83288739-b9a63580-a198-11ea-92cd-4c1c463cc9d5.gif)
