### PR TITLE
Update summit CTAs to promote the keynote

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,5 +1,5 @@
 {{ $name := "cloud-engineering-summit" }}
-{{ $summary := "The Cloud Engineering Summit replay is available! Watch all your favorite talks, on your schedule." }}
+{{ $summary := "The Cloud Engineering Summit replay is available! Watch all your favorite talks, on demand." }}
 {{ $url := "https://cloudengineering.heysummit.com/replays/?utm_campaign=summit-replay&utm_source=pulumi.com&utm_medium=top-banner" }}
 {{ $label := "Save Your Spot"}}
 {{ $external := true }}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,6 +1,6 @@
 {{ $name := "cloud-engineering-summit" }}
-{{ $summary := "Come join Pulumi for the industry's first Cloud Engineering Summit! October 7&ndash;8." }}
-{{ $url := "https://cloudengineeringsummit.com/?utm_campaign=summit&utm_source=pulumi.com&utm_medium=top-banner" }}
+{{ $summary := "The Cloud Engineering Summit replay is available! Watch all your favorite talks, on your schedule." }}
+{{ $url := "https://cloudengineering.heysummit.com/replays/?utm_campaign=summit-replay&utm_source=pulumi.com&utm_medium=top-banner" }}
 {{ $label := "Save Your Spot"}}
 {{ $external := true }}
 

--- a/layouts/partner/azure.html
+++ b/layouts/partner/azure.html
@@ -246,7 +246,7 @@
                 Cloud Engineering Summit
             </h3>
             <p class="py-0 my-0">
-                October 7-8, 2020 &bull; Presented by Pulumi
+                On Demand &bull; Presented by Pulumi
             </p>
             <div>
                 <p class="leading-relaxed mt-6 mb-10 text-2xl text-gray-700">
@@ -254,8 +254,8 @@
                     leveraging the cloud to innovate faster than ever before.
                 </p>
                 <div>
-                    <a href="https://cloudengineeringsummit.com/?utm_campaign=summit&utm_source=pulumi.com&utm_medium=web" rel="noopener noreferrer" target="_blank" class="btn group btn-orange py-3 px-4">
-                        <span>Register Now</span>
+                    <a href="https://cloudengineering.heysummit.com/talks/welcome-keynote/?utm_campaign=summit-replay&utm_source=pulumi.com&utm_medium=web" rel="noopener noreferrer" target="_blank" class="btn group btn-orange py-3 px-4">
+                        <span>Watch The Keynote</span>
                         <span class="inline-block pl-1 w-4 group-hover:pl-2 transition-all">&rarr;</span>
                     </a>
                 </div>

--- a/layouts/topics/kubernetes.html
+++ b/layouts/topics/kubernetes.html
@@ -220,7 +220,7 @@
                 Cloud Engineering Summit
             </h3>
             <p class="py-0 my-0">
-                October 7-8, 2020 &bull; Presented by Pulumi
+                On Demand &bull; Presented by Pulumi
             </p>
             <div>
                 <p class="leading-relaxed mt-6 mb-10 text-2xl text-gray-700">
@@ -228,8 +228,8 @@
                     leveraging the cloud to innovate faster than ever before.
                 </p>
                 <div>
-                    <a href="https://cloudengineeringsummit.com/?utm_campaign=summit&utm_source=pulumi.com&utm_medium=web" rel="noopener noreferrer" target="_blank" class="btn group btn-orange py-3 px-4">
-                        <span>Register Now</span>
+                    <a href="https://cloudengineering.heysummit.com/talks/welcome-keynote/?utm_campaign=summit-replay&utm_source=pulumi.com&utm_medium=web" rel="noopener noreferrer" target="_blank" class="btn group btn-orange py-3 px-4">
+                        <span>Watch The Keynote</span>
                         <span class="inline-block pl-1 w-4 group-hover:pl-2 transition-all">&rarr;</span>
                     </a>
                 </div>


### PR DESCRIPTION
Fixes: https://github.com/pulumi/marketing/issues/23

Now that the summit is "over", this PR updates the CTAs on the website to promote the on-demand content.