### PR TITLE
Update eks.md

### DIFF
--- a/content/docs/tutorials/kubernetes/eks.md
+++ b/content/docs/tutorials/kubernetes/eks.md
@@ -377,7 +377,7 @@ const guestbook = new k8s.yaml.ConfigFile("guestbook",
         ],
     },
     {
-        providers: { "kubernetes": clusterProvider },
+        providers: { "kubernetes": cluster.provider },
     },
 );
 


### PR DESCRIPTION
Fix typo in the guestbook snippet, to prevent a similar error to show up during `pulumi up`:

```shell
error TS2304: Cannot find name 'clusterProvider'.
```

### Proposed changes

This fix allows to correctly complete the related [tutorial](https://www.pulumi.com/docs/tutorials/kubernetes/eks/).
