### PR TITLE
Fix typo on JavaScript language page

### DIFF
--- a/content/docs/intro/languages/javascript.md
+++ b/content/docs/intro/languages/javascript.md
@@ -33,7 +33,7 @@ This will create a `Pulumi.yaml` [project file]({{< relref "../concepts/project"
 
 ## Pulumi Programming Model
 
-The Pulumi programming model includes a core concept of `Input` and `Output` values, which are used to track how outputs of one resource flow in as inputs to another resource.  This concept is important to understand when getting started with Go and Pulumi, and the [Inputs and Outputs]({{< relref "/docs/intro/concepts/programming-model#outputs" >}}) documentation is recommended to get a feel for how to work with this core part of Pulumi in common cases.
+The Pulumi programming model includes a core concept of `Input` and `Output` values, which are used to track how outputs of one resource flow in as inputs to another resource.  This concept is important to understand when getting started with JavaScript and Pulumi, and the [Inputs and Outputs]({{< relref "/docs/intro/concepts/programming-model#outputs" >}}) documentation is recommended to get a feel for how to work with this core part of Pulumi in common cases.
 
 ## Entrypoint
 


### PR DESCRIPTION
Fix "Go" -> "JavaScript"