### PR TITLE
Build PR buckets concurrently

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       # Turnstyle is used to prevent multiple push jobs from running at the same time. We
-      # exclude it for pull_requests to allow them to run concurrently.
+      # limit it to push jobs to allow PR jobs to run concurrently.
       - name: Turnstyle
         if: ${{ github.event_name == 'push' }}
         uses: softprops/turnstyle@v1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -13,9 +13,11 @@ jobs:
     name: Install deps and build site
     runs-on: ubuntu-latest
     steps:
-      # Turnstyle is used to prevent multiple push jobs from
-      # running at the same time.
+
+      # Turnstyle is used to prevent multiple push jobs from running at the same time. We
+      # exclude it for pull_requests to allow them to run concurrently.
       - name: Turnstyle
+        if: ${{ github.event_name == 'pull_request' }}
         uses: softprops/turnstyle@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       # Turnstyle is used to prevent multiple push jobs from running at the same time. We
       # exclude it for pull_requests to allow them to run concurrently.
       - name: Turnstyle
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'push' }}
         uses: softprops/turnstyle@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -20,7 +20,7 @@ const config = {
     // than "s3://bucket-name-123".
     originBucketNameOverride: stackConfig.get("originBucketNameOverride") || undefined,
     // pathToOriginBucketMetadata is the path to the file produced at the end of the
-    // bucketize script (i.e., scripts/bucketize.sh).
+    // sync-and-test-bucket script (i.e., scripts/sync-and-test-bucket.sh).
     pathToOriginBucketMetadata: stackConfig.require("pathToOriginBucketMetadata"),
 };
 

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -5,15 +5,16 @@ set -o errexit -o pipefail
 source ./scripts/common.sh
 
 export NODE_ENV="production"
+export BUILD_START="$(current_time_in_ms)"
 
 # Paths to the CSS and JS bundles we'll generate below. Note that environment variables
 # are read by some templates during the Hugo build process.
-export CSS_BUNDLE="public/css/styles.$(pr_number_or_git_sha).css"
-export JS_BUNDLE="public/js/bundle.min.$(pr_number_or_git_sha).js"
+export CSS_BUNDLE="public/css/styles.$(build_identifier).css"
+export JS_BUNDLE="public/js/bundle.min.$(build_identifier).js"
 
 # Relative paths to those same files, read by Hugo templates.
-export REL_CSS_BUNDLE="/css/styles.$(pr_number_or_git_sha).css"
-export REL_JS_BUNDLE="/js/bundle.min.$(pr_number_or_git_sha).js"
+export REL_CSS_BUNDLE="/css/styles.$(build_identifier).css"
+export REL_JS_BUNDLE="/js/bundle.min.$(build_identifier).js"
 
 printf "Copying prebuilt docs...\n\n"
 make copy_static_prebuilt
@@ -23,7 +24,7 @@ make build_components
 
 printf "Running Hugo...\n\n"
 if [ "$1" == "preview" ]; then
-    hugo --minify --templateMetrics --buildDrafts --buildFuture -e $(pr_number_or_git_sha)
+    hugo --minify --templateMetrics --buildDrafts --buildFuture -e $(build_identifier)
 else
     hugo --minify --templateMetrics -e production
 fi

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -5,7 +5,6 @@ set -o errexit -o pipefail
 source ./scripts/common.sh
 
 export NODE_ENV="production"
-export BUILD_START="$(current_time_in_ms)"
 
 # Paths to the CSS and JS bundles we'll generate below. Note that environment variables
 # are read by some templates during the Hugo build process.

--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -44,7 +44,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
             fi
         done
 
-        # Post a PR comment that any links to previously built previews won't work anymore.
+        # Post a PR comment that any links to previously built previews will no longer work.
         post_github_pr_comment \
             "Site previews for this pull request have been removed. ✨" \
             $pr_comment_api_url

--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -14,6 +14,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
     pr_action="$(echo $event | jq -r ".action")"
 
     if [[ "$pr_action" == "closed" ]]; then
+        pr_comment_api_url="$(echo $event | jq -r ".pull_request._links.comments.href")"
 
         # Find all commits associated with the PR.
         pr_commits="$(curl \
@@ -24,7 +25,6 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
         # For each PR commit, if a bucket exists for it, delete it.
         for commit in $(echo $pr_commits | jq -r ".[].sha"); do
             pr_bucket_name="$(get_bucket_for_commit $commit)"
-            pr_comment_api_url="$(echo $event | jq -r ".pull_request._links.comments.href")"
 
             if [ ! -z "$pr_bucket_name" ]; then
                 echo "Found bucket ${pr_bucket_name} associated with commit ${commit}."

--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -41,5 +41,5 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
         fi
     fi
 
-    echo "PR action was ${pr_action}, merged ${merged}, so skipping."
+    echo "PR action was ${pr_action}, merged ${pr_merged}, so skipping."
 fi

--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -2,8 +2,8 @@
 
 set -o errexit -o pipefail
 
-# This script handles closed pull requests. For PRs that are closed unmerged, it deletes
-# their associated buckets and posts a message back to the PR to that effect.
+# This script handles closed pull requests by finding all of their associated site-preview
+# buckets and deleting them.
 
 source ./scripts/ci-login.sh
 source ./scripts/common.sh
