### PR TITLE
Wrap "required" asterisks in tooltips

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -113,4 +113,15 @@ function getQueryVariable(variable) {
 
             $(list).removeClass("invisible");
         });
+
+    // Wrap "required" asterisks in tooltips.
+    $("dl.resources-properties dt.property-required")
+        .removeAttr("title")
+        .find(".property-indicator")
+        .replaceWith(
+            '<pulumi-tooltip>' +
+            '    <span class="property-indicator"></span>' +
+            '    <span slot="content">This property is required.</span>' +
+            '</pulumi-tooltip>'
+        );
 }(jQuery));

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -92,7 +92,7 @@ dl {
             }
 
             span {
-                vertical-align: middle;
+                @apply align-middle
             }
         }
     }

--- a/assets/sass/_tooltip.scss
+++ b/assets/sass/_tooltip.scss
@@ -4,6 +4,10 @@
 pulumi-tooltip {
     @apply relative;
 
+    // Use the currently applied line height and font size.
+    line-height: 1em;
+    font-size: 1em;
+
     .tooltip-content {
         @apply absolute block opacity-0 w-48 py-2 mb-2 px-3 bg-gray-700 rounded shadow font-body font-normal text-center text-xs text-white leading-normal z-50;
         @include transition();

--- a/assets/sass/_tooltip.scss
+++ b/assets/sass/_tooltip.scss
@@ -9,7 +9,7 @@ pulumi-tooltip {
     font-size: 1em;
 
     .tooltip-content {
-        @apply absolute block opacity-0 w-48 py-2 mb-2 px-3 bg-gray-700 rounded shadow font-body font-normal text-center text-xs text-white leading-normal z-50;
+        @apply absolute block opacity-0 pointer-events-none w-48 py-2 mb-2 px-3 bg-gray-700 rounded shadow font-body font-normal text-center text-xs text-white leading-normal z-50;
         @include transition();
 
         // Position the tooltip above the target, centered.


### PR DESCRIPTION
This change adds a bit of jQuery to wrap our "required" asterisks in tooltips. Fixes a little alignment issue with tooltips as well.

![asterisks mov](https://user-images.githubusercontent.com/274700/83309408-094b2800-a1be-11ea-8ae6-292f0697b9e4.gif)

Closes #2855.