### PR TITLE
Clean up re:invent takeover and add some use case callouts

### DIFF
--- a/content/partner/aws.md
+++ b/content/partner/aws.md
@@ -12,6 +12,47 @@ hero:
         AWS infrastructure, including containers, serverless functions, and
         other infrastructure using modern programming languages.
 
+awsx_code: |
+    import * as eks from "@pulumi/eks";
+
+    // Create an EKS cluster with the default configuration.
+    const cluster = new eks.Cluster("my-cluster", {
+        desiredCapacity: 5,
+        minSize: 3,
+        maxSize: 5,
+        deployDashboard: false,
+        enabledClusterLogTypes: [
+            "api",
+            "audit",
+            "authenticator",
+        ],
+    });
+
+    // Export the cluster's kubeconfig.
+    export const kubeconfig = cluster.kubeconfig;
+
+automation_api_code: |
+    func NewAddCmd() *cobra.Command {
+        return &cobra.Command{
+            Use:   "add",
+            Short: "add deploys an additional vm stack",
+            Run: func(cmd *cobra.Command, args []string) {
+                stackName := fmt.Sprintf("vmgr%d", rangeIn(10000000, 99999999))
+                s, err := auto.NewStackInlineSource(ctx, stackName, projectName, nil)
+                subnetID, rgName, err := EnsureNetwork(ctx, projectName)
+                stack.SetProgram(GetDeployVMFunc(subnetID, rgName))
+                stdoutStreamer := optup.ProgressStreams(os.Stdout)
+
+                res, err := s.Up(ctx, stdoutStreamer)
+                if err != nil {
+                    fmt.Printf("Failed to deploy vm stack: %v\n", err)
+                    os.Exit(1)
+                }
+                fmt.Printf("deployed server running at public IP %s\n", res.Outputs["ip"].Value)
+            },
+        }
+    }
+
 contact_us_form:
     section_id: contact-us
     hubspot_form_id: 8a0e0f30-b43e-468e-98cc-6b5d481e8660

--- a/layouts/partials/sparkle-arrow-cta.html
+++ b/layouts/partials/sparkle-arrow-cta.html
@@ -1,0 +1,27 @@
+<!-- Default text color is white but we support gray for lighter backgrounds. -->
+{{ $textColor := "text-white hover:text-white"}}
+{{ if eq .textColor "grey" }}
+    {{ $textColor = "text-gray-700 hover:text-gray-800" }}
+{{ end }}
+
+<!-- Default is to align the text in the center. -->
+{{ $textAlign := "text-center" }}
+{{ if eq .textAlign "right" }}
+    {{ $textAlign = "text-right" }}
+{{ else if eq .textAlign "left" }}
+    {{ $textAlign = "text-left" }}
+{{ end }}
+
+<p class="my-4 {{ $textAlign }} w-full">
+    <a class="inline-flex items-center {{ $textColor }} font-bold" href="{{ .url }}">
+        <span class="inline-block w-6 text-orange-300 mr-3">
+            <svg aria-hidden="true" focusable="false" data-prefix="fad" data-icon="sparkles" class="svg-inline--fa fa-sparkles fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g class="fa-group"><path class="fa-secondary" fill="currentColor" d="M423.16 186.58L448 127l59.58-24.84a8 8 0 0 0 0-14.32L448 63 423.16 3.42a8 8 0 0 0-14.32 0L384 63l-59.58 24.84a8 8 0 0 0 0 14.32L384 127l24.84 59.58a8 8 0 0 0 14.32 0zm-14.32 136.84L384 383l-59.58 24.84a8 8 0 0 0 0 14.32L384 447l24.84 59.58a8 8 0 0 0 14.32 0L448 447l59.58-24.84a8 8 0 0 0 0-14.32L448 383l-24.84-59.58a8 8 0 0 0-14.32 0z" opacity="0.4"></path><path class="fa-primary" fill="currentColor" d="M384 254.64a16.06 16.06 0 0 0-8.84-14.33l-112.57-56.39-56.28-112.77c-5.44-10.87-23.19-10.87-28.62 0l-56.28 112.77L8.84 240.31a16 16 0 0 0 0 28.67l112.57 56.39 56.28 112.77a16 16 0 0 0 28.62 0l56.28-112.77L375.16 269a16.07 16.07 0 0 0 8.84-14.36z"></path></g></svg>
+        </span>
+        <span class="mr-2 hover:mr-3 transition-all">
+            {{ .text }}
+        </span>
+        <span>
+            &rarr;
+        </span>
+    </a>
+</p>

