### PR TITLE
Update status of guest poster to 'guest'

### DIFF
--- a/data/team/team/itay-podhajcer.toml
+++ b/data/team/team/itay-podhajcer.toml
@@ -3,7 +3,7 @@ name = "Itay Podhajcer"
 title = "Chief Architect at Velocity Career Labs"
 weight = 1
 
-status = "active"
+status = "guest"
 
 [social]
 github = "ItayPodhajcer"


### PR DESCRIPTION
When we posted our recent guest blog post, the status of the author was set to `active` so they were displaying on our `/about` page. This PR changes their status to 'guest' so they are no longer listed in our Team section.

<img width="959" alt="pulumi-team-guest-post" src="https://user-images.githubusercontent.com/15146337/87838452-011d7980-c84c-11ea-9375-8f1190734ec2.png">