### PR TITLE
Add vanity url for crosswalk EKS page

### DIFF
--- a/content/docs/guides/crosswalk/aws/eks.md
+++ b/content/docs/guides/crosswalk/aws/eks.md
@@ -8,7 +8,9 @@ menu:
     parent: crosswalk-aws
     weight: 6
 
-aliases: ["/docs/reference/crosswalk/aws/eks/"]
+aliases:
+    - "/docs/reference/crosswalk/aws/eks/"
+    - "/eks"
 ---
 
 <a href="{{< relref "./" >}}">


### PR DESCRIPTION
This PR adds a vanity URL for the crosswalk EKS page, `/eks`.

Issue: https://github.com/pulumi/home/issues/955