### PR TITLE
Pass the Git SHA to the Pulumify build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ build:
 pulumify:
 	@echo -e "\033[0;32mBUILD PULUMIFY:\033[0m"
 	$(MAKE) ensure
-	./scripts/build-site.sh --buildDrafts --buildFuture
+	./scripts/build-site.sh preview
 
 .PHONY: test
 test:

--- a/layouts/docs/search-data.json
+++ b/layouts/docs/search-data.json
@@ -1,4 +1,5 @@
-{{- if eq hugo.Environment "production" -}}
+{{/* Don't build the search index by default in development. */}}
+{{- if ne hugo.Environment "development" -}}
 {
 {{- $pages := (where .Site.Pages ".Params.exclude_from_pulumi_search_index" "ne" true) -}}
 {{- $lastindex := (sub (len $pages) 1) -}}

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -20,7 +20,11 @@ printf "Building web components...\n\n"
 make build_components
 
 printf "Running Hugo...\n\n"
-hugo --minify "$@" --templateMetrics -e production
+if [ $1 == "preview" ]; then
+    hugo --minify --templateMetrics --buildDrafts --buildFuture -e ${GIT_SHA}
+else
+    hugo --minify --templateMetrics -e production
+fi
 
 printf "Compiling the JavaScripts...\n\n"
 yarn run tsc --outFile ${JS_BUNDLE}


### PR DESCRIPTION
A recent change [removed an argument](https://github.com/pulumi/docs/commit/f51a297d2f6889cac442bfa41f2215364612031c#diff-f0f811f11fd0a877df3dfbd92ca153bbL16) preventing Hugo `.Permalink`s from being fully qualified to point to `www`, which is the behavior we need for Pulumify builds. This change just restores that argument by passing the Git SHA as before.