--- a/layouts/partner/aws.html
+++ b/layouts/partner/aws.html
@@ -71,79 +71,6 @@
         </p>
     </section>
 
-    <!-- Start AWS re:Invent takeover content -->
-    <section id="workshops" class="container mx-auto text-center mb-12">
-        <p class="text-3xl font-bold">JOIN A WORKSHOP</p>
-        <ul class="flex flex-col lg:flex-row list-none text-left items-center">
-            {{ $webinars := (where $.Site.Pages "Type" "webinars") }}
-
-            {{ $reInventWorkshops := slice }}
-            {{ range $webinars }}
-                {{ if eq .Params.title "Building a Kubernetes Platform in Amazon EKS with Pulumi" }}
-                    {{ $reInventWorkshops = $reInventWorkshops | append . }}
-                {{ else if eq .Params.title "Deploying Microservices with Pulumi and AWS Lambda" }}
-                    {{ $reInventWorkshops = $reInventWorkshops | append . }}
-                {{ else if eq .Params.url_slug "introduction-to-pulumi" }}
-                    {{ $reInventWorkshops = $reInventWorkshops | append . }}
-                {{ end }}
-            {{ end }}
-
-
-            {{ range $reInventWorkshops }}
-                {{ $link := printf "/resources/%s" .Params.url_slug }}
-
-                {{ $displayDate := "" }}
-                {{ if .Params.multiple }}
-                    {{ $displayDate = dateFormat "January 2, 2006" (index (.Params.multiple) 0).datetime }}
-                {{ else }}
-                    {{ $displayDate = dateFormat "January 2, 2006" .Params.main.sortable_date }}
-                {{ end }}
-
-                {{ $tileOptions := (dict "pageContext" $pageContext "external" false "filters" "" "link" $link "icon" "users" "description" .Params.meta_desc "displayDate" $displayDate "data" . ) }}
-                {{ partial "content-tile.html" $tileOptions }}
-            {{ end }}
-        </ul>
-    </section>
-
-    <!-- Pick the blog listings. -->
-    {{ $blog := where $.Site.Pages "Type" "blog" }}
-
-    <section class="container mx-auto text-center mb-24">
-        <p class="text-3xl font-bold mb-16">AWS RE:INVENT NEWS & ANNOUNCEMENTS</p>
-        <div class="flex justify-center">
-            <div class="w-10/12">
-                <!-- This is a bit of hack to avoid listing Azure blogs on the AWS page
-                     during the re:Invent takeover. This section will be removed post re:Invent.
-                -->
-                {{ range first 3 ( where ( where $blog ".Params.title" "ne" "Deploying Minecraft on Azure" ) ".Params.title" "ne" "Get Up and Running with Azure Synapse and Pulumi") }}
-                    <div class="flex flex-col lg:flex-row mb-12">
-                        <div class="w-full lg:w-1/2 mr-8">
-                            <a href="{{ .RelPermalink }}">
-                                <img class="rounded-lg lg:my-8 border-2 border-gray-100"
-                                     src="{{ (.Resources.GetMatch .Params.meta_image).RelPermalink }}"
-                                     alt="{{ .Title }}">
-                            </a>
-                        </div>
-
-                        <div class="w-full lg:w-1/2 text-left flex flex-col justify-center">
-                            <p class="no-anchor text-2xl font-bold"><a data-track="post-{{ .Title | urlize }}" href="{{ .Permalink }}">{{ .Title }}</a></p>
-                            <div class="flex items-center">
-                                <span>
-                                    {{ partial "blog/authors.html" (dict "context" . "authors" .Params.authors ) }}
-                                </span>
-                                <span class="mr-2">∙</span>
-                                <time>
-                                    {{ .Date.Format "Monday, Jan 2, 2006" }}
-                                </time>
-                            </div>
-                        </div>
-                    </div>
-                {{ end }}
-            </div>
-        </div>
-    </section>
-    <!-- End AWS re:invent takeover content -->
-
     <div class="container mx-auto carousel-always-visible mb-24">
         <section class="w-full text-center">
             <div>
