### PR TITLE
Handle job re-runs, exit early when forked PRs are closed

### DIFF
--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -2,6 +2,12 @@
 
 set -o errexit -o pipefail
 
+# See if we have the requisite credentials. If not, we might be in a fork, so exit.
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${PULUMI_ACCESS_TOKEN:-}" ]; then
+    echo "Missing secret tokens, possibly due to a forked PR. Exiting."
+    exit
+fi
+
 # This script handles closed pull requests by finding all of their associated site-preview
 # buckets and deleting them.
 


### PR DESCRIPTION
Couple of fixes to the way we handle Actions jobs:

* For those whose buckets already exist, we attempt to reuse them (which is safe, as buckets are named by the current commit hash)

* When a PR based on a fork is closed, we exit early, as the cleanup work we do isn't necessary in that case (and currently fails due to missing secrets)

👇 Below, you'll find several PR comments showing multiple re-runs of identical commits.