### PR TITLE
Updating Google Cloud GS tutorial to align with AWS tutorial

### DIFF
--- a/content/docs/get-started/gcp/_index.md
+++ b/content/docs/get-started/gcp/_index.md
@@ -13,6 +13,6 @@ aliases: ["/docs/quickstart/gcp/"]
 
 {{< cloud-intro "Google Cloud" >}}
 
-To get started we will walk through installing Pulumi, installing your preferred language runtime (if needed), and configuring Pulumi with Google Cloud. Click the button below to get started.
+To get started, we will walk through installing Pulumi, installing your preferred language runtime (if needed), and configuring Pulumi with Google Cloud. Click the button below to get started.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/_index.md
+++ b/content/docs/get-started/gcp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Get Started with Google Cloud
-meta_desc: This page provides an overview and guide on how to get started with Google Cloud (GCP).
+meta_desc: This page provides an overview and guide on how to get started with Google Cloud.
 linktitle: Google Cloud
 weight: 1
 menu:
@@ -13,6 +13,6 @@ aliases: ["/docs/quickstart/gcp/"]
 
 {{< cloud-intro "Google Cloud" >}}
 
-To get started we will walk through installing Pulumi, installing your preferred language runtime (if needed), and setting up the GCP CLI. Click the button below to get started.
+To get started we will walk through installing Pulumi, installing your preferred language runtime (if needed), and configuring Pulumi with Google Cloud. Click the button below to get started.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/begin.md
+++ b/content/docs/get-started/gcp/begin.md
@@ -2,7 +2,7 @@
 title: Before You Begin | GCP
 h1: Before You Begin
 linktitle: Before You Begin
-meta_desc: This page provides an overview on how to get started with Pulumi when starting an Google Cloud project.
+meta_desc: This page provides an overview on how to get started with Pulumi and Google Cloud.
 weight: 2
 menu:
   getstarted:
@@ -58,11 +58,11 @@ Finally, configure Pulumi with Google Cloud.
 
 ### Configure Pulumi to access your Google Cloud account
 
-Pulumi requires cloud credentials to manage and provision resources. You must use an IAM user or service account that has **Programmatic access** with rights to deploy and manage resources handled through Pulumi. 
+Pulumi requires cloud credentials to manage and provision resources. You must use an IAM user or service account that has **Programmatic access** with rights to deploy and manage your Google Cloud resources.
 
 In this guide, you will need an IAM user account with permissions that can create and populate a Cloud Storage bucket, such as those in the predefined Storage Admin (`roles/storage.admin`) or the Storage Legacy Bucket Owner (`roles/storage.legacyBucketOwner`) roles.
 
-When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install) and login with the `gcloud` CLI tool as shown below.
+When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install) and log in with the `gcloud` CLI tool as shown below.
 
 {{< chooser os "linux,macos,windows" >}}
 {{% choosable os linux %}}

--- a/content/docs/get-started/gcp/begin.md
+++ b/content/docs/get-started/gcp/begin.md
@@ -62,39 +62,9 @@ Pulumi requires cloud credentials to manage and provision resources. You must us
 
 In this guide, you will need an IAM user account with permissions that can create and populate a Cloud Storage bucket, such as those in the predefined Storage Admin (`roles/storage.admin`) or the Storage Legacy Bucket Owner (`roles/storage.legacyBucketOwner`) roles.
 
-When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install) and log in with the `gcloud` CLI tool as shown below.
+{{% configure-gcp %}}
 
-{{< chooser os "linux,macos,windows" >}}
-{{% choosable os linux %}}
-
-```bash
-$ gcloud auth login
-$ gcloud config set project <YOUR_GCP_PROJECT_HERE>
-$ gcloud auth application-default login
-```
-
-{{% /choosable %}}
-{{% choosable os macos %}}
-
-```bash
-$ gcloud auth login
-$ gcloud config set project <YOUR_GCP_PROJECT_HERE>
-$ gcloud auth application-default login
-```
-
-{{% /choosable %}}
-{{% choosable os windows %}}
-
-```bat
-> gcloud auth login
-> gcloud config set project <YOUR_GCP_PROJECT_HERE>
-> gcloud auth application-default login
-```
-
-{{% /choosable %}}
-{{< /chooser >}}
-
-For additional information on how to setup Pulumi to work with Google Cloud, see [Google Cloud Setup]({{< relref "/docs/intro/cloud-providers/gcp/setup" >}}).
+For additional information on setting and using Google Cloud credentials, see [Google Cloud Setup]({{< relref "/docs/intro/cloud-providers/gcp/setup" >}}).
 
 Next, you'll create a new project.
 

--- a/content/docs/get-started/gcp/begin.md
+++ b/content/docs/get-started/gcp/begin.md
@@ -2,7 +2,7 @@
 title: Before You Begin | GCP
 h1: Before You Begin
 linktitle: Before You Begin
-meta_desc: This page provides an overview on how to get started with Pulumi when starting an GCP project.
+meta_desc: This page provides an overview on how to get started with Pulumi when starting an Google Cloud project.
 weight: 2
 menu:
   getstarted:
@@ -20,7 +20,7 @@ aliases: [
 ]
 ---
 
-Before we get started using Pulumi, let's run through a few quick steps to ensure our environment is setup correctly.
+Before you get started using Pulumi, let's run through a few quick steps to ensure your environment is setup correctly.
 
 ### Install Pulumi
 