@@ -280,6 +207,115 @@
             </div>
         </section>
     </div>
+
+    <!-- Automation API -->
+    <section id="automation-api" class="container mx-auto mb-12">
+        <div class="flex flex-col lg:flex-row">
+            <div class="w-full lg:w-5/12 px-8">
+                <p class="text-3xl font-bold inline-block">Enable Everyone To Do Everything</p>
+                <p>
+                    The Automation API gives you the ability to build bespoke deployment tools that allow
+                    application developers to self-serve their infrastructure, using codified best practices.
+                    No two applications or environments are the same and you can quickly hit edges with tools
+                    trying to be one-size-fits all solution. The Automation API enables you to write tooling that fits
+                    your use cases and works exactly the way you want it to. Everything from complex workflow
+                    orchestration to opinionated full-stack application frameworks is possible with the Automation API.
+                </p>
+                <p class="my-4 mt-8 text-left w-full">
+                    <a class="inline-flex items-center text-gray-700 hover:text-gray-800 font-bold text-xl" href="{{ relref . "/blog/automation-api" }}">
+                        <span class="inline-block w-6 text-orange-300 mr-3">
+                            <svg aria-hidden="true" focusable="false" data-prefix="fad" data-icon="sparkles" class="svg-inline--fa fa-sparkles fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g class="fa-group"><path class="fa-secondary" fill="currentColor" d="M423.16 186.58L448 127l59.58-24.84a8 8 0 0 0 0-14.32L448 63 423.16 3.42a8 8 0 0 0-14.32 0L384 63l-59.58 24.84a8 8 0 0 0 0 14.32L384 127l24.84 59.58a8 8 0 0 0 14.32 0zm-14.32 136.84L384 383l-59.58 24.84a8 8 0 0 0 0 14.32L384 447l24.84 59.58a8 8 0 0 0 14.32 0L448 447l59.58-24.84a8 8 0 0 0 0-14.32L448 383l-24.84-59.58a8 8 0 0 0-14.32 0z" opacity="0.4"></path><path class="fa-primary" fill="currentColor" d="M384 254.64a16.06 16.06 0 0 0-8.84-14.33l-112.57-56.39-56.28-112.77c-5.44-10.87-23.19-10.87-28.62 0l-56.28 112.77L8.84 240.31a16 16 0 0 0 0 28.67l112.57 56.39 56.28 112.77a16 16 0 0 0 28.62 0l56.28-112.77L375.16 269a16.07 16.07 0 0 0 8.84-14.36z"></path></g></svg>
+                        </span>
+                        <span class="mr-2 hover:mr-3 transition-all">
+                            Learn More About Automation API
+                        </span>
+                        <span>
+                            &rarr;
+                        </span>
+                    </a>
+                </p>
+            </div>
+
+            <div class="w-full lg:w-7/12">
+                {{ partial "code" (dict "code" .Params.automation_api_code "lang" "js" "mode" "dark" "chrome" true) }}
+            </div>
+        </div>
+    </section>
+
+    <!-- AWSX -->
+    <section id="awsx" class="container mx-auto mb-12">
+        <div class="flex flex-col lg:flex-row">
+            <div class="w-full lg:w-1/2">
+                {{ partial "code" (dict "code" .Params.awsx_code "lang" "js" "mode" "dark" "chrome" true) }}
+            </div>
+
+            <div class="w-full lg:w-1/2 px-8">
+                <p class="text-3xl font-bold inline-block">AWS Crosswalk</p>
+                <p class="mt-0">
+                    Pulumi Crosswalk for AWS is a collection of libraries that use automatic
+                    well-architected best practices to make common infrastructure-as-code
+                    tasks in AWS easier and more secure. Secure and cost-conscious defaults are chosen
+                    so that simple programs automatically use best practices for the underlying
+                    infrastructure, enabling better productivity with confidence.
+                </p>
+
+                <p class="text-lg font-bold">Application and Infrastructure Together</p>
+                <p>
+                    Crosswalk enables you to blur the lines between application and infrastructure code enabling
+                    you to author an entire full stack application in one program. With support for inline Lambda
+                    functions and ease-of-use helper functions, building robust applications on AWS has never
+                    been easier.
+                </p>
+                <p class="my-4 mt-8 text-left w-full">
+                    <a class="inline-flex items-center text-gray-700 hover:text-gray-800 font-bold text-xl" href="{{ relref . "/docs/guides/crosswalk/aws" }}">
+                        <span class="inline-block w-6 text-orange-300 mr-3">
+                            <svg aria-hidden="true" focusable="false" data-prefix="fad" data-icon="sparkles" class="svg-inline--fa fa-sparkles fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g class="fa-group"><path class="fa-secondary" fill="currentColor" d="M423.16 186.58L448 127l59.58-24.84a8 8 0 0 0 0-14.32L448 63 423.16 3.42a8 8 0 0 0-14.32 0L384 63l-59.58 24.84a8 8 0 0 0 0 14.32L384 127l24.84 59.58a8 8 0 0 0 14.32 0zm-14.32 136.84L384 383l-59.58 24.84a8 8 0 0 0 0 14.32L384 447l24.84 59.58a8 8 0 0 0 14.32 0L448 447l59.58-24.84a8 8 0 0 0 0-14.32L448 383l-24.84-59.58a8 8 0 0 0-14.32 0z" opacity="0.4"></path><path class="fa-primary" fill="currentColor" d="M384 254.64a16.06 16.06 0 0 0-8.84-14.33l-112.57-56.39-56.28-112.77c-5.44-10.87-23.19-10.87-28.62 0l-56.28 112.77L8.84 240.31a16 16 0 0 0 0 28.67l112.57 56.39 56.28 112.77a16 16 0 0 0 28.62 0l56.28-112.77L375.16 269a16.07 16.07 0 0 0 8.84-14.36z"></path></g></svg>
+                        </span>
+                        <span class="mr-2 hover:mr-3 transition-all">
+                            Learn More About Crosswalk
+                        </span>
+                        <span>
+                            &rarr;
+                        </span>
+                    </a>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Start AWS re:Invent takeover content -->
+    <section id="workshops" class="container mx-auto text-center mb-12">
+        <p class="text-3xl font-bold">JOIN A WORKSHOP</p>
+        <ul class="flex flex-col lg:flex-row list-none text-left items-center">
+            {{ $webinars := (where $.Site.Pages "Type" "webinars") }}
+
+            {{ $reInventWorkshops := slice }}
+            {{ range $webinars }}
+                {{ if eq .Params.title "Building a Kubernetes Platform in Amazon EKS with Pulumi" }}
+                    {{ $reInventWorkshops = $reInventWorkshops | append . }}
+                {{ else if eq .Params.title "Deploying Microservices with Pulumi and AWS Lambda" }}
+                    {{ $reInventWorkshops = $reInventWorkshops | append . }}
+                {{ else if eq .Params.url_slug "introduction-to-pulumi" }}
+                    {{ $reInventWorkshops = $reInventWorkshops | append . }}
+                {{ end }}
+            {{ end }}
+
+
+            {{ range $reInventWorkshops }}
+                {{ $link := printf "/resources/%s" .Params.url_slug }}
+
+                {{ $displayDate := "" }}
+                {{ if .Params.multiple }}
+                    {{ $displayDate = dateFormat "January 2, 2006" (index (.Params.multiple) 0).datetime }}
+                {{ else }}
+                    {{ $displayDate = dateFormat "January 2, 2006" .Params.main.sortable_date }}
+                {{ end }}
+
+                {{ $tileOptions := (dict "pageContext" $pageContext "external" false "filters" "" "link" $link "icon" "users" "description" .Params.meta_desc "displayDate" $displayDate "data" . ) }}
+                {{ partial "content-tile.html" $tileOptions }}
+            {{ end }}
+        </ul>
+    </section>
 
     <section class="container mx-auto mb-16">
             <h3 class="mt-12 mb-8 text-center text-4xl font-bold">

