### PR TITLE
Add alias to Kubernetes to handle /cloudnative links

### DIFF
--- a/content/topics/kubernetes.md
+++ b/content/topics/kubernetes.md
@@ -5,6 +5,9 @@ url: /kubernetes
 
 meta_desc: Pulumi provides a cloud native programming model for Kubernetes deployments and orchestration. Any code, any cloud, any app.
 
+aliases:
+  - /cloudnative
+
 hero:
     title: Kubernetes Superpowers
     body: >


### PR DESCRIPTION
In our press release, we linked to `/cloudnative` instead of `/kubernetes`. This PR adds an alias to `/kubernetes` for `/cloudnative` so we can avoid 404s.