### PR TITLE
Remove the code for the detached requestLogs bucket

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -180,17 +180,6 @@ archiveBucket.onObjectCreated("archive-bucket-subscription", new aws.lambda.Call
     },
 }));
 
-// logsBucket stores the request logs for incoming requests.
-const logsBucket = new aws.s3.Bucket(
-    "requestLogs",
-    {
-        bucket: `${config.targetDomain}-logs`,
-        acl: "private",
-    },
-    {
-        protect: true,
-    });
-
 // websiteLogsBucket stores the request logs for incoming requests.
 const websiteLogsBucket = new aws.s3.Bucket(
     "website-logs-bucket",


### PR DESCRIPTION
This change removes the code that's attempting to create a bucket we manually detached from the production stack yesterday. The bucket itself still exists (for archival purposes), so this code needs to be removed in order to prevent Pulumi from failing.