### PR TITLE
Fix typos in config / azure secrets provider

### DIFF
--- a/content/docs/intro/concepts/config.md
+++ b/content/docs/intro/concepts/config.md
@@ -395,13 +395,13 @@ If you have previously configured the AWS CLI, the same credentials will be used
 
 #### Azure Key Vault
 
-The `azurekeyvalue` provider uses an Azure Key Vault key for encryption. This key is specified using an [Azure Key object identifier](https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates), which includes both your key vault's name and the key to use: `azurekeyvault://mykeyvaultname.vault.azure.net/keys/mykeyname`.
+The `azurekeyvault` provider uses an Azure Key Vault key for encryption. This key is specified using an [Azure Key object identifier](https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates), which includes both your key vault's name and the key to use: `azurekeyvault://mykeyvaultname.vault.azure.net/keys/mykeyname`.
 
 For example, this configures a stack to use an Azure Key Vault key named `payroll` in vault `acmecorpsec`:
 
 ```bash
 $ pulumi stack init my-stack \
-    --secrets-provider="azurekeyvault://acmecorpvault.vault.azure.net/keys/payroll"
+    --secrets-provider="azurekeyvault://acmecorpsec.vault.azure.net/keys/payroll"
 ```
 
 By default, this provider will use [Azure Environment Authentication](https://docs.microsoft.com/en-us/azure/go/azure-sdk-go-authorization#use-environment-based-authentication). If you wish to login using the `az` command for authentication instead, set `AZURE_KEYVAULT_AUTH_VIA_CLI` to `true`.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
There were minor typos on [this page](https://www.pulumi.com/docs/intro/concepts/config/#azure-key-vault). `azurekeyvalue` should be `azurekeyvault` and `acmecorpvault` was changed to `acmecorpsec` in accordance to the preceding sentence.
