### PR TITLE
Ignore npm 429s

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -265,9 +265,9 @@ function getDefaultExcludedKeywords() {
 function excludeAcceptable(links) {
     return (links
 
-        // Ignore GitHub 429s (rate-limited). We should really be handling these more
+        // Ignore GitHub and npm 429s (rate-limited). We should really be handling these more
         // intelligently, but we can come back to that in a follow up.
-        .filter(b => !(b.reason === "HTTP_429" && b.destination.match(/github.com/)))
+        .filter(b => !(b.reason === "HTTP_429" && b.destination.match(/github.com|npmjs.com/)))
 
         // Ignore remote disconnects.
         .filter(b => b.reason !== "ERRNO_ECONNRESET")


### PR DESCRIPTION
Similarly to GitHub, we can ignore (i.e., not alert for) these for now.