### PR TITLE
Restore diagnostics to the conversion component

### DIFF
--- a/assets/sass/components/_convert.scss
+++ b/assets/sass/components/_convert.scss
@@ -211,7 +211,7 @@ pulumi-convert {
                 }
 
                 .alert {
-                    @apply hidden absolute right-0 left-0 z-10 bg-red-100 border-red-500 text-sm rounded-t border-2 border-red-800 text-red-800 py-2 px-4;
+                    @apply hidden absolute right-0 left-0 z-10 text-sm rounded-t border-2 py-2 px-4 max-h-25 overflow-y-scroll;
                     bottom: 100%;
 
                     p {
@@ -229,8 +229,20 @@ pulumi-convert {
                         @extend .fa-times;
                     }
 
-                    .alert {
-                        @apply block;
+                    .alert-error {
+                        @apply block bg-red-100 border-red-800 text-red-800 ;
+                    }
+                }
+
+                &.warn {
+                    .icon {
+                        @apply text-yellow-300;
+                        @extend .fas;
+                        @extend .fa-exclamation-triangle;
+                    }
+
+                    .alert-warn {
+                        @apply block bg-yellow-100 border-yellow-800 text-yellow-800 ;
                     }
                 }
             }
@@ -261,6 +273,14 @@ pulumi-convert {
                     .CodeMirror-scroll {
                         @apply opacity-0;
                     }
+                }
+            }
+
+            .diagnostics {
+                @apply mt-4 p-2 rounded bg-gray-100;
+
+                .details {
+                    @apply font-mono py-0 text-xs whitespace-pre overflow-scroll;
                 }
             }
         }

--- a/components/src/components/convert/convert.tsx
+++ b/components/src/components/convert/convert.tsx
@@ -363,11 +363,15 @@ export class Convert {
                     filename = this.supportedLanguages.find(sl => sl.key === language.key).filename;
                 }
 
+                // Additionally, the kube2pulumi endpoint returns "no diagnostics" when
+                // there are no diagnostics.
+                const diagnostics = result.diagnostics?.replace(/^no diagnostics$/, "") || ""
+
                 if (filename && code) {
                     this.setOutputResult({
                         filename,
                         code,
-                        diagnostics: result.diagnostics || "",
+                        diagnostics,
                         status: {
                             success: true,
                             message: filename,
@@ -375,8 +379,8 @@ export class Convert {
                     });
                 }
 
-                if (result.diagnostics) {
-                    this.outputResult.diagnostics = result.diagnostics;
+                if (diagnostics) {
+                    this.outputResult.diagnostics = diagnostics;
                 }
             }
         }


### PR DESCRIPTION
This change adds diagnostic details for incomplete conversions to the `pulumi-convert` component, along with a warning message and links for what to do when you encounter it.

![image](https://user-images.githubusercontent.com/274700/98286612-1c2a0b80-1f59-11eb-86ff-06fd926f7de3.png)

Fixes #4402.