### PR TITLE
Add a troubleshooting guide for common failures in CI services

### DIFF
--- a/content/docs/guides/continuous-delivery/_index.md
+++ b/content/docs/guides/continuous-delivery/_index.md
@@ -23,7 +23,7 @@ infrastructure the same way it would for your application code.
 Pulumi can easily integrate into any continuous integration/continuous deliver (CI/CD) system. If your CI/CD system isn't listed below or you are testing something new, see our guide for using Pulumi
 within a [generic CI/CD system]({{< relref "other" >}}).
 
-> Looking to troubleshoot failures related to running Pulumi in CI/CD? Checkout our [CI/CD troubleshooting guide]({{< relref troubleshooting-guide >}}).
+> Looking to troubleshoot failures related to running Pulumi in CI/CD? Check out our [CI/CD troubleshooting guide]({{< relref troubleshooting-guide >}}).
 
 <div class="supported-cicd-platforms">
     <a href="{{< relref aws-code-services >}}">

--- a/content/docs/guides/continuous-delivery/_index.md
+++ b/content/docs/guides/continuous-delivery/_index.md
@@ -23,6 +23,8 @@ infrastructure the same way it would for your application code.
 Pulumi can easily integrate into any continuous integration/continuous deliver (CI/CD) system. If your CI/CD system isn't listed below or you are testing something new, see our guide for using Pulumi
 within a [generic CI/CD system]({{< relref "other" >}}).
 
+> Looking to troubleshoot failures related to running Pulumi in CI/CD? Checkout our [CI/CD troubleshooting guide]({{< relref "/troublehsooting-guide" >}}).
+
 <div class="supported-cicd-platforms">
     <a href="{{< relref aws-code-services >}}">
         <img src="/logos/tech/ci-cd/aws-codedeploy.svg" alt="AWS Code Services">

--- a/content/docs/guides/continuous-delivery/_index.md
+++ b/content/docs/guides/continuous-delivery/_index.md
@@ -23,7 +23,7 @@ infrastructure the same way it would for your application code.
 Pulumi can easily integrate into any continuous integration/continuous deliver (CI/CD) system. If your CI/CD system isn't listed below or you are testing something new, see our guide for using Pulumi
 within a [generic CI/CD system]({{< relref "other" >}}).
 
-> Looking to troubleshoot failures related to running Pulumi in CI/CD? Checkout our [CI/CD troubleshooting guide]({{< relref "/troublehsooting-guide" >}}).
+> Looking to troubleshoot failures related to running Pulumi in CI/CD? Checkout our [CI/CD troubleshooting guide]({{< relref troublehsooting-guide >}}).
 
 <div class="supported-cicd-platforms">
     <a href="{{< relref aws-code-services >}}">

--- a/content/docs/guides/continuous-delivery/_index.md
+++ b/content/docs/guides/continuous-delivery/_index.md
@@ -23,7 +23,7 @@ infrastructure the same way it would for your application code.
 Pulumi can easily integrate into any continuous integration/continuous deliver (CI/CD) system. If your CI/CD system isn't listed below or you are testing something new, see our guide for using Pulumi
 within a [generic CI/CD system]({{< relref "other" >}}).
 
-> Looking to troubleshoot failures related to running Pulumi in CI/CD? Checkout our [CI/CD troubleshooting guide]({{< relref troublehsooting-guide >}}).
+> Looking to troubleshoot failures related to running Pulumi in CI/CD? Checkout our [CI/CD troubleshooting guide]({{< relref troubleshooting-guide >}}).
 
 <div class="supported-cicd-platforms">
     <a href="{{< relref aws-code-services >}}">

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -84,7 +84,7 @@ package(s) from the private feed are accessible or you can use a pre-built binar
 that folder whenever you run your pipeline subsequently. However, note that Pulumi dependencies have a post-install step that also pulls-down
 a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works/#resource-providers" >}}) binary from our CDN.
   * So be sure to cache the plugins path as well.
-  > Note that depending on the number of providers you use in your Pulumi app, the cache size can be huge. 
+  > Note that depending on the number of providers you use in your Pulumi app, the cache size can be huge.
   * If in doubt about problems encountered during execution, clear out all caches and restore dependencies from scratch.
 
 ## Cloud Provider Credentials

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -146,6 +146,6 @@ steps. This is a way to reduce repeating the installation step every time you wo
 
 #### Still need help?
 
