### PR TITLE
Handle missing credentials

### DIFF
--- a/scripts/ci-pull-request.sh
+++ b/scripts/ci-pull-request.sh
@@ -2,6 +2,15 @@
 
 set -o errexit -o pipefail
 
+# See if we have the requisite credentials. If not, we might be in a fork. In that case,
+# run a PR build, but skip all the deployment stuff.
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${PULUMI_ACCESS_TOKEN:-}" ]; then
+    echo "Missing secret tokens, possibly due to a forked PR."
+    echo "Running a build, but will skip the sync to S3 and Pulumi preview."
+    ./scripts/build-site.sh preview
+    exit
+fi
+
 source ./scripts/ci-login.sh
 
 ./scripts/build-site.sh preview


### PR DESCRIPTION
This change handles forked PRs by checking for required credentials before attempting to run previews.  (Which is exactly [what Pulumify did](https://github.com/pulumi/actions-pulumify/blob/master/infra/pulumify#L22-L26) -- I just forgot to do the same. 🤦 )