### PR TITLE
Add azure press release

### DIFF
--- a/data/newsroom.toml
+++ b/data/newsroom.toml
@@ -1,4 +1,10 @@
 [[releases]]
+date= "21st September 2020"
+title = "Pulumi is the Industry's First Infrastructure as Code Platform with 100% Azure Support"
+summary = "Pulumi is the Industry’s First Multi-Cloud, Multi-Language Infrastructure as Code Platform with 100% Azure Support"
+url = "https://info.pulumi.com/press-release/pulumi-azure-provider"
+
+[[releases]]
 date = "3rd September 2020"
 title = "Pulumi Announces First Annual Cloud Engineering Summit"
 summary = "Cloud engineering leader Pulumi today announced the first annual Cloud Engineering Summit."


### PR DESCRIPTION
This PR adds the Press Release for the Azure Provider to the Newsroom. The Press Release isn't live yet so the link is broken, I used the values present in HS to fill everything in.

<img width="929" alt="azure-press-release" src="https://user-images.githubusercontent.com/15146337/93516804-62f76f80-f8df-11ea-956c-048cb85c6ca0.png">

Part of: https://github.com/pulumi/marketing/issues/20