### PR TITLE
Exclude Twitter 400s in the link checker

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -260,7 +260,6 @@ function getDefaultExcludedKeywords() {
         "https://blog.coinbase.com/",
         "https://www.netfilter.org/",
         "https://codepen.io",
-        "https://twitter.com/pulumicorp"
     ];
 }
 
@@ -271,6 +270,9 @@ function excludeAcceptable(links) {
         // Ignore GitHub and npm 429s (rate-limited). We should really be handling these more
         // intelligently, but we can come back to that in a follow up.
         .filter(b => !(b.reason === "HTTP_429" && b.destination.match(/github.com|npmjs.com/)))
+
+        // Ignore 400s from Twitter.
+        .filter(b => !(b.reason === "HTTP_400" && b.destination.match(/twitter.com/)))
 
         // Ignore remote disconnects.
         .filter(b => b.reason !== "ERRNO_ECONNRESET")


### PR DESCRIPTION
Looks like Twitter is still experiencing issues with one of their APIs (https://api.twitterstat.us), so this change just ignores all 400s from them.