@@ -30,7 +30,7 @@ All Windows examples in this tutorial assume you are running in PowerShell.
 {{% /notes %}}
 {{< /install-pulumi >}}
 
-Next, we'll install the required language runtime.
+Next, install the required language runtime, if you have not already.
 
 ### Install Language Runtime
 
@@ -54,14 +54,18 @@ Next, we'll install the required language runtime.
 {{< install-dotnet >}}
 {{% /choosable %}}
 
-Next, we'll configure GCP.
+Finally, configure Pulumi with Google Cloud.
 
-### Configure GCP
+### Configure Pulumi to access your Google Cloud account
 
-The [Pulumi Google Cloud Platform Provider]({{< relref "/docs/intro/cloud-providers/gcp" >}}) needs to be configured with Google credentials
-before it can be used to create resources.
+Pulumi requires cloud credentials to manage and provision resources. You must use an IAM user or service account that has **Programmatic access** with rights to deploy and manage resources handled through Pulumi. 
 
-When developing locally, we recommend that you use `gcloud login` to configure your account credentials. First, install the [Google Cloud SDK](https://cloud.google.com/sdk/install), which includes the `gcloud` command line tool. Then, execute the following:
+In this guide, you will need an IAM user account with permissions that can create and populate a Cloud Storage bucket, such as those in the predefined Storage Admin (`roles/storage.admin`) or the Storage Legacy Bucket Owner (`roles/storage.legacyBucketOwner`) roles.
+
+When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install) and login with the `gcloud` CLI tool as shown below.
+
+{{< chooser os "linux,macos,windows" >}}
+{{% choosable os linux %}}
 
 ```bash
 $ gcloud auth login
@@ -69,8 +73,29 @@ $ gcloud config set project <YOUR_GCP_PROJECT_HERE>
 $ gcloud auth application-default login
 ```
 
-For more detailed setup information, please refer to our <a href="{{< relref "/docs/intro/cloud-providers/gcp/setup" >}}" target="_blank">GCP provider setup guide</a>
+{{% /choosable %}}
+{{% choosable os macos %}}
 
-Next, we'll create a new project.
+```bash
+$ gcloud auth login
+$ gcloud config set project <YOUR_GCP_PROJECT_HERE>
+$ gcloud auth application-default login
+```
+
+{{% /choosable %}}
+{{% choosable os windows %}}
+
+```bat
+> gcloud auth login
+> gcloud config set project <YOUR_GCP_PROJECT_HERE>
+> gcloud auth application-default login
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+
+For additional information on how to setup Pulumi to work with Google Cloud, see [Google Cloud Setup]({{< relref "/docs/intro/cloud-providers/gcp/setup" >}}).
+
+Next, you'll create a new project.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/create-project.md
+++ b/content/docs/get-started/gcp/create-project.md
@@ -2,7 +2,7 @@
 title: Create a New Project | GCP
 h1: Create a New Project
 linktitle: Create a New Project
-meta_desc: This page provides an overview of how to create a new Google Cloud (GCP) + Pulumi project.
+meta_desc: This page provides an overview of how to create a new Google Cloud + Pulumi project.
 weight: 3
 menu:
   getstarted:
@@ -12,7 +12,17 @@ menu:
 aliases: ["/docs/quickstart/gcp/create-project/"]
 ---
 
-Let's get started with a new project in a new directory.
+Now that you have set up your environment by installing Pulumi, installing your preferred language runtime, and configuring your Google Cloud credentials, let's get started with creating your first Pulumi program.
+
+In this guide you will:
+
+- Create a new Pulumi project.
+- Provision a new Google Cloud Storage bucket.
+- Add an `index.html` file to your bucket.
+- Serve the `index.html` as a static website.
+- Destroy the resources you've provisioned.
+
+To get started, first create a new directory and project.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
@@ -58,38 +68,19 @@ $ pulumi new gcp-csharp
 
 {{% /choosable %}}
 
+The [`pulumi new`]({{< relref "/docs/reference/cli/pulumi_new" >}}) command creates a new Pulumi project with some basic scaffolding based on the cloud and language specified.
+
 {{< cli-note >}}
 
 After logging in, the CLI will proceed with walking you through creating a new project.
 
-```
-This command will walk you through creating a new Pulumi project.
-
-Enter a value or leave blank to accept the (default), and press <ENTER>.
-Press ^C at any time to quit.
-
-project name: (quickstart)
-project description: (A minimal Google Cloud Pulumi program)
-Created project 'quickstart'
-
-stack name: (dev)
-Created stack 'dev'
-
-gcp:project: The Google Cloud project to deploy into:
-Saved config
-```
-
 First, you will be asked for a project name and description. Hit `ENTER` to accept the default values or specify new values.
 
-Next, you will be asked for the name of a stack. You can hit `ENTER` to accept the default value of `dev`.
+Next, you will be asked for the name of a stack. Hit `ENTER` to accept the default value of `dev`.
+
+Finally, you will be prompted for some configuration values for the stack. For Google Cloud projects, you will be prompted for the Google Cloud region. You can accept the default value or choose another value like `us-west1`.
 
 > What are [projects]({{< relref "/docs/intro/concepts/project" >}}) and [stacks]({{< relref "/docs/intro/concepts/stack" >}})? Pulumi projects and stacks let you organize Pulumi code. Consider a Pulumi _project_ to be analogous to a GitHub repo---a single place for code---and a _stack_ to be an instance of that code with a separate configuration. For instance, _Project Foo_ may have multiple stacks for different development environments (Dev, Test, or Prod), or perhaps for different cloud configurations (geographic region for example). See [Organizing Projects and Stacks]({{< relref "/docs/intro/concepts/organizing-stacks-projects" >}}) for some best practices on organizing your Pulumi projects and stacks.
-
-After logging in, the CLI will proceed with walking you through creating a new project.
-
-Next, you will be prompted for some configuration values for the stack.
-
-For GCP projects you will be prompted for the Google Cloud project to deploy into.
 
 {{% choosable language "javascript,typescript" %}}
 After some dependency installations from `npm`, the project and stack will be ready.

--- a/content/docs/get-started/gcp/deploy-changes.md
+++ b/content/docs/get-started/gcp/deploy-changes.md
@@ -2,7 +2,7 @@
 title: Deploy the Changes | GCP
 h1: Deploy the Changes
 linktitle: Deploy the Changes
-meta_desc: This page provides an overview of how deploy changes to a Google Cloud (GCP) project.
+meta_desc: This page provides an overview of how deploy changes to a Google Cloud project.
 weight: 7
 menu:
   getstarted:
@@ -12,55 +12,441 @@ menu:
 aliases: ["/docs/quickstart/gcp/deploy-changes/"]
 ---
 
-Now let's deploy our changes.
+Now let's deploy your changes.
 
 ```bash
 $ pulumi up
 ```
 
-Pulumi computes the minimally disruptive change to achieve the desired state described by the program.
+First, Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
-$ pulumi up
 Previewing update (dev):
-     Type                   Name               Plan       Info
-     pulumi:pulumi:Stack    quickstart-dev
- ~   └─ gcp:storage:Bucket  my-bucket          update     [diff: ~labels]
 
-Outputs:
-  ~ bucketName: "gs://my-bucket-d8d30a1" => output<string>
+     Type                         Name                   Plan
+     pulumi:pulumi:Stack          quickstart-dev
+ +   └─ gcp:storage:BucketObject  index.html             create
+
 
 Resources:
-    ~ 1 to update
-    1 unchanged
+    + 1 to create
+    2 unchanged
 
-Do you want to perform this update?  [Use arrows to move, enter to select, type to filter]
-  yes
-> no
+Do you want to perform this update?
+> yes
+  no
   details
 ```
 
