### PR TITLE
Update AWS content to be more aligned with workshop content

### DIFF
--- a/content/docs/get-started/aws/begin.md
+++ b/content/docs/get-started/aws/begin.md
@@ -20,13 +20,13 @@ aliases: [
 ]
 ---
 
-Before we get started using Pulumi, let's run through a few quick steps to ensure our environment is setup correctly.
+Before you get started using Pulumi, let's run through a few quick steps to ensure your environment is setup correctly.
 
 ### Install Pulumi
 
 {{< install-pulumi >}}
 
-Next, we'll install the required language runtime.
+Next, you'll install the required language runtime, if you haven't already.
 
 ### Install Language Runtime
 
@@ -50,7 +50,7 @@ Next, we'll install the required language runtime.
 {{< install-dotnet >}}
 {{% /choosable %}}
 
-Next, we'll configure AWS.
+Finally, you'll configure AWS.
 
 ### Configure AWS
 
@@ -61,6 +61,6 @@ If you have multiple AWS profiles set up, specify a different profile using one 
 * Set `AWS_PROFILE`as an <a href="{{< relref "/docs/intro/cloud-providers/aws/setup#environment-variables" >}}" target="_blank">environment variable</a>, or
 * After creating your project in the next step, run `pulumi config set aws:profile <profilename>`. See <a href="{{< relref "/docs/intro/cloud-providers/aws#configuration" >}}" target="_blank">AWS Configuration</a> for more configuration options.
 
-Next, we'll create a new project.
+Next, you'll create a new project.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/begin.md
+++ b/content/docs/get-started/aws/begin.md
@@ -20,7 +20,7 @@ aliases: [
 ]
 ---
 
-Before you get started using Pulumi, let's run through a few quick steps to ensure your environment is setup correctly.
+Before you get started using Pulumi, let's run through a few quick steps to ensure your environment is set up correctly.
 
 ### Install Pulumi
 

--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -20,7 +20,7 @@ Now that you have set up your environment by installing Pulumi, installing your 
 - Serve the `index.html` as a static website.
 - Destroy the resources you've provisioned.
 
-Let's get started with a new project in a new directory.
+To get started you will a create a new directory and a new project.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 

--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -14,8 +14,8 @@ aliases: ["/docs/quickstart/aws/create-project/"]
 
 Now that you have set up your environment by installing Pulumi, installing your preferred language runtime, and configuring your AWS credentials, let's get started with creating your first Pulumi program. In this guide you will:
 
-- Create a new project.
-- Provision a new S3 Bucket.
+- Create a new Pulumi project.
+- Provision a new Amazon S3 bucket.
 - Add an `index.html` file to your bucket.
 - Serve the `index.html` as a static website.
 - Destroy the resources you've provisioned.

--- a/content/docs/get-started/aws/create-project.md
+++ b/content/docs/get-started/aws/create-project.md
@@ -12,6 +12,14 @@ menu:
 aliases: ["/docs/quickstart/aws/create-project/"]
 ---
 
+Now that you have set up your environment by installing Pulumi, installing your preferred language runtime, and configuring your AWS credentials, let's get started with creating your first Pulumi program. In this guide you will:
+
+- Create a new project.
+- Provision a new S3 Bucket.
+- Add an `index.html` file to your bucket.
+- Serve the `index.html` as a static website.
+- Destroy the resources you've provisioned.
+
 Let's get started with a new project in a new directory.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -321,7 +321,7 @@ Finally, you can checkout your new static website at the URL in the `Outputs` se
 {{% choosable language javascript %}}
 
 ```bash
-$ curl $(pulumi stack output bucketName)
+$ curl $(pulumi stack output bucketEndpoint)
 ```
 
 {{% /choosable %}}
@@ -329,7 +329,7 @@ $ curl $(pulumi stack output bucketName)
 {{% choosable language typescript %}}
 
 ```bash
-$ curl $(pulumi stack output bucketName)
+$ curl $(pulumi stack output bucketEndpoint)
 ```
 
 {{% /choosable %}}
@@ -337,7 +337,7 @@ $ curl $(pulumi stack output bucketName)
 {{% choosable language python %}}
 
 ```bash
-$ curl $(pulumi stack output bucket_name)
+$ curl $(pulumi stack output bucket_endpoint)
 ```
 
 {{% /choosable %}}
@@ -345,7 +345,7 @@ $ curl $(pulumi stack output bucket_name)
 {{% choosable language go %}}
 
 ```bash
-$ curl $(pulumi stack output bucketName)
+$ curl $(pulumi stack output bucketEndpoint)
 ```
 
 {{% /choosable %}}
