### PR TITLE
Fix link to Kubernetes Extensions repository

### DIFF
--- a/content/docs/intro/cloud-providers/kubernetes/_index.md
+++ b/content/docs/intro/cloud-providers/kubernetes/_index.md
@@ -73,7 +73,7 @@ The [`pulumi/kubernetes`](https://github.com/pulumi/pulumi-kubernetes) SDK is av
 
 #### Extension Packages
 
-- [`pulumi/kx`](https://github.com/pulumi/eks) - Kubernetes Workload Extensions
+- [`pulumi/kx`](https://github.com/pulumi/pulumi-kubernetesx) - Kubernetes Workload Extensions
 
 [k8s]: https://kubernetes.io
 


### PR DESCRIPTION
### Proposed changes

Change the "Kubernetes Workload Extensions" link to point to https://github.com/pulumi/pulumi-kubernetesx. I hope that is the correct repo.