### PR TITLE
Fix broken webinar page

### DIFF
--- a/content/webinars/azure-infrastructure-as-code-workshop-2020-10-19/index.md
+++ b/content/webinars/azure-infrastructure-as-code-workshop-2020-10-19/index.md
@@ -1,18 +1,16 @@
 ---
 title: Azure Infrastructure as Code Workshop
-meta_desc: In this workshop, Mikhail Shilkov and Paul Stack from Pulumi show you
-  how to tackle common challenges using Infrastructure as Code through a series
-  of hands-on labs.
+meta_desc: In this workshop, Mikhail Shilkov and Paul Stack show you
+  how to tackle common challenges using Infrastructure as Code.
 featured: false
-pre_recorded: false
+pre_recorded: true
 pulumi_tv: false
 preview_image: /images/webinar/pulumi_workshop.jpg
 unlisted: false
 gated: true
 type: webinars
 external: false
-block_external_search_index: false
-url_slug: azure-infrastructure-as-code-workshop-2020-10-29
+url_slug: azure-infrastructure-as-code-workshop-2020-10-19
 hero:
   title: Azure Infrastructure as Code Workshop
   image: /icons/containers.svg
@@ -26,9 +24,7 @@ main:
     DNS, firewalls, load balancers, IAM, storage, logging, and performance
     monitoring, often spanning private, public, and hybrid cloud architectures.
 
-
     In this workshop, the Pulumi team will show you how to tackle these challenges using Infrastructure as Code (IaC) through a series of hands-on labs. The techniques work for any cloud -- Azure, AWS, and GCP. You'll be able to leverage your favorite languages including Python, Go, JavaScript, TypeScript, and C# instead of YAML or domain-specific languages.
-
 
     After completing this workshop, you'll be up and running with IaC fundamentals, modern application architectures across many clouds, and Kubernetes best-practices that are ready for production environments. You'll also be ready to empower your development teams to be more productive -- continuously deploying both their applications and infrastructure.
   presenters:


### PR DESCRIPTION
The breaking issue was a [meta description that was too long](https://github.com/pulumi/docs/runs/1128598389?check_suite_focus=true) (failed lint checks). Additionally, the CMS seems to have allowed for a combination of property values that the site itself doesn't know how to handle. 

* The index file was named `index-md-1.md`. It should be `index.md`.
* The actual path to the content and the `url_slug` were out of sync.
* The webinar appeared on the "Live" tab under "Upcoming" (and its link didn't work).

If we're going to use the CMS, we're probably going to want to do some additional validation there as well to prevent these kinds of breaking changes from being merged. At the very least, we should not merge PRs that did not produce a successful build.