### PR TITLE
Queue deploys to allow builds to run in parallel

### DIFF
--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -2,13 +2,14 @@
 
 set -o errexit -o pipefail
 
-# Wait for in-progress jobs to complete before proceeding.
-node ./scripts/await-in-progress.js
-
 source ./scripts/ci-login.sh
 
 ./scripts/build-site.sh
 ./scripts/sync-and-test-bucket.sh
 ./scripts/publish-sentry-release.sh
+
+# Wait for in-progress jobs to complete before proceeding.
+node ./scripts/await-in-progress.js
+
 ./scripts/run-pulumi.sh update
 ./scripts/make-s3-redirects.sh


### PR DESCRIPTION
When we deploy the website today, we pause to allow any currently running deployment jobs to finish first, in order to make sure we deploy website changes in commit order. This means that if commit A and commit B produce GHA runs 1 and 2 respectively, run 2 won't start until run 1 finishes, which is correct, but because a run can take ~30-45 minutes, it can easily take several hours to get just a few successive changes out into production.

This change moves the currently-running-job check up to the moment of deployment instead, allowing build and sync processes (the most time-consuming parts of the job) to run in parallel, which should result in queue times closer to ~3 minutes, or the amount of time it takes to run a `pulumi up`.
