### PR TITLE
Enable Git info

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -10,6 +10,10 @@ pygmentsUseClasses = true
 # built, it may disallow crawling.
 enableRobotsTXT = true
 
+# Enabling Git info allows us to have Hugo automatically set the lastmod date in sitemap
+# XML with the date the file was last changed (according to Git).
+enableGitInfo = true
+
 # Some of our API docs pages are very large with many shortcodes, which can take
 # a while to generate (especially in CI), so we raise the limit from the default
 # 10 seconds to avoid timeouts when generating the site.


### PR DESCRIPTION
This change adds a Hugo configuration item, `enableGitInfo`, that sets the `.Lastmod` Page param using the date the page was last modified (according to Git), which is useful for maintaining a more accurate `sitemap.xml`.

https://gohugo.io/getting-started/configuration/#all-configuration-settings

