### PR TITLE
CSS fixes for pulumi-convert

### DIFF
--- a/assets/sass/components/_convert.scss
+++ b/assets/sass/components/_convert.scss
@@ -107,9 +107,7 @@ pulumi-convert {
 
                 @screen xl {
                     @apply overflow-visible;
-                }
 
-                @screen xl {
                     pulumi-tooltip {
                         display: inherit;
                     }
@@ -123,7 +121,7 @@ pulumi-convert {
                     }
 
                     .label {
-                        @apply mx-2 font-body text-gray-500 whitespace-no-wrap overflow-scroll;
+                        @apply mx-2 font-body text-gray-500 whitespace-no-wrap overflow-hidden;
                     }
 
                     .indicator {
@@ -139,6 +137,15 @@ pulumi-convert {
 
                         .indicator {
                             @apply bg-orange-300;
+                        }
+                    }
+
+                    // Hide fourth (and greater) tabs until we have enough screen width to use them.
+                    &:nth-of-type(n + 4) {
+                        @apply hidden;
+
+                        @screen xl {
+                            @apply flex;
                         }
                     }
                 }


### PR DESCRIPTION
* Explicitly suppress scrollers in tab content
* Hide tabs beyond three until screen width reachees 1280px

Before:

![image](https://user-images.githubusercontent.com/274700/96498627-27630480-1201-11eb-92a0-7ce6844bbae9.png)

After:

![image](https://user-images.githubusercontent.com/274700/96498694-3e095b80-1201-11eb-9df9-264a1471157c.png)


Fixes https://github.com/pulumi/pulumi-azure-nextgen/issues/77