### PR TITLE
Remove double 'is' from public subnet description

### DIFF
--- a/content/docs/guides/crosswalk/aws/vpc.md
+++ b/content/docs/guides/crosswalk/aws/vpc.md
@@ -306,7 +306,7 @@ export const vpcPublicSubnetIds = vpc.publicSubnetIds;
 The `subnets` argument simply takes an array of subnet specifications. Each one can include this information:
 
 * `type`: A required type of subnet to create. There are three kinds available:
-    * A `public` subnet is is one whose traffic is routed to an
+    * A `public` subnet is one whose traffic is routed to an
     [Internet Gateway (IGW)](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html).
     * A `private` subnet is one that is configured to use a
     [NAT Gateway (NAT)](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat.html) so that it can reach the internet,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Type fix: Remove the double 'is' from the 'public' subnet description

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
