### PR TITLE
removing the x's from the product pricing table

### DIFF
--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -356,8 +356,8 @@
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label"><a data-track="grid-self-hosted" href="{{ relref . "/docs/guides/self-hosted" }}" class="link">Self-Hosting</a></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value">Available</span>
             </div>
 
@@ -409,7 +409,7 @@
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label"><a data-track="grid-webhooks" href="{{ relref . "/docs/intro/console/extensions/webhooks" }}" class="link">APIs and Webhooks</a></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
@@ -426,8 +426,8 @@
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label">Organization-wide Policies</span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
 
@@ -498,26 +498,26 @@
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label"><a data-track="grid-teams" href="{{ relref . "/docs/intro/console/collaboration/teams" }}" class="link">Team Management</a></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label">Multiple Admins</span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label"><a data-track="grid-roles" href="{{ relref . "/docs/intro/console/collaboration/organization-roles" }}" class="link">Role Based Access Control</a></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label"><a data-track="grid-saml" href="{{ relref . "/docs/guides/saml" }}" class="link">SAML/SSO</a></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value">
                     <a data-track="grid-saml-azure" href="{{ relref . "/docs/guides/saml/aad" }}" class="link">Azure Active Directory</a>,
                     <a data-track="grid-saml-gsuite" href="{{ relref . "/docs/guides/saml/gsuite" }}" class="link">G Suite</a>,
@@ -527,8 +527,8 @@
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label"><a data-track="grid-roles" href="{{ relref . "/blog/auditing-your-organizations-infrastructure-as-code-activity" }}" class="link">Audit Logs</a></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
 
@@ -544,26 +544,26 @@
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label">Onboarding and Training</span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value">Available</span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label">12×5 Support</span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value">Available</span>
                 <span class="pricing-item-value">Available</span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label">24×7 Support</span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value">Available</span>
             </div>
             <div class="pricing-item">
                 <span class="pricing-item-label">Enterprise Invoicing</span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
-                <span class="pricing-item-value"><i class="fas fa-times text-grey"></i></span>
+                <span class="pricing-item-value"></span>
+                <span class="pricing-item-value"></span>
                 <span class="pricing-item-value"><i class="fas fa-check-square text-green-500"></i></span>
             </div>
         </div>


### PR DESCRIPTION
### Proposed changes

Noticed the pricing plan details section uses both x's and checkmarks which can be a bit confusing, its also more difficult to quickly scan to see which features are included in each plan. This removes the x's all together leaving an empty space if that particular edition does not include that feature. Open to feedback if anyone has concerns or questions.