-Pulumi will create two new resources, and then update the previously created bucket with the new encryption settings we defined.
-
-Choosing `yes` will proceed with the update.
+Choosing `yes` will proceed with the update and upload your `index.html` file to your bucket.
 
 ```
 Do you want to perform this update? yes
 Updating (dev):
-     Type                   Name               Status      Info
-     pulumi:pulumi:Stack    quickstart-dev
- ~   └─ gcp:storage:Bucket  my-bucket          updated     [diff: ~labels]
+
+     Type                         Name                   Status
+     pulumi:pulumi:Stack          quickstart-dev
+ +   └─ gcp:storage:BucketObject  index.html             created
+
 
 Outputs:
-    bucketName: "gs://my-bucket-d8d30a1"
+    bucketName: "gs://my-bucket-11a9046"
 
 Resources:
-    ~ 1 updated
-    1 unchanged
+    + 1 created
+    2 unchanged
 
-Duration: 4s
+Duration: 3s
 ```
 
-Next, we'll destroy the stack.
+Once the update has completed, you can verify the object was created in your bucket by checking the Google Cloud Console or by running the following `gsutil` command:
+
+{{< chooser language "javascript,typescript,python,go,csharp" >}}
+
+{{% choosable language javascript %}}
+
+```bash
+$ gsutil ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```bash
+$ gsutil ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ gsutil ls $(pulumi stack output bucket_name)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ gsutil ls $(pulumi stack output bucketName)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ gsutil ls $(pulumi stack output BucketName)
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+
+Notice that your `index.html` file has been added to the bucket:
+
+```bash
+gs://my-bucket-11a9046/index.html-77a5d80
+```
+
+{{% choosable language javascript %}}
+Now that `index.html` is in your bucket, modify the program file to have the bucket serve `index.html` as a static website.
+
+First, set the `website` property on your bucket. And, to align with Google Cloud Storage recommendations, set uniform bucket-level access on the bucket to `true`.
+
+```javascript
+const bucket = new gcp.storage.Bucket("my-bucket", {
+    website: {
+        mainPageSuffix: "index.html"
+    },
+    uniformBucketLevelAccess: true
+});
+```
+
+Next, allow the contents of your bucket to be viewed anonymously over the Internet.
+
+```javascript
+const bucketIAMBinding = new gcp.storage.BucketIAMBinding("my-bucket-IAMBinding", {
+    bucket: bucket.name,
+    role: "roles/storage.objectViewer",
+    members: ["allUsers"]
+});
+```
+
+Also, change the content type of your `index.html` object so that it is served as HTML.
+
+```javascript
+const bucketObject = new gcp.storage.BucketObject("index.html", {
+    bucket: bucket.name,
+    contentType: "text/html",
+    content: fs.readFileSync("site/index.html").toString(),
+});
+```
+
+Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:
+
+```javascript
+exports.bucketEndpoint = pulumi.concat("http://storage.googleapis.com/", bucket.name, "/", bucketObject.name);
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+Now that `index.html` is in your bucket, modify the program file to have the bucket serve `index.html` as a static website.
+
+First, set the `website` property on your bucket. And, to align with Google Cloud Storage recommendations, set uniform bucket-level access on the bucket to `true`.
+
+```typescript
+const bucket = new gcp.storage.Bucket("my-bucket", {
+    website: {
+        mainPageSuffix: "index.html"
+    },
+    uniformBucketLevelAccess: true
+});
+```
+
+Next, allow the contents of your bucket to be viewed anonymously over the Internet.
+
+```typescript
+const bucketIAMBinding = new gcp.storage.BucketIAMBinding("my-bucket-IAMBinding", {
+    bucket: bucket.name,
+    role: "roles/storage.objectViewer",
+    members: ["allUsers"]
+});
+```
+
+Also, change the content type of your `index.html` object so that it is served as HTML.
+
+```typescript
+const bucketObject = new gcp.storage.BucketObject("index.html", {
+    bucket: bucket.name,
+    contentType: "text/html",
+    content: fs.readFileSync("site/index.html").toString(),
+});
+```
+
+Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:
+
+```typescript
+export const bucketEndpoint = pulumi.concat("http://storage.googleapis.com/", bucket.name, "/", bucketObject.name);
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+Now that `index.html` is in your bucket, modify the program file to have the bucket serve `index.html` as a static website.
+
+First, set the `website` property on your bucket. And, to align with Google Cloud Storage recommendations, set uniform bucket-level access on the bucket to `True`.
+
+```python
+bucket = storage.Bucket('my-bucket',
+    website=storage.BucketWebsiteArgs(
+        main_page_suffix='index.html'),
+    uniform_bucket_level_access=True,
+)
+```
+
+Next, allow the contents of your bucket to be viewed anonymously over the Internet.
+
+```python
+bucketIAMBinding = storage.BucketIAMBinding('my-bucket-IAMBinding',
+    bucket=bucket,
+    role="roles/storage.objectViewer",
+    members=["allUsers"]
+)
+```
+
+Also, change the content type of your `index.html` object so that it is served as HTML.
+
+```python
+bucketObject = storage.BucketObject(
+    'index.html',
+    bucket=bucket,
+    content_type='text/html',
+    content=open('site/index.html').read(),
+)
+```
+
+Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:
+
+```python
+pulumi.export('bucket_endpoint', pulumi.Output.concat('http://storage.googleapis.com/', bucket.id, "/", bucketObject.name))
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+Now that `index.html` is in your bucket, modify the program file to have the bucket serve `index.html` as a static website.
+
+First, set the `website` property on your bucket. And, to align with Google Cloud Storage recommendations, set uniform bucket-level access on the bucket to `true`.
+
+```go
+bucket, err := storage.NewBucket(ctx, "my-bucket", &storage.BucketArgs{
+    Website: storage.BucketWebsiteArgs{
+        MainPageSuffix: pulumi.String("index.html"),
+    },
+    UniformBucketLevelAccess: pulumi.Bool(true),
+})
+if err != nil {
+    return err
+}
+```
+
+Next, allow the contents of your bucket to be viewed anonymously over the Internet.
+
+```go
+_, err = storage.NewBucketIAMBinding(ctx, "my-bucket-IAMBinding", &storage.BucketIAMBindingArgs{
+    Bucket: bucket.Name,
+    Role:   pulumi.String("roles/storage.objectViewer"),
+    Members: pulumi.StringArray{
+        pulumi.String("allUsers"),
+    },
+})
+if err != nil {
+    return err
+}
+```
+
+Also, change the content type of your `index.html` object so that it is served as HTML.
+
+```go
+bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketObjectArgs{
+    Bucket:  bucket.Name,
+    Content: pulumi.String(string(htmlContent)),
+})
+if err != nil {
+    return err
+}
+```
+
+Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:
+
+```go
+ctx.Export("bucketEndpoint", pulumi.Sprintf("http://storage.googleapis.com/%s/%s", bucket.Name, bucketObject.Name))
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+Now that `index.html` is in your bucket, modify the program file to have the bucket serve `index.html` as a static website.
+
+First, set the `website` property on your bucket. And, to align with Google Cloud Storage recommendations, set uniform bucket-level access on the bucket to `true`.
+
+```csharp
+// Add this import
+using Pulumi.Gcp.Storage.Inputs;
+```
+
+```csharp
+var bucket = new Bucket("my-bucket", new BucketArgs
+{
+    Website = new BucketWebsiteArgs
+    {
+        MainPageSuffix = "index.html"
+    },
+    UniformBucketLevelAccess = true
+});
+```
+
+Next, allow the contents of your bucket to be viewed anonymously over the Internet.
+
+```csharp
+var bucketIAMBinding = new BucketIAMBinding("my-bucket-IAMBinding", new BucketIAMBindingArgs
+{
+    Bucket = bucket.Name,
+    Role = "roles/storage.objectViewer",
+    Members = "allUsers"
+});
+```
+
+Also, change the content type of your `index.html` object so that it is served as HTML.
+
+```csharp
+var bucketObject = new BucketObject("index.html", new BucketObjectArgs
+{
+    Bucket = bucket.Name,
+    ContentType = "text/html",
+    Content = htmlString,
+});
+```
+
+Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:
+
+```csharp
+this.BucketEndpoint = Output.Format($"http://storage.googleapis.com/{bucket.Name}/{bucketObject.Name}");
+```
+
+```csharp
+[Output] public Output<string> BucketEndpoint { get; set; }
+```
+
+{{% /choosable %}}
+
+Now update your stack to have your storage bucket serve your `index.html` file as a static website.
+
+```bash
+$ pulumi up
+```
+
+First, you will see a preview of your changes:
+
+```
+Previewing update (dev):
+
+     Type                    Name            Plan       Info
+     pulumi:pulumi:Stack              quickstart-dev
+ ~   ├─ gcp:storage:Bucket            my-bucket              update     [diff: +website]
+ +   └─ gcp:storage:BucketIAMBinding  my-bucket-IAMBinding   create
+
+Outputs:
+  + BucketEndpoint: "http://storage.googleapis.com/my-bucket-0167228/index.html-50b2ce9"
+
+Resources:
+    ~ 2 to update
+    1 unchanged
+
+Do you want to perform this update?
+> yes
+  no
+  details
+```
+
+Select `yes` to deploy both changes:
+
+```
+Do you want to perform this update? yes
+Updating (dev):
+
+     Type                     Name            Status      Info
+    pulumi:pulumi:Stack              quickstart-dev
+ ~   ├─ gcp:storage:Bucket            my-bucket              updated     [diff: +website]
+ +   └─ gcp:storage:BucketIAMBinding  my-bucket-IAMBinding   created
+
+Outputs:
+  + BucketEndpoint: "http://storage.googleapis.com/my-bucket-0167228/index.html-50b2ce9"
+    BucketName    : "gs://my-bucket-0167228"
+
+Resources:
+    + 1 created
+    ~ 1 updated
+    2 changes. 2 unchanged
+
+Duration: 8s
+```
+
+Finally, you can check out your new static website at the URL in the `Outputs` section of your update or you can make a `curl` request and see the contents of your `index.html` object printed out in your terminal.
+
+{{% choosable language javascript %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ curl $(pulumi stack output bucket_endpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ curl $(pulumi stack output BucketEndpoint)
+```
+
+{{% /choosable %}}
+
+And you should see:
+
+```bash
+<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>
+```
+
+Next you will destroy the resources.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/deploy-stack.md
+++ b/content/docs/get-started/gcp/deploy-stack.md
@@ -2,7 +2,7 @@
 title: Deploy the Stack | GCP
 h1: Deploy the Stack
 linktitle: Deploy the Stack
-meta_desc: This page provides an overview of how to deploy a Google Cloud (GCP) project as a Pulumi Stack.
+meta_desc: This page provides an overview of how to deploy changes to a Google Cloud project.
 weight: 5
 menu:
   getstarted:
@@ -12,20 +12,19 @@ menu:
 aliases: ["/docs/quickstart/gcp/deploy-stack/"]
 ---
 
-Let's go ahead and deploy the stack:
+Let's go ahead and deploy your stack:
 
 ```bash
 $ pulumi up
 ```
 
-This command instructs Pulumi to determine the resources needed to create the stack. First, a preview is shown of the changes that will be made:
+This command evaluates your program and determines the resource updates to make. First, a preview is shown that outlines the changes that will be made when you run the update:
 
 ```
-$ pulumi up
 Previewing update (dev):
-     Type                   Name       Plan
+     Type                   Name            Plan
  +   pulumi:pulumi:Stack    quickstart-dev  create
- +   └─ gcp:storage:Bucket  my-bucket  create
+ +   └─ gcp:storage:Bucket  my-bucket       create
 
 Resources:
     + 2 to create
@@ -36,7 +35,7 @@ Do you want to perform this update?  [Use arrows to move, enter to select, type 
   details
 ```
 
-Choosing `yes` will create resources in Google Cloud. This may take a minute or two.
+Once the preview has finished, you are given three options to choose from. Choosing `details` will show you a rich diff of the changes to be made. Choosing `yes` will create your new storage bucket in Google Cloud. Choosing `no` will return you to the user prompt without performing the update operation.
 
 ```
 Do you want to perform this update? yes
@@ -55,10 +54,52 @@ Resources:
 Duration: 3s
 ```
 
-The bucket URL that we exported is shown as a [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}).
+Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:
+
+{{% choosable language javascript %}}
+
+```bash
+$ pulumi stack output bucketName
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```bash
+$ pulumi stack output bucketName
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ pulumi stack output bucket_name
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ pulumi stack output bucketName
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ pulumi stack output BucketName
+```
+
+{{% /choosable %}}
+
+Running that command will print out the name of your bucket.
 
 {{< console-note >}}
 
-Next, we'll make some modifications to the program.
+Now that your bucket has been provisioned, let's modify the bucket to host a static website.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/destroy-stack.md
+++ b/content/docs/get-started/gcp/destroy-stack.md
@@ -20,7 +20,7 @@ To destroy resources, run the following:
 $ pulumi destroy
 ```
 
-You'll be prompted to make sure you really want to delete these resources. This can take a minute or two; Pulumi waits until all resources are shut down and deleted before it considers the destroy operation to be complete.
+You'll be prompted to make sure you really want to delete these resources. This can take a minute or two; Pulumi waits until all resources are shut down and deleted before it considers the destroy operation complete.
 
 ```
 Previewing destroy (dev):

--- a/content/docs/get-started/gcp/destroy-stack.md
+++ b/content/docs/get-started/gcp/destroy-stack.md
@@ -12,7 +12,7 @@ menu:
 aliases: ["/docs/quickstart/gcp/destroy-stack/"]
 ---
 
-Now that we've seen how to deploy changes to our program, let's clean up and tear down the resources that are part of our stack.
+Now that you've seen how to deploy changes to our program, let's clean up and tear down the resources that are part of your stack.
 
 To destroy resources, run the following:
 
@@ -20,38 +20,52 @@ To destroy resources, run the following:
 $ pulumi destroy
 ```
 
-You'll be prompted to make sure you really want to delete these resources.
+You'll be prompted to make sure you really want to delete these resources. This can take a minute or two; Pulumi waits until all resources are shut down and deleted before it considers the destroy operation to be complete.
 
 ```
 Previewing destroy (dev):
-     Type                   Name       Plan
- -   pulumi:pulumi:Stack    quickstart-dev  delete
- -   └─ gcp:storage:Bucket  my-bucket  delete
+
+ -   pulumi:pulumi:Stack              quickstart-dev         delete
+ -   ├─ gcp:storage:BucketIAMBinding  my-bucket-IAMBinding   delete
+ -   ├─ gcp:storage:BucketObject      index.html             delete
+ -   └─ gcp:storage:Bucket            my-bucket              delete
 
 Outputs:
-  - BucketName: "gs://my-bucket-b93323e"
+  - BucketEndpoint: "http://storage.googleapis.com/my-bucket-0167228/index.html-50b2ce9"
+  - BucketName    : "gs://my-bucket-0167228"
 
 Resources:
-    - 2 to delete
+    - 4 to delete
 
 Do you want to perform this destroy? yes
 Destroying (dev):
-     Type                   Name       Status
- -   pulumi:pulumi:Stack    quickstart-dev  deleted
- -   └─ gcp:storage:Bucket  my-bucket  deleted
+
+ -   pulumi:pulumi:Stack              quickstart-dev         deleted
+ -   ├─ gcp:storage:BucketIAMBinding  my-bucket-IAMBinding   deleted
+ -   ├─ gcp:storage:BucketObject      index.html             deleted
+ -   └─ gcp:storage:Bucket            my-bucket              deleted
 
 Outputs:
-  - BucketName: "gs://my-bucket-b93323e"
+  - BucketEndpoint: "http://storage.googleapis.com/my-bucket-0167228/index.html-50b2ce9"
+  - BucketName    : "gs://my-bucket-0167228"
 
 Resources:
-    - 2 deleted
+    - 4 deleted
 
-Duration: 2s
+Duration: 7s
 ```
 
-To delete the stack itself, run [`pulumi stack rm`]({{< relref "/docs/reference/cli/pulumi_stack_rm" >}}).
+> To delete the stack itself, run [`pulumi stack rm`]({{< relref "/docs/reference/cli/pulumi_stack_rm" >}}).
 Note that this removes the stack entirely from the Pulumi Service, along with all of its update history.
 
-Next, we'll look at some next steps.
+Congratulations! You've successfully provisioned some cloud resources using Pulumi. By completing this guide you have successfully:
+
+- Created a Pulumi new project.
+- Provisioned a new storage bucket.
+- Added an `index.html` file to your bucket.
+- Served the `index.html` as a static website.
+- Destroyed the resources you've provisioned.
+
+On the next page, we have a collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -12,119 +12,163 @@ menu:
 aliases: ["/docs/quickstart/gcp/modify-program/"]
 ---
 
-Now that we have an instance of our Pulumi program deployed, let's add some labels to it.
+Now that your storage bucket is provisioned, let's add an object to it. First, create a new directory called `site`.
 
-Replace the entire contents of {{< langfile >}} with the following:
+```bash
+mkdir site
+```
+
+Next, create a new `index.html` file with some content in it.
+
+{{< chooser os "macos,linux,windows" / >}}
+
+{{% choosable os macos %}}
+
+```bash
+cat <<EOT > site/index.html
+<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>
+EOT
+```
+
+{{% /choosable %}}
+
+{{% choosable os linux %}}
+
+```bash
+cat <<EOT > site/index.html
+<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>
+EOT
+```
+
+{{% /choosable %}}
+
+{{% choosable os windows %}}
+
+```batch
+(
+@echo.^<html^>
+@echo.  ^<body^>
+@echo.      ^<h1^>Hello, Pulumi!^</h1^>
+@echo.  ^</body^>
+@echo.^</html^>
+) > site/index.html
+```
+
+{{% /choosable %}}
+
+Now that you have your new `index.html` with some content, open your IDE or text editor and modify your program to add the contents of your `index.html` file to your storage bucket.
+
+To accomplish this, we will take advantage of your chosen programming language's native libraries to read the content of the file and assign it as an input to a new  `BucketObject`.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
 {{% choosable language javascript %}}
 
 ```javascript
-"use strict";
-const pulumi = require("@pulumi/pulumi");
-const gcp = require("@pulumi/gcp");
+const fs = require("fs");
+```
 
-// Create a GCP resource (Storage Bucket)
-const bucket = new gcp.storage.Bucket("my-bucket", {
-    labels: { "environment": "dev" }
+Next you will create a new bucket object on the lines right after creating the bucket itself.
+
+```javascript
+const bucketObject = new gcp.storage.BucketObject("index.html", {
+    bucket: bucket.name,
+    content: fs.readFileSync("site/index.html").toString(),
 });
-
-// Export the DNS name of the bucket
-exports.bucketName = bucket.url;
 ```
 
 {{% /choosable %}}
+
 {{% choosable language typescript %}}
 
 ```typescript
-import * as pulumi from "@pulumi/pulumi";
-import * as gcp from "@pulumi/gcp";
+import * as fs from "fs";
+```
 
-// Create a GCP resource (Storage Bucket)
-const bucket = new gcp.storage.Bucket("my-bucket", {
-    labels: { "environment": "dev" }
+Next you will create a new bucket object on the lines right after creating the bucket itself.
+
+```typescript
+const bucketObject = new gcp.storage.BucketObject("index.html", {
+    bucket: bucket.name,
+    content: fs.readFileSync("site/index.html").toString(),
 });
-
-// Export the DNS name of the bucket
-export const bucketName = bucket.url;
 ```
 
 {{% /choosable %}}
+
 {{% choosable language python %}}
 
+Next you will create a new bucket object on the lines right after creating the bucket itself.
+
 ```python
-import pulumi
-from pulumi_gcp import storage
-
-# Create a GCP resource (Storage Bucket)
-bucket = storage.Bucket('my-bucket',
-    labels={'environment': "dev"})
-
-# Export the DNS name of the bucket
-pulumi.export('bucket_name',  bucket.url)
+bucketObject = storage.BucketObject(
+    'index.html',
+    bucket=bucket,
+    content=open('site/index.html').read(),
+)
 ```
 
 {{% /choosable %}}
+
 {{% choosable language go %}}
 
 ```go
-package main
-
 import (
-    "github.com/pulumi/pulumi-gcp/sdk/v3/go/gcp/storage"
-    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+    "io/ioutil"
+    // Existing imports...
 )
+```
 
-func main() {
-    pulumi.Run(func(ctx *pulumi.Context) error {
-        // Create a GCP resource (Storage Bucket)
-        bucket, err := storage.NewBucket(ctx, "my-bucket", &storage.BucketArgs{
-            Labels: pulumi.StringMap{
-                "environment": pulumi.String("dev"),
-            },
-        })
-        if err != nil {
-            return err
-        }
+Next you will create a new bucket object on the lines right after creating the bucket itself.
 
-        // Export the DNS name of the bucket
-        ctx.Export("bucketName", bucket.Url)
-        return nil
-    })
+```go
+htmlContent, err := ioutil.ReadFile("site/index.html")
+if err != nil {
+    return err
+}
+
+bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketObjectArgs{
+    Bucket:  bucket.Name,
+    Content: pulumi.String(string(htmlContent)),
+})
+if err != nil {
+    return err
 }
 ```
 
 {{% /choosable %}}
+
 {{% choosable language csharp %}}
 
 ```csharp
-using Pulumi;
-using Pulumi.Gcp.Storage;
+using System.IO;
+```
 
-class MyStack : Stack
+Next you will create a new bucket object on the lines right after creating the bucket itself.
+
+```csharp
+var filePath = Path.GetFullPath("./site/index.html");
+var htmlString = File.ReadAllText(filePath);
+
+var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
-    public MyStack()
-    {
-        // Create a GCP resource (Storage Bucket)
-        var bucket = new Bucket("my-bucket", new BucketArgs{
-            Labels =
-            {
-                { "environment", "dev" }
-            }
-        });
-
-        // Export the DNS name of the bucket
-        this.BucketName = bucket.Url;
-    }
-
-    [Output]
-    public Output<string> BucketName { get; set; }
-}
+    Bucket = bucket.Name,
+    Content = htmlString,
+});
 ```
 
 {{% /choosable %}}
 
-Next, we'll deploy the changes.
+Notice how you provide the bucket you created earlier as an input to your new `BucketObject`. This is so Pulumi knows what storage bucket the object should live in.
+
+Next, you'll deploy your changes.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -52,14 +52,14 @@ EOT
 
 {{% choosable os windows %}}
 
-```batch
-(
-@echo.^<html^>
-@echo.  ^<body^>
-@echo.      ^<h1^>Hello, Pulumi!^</h1^>
-@echo.  ^</body^>
-@echo.^</html^>
-) > site/index.html
+```powershell
+@"
+<html>
+  <body>
+    <h1>Hello, Pulumi!</h1>
+  </body>
+</html>
+"@ | Out-File -FilePath site\index.html
 ```
 
 {{% /choosable %}}

