### PR TITLE
Correct the environment variable names for okta

### DIFF
--- a/content/docs/intro/cloud-providers/okta/setup.md
+++ b/content/docs/intro/cloud-providers/okta/setup.md
@@ -14,7 +14,7 @@ Once obtained, there are two ways to communicate your configuration tokens to Pu
 
 1. Set the environment variables `OKTA_ORG_NAME`, `OKTA_BASE_URL` and `OKTA_API_TOKEN`:
 
-    ```console
+    ```bash
     $ export OKTA_ORG_NAME=XXXXXX
     $ export OKTA_BASE_URL=YYYYYY
     $ export OKTA_API_TOKEN=ZZZZZZ
@@ -22,7 +22,7 @@ Once obtained, there are two ways to communicate your configuration tokens to Pu
 
 2. Set them using configuration, if you prefer that they be stored alongside your Pulumi stack for easy multi-user access:
 
-    ```console
+    ```bash
     $ pulumi config set okta:orgName XXXXXX
     $ pulumi config set okta:baseUrl YYYYYY
     $ pulumi config set --secret okta:apiToken ZZZZZZ

--- a/content/docs/intro/cloud-providers/okta/setup.md
+++ b/content/docs/intro/cloud-providers/okta/setup.md
@@ -12,20 +12,20 @@ The [Pulumi Okta provider]({{< relref "./" >}}) uses the Okta SDK to manage reso
 
 Once obtained, there are two ways to communicate your configuration tokens to Pulumi:
 
-1. Set the environment variables `OKTA_ORG_NAME`, `OKTA_BASE_URL` and `OKTA_API_KEY`:
+1. Set the environment variables `OKTA_ORG_NAME`, `OKTA_BASE_URL` and `OKTA_API_TOKEN`:
 
-    ```bash
+    ```console
     $ export OKTA_ORG_NAME=XXXXXX
     $ export OKTA_BASE_URL=YYYYYY
-    $ export OKTA_API_KEY=ZZZZZZ
+    $ export OKTA_API_TOKEN=ZZZZZZ
     ```
 
 2. Set them using configuration, if you prefer that they be stored alongside your Pulumi stack for easy multi-user access:
 
-    ```bash
+    ```console
     $ pulumi config set okta:orgName XXXXXX
     $ pulumi config set okta:baseUrl YYYYYY
-    $ pulumi config set okta:apiKey ZZZZZZ
+    $ pulumi config set --secret okta:apiToken ZZZZZZ
     ```
 
-Remember to pass `--secret` when setting `apiKey` so that it is properly encrypted.
+Remember to pass `--secret` when setting `apiToken` so that it is properly encrypted.


### PR DESCRIPTION
From personal experience of getting this error:
```
        * missing required configuration key "okta:apiToken": API Token granting privileges to Okta API.
```
and also [as seen in the example code](https://github.com/pulumi/pulumi-okta/blob/v2.1.3/examples/examples_test.go#L13)

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
