### PR TITLE
Publish sourcemaps to Sentry

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -54,6 +54,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive test results
@@ -67,3 +68,9 @@ jobs:
         with:
           name: origin-bucket-metadata
           path: origin-bucket-metadata.json
+
+      - name: Archive Sentry release
+        uses: actions/upload-artifact@v2
+        with:
+          name: sentry-release
+          path: sentry-release

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ cypress/screenshots
 # Ignore the files we generate during the build and deployment process.
 origin-bucket-metadata.json
 redirects.txt
+
+# Ignore the temporary directory created for Sentry releases.
+sentry-release

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -102,6 +102,9 @@
         Sentry.init({
             dsn: "https://02614bf2f18e4615a73218b810563ced@o433463.ingest.sentry.io/5388693",
             environment: "{{ hugo.Environment }}",
+            {{ if in "preview production" hugo.Environment }}
+                release: "{{ getenv "ASSET_BUNDLE_ID" }}",
+            {{ end }}
         });
     </script>
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^2.0.6",
+    "@sentry/cli": "^1.55.1",
     "autoprefixer": "^9.6.0",
     "broken-link-checker": "^0.7.8",
     "chokidar-cli": "^2.1.0",

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -8,12 +8,13 @@ export NODE_ENV="production"
 
 # Paths to the CSS and JS bundles we'll generate below. Note that environment variables
 # are read by some templates during the Hugo build process.
-export CSS_BUNDLE="public/css/styles.$(build_identifier).css"
-export JS_BUNDLE="public/js/bundle.min.$(build_identifier).js"
+export ASSET_BUNDLE_ID="$(build_identifier)"
+export CSS_BUNDLE="public/css/styles.${ASSET_BUNDLE_ID}.css"
+export JS_BUNDLE="public/js/bundle.min.${ASSET_BUNDLE_ID}.js"
 
 # Relative paths to those same files, read by Hugo templates.
-export REL_CSS_BUNDLE="/css/styles.$(build_identifier).css"
-export REL_JS_BUNDLE="/js/bundle.min.$(build_identifier).js"
+export REL_CSS_BUNDLE="/css/styles.${ASSET_BUNDLE_ID}.css"
+export REL_JS_BUNDLE="/js/bundle.min.${ASSET_BUNDLE_ID}.js"
 
 printf "Copying prebuilt docs...\n\n"
 make copy_static_prebuilt

--- a/scripts/ci-pull-request.sh
+++ b/scripts/ci-pull-request.sh
@@ -15,4 +15,5 @@ source ./scripts/ci-login.sh
 
 ./scripts/build-site.sh preview
 ./scripts/sync-and-test-bucket.sh preview
+./scripts/publish-sentry-release.sh
 ./scripts/run-pulumi.sh preview

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -6,5 +6,6 @@ source ./scripts/ci-login.sh
 
 ./scripts/build-site.sh
 ./scripts/sync-and-test-bucket.sh
+./scripts/publish-sentry-release.sh
 ./scripts/run-pulumi.sh update
 ./scripts/make-s3-redirects.sh

--- a/scripts/publish-sentry-release.sh
+++ b/scripts/publish-sentry-release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+# This script packages our JS source files and sourcemaps as a Sentry release.
+# https://docs.sentry.io/product/releases/
+
+source ./scripts/common.sh
+
+build_dir="public"
+source_dir="assets"
+
+# Make a folder to contain the source files and maps we upload to Sentry.
+release_dir="sentry-release"
+rm -rf "${release_dir}"
+mkdir -p "${release_dir}" "${release_dir}/assets"
+
+# Copy the files into that folder.
+cp -R "assets/js" "${release_dir}/assets/"
+find "${source_dir}" -name "*.js" -o -name "*.ts" -exec cp {} "${release_dir}/" \;
+find "${build_dir}" -name "*.js.map" -exec cp {} "${release_dir}/" \;
+
+# Create a new Sentry release and finalize it.
+export SENTRY_ORG="pulumi"
+export SENTRY_PROJECT="docs"
+yarn run sentry-cli releases new "$(build_identifier)"
+yarn run sentry-cli releases files "$(build_identifier)" upload-sourcemaps "${release_dir}"
+yarn run sentry-cli releases finalize "$(build_identifier)"

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -8,12 +8,13 @@ source ./scripts/common.sh
 # are read by some templates during the Hugo build process, and we write to the static
 # folder rather than public (which we do for production builds) in order to be able to
 # use LiveReload in development.
