### PR TITLE
Fix form component support non fieldset HubSpot forms

### DIFF
--- a/assets/js/resources.js
+++ b/assets/js/resources.js
@@ -1,0 +1,36 @@
+/**
+ * sortResourceItems sorts the visible items in the resource list.
+ *
+ * @param {bool} sortDescending Whether the items should be sorted in descending order.
+ */
+function sortResourceItems(sortDescending) {
+    const resourceList = $("ul.resource-list");
+    const items = resourceList.children("li");
+
+    items.detach().sort(function(a,b) {
+        const firstDate = $(a).attr("data-display-date");
+        const secondDate = $(b).attr("data-display-date");
+
+        if (sortDescending) {
+            return new Date(firstDate).getTime() < new Date(secondDate).getTime() ? 1 : -1;
+        }
+        return new Date(firstDate).getTime() > new Date(secondDate).getTime() ? 1 : -1;
+    });
+
+    resourceList.append(items);
+}
+
+$(function() {
+    const pathParts = location.pathname.split("/");
+    if (pathParts.length > 1 && pathParts[1] === "resources") {
+        window.addEventListener("hashchange", function() {
+            const shouldSortDescending = location.hash !== "#upcoming";
+            sortResourceItems(shouldSortDescending);
+        });
+
+        $(document).ready(function() {
+            const shouldSortDescending = location.hash !== "#upcoming";
+            sortResourceItems(shouldSortDescending);
+        });
+    }
+});