--- a/layouts/partner/aws.html
+++ b/layouts/partner/aws.html
@@ -21,19 +21,7 @@
                         srcdoc="<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img{position:absolute;width:100%;top:0;bottom:0;margin:auto}</style><a href=https://www.youtube.com/embed/M8PEXcFh_aQ?autoplay=1><img src='/images/partners/kube-interview-thumbnail.jpg' alt='Pulumi + AWS: Modern Infrastructure as Code'></a>"
                     ></iframe>
                 </div>
-                <p class="my-4 text-center w-full">
-                    <a class="inline-flex items-center text-white hover:text-white font-bold" href="{{ relref . "/case-studies/snowflake" }}">
-                        <span class="inline-block w-6 text-orange-300 mr-3">
-                            <svg aria-hidden="true" focusable="false" data-prefix="fad" data-icon="sparkles" class="svg-inline--fa fa-sparkles fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g class="fa-group"><path class="fa-secondary" fill="currentColor" d="M423.16 186.58L448 127l59.58-24.84a8 8 0 0 0 0-14.32L448 63 423.16 3.42a8 8 0 0 0-14.32 0L384 63l-59.58 24.84a8 8 0 0 0 0 14.32L384 127l24.84 59.58a8 8 0 0 0 14.32 0zm-14.32 136.84L384 383l-59.58 24.84a8 8 0 0 0 0 14.32L384 447l24.84 59.58a8 8 0 0 0 14.32 0L448 447l59.58-24.84a8 8 0 0 0 0-14.32L448 383l-24.84-59.58a8 8 0 0 0-14.32 0z" opacity="0.4"></path><path class="fa-primary" fill="currentColor" d="M384 254.64a16.06 16.06 0 0 0-8.84-14.33l-112.57-56.39-56.28-112.77c-5.44-10.87-23.19-10.87-28.62 0l-56.28 112.77L8.84 240.31a16 16 0 0 0 0 28.67l112.57 56.39 56.28 112.77a16 16 0 0 0 28.62 0l56.28-112.77L375.16 269a16.07 16.07 0 0 0 8.84-14.36z"></path></g></svg>
-                        </span>
-                        <span class="mr-2 hover:mr-3 transition-all">
-                            Read the Snowflake case study
-                        </span>
-                        <span>
-                            &rarr;
-                        </span>
-                    </a>
-                </p>
+                {{ partial "sparkle-arrow-cta" (dict "url" (relref . "/case-studies/snowflake") "text" "Read the Snowflake case study")}}
             </div>
         </div>
     </header>
