### PR TITLE
Handle deprecation of add-path

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -17,8 +17,7 @@ jobs:
         with:
           node-version: '14.x'
 
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.13.x
 

--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -18,15 +18,12 @@ jobs:
           node-version: '14.x'
 
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13.x
 
       - name: Install assume-role
         run: go get -u github.com/remind101/assume-role
-
-      - name: Add GOBIN to PATH
-        run: echo "::add-path::$(go env GOPATH)/bin"
 
       - name: Run make ci_bucket_cleanup
         run: make ci_bucket_cleanup

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,15 +27,12 @@ jobs:
           extended: true
 
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13.x
 
       - name: Install assume-role
         run: go get -u github.com/remind101/assume-role
-
-      - name: Add GOBIN to PATH
-        run: echo "::add-path::$(go env GOPATH)/bin"
 
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,22 +20,17 @@ jobs:
         with:
           node-version: '14.x'
 
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.13.x
+
+      - uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.55.4'
           extended: true
 
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.13.x
-
       - name: Install assume-role
         run: go get -u github.com/remind101/assume-role
-
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@releases/v1
 
       - name: Build and deploy
         run: make ci_${GITHUB_EVENT_NAME}

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -17,15 +17,12 @@ jobs:
           node-version: '14.x'
 
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13.x
 
       - name: Install assume-role
         run: go get -u github.com/remind101/assume-role
-
-      - name: Add GOBIN to PATH
-        run: echo "::add-path::$(go env GOPATH)/bin"
 
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -16,16 +16,12 @@ jobs:
         with:
           node-version: '14.x'
 
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.13.x
 
       - name: Install assume-role
         run: go get -u github.com/remind101/assume-role
-
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@releases/v1
 
       - name: Remove unused resources
         run: make ci_pull_request_closed


### PR DESCRIPTION
This change handles the [deprecation](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) of the GHA `add-path` command by updating to the latest version if `setup-go`, which takes care of adding GOBIN to the PATH.

Also removes `action-install-pulumi-cli` from deployment workfows, since Pulumi is now [installed on all Actions runners](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#tools).
