### PR TITLE
Run the broken-link-checker programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^2.0.6",
     "@sentry/cli": "^1.55.1",
+    "@slack/web-api": "^5.12.0",
     "autoprefixer": "^9.6.0",
     "broken-link-checker": "^0.7.8",
     "chokidar-cli": "^2.1.0",

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -1,0 +1,309 @@
+const { SiteChecker, HtmlUrlChecker } = require("broken-link-checker");
+const { WebClient, LogLevel } = require('@slack/web-api');
+const httpServer = require("http-server");
+const path = require("path");
+const fs = require("fs");
+
+/**
+ *  This script uses the programmatic API of https://github.com/stevenvachon/broken-link-checker
+    to check the links (including images, iframes, and client-side redirects) for either an individual page
+    or for a whole site. Usage:
+
+    # Check all links on pulumi.com:
+    $ node scripts/check-links.js "https://www.pulumi.com" "site"
+
+    # Check all links on pulumi.com, and retry failed runs up to 3 times:
+    $ node scripts/check-links.js "https://www.pulumi.com" "site" 3
+
+    # Check the links on pulumi.com/docs/get-started/install/versions:
+    $ node scripts/check-links.js "https://www.pulumi.com/docs/get-started/install/versions/" "page"
+
+    # Check the links of a local build (which starts a local server automatically):
+    $ node scripts/check-links.js "local" "site"
+
+    # Log successes as well as failures.
+    $ DEBUG=1 node scripts/check-links.js "https://www.pulumi.com" "site"
+ */
+
+let [ baseURL, checkScope, maxRetries ] = process.argv.slice(2);
+let retryCount = 0;
+
+if (!baseURL) {
+    throw new Error("A baseURL (e.g., 'https://pulumi.com') is required.");
+}
+
+if (!checkScope || !["site", "page"].includes(checkScope)) {
+    throw new Error("A checkScope of either 'site' or 'page' is required.");
+}
+
+if (!maxRetries || Number.isNaN(maxRetries)) {
+    maxRetries = 0;
+}
+
+// If the passed-in url is simply "local", assume that means we should start a server
+// and to test a local build at the usual location. Otherwise, just test the URL.
+if (baseURL === "local") {
+    baseURL = "http://localhost:8888";
+
+    const url = new URL(baseURL);
+    const buildDir = "public";
+
+    // Make sure there's a valid-looking build where one's supposed to be.
+    if (!fs.existsSync(buildDir) || !fs.existsSync(`${path.join(buildDir, "index.html")}`)) {
+        fail(new Error(`There's no build at ${buildDir}. You may need to run 'make build' first.`));
+    }
+
+    // Start a server, then run the checker.
+    httpServer
+        .createServer({
+            root: buildDir,
+        })
+        .listen(url.port, url.hostname, () => {
+            checkLinks();
+        });
+
+} else {
+
+    // Just run the checker.
+    checkLinks();
+}
+
+// Runs the checker.
+function checkLinks() {
+    const checker = getChecker(checkScope, []);
+    checker.enqueue(baseURL);
+}
+
+// Returns an instance of either HtmlUrlChecker or SiteChecker.
+function getChecker(scope, brokenLinks) {
+
+    // For details about each of the options used below, see the BLC docs at
+    // https://github.com/stevenvachon/broken-link-checker#options.
+    const requestMethod = "GET";
+    const filterLevel = 1;
+
+    if (scope === "page") {
+        const opts = {
+            requestMethod,
+            filterLevel,
+            excludeInternalLinks: true,
+            excludedKeywords: [
+                ...getDefaultExcludedKeywords(),
+                "https://www*"
+            ]
+        };
+
+        // https://github.com/stevenvachon/broken-link-checker#htmlurlchecker
+        return new HtmlUrlChecker(opts, getDefaultHandlers(brokenLinks));
+    }
+
+    if (scope === "site") {
+        const opts = {
+            requestMethod,
+            filterLevel,
+            excludedKeywords: getDefaultExcludedKeywords(),
+        };
+
+        // https://github.com/stevenvachon/broken-link-checker#sitechecker
+        return new SiteChecker(opts, getDefaultHandlers(brokenLinks));
+    }
+}
+
+// The set of event handlers common to HTMLUrlCheckers and SiteCheckers.
+// https://github.com/stevenvachon/broken-link-checker#htmlurlchecker
+// https://github.com/stevenvachon/broken-link-checker#sitechecker
+function getDefaultHandlers(brokenLinks) {
+    return {
+        link: (result) => {
+            try {
+                onLink(result, brokenLinks);
+            }
+            catch (error) {
+                fail(error);
+            }
+        },
+        error: (error) => {
+            fail(error);
+        },
+        page: (error, pageURL) => {
+            try {
+                onPage(error, pageURL, brokenLinks);
+            }
+            catch(error) {
+                fail(error);
+            }
+        },
+        end: async () => {
+            try {
+                await onComplete(brokenLinks);
+            }
+            catch (error) {
+                fail(error);
+            }
+        },
+    };
+}
+
+// Handles BLC 'link' events, adding broken links to the running list.
+function onLink(result, brokenLinks) {
+    const source = result.base.resolved;
+    const destination = result.url.resolved;
+
+    if (result.broken) {
+        const reason = result.brokenReason;
+
+        addLink(source, destination, reason, brokenLinks);
+
+        // Always log broken links to the console.
+        logLink(source, destination, reason);
+
+    } else if (process.env.DEBUG) {
+
+        // Log successes when DEBUG is truthy.
+        logLink(source, destination, result.http.response.statusCode);
+    }
+}
+
+// Handles BLC 'page' events. For page scope, we fail immediately, since that means the
+// requested page was not found. Otherwise, we just log the failed URL to the running list
+// of broken links.
+function onPage(error, pageURL, brokenLinks) {
+    if (error) {
+        if (checkScope === "page") {
+            throw new Error(`Failed to retrieve ${pageURL}: ${error.message}.`);
+        }
+        else {
+            addLink(pageURL, pageURL, error.message, brokenLinks);
+        }
+    }
+}
+
+// Handles the BLC 'complete' event, which is raised at the end of a run.
+async function onComplete(brokenLinks) {
+    const filtered = excludeAcceptable(brokenLinks);
+
+    if (filtered.length > 0) {
+
+        // If we failed and a retry count was provided, retry. Note that retry count !==
+        // run count, so a retry count of 1 means run once, then retry once, which means a
+        // total run count of two.
+        if (maxRetries > 0 && retryCount < maxRetries) {
+            retryCount += 1;
+            console.log(`Retrying (${retryCount} of ${maxRetries})...`);
+            checkLinks();
+            return;
+        }
+
+        const list = filtered
+            .map(link => `• <${link.source}|${new URL(link.source).pathname}> → ${link.destination} (${link.reason})`)
+            .join("\n");
+
+        // Post the results to Slack.
+        await postToSlack(
+            "ops-notifications",
+            `Eek! :scream_cat: There are broken links on ${new URL(baseURL).hostname}: \n\n ${list}`
+        );
+
+        throw new Error("Finished, but failed with errors. See the log for details.");
+    }
+}
+
+/**
+    We exclude some links:
+    - Our generated API docs have lots of broken links.
+    - Our available versions page includes links to private repos.
+    - GitHub Edit Links may be broken, because the page might not yet exist!
+    - Our LinkedIn page, for some reason, returns an HTTP error (despite being valid).
+    - Our Visual Studio Marketplace link for the Azure Pipelines task extension,
+      although valid and publicly available, is reported as a broken link.
+    - A number of synthetic illustrative links come from our examples/tutorials.
+    - GitLab 503s for requests for protected pages that don't contain certain cookies.
+*/
+function getDefaultExcludedKeywords() {
+    return [
+        "/docs/reference/pkg",
+        "/docs/get-started/install/versions",
+        "https://api.pulumi.com/",
+        "https://github.com/pulls?",
+        "https://github.com/pulumi/docs/edit/master",
+        "https://github.com/pulumi/docs/issues/new",
+        "https://www.linkedin.com/",
+        "https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task",
+        "https://blog.mapbox.com/",
+        "https://www.youtube.com/",
+        "https://apps.twitter.com/",
+        "https://www.googleapis.com/",
+        "https://us-central1-/",
+        "https://www.mysql.com/",
+        "https://ksonnet.io/",
+        "https://www.latlong.net/",
+        "https://www.packet.com/",
+        "https://www.random.org",
+        "https://mbrdna.com",
+        "https://www.linode.com/",
+        "https://www.hetzner.com/cloud",
+        "https://media.amazonwebservices.com/architecturecenter/AWS_ac_ra_web_01.pdf",
+        "https://kubernetes-charts-incubator.storage.googleapis.com",
+        "https://kubernetes-charts.storage.googleapis.com",
+        "http://web-lb-23139b7-1806442625.us-east-1.elb.amazonaws.com",
+        "https://ruby-app-7a54c5f5e006d5cf33c2-zgms4nzdba-uc.a.run.app",
+        "https://hello-a28eea2-q1wszdxb2b-ew.a.run.app",
+        "https://ruby-420a973-q1wszdxb2b-ew.a.run.app",
+        "https://280f2167f1.execute-api.us-east-1.amazonaws.com",
+        "http://my-bucket-1234567.s3-website.us-west-2.amazonaws.com",
+        "https://gitlab.com/users/sign_in",
+        "https://gitlab.com/profile/applications",
+    ];
+}
+
+// Filters out transient errors that needn't fail a link-check run.
+function excludeAcceptable(links) {
+    return links
+        // Ignore GitHub 429s (rate-limited). We should really be handling these more
+        // intelligently, but we can come back to that in a follow up.
+        .filter(b => !(b.reason === "HTTP_429" && b.destination.match(/github.com/)))
+        // Ignore remote disconnects.
+        .filter(b => b.reason !== "ERRNO_ECONNRESET")
+}
+
+// Posts a message to the designated Slack channel.
+function postToSlack(channel, text) {
+    const token = process.env.SLACK_ACCESS_TOKEN;
+
+    if (!token) {
+        console.warn("No SLACK_ACCESS_TOKEN on the environment. Skipping.");
+        return;
+    }
+
+    const client = new WebClient(token, { logLevel: LogLevel.ERROR });
+    return client.chat.postMessage({
+        text,
+        channel: `#${channel}`,
+        as_user: true,
+        mrkdwn: true,
+        unfurl_links: false,
+    });
+}
+
+// Adds a broken link to the running list.
+function addLink(source, destination, reason, links) {
+    links.push({
+        source,
+        destination,
+        reason,
+    });
+}
+
+// Logs a link result to the console.
+function logLink(source, destination, reason) {
+    console.log(source);
+    console.log(`  -> ${destination}`);
+    console.log(`  -> ${reason}`);
+    console.log();
+}
+
+// Logs and exits immediately.
+function fail(error) {
+    console.error(error.message);
+    process.exit(1);
+}

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -6,91 +6,27 @@ source ./scripts/common.sh
 CHECK_TYPE=${1-local}
 
 check_links_www() {
-    # We exclude some links:
-	#     - Our generated API docs have lots of broken links
-	#     - Our available versions page includes links to private repos
-	#     - GitHub Edit Links may be broken, because the page might not yet exist!
-	#     - Our LinkedIn page, for some reason, returns an HTTP error (despite being valid)
-	#     - Our Visual Studio Marketplace link for the Azure Pipelines task extension,
-	#       although valid and publicly available, is reported as a broken link.
-	#     - A number of synthetic illustrative links come from our examples/tutorials.
-    #     - GitLab 503s for requests for protected pages that don't contain certain cookies.
-    yarn run blc https://www.pulumi.com --recursive --follow --get \
-        --exclude "/docs/reference/pkg" \
-        --exclude "/docs/get-started/install/versions" \
-        --exclude "https://api.pulumi.com/" \
-        --exclude "https://github.com/pulls?" \
-        --exclude "https://github.com/pulumi/docs/edit/master" \
-        --exclude "https://github.com/pulumi/docs/issues/new" \
-        --exclude "https://www.linkedin.com/" \
-        --exclude "https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task" \
-        --exclude "https://blog.mapbox.com/" \
-        --exclude "https://www.youtube.com/" \
-        --exclude "https://apps.twitter.com/" \
-        --exclude "https://www.googleapis.com/" \
-        --exclude "https://us-central1-/" \
-        --exclude "https://www.mysql.com/" \
-        --exclude "https://ksonnet.io/" \
-        --exclude "https://www.latlong.net/" \
-        --exclude "https://www.packet.com/" \
-        --exclude "https://www.random.org" \
-        --exclude "https://mbrdna.com" \
-        --exclude "https://media.amazonwebservices.com/architecturecenter/AWS_ac_ra_web_01.pdf" \
-        --exclude "https://kubernetes-charts-incubator.storage.googleapis.com" \
-        --exclude "https://kubernetes-charts.storage.googleapis.com" \
-        --exclude "http://web-lb-23139b7-1806442625.us-east-1.elb.amazonaws.com" \
-        --exclude "https://ruby-app-7a54c5f5e006d5cf33c2-zgms4nzdba-uc.a.run.app" \
-        --exclude "https://hello-a28eea2-q1wszdxb2b-ew.a.run.app" \
-        --exclude "https://ruby-420a973-q1wszdxb2b-ew.a.run.app" \
-        --exclude "https://280f2167f1.execute-api.us-east-1.amazonaws.com" \
-        --exclude "http://my-bucket-1234567.s3-website.us-west-2.amazonaws.com" \
-        --exclude "https://gitlab.com/users/sign_in" \
-        --exclude "https://gitlab.com/profile/applications"
+    echo "Checking all links on pulumi.com..."
+    node scripts/check-links.js "https://www.pulumi.com" "site" 3
 }
 
