### PR TITLE
Change banner button label

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,7 +1,7 @@
 {{ $name := "cloud-engineering-summit" }}
-{{ $summary := "The Cloud Engineering Summit replay is available! Watch all your favorite talks, on demand." }}
+{{ $summary := "The Cloud Engineering Summit replay is available! See all your favorite talks, on demand." }}
 {{ $url := "https://cloudengineering.heysummit.com/replays/?utm_campaign=summit-replay&utm_source=pulumi.com&utm_medium=top-banner" }}
-{{ $label := "Save Your Spot"}}
+{{ $label := "Watch Now"}}
 {{ $external := true }}
 
 {{ if .IsHome }}


### PR DESCRIPTION
"Save your spot" feels less right, now that the event's passed. This just changes the button label to "Watch now".