### PR TITLE
Expose Pulumi access token to the cleanup workflow

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -20,4 +20,5 @@ jobs:
         env:
             AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
+            PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
             SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}


### PR DESCRIPTION
The `ci-login` script (which is sourced by `ci-bucket-cleanup`, which is now scheduled to run daily), needs this variable on the environment as well. 