### PR TITLE
Remove expect-no-changes from deployment script

### DIFF
--- a/infrastructure/lambdaEdge.ts
+++ b/infrastructure/lambdaEdge.ts
@@ -48,13 +48,8 @@ export class LambdaEdge extends pulumi.ComponentResource {
                 }],
                 Version: "2012-10-17",
             },
-        },
-        {
-            parent: this,
-            // The items in the policy's Service list are returned by AWS in an unreliable order,
-            // so we ignore any diffs to this property as a whole.
-            ignoreChanges: [ "assumeRolePolicy" ]
-        });
+        // tslint:disable-next-line:align
+        }, { parent: this });
 
         const rolePolicy = new aws.iam.RolePolicy("lambdaCloudWatchPolicy", {
             role: this.role,

--- a/scripts/run-pulumi.sh
+++ b/scripts/run-pulumi.sh
@@ -21,10 +21,8 @@ case ${PULUMI_ACTION} in
     update)
         # Given how frequently we update the CloudFront distribution, and how easy it can
         # be for our checkpointed CloudFront Etag to fall out of sync with what's current,
-        # we refresh the distribution on every update -- but we consider any other
-        # difference in stack state an error to be examined and corrected manually.
+        # we refresh the distribution on every update.
         pulumi -C infrastructure refresh -t "urn:pulumi:production::www.pulumi.com::aws:cloudfront/distribution:Distribution::cdn" --yes
-        pulumi -C infrastructure refresh --expect-no-changes --yes
 
         pulumi -C infrastructure up --yes
         ;;


### PR DESCRIPTION
In #5104, we added a line to ignore changes on an IAM policy thinking it'd allow us to tolerate some unexpected diffing (see https://github.com/pulumi/pulumi-aws/issues/1338 for details), but it looks like even with that change, we're still unable to run `refresh --expect-no-changes` successfully when only those properties of the policy change. 

This change removes the `refresh --expect-no-changes` line from the deployment script in order to keep the pipeline unblocked while we await a resolution on https://github.com/pulumi/pulumi-aws/issues/1338. 