### PR TITLE
Add doc for configuring SAML SSO with self-hosted installations

### DIFF
--- a/content/docs/guides/saml/_index.md
+++ b/content/docs/guides/saml/_index.md
@@ -14,6 +14,8 @@ aliases:
 
 The [Pulumi Console](https://app.pulumi.com) can be configured to work with any SAML 2.0 identity provider. SAML support requires Pulumi Enterprise Edition. To learn more about the capabilities of the Enterprise Edition, refer to the [pricing page]({{< relref "/pricing" >}}).
 
+> Looking for information on how to enable SAML SSO for self-hosted Pulumi? Learn more [here]({{< relref "docs/guides/self-hosted/saml-sso" ">}}).
+
 ## Single Sign-On (SSO)
 
 If you're a member of a SAML-based Pulumi organization, you can sign in to [your account]({{< relref "/docs/intro/console/accounts-and-organizations/accounts" >}}) via Single Sign-On. To learn about the important aspects of configuring SSO for your IdP, refer to the [SSO page]({{< relref "sso" >}}).

--- a/content/docs/guides/saml/_index.md
+++ b/content/docs/guides/saml/_index.md
@@ -14,7 +14,7 @@ aliases:
 
 The [Pulumi Console](https://app.pulumi.com) can be configured to work with any SAML 2.0 identity provider. SAML support requires Pulumi Enterprise Edition. To learn more about the capabilities of the Enterprise Edition, refer to the [pricing page]({{< relref "/pricing" >}}).
 
-> Looking for information on how to enable SAML SSO for self-hosted Pulumi? Learn more [here]({{< relref "docs/guides/self-hosted/saml-sso" ">}}).
+> Looking for information on how to enable SAML SSO for self-hosted Pulumi? Learn more [here]({{< relref "docs/guides/self-hosted/saml-sso" >}}).
 
 ## Single Sign-On (SSO)
 

--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -55,9 +55,9 @@ The API service is a Go-based application. This is a single binary application t
 
 | Variable Name | Description |
 | ------------- | ----------- |
-| PULUMI_OBJECTS_BUCKET | S3 bucket name for persisting state for stacks.<br><br>**Note**:Only used if hosted on AWS. |
+| PULUMI_OBJECTS_BUCKET | S3 bucket name for persisting state for stacks.<br><br>**Note**: Only used if hosted on AWS. |
 | RECAPTCHA_SECRET_KEY | reCAPTCHA secret key for self-service password reset. Create a site key and a secret key from Google [here](https://www.google.com/recaptcha/admin). |
-| SAML_CERTIFICATE_PUBLIC_KEY | Public key used by the [IdP]({{< relref "../saml/sso#terminology" >}}) to sign SAML assertions. |
-| SAML_CERTIFICATE_PRIVATE_KEY | Private key used by Pulumi to validate the SAML assertions sent by the IdP. |
+| SAML_CERTIFICATE_PUBLIC_KEY | Public key used by the [IdP]({{< relref "../saml/sso#terminology" >}}) to sign SAML assertions. Learn how to set this value [here]({{< relref "saml-sso" >}}). |
+| SAML_CERTIFICATE_PRIVATE_KEY | Private key used by Pulumi to validate the SAML assertions sent by the IdP. Learn how to set this value [here]({{< relref "saml-sso" >}}). |
 | GITHUB_OAUTH_ENDPOINT | Used for GitHub API calls. |
 | GITLAB_OAUTH_ENDPOINT | Used for GitLab API calls. |

--- a/content/docs/guides/self-hosted/saml-sso.md
+++ b/content/docs/guides/self-hosted/saml-sso.md
@@ -1,0 +1,57 @@
+---
+title: Enabling SAML SSO
+menu:
+    userguides:
+        parent: self_hosted
+        identifier: self_hosted_sso
+        weight: 3
+meta_desc: Learn how to make the self-hosted Pulumi ready for SAML SSO with any IdP. Self-hosting is available as part of the Enterprise Edition.
+---
+
+The self-hosted option allows you to control various aspects of the Pulumi Service including how users will logon to the [Pulumi Console]({{< relref "console" >}}).
+
+## Creating The Keys
+
+Before you can use SAML SSO to logon to the Console, however, you will need to ensure that the [API service]({{< relref "api" >}}) has a pair of keys that will be used to sign
+and validate requests/responses regardless of the IdP you choose to use.
+
+The credentials are simply a public/private key pair that will be supplied as environment variables to the API service.
+In the following snippets, we show you how you can generate a key pair by using `openssl`.
+The snippet shows the command for a self-hosted API service that is accessible via `api.company.com`.
+Be sure to adjust the value accordingly.
+
+> OpenSSL's official [wiki](https://wiki.openssl.org/index.php/Binaries) site contains links to pre-built binaries.
+
+```
+# Generate a new 2048-bit RSA key with a validity of 365 days.
+openssl \
+  req -x509 -newkey rsa:2048 \
+  -days 365 -nodes -subj "/CN=api.company.com" \
+  -keyout cert.key \
+  -out cert.cert
+```
+
+If you also want to additionally specify an SAN (Subject Alternative Name) for your public cert, you can do so by passing the `-addext` flag as shown below.
+
+> For this to work, though, you'll need to install _at least_ version 1.1. Once installed ensure that the 1.1 version is on your path when you run the command.
+> Otherwise `-addext` will not be recognized as a valid flag.
+
+```
+openssl \
+  req -x509 -newkey rsa:2048 \
+  -days 365 -nodes -subj "/CN=api.company.com" \
+  -keyout cert.key \
+  -addext "subjectAltName=DNS:anotherdomain.company.com" \
+  -out cert.cert
+```
+
+## Configure The API Service
+
+Once the key pair has been generated, set the value of the following environment variables for the API service.
+
+`SAML_CERTIFICATE_PUBLIC_KEY` should be set to the value of the `*.cert` file, i.e. the public key file.
+`SAML_CERTIFICATE_PRIVATE_KEY` should be set to the value of the `*.key` file, i.e. the private key file.
+
+For these values to take effect, you will need to restart the API Service.
+
+> Restart the service only if it is safe to do so or during a planned maintenance window.

--- a/content/docs/guides/self-hosted/saml-sso.md
+++ b/content/docs/guides/self-hosted/saml-sso.md
@@ -49,7 +49,7 @@ openssl \
 
 Once the key pair has been generated, set the value of the following environment variables for the API service:
 
-`SAML_CERTIFICATE_PUBLIC_KEY` should be set to the value of the `*cert.cert` file, i.e. the public key file.
+`SAML_CERTIFICATE_PUBLIC_KEY` should be set to the value of the `cert.cert` file, i.e. the public key file.
 `SAML_CERTIFICATE_PRIVATE_KEY` should be set to the value of the `cert.key` file, i.e. the private key file.
 
 For these values to take effect, you will need to restart the API Service.

--- a/content/docs/guides/self-hosted/saml-sso.md
+++ b/content/docs/guides/self-hosted/saml-sso.md
@@ -12,10 +12,10 @@ The self-hosted option allows you to control various aspects of the Pulumi Servi
 
 ## Creating The Keys
 
-Before you can use SAML SSO to logon to the Console, however, you will need to ensure that the [API service]({{< relref "api" >}}) has a pair of keys that will be used to sign
-and validate requests/responses regardless of the IdP you choose to use.
+Before you can use SAML SSO to logon to the Console, you will need to ensure that the [API service]({{< relref "api" >}}) has a pair of keys that will be used to sign
+and validate requests/responses, regardless of the IdP you choose to use.
 
-The credentials are simply a public/private key pair that will be supplied as environment variables to the API service.
+The credentials are simply a public/private key pair that are supplied as environment variables to the API service.
 In the following snippets, we show you how you can generate a key pair by using `openssl`.
 The snippet shows the command for a self-hosted API service that is accessible via `api.company.com`.
 Be sure to adjust the value accordingly.
@@ -47,11 +47,11 @@ openssl \
 
 ## Configure The API Service
 
-Once the key pair has been generated, set the value of the following environment variables for the API service.
+Once the key pair has been generated, set the value of the following environment variables for the API service:
 
-`SAML_CERTIFICATE_PUBLIC_KEY` should be set to the value of the `*.cert` file, i.e. the public key file.
-`SAML_CERTIFICATE_PRIVATE_KEY` should be set to the value of the `*.key` file, i.e. the private key file.
+`SAML_CERTIFICATE_PUBLIC_KEY` should be set to the value of the `*cert.cert` file, i.e. the public key file.
+`SAML_CERTIFICATE_PRIVATE_KEY` should be set to the value of the `cert.key` file, i.e. the private key file.
 
 For these values to take effect, you will need to restart the API Service.
 
-> Restart the service only if it is safe to do so or during a planned maintenance window.
+> Restart the service only during a planned maintenance window.


### PR DESCRIPTION
### Proposed changes

Add doc about generating and configuring the SAML key pair for enabling SSO in a self-hosted install.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A