@@ -353,7 +353,7 @@ $ curl $(pulumi stack output bucketName)
 {{% choosable language csharp %}}
 
 ```bash
-$ curl $(pulumi stack output BucketName)
+$ curl $(pulumi stack output BucketEndpoint)
 ```
 
 {{% /choosable %}}

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -172,9 +172,9 @@ Now that your `index.html` is in your bucket, modify the program to have the buc
 
 ```python
 bucket = s3.Bucket('my-bucket',
-    website={
-        'index_document': 'index.html',
-    })
+    website=s3.BucketWebsiteArgs(
+        index_document="index.html",
+    ))
 ```
 
 Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -108,7 +108,7 @@ Notice that your index.html file has been added:
 ```
 
 {{% choosable language javascript %}}
-Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First, you need to set the `website` property on your bucket.
+Now that your `index.html` is in your bucket, modify the program to have the bucket serve the file as a static website. First, you need to set the `website` property on your bucket.
 
 ```javascript
 const bucket = new aws.s3.Bucket("my-bucket", {
@@ -138,7 +138,7 @@ exports.bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
 {{% /choosable %}}
 
 {{% choosable language typescript %}}
-Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `website` property on your bucket.
+Now that your `index.html` is in your bucket, modify the program to have the bucket serve the file as a static website. First you need to set the `website` property on your bucket.
 
 ```typescript
 const bucket = new aws.s3.Bucket("my-bucket", {
@@ -168,7 +168,7 @@ export const bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint
 {{% /choosable %}}
 
 {{% choosable language python %}}
-Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `website` property on your bucket.
+Now that your `index.html` is in your bucket, modify the program to have the bucket serve the file as a static website. First you need to set the `website` property on your bucket.
 
 ```python
 bucket = s3.Bucket('my-bucket',
@@ -198,7 +198,7 @@ pulumi.export('bucket_endpoint', pulumi.Output.concat('http://', bucket.website_
 {{% /choosable %}}
 
 {{% choosable language go %}}
-Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `Website` property on your bucket.
+Now that your `index.html` is in your bucket, modify the program to have the bucket serve the file as a static website. First you need to set the `Website` property on your bucket.
 
 ```go
 bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
@@ -228,7 +228,7 @@ ctx.Export("bucketEndpoint", pulumi.Sprintf("http://%s", bucket.WebsiteEndpoint)
 {{% /choosable %}}
 
 {{% choosable language csharp %}}
-Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `Website` property on your bucket.
+Now that your `index.html` is in your bucket, modify the program to have the bucket serve the file as a static website. First you need to set the `Website` property on your bucket.
 
 ```csharp
 // Add this import
@@ -272,7 +272,7 @@ this.BucketEndpoint = Output.Format($"http://{bucket.WebsiteEndpoint}");
 
 {{% /choosable %}}
 
-Now let's update your stack to have your S3 bucket serve your `index.html` file as a static website.
+Now update your stack to have your S3 bucket serve your `index.html` file as a static website.
 
 ```bash
 $ pulumi up

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -57,7 +57,7 @@ Resources:
 Duration: 6s
 ```
 
-Once the update has completed, rerun the command to list the contents of your bucket.
+Once the update has completed, re-run the command to list the contents of the bucket.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
@@ -148,7 +148,7 @@ const bucket = new aws.s3.Bucket("my-bucket", {
 });
 ```
 
-Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
+Next, your `index.html` object will need two changes: an ACL of `public-read` so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
 
 ```typescript
 const bucketObject = new aws.s3.BucketObject("index.html", {
@@ -301,7 +301,7 @@ Do you want to perform this update?
   details
 ```
 
-Select `yes` to deploy all of the updates:
+Select `yes` to deploy both changes:
 
 ```
 Do you want to perform this update? yes

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -23,46 +23,351 @@ Pulumi computes the minimally disruptive change to achieve the desired state des
 ```
 Previewing update (dev):
 
-     Type                 Name            Plan       Info
-     pulumi:pulumi:Stack  quickstart-dev
- +   ├─ aws:kms:Key       my-key          create
- ~   └─ aws:s3:Bucket     my-bucket       update     [diff: +serverSideEncryptionConfiguration]
+     Type                    Name            Plan       Info
+     pulumi:pulumi:Stack     quickstart-dev
+ +   └─ aws:s3:BucketObject  index.html                 create
 
 Resources:
     + 1 to create
-    ~ 1 to update
-    2 changes. 1 unchanged
+    2 unchanged
 
 Do you want to perform this update?
-  yes
-> no
+> yes
+  no
   details
 ```
 
-Pulumi will create the KMS key and update the bucket with the new encryption configuration.
-
-Choosing `yes` will proceed with the update.
+Choosing `yes` will proceed with the update and upload your `index.html` file to your bucket.
 
 ```
 Do you want to perform this update? yes
 Updating (dev):
 
-     Type                 Name            Status      Info
-     pulumi:pulumi:Stack  quickstart-dev
- +   ├─ aws:kms:Key       my-key          created
- ~   └─ aws:s3:Bucket     my-bucket       updated     [diff: +serverSideEncryptionConfiguration]
+     Type                     Name            Status      Info
+     pulumi:pulumi:Stack      quickstart-dev
+  +   └─ aws:s3:BucketObject  index.html                  created
 
 Outputs:
-    bucket_name: "my-bucket-de014a8"
+    bucketName: "my-bucket-68e33ec"
 
 Resources:
     + 1 created
-    ~ 1 updated
-    2 changes. 1 unchanged
+    2 unchanged
 
-Duration: 10s
+Duration: 6s
 ```
 
-Next, we'll destroy the stack.
+Once the update has completed, rerun the command to list the contents of your bucket.
+
+{{< chooser language "javascript,typescript,python,go,csharp" / >}}
+
+{{% choosable language javascript %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output bucket_name)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output BucketName)
+```
+
+{{% /choosable %}}
+
+Notice that your index.html file has been added:
+
+```bash
+2020-08-27 12:30:24         68 index.html
+```
+
+Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First we need to set the `website` property on our bucket.
+
+{{% choosable language javascript %}}
+
+```javascript
+const bucket = new aws.s3.Bucket("my-bucket", {
+    website: {
+        indexDocument: "index.html",
+    },
+});
+```
+
+Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
+
+```javascript
+const bucketObject = new aws.s3.BucketObject("index.html", {
+    acl: "public-read",
+    contentType: "text/html",
+    bucket: bucket,
+    source: new pulumi.asset.FileAsset(filePath),
+});
+```
+
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+
+```javascript
+exports.bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```typescript
+const bucket = new aws.s3.Bucket("my-bucket", {
+    website: {
+        indexDocument: "index.html",
+    },
+});
+```
+
+Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
+
+```typescript
+const bucketObject = new aws.s3.BucketObject("index.html", {
+    acl: "public-read",
+    contentType: "text/html",
+    bucket: bucket,
+    source: new pulumi.asset.FileAsset(filePath),
+});
+```
+
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+
+```typescript
+export const bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+bucket = pulumi_aws.s3.Bucket('contentBucket',
+    website={
+        'index_document': 'index.html',
+    })
+```
+
+Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
+
+```python
+bucketObject = pulumi_aws.s3.BucketObject(
+    'index.html',
+    acl='public-read',
+    content_type='text/html',
+    bucket=bucket,
+    source=pulumi.FileAsset(filepath)
+)
+```
+
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+
+```python
+export('bucket-endpoint', Output.concat('http://', bucket.website_endpoint))
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+bucket, err := s3.NewBucket(ctx, "s3-website-bucket", &s3.BucketArgs{
+    Website: s3.BucketWebsiteArgs{
+        IndexDocument: pulumi.String("index.html"),
+    },
+})
+```
+
+Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
+
+```go
+_, err := s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
+    Acl:         pulumi.String("public-read"),
+    ContentType: pulumi.String("text/html"),
+    Bucket:      bucket.ID(),
+    Source:      pulumi.NewFileAsset(filePath),
+})
+```
+
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+
+```go
+ctx.Export("bucketEndpoint", pulumi.Sprintf("http://%s", siteBucket.WebsiteEndpoint))
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+var bucket = new Bucket("my-bucket", new BucketArgs
+{
+    Website = new BucketWebsiteArgs
+    {
+        IndexDocument = "index.html"
+    }
+});
+```
+
+Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
+
+```csharp
+var bucketObject = new BucketObject("index.html",
+{
+    Acl = "public-read",
+    ContentType = "text/html",
+    Bucket = bucket.BucketName,
+    Source = new FileAsset(filePath),
+});
+```
+
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+
+```csharp
+// Export the name of the bucket
+this.BucketName = bucket.Id;
+this.BucketEndpoint = Output.Format($"http://{bucket.WebsiteEndpoint}");
+```
+
+```csharp
+[Output] public Output<string> BucketName { get; set; }
+[Output] public Output<string> BucketEndpoint { get; set; }
+}
+```
+
+{{% /choosable %}}
+
+Now let's update our stack to have our S3 Bucket serve our `index.html` file as a static website.
+
+```bash
+$ pulumi up
+```
+
+First we will see a preview of our changes:
+
+```
+Previewing update (dev):
+
+     Type                    Name            Plan       Info
+     pulumi:pulumi:Stack     quickstart-dev
+ ~   ├─ aws:s3:Bucket        my-bucket           update     [diff: +website]
+ ~   └─ aws:s3:BucketObject  index.html          update     [diff: ~acl,contentType]
+
+Outputs:
+  + bucketEndpoint: output<string>
+
+Resources:
+    ~ 2 to update
+    1 unchanged
+
+Do you want to perform this update?
+> yes
+  no
+  details
+```
+
+Select `yes` to deploy all of the updates:
+
+```
+Do you want to perform this update? yes
+Updating (dev):
+
+     Type                     Name            Status      Info
+     pulumi:pulumi:Stack      quickstart-dev
+~   ├─ aws:s3:Bucket        my-bucket           updated     [diff: +website]
+~   └─ aws:s3:BucketObject  index.html          updated     [diff: ~acl,contentType]
+
+Outputs:
+  + bucketEndpoint: "http://my-bucket-b9c2eaa.s3-website-us-east-1.amazonaws.com"
+    bucketName    : "my-bucket-b9c2eaa"
+
+Resources:
+    ~ 2 updated
+    1 unchanged
+
+Duration: 12s
+```
+
+Finally, you can checkout your new static website at the URL in the `Outputs` section of your update or you can make a `curl` request and see the contents of your `index.html` printed out in your terminal.
+
+{{% choosable language javascript %}}
+
+```bash
+$ curl $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```bash
+$ curl $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ curl $(pulumi stack output bucket_name)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ curl $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ curl $(pulumi stack output BucketName)
+```
+
+{{% /choosable %}}
+
+And you should see:
+
+```bash
+<html>
+    <body>
+        <h1>Hello Pulumi</h1>
+    </body>
+</html>
+```
+
+Next you will destroy the resources.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -18,7 +18,7 @@ Now let's deploy your changes.
 $ pulumi up
 ```
 
-First Pulumi will run the `preview` step of the update. In the future you can run `pulumi up -y` to automatically run the update after a successful preview.
+First Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
 Previewing update (dev):
@@ -172,9 +172,9 @@ Now that your `index.html` is in your bucket, let's modify the program to have t
 
 ```python
 bucket = s3.Bucket('my-bucket',
-    website={
-        'index_document': 'index.html',
-    })
+    website=s3.BucketWebsiteArgs(
+        index_document="index.html",
+    ))
 ```
 
 Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -57,7 +57,7 @@ Resources:
 Duration: 6s
 ```
 
-Once the update has completed, re-run the command to list the contents of the bucket.
+Once the update has completed, you can verify the object was created in your bucket by checking the AWS Console or by running the following AWS CLI command:
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
@@ -125,7 +125,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
     acl: "public-read",
     contentType: "text/html",
     bucket: bucket,
-    source: new pulumi.asset.FileAsset(filePath),
+    content: fs.readFileSync("site/index.html").toString(),
 });
 ```
 
@@ -155,7 +155,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
     acl: "public-read",
     contentType: "text/html",
     bucket: bucket,
-    source: new pulumi.asset.FileAsset(filePath),
+    content: fs.readFileSync("site/index.html").toString(),
 });
 ```
 
@@ -172,9 +172,9 @@ Now that your `index.html` is in your bucket, let's modify the program to have t
 
 ```python
 bucket = s3.Bucket('my-bucket',
-    website=s3.BucketWebsiteArgs(
-        index_document="index.html",
-    ))
+    website={
+        'index_document': 'index.html',
+    })
 ```
 
 Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
@@ -185,7 +185,7 @@ bucketObject = s3.BucketObject(
     acl='public-read',
     content_type='text/html',
     bucket=bucket,
-    source=pulumi.FileAsset(filepath)
+    content=open('site/index.html').read(),
 )
 ```
 
@@ -215,7 +215,7 @@ _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Acl:         pulumi.String("public-read"),
     ContentType: pulumi.String("text/html"),
     Bucket:      bucket.ID(),
-    Source:      pulumi.NewFileAsset(filePath),
+    Content:     pulumi.String(string(htmlContent)),
 })
 ```
 
@@ -253,7 +253,7 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
     Acl = "public-read",
     ContentType = "text/html",
     Bucket = bucket.BucketName,
-    Source = new FileAsset(filePath),
+    Content = hmtlString,
 });
 ```
 
@@ -323,7 +323,7 @@ Resources:
 Duration: 12s
 ```
 
-Finally, you can checkout your new static website at the URL in the `Outputs` section of your update or you can make a `curl` request and see the contents of your `index.html` printed out in your terminal.
+Finally, you can checkout your new static website at the URL in the `Outputs` section of your update or you can make a `curl` request and see the contents of your `index.html` object printed out in your terminal.
 
 {{% choosable language javascript %}}
 
@@ -370,7 +370,7 @@ And you should see:
 ```bash
 <html>
     <body>
-        <h1>Hello Pulumi</h1>
+        <h1>Hello, Pulumi!</h1>
     </body>
 </html>
 ```

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -18,7 +18,7 @@ Now let's deploy your changes.
 $ pulumi up
 ```
 
-First Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
+First, Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
 Previewing update (dev):
@@ -108,7 +108,7 @@ Notice that your index.html file has been added:
 ```
 
 {{% choosable language javascript %}}
-Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `website` property on your bucket.
+Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First, you need to set the `website` property on your bucket.
 
 ```javascript
 const bucket = new aws.s3.Bucket("my-bucket", {
@@ -129,7 +129,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 });
 ```
 
-Finally, at the bottom of your program export the resulting bucket’s endpoint URL so you can easily access it:
+Finally, at the bottom of your program, export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```javascript
 exports.bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
@@ -272,13 +272,13 @@ this.BucketEndpoint = Output.Format($"http://{bucket.WebsiteEndpoint}");
 
 {{% /choosable %}}
 
-Now let's update your stack to have your S3 Bucket serve your `index.html` file as a static website.
+Now let's update your stack to have your S3 bucket serve your `index.html` file as a static website.
 
 ```bash
 $ pulumi up
 ```
 
-First you will see a preview of your changes:
+First, you will see a preview of your changes:
 
 ```
 Previewing update (dev):
@@ -323,7 +323,7 @@ Resources:
 Duration: 12s
 ```
 
-Finally, you can checkout your new static website at the URL in the `Outputs` section of your update or you can make a `curl` request and see the contents of your `index.html` object printed out in your terminal.
+Finally, you can check out your new static website at the URL in the `Outputs` section of your update or you can make a `curl` request and see the contents of your `index.html` object printed out in your terminal.
 
 {{% choosable language javascript %}}
 

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -12,13 +12,13 @@ menu:
 aliases: ["/docs/quickstart/aws/deploy-changes/"]
 ---
 
-Now let's deploy our changes.
+Now let's deploy your changes.
 
 ```bash
 $ pulumi up
 ```
 
-Pulumi computes the minimally disruptive change to achieve the desired state described by the program.
+First Pulumi will run the `preview` step of the update. In the future you can run `pulumi up -y` to automatically run the update after a successful preview.
 
 ```
 Previewing update (dev):
@@ -107,9 +107,8 @@ Notice that your index.html file has been added:
 2020-08-27 12:30:24         68 index.html
 ```
 
-Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First we need to set the `website` property on our bucket.
-
 {{% choosable language javascript %}}
+Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `website` property on your bucket.
 
 ```javascript
 const bucket = new aws.s3.Bucket("my-bucket", {
@@ -130,7 +129,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 });
 ```
 
-Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```javascript
 exports.bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
@@ -139,6 +138,7 @@ exports.bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
 {{% /choosable %}}
 
 {{% choosable language typescript %}}
+Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `website` property on your bucket.
 
 ```typescript
 const bucket = new aws.s3.Bucket("my-bucket", {
@@ -159,7 +159,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 });
 ```
 
-Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```typescript
 export const bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
@@ -168,6 +168,7 @@ export const bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint
 {{% /choosable %}}
 
 {{% choosable language python %}}
+Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `website` property on your bucket.
 
 ```python
 bucket = s3.Bucket('my-bucket',
@@ -188,7 +189,7 @@ bucketObject = s3.BucketObject(
 )
 ```
 
-Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```python
 pulumi.export('bucket_endpoint', pulumi.Output.concat('http://', bucket.website_endpoint))
@@ -197,6 +198,7 @@ pulumi.export('bucket_endpoint', pulumi.Output.concat('http://', bucket.website_
 {{% /choosable %}}
 
 {{% choosable language go %}}
+Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `Website` property on your bucket.
 
 ```go
 bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
@@ -217,7 +219,7 @@ _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
 })
 ```
 
-Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```go
 ctx.Export("bucketEndpoint", pulumi.Sprintf("http://%s", bucket.WebsiteEndpoint))
