### PR TITLE
Remove old intro to pulumi workshop

### DIFF
--- a/content/resources/introduction-to-pulumi/index.md
+++ b/content/resources/introduction-to-pulumi/index.md
@@ -45,10 +45,6 @@ hero:
 
 # Webinar pages support multiple session via the 'multiple' property.
 multiple:
-    - datetime: 2020-11-17T09:30:00-08:00
-      hubspot_form_id: 98e735f4-055d-459d-a474-dff38c540bea
-      gotowebinar_key: ""
-
     - datetime: 2020-12-01T17:00:00-08:00
       hubspot_form_id: 062d9849-0deb-4c26-a578-5d8f3c4fa8e6
       gotowebinar_key: ""


### PR DESCRIPTION
This PR removes the listing for the November 17th Introduction to Pulumi workshop. There will be a follow-up PR to add the on-demand listing but there is some more engineering work involved in making that possible. So this PR simply removes it to so that the session picker defaults to the upcoming session.