### PR TITLE
Revert back to the usual CTAs

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,27 +12,17 @@
                 <p class="mt-2">
                     {{ .Params.subhead | markdownify }}
                 </p>
-                <div class="md:absolute inline-block" style="top: -5.4rem; right: -14rem;">
-                    <a href="https://cloudengineeringsummit.com/?utm_campaign=summit&utm_source=pulumi.com&utm_medium=home-page-hero"
-                            target="_blank" rel="noopener noreferrer" title="Attend the Cloud Engineering Summit">
-                        <img class="w-48" src="/images/cloud-eng-summit.svg" alt="Cloud Engineering Summit">
-                    </a>
+                <div class="md:absolute inline-block" style="top: -4rem; right: -14rem;">
+                    <img class="w-48" src="/images/mascot/pulumipus.svg" alt="Pulumi mascot">
                 </div>
             </div>
 
-            <div class="mt-4">
-                <div class="inline-flex mx-auto flex-col md:flex-row justify-center">
-                    <a href="{{ relref . "/docs/get-started" }}"
-                            class="my-2 md:my-0 md:mx-2 btn bg-purple-300 hover:bg-purple-200 border-none px-8 py-4 transition-all text-sm rounded-full uppercase shadow-lg"
-                            title="Create your first project with Pulumi">
-                        Get Started
-                    </a>
-                    <a href="https://cloudengineering.heysummit.com/talks/welcome-keynote/?utm_campaign=summit&utm_source=pulumi.com&utm_medium=home-page-hero"
-                            target="_blank" rel="noopener noreferrer" class="my-2 md:my-0 md:mx-2 btn bg-purple-300 hover:bg-purple-200 border-none px-8 py-4 transition-all text-sm rounded-full uppercase shadow-lg"
-                            title="Attend the Cloud Engineering Summit">
-                        Watch The Summit Keynote
-                    </a>
-                </div>
+            <div class="mt-8">
+                <a href="{{ relref . "/docs/get-started" }}"
+                        class="my-2 md:my-0 md:mx-2 btn bg-purple-300 hover:bg-purple-200 border-none px-8 py-4 transition-all text-sm rounded-full uppercase shadow-lg"
+                        title="Create your first project with Pulumi">
+                    Get Started
+                </a>
             </div>
             <div class="mt-8 text-sm text-purple-100">
                 Pulumi is <a class="text-white hover:underline" href="{{ relref . "/pricing#community-edition" }}">free</a>


### PR DESCRIPTION
This goes back to the mascot and standard get started CTAs in the
hero, keeping the summit in the alert as we are still working on
adding a cloud engineering page that it will link to.
