### PR TITLE
Adjust the definition of security groups

### DIFF
--- a/content/docs/guides/crosswalk/aws/vpc.md
+++ b/content/docs/guides/crosswalk/aws/vpc.md
@@ -392,9 +392,7 @@ routed to in a round-robin fashion from the availability zones with NAT gateways
 
 ## Configuring Security Groups for a VPC
 
-All traffic in and out of a VPC is controlled by
-[Security Groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html), which act as virtual
-firewalls that limit inbound traffic to and outbound traffic from your VPC.
+A [security group](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) acts as a virtual firewall for your instance (e.g EC2) to control inbound and outbound traffic. Security groups act at the instance level, not the subnet level. Therefore, each instance in a subnet in your VPC can be assigned to a different set of security groups.
 
 For security groups, you add _rules_ that control traffic what traffic is permitted in the form of _ingress rules_ (for
 inbound traffic) and _egress rules_ (outbound traffic). In addition to specifying what network protocol and ports


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Currently the definition of security groups in the documentation states that they are meant to act as a firewall to VPCs, but in reality they are made to control the traffic of instances as they are applied to an instance rather than a VPC. This might introduce confusion to new comers of AWS. The definition has been updated to reflect the definition that is provided by the [AWS documentation](SOURCE)

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