@@ -226,6 +228,7 @@ ctx.Export("bucketEndpoint", pulumi.Sprintf("http://%s", bucket.WebsiteEndpoint)
 {{% /choosable %}}
 
 {{% choosable language csharp %}}
+Now that your `index.html` is in your bucket, let's modify the program to have the bucket serve the file as a static website. First you need to set the `Website` property on your bucket.
 
 ```csharp
 // Add this import
@@ -254,7 +257,7 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 });
 ```
 
-Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
+Finally, at the bottom of your program export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```csharp
 // Export the name of the bucket
@@ -269,13 +272,13 @@ this.BucketEndpoint = Output.Format($"http://{bucket.WebsiteEndpoint}");
 
 {{% /choosable %}}
 
-Now let's update our stack to have our S3 Bucket serve our `index.html` file as a static website.
+Now let's update your stack to have your S3 Bucket serve your `index.html` file as a static website.
 
 ```bash
 $ pulumi up
 ```
 
-First we will see a preview of our changes:
+First you will see a preview of your changes:
 
 ```
 Previewing update (dev):

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -170,7 +170,7 @@ export const bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint
 {{% choosable language python %}}
 
 ```python
-bucket = pulumi_aws.s3.Bucket('contentBucket',
+bucket = s3.Bucket('my-bucket',
     website={
         'index_document': 'index.html',
     })
@@ -179,7 +179,7 @@ bucket = pulumi_aws.s3.Bucket('contentBucket',
 Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
 
 ```python
-bucketObject = pulumi_aws.s3.BucketObject(
+bucketObject = s3.BucketObject(
     'index.html',
     acl='public-read',
     content_type='text/html',
@@ -191,7 +191,7 @@ bucketObject = pulumi_aws.s3.BucketObject(
 Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
 
 ```python
-export('bucket-endpoint', Output.concat('http://', bucket.website_endpoint))
+pulumi.export('bucket_endpoint', pulumi.Output.concat('http://', bucket.website_endpoint))
 ```
 
 {{% /choosable %}}
@@ -199,7 +199,7 @@ export('bucket-endpoint', Output.concat('http://', bucket.website_endpoint))
 {{% choosable language go %}}
 
 ```go
-bucket, err := s3.NewBucket(ctx, "s3-website-bucket", &s3.BucketArgs{
+bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
     Website: s3.BucketWebsiteArgs{
         IndexDocument: pulumi.String("index.html"),
     },
@@ -209,7 +209,7 @@ bucket, err := s3.NewBucket(ctx, "s3-website-bucket", &s3.BucketArgs{
 Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
 
 ```go
-_, err := s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
+_, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Acl:         pulumi.String("public-read"),
     ContentType: pulumi.String("text/html"),
     Bucket:      bucket.ID(),
@@ -220,12 +220,17 @@ _, err := s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
 Finally, at the bottom of your program export the resulting bucket’s endpoint URL so we can easily access it:
 
 ```go
-ctx.Export("bucketEndpoint", pulumi.Sprintf("http://%s", siteBucket.WebsiteEndpoint))
+ctx.Export("bucketEndpoint", pulumi.Sprintf("http://%s", bucket.WebsiteEndpoint))
 ```
 
 {{% /choosable %}}
 
 {{% choosable language csharp %}}
+
+```csharp
+// Add this import
+using Pulumi.Aws.S3.Inputs;
+```
 
 ```csharp
 var bucket = new Bucket("my-bucket", new BucketArgs
@@ -240,7 +245,7 @@ var bucket = new Bucket("my-bucket", new BucketArgs
 Next, your `index.html` object will need two changes: an ACL of public-read so that it can be accessed anonymously over the Internet, and a content type so that it is served as HTML:
 
 ```csharp
-var bucketObject = new BucketObject("index.html",
+var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Acl = "public-read",
     ContentType = "text/html",
@@ -260,7 +265,6 @@ this.BucketEndpoint = Output.Format($"http://{bucket.WebsiteEndpoint}");
 ```csharp
 [Output] public Output<string> BucketName { get; set; }
 [Output] public Output<string> BucketEndpoint { get; set; }
-}
 ```
 
 {{% /choosable %}}

--- a/content/docs/get-started/aws/deploy-stack.md
+++ b/content/docs/get-started/aws/deploy-stack.md
@@ -12,13 +12,13 @@ menu:
 aliases: ["/docs/quickstart/aws/deploy-stack/"]
 ---
 
-Let's go ahead and run our first update:
+Let's go ahead and run your first update:
 
 ```bash
 $ pulumi up
 ```
 
-This command evaluates your program and determines the resource updates to make. First, a preview is shown that outlines the changes that will be made:
+This command evaluates your program and determines the resource updates to make. First, a preview is shown that outlines the changes that will be made when you run the update:
 
 ```
 Previewing update (dev):
@@ -61,7 +61,7 @@ Resources:
 Duration: 14s
 ```
 
-Remember the output we defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of our update. For example, the name of the bucket created above is `my-bucket-68e33ec`. To confirm our bucket has been created, let's list the contents of our bucket.
+Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. For example, the name of the bucket created above is `my-bucket-68e33ec`. To confirm your bucket has been created, let's try to list the contents of your bucket.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
@@ -105,6 +105,6 @@ $ aws s3 ls $(pulumi stack output BucketName)
 
 {{% /choosable %}}
 
-Running that command should result in no output as our bucket is currently empty. Let's change that by modifying our bucket to host a static website.
+Running that command should result in no output as your bucket is currently empty. Let's change that by modifying your bucket to host a static website.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/deploy-stack.md
+++ b/content/docs/get-started/aws/deploy-stack.md
@@ -36,7 +36,7 @@ Do you want to perform this update?
   details
 ```
 
-Once the preview has finished you are given three options to choose from. Choosing `details` will show you a rich diff of the changes to be made. Choosing `yes` will create your new S3 Bucket in AWS.
+Once the preview has finished you are given three options to choose from. Choosing `details` will show you a rich diff of the changes to be made. Choosing `yes` will create your new S3 bucket in AWS.
 
 ```
 Do you want to perform this update? yes

--- a/content/docs/get-started/aws/deploy-stack.md
+++ b/content/docs/get-started/aws/deploy-stack.md
@@ -12,7 +12,7 @@ menu:
 aliases: ["/docs/quickstart/aws/deploy-stack/"]
 ---
 
-Let's go ahead and run your first update:
+Let's go ahead and deploy your stack:
 
 ```bash
 $ pulumi up
@@ -36,13 +36,7 @@ Do you want to perform this update?
   details
 ```
 
-Once the preview has finished you are given three options to choose from:
-
-- `yes` will run your update.
-- `no` will not run the update.
-- `details` will show you the diff for the full set of properties within the stack.
-
-Select `yes` to create your bucket.
+Once the preview has finished you are given three options to choose from. Choosing `details` will show you a rich diff of the changes to be made. Choosing `yes` will create your new S3 Bucket in AWS.
 
 ```
 Do you want to perform this update? yes

--- a/content/docs/get-started/aws/deploy-stack.md
+++ b/content/docs/get-started/aws/deploy-stack.md
@@ -12,13 +12,13 @@ menu:
 aliases: ["/docs/quickstart/aws/deploy-stack/"]
 ---
 
-Let's go ahead and deploy the stack:
+Let's go ahead and run our first update:
 
 ```bash
 $ pulumi up
 ```
 
-This command instructs Pulumi to determine the resources needed to create the stack. First, a preview is shown of the changes that will be made:
+This command evaluates your program and determines the resource updates to make. First, a preview is shown that outlines the changes that will be made:
 
 ```
 Previewing update (dev):
@@ -31,12 +31,18 @@ Resources:
     + 2 to create
 
 Do you want to perform this update?
-  yes
-> no
+> yes
+  no
   details
 ```
 
-Choosing `yes` will create resources in AWS.
+Once the preview has finished you are given three options to choose from:
+
+- `yes` will run your update.
+- `no` will not run the update.
+- `details` will show you the diff for the full set of properties within the stack.
+
+Select `yes` to create your bucket.
 
 ```
 Do you want to perform this update? yes
@@ -55,8 +61,50 @@ Resources:
 Duration: 14s
 ```
 
-The name of the bucket that we exported is shown as a [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}).
+Remember the output we defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of our update. For example, the name of the bucket created above is `my-bucket-68e33ec`. To confirm our bucket has been created, let's list the contents of our bucket.
 
-Next, we'll make some modifications to the program.
+{{< chooser language "javascript,typescript,python,go,csharp" / >}}
+
+{{% choosable language javascript %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output bucket_name)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ aws s3 ls $(pulumi stack output BucketName)
+```
+
+{{% /choosable %}}
+
+Running that command should result in no output as our bucket is currently empty. Let's change that by modifying our bucket to host a static website.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/deploy-stack.md
+++ b/content/docs/get-started/aws/deploy-stack.md
@@ -57,8 +57,6 @@ Duration: 14s
 
 Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:
 
-{{< chooser language "javascript,typescript,python,go,csharp" / >}}
-
 {{% choosable language javascript %}}
 
 ```bash

--- a/content/docs/get-started/aws/deploy-stack.md
+++ b/content/docs/get-started/aws/deploy-stack.md
@@ -55,14 +55,14 @@ Resources:
 Duration: 14s
 ```
 
-Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. For example, the name of the bucket created above is `my-bucket-68e33ec`. To confirm your bucket has been created, let's try to list the contents of your bucket.
+Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
 {{% choosable language javascript %}}
 
 ```bash
-$ aws s3 ls $(pulumi stack output bucketName)
+$ pulumi stack output bucketName
 ```
 
 {{% /choosable %}}
@@ -70,7 +70,7 @@ $ aws s3 ls $(pulumi stack output bucketName)
 {{% choosable language typescript %}}
 
 ```bash
-$ aws s3 ls $(pulumi stack output bucketName)
+$ pulumi stack output bucketName
 ```
 
 {{% /choosable %}}
@@ -78,7 +78,7 @@ $ aws s3 ls $(pulumi stack output bucketName)
 {{% choosable language python %}}
 
 ```bash
-$ aws s3 ls $(pulumi stack output bucket_name)
+$ pulumi stack output bucket_name
 ```
 
 {{% /choosable %}}
@@ -86,7 +86,7 @@ $ aws s3 ls $(pulumi stack output bucket_name)
 {{% choosable language go %}}
 
 ```bash
-$ aws s3 ls $(pulumi stack output bucketName)
+$ pulumi stack output bucketName
 ```
 
 {{% /choosable %}}
@@ -94,11 +94,11 @@ $ aws s3 ls $(pulumi stack output bucketName)
 {{% choosable language csharp %}}
 
 ```bash
-$ aws s3 ls $(pulumi stack output BucketName)
+$ pulumi stack output BucketName
 ```
 
 {{% /choosable %}}
 
-Running that command should result in no output as your bucket is currently empty. Let's change that by modifying your bucket to host a static website.
+Running that command will print out the name of your bucket. Now that your bucket has been provisioned, let's modify the bucket to host a static website.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/destroy-stack.md
+++ b/content/docs/get-started/aws/destroy-stack.md
@@ -27,8 +27,12 @@ Previewing destroy (dev):
 
      Type                 Name            Plan
  -   pulumi:pulumi:Stack  quickstart-dev  delete
- -   ├─ aws:s3:Bucket     my-bucket       delete
- -   └─ aws:kms:Key       my-key          delete
+ -   ├─ aws:s3:BucketObject  index.html          delete
+ -   └─ aws:s3:Bucket        my-bucket           delete
+
+Outputs:
+  - bucketEndpoint: "http://my-bucket-b9c2eaa.s3-website-us-east-1.amazonaws.com"
+  - bucketName    : "my-bucket-b9c2eaa"
 
 Resources:
     - 3 to delete
@@ -38,19 +42,23 @@ Destroying (dev):
 
      Type                 Name            Status
  -   pulumi:pulumi:Stack  quickstart-dev  deleted
- -   ├─ aws:s3:Bucket     my-bucket       deleted
- -   └─ aws:kms:Key       my-key          deleted
+ -   ├─ aws:s3:BucketObject  index.html          deleted
+ -   └─ aws:s3:Bucket        my-bucket           deleted
+
+Outputs:
+  - bucketEndpoint: "http://my-bucket-b9c2eaa.s3-website-us-east-1.amazonaws.com"
+  - bucketName    : "my-bucket-b9c2eaa"
 
 Resources:
     - 3 deleted
 
-Duration: 26s
+Duration: 7s
 ```
 
-To delete the stack itself, run [`pulumi stack rm`]({{< relref
+> To delete the stack itself, run [`pulumi stack rm`]({{< relref
 "/docs/reference/cli/pulumi_stack_rm" >}}). Note that this removes the stack
 entirely from the Pulumi Service, along with all of its update history.
 
-Next, we'll look at some next steps.
+Congratulations! You've successfully provisioned some cloud resources using Pulumi. On the next page we have collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/destroy-stack.md
+++ b/content/docs/get-started/aws/destroy-stack.md
@@ -67,6 +67,6 @@ Congratulations! You've successfully provisioned some cloud resources using Pulu
 - Served the `index.html` as a static website.
 - Destroyed the resources you've provisioned.
 
-On the next page we have collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
+On the next page we have a collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/destroy-stack.md
+++ b/content/docs/get-started/aws/destroy-stack.md
@@ -62,11 +62,11 @@ entirely from the Pulumi Service, along with all of its update history.
 Congratulations! You've successfully provisioned some cloud resources using Pulumi. By completing this guide you have successfully:
 
 - Created a Pulumi new project.
-- Provisioned a new S3 Bucket.
+- Provisioned a new S3 bucket.
 - Added an `index.html` file to your bucket.
 - Served the `index.html` as a static website.
 - Destroyed the resources you've provisioned.
 
-On the next page we have a collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
+On the next page, we have a collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/destroy-stack.md
+++ b/content/docs/get-started/aws/destroy-stack.md
@@ -59,6 +59,14 @@ Duration: 7s
 "/docs/reference/cli/pulumi_stack_rm" >}}). Note that this removes the stack
 entirely from the Pulumi Service, along with all of its update history.
 
-Congratulations! You've successfully provisioned some cloud resources using Pulumi. On the next page we have collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
+Congratulations! You've successfully provisioned some cloud resources using Pulumi. By completing this guide you have successfully:
+
+- Created a Pulumi new project.
+- Provisioned a new S3 Bucket.
+- Added an `index.html` file to your bucket.
+- Served the `index.html` as a static website.
+- Destroyed the resources you've provisioned.
+
+On the next page we have collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/destroy-stack.md
+++ b/content/docs/get-started/aws/destroy-stack.md
@@ -12,7 +12,7 @@ menu:
 aliases: ["/docs/quickstart/aws/destroy-stack/"]
 ---
 
-Now that we've seen how to deploy changes to our program, let's clean up and tear down the resources that are part of our stack.
+Now that you've seen how to deploy changes to our program, let's clean up and tear down the resources that are part of your stack.
 
 To destroy resources, run the following:
 
@@ -59,6 +59,6 @@ Duration: 7s
 "/docs/reference/cli/pulumi_stack_rm" >}}). Note that this removes the stack
 entirely from the Pulumi Service, along with all of its update history.
 
-Congratulations! You've successfully provisioned some cloud resources using Pulumi. On the next page we have collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure.
+Congratulations! You've successfully provisioned some cloud resources using Pulumi. On the next page we have collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -56,24 +56,22 @@ Once you've created your `index.html` file, add some content to it:
 </html>
 ```
 
-Now that you have your new `index.html` with some content, let's modify your program to upload the file to your S3 Bucket. To successfully upload the file you need to give Pulumi the absolute path to your file. We can easily accomplish this by taking advantage of libraries native to your programming language of choice.
+Now that you have your new `index.html` with some content, let's modify your program to add the contents of your `index.html` file to your S3 Bucket. To accomplish this we will take advantage of your chosen programming language's native libraries to read the contents of your `index.html` and assign the contents as an input to your new `BucketObject`.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
 {{% choosable language javascript %}}
 
 ```javascript
-const path = require("path");
+const fs = require("fs");
 ```
 
 Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```javascript
-const filePath = path.join(__dirname, "site", "index.html");
-
 const bucketObject = new aws.s3.BucketObject("index.html", {
     bucket: bucket,
-    source: new pulumi.asset.FileAsset(filePath),
+    content: fs.readFileSync("site/index.html").toString(),
 });
 ```
 
@@ -82,17 +80,15 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 {{% choosable language typescript %}}
 
 ```typescript
-import * as path from "path";
+import * as fs from "fs";
 ```
 
 Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```typescript
-const filePath = path.join(__dirname, "site", "index.html");
-
 const bucketObject = new aws.s3.BucketObject("index.html", {
     bucket: bucket,
-    source: new pulumi.asset.FileAsset(filePath),
+    content: fs.readFileSync("site/index.html").toString(),
 });
 ```
 
@@ -100,19 +96,13 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 
 {{% choosable language python %}}
 
-```python
-import os
-```
-
 Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```python
-filepath = os.path.abspath('site/index.html')
-
 bucketObject = s3.BucketObject(
     'index.html',
     bucket=bucket,
-    source=pulumi.FileAsset(filepath)
+    content=open('site/index.html').read(),
 )
 ```
 
@@ -122,7 +112,7 @@ bucketObject = s3.BucketObject(
 
 ```go
 import (
-    "path/filepath"
+    "io/ioutil"
     // Existing imports...
 )
 ```
@@ -130,11 +120,14 @@ import (
 Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```go
-filePath, err := filepath.Abs("./site/index.html")
+htmlContent, err := ioutil.ReadFile("site/index.html")
+if err != nil {
+    return err
+}
 
 _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
-    Bucket: bucket.ID(),
-    Source: pulumi.NewFileAsset(filePath),
+    Bucket:  bucket.ID(),
+    Content: pulumi.String(string(htmlContent)),
 })
 if err != nil {
     return err
@@ -153,11 +146,12 @@ Next you will create a new bucket object on the lines right after creating the b
 
 ```csharp
 var filePath = Path.GetFullPath("./site/index.html");
+var hmtlString = File.ReadAllText(filePath);
 
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.BucketName,
-    Source = new FileAsset(filePath),
+    Content = hmtlString,
 });
 ```
 

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -163,8 +163,8 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 
 {{% /choosable %}}
 
-Notice how you provide the bucket you created earlier as an input to your new `BucketObject`. This is so Pulumi knows what S3 Bucket the object should live in. You can learn more about Inputs and Outputs [here](/docs/intro/concepts/programming-model/#outputs).
+Notice how you provide the bucket you created earlier as an input to your new `BucketObject`. This is so Pulumi knows what S3 Bucket the object should live in.
 
-Next, you'll deploy the changes.
+Next, you'll deploy your changes.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -63,7 +63,7 @@ Now that we have our new `index.html` with some content, let's modify our progra
 {{% choosable language javascript %}}
 
 ```javascript
-const path = require("path);
+const path = require("path");
 ```
 
 Next we will create a new bucket object on the lines right after creating the bucket itself.
@@ -107,10 +107,10 @@ import os
 Next we will create a new bucket object on the lines right after creating the bucket itself.
 
 ```python
-filepath = os.path.abspath("site/index.html")
+filepath = os.path.abspath('site/index.html')
 
-bucketObject = pulumi_aws.s3.BucketObject(
-    "index.html",
+bucketObject = s3.BucketObject(
+    'index.html',
     bucket=bucket,
     source=pulumi.FileAsset(filepath)
 )
@@ -122,9 +122,8 @@ bucketObject = pulumi_aws.s3.BucketObject(
 
 ```go
 import (
+    "path/filepath"
     // Existing imports...
-    "path"
-	"path/filepath"
 )
 ```
 
@@ -133,7 +132,7 @@ Next we will create a new bucket object on the lines right after creating the bu
 ```go
 filePath, err := filepath.Abs("./site/index.html")
 
-_, err := s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
+_, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Bucket: bucket.ID(),
     Source: pulumi.NewFileAsset(filePath),
 })
@@ -155,7 +154,7 @@ Next we will create a new bucket object on the lines right after creating the bu
 ```csharp
 var filePath = Path.GetFullPath("./site/index.html");
 
-var bucketObject = new BucketObject("index.html",
+var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.BucketName,
     Source = new FileAsset(filePath),

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -12,7 +12,7 @@ menu:
 aliases: ["/docs/quickstart/aws/modify-program/"]
 ---
 
-Now that your S3 Bucket is provisioned, let's add an object to your bucket. First let's create a new directory called `site`.
+Now that your S3 bucket is provisioned, let's add an object to it. First, create a new directory called `site`.
 
 ```bash
 $ mkdir site
@@ -56,7 +56,7 @@ Once you've created your `index.html` file, add some content to it:
 </html>
 ```
 
-Now that you have your new `index.html` with some content, let's modify your program to add the contents of your `index.html` file to your S3 Bucket. To accomplish this we will take advantage of your chosen programming language's native libraries to read the contents of your `index.html` and assign the contents as an input to your new `BucketObject`.
+Now that you have your new `index.html` with some content, let's modify your program to add the contents of your `index.html` file to your S3 bucket. To accomplish this, we will take advantage of your chosen programming language's native libraries to read the content of the file and assign it as an input to a new  `BucketObject`.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
@@ -157,7 +157,7 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 
 {{% /choosable %}}
 
-Notice how you provide the bucket you created earlier as an input to your new `BucketObject`. This is so Pulumi knows what S3 Bucket the object should live in.
+Notice how you provide the bucket you created earlier as an input to your new `BucketObject`. This is so Pulumi knows what S3 bucket the object should live in.
 
 Next, you'll deploy your changes.
 

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -12,13 +12,13 @@ menu:
 aliases: ["/docs/quickstart/aws/modify-program/"]
 ---
 
-Now that our S3 Bucket is provisioned, let's add an object to our bucket. First let's create a new directory call `site`.
+Now that your S3 Bucket is provisioned, let's add an object to your bucket. First let's create a new directory called `site`.
 
 ```bash
 $ mkdir site
 ```
 
-Next let's create an `index.html` file we will upload to our bucket.
+Next let's create an `index.html` file you will upload to your bucket.
 
 {{< chooser os "macos,linux,windows" / >}}
 
@@ -56,7 +56,7 @@ Once you've created your `index.html` file, let's add some content:
 </html>
 ```
 
-Now that we have our new `index.html` with some content, let's modify our program to upload the file to your S3 Bucket. To successfully upload the file we need to give Pulumi the absolute path to our file. We can easily accomplish this by taking advantage of libraries native to your programming language of choice.
+Now that you have your new `index.html` with some content, let's modify your program to upload the file to your S3 Bucket. To successfully upload the file you need to give Pulumi the absolute path to your file. We can easily accomplish this by taking advantage of libraries native to your programming language of choice.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
@@ -66,7 +66,7 @@ Now that we have our new `index.html` with some content, let's modify our progra
 const path = require("path");
 ```
 
-Next we will create a new bucket object on the lines right after creating the bucket itself.
+Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```javascript
 const filePath = path.join(__dirname, "site", "index.html");
@@ -85,7 +85,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 import * as path from "path";
 ```
 
-Next we will create a new bucket object on the lines right after creating the bucket itself.
+Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```typescript
 const filePath = path.join(__dirname, "site", "index.html");
@@ -104,7 +104,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 import os
 ```
 
-Next we will create a new bucket object on the lines right after creating the bucket itself.
+Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```python
 filepath = os.path.abspath('site/index.html')
@@ -127,7 +127,7 @@ import (
 )
 ```
 
-Next we will create a new bucket object on the lines right after creating the bucket itself.
+Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```go
 filePath, err := filepath.Abs("./site/index.html")
@@ -149,7 +149,7 @@ if err != nil {
 using System.IO;
 ```
 
-Next we will create a new bucket object on the lines right after creating the bucket itself.
+Next you will create a new bucket object on the lines right after creating the bucket itself.
 
 ```csharp
 var filePath = Path.GetFullPath("./site/index.html");
@@ -163,8 +163,8 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 
 {{% /choosable %}}
 
-Notice how we provide the bucket we created earlier as an input to our new `BucketObject`. This is so Pulumi knows what S3 Bucket the object should live in. You can learn more about Inputs and Outputs [here](/docs/intro/concepts/programming-model/#outputs).
+Notice how you provide the bucket you created earlier as an input to your new `BucketObject`. This is so Pulumi knows what S3 Bucket the object should live in. You can learn more about Inputs and Outputs [here](/docs/intro/concepts/programming-model/#outputs).
 
-Next, we'll deploy the changes.
+Next, you'll deploy the changes.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -46,12 +46,12 @@ $ type nul > site/index.html
 
 {{% /choosable %}}
 
-Once you've created your `index.html` file, let's add some content:
+Once you've created your `index.html` file, add some content to it:
 
 ```html
 <html>
     <body>
-        <h1>Hello Pulumi</h1>
+        <h1>Hello, Pulumi!</h1>
     </body>
 </html>
 ```

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -12,175 +12,159 @@ menu:
 aliases: ["/docs/quickstart/aws/modify-program/"]
 ---
 
-Now that we have an instance of our Pulumi program deployed, let's enable encryption on our S3 bucket.
+Now that our S3 Bucket is provisioned, let's add an object to our bucket. First let's create a new directory call `site`.
 
-Replace the entire contents of {{< langfile >}} with the following:
+```bash
+$ mkdir site
+```
+
+Next let's create an `index.html` file we will upload to our bucket.
+
+{{< chooser os "macos,linux,windows" / >}}
+
+{{% choosable os macos %}}
+
+```bash
+$ touch site/index.html
+```
+
+{{% /choosable %}}
+
+{{% choosable os linux %}}
+
+```bash
+$ touch site/index.html
+```
+
+{{% /choosable %}}
+
+{{% choosable os windows %}}
+
+```bash
+$ type nul > site/index.html
+```
+
+{{% /choosable %}}
+
+Once you've created your `index.html` file, let's add some content:
+
+```html
+<html>
+    <body>
+        <h1>Hello Pulumi</h1>
+    </body>
+</html>
+```
+
+Now that we have our new `index.html` with some content, let's modify our program to upload the file to your S3 Bucket. To successfully upload the file we need to give Pulumi the absolute path to our file. We can easily accomplish this by taking advantage of libraries native to your programming language of choice.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
 {{% choosable language javascript %}}
 
 ```javascript
-"use strict";
-const pulumi = require("@pulumi/pulumi");
-const aws = require("@pulumi/aws");
-const awsx = require("@pulumi/awsx");
+const path = require("path);
+```
 
-// Create a KMS Key for S3 server-side encryption
-const key = new aws.kms.Key("my-key");
+Next we will create a new bucket object on the lines right after creating the bucket itself.
 
-// Create an AWS resource (S3 Bucket)
-const bucket = new aws.s3.Bucket("my-bucket", {
-    serverSideEncryptionConfiguration: {
-        rule: {
-            applyServerSideEncryptionByDefault: {
-                sseAlgorithm: "aws:kms",
-                kmsMasterKeyId: key.id,
-            }
-        }
-    }
+```javascript
+const filePath = path.join(__dirname, "site", "index.html");
+
+const bucketObject = new aws.s3.BucketObject("index.html", {
+    bucket: bucket,
+    source: new pulumi.asset.FileAsset(filePath),
 });
-
-// Export the name of the bucket
-exports.bucketName = bucket.id;
 ```
 
 {{% /choosable %}}
+
 {{% choosable language typescript %}}
 
 ```typescript
-import * as pulumi from "@pulumi/pulumi";
-import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
+import * as path from "path";
+```
 
-// Create a KMS Key for S3 server-side encryption
-const key = new aws.kms.Key("my-key");
+Next we will create a new bucket object on the lines right after creating the bucket itself.
 
-// Create an AWS resource (S3 Bucket)
-const bucket = new aws.s3.Bucket("my-bucket", {
-    serverSideEncryptionConfiguration: {
-        rule: {
-            applyServerSideEncryptionByDefault: {
-                sseAlgorithm: "aws:kms",
-                kmsMasterKeyId: key.id,
-            }
-        }
-    }
+```typescript
+const filePath = path.join(__dirname, "site", "index.html");
+
+const bucketObject = new aws.s3.BucketObject("index.html", {
+    bucket: bucket,
+    source: new pulumi.asset.FileAsset(filePath),
 });
-
-// Export the name of the bucket
-export const bucketName = bucket.id;
 ```
 
 {{% /choosable %}}
+
 {{% choosable language python %}}
 
 ```python
-import pulumi
-from pulumi_aws import kms, s3
+import os
+```
 
-# Create a KMS Key for S3 server-side encryption
-key = kms.Key('my-key')
+Next we will create a new bucket object on the lines right after creating the bucket itself.
 
-# Create an AWS resource (S3 Bucket)
-bucket = s3.Bucket('my-bucket',
-    server_side_encryption_configuration={
-        'rule': {
-            'apply_server_side_encryption_by_default': {
-                'sse_algorithm': 'aws:kms',
-                'kms_master_key_id': key.id
-            }
-        }
-    })
+```python
+filepath = os.path.abspath("site/index.html")
 
-# Export the name of the bucket
-pulumi.export('bucket_name',  bucket.id)
+bucketObject = pulumi_aws.s3.BucketObject(
+    "index.html",
+    bucket=bucket,
+    source=pulumi.FileAsset(filepath)
+)
 ```
 
 {{% /choosable %}}
+
 {{% choosable language go %}}
 
 ```go
-package main
-
 import (
-    "github.com/pulumi/pulumi-aws/sdk/v3/go/aws/kms"
-    "github.com/pulumi/pulumi-aws/sdk/v3/go/aws/s3"
-    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+    // Existing imports...
+    "path"
+	"path/filepath"
 )
+```
 
-func main() {
-    pulumi.Run(func(ctx *pulumi.Context) error {
-        // Create a KMS Key for S3 server-side encryption
-        key, err := kms.NewKey(ctx, "my-key", nil)
-        if err != nil {
-            return err
-        }
+Next we will create a new bucket object on the lines right after creating the bucket itself.
 
-        // Create an AWS resource (S3 Bucket)
-        bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
-            ServerSideEncryptionConfiguration: s3.BucketServerSideEncryptionConfigurationArgs{
-                Rule: s3.BucketServerSideEncryptionConfigurationRuleArgs{
-                    ApplyServerSideEncryptionByDefault: s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs{
-                        SseAlgorithm:   pulumi.StringInput(pulumi.String("aws:kms")),
-                        KmsMasterKeyId: key.ID(),
-                    },
-                },
-            },
-        })
-        if err != nil {
-            return err
-        }
+```go
+filePath, err := filepath.Abs("./site/index.html")
 
-        // Export the name of the bucket
-        ctx.Export("bucketName", bucket.ID())
-        return nil
-    })
+_, err := s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
+    Bucket: bucket.ID(),
+    Source: pulumi.NewFileAsset(filePath),
+})
+if err != nil {
+    return err
 }
 ```
 
 {{% /choosable %}}
+
 {{% choosable language csharp %}}
 
 ```csharp
-using Pulumi;
-using Aws = Pulumi.Aws;
+using System.IO;
+```
 
-class MyStack : Stack
+Next we will create a new bucket object on the lines right after creating the bucket itself.
+
+```csharp
+var filePath = Path.GetFullPath("./site/index.html");
+
+var bucketObject = new BucketObject("index.html",
 {
-    public MyStack()
-    {
-        // Create a KMS Key for S3 server-side encryption
-        var key = new Aws.Kms.Key("my-key");
-
-        // Create an AWS resource (S3 Bucket)
-        var bucket = new Aws.S3.Bucket("my-bucket", new Aws.S3.BucketArgs
-        {
-            ServerSideEncryptionConfiguration = new Aws.S3.Inputs.BucketServerSideEncryptionConfigurationArgs
-            {
-                Rule = new Aws.S3.Inputs.BucketServerSideEncryptionConfigurationRuleArgs
-                {
-                    ApplyServerSideEncryptionByDefault = new Aws.S3.Inputs.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs
-                    {
-                        SseAlgorithm = "aws:kms",
-                        KmsMasterKeyId = key.Id,
-                    },
-                },
-            },
-        });
-
-        // Export the name of the bucket
-        this.BucketName = bucket.Id;
-    }
-
-    [Output]
-    public Output<string> BucketName { get; set; }
-}
+    Bucket = bucket.BucketName,
+    Source = new FileAsset(filePath),
+});
 ```
 
 {{% /choosable %}}
 
-Our program now creates a KMS key and enables server-side encryption on the S3 bucket using the KMS key.
+Notice how we provide the bucket we created earlier as an input to our new `BucketObject`. This is so Pulumi knows what S3 Bucket the object should live in. You can learn more about Inputs and Outputs [here](/docs/intro/concepts/programming-model/#outputs).
 
 Next, we'll deploy the changes.
 

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -18,7 +18,7 @@ Now that your S3 bucket is provisioned, let's add an object to it. First, create
 $ mkdir site
 ```
 
-Next let's create an `index.html` file you will upload to your bucket.
+Next create an `index.html` file you will upload to your bucket.
 
 {{< chooser os "macos,linux,windows" / >}}
 
@@ -56,7 +56,7 @@ Once you've created your `index.html` file, add some content to it:
 </html>
 ```
 
-Now that you have your new `index.html` with some content, let's modify your program to add the contents of your `index.html` file to your S3 bucket. To accomplish this, we will take advantage of your chosen programming language's native libraries to read the content of the file and assign it as an input to a new  `BucketObject`.
+Now that you have your new `index.html` with some content, modify your program to add the contents of your `index.html` file to your S3 bucket. To accomplish this, we will take advantage of your chosen programming language's native libraries to read the content of the file and assign it as an input to a new  `BucketObject`.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 

--- a/content/docs/get-started/aws/next-steps.md
+++ b/content/docs/get-started/aws/next-steps.md
@@ -14,7 +14,7 @@ menu:
 aliases: ["/docs/quickstart/aws/next-steps/"]
 ---
 
-We've seen how to quickly get started using AWS with Pulumi.
+You've seen how to quickly get started using AWS with Pulumi.
 
 From here, you can dive deeper with additional AWS tutorials:
 

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -15,7 +15,7 @@ aliases: ["/docs/quickstart/aws/review-project/"]
 Let's review some of the generated project files:
 
 - `Pulumi.yaml` defines the [project]({{< relref "/docs/intro/concepts/project" >}}).
-- `Pulumi.dev.yaml` contains [configuration]({{< relref "/docs/intro/concepts/config" >}}) values for the [stack]({{< relref "/docs/intro/concepts/stack" >}}) we initialized.
+- `Pulumi.dev.yaml` contains [configuration]({{< relref "/docs/intro/concepts/config" >}}) values for the [stack]({{< relref "/docs/intro/concepts/stack" >}}) you initialized.
 
 {{% choosable language csharp %}}
 
@@ -23,7 +23,7 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-- {{< langfile >}} is the Pulumi program that defines our stack resources. Let's examine it.
+- {{< langfile >}} is the Pulumi program that defines your stack resources. Let's examine it.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
@@ -126,11 +126,11 @@ class MyStack : Stack
 
 {{% /choosable %}}
 
-This Pulumi program creates a new S3 bucket. To inspect your new bucket, you will need its physical AWS name. Pulumi records a logical name, my-bucket, however the resulting AWS name will be different.
+This Pulumi program creates a new S3 bucket. To inspect your new bucket, you will need its physical AWS name. Pulumi records a logical name, in this case `my-bucket`, however the resulting AWS name will be different.
 
 > The difference between logical and physical names is in part due to “auto-naming” which Pulumi does to ensure side-by-side projects and zero-downtime upgrades work seamlessly. It can be disabled if you wish; [read more about auto-naming here](https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming).
 
-Programs can export variables which will be shown in the CLI and recorded for each deployment. In the program we just created, we export the name of the bucket so that we can verify our bucket was created.
+Programs can export variables which will be shown in the CLI and recorded for each deployment. In the program you just created the name of the bucket is exported so that we can easily verify our bucket was created with the AWS CLI.
 
 {{% choosable language javascript %}}
 
@@ -173,6 +173,6 @@ public Output<string> BucketName { get; set; }
 
 {{% /choosable %}}
 
-Next, we will run our first update which will provision our S3 Bucket.
+Next, you will run your first update which will provision your S3 Bucket.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -126,11 +126,7 @@ class MyStack : Stack
 
 {{% /choosable %}}
 
-This Pulumi program creates a new S3 bucket. To inspect your new bucket, you will need its physical AWS name. Pulumi records a logical name, in this case `my-bucket`, however the resulting AWS name will be different.
-
-> The difference between logical and physical names is in part due to “auto-naming” which Pulumi does to ensure side-by-side projects and zero-downtime upgrades work seamlessly. It can be disabled if you wish; [read more about auto-naming here](https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming).
-
-Programs can export variables which will be shown in the CLI and recorded for each deployment. In the program you just created, the name of the bucket is exported, which makes it easy to verify that your bucket was created.
+This Pulumi program creates a new S3 Bucket and exports the name of the bucket.
 
 {{% choosable language javascript %}}
 
@@ -173,6 +169,6 @@ public Output<string> BucketName { get; set; }
 
 {{% /choosable %}}
 
-Next, you will run your first update which will provision your S3 bucket.
+Next, you will deploy your stack which will provision your S3 bucket.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -126,8 +126,53 @@ class MyStack : Stack
 
 {{% /choosable %}}
 
-This Pulumi program creates an S3 bucket and exports the name of the bucket.
+This Pulumi program creates a new S3 bucket. To inspect your new bucket, you will need its physical AWS name. Pulumi records a logical name, my-bucket, however the resulting AWS name will be different.
 
-Next, we'll deploy the stack.
+> The difference between logical and physical names is in part due to “auto-naming” which Pulumi does to ensure side-by-side projects and zero-downtime upgrades work seamlessly. It can be disabled if you wish; [read more about auto-naming here](https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming).
+
+Programs can export variables which will be shown in the CLI and recorded for each deployment. In the program we just created, we export the name of the bucket so that we can verify our bucket was created.
+
+{{% choosable language javascript %}}
+
+```javascript
+exports.bucketName = bucket.id;
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```typescript
+export const bucketName = bucket.id;
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+pulumi.export('bucket_name',  bucket.id)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+ctx.Export("bucketName", bucket.ID())
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+[Output]
+public Output<string> BucketName { get; set; }
+```
+
+{{% /choosable %}}
+
+Next, we will run our first update which will provision our S3 Bucket.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -130,7 +130,7 @@ This Pulumi program creates a new S3 bucket. To inspect your new bucket, you wil
 
 > The difference between logical and physical names is in part due to “auto-naming” which Pulumi does to ensure side-by-side projects and zero-downtime upgrades work seamlessly. It can be disabled if you wish; [read more about auto-naming here](https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming).
 
-Programs can export variables which will be shown in the CLI and recorded for each deployment. In the program you just created the name of the bucket is exported so that we can easily verify our bucket was created with the AWS CLI.
+Programs can export variables which will be shown in the CLI and recorded for each deployment. In the program you just created, the name of the bucket is exported, which makes it easy to verify that your bucket was created.
 
 {{% choosable language javascript %}}
 
@@ -173,6 +173,6 @@ public Output<string> BucketName { get; set; }
 
 {{% /choosable %}}
 
-Next, you will run your first update which will provision your S3 Bucket.
+Next, you will run your first update which will provision your S3 bucket.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/review-project.md
+++ b/content/docs/get-started/aws/review-project.md
@@ -126,7 +126,7 @@ class MyStack : Stack
 
 {{% /choosable %}}
 
-This Pulumi program creates a new S3 Bucket and exports the name of the bucket.
+This Pulumi program creates a new S3 bucket and exports the name of the bucket.
 
 {{% choosable language javascript %}}
 
@@ -169,6 +169,6 @@ public Output<string> BucketName { get; set; }
 
 {{% /choosable %}}
 
-Next, you will deploy your stack which will provision your S3 bucket.
+Next, you'll deploy your stack, which will provision your S3 bucket.
 
 {{< get-started-stepper >}}


### PR DESCRIPTION
Fixes: https://github.com/pulumi/docs/issues/3708

This PR changes the content we use in the AWS Getting Started Guide to using similar content as to what we present in workshops. This implements the first half of Module 01 from workshop on this page: https://pulumi.awsworkshop.io/