### PR TITLE
Install Go tooling for the bucket-cleanup workflow

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -12,9 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+
+      - name: Install assume-role
+        run: go get -u github.com/remind101/assume-role
+
+      - name: Add GOBIN to PATH
+        run: echo "::add-path::$(go env GOPATH)/bin"
+
       - name: Run make ci_bucket_cleanup
         run: make ci_bucket_cleanup
         env:


### PR DESCRIPTION
The bucket-cleanup workflow runs a script that uses `assume-role`. The steps added here are just copied from other workflows in this repo that do the same.