### PR TITLE
Document the PULUMI_CONSOLE_DOMAIN env var

### DIFF
--- a/content/docs/reference/cli/environment-variables.md
+++ b/content/docs/reference/cli/environment-variables.md
@@ -17,3 +17,4 @@ meta_desc: A list of different environemt variables the Pulumi CLI supports.
 | `PULUMI_DEBUG_PROMISE_LEAKS` | `true` | As of [`v0.12.2`](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0166-2018-11-28), the promise leak experience has been improved and shows a simple error message. Set this environment variable to get more verbose error messages when debugging promise leaks. |
 | `PULUMI_PREFER_YARN` | `1` or `true` | Set this environment variable to opt-in to using `yarn` instead of `npm` for installing Node.js dependencies. |
 | `PULUMI_SKIP_CONFIRMATIONS` | `1` or `true` | As of [`v2.0.0`](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#200-2020-04-16), an explicit confirmation was required when running in non-interactive mode. Set this environment variable to make that explicit confirmation. |
+| `PULUMI_CONSOLE_DOMAIN` | `<custom-domain-name>` | Overrides the domain used when generating links to the Pulumi Console.


### PR DESCRIPTION
### Proposed changes

Add `PULUMI_CONSOLE_DOMAIN` to the documentation for supported environment variables.

### Unreleased product version (optional)

This has long-since shipped in the CLI, added in https://github.com/pulumi/pulumi/pull/4410. 😓 

### Related issues (optional)

Fixes #2995
