### PR TITLE
Fix broken link

### DIFF
--- a/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
+++ b/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
@@ -83,4 +83,4 @@ We hope you like these helpers. If you're keen to get stuck in:
 - Try out the [many examples we have](https://app.pulumi.com), and
   [dive into the docs]({{< relref "/docs/reference" >}}).
 - [Submit new templates as PRs](https://github.com/pulumi/templates) -
-  contribution == [t-shirts at least](https://info.pulumi.com/community/give-me-a-tshirt).
+  contribution == t-shirts at least.


### PR DESCRIPTION
This PR fixes a broken link in one of our older blog posts. The link was to a HubSpot generated form for t-shirt requests that aren't actively being triaged so I have killed the form for the time being. 