--- a/components/src/components/hubspot-form/hubspot-form.tsx
+++ b/components/src/components/hubspot-form/hubspot-form.tsx
@@ -53,8 +53,7 @@ export class HubspotForm {
             // the form which is less then desirable. So we need to find the hidden
             // form fields and then hide the parent <fieldset> for it. We will also need
             // to populate those fields with the correct values.
-
-            waitForElementToExist(`${hsFormTargetId} form fieldset div`).then(() => {
+            waitForElementToExist(`${hsFormTargetId} form div[class="input"]`).then(() => {
                 const fieldSets = document.querySelectorAll(`${hsFormTargetId} form fieldset div[style*="display:none"]`);
                 fieldSets.forEach((fieldset: any) => {
                     fieldset.parentElement.style.display = "none";

--- a/layouts/partials/content-tile.html
+++ b/layouts/partials/content-tile.html
@@ -8,7 +8,7 @@
         {{ $relref = "" }}
         {{ $target = "" }}
 
-        {{ if eq .multiple true }}
+        {{ if isset . "multiple" }}
             {{ $href = .link}}
         {{ end }}
     {{ end }}

--- a/layouts/partials/content-tile.html
+++ b/layouts/partials/content-tile.html
@@ -1,4 +1,4 @@
-<li class="w-full m-0 p-2 md:w-1/2 xl:w-1/3 event-list-item" data-filters="{{ delimit .filters " " }}">
+<li data-display-date="{{ .displayDate }}" class="w-full m-0 p-2 md:w-1/2 xl:w-1/3 event-list-item" data-filters="{{ delimit .filters " " }}">
     {{ $href := .link }}
     {{ $relref := "noopener noreferrer" }}
     {{ $target := "_blank" }}
@@ -13,7 +13,7 @@
         {{ end }}
     {{ end }}
 
-    <article class="rounded shadow-md bg-white border border-gray-200 mb-10 flex flex-col mx-2 md:mx-0">
+    <article class="rounded shadow-md bg-white border border-gray-200 mb-10 flex flex-col mx-2 md:mx-0 content-tile">
         <a href="{{ $href }}" rel="{{ $relref }}" target="{{ $target }}" class="w-full h-full">
             <span class="block w-full h-full p-4 relative">
                 <span class="block flex border-solid border-b border-gray-200 pb-2">

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -33,9 +33,10 @@
 
             <!-- If the webinar has multiple sessions we will choose the earliest session -->
             {{ if isset .Params "multiple" }}
-                {{ $sortedSessions := sort .Params.multiple "datetime" "asc" }}
-                {{ $earliestSession := index ($sortedSessions) 0 }}
-                {{ $resourcesWithDate = $resourcesWithDate | append (dict "date" $earliestSession.datetime "data" .) }}
+                {{ $multipleEventData := . }}
+                {{ range .Params.multiple }}
+                    {{ $resourcesWithDate = $resourcesWithDate | append (dict "date" .datetime "data" $multipleEventData) }}
+                {{ end }}
             {{ else }}
                 {{ $resourcesWithDate = $resourcesWithDate | append (dict "date" .Params.main.sortable_date "data" .) }}
             {{ end }}
@@ -107,7 +108,7 @@
             <ul class="flex flex-wrap justify-center list-none p-0 sm:p-2 resource-list">
 
                 <!-- Loop over the resource items and create the tiles. -->
-                {{ range sort $resourcesWithDate "date" "desc" }}
+                {{ range sort $resourcesWithDate "date" "asc" }}
                     {{ $data := .data }}
 
                     <!-- Create the values for rendering. -->
@@ -121,7 +122,7 @@
                     <!-- Set the values based on the type of the page. -->
                     {{ if eq $data.Type "webinars" }}
                         {{ $description = $data.Params.meta_desc }}
-                        {{ $displayDate = dateFormat "January 2, 2006" $data.Params.main.sortable_date }}
+                        {{ $displayDate = dateFormat "January 2, 2006" .date }}
 
                         <!-- Set the url to link to. -->
                         {{ if $data.Params.external }}
@@ -129,6 +130,10 @@
                             {{ $external = true }}
                         {{ else }}
                             {{ $link = printf "/resources/%s" $data.Params.url_slug }}
+                        {{ end }}
+
+                        {{ if isset $data.Params "multiple" }}
+                            {{ $link = printf "%s?date=%s" $link  (dateFormat "2006/01/02" .date)}}
                         {{ end }}
 
                         <!-- If the webinar is featured add the feature filter. -->
@@ -162,18 +167,8 @@
                         {{ end }}
                     {{ end }}
 
-                    {{ if isset $data.Params "multiple" }}
-                        {{ range $data.Params.multiple }}
-                            {{ $multipleDisplayDate := dateFormat "January 2, 2006" .datetime }}
-                            {{ $multipleLink := printf "%s?date=%s" $link  (dateFormat "2006/01/02" .datetime)}}
-
-                            {{ $tileOptions := (dict "multiple" true "pageContext" $pageContext "external" $external "filters" $filters "link" $multipleLink "icon" $icon "description" $description "displayDate" $multipleDisplayDate "data" $data)}}
-                            {{ partial "content-tile.html" $tileOptions }}
-                        {{ end }}
-                    {{ else }}
-                        {{ $tileOptions := (dict "pageContext" $pageContext "external" $external "filters" $filters "link" $link "icon" $icon "description" $description "displayDate" $displayDate "data" $data)}}
-                        {{ partial "content-tile.html" $tileOptions }}
-                    {{ end }}
+                    {{ $tileOptions := (dict "multiple" $data.Params.multiple "pageContext" $pageContext "external" $external "filters" $filters "link" $link "icon" $icon "description" $description "displayDate" $displayDate "data" $data)}}
+                    {{ partial "content-tile.html" $tileOptions }}
                 {{ end }}
             </ul>
         </div>

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -108,7 +108,7 @@
             <ul class="flex flex-wrap justify-center list-none p-0 sm:p-2 resource-list">
 
                 <!-- Loop over the resource items and create the tiles. -->
-                {{ range sort $resourcesWithDate "date" "asc" }}
+                {{ range sort $resourcesWithDate "date" "desc" }}
                     {{ $data := .data }}
 
                     <!-- Create the values for rendering. -->

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "assets/js/event-filtering.js",
         "assets/js/copybutton.js",
         "assets/js/code-tabbed.js",
+        "assets/js/resources.js",
         "node_modules/clipboard-polyfill/build/clipboard-polyfill.promise.js",
     ],
     "exclude": [


### PR DESCRIPTION
Fixes: https://github.com/pulumi/docs/issues/4905

The form component was throwing an error because the Newsletter form doesn't have a `fieldset` element on it so the code thought it never existed. Fortunately, this did not cause any user interruption outside of an error being logged to the console. This PR fixes up the selector that is used to wait for the form to load so that both types of HubSpot forms are supported.

Also while I was in here, Wendy had suggested we order our events in ascending order on the resources page so that is included here as well.