### PR TITLE
Update docs with TLS for migrations.

### DIFF
--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -100,7 +100,7 @@ The service is configurable to enable connections to the backend SQL database ov
 
 ##### Migrations
 
-The database migrations are configurable to enable connections to the database over TLS. If you are intending to connect to the database over TLS to run the migrations the following environment variable must be set in order to enable this. If this variable is set connections to the database will be establised over TLS, otherwise connections will default to not using TLS.
+The database migrations container is configurable to enable connections to the database over TLS. To use TLS, the following environment variable must be set. The default is to not use TLS.
 
 | Variable Name            | Description                                                                                                   |
 |--------------------------|---------------------------------------------------------------------------------------------------------------|

--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -89,9 +89,19 @@ openssl \
 
 #### Database Connections
 
+##### API Service
+
 The service is configurable to enable connections to the backend SQL database over TLS. The following environment variables are _all_ required to connect to the database using TLS. If these variables are set the service will establish connections to the database using TLS, otherwise the service will default to connecting without TLS. The same ports will be used for communication to the database regardless of whether TLS is configured or not.
 
 | Variable Name            | Description                                                                                                   |
 |--------------------------|---------------------------------------------------------------------------------------------------------------|
 | DATABASE_CA_CERTIFICATE  | The CA certificate used to establish TLS connections with the database. This certificate must be PEM encoded. This must be set to the value of the certificate itself and _not_ a filepath to the location of the certificate file. |
 | DATABASE_MIN_TLS_VERSION | The minimum TLS version to use for database connections (must be in \<major>.\<minor> format, e.g. `1.2`).    |
+
+##### Migrations
+
+The database migrations are configurable to enable connections to the database over TLS. If you are intending to connect to the database over TLS to run the migrations the following environment variable must be set in order to enable this. If this variable is set connections to the database will be establised over TLS, otherwise connections will default to not using TLS.
+
+| Variable Name            | Description                                                                                                   |
+|--------------------------|---------------------------------------------------------------------------------------------------------------|
+| DATABASE_CA_CERTIFICATE  | The CA certificate used to establish TLS connections with the database. This certificate must be PEM encoded. This must be set to the value of the certificate itself and _not_ a filepath to the location of the certificate file. |


### PR DESCRIPTION
This is an update to the self-hosted docs with instructions on how to enable TLS for database migrations. I just added it under the Database Connections section as part of the Service doc for now. I felt this was the most logical place to put this rather than create a whole new page just for the migrations.