### PR TITLE
Add instruction to clone github example

### DIFF
--- a/content/docs/tutorials/azure/azure-ts-webserver.md
+++ b/content/docs/tutorials/azure/azure-ts-webserver.md
@@ -29,6 +29,8 @@ This example provisions a Linux web server in an Azure Virtual Machine and gives
 
 ## Running the App
 
+1. Clone the example code from GitHub onto your local machine.
+
 1.  Create a new stack:
 
     ```


### PR DESCRIPTION
### Proposed changes

Adding an instruction to the azure VM tutorial so new users know they need to clone the example repo.

### Related issues (optional)

Fixes #3858