--- a/content/docs/get-started/gcp/next-steps.md
+++ b/content/docs/get-started/gcp/next-steps.md
@@ -3,7 +3,7 @@ title: Next Steps | GCP
 h1: Next Steps
 linktitle: Next Steps
 meta_desc: This page provides a list of tutorials that take a deeper dive into
-            GCP cloud resources.
+            Google Cloud cloud resources.
 weight: 9
 menu:
   getstarted:
@@ -13,7 +13,7 @@ menu:
 aliases: ["/docs/quickstart/gcp/next-steps/"]
 ---
 
-We've seen how to quickly get started using Google Cloud with Pulumi.
+You've seen how to quickly get started using Google Cloud with Pulumi.
 
 From here, you can dive deeper with additional Google Cloud examples:
 

--- a/content/docs/get-started/gcp/review-project.md
+++ b/content/docs/get-started/gcp/review-project.md
@@ -2,7 +2,7 @@
 title: Review the New Project | GCP
 h1: Review the New Project
 linktitle: Review the New Project
-meta_desc: This page provides an overview on how to a review a new GCP project.
+meta_desc: This page provides an overview on how to a review a new Google Cloud project.
 weight: 4
 menu:
   getstarted:
@@ -15,7 +15,7 @@ aliases: ["/docs/quickstart/gcp/review-project/"]
 Let's review some of the generated project files:
 
 - `Pulumi.yaml` defines the [project]({{< relref "/docs/intro/concepts/project" >}}).
