### PR TITLE
Suppress position locations, apply styles for consistency

### DIFF
--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -64,7 +64,7 @@ module.exports = {
             whitelist: ["supported-cicd-platforms", ":not", ":target", "md:max-w-lg", "blink", "typing", "char", "resource-deprecated", "btn-scroll-top"],
 
             // Whitelist custom parent selectors and their children.
-            whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/, /^bg-/],
+            whitelistPatterns: [/^fa-/, /^hs-/, /^highlight$/, /^pagination$/, /^code-/, /^copy-/, /^carousel/, /^bg-/, /BambooHR-/],
             whitelistPatternsChildren: [
                 /^hs-/,
                 /^highlight$/,

--- a/assets/sass/_careers.scss
+++ b/assets/sass/_careers.scss
@@ -1,0 +1,38 @@
+#BambooHR-ATS {
+
+    .BambooHR-ATS-board {
+        > h2 {
+            @apply hidden;
+        }
+
+        .BambooHR-ATS-Department-Item {
+            @apply pb-4;
+
+            .BambooHR-ATS-Department-Header {
+                @apply font-display text-lg text-gray-700;
+            }
+
+            .BambooHR-ATS-Jobs-List {
+                @apply border-none border-0 p-0;
+
+                .BambooHR-ATS-Jobs-Item {
+                    a {
+                        @apply font-normal text-blue-600;
+                    }
+
+                    .BambooHR-ATS-Location {
+                        display: none;
+                    }
+                }
+            }
+        }
+
+        .BambooHR-ATS-Department-Header {
+            @apply border-none;
+        }
+    }
+
+    + #BambooHR-Footer {
+        @apply mt-8 text-left;
+    }
+}

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -10,6 +10,7 @@
 @import "badges";
 @import "breadcrumb";
 @import "buttons";
+@import "careers";
 @import "chooser";
 @import "components/banner";
 @import "components/chooser";

--- a/layouts/careers/list.html
+++ b/layouts/careers/list.html
@@ -22,8 +22,21 @@
 {{ end }}
 
 {{ define "main" }}
-    <section class="max-w-4xl container mx-auto py-8 px-4 text-center text-lg">
-        <div id="BambooHR" class="text-base">
+
+    <section class="bamboo-hr-widget  max-w-4xl container mx-auto py-8 px-4 text-center text-lg">
+        <div class="text-base text-left mb-8">
+            <h2>Open Positions</h2>
+            <p>
+                While we have a fabulous office in downtown Seattle, Pulumi cares about
+                the health, safety and happiness of our employees, and we've been a fully
+                remote company since early March. We've learned and grown as a company
+                this year, and &mdash; unless otherwise specified &mdash; all of our open positions are
+                remote. We will continue to collaborate and grow from different locations,
+                and are committed to making sure our team is successful from their home
+                offices.
+            </p>
+        </div>
+        <div id="BambooHR" class=" text-base">
             <script src="https://pulumi.bamboohr.com/js/jobs2.php" type="text/javascript"></script>
             <div id="BambooHR-Footer">
                 Powered by


### PR DESCRIPTION
This change just applies some styling to suppress the locations currently shown by the BambooHR widget, since they seem to be giving applicants the wrong impression, and adds a note to make it clear we're currently all-remote. Also applies a bit of styling to make things look more like the rest of the site. (Copy courtesy of Liz.)

![image](https://user-images.githubusercontent.com/274700/95393330-4089be00-08af-11eb-9b1f-fccf320975a6.png)
