### PR TITLE
Remove docs on missing webhook functionality

### DIFF
--- a/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
+++ b/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
@@ -142,13 +142,12 @@ That's it! As stacks are created, updated, and so on, the webhook
 handler will be notified and you can start building any custom actions
 you can think of.
 
-For our initial release, there are four kinds of webhook events. But
+For our initial release, there are three kinds of webhook events. But
 we'll quickly be expanding coverage in the coming weeks.
 
 | **Event Type**                    | **Trigger**
 | --------------------------------- | ----------------------------------
 | `stack`                           | Fired whenever a stack is created or deleted within an organization.
-| `team`                            | Fired when a team is created, updated, or deleted within an organization.
 | `stack_update`                    | Fired when a stack is updated. (Be it from `pulumi up`, `pulumi refresh`, or `pulumi destroy`.)
 | `stack_preview`                   | Fired whenever changes to a stack  are previewed.
 

--- a/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
+++ b/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
@@ -142,8 +142,7 @@ That's it! As stacks are created, updated, and so on, the webhook
 handler will be notified and you can start building any custom actions
 you can think of.
 
-For our initial release, there are three kinds of webhook events. But
-we'll quickly be expanding coverage in the coming weeks.
+There are three kinds of webhook events.
 
 | **Event Type**                    | **Trigger**
 | --------------------------------- | ----------------------------------

--- a/content/blog/managing-github-webhooks-with-pulumi/index.md
+++ b/content/blog/managing-github-webhooks-with-pulumi/index.md
@@ -131,7 +131,7 @@ secret value, set it as a configuration value in my project:
 
     $ pulumi config set --secret hookSecret [READACTED]
 
-Once that's done, I can use this value to validate the signiture. We'll
+Once that's done, I can use this value to validate the signature. We'll
 use some functions from node's `crypto` library at runtime to handle
 this. If the signature we computed doesn't match what was provided with
 the request, we'll return error code 400. Our program now looks like

--- a/content/docs/intro/console/extensions/webhooks.md
+++ b/content/docs/intro/console/extensions/webhooks.md
@@ -11,7 +11,7 @@ aliases:
 
 Pulumi Webhooks allow you to notify external services of events
 happening within your Pulumi organization or stack. For example,
-you can trigger a notification whenever a stack is updated or a team is modified.
+you can trigger a notification whenever a stack is updated.
 Whenever an event occurs, Pulumi will send an HTTP `POST` request to
 all registered webhooks. The webhook can then be used to emit some
 notification, start running integration tests, or even update additional stacks.
@@ -24,8 +24,7 @@ of most _ChatOps_ workflows.
 Webhooks can be attached to either a stack or an organization. Stack webhooks
 will be notified whenever a stack is updated or changed. Organization
 webhooks will be notified for events happening within each of the organization's
-stacks and organization-specific events like team or membership
-changes.
+stacks.
 
 > There are some restrictions for the number of webhooks that can be registered
 > when using the Pulumi Team editions. [Contact us]({{< relref "/about#contact-us" >}})
@@ -66,7 +65,6 @@ The following events are only delivered to organization-based webhooks.
 | Event Kind | Triggered |
 | --- | --- |
 | `stack` | Whenever a stack is created or deleted within an organization. |
-| `team`  | Whenever a team is created, updated, or deleted. |
 
 ## Payloads
 


### PR DESCRIPTION
Fixes #5103 

FYI, In addition to removing the description for the `team` event type, I also trimmed out content that seemed related in the conceptual portion of the docs. 