### PR TITLE
Use actions/checkout for Pulumify builds

### DIFF
--- a/.github/workflows/pulumify.yml
+++ b/.github/workflows/pulumify.yml
@@ -5,7 +5,8 @@ jobs:
     name: Update Live Preview
     runs-on: ubuntu-latest
     steps:
-    - uses: docker://pulumi/pulumify:v0.1.8
+    - uses: actions/checkout@v2
+    - uses: docker://pulumi/pulumify:v0.2.0
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This change updates the Pulumify workflow to use the latest version of Pulumify, which [removed the code responsible for checking out the PR branch](https://github.com/pulumi/actions-pulumify/pull/19). Instead, we'll now use `actions/checkout`, as we do for `master` builds, to handle that for us. 

This should remove the need to rebase and force-push PR builds in order to pull in the commits that happen on master after a PR is initially submitted. (In other words, it should be closer to that the actual production site will look like post-merge.)