### PR TITLE
Pulumi.HCloud only has `RunAsync` method

### DIFF
--- a/content/docs/intro/cloud-providers/hcloud/_index.md
+++ b/content/docs/intro/cloud-providers/hcloud/_index.md
@@ -81,7 +81,7 @@ using Pulumi.HCloud;
 class Program
 {
     static Task Main() =>
-        Deployment.Run(() => {
+        Deployment.RunAsync(() => {
             var network = new Network("demo-network", new NetworkArgs
             {
                 IpRange = "10.0.1.0/24",


### PR DESCRIPTION
### Proposed changes

The example C# code does not compile because nuget `Pulumi.HCloud` only contains a `Deployment.RunAsync` method instead of a `Deployment.Run` method.