### PR TITLE
Update TLS info in self-hosted docs.

### DIFF
--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -38,7 +38,7 @@ The Pulumi API is one of the components required for self-hosting Pulumi in your
 
 ## What's In The Container?
 
-The API service is a Go-based application. This is a single binary application that has all of the dependencies it needs in order to run.
+The API service is a Go-based application. This is a single binary application that has all of the dependencies it needs in order to run. This container will serve using port `8080` over HTTP by default or port `8443` over HTTPS when [TLS](#tls-environment-variables) is configured.
 
 ## Primary Environment Variables
 
@@ -66,7 +66,7 @@ The API service is a Go-based application. This is a single binary application t
 
 #### API Service
 
-The service is configurable to serve the API using TLS. The following environment variables are _all_ required in order to enable TLS.
+The service is configurable to serve the API using TLS. The following environment variables are _all_ required in order to enable TLS. The values of the environment variables may either be a filepath or the actual value of the entity. If these variables are set, the service will be served over HTTPS (i.e using TLS) using port `8443`. If the following variables are not set the service will default to serving over HTTP using port `8080`.
 
 | Variable Name       | Description                                                                                               |
 |---------------------|-----------------------------------------------------------------------------------------------------------|
@@ -85,9 +85,9 @@ openssl \
 
 #### Database Connections
 
-The service is configurable to enable connections to the backend SQL database over TLS. The following environment variables are _all_ required to connect to the database using TLS.
+The service is configurable to enable connections to the backend SQL database over TLS. The following environment variables are _all_ required to connect to the database using TLS. If these variables are set the service will establish connections to the database using TLS, otherwise the service will default to connecting without TLS. The same ports will be used for communication to the database regardless of whether TLS is configured or not.
 
 | Variable Name            | Description                                                                                                   |
 |--------------------------|---------------------------------------------------------------------------------------------------------------|
-| DATABASE_CA_CERTIFICATE  | The CA certificate used to establish TLS connections with the database. This certificate must be PEM encoded. |
+| DATABASE_CA_CERTIFICATE  | The CA certificate used to establish TLS connections with the database. This certificate must be PEM encoded. This must be set to the value of the certificate itself and _not_ a filepath to the location of the certificate file. |
 | DATABASE_MIN_TLS_VERSION | The minimum TLS version to use for database connections (must be in \<major>.\<minor> format, e.g. `1.2`).    |

--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -38,7 +38,11 @@ The Pulumi API is one of the components required for self-hosting Pulumi in your
 
 ## What's In The Container?
 
-The API service is a Go-based application. This is a single binary application that has all of the dependencies it needs in order to run. This container will serve using port `8080` over HTTP by default or port `8443` over HTTPS when [TLS](#tls-environment-variables) is configured.
+The API service is a Go-based application. This is a single binary application that has all of the dependencies it needs in order to run.
+
+### Server
+
+This container runs an HTTP server which provides the APIs needed by the Console and the CLI. By default this container will serve using port `8080` over standard HTTP. If [TLS](#tls-environment-variables) is configured the server will instead serve over port `8443` using HTTPS.
 
 ## Primary Environment Variables
 

--- a/content/docs/guides/self-hosted/console.md
+++ b/content/docs/guides/self-hosted/console.md
@@ -36,7 +36,11 @@ You can run this container on the same host that your API container is running o
 
 ## What's In The Container?
 
-The Console container is a Node 10-based image. A single web server handles delivering UI static assets to your web browser, as well as handling authentication callbacks. The console will be served using port `3000` over HTTP by default. If [TLS](#tls-environment-variables) is configured the console will be served using port `3443` over HTTPS.
+The Console container runs a web server using a Node 10-based image.
+
+### Server
+
+The container runs a single web server which handles delivering UI static assets to your web browser, as well as handling authentication callbacks. The console will be served using port `3000` over HTTP by default. If [TLS](#tls-environment-variables) is configured the console will instead be served using port `3443` over HTTPS.
 
 ## Primary Environment Variables
 

--- a/content/docs/guides/self-hosted/console.md
+++ b/content/docs/guides/self-hosted/console.md
@@ -36,7 +36,7 @@ You can run this container on the same host that your API container is running o
 
 ## What's In The Container?
 
-The Console container is a Node 10-based image. A single web server handles delivering UI static assets to your web browser, as well as handling authentication callbacks.
+The Console container is a Node 10-based image. A single web server handles delivering UI static assets to your web browser, as well as handling authentication callbacks. The console will be served using port `3000` over HTTP by default. If [TLS](#tls-environment-variables) is configured the console will be served using port `3443` over HTTPS.
 
 ## Primary Environment Variables
 
@@ -82,7 +82,7 @@ The following are the core environment variables that are required at a minimum.
 
 ### TLS Environment Variables
 
-The following environment variables must be configured to enable TLS.
+The following environment variables must be configured to enable TLS. The values of the environment variables may either be a filepath or the actual value of the entity. If these variables are set, the console will be served over HTTPS (i.e. using TLS) using port `3443`. If the following variables are not set the console will default to serving over HTTP using port `3000`. 
 
 | Variable Name       | Description                                                                                                       |
 |---------------------|-------------------------------------------------------------------------------------------------------------------|

--- a/content/docs/guides/self-hosted/console.md
+++ b/content/docs/guides/self-hosted/console.md
@@ -82,7 +82,7 @@ The following are the core environment variables that are required at a minimum.
 
 ### TLS Environment Variables
 
-The following environment variables must be configured to enable TLS. The values of the environment variables may either be a filepath or the actual value of the entity. If these variables are set, the console will be served over HTTPS (i.e. using TLS) using port `3443`. If the following variables are not set the console will default to serving over HTTP using port `3000`. 
+The following environment variables must be configured to enable TLS. The values of the environment variables may either be a filepath or the actual value of the entity. If these variables are set, the console will be served over HTTPS (i.e. using TLS) using port `3443`. If the following variables are not set the console will default to serving over HTTP using port `3000`.
 
 | Variable Name       | Description                                                                                                       |
 |---------------------|-------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
This is just adding some updates to the self-hosted docs concerning TLS configuration. I apologize, I meant to add in this information about the port changes on Tuesday before merging, but it must have slipped my mind in the rush of trying to get everything out.