### PR TITLE
Fix typo in example code - `obh` -> `obj`.

### DIFF
--- a/content/blog/kubernetes-is-better-with-pulumi/index.md
+++ b/content/blog/kubernetes-is-better-with-pulumi/index.md
@@ -78,7 +78,7 @@ Pulumi is not just for developers; operators can leverage it to manage Kubernete
 ```python
 def set_namespace(namespace):
    def f(obj):
-      if "metadata" in obh:
+      if "metadata" in obj:
          obj["metadata"]["namespace"] = namespace
       else:
          obj["metadata"] = {"namespace": namespace}


### PR DESCRIPTION
### Proposed changes

Fix typo in example code.

