### PR TITLE
Ignore changes on the Lambda edge role

### DIFF
--- a/infrastructure/lambdaEdge.ts
+++ b/infrastructure/lambdaEdge.ts
@@ -48,8 +48,13 @@ export class LambdaEdge extends pulumi.ComponentResource {
                 }],
                 Version: "2012-10-17",
             },
-        // tslint:disable-next-line:align
-        }, { parent: this });
+        },
+        {
+            parent: this,
+            // The items in the policy's Service list are returned by AWS in an unreliable order,
+            // so we ignore any diffs to this property as a whole.
+            ignoreChanges: [ "assumeRolePolicy" ]
+        });
 
         const rolePolicy = new aws.iam.RolePolicy("lambdaCloudWatchPolicy", {
             role: this.role,


### PR DESCRIPTION
Builds are [randomly failing](https://github.com/pulumi/docs/runs/1809512983?check_suite_focus=true) on the `pulumi refresh --expect-no-changes` we run before deployment because of what looks like inconsistent results returned by AWS. This PR ignores changes to the Lambda Edge policy in order to unblock the pipeline.