@@ -12,34 +12,43 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
     event="$(cat "$GITHUB_EVENT_PATH")"
     pr_number="$(echo $event | jq -r ".number")"
     pr_action="$(echo $event | jq -r ".action")"
-    pr_merged="$(echo $event | jq -r ".pull_request.merged")"
 
-    if [[ "$pr_action" == "closed" && "$pr_merged" == "false" ]]; then
-        pr_bucket_name="$(origin_bucket_prefix)-pr-${pr_number}"
-        pr_comment_api_url="$(echo $event | jq -r ".pull_request._links.comments.href")"
+    if [[ "$pr_action" == "closed" ]]; then
 
-        if [ -z "$(aws s3api head-bucket --bucket $pr_bucket_name || echo '')" ]; then
-            echo "Bucket ${pr_bucket_name} wasn't found. Exiting."
-            exit 0
-        fi
+        # Find all commits associated with the PR.
+        pr_commits="$(curl \
+            -s \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/commits")"
 
-        echo "Found bucket ${pr_bucket_name}."
-        prod_bucket_name="$(pulumi -C infrastructure stack output originBucketName)"
+        # For each PR commit, if a bucket exists for it, delete it.
+        for commit in $(echo $pr_commits | jq -r ".[].sha"); do
+            pr_bucket_name="$(get_bucket_for_commit $commit)"
+            pr_comment_api_url="$(echo $event | jq -r ".pull_request._links.comments.href")"
 
-        if [ "$pr_bucket_name" == "$prod_bucket_name" ]; then
-            echo "PR bucket name (${pr_bucket_name}) matches production bucket name (${prod_bucket_name}). Skipping delete."
-            exit 0
-        else
-            echo "Removing the bucket."
+            if [ ! -z "$pr_bucket_name" ]; then
+                echo "Found bucket ${pr_bucket_name} associated with commit ${commit}."
+                echo "Attempting to delete..."
 
-            # Deliberately logging this at first just to make sure it works as designed.
-            echo "aws s3 rb s3://${pr_bucket_name} --force"
+                # aws s3api head-bucket is a quick way to determine whether the bucket exists
+                # and we have access to it.
+                if aws s3api head-bucket --bucket "$pr_bucket_name" 2>/dev/null; then
 
-            post_github_pr_comment \
-                "The site preview for this pull request was removed. ✨" \
-                $pr_comment_api_url
-        fi
+                    # Deliberately logging this at first just to make sure it works as designed.
+                    echo "aws s3 rb s3://${pr_bucket_name} --force"
+                else
+                    echo "Unable to delete ${pr_bucket_name}. Skipping."
+                fi
+            else
+                echo "No bucket found for commit ${commit}. Skipping."
+            fi
+        done
+
+        # Post a PR comment that any links to previously built previews won't work anymore.
+        post_github_pr_comment \
+            "Site previews for this pull request have been removed. ✨" \
+            $pr_comment_api_url
     fi
 
-    echo "PR action was ${pr_action}, merged ${pr_merged}, so skipping."
+    echo "PR action was ${pr_action}. Skipping."
 fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -60,12 +60,8 @@ origin_bucket_metadata_filepath() {
     echo "./origin-bucket-metadata.json"
 }
 
