### PR TITLE
Allow indentation on unordered lists in markdown

### DIFF
--- a/content/docs/intro/cloud-providers/kubernetes/_index.md
+++ b/content/docs/intro/cloud-providers/kubernetes/_index.md
@@ -56,12 +56,14 @@ The following SDKs are available to work with IaaS resources, and managed or sel
 
 The [`pulumi/kubernetes`](https://github.com/pulumi/pulumi-kubernetes) SDK is available to work with, and deploy app workloads to running Kubernetes clusters:
 
+<!-- markdownlint-disable ul-indent -->
 - JavaScript/TypeScript: [npm](https://www.npmjs.com/package/@pulumi/kubernetes)
 - Python: [PyPI](https://pypi.org/project/pulumi-kubernetes/)
 - Go:
   - Import package: `github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes`
   - [GitHub](https://github.com/pulumi/pulumi-kubernetes/tree/master/sdk/go/kubernetes)
 - .NET: [`Pulumi.Kubernetes`](https://www.nuget.org/packages/Pulumi.Kubernetes)
+<!-- markdownlint-enable ul-indent -->
 
 [k8s]: https://kubernetes.io
 

--- a/content/docs/intro/cloud-providers/kubernetes/_index.md
+++ b/content/docs/intro/cloud-providers/kubernetes/_index.md
@@ -56,14 +56,12 @@ The following SDKs are available to work with IaaS resources, and managed or sel
 
 The [`pulumi/kubernetes`](https://github.com/pulumi/pulumi-kubernetes) SDK is available to work with, and deploy app workloads to running Kubernetes clusters:
 
-<!-- markdownlint-disable ul-indent -->
 - JavaScript/TypeScript: [npm](https://www.npmjs.com/package/@pulumi/kubernetes)
 - Python: [PyPI](https://pypi.org/project/pulumi-kubernetes/)
 - Go:
   - Import package: `github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes`
   - [GitHub](https://github.com/pulumi/pulumi-kubernetes/tree/master/sdk/go/kubernetes)
 - .NET: [`Pulumi.Kubernetes`](https://www.nuget.org/packages/Pulumi.Kubernetes)
-<!-- markdownlint-enable ul-indent -->
 
 [k8s]: https://kubernetes.io
 

--- a/scripts/markdown_seo_lint.js
+++ b/scripts/markdown_seo_lint.js
@@ -261,6 +261,8 @@ const opts = {
         MD023: false,
         // Allow blank lines in blockquotes.
         MD028: false,
+        // Allow indentation in unordered lists.
+        MD007: false,
     },
 };
 


### PR DESCRIPTION
Recently a linting error was merged into master breaking all subsequent builds. This PR adds a linting ignores to bypass the linting for the nested list. 