### PR TITLE
Don't throw on unexpected input

### DIFF
--- a/content/topics/kube2pulumi.md
+++ b/content/topics/kube2pulumi.md
@@ -389,9 +389,6 @@ function getCannedExample(id) {
 
     let comment = "#"; // to suppress Markdown lint errors.
     switch (id) {
-        case "":
-            return "";
-
         case "nginx_pod":
             return `apiVersion: v1
 kind: Pod
@@ -534,7 +531,7 @@ rules:
 `;
 
         default:
-            throw new Error("unrecognized canned example ID: " + id);
+            return "";
     }
 }
 


### PR DESCRIPTION
Logs show somehow folks are still hitting `undefined` here, so rather than throw (which notifies us as an unhandled exception), let's just return empty for anything unanticipated.

https://sentry.io/organizations/pulumi/issues/1840380756