### PR TITLE
Expire banner dismissals, run component tests on PRs

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -5,7 +5,7 @@
   "module": "dist/index.mjs",
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "files": [

--- a/components/src/components/banner/banner.tsx
+++ b/components/src/components/banner/banner.tsx
@@ -19,7 +19,7 @@ export class Banner {
     @Prop()
     name: string;
 
-    // Whether the banner can be closed. Controls whether the "x" symbols appears.
+    // Whether the banner can be closed. Controls whether the "x" symbol appears.
     @Prop()
     dismissible: boolean = true;
 
@@ -34,9 +34,10 @@ export class Banner {
         this.store.mapDispatchToProps(this, { dismissBanner });
 
         this.storeUnsubscribe = this.store.mapStateToProps(this, (state: AppState) => {
+
             return {
                 // Banners are visible if they have a name and haven't been dismissed.
-                visible: !!this.name && !state.banners.dismissed.includes(this.name),
+                visible: !!this.name && !state.banners.dismissed.find(b => b.name),
             }
         });
     }

--- a/components/src/store/actions/banners.ts
+++ b/components/src/store/actions/banners.ts
@@ -2,14 +2,20 @@ import { TypeKeys } from "./index";
 
 export interface DismissBanner {
     type: TypeKeys.DISMISS_BANNER;
-    name: string;
+    payload: {
+        name: string;
+        dismissedAt: number;
+    }
 }
 
 // Dismiss the banner component.
 export const dismissBanner = (name: string) => (dispatch, _getState) => {
     const action: DismissBanner = {
         type: TypeKeys.DISMISS_BANNER,
-        name
+        payload: {
+            name,
+            dismissedAt: Date.now(),
+        },
     };
     dispatch(action);
 };

--- a/components/src/store/reducers/banners.ts
+++ b/components/src/store/reducers/banners.ts
@@ -14,7 +14,15 @@ export const banners = (currentState = getInitialState(), action: BannersAction)
 
     switch (action.type) {
         case TypeKeys.DISMISS_BANNER:
-            return { ...currentState, dismissed: [ ...currentState.dismissed, action.name ] };
+            const { name, dismissedAt } = action.payload;
+
+            return {
+                ...currentState,
+                dismissed: [
+                    ...currentState.dismissed.filter(b => b.name !== name),
+                    { name, dismissedAt }
+                ]
+            };
         default:
             return currentState;
     }

--- a/components/src/store/state.d.ts
+++ b/components/src/store/state.d.ts
@@ -10,8 +10,13 @@ export interface PreferencesState {
     cloud: CloudKey,
 }
 
+export interface Banner {
+    name: string;
+    dismissedAt: number;
+}
+
 export interface BannersState {
-    dismissed: string[];
+    dismissed: Banner[];
 }
 
 export interface AppState {

--- a/components/src/store/store.spec.ts
+++ b/components/src/store/store.spec.ts
@@ -1,0 +1,86 @@
+import { normalizeState } from './index';
+
+describe("normalizeState", () => {
+
+    describe("given bogus data", () => {
+
+        it("returns an empty state object", () => {
+            expect(normalizeState({ lol: "haha" })).toStrictEqual({});
+            expect(normalizeState("stuff")).toStrictEqual({});
+            expect(normalizeState(14)).toStrictEqual({});
+            expect(normalizeState(null)).toStrictEqual({});
+            expect(normalizeState(undefined)).toStrictEqual({});
+            expect(normalizeState(["sandwich", () => {}, false])).toStrictEqual({});
+        });
+    });
+
+    describe("given a preferences slice", () => {
+        let preferencesSlice;
+
+        describe("that is incomplete", () => {
+            beforeEach(() => {
+                preferencesSlice = {
+                    preferences: {
+                        language: "typescript",
+                    }
+                };
+            });
+
+            it("returns the default preferences slice", () => {
+                expect(normalizeState(preferencesSlice)).toStrictEqual({
+                    preferences: {
+                        language: "typescript",
+                        os: "macos",
+                        cloud: "aws",
+                        inputKind: "code",
+                        k8sLanguage: "typescript",
+                    },
+                });
+            });
+        });
+    });
+
+    describe("given a banners slice", () => {
+        let bannersSlice;
+
+        describe("that is incomplete", () => {
+            beforeEach(() => {
+                bannersSlice = { banners: { dismissed: [ "some-banner" ] } };
+            });
+
+            it ("returns the default banners slice", () => {
+                expect(normalizeState(bannersSlice)).toStrictEqual({ banners: { dismissed: [] } });
+            });
+        });
+
+        describe("with recent dismissals", () => {
+            beforeEach(() => {
+                const tenSecondsAgo = Date.now() - 10000;
+                bannersSlice = {
+                    banners: {
+                        dismissed: [ { name: "some-banner", dismissedAt: tenSecondsAgo } ],
+                    },
+                };
+            });
+
+            it("includes them in the list of dismissed banners", () => {
+                expect(normalizeState(bannersSlice)).toStrictEqual(bannersSlice);
+            });
+        });
+
+        describe("with outdated dismissals", () => {
+            beforeEach(() => {
+                const september7th2020 = 1599444674986;
+                bannersSlice = {
+                    banners: {
+                        dismissed: [ { name: "some-banner", dismissedAt: september7th2020 } ]
+                    }
+                };
+            });
+
+            it("excludes them from the list of dismissed banners", () => {
+                expect(normalizeState(bannersSlice)).toStrictEqual({ banners: { dismissed: [] } });
+            });
+        });
+    });
+});

--- a/scripts/ci-pull-request.sh
+++ b/scripts/ci-pull-request.sh
@@ -13,6 +13,7 @@ fi
 
 source ./scripts/ci-login.sh
 
+./scripts/run-unit-tests.sh
 ./scripts/build-site.sh preview
 ./scripts/sync-and-test-bucket.sh preview
 ./scripts/publish-sentry-release.sh

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yarn --cwd components test


### PR DESCRIPTION
This change adds a bit of logic to expire the dismissal of a banner after a period of four days. (Meaning after four days, the banner will reappear.) By virtue of this chance, all users will see the current banner again as well.

The change also adds a script that runs the Stencil tests on pull requests.