### PR TITLE
Fix PR bucket cleanups

### DIFF
--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -25,6 +25,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
         # Find all commits associated with the PR.
         pr_commits="$(curl \
             -s \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/commits")"
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -114,17 +114,7 @@ set_bucket_for_commit() {
         --overwrite
 }
 
-# Get the GitHub pull_request object associated with a particular commit.
-# Note that this GitHub API is still in preview:
-# https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
-get_pr_for_commit() {
-    curl -s \
-         -f \
-         -H "Accept: application/vnd.github.groot-preview+json" \
-         "https://api.github.com/repos/pulumi/docs/commits/$1/pulls" || echo ""
-}
-
-# List the 50 most recent bucket in the current account, sorted descendingly by
+# List the 100 most recent bucket in the current account, sorted descendingly by
 # CreationDate, matching the prefix we use to name website buckets. Supports an optional
 # suffix to filter by (e.g., "pr" or "push").
 get_recent_buckets() {


### PR DESCRIPTION
The daily job to clean up closed PR buckets (for those that happen to slip by the GitHub action that runs when a PR is closed, as happens occasionally) has been failing to detect deletable buckets when their commits aren't associated with any PR that GitHub knows about. This makes sense given that our default merge strategy for this repo is to squash and merge, which creates a _new_ commit, but what I didn't realize is that when that happens, GitHub "forgets" all of the commits that _were_ associated with the PR before it was squash-merged. 

So this change just plucks the PR number out of the bucket name, asks GitHub whether it's still open, and if not, adds it to the list of deletables. Also adds the GITHUB_TOKEN environment variable to handle API rate limits.