### PR TITLE
Handle missing HubSpot form object

### DIFF
--- a/layouts/partials/hubspot-form.html
+++ b/layouts/partials/hubspot-form.html
@@ -1,21 +1,17 @@
 <script src="//js.hsforms.net/forms/v2.js"></script>
-{{ if .goToWebinarKey }}
-    <script>
+<script>
+    // When successfully loaded, the HubSpot forms script exposes an `hbspt` global.
+    if (typeof hbspt !== "undefined" && hbspt.forms && typeof hbspt.forms.create === "function") {
         hbspt.forms.create({
             portalId: "4429525",
             formId: {{ .hubspotFormID }},
             css: "",
             cssClass: "{{ .classNames }}",
-            goToWebinarWebinarKey: "{{ .goToWebinarKey }}",
+            {{ if .goToWebinarKey }}
+                goToWebinarWebinarKey: "{{ .goToWebinarKey }}",
+            {{ end }}
         });
-    </script>
-{{ else }}
-    <script>
-        hbspt.forms.create({
-            portalId: "4429525",
-            formId: {{ .hubspotFormID }},
-            css: "",
-            cssClass: "{{ .classNames }}",
-        });
-    </script>
-{{ end }}
+    } else {
+        console.log("Unable to load HubSpot form.");
+    }
+</script>


### PR DESCRIPTION
Logs show this script is sometimes not loaded. This change just checks to make sure the `hbspt` global exists before attempting to use it. Also refactors a bit just to reduce some duplication.

Fixes #4014.