### PR TITLE
Clean up website buckets daily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,3 +101,5 @@ ci_schedule:
 	$(MAKE) banner
 	$(MAKE) ensure
 	./scripts/check-links.sh www
+	./scripts/remove-recent-buckets.sh push
+	./scripts/remove-recent-buckets.sh pr

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -119,6 +119,7 @@ set_bucket_for_commit() {
 # https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
 get_pr_for_commit() {
     curl -s \
+         -f \
          -H "Accept: application/vnd.github.groot-preview+json" \
          "https://api.github.com/repos/pulumi/docs/commits/$1/pulls" || echo ""
 }
@@ -128,7 +129,7 @@ get_pr_for_commit() {
 # suffix to filter by (e.g., "pr" or "push").
 get_recent_buckets() {
     aws s3api list-buckets \
-        --query "reverse(sort_by(Buckets,&CreationDate))[:50].{id:Name,date:CreationDate}|[?starts_with(id,'$(origin_bucket_prefix)-${1}')]" \
+        --query "reverse(sort_by(Buckets,&CreationDate))[:100].{id:Name,date:CreationDate}|[?starts_with(id,'$(origin_bucket_prefix)-${1}')]" \
         --output json | jq -r '.[].id'
 }
 

--- a/scripts/list-recent-buckets.sh
+++ b/scripts/list-recent-buckets.sh
@@ -71,7 +71,7 @@ deletables=()
 for bucket in $buckets; do
     maybe_echo
     maybe_echo "Fetching metadata for ${bucket}..."
-    metadata="$(aws s3 cp "s3://${bucket}/metadata.json" - || echo '')"
+    metadata="$(aws s3 cp "s3://${bucket}/metadata.json" 2>/dev/null - || echo '')"
 
     if [ ! -z "$metadata" ]; then
         bucket_url="$(echo $metadata | jq -r '.url')"
@@ -108,7 +108,7 @@ for bucket in $buckets; do
                 deletables+=($bucket_name)
             fi
         elif [ "$1" == "pr" ]; then
-            associated_pr="$(get_pr_for_commit $bucket_commit)"
+            associated_pr="$(get_pr_for_commit $bucket_commit || echo '')"
 
             if [ ! -z "$associated_pr" ]; then
                 pr_number="$(echo $associated_pr | jq -r '.[0].number')"

--- a/scripts/remove-recent-buckets.sh
+++ b/scripts/remove-recent-buckets.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+# This script uses the list-recent-buckets script to find buckets that can be safely
+# deleted, then deletes them. See that script for details, but in general, a bucket is
+# deletable if and only if:
+#
+# * It's not currently serving the website AND some number of buckets behind the one
+#   currently serving the website, or
+# * It's associated with a PR that's been closed.
+
+echo "Finding deletable $1 buckets..."
+
+buckets_to_remove="$(./scripts/list-recent-buckets.sh "$1" --only-deletables)"
+
+if [ -z "$buckets_to_remove" ]; then
+    echo "None found."
+    exit
+fi
+
+echo
+echo "Buckets to remove:"
+echo "$buckets_to_remove"
+echo
+
+for bucket in $buckets_to_remove; do
+    echo "Removing ${bucket}..."
+    aws s3 rb "s3://${bucket}" --force
+    echo
+done
+
+echo "Done!"


### PR DESCRIPTION
This change adds a script to be run once daily that deletes all website buckets that can be safely deleted.

I've been running this script manually for several weeks now, and it's behaved as expected, so I feel comfortable having it run automatically now.