### PR TITLE
Document SAML_SSO_ENABLED for self-hosted Pulumi Service

### DIFF
--- a/content/docs/guides/self-hosted/console.md
+++ b/content/docs/guides/self-hosted/console.md
@@ -60,7 +60,7 @@ The following are the core environment variables that are required at a minimum.
 | Variable Name | Description |
 | ------------- | ----------- |
 | RECAPTCHA_SITE_KEY | Used for password reset requests by users. [Create a new reCaptcha v2](https://www.google.com/recaptcha/admin). |
-| SAML_SSO_ENABLED | Default is `false`. Set to `true` to enable the SAML SSO login option. Before enabling, make sure you have completed the steps in the [Enabling SAML SSO]({{< relref "saml-sso" >}}) guide. |
+| SAML_SSO_ENABLED | Default is `false`. Set to `true` to enable the SAML SSO signin/signup option. Before enabling, make sure you have completed the steps in the [Enabling SAML SSO]({{< relref "saml-sso" >}}) guide. |
 
 ### GitHub OAuth
 

--- a/content/docs/guides/self-hosted/console.md
+++ b/content/docs/guides/self-hosted/console.md
@@ -59,7 +59,8 @@ The following are the core environment variables that are required at a minimum.
 
 | Variable Name | Description |
 | ------------- | ----------- |
-| RECAPTCHA_SITE_KEY | Use for password reset requests by users. [Create a new reCaptcha v2](https://www.google.com/recaptcha/admin). |
+| RECAPTCHA_SITE_KEY | Used for password reset requests by users. [Create a new reCaptcha v2](https://www.google.com/recaptcha/admin). |
+| SAML_SSO_ENABLED | Default is `false`. Set to `true` to enable the SAML SSO login option. Before enabling, make sure you have completed the steps in the [Enabling SAML SSO]({{< relref "saml-sso" >}}) guide. |
 
 ### GitHub OAuth
 

--- a/content/docs/guides/self-hosted/saml-sso.md
+++ b/content/docs/guides/self-hosted/saml-sso.md
@@ -55,3 +55,8 @@ Once the key pair has been generated, set the value of the following environment
 For these values to take effect, you will need to restart the API Service.
 
 > Restart the service only during a planned maintenance window.
+
+## Enabling SAML SSO as an identity option
+
+Once you have completed the above steps, you may enable SAML SSO as a login option for your users.
+Set the `SAML_SSO_ENABLED` environment variable for the [console]({{< relref "console" >}}) container to `true` and restart the service.

--- a/content/docs/guides/self-hosted/saml-sso.md
+++ b/content/docs/guides/self-hosted/saml-sso.md
@@ -59,5 +59,5 @@ For these values to take effect, you will need to restart the API Service.
 ## Enabling SAML SSO as an identity option
 
 By default, the SAML SSO signin/signup option is not displayed to end users of the Console service.
-Set the `SAML_SSO_ENABLED` environment variable for the [console]({{< relref "console" >}}) container to `true`
+To enable this, set the `SAML_SSO_ENABLED` environment variable for the [console]({{< relref "console" >}}) container to `true`
 and restart the service.

--- a/content/docs/guides/self-hosted/saml-sso.md
+++ b/content/docs/guides/self-hosted/saml-sso.md
@@ -58,5 +58,6 @@ For these values to take effect, you will need to restart the API Service.
 
 ## Enabling SAML SSO as an identity option
 
-Once you have completed the above steps, you may enable SAML SSO as a login option for your users.
-Set the `SAML_SSO_ENABLED` environment variable for the [console]({{< relref "console" >}}) container to `true` and restart the service.
+By default, the SAML SSO signin/signup option is not displayed to end users of the Console service.
+Set the `SAML_SSO_ENABLED` environment variable for the [console]({{< relref "console" >}}) container to `true`
+and restart the service.


### PR DESCRIPTION
### Proposed changes

The `SAML_SSO_ENABLED` env var allows a system admin of a self-hosted Pulumi Service instance to control the visibility of a SAML SSO signin/signup option.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A
