### PR TITLE
Change contact link to go to Support.

### DIFF
--- a/content/docs/guides/saml/aad.md
+++ b/content/docs/guides/saml/aad.md
@@ -121,4 +121,4 @@ sign into to your Azure AD instance, and then immediately redirected back to the
 ## Troubleshooting
 
 If you have any trouble configuring Azure AD, signing into Pulumi, or need additional assistance, please
-[contact us]({{< relref "/about#contact-us" >}}).
+[contact support](https://support.pulumi.com/).


### PR DESCRIPTION
Previous link went to the About Us page using an anchor that didn't work.