@@ -209,7 +197,7 @@
     </div>
 
     <!-- Automation API -->
-    <section id="automation-api" class="container mx-auto mb-12">
+    <section id="automation-api" class="container mx-auto mb-12 px-8 lg:px-0">
         <div class="flex flex-col lg:flex-row">
             <div class="w-full lg:w-5/12 px-8">
                 <p class="text-3xl font-bold inline-block">Enable Everyone To Do Everything</p>
@@ -217,39 +205,27 @@
                     The Automation API gives you the ability to build bespoke deployment tools that allow
                     application developers to self-serve their infrastructure, using codified best practices.
                     No two applications or environments are the same and you can quickly hit edges with tools
-                    trying to be one-size-fits all solution. The Automation API enables you to write tooling that fits
+                    trying to be one-size-fits-all solution. The Automation API enables you to write tooling that fits
                     your use cases and works exactly the way you want it to. Everything from complex workflow
                     orchestration to opinionated full-stack application frameworks is possible with the Automation API.
                 </p>
-                <p class="my-4 mt-8 text-left w-full">
-                    <a class="inline-flex items-center text-gray-700 hover:text-gray-800 font-bold text-xl" href="{{ relref . "/blog/automation-api" }}">
-                        <span class="inline-block w-6 text-orange-300 mr-3">
-                            <svg aria-hidden="true" focusable="false" data-prefix="fad" data-icon="sparkles" class="svg-inline--fa fa-sparkles fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g class="fa-group"><path class="fa-secondary" fill="currentColor" d="M423.16 186.58L448 127l59.58-24.84a8 8 0 0 0 0-14.32L448 63 423.16 3.42a8 8 0 0 0-14.32 0L384 63l-59.58 24.84a8 8 0 0 0 0 14.32L384 127l24.84 59.58a8 8 0 0 0 14.32 0zm-14.32 136.84L384 383l-59.58 24.84a8 8 0 0 0 0 14.32L384 447l24.84 59.58a8 8 0 0 0 14.32 0L448 447l59.58-24.84a8 8 0 0 0 0-14.32L448 383l-24.84-59.58a8 8 0 0 0-14.32 0z" opacity="0.4"></path><path class="fa-primary" fill="currentColor" d="M384 254.64a16.06 16.06 0 0 0-8.84-14.33l-112.57-56.39-56.28-112.77c-5.44-10.87-23.19-10.87-28.62 0l-56.28 112.77L8.84 240.31a16 16 0 0 0 0 28.67l112.57 56.39 56.28 112.77a16 16 0 0 0 28.62 0l56.28-112.77L375.16 269a16.07 16.07 0 0 0 8.84-14.36z"></path></g></svg>
-                        </span>
-                        <span class="mr-2 hover:mr-3 transition-all">
-                            Learn More About Automation API
-                        </span>
-                        <span>
-                            &rarr;
-                        </span>
-                    </a>
-                </p>
+                {{ partial "sparkle-arrow-cta" (dict "url" (relref . "/blog/automation-api") "text" "Learn More About Automation API" "textColor" "grey" "textAlign" "left") }}
             </div>
 
