### PR TITLE
Remove the .travis.yml file as it is no longer used.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: generic
-dist: xenial
-sudo: true
-branches:
-  only:
-  - master
-script:
-- echo "The use of Travis is deprecated. See .github/workflows/hugo-build.yml."


### PR DESCRIPTION
We have migrated this repo to use GitHub Actions and haven't been using Travis for over 2 months now.