### PR TITLE
Fix the bucket-cleanup workflow

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -1,4 +1,4 @@
-name: "Scheduled jobs: Remove buckets"
+name: "Scheduled jobs: Bucket cleanup"
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string.
@@ -8,14 +8,16 @@ jobs:
   all:
     env:
       GOPATH: ${{ github.workspace }}
-    name: Remove buckets
+    name: Bucket cleanup
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Run make remove_buckets
-        run: make remove_buckets
+      - name: Run make ci_bucket_cleanup
+        run: make ci_bucket_cleanup
         env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
             SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -83,13 +83,6 @@ check_links:
 	$(MAKE) ensure
 	./scripts/check-links.sh www
 
-.PHONY: remove_buckets
-remove_buckets:
-	$(MAKE) banner
-	$(MAKE) ensure
-	./scripts/remove-recent-buckets.sh push
-	./scripts/remove-recent-buckets.sh pr
-
 .PHONY: ci_push
 ci_push::
 	$(MAKE) banner
@@ -108,3 +101,8 @@ ci_pull_request:
 ci_pull_request_closed:
 	$(MAKE) banner
 	./scripts/ci-pull-request-closed.sh
+
+.PHONY: ci_bucket_cleanup
+ci_bucket_cleanup:
+	$(MAKE) banner
+	./scripts/ci-bucket-cleanup.sh

--- a/scripts/ci-bucket-cleanup.sh
+++ b/scripts/ci-bucket-cleanup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+# This script runs the bucket-removal script to clean up old buckets produced by PR and push jobs.
+
+# See if we have the requisite credentials. If not, we might be in a fork, so exit.
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    echo "Missing secret tokens, possibly due to a forked PR. Exiting."
+    exit
+fi
+
+source ./scripts/ci-login.sh
+
+./scripts/remove-recent-buckets.sh push
+./scripts/remove-recent-buckets.sh pr

--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -2,14 +2,14 @@
 
 set -o errexit -o pipefail
 
+# This script handles closed pull requests by finding all of their associated site-preview
+# buckets and deleting them.
+
 # See if we have the requisite credentials. If not, we might be in a fork, so exit.
 if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${PULUMI_ACCESS_TOKEN:-}" ]; then
     echo "Missing secret tokens, possibly due to a forked PR. Exiting."
     exit
 fi
-
-# This script handles closed pull requests by finding all of their associated site-preview
-# buckets and deleting them.
 
 source ./scripts/ci-login.sh
 source ./scripts/common.sh


### PR DESCRIPTION
This change adds the AWS creds required to make the bucket-cleanup script work, and then adds a new script that wraps that script in order to handle the additional login step we need in CI.