### PR TITLE
add a repository dispatch event

### DIFF
--- a/.github/workflows/tfgen-provider.yml
+++ b/.github/workflows/tfgen-provider.yml
@@ -1,0 +1,74 @@
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+name: provider docs build
+on:
+  repository_dispatch:
+    types:
+      - tfgen-provider
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    needs: build-tfgen-provider-docs
+    steps:
+      - name: checkout docs repo
+        uses: actions/checkout@v2
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "${{ github.event.client_payload.project-shortname }}/${{ github.run_id }}-${{ github.run_number }}"
+          destination_branch: "master"
+          pr_title: "Regen docs ${{ github.event.client_payload.project-shortname }}@${{ github.event.client_payload.ref }}"
+          pr_body: ""
+          pr_label: "automation/tfgen-provider-docs"
+          github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+
+  build-tfgen-provider-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout docs repo
+        uses: actions/checkout@v2
+        with:
+          path: docs
+      - name: checkout pulumi repo
+        uses: actions/checkout@v2
+        with:
+          repository: pulumi/pulumi
+          path: pulumi
+      - name: checkout tfgen provider
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.client_payload.repo }}
+          ref: ${{ github.event.client_payload.ref }}
+          path: ${{ github.event.client_payload.project }}
+      - name: setup go
+        uses: actions/setup-go@v2
+      - name: setup node
+        uses: actions/setup-node@v2-beta
+      - name: setup python
+        uses: actions/setup-python@v2
+      - name: setup pipenv
+        uses: dschep/install-pipenv-action@v1
+      - name: setup dotnet
+        uses: actions/setup-dotnet@v1
+      - run: make ensure ensure_tools
+        working-directory: docs
+      - name: run typedoc
+        run: PKGS=${{ github.event.client_payload.project }} NOBUILD=true ./scripts/run_typedoc.sh
+        working-directory: docs
+      - name: generate resource docs
+        run: ./scripts/gen_resource_docs.sh "${{ github.event.client_payload.project-shortname }}" true "${{ github.event.client_payload.ref }}"
+        working-directory: docs
+      - name: generate python docs
+        run: ./scripts/generate_python_docs.sh "${{ github.event.client_payload.project-shortname }}"
+        working-directory: docs
+      - name: git status
+        run: git status && git diff
+        working-directory: docs
+      - name: commit changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          ref: "${{ github.event.client_payload.project-shortname }}/${{ github.run_id }}-${{ github.run_number }}"
+          author_name: pulumi-bot
+          author_email: "bot@pulumi.com"
+          cwd: docs


### PR DESCRIPTION
### Proposed changes

Our current docs build is run from within the provider repositories. Now
that we're moving to GitHub Actions we have an option to use a
repository dispatch event to trigger the builds from within this repo.

This event will not run unless a `POST` event is sent to this repo. It
will do the following:

- run typedocs
- run the resource generator docs
- run the python doc generator
- commit the changed files
- push them to a branch
- open a pull request

You can find an example of this in action here:
action: https://github.com/jaxxstorm/docs/actions/runs/129271369
pull request: https://github.com/jaxxstorm/docs/pull/2





<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->