### PR TITLE
Fix the role policy invalid reference

### DIFF
--- a/content/docs/reference/pkg/aws/iam/role.md
+++ b/content/docs/reference/pkg/aws/iam/role.md
@@ -19,7 +19,7 @@ Provides an IAM role.
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
-const instance-assume-role-policy = aws.iam.getPolicyDocument({
+const instance_assume_role_policy = aws.iam.getPolicyDocument({
     statements: [{
         actions: ["sts:AssumeRole"],
         principals: [{


### PR DESCRIPTION
Line 33: `assumeRolePolicy: instance_assume_role_policy.then(instance_assume_role_policy => instance_assume_role_policy.json),`  was giving me invalid referencing error. This PR updates the variable naming to reflect the correct reference