-check_links_local() {
-    # We only link to get.pulumi.com in /docs/get-started/install/ and /docs/get-started/install/versions
-    yarn run blc http://localhost:$HTTP_SERVER_PORT/docs/get-started/install/versions/ --follow \
-        --exclude-internal \
-        --exclude "https://www*"
-
-    yarn run blc http://localhost:$HTTP_SERVER_PORT/docs/get-started/install/ --follow \
-        --exclude-internal \
-        --exclude "https://www*"
+check_get_pulumi_links() {
+    echo "Checking get.pulumi.com links..."
+    # We only link to get.pulumi.com in /docs/get-started/install/ and /docs/get-started/install/versions.
+    node scripts/check-links.js "${1}/docs/get-started/install/versions/" "page"
+    node scripts/check-links.js "${1}/docs/get-started/install/" "page"
 }
 
 if [ $CHECK_TYPE = "local" ]; then
-
-    # Start an HTTP server listening at the root of the built website.
-    HTTP_SERVER_PORT=8888
-    yarn run http-server public --port $HTTP_SERVER_PORT &>/dev/null &
-    HTTP_SERVER_PID=$!
-
-    # Run the link checker once the HTTP server is listening.
-    while ! nc -z localhost $HTTP_SERVER_PORT; do sleep 0.1; done
-
-    echo "Checking only get.pulumi.com links"
-    retry check_links_local 3 15
-
-    # Kill the server process.
-    kill $HTTP_SERVER_PID
+    check_get_pulumi_links "local"
 fi
 
 if [ $CHECK_TYPE = "www" ]; then
-    echo "Checking all links on pulumi.com"
-    retry check_links_www 3 15 || (post_to_slack "ops-notifications" "Eek! :scream_cat: There are broken links on pulumi.com. See the GitHub Actions log for details. https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" && exit 1)
+    check_links_www
 fi
 
 # This variation lets us check important links at a specified URL.
 if [ $CHECK_TYPE = "url" ]; then
     base_url="$2"
-
-    # We only link to get.pulumi.com in /docs/get-started/install/ and /docs/get-started/install/versions
-    yarn run blc "${base_url}/docs/get-started/install/versions/" --follow \
-        --exclude-internal \
-        --exclude "https://www*"
-
-    yarn run blc "${base_url}/docs/get-started/install/" --follow \
-        --exclude-internal \
-        --exclude "https://www*"
+    check_get_pulumi_links "$base_url"
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,6 +85,35 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
+"@slack/logger@>=1.0.0 <3.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-2.0.0.tgz#6a4e1c755849bc0f66dac08a8be54ce790ec0e6b"
+  integrity sha512-OkIJpiU2fz6HOJujhlhfIGrc8hB4ibqtf7nnbJQDerG0BqwZCfmgtK5sWzZ0TkXVRBKD5MpLrTmCYyMxoMCgPw==
+  dependencies:
+    "@types/node" ">=8.9.0"
+
+"@slack/types@^1.7.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.9.0.tgz#aa8f90b2f66ac54a77e42606644366f93cff4871"
+  integrity sha512-RmwgMWqOtzd2JPXdiaD/tyrDD0vtjjRDFdxN1I3tAxwBbg4aryzDUVqFc8na16A+3Xik/UN8X1hvVTw8J4EB9w==
+
+"@slack/web-api@^5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-5.12.0.tgz#1de5e660f20fa64091bcc73eb41e3c1d3ae8e13c"
+  integrity sha512-ygSnNHVid7PltGo7W36f2SNVHyliemkzxn9uSwgnWNF7CHmWBKWAylU/eoDml9l5K7akMOxbousiurOw4XqOFg==
+  dependencies:
+    "@slack/logger" ">=1.0.0 <3.0.0"
+    "@slack/types" "^1.7.0"
+    "@types/is-stream" "^1.1.0"
+    "@types/node" ">=8.9.0"
+    "@types/p-queue" "^2.3.2"
+    axios "^0.19.0"
+    eventemitter3 "^3.1.0"
+    form-data "^2.5.0"
+    is-stream "^1.1.0"
+    p-queue "^2.4.2"
+    p-retry "^4.0.0"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -99,6 +128,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/is-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
+  integrity sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/minimatch@*", "@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -109,10 +145,25 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
   integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
 
+"@types/node@>=8.9.0":
+  version "14.11.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
+  integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
+
+"@types/p-queue@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/p-queue/-/p-queue-2.3.2.tgz#16bc5fece69ef85efaf2bce8b13f3ebe39c5a1c8"
+  integrity sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/retry@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/sinonjs__fake-timers@6.0.1":
   version "6.0.1"
@@ -352,6 +403,13 @@ aws4@^1.8.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
+
+axios@^0.19.0:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
 
 backbone@^1.4.0:
   version "1.4.0"
@@ -1203,6 +1261,13 @@ debug@4, debug@4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1443,6 +1508,11 @@ eventemitter2@6.4.2:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.2.tgz#f31f8b99d45245f0edbc5b00797830ff3b388970"
   integrity sha512-r/Pwupa5RIzxIHbEKCkNXqpEQIIT4uQDxmP4G/Lug/NokVUWj0joz/WzWl3OxRpC5kDrH/WdiUJoR+IrwvXJEw==
 
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
 eventemitter3@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
@@ -1621,6 +1691,13 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.10.0.tgz#01f5263aee921c6a54fb91667f08f4155ce169eb"
@@ -1649,6 +1726,15 @@ form-data2@^1.0.0:
     lodash "^2.4.1"
     mime "^1.2.11"
     uuid "^2.0.1"
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -3385,6 +3471,19 @@ p-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
 
+p-queue@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-2.4.2.tgz#03609826682b743be9a22dba25051bd46724fc34"
+  integrity sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==
+
+p-retry@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.2.0.tgz#ea9066c6b44f23cab4cd42f6147cdbbc6604da5d"
+  integrity sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==
+  dependencies:
+    "@types/retry" "^0.12.0"
+    retry "^0.12.0"
+
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
@@ -4227,6 +4326,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 rgb-regex@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Running this programmatically gives us quite a bit more flexibility than we get with the command-line interface. The main goal here is to make sure we only notify ourselves when something really is broken, and with actionable info.