### PR TITLE
Fix a broken link in the broken-link checking script

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -76,5 +76,5 @@ fi
 if [ $CHECK_TYPE = "www" ]; then
 
     echo "Checking all links on pulumi.com"
-    retry check_links_www 3 15 || post_to_slack "ops-notifications" "Eek! :scream_cat: There are broken links on pulumi.com. See the GitHub Actions log for details. https://github.com/${GITHUB_REPOSITORY}/runs/${GITHUB_RUN_ID}"
+    retry check_links_www 3 15 || (post_to_slack "ops-notifications" "Eek! :scream_cat: There are broken links on pulumi.com. See the GitHub Actions log for details. https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" && exit 1)
 fi


### PR DESCRIPTION
This change fixes the link to the failed GitHub Actions run and explicitly exits 1 on failure in order to properly fail the run. (Currently, we're exiting 0 because the `echo` statement completes successfully.) 