### PR TITLE
Fix broken k8s URLs

### DIFF
--- a/content/docs/guides/crosswalk/kubernetes/app-services.md
+++ b/content/docs/guides/crosswalk/kubernetes/app-services.md
@@ -377,7 +377,7 @@ Internet using a [load balanced Service][k8s-lb-svc].
 > Note: NGINX requires a privileged PSP given its [use][nginx-priv-use] of `allowPrivilegeEscalation: true`.
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.30.0/deploy/static/mandatory.yaml -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.30.0/deploy/static/provider/cloud-generic.yaml
 ```
 
 Check that the NGINX deployment is running.

--- a/content/docs/intro/cloud-providers/kubernetes/setup.md
+++ b/content/docs/intro/cloud-providers/kubernetes/setup.md
@@ -99,4 +99,4 @@ to the constructor of a `new kubernetes.Provider` to construct a specific instan
 Each Kubernetes resource managed by Pulumi will have a link in the corresponding [Pulumi Console](https://app.pulumi.com")
 to view the resource in the cluster. These links are local, and require the client run `kubectl proxy` beforehand to access the resource.
 
-To learn more about `kubectl proxy` check out the [reference docs](https://kubernetes.io/docs/tasks/access-kubernetes-api/http-proxy-access-api/).
+To learn more about `kubectl proxy` check out the [reference docs](https://kubernetes.io/docs/concepts/cluster-administration/proxies/).


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- Update crosswalk-for-k8s app-services nginx manifest URLs
- Update k8s setup page broken link to kubectl proxy