### PR TITLE
Properly set default values and allow overrides on converter pages

### DIFF
--- a/content/migrate/tf2pulumi.md
+++ b/content/migrate/tf2pulumi.md
@@ -233,7 +233,7 @@ function displayCouldNotConvert(language) {
 }
 
 // Now set up our event handler for conversion.
-function convertCode(language) {
+function convertCode(language, inputKind) {
     // If we got called without an explicit language, look it up.
     language = language || getCurrentLanguage();
 
@@ -261,7 +261,7 @@ function convertCode(language) {
     }
 
     // Read the input kind and verify that we've got what we need.
-    let tfIk = getCurrentInputKind();
+    let tfIk = inputKind || getCurrentInputKind();
     switch (tfIk) {
     case "url":
         if (tfUrl === "") {
@@ -541,9 +541,12 @@ window.onload = function() {
         // If there are querystring parameters populate the fields.
         let tfUrl = getQueryVariable("url");
         let tfCode = getQueryVariable("code");
+
+        // Let's initialize the code conversion component.
         if (tfUrl) {
             $("#terraform-url").val(tfUrl);
             setCurrentInputKind("url");
+            convertCode(getCurrentLanguage() || "typescript", "url");
         } else {
             if (tfCode) {
                 $("#terraform-code").val(tfCode);
@@ -551,6 +554,7 @@ window.onload = function() {
                 loadCannedExample();
             }
             setCurrentInputKind("code");
+            convertCode(getCurrentLanguage() || "typescript", "code");
         }
 
         // We auto-submit the code based on user interaction, including (1) after they finish typing,
@@ -617,12 +621,17 @@ window.onload = function() {
         // Hook up event handlers for the language choosers.
         $("pulumi-chooser[type='language'] > ul > li > a").each(function (i, e) {
             $(e).click(function() {
-                convertCode($(e).text().trim().toLowerCase());
+                // We need to check that the inputKind has been properly set and if it
+                // has not, let's set the value to "code" and update the handler.
+                let inputKind = getCurrentInputKind();
+                if (inputKind === undefined) {
+                    setCurrentInputKind("code");
+                    inputKind = "code";
+                }
+
+                convertCode($(e).text().trim().toLowerCase(), inputKind);
             });
         });
-
-        // Fire off a conversion just to get started using the default code snippet example.
-        convertCode(getCurrentLanguage() || "typescript");
     });
 }
 </script>

--- a/content/topics/kube2pulumi.md
+++ b/content/topics/kube2pulumi.md
@@ -233,7 +233,7 @@ function displayCouldNotConvert(language) {
 }
 
 // Now set up our event handler for conversion.
-function convertCode(language) {
+function convertCode(language, inputKind) {
     // If we got called without an explicit language, look it up.
     language = language || getCurrentLanguage();
 
@@ -261,7 +261,7 @@ function convertCode(language) {
     }
 
     // Read the input kind and verify that we've got what we need.
-    let tfIk = getCurrentInputKind();
+    let tfIk = inputKind || getCurrentInputKind();
     switch (tfIk) {
     case "url":
         if (tfUrl === "") {
@@ -544,9 +544,12 @@ window.onload = function() {
         // If there are querystring parameters populate the fields.
         let tfUrl = getQueryVariable("url");
         let tfCode = getQueryVariable("code");
+
+        // Let's initialize the code conversion component.
         if (tfUrl) {
             $("#terraform-url").val(tfUrl);
             setCurrentInputKind("url");
+            convertCode(getCurrentLanguage() || "typescript", "url");
         } else {
             if (tfCode) {
                 $("#terraform-code").val(tfCode);
@@ -554,6 +557,7 @@ window.onload = function() {
                 loadCannedExample();
             }
             setCurrentInputKind("code");
+            convertCode(getCurrentLanguage() || "typescript", "code");
         }
 
         // We auto-submit the code based on user interaction, including (1) after they finish typing,
@@ -620,12 +624,17 @@ window.onload = function() {
         // Hook up event handlers for the language choosers.
         $("pulumi-chooser[type='language'] > ul > li > a").each(function (i, e) {
             $(e).click(function() {
-                convertCode($(e).text().trim().toLowerCase());
+                // We need to check that the inputKind has been properly set and if it
+                // has not, let's set the value to "code" and update the handler.
+                let inputKind = getCurrentInputKind();
+                if (inputKind === undefined) {
+                    setCurrentInputKind("code");
+                    inputKind = "code";
+                }
+
+                convertCode($(e).text().trim().toLowerCase(), inputKind);
             });
         });
-
-        // Fire off a conversion just to get started using the default code snippet example.
-        convertCode(getCurrentLanguage() || "typescript");
     });
 }
 </script>


### PR DESCRIPTION
Fixes: https://github.com/pulumi/docs/issues/4029

There was weird behavior going on the *2pulumi pages that caused in some cases the input text area to disappear or somethings the output would be gone. This PR changes the way we initialize the code converter and adds an optional parameter (though it is JavaScript, so I suppose everything is optional 😄 ). 

This change defaults the input to always be the "code" option (which was I understood is the expected behavior from what I was reading in the code). 

The main issue I saw is the way we were are handling state applications with some of the logic being in the stencil component and other parts of the logic being outside of the stencil component in pure JS. The issue is that calls to update state from the in the pure JS are not exactly safe. For example, when creating the component we call `setCurrentInputKind` in the pure JS, then call `convertCode` which in turn calls `getCurrentInputKind`. There is no guarantee that `setCurrentInputKind` has completed by the time we call `getCurrentInputKind` and that is what I am guessing was leading to unexpected behavior. The bug was difficult to reproduce so that makes sense it was some sort of race condition we were seeing with state updates.

We should consider moving pages like this to be its own microsite written in React or something similar. We could apply some vanity URL like `kube2.pulumi.com` as well. The way this page is written today will make it tough to debug issues and ultimately make changes to how the app functions. 