### PR TITLE
Updated crosswalk awsx example.

### DIFF
--- a/content/docs/guides/crosswalk/aws/vpc.md
+++ b/content/docs/guides/crosswalk/aws/vpc.md
@@ -411,7 +411,7 @@ import * as awsx from "@pulumi/awsx";
 const vpc = new awsx.ec2.Vpc("custom", { /*...*/ });
 
 // Allocate a security group and then a series of rules:
-const sg = new awsx.ec2.SecurityGroup("sg", { vpc });
+const sg = new awsx.ec2.SecurityGroup("webserver-sg", { vpc });
 
 // 1) inbound SSH traffic on port 22 from a specific IP address
 sg.createIngressRule("ssh-access", {

--- a/content/docs/guides/crosswalk/aws/vpc.md
+++ b/content/docs/guides/crosswalk/aws/vpc.md
@@ -475,6 +475,8 @@ For additional details about configuring security group rules, See the
 [Security Groups for Your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) documentation.
 
 ## How to use your VPC, Security Group, and EC2 instance
+This example shows how to deploy an EC2 instance using a VPC and Security Group provisioned with the Crosswalk AWS component:
+
 
 ```typescript
 import * as awsx from "@pulumi/awsx";
@@ -508,7 +510,9 @@ const server = new aws.ec2.Instance("webserver-www", {
 });
 ```
 
-This example launches an ec2 instance in the vpc and security group that was created above.
+If we run `pulumi up`, the `aws.ec2.Instance` will be provisioned using the _first_ public subnet from the `awsx.ec2.Vpc` component and the security group provisioned with the `awsx.ec2.SecurityGroup` component:
+
+
 
 ```bash
 $ pulumi up

--- a/content/docs/guides/crosswalk/aws/vpc.md
+++ b/content/docs/guides/crosswalk/aws/vpc.md
@@ -119,7 +119,7 @@ The following code creates a new VPC using all default settings:
 import * as awsx from "@pulumi/awsx";
 
 // Allocate a new VPC with the default settings:
-const vpc = new awsx.ec2.Vpc("custom");
+const vpc = new awsx.ec2.Vpc("custom", {});
 
 // Export a few resulting fields to make them easy to use:
 export const vpcId = vpc.id;

--- a/content/docs/guides/crosswalk/aws/vpc.md
+++ b/content/docs/guides/crosswalk/aws/vpc.md
@@ -475,8 +475,8 @@ For additional details about configuring security group rules, See the
 [Security Groups for Your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) documentation.
 
 ## How to use your VPC, Security Group, and EC2 instance
-This example shows how to deploy an EC2 instance using a VPC and Security Group provisioned with the Crosswalk AWS component:
 
+This example shows how to deploy an EC2 instance using a VPC and Security Group provisioned with the Crosswalk AWS component:
 
 ```typescript
 import * as awsx from "@pulumi/awsx";
@@ -511,8 +511,6 @@ const server = new aws.ec2.Instance("webserver-www", {
 ```
 
 If we run `pulumi up`, the `aws.ec2.Instance` will be provisioned using the _first_ public subnet from the `awsx.ec2.Vpc` component and the security group provisioned with the `awsx.ec2.SecurityGroup` component:
-
-
 
 ```bash
 $ pulumi up

--- a/content/docs/guides/crosswalk/aws/vpc.md
+++ b/content/docs/guides/crosswalk/aws/vpc.md
@@ -507,46 +507,47 @@ const server = new aws.ec2.Instance("webserver-www", {
     ami: ami.id,
 });
 ```
+
 This example launches an ec2 instance in the vpc and security group that was created above.
+
 ```bash
 $ pulumi up
 Updating (dev):
-     Type                                    Name                    Status      
- +   pulumi:pulumi:Stack                     crosswalk-dev           created     
- +   ├─ awsx:x:ec2:SecurityGroup             webserver-sg            created     
- +   │  └─ aws:ec2:SecurityGroup             webserver-sg            created     
- +   ├─ awsx:x:ec2:Vpc                       custom                  created     
- +   │  ├─ awsx:x:ec2:Subnet                 custom-public-1         created     
- +   │  │  ├─ aws:ec2:RouteTable             custom-public-1         created     
- +   │  │  ├─ aws:ec2:Subnet                 custom-public-1         created     
- +   │  │  ├─ aws:ec2:RouteTableAssociation  custom-public-1         created     
- +   │  │  └─ aws:ec2:Route                  custom-public-1-ig      created     
- +   │  ├─ awsx:x:ec2:NatGateway             custom-1                created     
- +   │  │  ├─ aws:ec2:Eip                    custom-1                created     
- +   │  │  └─ aws:ec2:NatGateway             custom-1                created     
- +   │  ├─ awsx:x:ec2:Subnet                 custom-private-0        created     
- +   │  │  ├─ aws:ec2:RouteTable             custom-private-0        created     
- +   │  │  ├─ aws:ec2:Subnet                 custom-private-0        created     
- +   │  │  ├─ aws:ec2:RouteTableAssociation  custom-private-0        created     
- +   │  │  └─ aws:ec2:Route                  custom-private-0-nat-0  created     
- +   │  ├─ awsx:x:ec2:Subnet                 custom-private-1        created     
- +   │  │  ├─ aws:ec2:RouteTable             custom-private-1        created     
- +   │  │  ├─ aws:ec2:Subnet                 custom-private-1        created     
- +   │  │  ├─ aws:ec2:RouteTableAssociation  custom-private-1        created     
- +   │  │  └─ aws:ec2:Route                  custom-private-1-nat-1  created     
- +   │  ├─ awsx:x:ec2:Subnet                 custom-public-0         created     
- +   │  │  ├─ aws:ec2:RouteTable             custom-public-0         created     
- +   │  │  ├─ aws:ec2:Subnet                 custom-public-0         created     
- +   │  │  ├─ aws:ec2:RouteTableAssociation  custom-public-0         created     
- +   │  │  └─ aws:ec2:Route                  custom-public-0-ig      created     
- +   │  ├─ awsx:x:ec2:NatGateway             custom-0                created     
- +   │  │  ├─ aws:ec2:Eip                    custom-0                created     
- +   │  │  └─ aws:ec2:NatGateway             custom-0                created     
- +   │  ├─ awsx:x:ec2:InternetGateway        custom                  created     
- +   │  │  └─ aws:ec2:InternetGateway        custom                  created     
- +   │  └─ aws:ec2:Vpc                       custom                  created     
- +   └─ aws:ec2:Instance                     webserver-www           created     
- 
+     Type                                    Name                    Status  
+ +   pulumi:pulumi:Stack                     crosswalk-dev           created
+ +   ├─ awsx:x:ec2:SecurityGroup             webserver-sg            created
+ +   │  └─ aws:ec2:SecurityGroup             webserver-sg            created
+ +   ├─ awsx:x:ec2:Vpc                       custom                  created
+ +   │  ├─ awsx:x:ec2:Subnet                 custom-public-1         created
+ +   │  │  ├─ aws:ec2:RouteTable             custom-public-1         created
+ +   │  │  ├─ aws:ec2:Subnet                 custom-public-1         created
+ +   │  │  ├─ aws:ec2:RouteTableAssociation  custom-public-1         created
+ +   │  │  └─ aws:ec2:Route                  custom-public-1-ig      created
+ +   │  ├─ awsx:x:ec2:NatGateway             custom-1                created
+ +   │  │  ├─ aws:ec2:Eip                    custom-1                created
+ +   │  │  └─ aws:ec2:NatGateway             custom-1                created
+ +   │  ├─ awsx:x:ec2:Subnet                 custom-private-0        created
+ +   │  │  ├─ aws:ec2:RouteTable             custom-private-0        created
+ +   │  │  ├─ aws:ec2:Subnet                 custom-private-0        created
+ +   │  │  ├─ aws:ec2:RouteTableAssociation  custom-private-0        created
+ +   │  │  └─ aws:ec2:Route                  custom-private-0-nat-0  created
+ +   │  ├─ awsx:x:ec2:Subnet                 custom-private-1        created
+ +   │  │  ├─ aws:ec2:RouteTable             custom-private-1        created
+ +   │  │  ├─ aws:ec2:Subnet                 custom-private-1        created
+ +   │  │  ├─ aws:ec2:RouteTableAssociation  custom-private-1        created
+ +   │  │  └─ aws:ec2:Route                  custom-private-1-nat-1  created
+ +   │  ├─ awsx:x:ec2:Subnet                 custom-public-0         created
+ +   │  │  ├─ aws:ec2:RouteTable             custom-public-0         created
+ +   │  │  ├─ aws:ec2:Subnet                 custom-public-0         created
+ +   │  │  ├─ aws:ec2:RouteTableAssociation  custom-public-0         created
+ +   │  │  └─ aws:ec2:Route                  custom-public-0-ig      created
+ +   │  ├─ awsx:x:ec2:NatGateway             custom-0                created
+ +   │  │  ├─ aws:ec2:Eip                    custom-0                created
+ +   │  │  └─ aws:ec2:NatGateway             custom-0                created
+ +   │  ├─ awsx:x:ec2:InternetGateway        custom                  created
+ +   │  │  └─ aws:ec2:InternetGateway        custom                  created
+ +   │  └─ aws:ec2:Vpc                       custom                  created
+ +   └─ aws:ec2:Instance                     webserver-www           created
 Resources:
     + 34 created
 ```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

1. Fixed aws vpc crosswalk arguments
2. Fixed the security group name, since (sg-) does not work as per amazon.
3. Added a section of How to use vpc, security group, and ec2 instance


### Related issues (optional)
 Fix for [4765](https://github.com/pulumi/docs/issues/4765)
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