-# build_identifier returns a string for use in identifying the current build, mainly for
-# use in uniquely naming S3 buckets and asset bundles.
-#
-# Any changes made to the way these identifiers are generated should be paired with
-# modifications to the scripts responsible for bucket cleanup, including:
-# - scripts/ci-pull-request-closed.sh
+# build_identifier returns a string that is used to identify the current build for naming
+# S3 buckets and asset bundles.
 build_identifier() {
     local identifier
 
@@ -81,12 +77,12 @@ build_identifier() {
 
         identifier="${identifier}-$(git_sha_short)"
     else
-        # By default, just use the current SHA.
-        identifier="$(git_sha_short)"
+        # For on-demand builds, if an identifier's been set, use it.
+        identifier="$BUILD_IDENTIFIER"
 
-        # If a BUILD_START time has been set, append that as well.
-        if [ ! -z "$BUILD_START" ]; then
-            identifier="${identifier}-${BUILD_START}"
+        # Otherwise, just use the current Git SHA.
+        if [ -z "$BUILD_IDENTIFIER" ]; then
+            identifier="$(git_sha_short)"
         fi
     fi
 

--- a/scripts/on-demand-build-sync-test.sh
+++ b/scripts/on-demand-build-sync-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+# This script runs a full site build, creates an S3 bucket for it, pushes to that bucket,
+# tests it, and tags the bucket as being associated with the current Git SHA. It is
+# intended to be used for local development with dev stacks, but can be used in any
+# context that requires a full build with a corresponding bucket.
+
+source ./scripts/common.sh
+
+# In CI contexts, this identifier (defined in common.sh) will be set automatically based
+# on the environment, but when running builds manually, we need to set it ourselves.
+export BUILD_IDENTIFIER="$(git_sha_short)-$(current_time_in_ms)"
+
+./scripts/build-site.sh
+./scripts/sync-and-test-bucket.sh
+./scripts/make-s3-redirects.sh

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -4,8 +4,6 @@ set -o errexit -o pipefail
 
 source ./scripts/common.sh
 
-export BUILD_START="$(current_time_in_ms)"
-
 # Paths to the CSS and JS bundles we'll generate below. Note that environment variables
 # are read by some templates during the Hugo build process, and we write to the static
 # folder rather than public (which we do for production builds) in order to be able to

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -4,16 +4,18 @@ set -o errexit -o pipefail
 
 source ./scripts/common.sh
 
+export BUILD_START="$(current_time_in_ms)"
+
 # Paths to the CSS and JS bundles we'll generate below. Note that environment variables
 # are read by some templates during the Hugo build process, and we write to the static
 # folder rather than public (which we do for production builds) in order to be able to
 # use LiveReload in development.
-export CSS_BUNDLE="static/css/styles.$(pr_number_or_git_sha).css"
-export JS_BUNDLE="static/js/bundle.min.$(pr_number_or_git_sha).js"
+export CSS_BUNDLE="static/css/styles.$(build_identifier).css"
+export JS_BUNDLE="static/js/bundle.min.$(build_identifier).js"
 
 # Relative paths to those same files, read by Hugo templates.
-export REL_CSS_BUNDLE="/css/styles.$(pr_number_or_git_sha).css"
-export REL_JS_BUNDLE="/js/bundle.min.$(pr_number_or_git_sha).js"
+export REL_CSS_BUNDLE="/css/styles.$(build_identifier).css"
+export REL_JS_BUNDLE="/js/bundle.min.$(build_identifier).js"
 
 watch_hugo() {
     hugo server --buildDrafts --buildFuture --renderToDisk

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -3,7 +3,7 @@
 set -o errexit -o pipefail
 
 # This script takes the built Hugo site and:
-#   - creates a new S3 bucket named with either the current PR number or Git SHA
+#   - creates a new S3 bucket named according to whether the action is a push or pull_request.
 #   - creates a list of all Hugo-generated client-side ("meta-refresh") redirects that
 #   - we'll use to produce proper 301s later.
 #   - pushes the content of the website into the new S3 bucket.
@@ -31,7 +31,7 @@ fi
 
 # For previews, name the destination bucket with the PR number, to reduce the number of
 # buckets we create and to facilitate shorter sync times.
-destination_bucket="$(origin_bucket_prefix)-$(pr_number_or_git_sha)"
+destination_bucket="$(origin_bucket_prefix)-$(build_identifier)"
 destination_bucket_uri="s3://${destination_bucket}"
 
 # Translate Hugo redirects into a file we'll use for making 301 redirects later. Note that
@@ -45,8 +45,8 @@ aws_region="$(pulumi -C infrastructure config get 'aws:region')"
 # Push site content to the bucket.
 echo "Synchronizing to $destination_bucket_uri..."
 
-# Make the bucket. If this fails, assume that means we've already made it.
-aws s3 mb $destination_bucket_uri --region $aws_region || echo "Bucket already exists. Continuing..."
+# Make the bucket. If this fails, we can't make the bucket, so we shouldn't proceed.
+aws s3 mb $destination_bucket_uri --region $aws_region
 
 # Make the bucket an S3 website.
 aws s3 website $destination_bucket_uri --index-document index.html --error-document 404.html
@@ -90,7 +90,7 @@ metadata='{
     "bucket": "%s",
     "url": "%s"
 }'
-printf "$metadata" "$(node -e 'console.log(Date.now())')" "$(git_sha)" "$destination_bucket" "$s3_website_url" > "$metadata_file"
+printf "$metadata" "$(current_time_in_ms)" "$(git_sha)" "$destination_bucket" "$s3_website_url" > "$metadata_file"
 
 # Copy the file to the destination bucket, for future reference.
 aws s3 cp "$metadata_file" "${destination_bucket_uri}/metadata.json" --region $aws_region --acl public-read

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -96,12 +96,7 @@ printf "$metadata" "$(current_time_in_ms)" "$(git_sha)" "$destination_bucket" "$
 aws s3 cp "$metadata_file" "${destination_bucket_uri}/metadata.json" --region $aws_region --acl public-read
 
 # Persist an association between the current commit and the bucket we just deployed to.
-aws ssm put-parameter \
-    --name "$(ssm_parameter_key_for_commit $(git_sha))" \
-    --value "$destination_bucket" \
-    --type String \
-    --region $aws_region \
-    --overwrite
+set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$aws_region"
 
 # Finally, if it's a preview, post a comment to the PR that directs the user to the resulting bucket URL.
 if [ "$1" == "preview" ]; then


### PR DESCRIPTION
This change allows our PR jobs to run concurrently, with each commit creating its own bucket, and updates the PR cleanup script accordingly. (Note that that script doesn't actually delete any buckets yet -- I want to make sure the commands it'll run are correct before setting it loose.) The change also adds a script that can be used for creating new builds and buckets on demand, mainly for use with development stacks (as this process is a little opaque otherwise).

Fixes #3871.