### PR TITLE
change try open source link

### DIFF
--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -7,7 +7,7 @@
             </p>
             <div class="mt-10 text-lg">
                 Prefer to manage your own backend?
-                <a class="text-purple-500 hover:underline font-bold" href="{{ relref . "/docs/intro/concepts/state" }}">Try open source</a>
+                <a class="text-purple-500 hover:underline font-bold" href="{{ relref . "/docs/get-started" }}">Try open source</a>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## overview
the try open source link should link to the getting started page until we do the updates to the state and backends page, this fixes it