### PR TITLE
Add quotes to example shell commands to help prevent user error.

### DIFF
--- a/content/docs/intro/concepts/config.md
+++ b/content/docs/intro/concepts/config.md
@@ -245,10 +245,10 @@ Structured configuration is also supported and can be set using `pulumi config s
 For example:
 
 ```bash
-$ pulumi config set --path data.active true
-$ pulumi config set --path data.nums[0] 1
-$ pulumi config set --path data.nums[1] 2
-$ pulumi config set --path data.nums[2] 3
+$ pulumi config set --path 'data.active' true
+$ pulumi config set --path 'data.nums[0]' 1
+$ pulumi config set --path 'data.nums[1]' 2
+$ pulumi config set --path 'data.nums[2]' 3
 ```
 
 The structure of `data` is persisted in the stack's `Pulumi.<stack-name>.yaml` file as:


### PR DESCRIPTION
Copying and pasting the non-quoted commands results in an error from `zsh` and likely other shells. We should show quoted values to help prevent users from hitting this error.