### PR TITLE
Extend the AWS session duration to 2h

### DIFF
--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -3,7 +3,7 @@
 set -o errexit -o pipefail
 
 echo "Assuming the production CI role..."
-eval $(assume-role "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
+eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
 
 echo "Selecting the pulumi/production stack"
 pulumi login


### PR DESCRIPTION
Some CI jobs (especially bucket cleanups) can take longer than the default session duration of one hour (and subsequently fail). This extends the duration to two hours, which should suffice. 