### PR TITLE
Adding a docs section for convertors

### DIFF
--- a/content/blog/introducing-crd2pulumi/index.md
+++ b/content/blog/introducing-crd2pulumi/index.md
@@ -2,6 +2,11 @@
 title: "Introducing crd2pulumi: Typed CustomResources for Kubernetes"
 date: 2020-08-12
 meta_desc: Generate Kubernetes CustomResource types in TypeScript, Python, C#, and Go.
+menu:
+  converters:
+    identifier: crd2pulumi
+linktitle: crd2pulumi
+weight: 2
 meta_image: crd.png
 authors:
     - levi-blackstone

--- a/content/migrate/arm2pulumi.md
+++ b/content/migrate/arm2pulumi.md
@@ -2,6 +2,12 @@
 title: Convert Your Azure ARM Template to a Modern Language
 url: /arm2pulumi
 layout: arm2pulumi
+linktitle: arm2pulumi
+menu:
+  converters:
+    identifier: arm2pulumi
+    weight: 1
+    
 meta_desc: See what your Azure ARM Template would look like in a modern language thanks to Pulumi.
 
 examples:

--- a/content/migrate/kube2pulumi.md
+++ b/content/migrate/kube2pulumi.md
@@ -2,6 +2,11 @@
 title: Upgrade Your Kubernetes YAML to a Modern Language
 url: /kube2pulumi
 layout: kube2pulumi
+linktitle: kube2pulumi
+menu:
+  converters:
+    identifier: kube2pulumi
+    weight: 3
 meta_desc: See what your Kubernetes YAML would look like in a modern language thanks to Pulumi.
 
 examples:

--- a/content/migrate/tf2pulumi.md
+++ b/content/migrate/tf2pulumi.md
@@ -2,6 +2,11 @@
 title: Convert Your Terraform to a Modern Language
 url: /tf2pulumi
 layout: tf2pulumi
+linktitle: tf2pulumi
+menu:
+  converters:
+    identifier: tf2pulumi
+    weight: 4
 meta_desc: See what your Terraform HCL would look like in a modern language thanks to Pulumi.
 
 examples:

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -7,8 +7,8 @@
     {{ else if hasPrefix .RelPermalink "/docs/" }}
         {{/* Render a top-level menu for our major docs sections */}}
         {{ $toc_page := . }}
-        {{ $toc_sections := slice "Getting Started" "Intro" "User Guides" "Reference" "Support" }}
-        {{ $toc_menus := dict "Getting Started" .Site.Menus.getstarted "Intro" .Site.Menus.intro "User Guides" .Site.Menus.userguides "Reference" .Site.Menus.reference "Support" .Site.Menus.troubleshooting }}
+        {{ $toc_sections := slice "Getting Started" "Intro" "User Guides" "Converters" "Reference" "Support" }}
+        {{ $toc_menus := dict "Getting Started" .Site.Menus.getstarted "Intro" .Site.Menus.intro "User Guides" .Site.Menus.userguides "Converters" .Site.Menus.converters "Reference" .Site.Menus.reference "Support" .Site.Menus.troubleshooting }}
         {{ range $toc_sections }}
             {{ $toc_name := . }}
             {{ $toc_menu := (index $toc_menus $toc_name) }}


### PR DESCRIPTION
Fixes: #4710

Please note that this adds a link title to the crd2pulumi doc that
only affects the docs navigation not the blog post listing itself