### PR TITLE
Refactor link-checking workflow, notify on failure

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,30 @@
+name: Scheduled jobs
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string.
+    # Run every day at 12:00AM UTC.
+    - cron:  '0 0 * * *'
+jobs:
+  buildSite:
+    env:
+      GOPATH: ${{ github.workspace }}
+    name: Install deps and build site
+    runs-on: ubuntu-latest
+    steps:
+      # Turnstyle is used to prevent multiple push jobs from
+      # running at the same time.
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Check links
+        run: make ci_schedule
+        env:
+            SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,19 +11,10 @@ jobs:
     name: Install deps and build site
     runs-on: ubuntu-latest
     steps:
-      # Turnstyle is used to prevent multiple push jobs from
-      # running at the same time.
-      - name: Turnstyle
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: actions/checkout@v2
-
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-
       - name: Check links
         run: make ci_schedule
         env:

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -51,12 +51,7 @@ jobs:
         uses: pulumi/action-install-pulumi-cli@releases/v1
 
       - run: make ci_${GITHUB_EVENT_NAME}
-        if: github.event_name != 'schedule'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      
-      - name: Run scheduled job
-        run: make ci_cron
-        if: github.event_name == 'schedule'

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,13 @@ build:
 
 .PHONY: test
 test:
-	./scripts/check-links.sh
+	$(MAKE) check_links_local
+
+.PHONY: check_links_local
+check_links_local::
+	$(MAKE) banner
+	$(MAKE) ensure
+	./scripts/check-links.sh local
 
 .PHONY: ci_push
 ci_push::
@@ -79,12 +85,11 @@ ci_pull_request::
 	$(MAKE) banner
 	$(MAKE) ensure
 	$(MAKE) build
-	./scripts/check-links.sh pull_request
+	$(MAKE) test
 	./scripts/run-pulumi.sh preview production
 
-.PHONY: ci_cron
-ci_cron::
+.PHONY: ci_schedule
+ci_schedule::
 	$(MAKE) banner
 	$(MAKE) ensure
-	$(MAKE) build
-	$(MAKE) test
+	./scripts/check-links.sh www

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -o nounset -o errexit -o pipefail
 
-BUILD_TYPE=${1-schedule}
-HTTP_SERVER_PORT=8888
+source ./scripts/common.sh
 
-check_links() {
+CHECK_TYPE=${1-local}
+
+check_links_www() {
     # We exclude some links:
 	#     - Our generated API docs have lots of broken links
 	#     - Our available versions page includes links to private repos
@@ -13,7 +14,7 @@ check_links() {
 	#     - Our Visual Studio Marketplace link for the Azure Pipelines task extension,
 	#       although valid and publicly available, is reported as a broken link.
 	#     - A number of synthetic illustrative links come from our examples/tutorials.
-    ./node_modules/.bin/blc http://localhost:$HTTP_SERVER_PORT --recursive --follow --get \
+    npx blc https://www.pulumi.com --recursive --follow --get \
         --exclude "/docs/reference/pkg" \
         --exclude "/docs/get-started/install/versions" \
         --exclude "https://api.pulumi.com/" \
@@ -44,7 +45,7 @@ check_links() {
         --exclude "http://my-bucket-1234567.s3-website.us-west-2.amazonaws.com"
 }
 
-check_get_pulumi_links() {
+check_links_local() {
     # We only link to get.pulumi.com in /docs/get-started/install/ and /docs/get-started/install/versions
     npx blc http://localhost:$HTTP_SERVER_PORT/docs/get-started/install/versions/ --follow \
         --exclude-internal \
@@ -55,40 +56,25 @@ check_get_pulumi_links() {
         --exclude "https://www*"
 }
 
-retry() {
-    local n=1
-    local max=3
-    local delay=15
-    while true; do
-    "$@" && break || {
-        if [[ $n -lt $max ]]; then
-            ((n++))
-            echo "Command failed. Attempt $n/$max:"
-            sleep $delay;
-        else
-            echo "The command has failed after $n attempts." >&2
-            exit 1
-        fi
-    }
-    done
-}
+if [ $CHECK_TYPE = "local" ]; then
 
-# Start an HTTP server listening at the root of the built website.
-yarn run http-server public --port $HTTP_SERVER_PORT &>/dev/null &
-HTTP_SERVER_PID=$!
+    # Start an HTTP server listening at the root of the built website.
+    HTTP_SERVER_PORT=8888
+    yarn run http-server public --port $HTTP_SERVER_PORT &>/dev/null &
+    HTTP_SERVER_PID=$!
 
-# Run the link checker once the HTTP server is listening.
-while ! nc -z localhost $HTTP_SERVER_PORT; do sleep 0.1; done
+    # Run the link checker once the HTTP server is listening.
+    while ! nc -z localhost $HTTP_SERVER_PORT; do sleep 0.1; done
 
-# Re-run the link checker up to three times, to handle the occasional transient failure.
-if [ $BUILD_TYPE = "pull_request" ]
-then
     echo "Checking only get.pulumi.com links"
-    retry check_get_pulumi_links
-else
-    echo "Checking all links"
-    retry check_links
+    retry check_links_local 3 15
+
+    # Kill the server process.
+    kill $HTTP_SERVER_PID
 fi
 
-# Kill the server process.
-kill $HTTP_SERVER_PID
+if [ $CHECK_TYPE = "www" ]; then
+
+    echo "Checking all links on pulumi.com"
+    retry check_links_www 3 15 || post_to_slack "ops-notifications" "Eek! :scream_cat: There are broken links on pulumi.com. See the GitHub Actions log for details. https://github.com/${GITHUB_REPOSITORY}/runs/${GITHUB_RUN_ID}"
+fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Posts a message to Slack. Requires a valid access token is available in $SLACK_ACCESS_TOKEN.
+# Usage: post_to_slack <channel> <message>
+post_to_slack() {
+    local channel=$1
+    local message=$2
+
+    local escaped=$(echo ${message} | sed 's/"/\"/g' | sed "s/'/\'/g" )
+    local json="{\"channel\": \"#${channel}\", \"text\": \"${escaped}\", \"as_user\": true}"
+
+    curl \
+        -X POST \
+        -H "Content-type: application/json" \
+        -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
+        -d  "${json}" \
+        https://slack.com/api/chat.postMessage > /dev/null
+}
+
+# Retry the given command some number of times, with a delay of some number of seconds between calls.
+# Usage: retry some_command <retry-count> <delay-in-seconds>
+retry() {
+    local n=1
+    local max=$2
+    local delay=$3
+    while true; do
+    "$@" && break || {
+        if [[ $n -lt $max ]]; then
+            ((n++))
+            echo "Command failed. Attempt $n/$max:"
+            sleep $delay;
+        else
+            echo "The command has failed after $n attempts." >&2
+            return 1
+        fi
+    }
+    done
+}


### PR DESCRIPTION
This change pulls the link-checking task that we run once a day into its own GitHub Actions workflow and updates the logic for that task to use pulumi.com instead of a locally running copy of the website. It also adds a Slack notification that posts to #ops-notifications when that task fails.

Closes #3231.