### PR TITLE
Fix timezone issue on workshops

### DIFF
--- a/content/resources/introduction-to-pulumi/index.md
+++ b/content/resources/introduction-to-pulumi/index.md
@@ -45,11 +45,11 @@ hero:
 
 # Webinar pages support multiple session via the 'multiple' property.
 multiple:
-    - datetime: 2020-11-17T09:30:00-07:00
+    - datetime: 2020-11-17T09:30:00-08:00
       hubspot_form_id: 98e735f4-055d-459d-a474-dff38c540bea
       gotowebinar_key: ""
 
-    - datetime: 2020-12-01T18:00:00-07:00
+    - datetime: 2020-12-01T17:00:00-08:00
       hubspot_form_id: 062d9849-0deb-4c26-a578-5d8f3c4fa8e6
       gotowebinar_key: ""
 


### PR DESCRIPTION
As the title states, this fixes a timezone issue on the Introduction to Pulumi workshops. I'll need to investigate a bit further to find a better way to handle this automatically, but this fix at least gets the time right on the website.