### PR TITLE
Add GitHub token to cleanup workflow, restrict to closed

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -35,3 +35,4 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
             PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
             SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/list-recent-buckets.sh
+++ b/scripts/list-recent-buckets.sh
@@ -121,7 +121,7 @@ for bucket in $buckets; do
 
             pr_state="$(echo $pr_metadata | jq -r '.state')"
 
-            if [ "$pr_state" != "open" ]; then
+            if [ "$pr_state" == "closed" ]; then
                 maybe_echo
                 maybe_echo "❌ This bucket's PR state is ${pr_state} (https://github.com/pulumi/docs/pull/${pr_number}), so it can safely be deleted."
                 maybe_echo "   aws s3 rb s3://${bucket_name} --force"


### PR DESCRIPTION
After noticing one of my PR buckets had been cleaned up unexpectedly, I saw that the bucket-cleanup workflow's environment was missing the `GITHUB_TOKEN` environment variable. This script adds that variable, and also changes the deletable check to require a PR state of `closed` (rather than "anything that isn't `open`"), since in this case, the missing environment variable caused the GitHub API request we make to check PR status itself to fail, causing the test to evaluate true, and the bucket to be erroneously deleted.