### PR TITLE
Run the await script after dependencies are installed

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,12 +40,6 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
 
-      - name: Wait for running jobs to complete
-        if: ${{ github.event_name == 'push' }}
-        run: node scripts/await-in-progress.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and deploy
         run: make ci_${GITHUB_EVENT_NAME}
         env:

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -2,6 +2,9 @@
 
 set -o errexit -o pipefail
 
+# Wait for in-progress jobs to complete before proceeding.
+node ./scripts/await-in-progress.js
+
 source ./scripts/ci-login.sh
 
 ./scripts/build-site.sh


### PR DESCRIPTION
This change runs the await script after dependencies are installed (rather than before, which makes it go :boom:, but still before logging in) and logs to the console on each execution (even those that pass, so we can always see what values were used to make that determination).