### PR TITLE
Fix some broken links

### DIFF
--- a/content/blog/data-science-on-demand-spinning-up-a-wallaroo-cluster-is-easy-with-pulumi/index.md
+++ b/content/blog/data-science-on-demand-spinning-up-a-wallaroo-cluster-is-easy-with-pulumi/index.md
@@ -9,12 +9,9 @@ tags: ["Infrastructure","Customer"]
 ---
 
 *This guest post is from Simon Zelazny of
-[Wallaroo Labs](https://www.wallaroolabs.com/), and previously appeared on the
-[Wallaroo Labs blog](https://blog.wallaroolabs.com/).
+[Wallaroo Labs](https://www.wallaroo.ai/).
 Find out how Wallaroo powered their cluster provisioning with Pulumi,
 for data science on demand.*
-
-## Oh no, more data!
 
 Last month, we took a
 [long-running pandas classifier](https://github.com/WallarooLabs/wallaroo_blog_examples/tree/master/provisioned-classifier/classifier)

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -259,6 +259,7 @@ function getDefaultExcludedKeywords() {
         "https://gitlab.com/profile/applications",
         "https://blog.coinbase.com/",
         "https://www.netfilter.org/",
+        "https://codepen.io",
     ];
 }
 


### PR DESCRIPTION
Couple of broken-link fixes:

* Codepen's fine, it just doesn't respond OK to regular GET requests anymore, so this addds an exception for it.

* Wallaroo's www host doesn't appears to be gone, but wallaroo.ai is still there, so this changes our link to point to that URL instead, removes a bit about the post also appearing on the Wallaroo blog -- Wallaroo appears to have two blogs now, but this post doesn't appear on either of them -- and removes a not-so-valuable heading that was causing the post to render as though it were two posts in the listing: 

![image](https://user-images.githubusercontent.com/274700/101675592-dc9a8780-3a0e-11eb-938f-57a9b22fb68f.png)
