### PR TITLE
Update Python install instructions

### DIFF
--- a/content/docs/intro/languages/python.md
+++ b/content/docs/intro/languages/python.md
@@ -14,7 +14,7 @@ aliases: ["/docs/reference/python/"]
 
 Pulumi supports programs written in Python 3. Python version 3.6 or later is required.
 
-<a class="btn" href="https://www.python.org/downloads/" target="_blank" title="Install Python 3">INSTALL PYTHON 3</a>
+{{< install-python >}}
 
 ## Getting Started
 

--- a/layouts/shortcodes/install-dotnet.html
+++ b/layouts/shortcodes/install-dotnet.html
@@ -1,6 +1,6 @@
 <p class="mt-4">
     Install <strong><a
-    href="https://dotnet.microsoft.com/download" target="_blank">.NET Core 3.0 SDK or later</a></strong>.
+    href="https://dotnet.microsoft.com/download" target="_blank" rel="noopener">.NET Core 3.1 SDK or later</a></strong>.
 </p>
 
 <div class="note note-info" role="alert">

--- a/layouts/shortcodes/install-python.html
+++ b/layouts/shortcodes/install-python.html
@@ -1,7 +1,20 @@
 <p class="mt-4">
-    Install <strong><a href="https://www.python.org/downloads/" target="_blank">Python
+    Install <strong><a href="https://www.python.org/downloads/" target="_blank" rel="noopener">Python
             version 3.6 or later</a></strong>.
 </p>
+
+<div class="note note-info" role="alert">
+    <p>
+        <i class="fas fa-question-circle pr-2"></i>
+        <code>pip</code> is required to install dependencies. If you installed Python from source, with an installer
+        from <a href="https://python.org/" target="_blank" rel="noopener">python.org</a>, or via
+        <a href="https://brew.sh/" target="_blank" rel="noopener">Homebrew</a> you should already have <code>pip</code>.
+        If Python is installed using your OS package manager, you may have to install <code>pip</code> separately,
+        see <a href="https://packaging.python.org/guides/installing-using-linux-tools/" target="_blank" rel="noopener">
+        Installing pip/setuptools/wheel with Linux Package Managers</a>. For example, on Debian/Ubuntu you must run
+        <code>sudo apt install python3-venv python3-pip</code>.
+    </p>
+</div>
 
 <div class="note note-info" role="alert">
     <p>


### PR DESCRIPTION
We require pip to be available, which is typically included with Python installs, but some Linux distros require it to be installed separately using the OS's package manager. Update the Python install instructions to mention this.

Also, update the .NET required version, since I noticed it was out-of-date.

Fixes https://github.com/pulumi/docs/issues/3765