### PR TITLE
Preload component.js files

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -120,8 +120,8 @@
     {{ end }}
 
     <!-- Preload the component JavaScript to help our Google Page Speed score. -->
-    <link rel="preload" href="/js/components/components.esm.js" as="script">
-    <link rel="preload" href="/js/components.js" as="script">
+    <link rel="preload" href="/js/components/components.esm.js" as="script" crossorigin>
+    <link rel="preload" href="/js/components.js" as="script" crossorigin>
 
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") .IsPage }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -119,6 +119,10 @@
         </script>
     {{ end }}
 
+    <!-- Preload the component JavaScript to help our Google Page Speed score. -->
+    <link rel="prefetch" href="/js/components/components.esm.js" as="script">
+    <link rel="prefetch" href="/js/components.js" as="script">
+
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") .IsPage }}
         {{ if not .Params.authors }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -119,6 +119,10 @@
         </script>
     {{ end }}
 
+    <!-- Preload the component JavaScript to help our Google Page Speed score. -->
+    <link rel="preload" href="/js/components/components.esm.js" as="script" crossorigin>
+    <link rel="preload" href="/js/components.js" as="script" crossorigin>
+
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") .IsPage }}
         {{ if not .Params.authors }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -119,10 +119,6 @@
         </script>
     {{ end }}
 
-    <!-- Preload the component JavaScript to help our Google Page Speed score. -->
-    <link rel="preload" href="/js/components/components.esm.js" as="script" crossorigin>
-    <link rel="preload" href="/js/components.js" as="script" crossorigin>
-
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") .IsPage }}
         {{ if not .Params.authors }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -120,7 +120,7 @@
     {{ end }}
 
     <!-- Preload the component JavaScript to help our Google Page Speed score. -->
-    <link rel="preload" href="/js/components/components.esm.js" as="script" crossorigin>
+    <link rel="preload" href="/js/components/components.esm.js" as="script" crossorigin="anonymous">
 
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") .IsPage }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -120,8 +120,7 @@
     {{ end }}
 
     <!-- Preload the component JavaScript to help our Google Page Speed score. -->
-    <link rel="preload" href="/js/components/components.esm.js" as="script" crossorigin>
-    <link rel="preload" href="/js/components.js" as="script" crossorigin>
+    <link rel="preload" href="/js/components/components.esm.js" as="script">
 
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") .IsPage }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -120,8 +120,8 @@
     {{ end }}
 
     <!-- Preload the component JavaScript to help our Google Page Speed score. -->
-    <link rel="prefetch" href="/js/components/components.esm.js" as="script">
-    <link rel="prefetch" href="/js/components.js" as="script">
+    <link rel="preload" href="/js/components/components.esm.js" as="script">
+    <link rel="preload" href="/js/components.js" as="script">
 
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") .IsPage }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -120,7 +120,7 @@
     {{ end }}
 
     <!-- Preload the component JavaScript to help our Google Page Speed score. -->
-    <link rel="preload" href="/js/components/components.esm.js" as="script">
+    <link rel="preload" href="/js/components/components.esm.js" as="script" crossorigin>
 
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") .IsPage }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -12,5 +12,5 @@
     responsible for loading child components, whose filenames will contain content-based
     hashes, they must not be cached.
 -->
-<script type="module" src="/js/components/components.esm.js" defer></script>
-<script nomodule src="/js/components.js" defer></script>
+<script type="module" src="/js/components/components.esm.js" async></script>
+<script nomodule src="/js/components.js" async></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -12,5 +12,5 @@
     responsible for loading child components, whose filenames will contain content-based
     hashes, they must not be cached.
 -->
-<script type="module" src="/js/components/components.esm.js" async></script>
-<script nomodule src="/js/components.js" async></script>
+<script type="module" src="/js/components/components.esm.js" defer></script>
+<script nomodule src="/js/components.js" defer></script>


### PR DESCRIPTION
We seemed to have regressed a bit in our Google Page Speed score and the biggest item is the loading of `component.js` scripts. In reality, this change doesn't really make the site faster and you can see that in the screenshots below, but it does make Google Page Speed Score increase which plays a role in Google Search Rankings. Our ranking for the term `terraform` has been fluctuating a bit recently between 7/8, which is the difference between page one and page two currently. I checked terraform.io's page speed and they are tied with us. This change should get us a few points above them and in turn, help our content rank a bit better.

This PR adds two `preload` tags to `head.html`. More info on `preload` here: https://web.dev/uses-rel-preload/

I ran the Page Speed tests a bunch of times and with the `preload` tags the score was around ~6 points higher each run.

Preview Bucket Page Speed from PR w/ out `preload`
![developers google com_speed_pagespeed_insights__url=http%3A%2F%2Fpulumi-docs-origin-pr-3912-367f6211 s3-website us-west-2 amazonaws com%2F](https://user-images.githubusercontent.com/15146337/90189550-3eedbf00-dd72-11ea-8a1f-c3172c23ff9c.png)

Page Speed for this PR:
![developers google com_speed_pagespeed_insights__url=http%3A%2F%2Fpulumi-docs-origin-pr-3922-a4a073f1 s3-website us-west-2 amazonaws com%2F](https://user-images.githubusercontent.com/15146337/90189611-53ca5280-dd72-11ea-9ac3-7d901be3a47b.png)
