### PR TITLE
Fix import for aws.s3.BucketEvent interface

### DIFF
--- a/content/docs/guides/crosswalk/aws/lambda.md
+++ b/content/docs/guides/crosswalk/aws/lambda.md
@@ -306,7 +306,7 @@ so updates are always based only on what's changed.
 For example, maybe we've defined our callback function in `./app`:
 
 ```typescript
-import * as aws from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
 export async function handleDocument(e: aws.s3.BucketEvent): Promise<void> {
    // your lambda code goes here
 }


### PR DESCRIPTION
For the typescript example that handles an s3 `BucketEvent` the import for the TS interface is being imported from `@pulumi/pulumi` package instead of `@pulumi/aws`. This import is fixed in this PR.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Changed the import statement from `import * as aws from "@pulumi/pulumi";` to `import * as aws from "@pulumi/aws";`
