### PR TITLE
Fix typo in url for the Armory webinar

### DIFF
--- a/content/webinars/armory-continuous-delivery-for-infrastructure/index.md
+++ b/content/webinars/armory-continuous-delivery-for-infrastructure/index.md
@@ -3,6 +3,9 @@
 title: "Armory + Pulumi: Continuous Delivery for your IaC"
 meta_desc: "Learn how the Pulumi plugin for Spinnaker simplifies your deployments by having infrastructure and application code in a single workflow."
 
+aliases:
+  - /webinars/armory-continuos-delivery-for-infrastructure
+
 # A featured webinar will display first in the list.
 featured: false
 


### PR DESCRIPTION
The folder containing the Armory webinar content files had a typo in it and that was causing a 404 when clicking on it from the webinar listing page. This PR fixes that typo.