### PR TITLE
Document requirements for transferring stacks

### DIFF
--- a/content/docs/intro/console/collaboration/organization-roles.md
+++ b/content/docs/intro/console/collaboration/organization-roles.md
@@ -25,12 +25,12 @@ be a member of that GitLab group.
 
 There are several kinds of organization roles a user may be assigned.
 
-`**MEMBER**`
+**`MEMBER`**
 
 A member of a Pulumi organization can be added to organization [teams]({{< relref "teams" >}}), and
 depending on organization settings, may be able to create or delete stacks.
 
-`**ADMIN**`
+**`ADMIN`**
 
 Pulumi organization admins have `ADMIN` access to _all_ organization stacks,
 and can manage organization settings and team memberships.
@@ -74,6 +74,15 @@ or not organization members can delete stacks.
 
 If enabled, any organization member with `ADMIN` permission on the stack can delete
 it. Otherwise, only Pulumi  organization admins can.
+
+### Stack Transfer
+
+If enabled, organization members will be able to transfer stacks to another
+Pulumi organization.
+
+Transfering a stack to another organization requires that the user performing the action
+has both `ADMIN` permission to the stack being moved, and has the `MEMBER` or `ADMIN` _role_
+within the organization the stack is being transferred to.
 
 ## Next Steps
 

--- a/content/docs/intro/console/collaboration/stack-permissions.md
+++ b/content/docs/intro/console/collaboration/stack-permissions.md
@@ -34,6 +34,7 @@ These stack permissions allow users to perform the following actions:
 | Export stack checkpoint | | ✅ | ✅ | ✅ |
 | Import stack checkpoint |  | | ✅ | ✅ |
 | Delete stack (`pulumi stack rm`) | | | | ✅ |
+| Transfer to another organization | | | | ✅ |
 
 ## Assigning Stack Permissions
 


### PR DESCRIPTION
Document the requirements for transferring stacks to another organization. This was a feature we added to the Pulumi Console a while back, but never mentioned it in our docs.

- Mention the Organization Setting for transferring stacks:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/4029847/85906732-13b01000-b7c4-11ea-8398-71dd1cfc7d7a.png">

- Add "transfer to another organization" to the list of things that require stack permissions:

<img width="613" alt="image" src="https://user-images.githubusercontent.com/4029847/85906761-2cb8c100-b7c4-11ea-8b9a-242fc5325799.png">

- Fixes a rendering problem on https://www.pulumi.com/docs/intro/console/collaboration/organization-roles/#organization-roles. Evidently in Markdown **`BOLD-THEN-CODE`** is a thing, but `**CODE-THEN-BOLD**` is not.
