### PR TITLE
Block external webinar pages from being indexed by Google

### DIFF
--- a/archetypes/webinar/index.md
+++ b/archetypes/webinar/index.md
@@ -26,8 +26,11 @@ gated: false
 type: webinars
 
 # External webinars will link to an external page instead of a webinar
-# landing/registration page.
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
 external: false
+block_external_search_index: false
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/aws-howdy-partner-twitch-2020-06-01/index.md
+++ b/content/webinars/aws-howdy-partner-twitch-2020-06-01/index.md
@@ -3,8 +3,6 @@
 title: "AWS - Howdy Partner"
 meta_desc: "Watch Pulumi VP of Engineering Lee Zen build serverless applications in real time, using both Python and TypeScript."
 
-block_external_search_index: true
-
 # A featured webinar will display first in the list.
 featured: false
 
@@ -30,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/aws-mapbox/index.md
+++ b/content/webinars/aws-mapbox/index.md
@@ -24,6 +24,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/cncf-production-ready-kubernetes/index.md
+++ b/content/webinars/cncf-production-ready-kubernetes/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/dev-095-2020-06-11/index.md
+++ b/content/webinars/dev-095-2020-06-11/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/devops-belfast-2020-05-19/index.md
+++ b/content/webinars/devops-belfast-2020-05-19/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/devops-nyc-2020-06-24/index.md
+++ b/content/webinars/devops-nyc-2020-06-24/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/fsharp-conf-2020-06-05/index.md
+++ b/content/webinars/fsharp-conf-2020-06-05/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/infrastructure-as-code-go-2020-04-01/index.md
+++ b/content/webinars/infrastructure-as-code-go-2020-04-01/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/kubernetes-on-digital-ocean/index.md
+++ b/content/webinars/kubernetes-on-digital-ocean/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/ndc-oslo-2020-06-12/index.md
+++ b/content/webinars/ndc-oslo-2020-06-12/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/stack-conf-eu-2020-06-16/index.md
+++ b/content/webinars/stack-conf-eu-2020-06-16/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/content/webinars/tech-strong-con-2020-06-04/index.md
+++ b/content/webinars/tech-strong-con-2020-06-04/index.md
@@ -28,6 +28,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: true
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.


### PR DESCRIPTION
Currently, our external webinar pages are being indexed by Google. This PR adds the `block_external_search_index` to the webinar archetype and sets the flag to `true` on all the existing external webinars.

cc// @isaac-pulumi 