### PR TITLE
Add command to only build marketing part of docs site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ serve:
 	$(MAKE) lint
 	./scripts/serve.sh
 
+.PHONY: serve_marketing
+serve_marketing:
+	@echo -e "\033[0;32mSERVE MARKETING:\033[0m"
+	$(MAKE) lint
+	HUGO_ENVIRONMENT=marketing-dev ./scripts/serve.sh
+
 .PHONY: serve_components
 serve_components:
 	@echo -e "\033[0;32mSERVE COMPONENTS:\033[0m"

--- a/config/marketing-dev/config.toml
+++ b/config/marketing-dev/config.toml
@@ -1,0 +1,2 @@
+ignoreFiles = [ "content/docs/.*" ]
+refLinksErrorLevel = "WARNING"


### PR DESCRIPTION
As we are all aware the `docs` site is massive and it can be a pain to run locally. I know for myself some days the `make serve` command will crash every time I save, making the dev loop really frustrating. This PR adds a `make serve_marketing` command that will only serve the marketing part of the site (everything not in `/docs`) which greatly decreases the dev loop time. To enable this I had to create a `marketing-dev` environment and in Hugo that logs `relref` errors as WARNINGs instead of ERRORs that cause the process to exit.