### PR TITLE
Fix string format template

### DIFF
--- a/content/docs/intro/concepts/config.md
+++ b/content/docs/intro/concepts/config.md
@@ -110,7 +110,7 @@ console.log(`Password: ${config.require("dbPassword")}`);
 ```python
 import pulumi
 config = pulumi.Config()
-print('Password: %s'.format(config.require('dbPassword')))
+print('Password: {}'.format(config.require('dbPassword')))
 ```
 
 {{% /choosable %}}

--- a/content/docs/intro/concepts/programming-model.md
+++ b/content/docs/intro/concepts/programming-model.md
@@ -502,7 +502,7 @@ let role = new aws.iam.Role("my-role", {
 
 ```python
 role = iam.Role('my-role', {
-    name='my-role-%s-%s'.format(pulumi.get_project(), pulumi.get_stack())
+    name='my-role-{}-{}'.format(pulumi.get_project(), pulumi.get_stack())
 }, opts=ResourceOptions(delete_before_replace=True))
 ```
 


### PR DESCRIPTION
### Proposed changes

Two examples that use Python's string templating use the wrong symbol. `%s` should be `{}`. I think the confusion arose because `%s` is used on a different Python templating mechanism.

