### PR TITLE
Update trial links to point to new trial url

### DIFF
--- a/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
+++ b/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
@@ -17,7 +17,7 @@ cloud native infrastructure.
 
 Pulumi Webhooks are available for the Team and Enterprise editions of
 Pulumi. If you're keen to try them out, start a trial of
-[Team Edition here](https://app.pulumi.com/site/organizations/add).
+[Team Edition here](https://app.pulumi.com/site/trial).
 <!--more-->
 
 ChatOps --- the idea of conversation-driven collaboration --- is an

--- a/content/docs/guides/continuous-delivery/gitlab-app.md
+++ b/content/docs/guides/continuous-delivery/gitlab-app.md
@@ -14,7 +14,7 @@ posted to the Pulumi Service via [GitLab Webhooks](https://docs.gitlab.com/ee/us
 To enable the integration with your GitLab project, you will need to ensure you have done the following two things:
 
 * [Signup](https://app.pulumi.com/signup) for a Pulumi account with your GitLab identity (or link your GitLab identity with an existing account.)
-* If your GitLab Project is under a GitLab Group, ensure that the group is added to Pulumi as an [organization](https://app.pulumi.com/site/organizations/add)
+* If your GitLab Project is under a GitLab Group, ensure that the group is added to Pulumi as an [organization](https://app.pulumi.com/site/trial)
 
 ## Configuring the GitLab Webhook
 

--- a/content/docs/intro/console/accounts-and-organizations/organizations.md
+++ b/content/docs/intro/console/accounts-and-organizations/organizations.md
@@ -27,7 +27,7 @@ to your organization's stacks
 
 You can create a new Pulumi organization directly from the Pulumi Console.
 
-<a class="btn btn-secondary" href="https://app.pulumi.com/site/organizations/add"
+<a class="btn btn-secondary" href="https://app.pulumi.com/site/trial"
 target="_blank">
     CREATE ORGANIZATION
 </a>

--- a/content/docs/intro/console/extensions/ci-cd-integration-assistant.md
+++ b/content/docs/intro/console/extensions/ci-cd-integration-assistant.md
@@ -4,7 +4,7 @@ meta_desc: An overview of the CI/CD integration assistant in the Pulumi Console.
 ---
 
 > This feature is available on the Pulumi Team Pro and Enterprise editions.
-> If you would like to try this feature, [start a trial](https://app.pulumi.com/site/organizations/add) now
+> If you would like to try this feature, [start a trial](https://app.pulumi.com/site/trial) now
 > or contact us at <a href="mailto:sales@pulumi.com">sales@pulumi.com</a>.
 
 The CI/CD integration assistant helps you integrate Pulumi into CI/CD systems for automatically deploying stacks.

--- a/content/docs/intro/console/extensions/webhooks.md
+++ b/content/docs/intro/console/extensions/webhooks.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 > Pulumi Webhooks is a feature available on the Pulumi Team and Enterprise editions.
-> If you’re keen to try it out, start a [Team Edition trial](https://app.pulumi.com/site/organizations/add) now.
+> If you’re keen to try it out, start a [Team Edition trial](https://app.pulumi.com/site/trial) now.
 
 Pulumi Webhooks allow you to notify external services of events
 happening within your Pulumi organization or stack. For example,

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -106,7 +106,7 @@
                             </ul>
                         </div>
                         <div class="lg:hidden mt-6">
-                            <a href="https://app.pulumi.com/site/organizations/add" class="btn btn-purple px-6 py-3">TRY FOR FREE</a>
+                            <a href="https://app.pulumi.com/site/trial" class="btn btn-purple px-6 py-3">TRY FOR FREE</a>
                         </div>
                     </div>
                     <div class="pricing-plans-item-container mt-12 lg:mt-0">
@@ -157,7 +157,7 @@
                             </ul>
                         </div>
                         <div class="lg:hidden mt-6">
-                            <a class="btn btn-purple px-6 py-3" href="https://app.pulumi.com/site/organizations/add">TRY FOR FREE</a>
+                            <a class="btn btn-purple px-6 py-3" href="https://app.pulumi.com/site/trial">TRY FOR FREE</a>
                         </div>
                     </div>
                     <div class="pricing-plans-item-container mt-12 lg:mt-0">
@@ -202,13 +202,13 @@
                             </ul>
                         </div>
                         <div class="lg:hidden mt-6">
-                            <a class="btn btn-purple px-6 py-3" href="https://app.pulumi.com/site/organizations/add">TRY FOR FREE</a>
+                            <a class="btn btn-purple px-6 py-3" href="https://app.pulumi.com/site/trial">TRY FOR FREE</a>
                         </div>
                     </div>
                 </div>
 
                 <div class="w-full text-center hidden lg:inline-block lg:mt-10 lg:pt-1">
-                    <a href="https://app.pulumi.com/site/organizations/add" class="btn btn-purple px-6 py-3">TRY FOR FREE</a>
+                    <a href="https://app.pulumi.com/site/trial" class="btn btn-purple px-6 py-3">TRY FOR FREE</a>
                 </div>
             </div>
         </div>
@@ -803,15 +803,15 @@
                 </div>
                 <div class="compare-plans-table-row-item">
                     <p class="hidden md:block text-purple-500 font-bold text-lg mt-0">TEAM STARTER</p>
-                    <a class="btn btn-purple-transparent px-6 py-3" href="https://app.pulumi.com/site/organizations/add">TRY FOR FREE</a>
+                    <a class="btn btn-purple-transparent px-6 py-3" href="https://app.pulumi.com/site/trial">TRY FOR FREE</a>
                 </div>
                 <div class="compare-plans-table-row-item hidden md:block">
                     <p class="text-purple-500 font-bold text-lg mt-0">TEAM PRO</p>
-                    <a class="btn btn-purple px-6 py-3" href="https://app.pulumi.com/site/organizations/add">TRY FOR FREE</a>
+                    <a class="btn btn-purple px-6 py-3" href="https://app.pulumi.com/site/trial">TRY FOR FREE</a>
                 </div>
                 <div class="compare-plans-table-row-item hidden md:block">
                     <p class="text-purple-500 font-bold text-lg mt-0">ENTERPRISE</p>
-                    <a class="btn btn-purple-transparent px-6 py-3" href="https://app.pulumi.com/site/organizations/add">TRY FOR FREE</a>
+                    <a class="btn btn-purple-transparent px-6 py-3" href="https://app.pulumi.com/site/trial">TRY FOR FREE</a>
                 </div>
             </div>
         </div>
@@ -845,7 +845,7 @@
                         <p>
                             To get started with a team-based plan, simply <a href="https://app.pulumi.com/signup">
                             sign up for free</a> using your identity provider of choice (ideally the same one your organization will
-                            be backed by). From there, <a href="https://app.pulumi.com/site/organizations/add">
+                            be backed by). From there, <a href="https://app.pulumi.com/site/trial">
                             create an organization</a> that your team members will use.
                         </p>
                         <p>


### PR DESCRIPTION
Recently we updated the landing page for the new trial flow: https://github.com/pulumi/pulumi-service/pull/5703

This PR updates the trial/organization URLs across our marketing pages.