### PR TITLE
Update Console docs re: inviting users

### DIFF
--- a/content/docs/intro/console/accounts-and-organizations/accounts.md
+++ b/content/docs/intro/console/accounts-and-organizations/accounts.md
@@ -19,9 +19,9 @@ Your account lets you authenticate into the Pulumi Console, where you can do the
 following:
 
 * Manage your profile settings, including your account password, access tokens, and subscriptions
-* [Add an organization]({{< relref "organizations" >}}) backed by Atlassian, GitHub, GitLab, or a SAML
+* [Add an organization]({{< relref "/docs/intro/console/accounts-and-organizations/organizations" >}}) backed by Atlassian, GitHub, GitLab, or a SAML
   2.0-compatible identity provider, such as Active Directory, Okta, or G Suite
-* [Manage your projects and stacks]({{< relref "../collaboration/project-and-stack-management" >}})
+* [Manage your projects and stacks]({{< relref "/docs/intro/console/collaboration/project-and-stack-management" >}})
 
 ## Profile
 
@@ -39,7 +39,7 @@ From this tab, you can:
 
 * Update your display name and Avatar URL
 * Update the email address associated with your Pulumi account
-* Add third party identities for [collaborating with other developers]({{< relref "../collaboration/organization-roles" >}})
+* Add third party identities for [collaborating with other developers]({{< relref "/docs/intro/console/collaboration/organization-roles" >}})
 
 ### Adding New Identities{#adding-new-identities}
 
@@ -80,4 +80,4 @@ This tab provides a list of Pulumi's Continuous Delivery guides. Click on your f
 
 ## Next Steps
 
-* [Organizations]({{< relref "organizations" >}})
+* [Organizations]({{< relref "/docs/intro/console/accounts-and-organizations/organizations" >}})

--- a/content/docs/intro/console/accounts-and-organizations/organizations.md
+++ b/content/docs/intro/console/accounts-and-organizations/organizations.md
@@ -17,10 +17,10 @@ with other developers.
 If you're an admin of a Pulumi organization, you have the
 ability to:
 
-* [Add users]({{< relref "../collaboration/organization-roles/#organization-membership" >}})
+* [Invite users]({{< relref "/docs/intro/console/collaboration/organization-roles#organization-membership" >}})
 * Manage default stack permissions for the organization
-* Create [teams]({{< relref "../collaboration/teams" >}}) and manage their permissions
-* Assign [organization roles]({{< relref "../collaboration/organization-roles" >}}) for role-based access control (RBAC)
+* Create [teams]({{< relref "/docs/intro/console/collaboration/teams" >}}) and manage their permissions
+* Assign [organization roles]({{< relref "/docs/intro/console/collaboration/organization-roles" >}}) for role-based access control (RBAC)
 to your organization's stacks
 
 ## Creating a New Organization
@@ -50,8 +50,8 @@ Similarly, as soon as someone loses access to the GitHub organization, they will
 longer have access to the Pulumi organization it is backing.
 
 {{% notes %}}
-See [Organization Roles]({{< relref "organization-roles" >}}) or
-[Adding New Identities]({{< relref "accounts#adding-new-identities" >}})
+See [Organization Roles]({{< relref "/docs/intro/console/collaboration/organization-roles" >}}) or
+[Adding New Identities]({{< relref "/docs/intro/console/accounts-and-organizations/accounts#adding-new-identities" >}})
 for more information.
 {{% /notes %}}
 
@@ -141,7 +141,7 @@ and Settings tabs.
 
 | Console Tab | Description |
 |--------|--------|
-| Stacks | A searchable list of organization stacks that you can group by project and tag. See [Project and Stack Management]({{< relref "../collaboration/project-and-stack-management">}}) to learn more. |
+| Stacks | A searchable list of organization stacks that you can group by project and tag. See [Project and Stack Management]({{< relref "/docs/intro/console/collaboration/project-and-stack-management">}}) to learn more. |
 | People | A list of active members of the Pulumi organization. |
 | Teams | A [Team Pro]({{< relref "/pricing" >}}) feature that provides a way to assign stack permissions to groups of organization members. |
 | Webhooks | A [Team Pro]({{< relref "/pricing" >}}) feature that allows external services to be notified about events happening on an organization, including events occurring on organization stacks. |
@@ -149,4 +149,4 @@ and Settings tabs.
 
 ## Next Steps
 
-* [Organization Roles]({{< relref "../collaboration/organization-roles" >}})
+* [Organization Roles]({{< relref "/docs/intro/console/collaboration/organization-roles" >}})

--- a/content/docs/intro/console/collaboration/organization-roles.md
+++ b/content/docs/intro/console/collaboration/organization-roles.md
@@ -13,8 +13,8 @@ organization.
 > This only applies to newer organizations on the per-member subscription plan.
 > Organizations billed per stack have slightly different rules regarding membership.
 
-To become a member of a Pulumi organization, you must be added by an existing Pulumi
-organization administrator. However, depending on the [organization type]({{< relref "organizations#organization-kind" >}}), you must also be a member of the third-party organization or group backing the Pulumi
+To become a member of a Pulumi organization, you must be invited by an existing Pulumi
+organization administrator, or you must submit a request to the administrator for approval. In addition, depending on the [organization type]({{< relref "organizations#organization-kind" >}}), you must also be a member of the third-party organization or group backing the Pulumi
 organization.
 
 For example, to become a member of a Pulumi organization backed by a GitLab Group,


### PR DESCRIPTION
This is a small update to reflect the new invite/request flow rather than admins manually adding other users by Pulumi username.  I will wait to merge until after the features are released in the Console.

