### PR TITLE
Remove "preview" note about Python support.

### DIFF
--- a/content/docs/get-started/crossguard/_index.md
+++ b/content/docs/get-started/crossguard/_index.md
@@ -16,7 +16,7 @@ Often organizations want to empower developers to manage their infrastructure ye
 
 Using Policy as Code, users can express business or security rules as functions that are executed against resources in their stacks. Then using CrossGuard, organization administrators can apply these rules to particular stacks within their organization. When policies are executed as part of your Pulumi deployments, any violation will gate or block that update from proceeding.
 
-Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here](/docs/guides/crossguard/#languages).
+Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here]({{< relref "/docs/guides/crossguard#languages" >}}).
 
 ## Terminology
 

--- a/content/docs/get-started/crossguard/_index.md
+++ b/content/docs/get-started/crossguard/_index.md
@@ -18,10 +18,6 @@ Using Policy as Code, users can express business or security rules as functions 
 
 Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to stacks written in any language.
 
-{{% notes %}}
-Python support is currently in preview.
-{{% /notes %}}
-
 ## Terminology
 
 * **Policy Pack** - a set of related policies - i.e. “Security”, “Cost Optimization”, “Data Location”. The categorization of policies into a policy pack is left up to the user.

--- a/content/docs/get-started/crossguard/_index.md
+++ b/content/docs/get-started/crossguard/_index.md
@@ -16,7 +16,7 @@ Often organizations want to empower developers to manage their infrastructure ye
 
 Using Policy as Code, users can express business or security rules as functions that are executed against resources in their stacks. Then using CrossGuard, organization administrators can apply these rules to particular stacks within their organization. When policies are executed as part of your Pulumi deployments, any violation will gate or block that update from proceeding.
 
-Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to stacks written in any language.
+Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here](/docs/guides/crossguard/#languages).
 
 ## Terminology
 

--- a/content/docs/get-started/crossguard/authoring-a-policy-pack.md
+++ b/content/docs/get-started/crossguard/authoring-a-policy-pack.md
@@ -11,7 +11,7 @@ aliases: ["/docs/get-started/policy-as-code/authoring-a-policy-pack/"]
 ---
 <!-- markdownlint-disable emphasis ul -->
 
-Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here](/docs/guides/crossguard/#languages).
+Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here]({{< relref "/docs/guides/crossguard#languages" >}}).
 
 {{< chooser language "typescript,python" >}}
 

--- a/content/docs/get-started/crossguard/authoring-a-policy-pack.md
+++ b/content/docs/get-started/crossguard/authoring-a-policy-pack.md
@@ -11,11 +11,7 @@ aliases: ["/docs/get-started/policy-as-code/authoring-a-policy-pack/"]
 ---
 <!-- markdownlint-disable emphasis ul -->
 
-Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language.
-
-{{% notes %}}
-Python support is currently in preview.
-{{% /notes %}}
+Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here](/docs/guides/crossguard/#languages).
 
 {{< chooser language "typescript,python" >}}
 

--- a/content/docs/guides/crossguard/_index.md
+++ b/content/docs/guides/crossguard/_index.md
@@ -20,7 +20,7 @@ Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be 
 | ------------------------------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | <img src="/logos/tech/logo-ts.png" class="h-10" />     | [TypeScript]({{< relref "/docs/reference/pkg/nodejs/pulumi/policy" >}}) | Stable                                                            |
 | <img src="/logos/tech/logo-js.png" class="h-10" />     | [JavaScript]({{< relref "/docs/reference/pkg/nodejs/pulumi/policy" >}}) | Stable                                                            |
-| <img src="/logos/tech/logo-python.png" class="h-10" /> | [Python]({{< relref "/docs/reference/pkg/python/pulumi_policy" >}})     | Preview                                                           |
+| <img src="/logos/tech/logo-python.png" class="h-10" /> | [Python]({{< relref "/docs/reference/pkg/python/pulumi_policy" >}})     | Stable                                                             |
 | <img src="/logos/tech/dotnet.png" class="h-10" />      | .NET                                                                    | [Coming Soon](https://github.com/pulumi/pulumi-policy/issues/229) |
 | <img src="/logos/tech/logo-golang.png" class="h-10" /> | Go                                                                      | [Coming Soon](https://github.com/pulumi/pulumi-policy/issues/230) |
 

--- a/content/docs/guides/crossguard/core-concepts.md
+++ b/content/docs/guides/crossguard/core-concepts.md
@@ -12,7 +12,7 @@ menu:
 
 Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here]({{< relref "/docs/guides/crossguard#languages" >}}).
 
-{{< chooser language "typescript,python" >}}
+{{< chooser language "typescript,python" />}}
 
 ## Policy
 

--- a/content/docs/guides/crossguard/core-concepts.md
+++ b/content/docs/guides/crossguard/core-concepts.md
@@ -10,11 +10,9 @@ menu:
     parent: crossguard
 ---
 
-{{< chooser language "typescript,python" />}}
+Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here](/docs/guides/crossguard/#languages).
 
-{{% notes %}}
-Python support is currently in preview.
-{{% /notes %}}
+{{< chooser language "typescript,python" >}}
 
 ## Policy
 

--- a/content/docs/guides/crossguard/core-concepts.md
+++ b/content/docs/guides/crossguard/core-concepts.md
@@ -10,7 +10,7 @@ menu:
     parent: crossguard
 ---
 
-Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here](/docs/guides/crossguard/#languages).
+Policies can be written in TypeScript/JavaScript (Node.js) or Python and can be applied to Pulumi stacks written in any language. More information on language support for policies is [here]({{< relref "/docs/guides/crossguard#languages" >}}).
 
 {{< chooser language "typescript,python" >}}
 

--- a/content/docs/reference/pkg/_index.md
+++ b/content/docs/reference/pkg/_index.md
@@ -74,10 +74,7 @@ SDK reference documentation, organized by language.
     <dt>Pulumi SDK</dt>
     <dd><a href="{{< relref "/docs/reference/pkg/python/pulumi" >}}">pulumi</a></dd>
     <dt>Pulumi Policy</dt>
-    <dd>
-        <a href="{{< relref "/docs/reference/pkg/python/pulumi_policy" >}}">pulumi_policy</a>
-        <span class="ml-2 badge badge-preview">PREVIEW</span>
-    </dd>
+    <dd><a href="{{< relref "/docs/reference/pkg/python/pulumi_policy" >}}">pulumi_policy</a></dd>
     <dt>Pulumi Terraform</dt>
     <dd><a href="{{< relref "/docs/reference/pkg/python/pulumi_terraform" >}}">pulumi_terraform</a></dd>
 </dl>


### PR DESCRIPTION
Removes the "preview" note about Python support since it's now GA.