### PR TITLE
Do cleanup as a separate Actions job

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,21 @@
+name: "Scheduled jobs: Check links"
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string.
+    # Run every day at 3:00PM UTC.
+    - cron:  '0 15 * * *'
+jobs:
+  all:
+    env:
+      GOPATH: ${{ github.workspace }}
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Run make check_links
+        run: make check_links
+        env:
+            SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}

--- a/.github/workflows/remove-buckets.yml
+++ b/.github/workflows/remove-buckets.yml
@@ -1,4 +1,4 @@
-name: "Scheduled jobs: Daily"
+name: "Scheduled jobs: Remove buckets"
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string.
@@ -8,14 +8,14 @@ jobs:
   all:
     env:
       GOPATH: ${{ github.workspace }}
-    name: Run all jobs
+    name: Remove buckets
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Run make ci_schedule
-        run: make ci_schedule
+      - name: Run make remove_buckets
+        run: make remove_buckets
         env:
             SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,19 @@ check_links_local:
 	$(MAKE) ensure
 	./scripts/check-links.sh local
 
+.PHONY: check_links
+check_links:
+	$(MAKE) banner
+	$(MAKE) ensure
+	./scripts/check-links.sh www
+
+.PHONY: remove_buckets
+remove_buckets:
+	$(MAKE) banner
+	$(MAKE) ensure
+	./scripts/remove-recent-buckets.sh push
+	./scripts/remove-recent-buckets.sh pr
+
 .PHONY: ci_push
 ci_push::
 	$(MAKE) banner
@@ -95,11 +108,3 @@ ci_pull_request:
 ci_pull_request_closed:
 	$(MAKE) banner
 	./scripts/ci-pull-request-closed.sh
-
-.PHONY: ci_schedule
-ci_schedule:
-	$(MAKE) banner
-	$(MAKE) ensure
-	./scripts/check-links.sh www
-	./scripts/remove-recent-buckets.sh push
-	./scripts/remove-recent-buckets.sh pr


### PR DESCRIPTION
Given how frequently the link-checker fails (often for legitimate reasons), this change breaks the bucket-cleanup scripts into their own scheduled workflow.  