### PR TITLE
Add exclusion for netfilter.org

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -258,6 +258,7 @@ function getDefaultExcludedKeywords() {
         "https://gitlab.com/users/sign_in",
         "https://gitlab.com/profile/applications",
         "https://blog.coinbase.com/",
+        "https://www.netfilter.org/",
     ];
 }
 


### PR DESCRIPTION
The netfilter.org site returns a 403 to broken-link-checker, for reasons that have to do with the library and settings being used by BLC, so this just ignores errors related to that particular domain.