### PR TITLE
Delete PR buckets on close

### DIFF
--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -33,9 +33,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
                 # aws s3api head-bucket is a quick way to determine whether the bucket exists
                 # and we have access to it.
                 if aws s3api head-bucket --bucket "$pr_bucket_name" 2>/dev/null; then
-
-                    # Deliberately logging this at first just to make sure it works as designed.
-                    echo "aws s3 rb s3://${pr_bucket_name} --force"
+                    aws s3 rb "s3://${pr_bucket_name}" --force
                 else
                     echo "Unable to delete ${pr_bucket_name}. Skipping."
                 fi
@@ -48,7 +46,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
         post_github_pr_comment \
             "Site previews for this pull request have been removed. ✨" \
             $pr_comment_api_url
+    else
+        echo "PR action was ${pr_action}. Skipping."
     fi
-
-    echo "PR action was ${pr_action}. Skipping."
 fi


### PR DESCRIPTION
This change deletes all buckets associated with a closed PR. (To err on the safe side, I had been simply echoing the command to be run, but it appears to be functioning as expected, so I feel okay about switching it on.)

Fixes #3879.