-            <div class="w-full lg:w-7/12">
+            <div class="w-full mt-8 lg:mt-0 lg:w-7/12">
                 {{ partial "code" (dict "code" .Params.automation_api_code "lang" "js" "mode" "dark" "chrome" true) }}
             </div>
         </div>
     </section>
 
     <!-- AWSX -->
-    <section id="awsx" class="container mx-auto mb-12">
+    <section id="awsx" class="container mx-auto mb-12 px-8 lg:px-0">
         <div class="flex flex-col lg:flex-row">
-            <div class="w-full lg:w-1/2">
+            <div class="w-full order-last mt-8 lg:mt-0 lg:order-first lg:w-1/2">
                 {{ partial "code" (dict "code" .Params.awsx_code "lang" "js" "mode" "dark" "chrome" true) }}
             </div>
 
-            <div class="w-full lg:w-1/2 px-8">
+            <div class="w-full order-first lg:order-last lg:w-1/2 px-8">
                 <p class="text-3xl font-bold inline-block">AWS Crosswalk</p>
                 <p class="mt-0">
                     Pulumi Crosswalk for AWS is a collection of libraries that use automatic
@@ -262,31 +238,19 @@
                 <p class="text-lg font-bold">Application and Infrastructure Together</p>
                 <p>
                     Crosswalk enables you to blur the lines between application and infrastructure code enabling
-                    you to author an entire full stack application in one program. With support for inline Lambda
+                    you to author an entire full-stack application in one program. With support for inline Lambda
                     functions and ease-of-use helper functions, building robust applications on AWS has never
                     been easier.
                 </p>
-                <p class="my-4 mt-8 text-left w-full">
-                    <a class="inline-flex items-center text-gray-700 hover:text-gray-800 font-bold text-xl" href="{{ relref . "/docs/guides/crosswalk/aws" }}">
-                        <span class="inline-block w-6 text-orange-300 mr-3">
-                            <svg aria-hidden="true" focusable="false" data-prefix="fad" data-icon="sparkles" class="svg-inline--fa fa-sparkles fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g class="fa-group"><path class="fa-secondary" fill="currentColor" d="M423.16 186.58L448 127l59.58-24.84a8 8 0 0 0 0-14.32L448 63 423.16 3.42a8 8 0 0 0-14.32 0L384 63l-59.58 24.84a8 8 0 0 0 0 14.32L384 127l24.84 59.58a8 8 0 0 0 14.32 0zm-14.32 136.84L384 383l-59.58 24.84a8 8 0 0 0 0 14.32L384 447l24.84 59.58a8 8 0 0 0 14.32 0L448 447l59.58-24.84a8 8 0 0 0 0-14.32L448 383l-24.84-59.58a8 8 0 0 0-14.32 0z" opacity="0.4"></path><path class="fa-primary" fill="currentColor" d="M384 254.64a16.06 16.06 0 0 0-8.84-14.33l-112.57-56.39-56.28-112.77c-5.44-10.87-23.19-10.87-28.62 0l-56.28 112.77L8.84 240.31a16 16 0 0 0 0 28.67l112.57 56.39 56.28 112.77a16 16 0 0 0 28.62 0l56.28-112.77L375.16 269a16.07 16.07 0 0 0 8.84-14.36z"></path></g></svg>
-                        </span>
-                        <span class="mr-2 hover:mr-3 transition-all">
-                            Learn More About Crosswalk
-                        </span>
-                        <span>
-                            &rarr;
-                        </span>
-                    </a>
-                </p>
+                {{ partial "sparkle-arrow-cta" (dict "url" (relref . "/docs/guides/crosswalk/aws") "text" "Learn More About Crosswalk" "textColor" "grey" "textAlign" "left") }}
             </div>
         </div>
     </section>
 
     <!-- Start AWS re:Invent takeover content -->
     <section id="workshops" class="container mx-auto text-center mb-12">