-- `Pulumi.dev.yaml` contains [configuration]({{< relref "/docs/intro/concepts/config" >}}) values for the [stack]({{< relref "/docs/intro/concepts/stack" >}}) we initialized.
+- `Pulumi.dev.yaml` contains [configuration]({{< relref "/docs/intro/concepts/config" >}}) values for the [stack]({{< relref "/docs/intro/concepts/stack" >}}) you initialized.
 
 {{% choosable language csharp %}}
 
@@ -23,7 +23,7 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-- {{< langfile >}} is the Pulumi program that defines our stack resources. Let's examine it.
+- {{< langfile >}} is the Pulumi program that defines your stack resources. Let's examine it.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
@@ -42,6 +42,7 @@ exports.bucketName = bucket.url;
 ```
 
 {{% /choosable %}}
+
 {{% choosable language typescript %}}
 
 ```typescript
@@ -56,6 +57,7 @@ export const bucketName = bucket.url;
 ```
 
 {{% /choosable %}}
+
 {{% choosable language python %}}
 
 ```python
@@ -70,13 +72,14 @@ pulumi.export('bucket_name',  bucket.url)
 ```
 
 {{% /choosable %}}
+
 {{% choosable language go %}}
 
 ```go
 package main
 
 import (
-    "github.com/pulumi/pulumi-gcp/sdk/v3/go/gcp/storage"
+    "github.com/pulumi/pulumi-gcp/sdk/v4/go/gcp/storage"
     "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
@@ -96,6 +99,7 @@ func main() {
 ```
 
 {{% /choosable %}}
+
 {{% choosable language csharp %}}
 
 ```csharp
@@ -120,8 +124,49 @@ class MyStack : Stack
 
 {{% /choosable %}}
 
-This Pulumi program creates a storage bucket and exports the bucket URL.
+This Pulumi program creates a new storage bucket and exports the DNS name of the bucket.
 
-Next, we'll deploy the stack.
+{{% choosable language javascript %}}
+
+```javascript
+exports.bucketName = bucket.url;
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```typescript
+export const bucketName = bucket.url;
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+pulumi.export('bucket_name',  bucket.url)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+ctx.Export("bucketName", bucket.Url)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+[Output]
+public Output<string> BucketName { get; set; }
+```
+
+{{% /choosable %}}
+
+Next, you'll deploy your stack, which will provision your storage bucket.
 
 {{< get-started-stepper >}}

--- a/content/docs/intro/cloud-providers/gcp/setup.md
+++ b/content/docs/intro/cloud-providers/gcp/setup.md
@@ -10,15 +10,11 @@ aliases: ["/docs/reference/clouds/gcp/setup/"]
 The [Pulumi Google Cloud Platform Provider] needs to be configured with Google credentials
 before it can be used to create resources.
 
-When developing locally, we recommend that you use `gcloud login` to configure your account credentials. First, install the [Google Cloud SDK](https://cloud.google.com/sdk/install), which includes the `gcloud` command line tool. Then, execute the following:
+{{% configure-gcp %}}
 
-```bash
-$ gcloud auth login
-$ gcloud config set project <YOUR_GCP_PROJECT_HERE>
-$ gcloud auth application-default login
-```
-
+{{% notes "info" %}}
 If you are using Pulumi in an non-interactive setting (such as a CI/CD system) you will need to [configure and use a service account]({{< relref "service-account" >}}) instead.
+{{% /notes %}}
 
 ## Optional Settings
 

--- a/layouts/shortcodes/configure-gcp.html
+++ b/layouts/shortcodes/configure-gcp.html
@@ -1,0 +1,14 @@
+When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install)
+and then [authorize access access with a user account](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account). 
+
+If `gcloud` is not configured to interact with your Google Cloud project, set it through the `config` command.
+
+```bash
+gcloud config set project <YOUR_GCP_PROJECT_HERE>
+```
+
+Next, Pulumi requires default application credentials to interact with your Google Cloud resources, so run `auth application-default login` command to obtain those credentials.
+
+```bash
+gcloud auth application-default login
+```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This update changes the goal of the Google Cloud tutorial from adding a label on an storage bucket to creating a static website (like the AWS tutorial does).

FYI: There is a fair amount of content reuse between this update and the AWS tutorial (for consistency between the tutorials). After I update the Azure tutorial in a future PR, I'll look at standardizing the tutorial text through shortcodes.
