### PR TITLE
Set a temporary timeout for Turnstyle

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Turnstyle
         if: ${{ github.event_name == 'push' }}
         uses: softprops/turnstyle@v1
+        with:
+            # Stop waiting after 30 minutes -- this is temporary, just to release what's currently queued.
+            # A follow-up PR will raise this to a value closer to the default GHA job timeout.
+            continue-after-seconds: 1800
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This change sets a timeout that instructs [Turnstyle](https://github.com/softprops/turnstyle) to stop waiting after 30 minutes and proceed with a build. The timeout is intentionally short for now, as we've got several builds queued up that need to go out; I'll follow this up with another that sets it closer to the default GHA limit of 6 hours.