-        <p class="text-3xl font-bold">JOIN A WORKSHOP</p>
-        <ul class="flex flex-col lg:flex-row list-none text-left items-center">
+        <h3 class="text-3xl font-bold">JOIN A WORKSHOP</h3>
+        <ul class="flex flex-col px-0 lg:flex-row list-none text-left items-center">
             {{ $webinars := (where $.Site.Pages "Type" "webinars") }}
 
             {{ $reInventWorkshops := slice }}
@@ -299,7 +263,6 @@
                     {{ $reInventWorkshops = $reInventWorkshops | append . }}
                 {{ end }}
             {{ end }}
-
 
             {{ range $reInventWorkshops }}
                 {{ $link := printf "/resources/%s" .Params.url_slug }}
@@ -322,13 +285,13 @@
                 Begin Your Pulumi Adventure
             </h3>
             <div class="w-full flex flex-wrap">
-                <div class="w-full lg:w-1/2 p-3">
+                <div class="w-full lg:w-1/2 p-4">
                     <div class="flex flex-wrap border rounded shadow-xl">
-                        <div class="w-full lg:w-1/2 p-3">
+                        <div class="w-full lg:w-1/2 p-4">
                             <img class="h-64 mx-auto" src="/images/mascot/babypus.svg" />
                         </div>
 
-                        <div class="w-full lg:w-1/2 p-3">
+                        <div class="w-full lg:w-1/2 p-4">
                             <p class="mt-0 font-bold text-2xl">Start from scratch</p>
                             <p>
                                 If you are new to Pulumi our Getting Started Guides are the place for you. In
@@ -342,13 +305,13 @@
                     </div>
                 </div>
 
-                <div class="w-full lg:w-1/2 p-3">
+                <div class="w-full lg:w-1/2 p-4">
                     <div class="flex flex-wrap border rounded">
-                        <div class="w-full lg:w-1/2 p-3">
+                        <div class="w-full lg:w-1/2 p-4">
                             <img class="h-64 mx-auto" src="/images/mascot/gandalfpus.svg" />
                         </div>
 
-                        <div class="w-full lg:w-1/2 p-3">
+                        <div class="w-full lg:w-1/2 p-4">
                             <p class="mt-0 font-bold text-2xl">Import an existing resource</p>
                             <p>
                                 For people who are already managing infrastructure with a different tool
@@ -362,13 +325,13 @@
                     </div>
                 </div>
 
-                <div class="w-full lg:w-1/2 p-3">
+                <div class="w-full lg:w-1/2 p-4">
                     <div class="flex flex-wrap border rounded">
-                        <div class="w-full lg:w-1/2 p-3">
+                        <div class="w-full lg:w-1/2 p-4">
                             <img class="h-64 mx-auto" src="/images/mascot/rocketpus.svg" />
                         </div>
 
-                        <div class="w-full lg:w-1/2 p-3">
+                        <div class="w-full lg:w-1/2 p-4">
                             <p class="mt-0 font-bold text-2xl">Clone an example</p>
                             <p>
                                 We have created 150+ examples for you to choose from as a way for
@@ -382,13 +345,13 @@
                     </div>
                 </div>
 
-                <div class="w-full lg:w-1/2 p-3">
+                <div class="w-full lg:w-1/2 p-4">
                     <div class="flex flex-wrap border rounded">
-                        <div class="w-full lg:w-1/2 p-3">
+                        <div class="w-full lg:w-1/2 p-4">
                             <img class="h-64 mx-auto" src="/images/mascot/eggpus.svg" />
                         </div>
 
-                        <div class="w-full lg:w-1/2 p-3">
+                        <div class="w-full lg:w-1/2 p-4">
                             <p class="mt-0 font-bold text-2xl">Convert Terraform</p>
                             <p>
                                 If you are already using Terraform to manage your infrastructure, we have


### PR DESCRIPTION
During re:Invent we added some sections to the `/aws` page and this PR removes those sections and replaces them with more generic feature callout sections.