-If the above tips don't help you solve your particular issue, then there is always the power of the strong,
+If the above tips don't help solve your particular issue, then there is always the power of the strong,
 knowledgeable [Pulumi Slack Community](https://slack.pulumi.com). Signup is free and quick. In addition to other
 community members, various members of the Pulumi team themselves hang out in the Slack channels and would be happy to help you.

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -19,7 +19,7 @@ In order to run a Pulumi command, the following are the requirements for any con
 Create one [here](https://app.pulumi.com/account/tokens) by logging in with the appropriate account.
 * A stack that you would like to update the automated pipeline.
 * Build tools (more on this below) based on the runtime of your Pulumi app.
-* Restore all dependencies for your Pulumi app.
+* Dependencies for your Pulumi app.
 * The right cloud provider credentials.
 
 ## Pulumi Access Token
@@ -48,16 +48,21 @@ beforehand using the `pulumi stack init` command and in the **appropriate organi
 * Ensure that the account represented by the token you are using, has access to the stack.
   * This can lead to 404s being returned from the Pulumi Service because the token is invalid for any number of reasons.
 * Ensure that you use the fully-qualified stack name when passing the stack name to `pulumi` commands.
+  * A fully-qualified stack name is of the format `<org_name>/<project_name>/<stack_name>`.
+  * For example, for a stack called `production` in an org called `pulumi` and project `slack-bot`, its FQDN is `pulumi/slack-bot/production`.
+  * Using an FQDN in your automated pipelines removes any ambiguity as to which stack is being used, even though Pulumi is smart to figure out
+  which one you meant based on the project name in your `Pulumi.yaml` file. It makes it explicit for anyone in your team looking at the CI configuration.
 * Ensure that you are running the `pulumi` command from the folder containing the `Pulumi.yaml` file that contains your Pulumi project's name.
 * If your stack has configuration, then the stack configuration file must also be co-located with the project file.
-  * For example, for a stack named `production`, the `Pulumi.production.yaml` file must exist alongside the `Pulumi.production.yaml`.
+  * For example, for a stack named `production`, the `Pulumi.production.yaml` file must exist alongside the `Pulumi.yaml`.
   * If your Pulumi app is in a different folder, you can use the `--cwd` flag with almost every `pulumi` command.
   Learn more about the global flags [here]({{< relref "/docs/reference/cli/#options" >}}).
 
 ## Build Tools
 
 Pulumi invokes the build tool that corresponds to your Pulumi project's runtime. If your pipeline is missing one of these tools,
-Pulumi cannot run your infrastructure app.
+Pulumi cannot run your infrastructure app. For example, if your Pulumi project uses the `nodejs` runtime, then making sure that a valid
+version of `Node` installed along with `npm` or `yarn` depending on whichever package manager you are using to manage dependencies.
 
 ### Tips
 
@@ -80,7 +85,7 @@ when you run `pulumi preview` or `pulumi update --yes`.
 * There is an exception to restoring dependencies automatically for `.NET` when you use a private package feed. You must ensure that the
 package(s) from the private feed are accessible or you can use a pre-built binary (see the `binary` option [here]({{< relref "/docs/intro/concepts/project" >}})) with Pulumi to avoid rebuilding your `.NET` solution again.
   * Note that if you do choose to use a pre-built binary, automatic plugin acquisition for Pulumi
-* You are caching the library dependencies but not the Pulumi plugins. Some services offer dependency caching by captuing a specific folder and restoring
+* You are caching the library dependencies but not the Pulumi plugins. Some services offer dependency caching by capturing a specific folder and restoring
 that folder whenever you run your pipeline subsequently. However, note that Pulumi dependencies have a post-install step that also pulls-down
 a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works/#resource-providers" >}}) binary from our CDN.
   * So be sure to cache the plugins path as well.
@@ -119,4 +124,4 @@ steps. This is a way to reduce repeating the installation step every time you wo
 If your error is not related to any of the above categories, it is likely that there is a problem with the code in your infrastructure code.
 Our Programming Model docs can be very helpful in understanding the concepts of programming an infrastructure app. If that doesn't help you solve your
 particular issue, then there is always the power of the strong, knowledgable [Pulumi Slack Community](https://slack.pulumi.com). Signup is free and quick. In addition to other
-community members, various members of the Pulumi team themsevles hang out in the Slack channels and are willing to help you.
+community members, various members of the Pulumi team themselves hang out in the Slack channels and would be happy to help you.

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -18,6 +18,7 @@ In order to run a Pulumi command, the following are required:
 * A [Pulumi access token]({{< relref "/docs/intro/console/accounts-and-organizations/accounts#access-tokens" >}}) for the account you wish to use.
 Create one [here](https://app.pulumi.com/account/tokens) by logging in with the appropriate account.
 * A stack that you would like to update the automated pipeline.
+* Pulumi CLI available in the system `PATH`.
 * Build tools (more on this below) based on the runtime of your Pulumi app.
 * Dependencies for your Pulumi app.
 * The right cloud provider credentials.
@@ -64,6 +65,34 @@ beforehand using the `pulumi stack init` command and in the **appropriate organi
   For example, for a stack named `production`, the `Pulumi.production.yaml` file must exist alongside the `Pulumi.yaml`.
   If your Pulumi app is in a different folder, you can use the `--cwd` flag with almost every `pulumi` command.
   Learn more about the global flags [here]({{< relref "/docs/reference/cli#options" >}}).
+
+### Installing the Pulumi CLI
+
+Depending on the CI service, there may be a few ways to install the Pulumi CLI. The following CI systems have native extensions that provide
+an easy-to-use mechanism for installing and running the various `pulumi` commands.
+
+* [Azure Pipelines Task Extension](https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task) - [Guide]({{< relref "azure-devops" >}})
+* GitHub Actions - [JavaScript Action](https://github.com/pulumi/action-install-pulumi-cli), [Docker Action](https://github.com/pulumi/actions) - [Guide]({{< relref "github-actions" >}})
+
+> Pulumi CLI is now pre-installed on GitHub Actions runners. However, if you need to install a specific version, you can always use one of the aforementioned actions.
+
+* [CircleCI Orb](https://circleci.com/developer/orbs/orb/compute/pulumi) - [Guide]({{< relref "circleci" >}})
+* [Octopus Deploy](https://library.octopus.com/step-templates/76296cd1-7d8c-47e8-b33f-027ecd3ff6b5/actiontemplate-run-pulumi-(linux)) - [Guide]({{< relref "octopus-deploy" >}})
+* [Spinnaker](https://github.com/pulumi/spinnaker-preconfigured-job-plugin) - [Guide]({{< relref "spinnaker" >}})
+
+If you are using a CI system that does not have a native extension for installing the CLI, you can always run an inline script step
+to [install the CLI manually]({{< relref "/docs/get-started/install" >}}).
+
+#### Tips
+
+* Ensure that the `pulumi` CLI is available in the environment across multiple steps.
+
+  In most cases, the official Pulumi installation script will try to add `pulumi` to the system `PATH` automatically.
+
+  This problem is especially prevalent for users using a Docker container-based pipeline. With most Docker container pipelines, the state of the container
+  does not persist across steps, so you cannot split-out the installation step of the Pulumi CLI into another step and expect to use the modified environment
+  in the following step. There are exceptions to this. Some CI services allow you to create a reusable template step that you can inject as a pre-cursor to other
+  steps. This is a way to reduce repeating the installation step every time you would like to run `pulumi` command.
 
 ### Build Tools
 
@@ -136,13 +165,6 @@ In almost all cases, specifying the credentials through environment variables wi
 environment variables to use.
 
 ### Other Errors
-
-#### Pulumi not found in the PATH
-
-This problem is especially prevalent for users using a Docker container-based pipeline. With most Docker container pipelines, the state of the container
-does not persist across steps, so you cannot split-out the installation step of the Pulumi CLI into another step and expect to use the modified environment
-in the following step. There are exceptions to this. Some CI services allow you to create a reusable template step that you can inject as a pre-cursor to other
-steps. This is a way to reduce repeating the installation step every time you would like to run `pulumi` command.  
 
 #### Still need help?
 

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -77,8 +77,8 @@ an easy-to-use mechanism for installing and running the various `pulumi` command
 > Pulumi CLI is now pre-installed on GitHub Actions runners. However, if you need to install a specific version, you can always use one of the aforementioned actions.
 
 * [CircleCI Orb](https://circleci.com/developer/orbs/orb/compute/pulumi) - Access the guide [here]({{< relref "circleci" >}})
-* [Octopus Deploy](https://library.octopus.com/step-templates/76296cd1-7d8c-47e8-b33f-027ecd3ff6b5/actiontemplate-run-pulumi-(linux)) - Access the guide [here]({{< relref "octopus-deploy" >}})
-* [Spinnaker](https://github.com/pulumi/spinnaker-preconfigured-job-plugin) - Access the guide [here]({{< relref "spinnaker" >}})
+* [Octopus Deploy Step Template](https://library.octopus.com/step-templates/76296cd1-7d8c-47e8-b33f-027ecd3ff6b5/actiontemplate-run-pulumi-(linux)) - Access the guide [here]({{< relref "octopus-deploy" >}})
+* [Spinnaker Plugin](https://github.com/pulumi/spinnaker-preconfigured-job-plugin) - Access the guide [here]({{< relref "spinnaker" >}})
 
 If you are using a CI system that does not have a native extension for installing the CLI, you can always run an inline script step
 to [install the CLI manually]({{< relref "/docs/get-started/install" >}}).

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -15,19 +15,19 @@ The type of failure you experience is likely related to one of these steps.
 
 In order to run a Pulumi command, the following are required:
 
-* A [Pulumi access token] https://www.pulumi.com/docs/intro/console/accounts-and-organizations/accounts/#access-tokens) for the account you wish to use.
+* A [Pulumi access token]({{< relref "/docs/intro/console/accounts-and-organizations/accounts#access-tokens" >}}) for the account you wish to use.
 Create one [here](https://app.pulumi.com/account/tokens) by logging in with the appropriate account.
 * A stack that you would like to update the automated pipeline.
 * Build tools (more on this below) based on the runtime of your Pulumi app.
 * Dependencies for your Pulumi app.
 * The right cloud provider credentials.
 
-## Pulumi Access Token
+### Pulumi Access Token
 
 Pulumi has the smarts to know when it is run inside of a CI service by detecting the environment configuration. When this happens,
 Pulumi automatically executes a `pulumi login` command using the non-interactive mechanism.
 
-### Tips
+#### Tips
 
 * Ensure that the access token is saved in an environment variable called `PULUMI_ACCESS_TOKEN`.
   * Most services support marking environment variables as a secret. Your Pulumi Access Token is indeed a sensitive value
@@ -36,94 +36,116 @@ Pulumi automatically executes a `pulumi login` command using the non-interactive
 * Several CI systems have the concept of restricting access to environment secrets to specific branches. So make sure that your branch and the job
 running the `pulumi` command can access the env var.
 
-## Stack Name
+### Stack Name
 
 > Learn about [stacks]({{< relref "/docs/intro/concepts/stack" >}}) and their [configuration]({{< relref "/docs/intro/concepts/config" >}}).
 
 A stack represents a specific configuration state for your infrastructure resources. For a typical CI pipeline, the stack must have been created
 beforehand using the `pulumi stack init` command and in the **appropriate organization**.
 
-### Tips
+#### Tips
 
 * Ensure that the account represented by the token you are using has access to the stack.
-  * This can lead to 404s being returned from the Pulumi Service because the token is invalid for any number of reasons.
+
+  This can lead to 404s being returned from the Pulumi Service because the token is invalid for any number of reasons.
+  One way to check this is, that you are able to navigate to the stack in the [Pulumi Console](https://app.pulumi.com) using the same account you are using in CI.
+
 * Ensure that you use the fully-qualified stack name when passing the stack name to `pulumi` commands.
-  * A fully-qualified stack name is of the format `<org_name>/<project_name>/<stack_name>`.
-  * For example, for a stack called `production` in an org called `pulumi` and project `slack-bot`, its FQDN is `pulumi/slack-bot/production`.
-  * Using an FQDN in your automated pipelines removes any ambiguity as to which stack is being used, even though Pulumi is smart to figure out
-  which one you meant based on the project name in your `Pulumi.yaml` file. It makes it explicit for anyone in your team looking at the CI configuration.
+
+  A fully-qualified stack name is of the format `<org_name>/<project_name>/<stack_name>`.
+  For example, for a stack called `production` in an org called `pulumi` and project `slack-bot`, its FQDN is `pulumi/slack-bot/production`.
+  Using an FQDN, thought optional, in your automated pipelines removes any ambiguity as to which stack is used,
+  even though Pulumi determines the correct stack by automatically taking into account the project name in your
+  `Pulumi.yaml` file. It makes it explicit for anyone in your team looking at the CI configuration.
+
 * Ensure that you are running the `pulumi` command from the folder containing the `Pulumi.yaml` file that contains your Pulumi project's name.
 * If your stack has configuration, then the stack configuration file must also be co-located with the project file.
-  * For example, for a stack named `production`, the `Pulumi.production.yaml` file must exist alongside the `Pulumi.yaml`.
-  * If your Pulumi app is in a different folder, you can use the `--cwd` flag with almost every `pulumi` command.
+
+  For example, for a stack named `production`, the `Pulumi.production.yaml` file must exist alongside the `Pulumi.yaml`.
+  If your Pulumi app is in a different folder, you can use the `--cwd` flag with almost every `pulumi` command.
   Learn more about the global flags [here]({{< relref "/docs/reference/cli#options" >}}).
 
-## Build Tools
+### Build Tools
 
 Pulumi invokes the build tool that corresponds to your Pulumi project's runtime. If your pipeline is missing one of these tools,
 Pulumi cannot run your infrastructure app. For example, if your Pulumi project uses the `nodejs` runtime, then making sure that a valid
 version of `Node` installed along with `npm` or `yarn` depending on whichever package manager you are using to manage dependencies.
 
-### Tips
+#### Tips
 
-* Ensure that your Pulumi project's build tools are installed on your CI runner's build agent.
-  * Many CI services offer built-in mechanisms to acquire language runtimes of a specific version.
-    * For example, GitHub Actions offers the `actions/setup-node` action that can install `node`, `npm`, and `yarn`. Similarly, there is a GitHub Action for installing
-    the runtime for [Python](https://github.com/actions/setup-python), [Go](https://github.com/actions/setup-go), as well as [.NET](https://github.com/actions/setup-dotnet).
-  * If you are using a Docker container-based build, consider using one of Pulumi's [SDK images](https://github.com/pulumi/pulumi/tree/master/docker#sdk-images) for your respective language.
+Ensure that your Pulumi project's build tools are installed on your CI runner's build agent.
 
-## Restoring Dependencies
+  Many CI services offer built-in mechanisms to acquire language runtimes of a specific version.
+  For example, GitHub Actions offers the `actions/setup-node` action that can install `node`, `npm`, and `yarn`. Similarly, there is a GitHub Action for installing
+  the runtime for [Python](https://github.com/actions/setup-python), [Go](https://github.com/actions/setup-go), as well as [.NET](https://github.com/actions/setup-dotnet).
+
+  If you are using a Docker container-based build, consider using one of Pulumi's [SDK images](https://github.com/pulumi/pulumi/tree/master/docker#sdk-images) for your respective language.
+
+### Restoring Dependencies
 
 Regardless of the language you pick for your Pulumi app, you will have dependencies on at least one other package or library. You must ensure that you
 restore these dependencies before running a `pulumi` command. In the case of `.NET` and `Go` runtimes, those dependencies are automatically restored for you
 when you run `pulumi preview` or `pulumi update --yes`.
 
-### Tips
+#### Tips
 
-* For `Node` and `Python` runtimes, you will need to run the step to restore the dependencies ahead of time.
-* For `.NET` and `Go` runtimes, the dependencies are restored for you automatically when you run `pulumi preview` or `pulumi update --yes`.
+* For `nodejs` and `python` runtimes, add a step prior to running any `pulumi` commands to restore the dependencies.
+* For `dotnet` and `go` runtimes, the dependencies are restored for you automatically when you run `pulumi preview` or `pulumi update --yes`.
 * There is an exception to restoring dependencies automatically for `.NET` when you use a private package feed. You must ensure that the
 package(s) from the private feed are accessible or you can use a pre-built binary (see the `binary` option [here]({{< relref "/docs/intro/concepts/project" >}})) with Pulumi to avoid rebuilding your `.NET` solution again.
-  * Note that if you do choose to use a pre-built binary, automatic plugin acquisition for Pulumi
-* You are caching the library dependencies but not the Pulumi plugins. Some services offer dependency caching by capturing a specific folder and restoring
-that folder whenever you run your pipeline subsequently. However, note that Pulumi dependencies have a post-install step that also pulls-down
-a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works#resource-providers" >}}) binary from our CDN.
-  * So be sure to cache the plugins path as well.
-  * If in doubt about problems encountered during execution, clear out all caches and restore dependencies from scratch.
+
+> Note that if you do choose to use a pre-built binary, you will need to install the necessary Pulumi plugins manually using `pulumi plugin install`.
+
+* You might be caching the library dependencies but not the Pulumi plugins. Some services offer dependency caching by capturing a specific folder and restoring
+that folder when your pipeline executes. However, note that Pulumi dependencies have a post-install step that also pulls-down
+a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works#resource-providers" >}}) binary from our CDN. So be sure to cache the plugins path as well.
+
+  If in doubt about problems encountered during execution, clear out all caches and restore dependencies from scratch.
 
 > Note that depending on the number of providers you use in your Pulumi app, the cache size can get big. Some CI services have
 > restrictions on the max size of the cache.
 
-## Cloud Provider Credentials
+### Cloud Provider Credentials
 
 Cloud provider credentials are another common point of failure. The class of errors related to cloud provider credentials can include:
 
 * Incorrect credentials (wrong account, mismatched keys, etc.)
 * Keys with a strict access scope that don't have access to creating specific resources
 
-### Tips
+#### Tips
 
-* Cloud provider credentials not specified using a recognized mechanism. In almost all cases, specifying the credentials through environment variables will work.
-  * Some cloud providers also support authentication via their respective CLIs. For example, the Azure provider supports authentication via the Azure CLI.
-  * In the above example, if the Azure CLI is not properly authenticated, then Pulumi will not be able to acquire the necessary credentials.
-* Ensure that the Pulumi step has access to the environment variables containing the credentials.
-  * If your CI service has features that allow you to restrict which pipelines or steps in a pipeline can access the secrets, then ensure that
+* Make sure that the cloud provider credentials are made accessible to `pulumi` using a valid mechanism.
+In almost all cases, specifying the credentials through environment variables will work.
+
+  Some cloud providers also support authentication via their respective CLIs.
+  For example, the Azure provider supports authentication via the Azure CLI.
+  But if the Azure CLI is not properly authenticated (account doesn't have the right role, subscription etc.),
+  then Pulumi will not be able to acquire the necessary credentials.
+
+* Ensure that the step with the `pulumi` command can actually access to the environment variables containing the credentials.
+
+  If your CI service has features that allow you to restrict which pipelines or steps in a pipeline can access the secrets, then ensure that
   your pipeline/steps can access them.
-* Typo in the name of the environment variables. Refer to our [Cloud Providers]({{< relref "/docs/intro/cloud-providers" >}}) docs and the respective setup pages for each to find the correct
+  Many CI services allow you to group steps in the form of `jobs` or `stages`. If you are using one of those, make sure that the `job` or `stage`
+  in which you are running the `pulumi` command has the expected environment variables. Sometimes build agent environments get reset across
+  jobs, stages etc. depending on how the CI service you are using works.
+
+* Check that there are not typos in the name of the environment variables.
+
+> Refer to the [Cloud Providers]({{< relref "/docs/intro/cloud-providers" >}}) docs and the respective setup pages for each to find the correct
 environment variables to use.
 
-## Other Errors
+### Other Errors
 
-### Pulumi not found in the PATH
+#### Pulumi not found in the PATH
 
 This problem is especially prevalent for users using a Docker container-based pipeline. With most Docker container pipelines, the state of the container
 does not persist across steps, so you cannot split-out the installation step of the Pulumi CLI into another step and expect to use the modified environment
 in the following step. There are exceptions to this. Some CI services allow you to create a reusable template step that you can inject as a pre-cursor to other
 steps. This is a way to reduce repeating the installation step every time you would like to run `pulumi` command.  
 
-### Still need help?
+#### Still need help?
 
-If your error is not related to any of the above categories, it is likely that there is a problem with the code in your infrastructure code.
-Our [Programming Model]({{< relref "/docs/intro/concepts/programming-model" >}}) docs can be very helpful in understanding the concepts of programming an infrastructure app. If that doesn't help you solve your
-particular issue, then there is always the power of the strong, knowledgable [Pulumi Slack Community](https://slack.pulumi.com). Signup is free and quick. In addition to other
+If the above tips don't help you solve your particular issue, then there is always the power of the strong,
+knowledgeable [Pulumi Slack Community](https://slack.pulumi.com). Signup is free and quick. In addition to other
 community members, various members of the Pulumi team themselves hang out in the Slack channels and would be happy to help you.

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -164,8 +164,6 @@ In almost all cases, specifying the credentials through environment variables wi
 > Refer to the [Cloud Providers]({{< relref "/docs/intro/cloud-providers" >}}) docs and the respective setup pages for each to find the correct
 environment variables to use.
 
-### Other Errors
-
 #### Still need help?
 
 If the above tips don't help solve your particular issue, then there is always the power of the strong,

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting Pulumi in CI
-meta_desc: This page walks-through the common failures encountered while running Pulumi in CI, as well as tips on how to fix them.
+meta_desc: This page walks through the common failures encountered while running Pulumi in CI, as well as tips on how to fix them.
 menu:
     userguides:
         parent: cont_delivery
@@ -13,9 +13,9 @@ The type of failure you experience is likely related to one of these steps.
 
 ## Overall Requirements
 
-In order to run a Pulumi command, the following are the requirements for any configuration involving Pulumi:
+In order to run a Pulumi command, the following are required:
 
-* A Pulumi Access Token for the account you wish to use.
+* A [Pulumi access token] https://www.pulumi.com/docs/intro/console/accounts-and-organizations/accounts/#access-tokens) for the account you wish to use.
 Create one [here](https://app.pulumi.com/account/tokens) by logging in with the appropriate account.
 * A stack that you would like to update the automated pipeline.
 * Build tools (more on this below) based on the runtime of your Pulumi app.
@@ -45,7 +45,7 @@ beforehand using the `pulumi stack init` command and in the **appropriate organi
 
 ### Tips
 
-* Ensure that the account represented by the token you are using, has access to the stack.
+* Ensure that the account represented by the token you are using has access to the stack.
   * This can lead to 404s being returned from the Pulumi Service because the token is invalid for any number of reasons.
 * Ensure that you use the fully-qualified stack name when passing the stack name to `pulumi` commands.
   * A fully-qualified stack name is of the format `<org_name>/<project_name>/<stack_name>`.
@@ -96,9 +96,9 @@ a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works#resource-providers"
 
 ## Cloud Provider Credentials
 
-Another common point of failure is the cloud provider credentials. The class of errors related to the credentials can be, but not limited to:
+Cloud provider credentials are another common point of failure. The class of errors related to cloud provider credentials can include:
 
-* Incorrect credentials (wrong account, mismatched keys etc.)
+* Incorrect credentials (wrong account, mismatched keys, etc.)
 * Keys with a strict access scope that don't have access to creating specific resources
 
 ### Tips

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -71,14 +71,14 @@ beforehand using the `pulumi stack init` command and in the **appropriate organi
 Depending on the CI service, there may be a few ways to install the Pulumi CLI. The following CI systems have native extensions that provide
 an easy-to-use mechanism for installing and running the various `pulumi` commands.
 
-* [Azure Pipelines Task Extension](https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task) - [Guide]({{< relref "azure-devops" >}})
-* GitHub Actions - [JavaScript Action](https://github.com/pulumi/action-install-pulumi-cli), [Docker Action](https://github.com/pulumi/actions) - [Guide]({{< relref "github-actions" >}})
+* [Azure Pipelines Task Extension](https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task) - Access the guide [here]({{< relref "azure-devops" >}})
+* GitHub Actions - [JavaScript Action](https://github.com/pulumi/action-install-pulumi-cli), [Docker Action](https://github.com/pulumi/actions) - Access the guide [here]({{< relref "github-actions" >}})
 
 > Pulumi CLI is now pre-installed on GitHub Actions runners. However, if you need to install a specific version, you can always use one of the aforementioned actions.
 
-* [CircleCI Orb](https://circleci.com/developer/orbs/orb/compute/pulumi) - [Guide]({{< relref "circleci" >}})
-* [Octopus Deploy](https://library.octopus.com/step-templates/76296cd1-7d8c-47e8-b33f-027ecd3ff6b5/actiontemplate-run-pulumi-(linux)) - [Guide]({{< relref "octopus-deploy" >}})
-* [Spinnaker](https://github.com/pulumi/spinnaker-preconfigured-job-plugin) - [Guide]({{< relref "spinnaker" >}})
+* [CircleCI Orb](https://circleci.com/developer/orbs/orb/compute/pulumi) - Access the guide [here]({{< relref "circleci" >}})
+* [Octopus Deploy](https://library.octopus.com/step-templates/76296cd1-7d8c-47e8-b33f-027ecd3ff6b5/actiontemplate-run-pulumi-(linux)) - Access the guide [here]({{< relref "octopus-deploy" >}})
+* [Spinnaker](https://github.com/pulumi/spinnaker-preconfigured-job-plugin) - Access the guide [here]({{< relref "spinnaker" >}})
 
 If you are using a CI system that does not have a native extension for installing the CLI, you can always run an inline script step
 to [install the CLI manually]({{< relref "/docs/get-started/install" >}}).

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -124,6 +124,6 @@ steps. This is a way to reduce repeating the installation step every time you wo
 ### Still need help?
 
 If your error is not related to any of the above categories, it is likely that there is a problem with the code in your infrastructure code.
-Our Programming Model docs can be very helpful in understanding the concepts of programming an infrastructure app. If that doesn't help you solve your
+Our [Programming Model]({{< relref "/docs/intro/concepts/programming-model" >}}) docs can be very helpful in understanding the concepts of programming an infrastructure app. If that doesn't help you solve your
 particular issue, then there is always the power of the strong, knowledgable [Pulumi Slack Community](https://slack.pulumi.com). Signup is free and quick. In addition to other
 community members, various members of the Pulumi team themselves hang out in the Slack channels and would be happy to help you.

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -56,7 +56,7 @@ beforehand using the `pulumi stack init` command and in the **appropriate organi
 * If your stack has configuration, then the stack configuration file must also be co-located with the project file.
   * For example, for a stack named `production`, the `Pulumi.production.yaml` file must exist alongside the `Pulumi.yaml`.
   * If your Pulumi app is in a different folder, you can use the `--cwd` flag with almost every `pulumi` command.
-  Learn more about the global flags [here]({{< relref "/docs/reference/cli/#options" >}}).
+  Learn more about the global flags [here]({{< relref "/docs/reference/cli#options" >}}).
 
 ## Build Tools
 
@@ -87,7 +87,7 @@ package(s) from the private feed are accessible or you can use a pre-built binar
   * Note that if you do choose to use a pre-built binary, automatic plugin acquisition for Pulumi
 * You are caching the library dependencies but not the Pulumi plugins. Some services offer dependency caching by capturing a specific folder and restoring
 that folder whenever you run your pipeline subsequently. However, note that Pulumi dependencies have a post-install step that also pulls-down
-a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works/#resource-providers" >}}) binary from our CDN.
+a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works#resource-providers" >}}) binary from our CDN.
   * So be sure to cache the plugins path as well.
   > Note that depending on the number of providers you use in your Pulumi app, the cache size can be huge.
   * If in doubt about problems encountered during execution, clear out all caches and restore dependencies from scratch.
@@ -107,7 +107,7 @@ Another common point of failure are the cloud provider credentials. The class of
 * Ensure that the Pulumi step has access to the environment variables containing the credentials.
   * If your CI service has features that allow you to restrict which pipelines or steps in a pipeline can access the secrets, then ensure that
   your pipeline/steps can access them.
-* Typo in the name of the environment variables. Refer to our [Cloud Providers]({{< relref "/docs/intro/cloud-providers/" >}}) docs and the respective setup pages for each to find the correct
+* Typo in the name of the environment variables. Refer to our [Cloud Providers]({{< relref "/docs/intro/cloud-providers" >}}) docs and the respective setup pages for each to find the correct
 environment variables to use.
 
 ## Other Errors

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -1,6 +1,6 @@
 ---
-title: Other
-meta_desc: This page walks-through the common failures encountered while running Pulumi in CI/CD, as well as tips on how to fix them.
+title: Troubleshooting Guide for Pulumi in CI
+meta_desc: This page walks-through the common failures encountered while running Pulumi in CI, as well as tips on how to fix them.
 menu:
     userguides:
         parent: cont_delivery
@@ -8,7 +8,7 @@ menu:
 ---
 
 In order to understand the errors encountered during an automated pipeline execution, it is important to understand
-the steps involved in a typical CI/CD configuration for Pulumi regardless of the CI/CD service you are using.
+the steps involved in a typical CI configuration for Pulumi regardless of the CI service you are using.
 The type of failure you experience is likely related to one of these steps.
 
 ## Overall Requirements
@@ -24,7 +24,7 @@ Create one [here](https://app.pulumi.com/account/tokens) by logging in with the 
 
 ## Pulumi Access Token
 
-Pulumi has the smarts to know when it is run inside of a CI/CD service by detecting the environment configuration. When this happens,
+Pulumi has the smarts to know when it is run inside of a CI service by detecting the environment configuration. When this happens,
 Pulumi automatically executes a `pulumi login` command using the non-interactive mechanism.
 
 ### Tips
@@ -33,14 +33,14 @@ Pulumi automatically executes a `pulumi login` command using the non-interactive
   * Most services support marking environment variables as a secret. Your Pulumi Access Token is indeed a sensitive value
   and as such should be saved as a secret env var.
 * Ensure that the environment variable is actually accessible to the job that is running the `pulumi` command.
-* Several CI/CD systems have the concept of restricting access to environment secrets to specific branches. So make sure that your branch and the job
+* Several CI systems have the concept of restricting access to environment secrets to specific branches. So make sure that your branch and the job
 running the `pulumi` command can access the env var.
 
 ## Stack Name
 
 > Learn about [stacks]({{< relref "/docs/intro/concepts/stack" >}}) and their [configuration]({{< relref "/docs/intro/concepts/config" >}}).
 
-A stack represents a specific configuration state for your infrastructure resources. For a typical CI/CD pipeline, the stack must have been created
+A stack represents a specific configuration state for your infrastructure resources. For a typical CI pipeline, the stack must have been created
 beforehand using the `pulumi stack init` command and in the **appropriate organization**.
 
 ### Tips
@@ -66,8 +66,8 @@ version of `Node` installed along with `npm` or `yarn` depending on whichever pa
 
 ### Tips
 
-* Ensure that your Pulumi project's build tools are installed on your CI/CD runner's build agent.
-  * Many CI/CD services offer built-in mechanisms to acquire language runtimes of a specific version.
+* Ensure that your Pulumi project's build tools are installed on your CI runner's build agent.
+  * Many CI services offer built-in mechanisms to acquire language runtimes of a specific version.
     * For example, GitHub Actions offers the `actions/setup-node` action that can install `node`, `npm`, and `yarn`. Similarly, there is a GitHub Action for installing
     the runtime for [Python](https://github.com/actions/setup-python), [Go](https://github.com/actions/setup-go), as well as [.NET](https://github.com/actions/setup-dotnet).
   * If you are using a Docker container-based build, consider using one of Pulumi's [SDK images](https://github.com/pulumi/pulumi/tree/master/docker#sdk-images) for your respective language.

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -96,7 +96,7 @@ a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works#resource-providers"
 
 ## Cloud Provider Credentials
 
-Another common point of failure are the cloud provider credentials. The class of errors related to the credentials can be, but not limited to:
+Another common point of failure is the cloud provider credentials. The class of errors related to the credentials can be, but not limited to:
 
 * Incorrect credentials (wrong account, mismatched keys etc.)
 * Keys with a strict access scope that don't have access to creating specific resources

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting Guide for Pulumi in CI
+title: Troubleshooting Pulumi in CI
 meta_desc: This page walks-through the common failures encountered while running Pulumi in CI, as well as tips on how to fix them.
 menu:
     userguides:
@@ -89,8 +89,10 @@ package(s) from the private feed are accessible or you can use a pre-built binar
 that folder whenever you run your pipeline subsequently. However, note that Pulumi dependencies have a post-install step that also pulls-down
 a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works#resource-providers" >}}) binary from our CDN.
   * So be sure to cache the plugins path as well.
-  > Note that depending on the number of providers you use in your Pulumi app, the cache size can be huge.
   * If in doubt about problems encountered during execution, clear out all caches and restore dependencies from scratch.
+
+> Note that depending on the number of providers you use in your Pulumi app, the cache size can get big. Some CI services have
+> restrictions on the max size of the cache.
 
 ## Cloud Provider Credentials
 
@@ -112,7 +114,7 @@ environment variables to use.
 
 ## Other Errors
 
-### Pulumi not found in the `PATH`
+### Pulumi not found in the PATH
 
 This problem is especially prevalent for users using a Docker container-based pipeline. With most Docker container pipelines, the state of the container
 does not persist across steps, so you cannot split-out the installation step of the Pulumi CLI into another step and expect to use the modified environment

--- a/content/docs/guides/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/guides/continuous-delivery/troubleshooting-guide.md
@@ -1,0 +1,122 @@
+---
+title: Other
+meta_desc: This page walks-through the common failures encountered while running Pulumi in CI/CD, as well as tips on how to fix them.
+menu:
+    userguides:
+        parent: cont_delivery
+        weight: 2
+---
+
+In order to understand the errors encountered during an automated pipeline execution, it is important to understand
+the steps involved in a typical CI/CD configuration for Pulumi regardless of the CI/CD service you are using.
+The type of failure you experience is likely related to one of these steps.
+
+## Overall Requirements
+
+In order to run a Pulumi command, the following are the requirements for any configuration involving Pulumi:
+
+* A Pulumi Access Token for the account you wish to use.
+Create one [here](https://app.pulumi.com/account/tokens) by logging in with the appropriate account.
+* A stack that you would like to update the automated pipeline.
+* Build tools (more on this below) based on the runtime of your Pulumi app.
+* Restore all dependencies for your Pulumi app.
+* The right cloud provider credentials.
+
+## Pulumi Access Token
+
+Pulumi has the smarts to know when it is run inside of a CI/CD service by detecting the environment configuration. When this happens,
+Pulumi automatically executes a `pulumi login` command using the non-interactive mechanism.
+
+### Tips
+
+* Ensure that the access token is saved in an environment variable called `PULUMI_ACCESS_TOKEN`.
+  * Most services support marking environment variables as a secret. Your Pulumi Access Token is indeed a sensitive value
+  and as such should be saved as a secret env var.
+* Ensure that the environment variable is actually accessible to the job that is running the `pulumi` command.
+* Several CI/CD systems have the concept of restricting access to environment secrets to specific branches. So make sure that your branch and the job
+running the `pulumi` command can access the env var.
+
+## Stack Name
+
+> Learn about [stacks]({{< relref "/docs/intro/concepts/stack" >}}) and their [configuration]({{< relref "/docs/intro/concepts/config" >}}).
+
+A stack represents a specific configuration state for your infrastructure resources. For a typical CI/CD pipeline, the stack must have been created
+beforehand using the `pulumi stack init` command and in the **appropriate organization**.
+
+### Tips
+
+* Ensure that the account represented by the token you are using, has access to the stack.
+  * This can lead to 404s being returned from the Pulumi Service because the token is invalid for any number of reasons.
+* Ensure that you use the fully-qualified stack name when passing the stack name to `pulumi` commands.
+* Ensure that you are running the `pulumi` command from the folder containing the `Pulumi.yaml` file that contains your Pulumi project's name.
+* If your stack has configuration, then the stack configuration file must also be co-located with the project file.
+  * For example, for a stack named `production`, the `Pulumi.production.yaml` file must exist alongside the `Pulumi.production.yaml`.
+  * If your Pulumi app is in a different folder, you can use the `--cwd` flag with almost every `pulumi` command.
+  Learn more about the global flags [here]({{< relref "/docs/reference/cli/#options" >}}).
+
+## Build Tools
+
+Pulumi invokes the build tool that corresponds to your Pulumi project's runtime. If your pipeline is missing one of these tools,
+Pulumi cannot run your infrastructure app.
+
+### Tips
+
+* Ensure that your Pulumi project's build tools are installed on your CI/CD runner's build agent.
+  * Many CI/CD services offer built-in mechanisms to acquire language runtimes of a specific version.
+    * For example, GitHub Actions offers the `actions/setup-node` action that can install `node`, `npm`, and `yarn`. Similarly, there is a GitHub Action for installing
+    the runtime for [Python](https://github.com/actions/setup-python), [Go](https://github.com/actions/setup-go), as well as [.NET](https://github.com/actions/setup-dotnet).
+  * If you are using a Docker container-based build, consider using one of Pulumi's [SDK images](https://github.com/pulumi/pulumi/tree/master/docker#sdk-images) for your respective language.
+
+## Restoring Dependencies
+
+Regardless of the language you pick for your Pulumi app, you will have dependencies on at least one other package or library. You must ensure that you
+restore these dependencies before running a `pulumi` command. In the case of `.NET` and `Go` runtimes, those dependencies are automatically restored for you
+when you run `pulumi preview` or `pulumi update --yes`.
+
+### Tips
+
+* For `Node` and `Python` runtimes, you will need to run the step to restore the dependencies ahead of time.
+* For `.NET` and `Go` runtimes, the dependencies are restored for you automatically when you run `pulumi preview` or `pulumi update --yes`.
+* There is an exception to restoring dependencies automatically for `.NET` when you use a private package feed. You must ensure that the
+package(s) from the private feed are accessible or you can use a pre-built binary (see the `binary` option [here]({{< relref "/docs/intro/concepts/project" >}})) with Pulumi to avoid rebuilding your `.NET` solution again.
+  * Note that if you do choose to use a pre-built binary, automatic plugin acquisition for Pulumi
+* You are caching the library dependencies but not the Pulumi plugins. Some services offer dependency caching by captuing a specific folder and restoring
+that folder whenever you run your pipeline subsequently. However, note that Pulumi dependencies have a post-install step that also pulls-down
+a [plugin]({{< relref "/docs/intro/concepts/how-pulumi-works/#resource-providers" >}}) binary from our CDN.
+  * So be sure to cache the plugins path as well.
+  > Note that depending on the number of providers you use in your Pulumi app, the cache size can be huge. 
+  * If in doubt about problems encountered during execution, clear out all caches and restore dependencies from scratch.
+
+## Cloud Provider Credentials
+
+Another common point of failure are the cloud provider credentials. The class of errors related to the credentials can be, but not limited to:
+
+* Incorrect credentials (wrong account, mismatched keys etc.)
+* Keys with a strict access scope that don't have access to creating specific resources
+
+### Tips
+
+* Cloud provider credentials not specified using a recognized mechanism. In almost all cases, specifying the credentials through environment variables will work.
+  * Some cloud providers also support authentication via their respective CLIs. For example, the Azure provider supports authentication via the Azure CLI.
+  * In the above example, if the Azure CLI is not properly authenticated, then Pulumi will not be able to acquire the necessary credentials.
+* Ensure that the Pulumi step has access to the environment variables containing the credentials.
+  * If your CI service has features that allow you to restrict which pipelines or steps in a pipeline can access the secrets, then ensure that
+  your pipeline/steps can access them.
+* Typo in the name of the environment variables. Refer to our [Cloud Providers]({{< relref "/docs/intro/cloud-providers/" >}}) docs and the respective setup pages for each to find the correct
+environment variables to use.
+
+## Other Errors
+
+### Pulumi not found in the `PATH`
+
+This problem is especially prevalent for users using a Docker container-based pipeline. With most Docker container pipelines, the state of the container
+does not persist across steps, so you cannot split-out the installation step of the Pulumi CLI into another step and expect to use the modified environment
+in the following step. There are exceptions to this. Some CI services allow you to create a reusable template step that you can inject as a pre-cursor to other
+steps. This is a way to reduce repeating the installation step every time you would like to run `pulumi` command.  
+
+### Still need help?
+
+If your error is not related to any of the above categories, it is likely that there is a problem with the code in your infrastructure code.
+Our Programming Model docs can be very helpful in understanding the concepts of programming an infrastructure app. If that doesn't help you solve your
+particular issue, then there is always the power of the strong, knowledgable [Pulumi Slack Community](https://slack.pulumi.com). Signup is free and quick. In addition to other
+community members, various members of the Pulumi team themsevles hang out in the Slack channels and are willing to help you.


### PR DESCRIPTION
### Proposed changes

As the title states, this adds a new page under our Continuous Delivery category to help our users troubleshoot common CI/CD failures when running Pulumi. This guide will be linked to from the Pulumi Console as part of its workflow configuration wizard.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A