### PR TITLE
Update learn bullets for eks workshop

### DIFF
--- a/content/resources/building-a-kubernetes-platform-in-amazon-eks/index.md
+++ b/content/resources/building-a-kubernetes-platform-in-amazon-eks/index.md
@@ -85,8 +85,6 @@ main:
     learn:
         - How-to provision a production-ready Amazon EKS cluster with key features enabled using Pulumi
         - Provisioning the aws-load-balancer-controller to automate ingress creation
-        - How to provision the external-dns add-on to automate DNS entry for Ingress resources
-        - How to install cert-manager to automate the creation of TLS certificates for applications
         - Install an example application to show the end-to-end user experience for users.
 form:
     hubspot_form_id: "013aa0b8-7aac-4de9-912e-c0f22e53eff2"


### PR DESCRIPTION
As the title states, this PR removes two bullet points from the `Learn` section of the EKS workshop.