### PR TITLE
Update _index.md

### DIFF
--- a/content/docs/intro/cloud-providers/alicloud/_index.md
+++ b/content/docs/intro/cloud-providers/alicloud/_index.md
@@ -104,7 +104,7 @@ class Program
 
 ## Libraries
 
-The following packages are available in packager managers:
+The following packages are available in package managers:
 
 * JavaScript/TypeScript: [`@pulumi/alicloud`](https://www.npmjs.com/package/@pulumi/alicloud)
 * Python: [`pulumi-alicloud`](https://pypi.org/project/pulumi-alicloud/)


### PR DESCRIPTION
### Proposed changes
Fixed spelling mistake, should be 'package manager' not 'packager manager'.

I observe that this same mistake is also present in the docs for various other Cloud Providers.  This PR fixes only the instance that I observed. 
