### PR TITLE
Update site banner and home page alert for re:Invent

### DIFF
--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,4 +1,4 @@
-{{ $text := "Join us during re:Invent! Checkout our AWS page for the latest news and workshops." }}
+{{ $text := "Join us during re:Invent! Check out the latest news and workshops." }}
 {{ $url := relref . "/partner/aws" }}
 {{ $color := "orange"}}
 

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,5 +1,5 @@
-{{ $text := "Pulumi raises $37.5M in Series B round to keep building the tools you love. Read the blog to learn more." }}
-{{ $url := relref . "/blog/series-b" }}
+{{ $text := "Join us during re:Invent! Checkout our AWS page for the latest news and workshops." }}
+{{ $url := relref . "/partner/aws" }}
 {{ $color := "orange"}}
 
 <div class="mx-auto mb-12">

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,6 +1,6 @@
-{{ $name := "introduction-to-pulumi" }}
-{{ $summary := "Get started with Pulumi in a free one hour introductory workshop." }}
-{{ $url := relref . "/resources/introduction-to-pulumi" }}
+{{ $name := "lambda-microservices" }}
+{{ $summary := "Want to learn about running containers in Lambda? Join our free hands-on workshop." }}
+{{ $url := relref . "/resources/deplying-microservices-with-pulumi-and-aws-lambda" }}
 {{ $label := "Register Now"}}
 {{ $external := false }}
 


### PR DESCRIPTION
This PR updates the site banner and home page alert to promote our AWS page and the upcoming workshop this week. The AWS page has a list of our latest announcements so that seemed like the natural place to link from the alert for the next few weeks.