### PR TITLE
Fix a rendering issue in ResourceOptions.merge

### DIFF
--- a/content/docs/reference/pkg/python/pulumi/_index.md
+++ b/content/docs/reference/pkg/python/pulumi/_index.md
@@ -361,22 +361,13 @@ instance in it with the attributes of <code class="docutils literal notranslate"
 <code class="docutils literal notranslate"><span class="pre">opts2</span></code> can be <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case its attributes are ignored.</p>
 <p>Conceptually attributes merging follows these basic rules:</p>
 <ol class="arabic simple">
-<li><dl class="simple">
-<dt>if the attributes is a collection, the final value will be a collection containing the</dt><dd><p>values from each options object. Both original collections in each options object will
-be unchanged.</p>
-</dd>
-</dl>
-</li>
-<li><dl class="simple">
-<dt>Simple scalar values from <code class="docutils literal notranslate"><span class="pre">opts2</span></code> (i.e. strings, numbers, bools) will replace the values</dt><dd><p>from <code class="docutils literal notranslate"><span class="pre">opts1</span></code>.</p>
-</dd>
-</dl>
-</li>
-<li><dl class="simple">
-<dt>For the purposes of merging <code class="docutils literal notranslate"><span class="pre">depends_on</span></code>, <code class="docutils literal notranslate"><span class="pre">provider</span></code> and <code class="docutils literal notranslate"><span class="pre">providers</span></code> are always treated</dt><dd><p>as collections, even if only a single value was provided.</p>
-</dd>
-</dl>
-</li>
+<li><p>If the attributes is a collection, the final value will be a collection containing the
+values from each options object. Both original collections in each options object will
+be unchanged.</p></li>
+<li><p>Simple scalar values from <code class="docutils literal notranslate"><span class="pre">opts2</span></code> (i.e. strings, numbers, bools) will replace the values
+from <code class="docutils literal notranslate"><span class="pre">opts1</span></code>.</p></li>
+<li><p>For the purposes of merging <code class="docutils literal notranslate"><span class="pre">depends_on</span></code>, <code class="docutils literal notranslate"><span class="pre">provider</span></code> and <code class="docutils literal notranslate"><span class="pre">providers</span></code> are always treated
+as collections, even if only a single value was provided.</p></li>
 <li><p>Attributes with value ‘None’ will not be copied over.</p></li>
 </ol>
 <p>This method can be called either as static-method like <code class="docutils literal notranslate"><span class="pre">ResourceOptions.merge(opts1,</span> <span class="pre">opts2)</span></code>


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Fixing a rendering issue in python api docs.

**Before**

<img width="566" alt="Screen Shot 2021-01-26 at 4 21 57 PM" src="https://user-images.githubusercontent.com/24326455/105919300-9e731a80-5ff2-11eb-86d0-d55294c63337.png">

**After**

<img width="574" alt="Screen Shot 2021-01-26 at 4 21 26 PM" src="https://user-images.githubusercontent.com/24326455/105919346-b8acf880-5ff2-11eb-9e58-b0b7484b88da.png">


### Related issues (optional)

Fixes: https://github.com/pulumi/docs/issues/4607
