### PR TITLE
Fix some broken links and a couple typos

### DIFF
--- a/content/blog/getting-started-with-k8s-part6/index.md
+++ b/content/blog/getting-started-with-k8s-part6/index.md
@@ -45,7 +45,7 @@ Maintaining a Kubernetes cluster and modern applications can be varied and compl
 Each article in this series is intended to be independent of each other. However, we build upon concepts introduced in previous articles. If some concepts or terminology are unfamiliar, I encourage reading the earlier articles:
 
 - [Building a Kubernetes cluster on cloud providers]({{< relref "/blog/getting-started-with-k8s-part1" >}})
-- [Basic application deployment]({{{< relref "/blog/getting-started-with-k8s-part2" >}})
+- [Basic application deployment]({{< relref "/blog/getting-started-with-k8s-part2" >}})
 - [Advance application deployment and Helm charts]({{< relref "/blog/getting-started-with-k8s-part3" >}})
 - [Stateful applications]({{< relref "/blog/getting-started-with-k8s-part4" >}})
 - [Networking]({{< relref "/blog/getting-started-with-k8s-part5" >}})

--- a/content/blog/pulumi-kubernetes-operator/index.md
+++ b/content/blog/pulumi-kubernetes-operator/index.md
@@ -17,14 +17,14 @@ controller that deploys cloud infrastructure in Pulumi Stacks for you and your
 team.
 
 These program stacks include virtual machines, block storage,
-managed Kuberentes clusters, API resources, serverless functions and more!
+managed Kubernetes clusters, API resources, serverless functions and more!
 
 <!--more-->
 
 ## Overview
 
 The [Pulumi Kubernetes Operator][pulumi-k8s-op] is an [extension pattern][k8s-ext-pattern] that
-enables Kuberentes users to create a Pulumi [`Stack`][stack] as a first-class API
+enables Kubernetes users to create a Pulumi [`Stack`][stack] as a first-class API
 resource, and use the `StackController` to drive the updates of the Stack until
 success.
 
@@ -663,6 +663,6 @@ with users and the Pulumi team.
 [pulumi-k8s-nginx]: https://github.com/metral/pulumi-nginx
 [pulumi-aws-eks]: https://github.com/metral/pulumi-aws-eks
 [p-examples]: https://github.com/pulumi/examples
-[stack]:({{< relref "/docs/intro/concepts/stack" >}})
-[pulumi-config]:({{< relref "/docs/intro/concepts/config" >}})
-[pulumi-providers]:({{< relref "/docs/intro/cloud-providers" >}})
+[stack]:{{< relref "/docs/intro/concepts/stack" >}}
+[pulumi-config]:{{< relref "/docs/intro/concepts/config" >}}
+[pulumi-providers]:{{< relref "/docs/intro/cloud-providers" >}}


### PR DESCRIPTION
Saw these come through this morning, so figured I'd fix 'em.

```
2020-08-12T15:35:18.1633718Z Getting links from: https://www.pulumi.com/blog/pulumi-kubernetes-operator/
2020-08-12T15:35:18.3450885Z ├─BROKEN─ https://www.pulumi.com/blog/pulumi-kubernetes-operator/(/docs/intro/concepts/stack/) (HTTP_403)
2020-08-12T15:35:18.4780752Z ├─BROKEN─ https://www.pulumi.com/blog/pulumi-kubernetes-operator/(/docs/intro/concepts/stack/) (HTTP_403)
2020-08-12T15:35:18.5210916Z ├─BROKEN─ https://www.pulumi.com/blog/pulumi-kubernetes-operator/(/docs/intro/cloud-providers/) (HTTP_403)
2020-08-12T15:35:18.6277102Z ├─BROKEN─ https://www.pulumi.com/blog/pulumi-kubernetes-operator/(/docs/intro/concepts/config/) (HTTP_403)

2020-08-12T15:35:20.2570530Z Getting links from: https://www.pulumi.com/blog/getting-started-with-k8s-part6/
2020-08-12T15:35:20.4041268Z ├─BROKEN─ https://www.pulumi.com/blog/getting-started-with-k8s-part6/%7B/blog/getting-started-with-k8s-part2/ (HTTP_403)

```