### PR TITLE
WIP: Use an S3 Bucket website for AWS Getting Started

### DIFF
--- a/assets/sass/_pygments.scss
+++ b/assets/sass/_pygments.scss
@@ -59,10 +59,10 @@
 /* LiteralNumberOct */ .highlight .mo { color: #40a070 }
 /* Operator */ .highlight .o { color: #666666 }
 /* OperatorWord */ .highlight .ow { color: #007020; font-weight: bold }
-/* Comment */ .highlight .c { color: #60a0b0; font-style: italic }
-/* CommentHashbang */ .highlight .ch { color: #60a0b0; font-style: italic }
-/* CommentMultiline */ .highlight .cm { color: #60a0b0; font-style: italic }
-/* CommentSingle */ .highlight .c1 { color: #60a0b0; font-style: italic }
+/* Comment */ .highlight .c { color: #60a0b0; }
+/* CommentHashbang */ .highlight .ch { color: #60a0b0; }
+/* CommentMultiline */ .highlight .cm { color: #60a0b0; }
+/* CommentSingle */ .highlight .c1 { color: #60a0b0; }
 /* CommentSpecial */ .highlight .cs { color: #60a0b0; background-color: #fff0f0 }
 /* CommentPreproc */ .highlight .cp { color: #007020 }
 /* CommentPreprocFile */ .highlight .cpf { color: #007020 }

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -23,10 +23,13 @@ Pulumi computes the minimally disruptive change to achieve the desired state des
 ```
 Previewing update (dev):
 
-     Type                 Name            Plan       Info
-     pulumi:pulumi:Stack  quickstart-dev
- +   ├─ aws:kms:Key       my-key          create
- ~   └─ aws:s3:Bucket     my-bucket       update     [diff: +serverSideEncryptionConfiguration]
+     Type                    Name                Plan       Info
+     pulumi:pulumi:Stack     quickstart-dev
+ ~   ├─ aws:s3:Bucket        my-bucket           update     [diff: +website]
+ +   └─ aws:s3:BucketObject  index.html          create
+
+Outputs:
+  + websiteEndpoint: output<string>
 
 Resources:
     + 1 to create
@@ -39,28 +42,34 @@ Do you want to perform this update?
   details
 ```
 
-Pulumi will create the KMS key and update the bucket with the new encryption configuration.
+Pulumi will create the home page and update the bucket with the new website configuration.
 
 Choosing `yes` will proceed with the update.
 
 ```
 Do you want to perform this update? yes
 Updating (dev):
-
-     Type                 Name            Status      Info
-     pulumi:pulumi:Stack  quickstart-dev
- +   ├─ aws:kms:Key       my-key          created
- ~   └─ aws:s3:Bucket     my-bucket       updated     [diff: +serverSideEncryptionConfiguration]
+     Type                    Name                Status      Info
+     pulumi:pulumi:Stack     get-started-ts-dev
+ ~   ├─ aws:s3:Bucket        my-bucket           updated     [diff: +website]
+ +   └─ aws:s3:BucketObject  index.html          created
 
 Outputs:
-    bucket_name: "my-bucket-de014a8"
+    bucketName     : "my-bucket-de014a8"
+  + websiteEndpoint: "http://my-bucket-de014a8.s3-website-us-west-2.amazonaws.com"
 
 Resources:
     + 1 created
     ~ 1 updated
     2 changes. 1 unchanged
 
-Duration: 10s
+Duration: 8s
+```
+
+You can browse to the page either by copying the `websiteEndpoint` value and pasting it into your browser or by using `pulumi stack export`:
+
+```
+open "http://$(pulumi stack output websiteEndpoint)"
 ```
 
 Next, we'll destroy the stack.


### PR DESCRIPTION
In the interest of making our getting-started guides a bit more interesting, this change makes a small tweak to the getting-started guide for AWS to configure the S3 bucket as a static website.  

Fixes #3708.