-export CSS_BUNDLE="static/css/styles.$(build_identifier).css"
-export JS_BUNDLE="static/js/bundle.min.$(build_identifier).js"
+export ASSET_BUNDLE_ID="$(build_identifier)"
+export CSS_BUNDLE="static/css/styles.${ASSET_BUNDLE_ID}.css"
+export JS_BUNDLE="static/js/bundle.min.${ASSET_BUNDLE_ID}.js"
 
 # Relative paths to those same files, read by Hugo templates.
-export REL_CSS_BUNDLE="/css/styles.$(build_identifier).css"
-export REL_JS_BUNDLE="/js/bundle.min.$(build_identifier).js"
+export REL_CSS_BUNDLE="/css/styles.${ASSET_BUNDLE_ID}.css"
+export REL_JS_BUNDLE="/js/bundle.min.${ASSET_BUNDLE_ID}.js"
 
 watch_hugo() {
     hugo server --buildDrafts --buildFuture --renderToDisk

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -37,7 +37,7 @@ destination_bucket_uri="s3://${destination_bucket}"
 # Translate Hugo redirects into a file we'll use for making 301 redirects later. Note that
 # we do this before syncing the site, as having the redirects file available for reference
 # can be helpful for debugging purposes.
-node scripts/translate-redirects.js "$build_dir" "$(pulumi -C infrastructure config get redirectDomain || echo '')"
+node scripts/translate-redirects.js "$build_dir" "$(pulumi -C infrastructure config get redirectDomain 2>/dev/null || echo '')"
 
 # Read the region from the stack's config -- we use it below.
 aws_region="$(pulumi -C infrastructure config get 'aws:region')"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
     "compilerOptions": {
         "allowJs": true,
         "removeComments": true,
+        "sourceMap": true,
+        "sourceRoot": "/"
     },
     "files": [
         "assets/js/main.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,17 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sentry/cli@^1.55.1":
+  version "1.55.1"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.55.1.tgz#91b11cf3c0118e095bc9f3b0e27dc3c3a7873557"
+  integrity sha512-qqSiBS7Hvo19+pv09MlIxF1kx5il0VPePZt/AeLSjVd1sFA/a9kzPCSz8dwVQG7xnmxAw3IG0kNgarSnk4MN0g==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.0"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -117,6 +128,13 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+agent-base@6:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  dependencies:
+    debug "4"
 
 ajv@^6.5.5:
   version "6.12.2"
@@ -1178,7 +1196,7 @@ date-fns@^2.0.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
   integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
 
-debug@4.1.1:
+debug@4, debug@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -2052,6 +2070,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 humanize-duration@^3.9.1:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.16.0.tgz#c7ec3b898305f007c63893f891870b2b5a2e0a7d"
@@ -2922,7 +2948,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.4:
+"mkdirp@>=0.5 0", mkdirp@^0.5.4, mkdirp@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -3003,6 +3029,11 @@ node-emoji@^1.8.1:
   integrity sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
   dependencies:
     lodash.toarray "^4.4.0"
+
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-gyp@^3.8.0:
   version "3.8.0"
@@ -3887,6 +3918,11 @@ progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This change adds a step to the build process to publish our sourcemaps to Sentry, for better stack traces in error reports. For example:

![image](https://user-images.githubusercontent.com/274700/90295280-62317080-de3d-11ea-94ec-3d820071e336.png)
 
Also contains a tiny fix to suppress the error message emitted by Pulumi when an optional config value isn't defined.