### PR TITLE
Fix Python structured config example

### DIFF
--- a/content/docs/intro/concepts/config.md
+++ b/content/docs/intro/concepts/config.md
@@ -297,7 +297,7 @@ console.log(`Active: ${data.active}`);
 ```python
 config = pulumi.Config()
 data = config.require_object("data")
-print(f"Active: ${data.active}")
+print("Active:", data.get("active"))
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
Fixes: #3833

Reported as per twitter and now works as follows:

```
▶ pulumi up --non-interactive --yes --skip-preview
Updating (dev):

    pulumi:pulumi:Stack python-config-dev running
    pulumi:pulumi:Stack python-config-dev running Active: True
    pulumi:pulumi:Stack python-config-dev  1 message

Diagnostics:
  pulumi:pulumi:Stack (python-config-dev):
    Active: True
```


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->