### PR TITLE
gcloud doesn't support multiple roles

### DIFF
--- a/content/docs/guides/crosswalk/kubernetes/identity.md
+++ b/content/docs/guides/crosswalk/kubernetes/identity.md
@@ -333,7 +333,8 @@ the `roles/editor` role, and authenticate as the ServiceAccount to use with the 
 ```bash
 $ gcloud iam service-accounts create my-service-account --description MyServiceAccount --display-name MyServiceAccount
 $ gcloud iam service-accounts keys create ~/key.json --iam-account my-service-account@pulumi-development.iam.gserviceaccount.com
-$ gcloud projects add-iam-policy-binding pulumi-development  --member serviceAccount:my-service-account@pulumi-development.iam.gserviceaccount.com --role roles/editor --role roles/container.clusterAdmin
+$ gcloud projects add-iam-policy-binding pulumi-development --member serviceAccount:my-service-account@pulumi-development.iam.gserviceaccount.com --role roles/editor
+$ gcloud projects add-iam-policy-binding pulumi-development --member serviceAccount:my-service-account@pulumi-development.iam.gserviceaccount.com --role roles/container.clusterAdmin
 $ gcloud auth activate-service-account --key-file ~/key.json
 ```
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
Run the gcloud command twice to assign multiple roles, the gcloud command doesn't support adding multiple roles at once.


### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

https://github.com/cloudfoundry/bosh-google-cpi-release/issues/142

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
