### PR TITLE
Update mysql post for change to protect property

### DIFF
--- a/content/blog/managing-your-mysql-databases-with-pulumi/index.md
+++ b/content/blog/managing-your-mysql-databases-with-pulumi/index.md
@@ -114,7 +114,7 @@ const rds = new aws.rds.Instance('sample', {
   availabilityZone: 'us-east-1b',
   instanceClass: 'db.t2.micro',
   allocatedStorage: 20,
-  protect: true,
+  deletionProtection: true,
 
   // For a VPC cluster, you will also need the following:
   // dbSubnetGroupName: 'sg-db01-replication-1',


### PR DESCRIPTION
At some point in the past, the post for managing RDS instances
has gone out of date. `protect` -> `deletionProtection` has occurred
as RS released their own way of managing it rather than via the
upstream Terraform provider

Fixes: https://github.com/pulumi/pulumi-mysql/issues/52