### PR TITLE
Add missing imports to ec2-webserver example

### DIFF
--- a/content/docs/tutorials/aws/ec2-webserver.md
+++ b/content/docs/tutorials/aws/ec2-webserver.md
@@ -78,6 +78,7 @@ Open {{< langfile >}} and replace the contents with the following:
 
 ```javascript
 const aws = require("@pulumi/aws");
+const pulumi = require("@pulumi/pulumi");
 
 let size = "t2.micro";     // t2.micro is available in the AWS free tier
 let ami = pulumi.output(aws.getAmi({
@@ -110,6 +111,7 @@ exports.publicHostName = server.publicDns;
 
 ```typescript
 import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
 
 const size = "t2.micro";     // t2.micro is available in the AWS free tier
 const ami = pulumi.output(aws.getAmi({


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

The Typescript EC2 webserver example fails with
`index.ts(4,13): errorTS2304: Cannot find name 'pulumi'.` as it is at
the moment.

Importing `@pulumi/pulumi` fixes it, and follows the pattern of the
other examples (e.g
https://www.pulumi.com/docs/tutorials/aws/rest-api/#step-3-review-your-stack-resources).

I've also updated the Javascript example as I suspect it suffers from
the same error.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
