### PR TITLE
Don't pass the delete option to s3 sync

### DIFF
--- a/infrastructure/sync.sh
+++ b/infrastructure/sync.sh
@@ -48,10 +48,11 @@ done
 
 cd ..
 
-# Synchronize the remaining contents of the local folder and site bucket, deleting
-# whatever files exist remotely but not locally.
+# Push remaining content to the site bucket. Note we do not pass the --delete option to
+# s3 sync, which means that files in the s3 bucket that aren't in the local build will be
+# left in the bucket.
 echo "Synchronizing to $site_bucket..."
-aws s3 sync site_contents "$site_bucket" --acl public-read --delete
+aws s3 sync site_contents "$site_bucket" --acl public-read
 
 # Create an S3 object for each of the items in the redirect list so it returns a 301
 # redirect (instead of serving the HTML with a meta-redirect). This ensures the right HTTP


### PR DESCRIPTION
By not passing the `--delete` option to `aws s3 sync`, we'll leave deleted files in the S3 bucket, reducing the risk of 404s for files that haven't yet been cached for some users by CloudFront. [See here for additional context](https://pulumi.slack.com/archives/C85BS3LJZ/p1593882723012500?thread_ts=1593818195.480600&cid=C85BS3LJZ).