### PR TITLE
Refactor HubSpot forms component

### DIFF
--- a/components/src/components/hubspot-form/hubspot-form.e2e.ts
+++ b/components/src/components/hubspot-form/hubspot-form.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage } from "@stencil/core/testing";
 
-describe('pulumi-hubspot-form', () => {
-  it('renders', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<pulumi-hubspot-form></pulumi-hubspot-form>');
+describe("pulumi-hubspot-form", () => {
+    it("renders", async () => {
+        const page = await newE2EPage();
+        await page.setContent(`<pulumi-hubspot-form form-id="12345"></pulumi-hubspot-form>`);
 
-    const element = await page.find('pulumi-hubspot-form');
-    expect(element).toHaveClass('hydrated');
-  });
+        const element = await page.find("pulumi-hubspot-form");
+        expect(element).toHaveClass("hydrated");
+    });
 });

--- a/components/src/components/hubspot-form/hubspot-form.scss
+++ b/components/src/components/hubspot-form/hubspot-form.scss
@@ -1,3 +1,3 @@
 :host {
-  display: block;
+    display: block;
 }

--- a/components/src/components/hubspot-form/hubspot-form.spec.ts
+++ b/components/src/components/hubspot-form/hubspot-form.spec.ts
@@ -1,7 +1,7 @@
-import { HubspotForm } from './hubspot-form';
+import { HubspotForm } from "./hubspot-form";
 
-describe('pulumi-hubspot-form', () => {
-  it('builds', () => {
-    expect(new HubspotForm()).toBeTruthy();
-  });
+describe("pulumi-hubspot-form", () => {
+    it("builds", () => {
+        expect(new HubspotForm()).toBeTruthy();
+    });
 });

--- a/components/src/components/hubspot-form/hubspot-form.tsx
+++ b/components/src/components/hubspot-form/hubspot-form.tsx
@@ -1,12 +1,23 @@
-import { Component, Prop, h, State } from '@stencil/core';
-import { waitForWindowPropertyToExist, parseCookie, parseUTMCookieString, waitForElementToExist } from "../../util/util";
+import { Component, Element, h, Prop, State, } from '@stencil/core';
+import { parseCookie, parseUTMCookieString } from "../../util/util";
+
+interface UTMData {
+    campaign: string;
+    source: string;
+    medium: string;
+}
+
+// The types of form events we expect to receive from HubSpot.
+// https://legacydocs.hubspot.com/docs/methods/forms/advanced_form_options
+type HubSpotFormEvent = "onBeforeFormInit" | "onBeforeValidationInit" | "onFormReady" | "onFormSubmit" | "onFormDefinitionFetchError";
 
 @Component({
-    tag: 'pulumi-hubspot-form',
-    styleUrl: 'hubspot-form.scss',
+    tag: "pulumi-hubspot-form",
+    styleUrl: "hubspot-form.scss",
     shadow: false
 })
 export class HubspotForm {
+
     // The formId is the HubSpot defined form ID this form will submit to.
     @Prop()
     formId: string;
@@ -20,136 +31,157 @@ export class HubspotForm {
     @Prop()
     class?: string;
 
-    // isLoading lets us know if the form is loading.
+    // Whether the HubSpot form is loading.
     @State()
     isLoading: boolean = true;
 
-    // didLoad lets us know if the form successfully loaded.
+    // Whether the HubSpot form was successfully loaded.
     @State()
     didLoad: boolean = false;
 
-    // The window event listener used to handle submitting form data to Segment.
-    windowEventHandler: (this: Window, ev: MessageEvent) => any;
+    @Element()
+    el: HTMLElement;
 
-    // When the component loads we need to wait for the 'hbspt' property to
-    // propagate up to the global window object. Then once it is available
-    // we should create the HubSpot form.
+    // The HTML element that will contain the HubSpot form.
+    hubspotFormTargetId: string;
+
+    // The handler for HubSpot window messages.
+    messageHandler: (event: MessageEvent) => void;
+
     componentDidLoad() {
-        const hsFormTargetId = `#hubspotForm_${this.formId}`;
 
-        waitForWindowPropertyToExist("hbspt").then((hbspt: any) => {
-            hbspt.forms.create({
+        if (!this.formId) {
+            throw new Error("The required attribute `form-id` was not provided.");
+        }
+
+        this.hubspotFormTargetId = `hubspotForm_${this.formId}`;
+
+        const hubspot = window["hbspt"];
+        if (hubspot) {
+            hubspot.forms.create({
                 portalId: "4429525",
                 formId: this.formId,
                 css: "",
                 cssClass: this.class,
                 goToWebinarWebinarKey: this.goToWebinarKey,
-                target: hsFormTargetId,
+                target: `#${this.hubspotFormTargetId}`,
             });
+        } else {
             this.isLoading = false;
-            this.didLoad = true;
-
-            // Hidden form fields from HubSpot created forms causes gaps to appear in
-            // the form which is less then desirable. So we need to find the hidden
-            // form fields and then hide the parent <fieldset> for it. We will also need
-            // to populate those fields with the correct values.
-            waitForElementToExist(`${hsFormTargetId} form div[class="input"]`).then(() => {
-                const fieldSets = document.querySelectorAll(`${hsFormTargetId} form fieldset div[style*="display:none"]`);
-                fieldSets.forEach((fieldset: any) => {
-                    fieldset.parentElement.style.display = "none";
-                });
-
-                // Populate the UTM parameter fields.
-                const cookies = parseCookie();
-                const utmCookie: any = parseUTMCookieString(cookies["__utmzz"]);
-                const utmCampaign = utmCookie.utmccn || "(not set)";
-                const utmSource = utmCookie.utmcsr || "(direct)";
-                const utmMedium = utmCookie.utmcmd || "(none)";
-
-                const utmCampaignInput = document.querySelector<HTMLInputElement>(`${hsFormTargetId} input[name="last_utm_campaign"]`);
-                if (utmCampaignInput) {
-                    utmCampaignInput.value = utmCampaign;
-                }
-
-                const utmSourceInput = document.querySelector<HTMLInputElement>(`${hsFormTargetId} input[name="last_utm_source"]`);
-                if (utmSourceInput) {
-                    utmSourceInput.value = utmSource;
-                }
-
-                const utmMediumInput = document.querySelector<HTMLInputElement>(`${hsFormTargetId} input[name="last_utm_medium"]`);
-                if (utmMediumInput) {
-                    utmMediumInput.value = utmMedium;
-                }
-            });
-        }).catch((err) => {
-            this.isLoading = false;
-            console.log("Unable to load HubSpot form.");
-            console.log(err);
-        });
+            this.didLoad = false;
+        }
 
         // Listen for the HubSpot form to be loaded.
-        this.windowEventHandler = this.handleWindowMessage.bind(this);
-        window.addEventListener("message", this.windowEventHandler);
+        this.messageHandler = this.onMessage.bind(this);
+        window.addEventListener("message", this.messageHandler);
     }
 
     disconnectedCallback() {
-        window.removeEventListener("message", this.windowEventHandler);
+        window.removeEventListener("message", this.messageHandler);
     }
 
-    private handleWindowMessage(event: MessageEvent) {
-        if (event.data.type === "hsFormCallback" && event.data.eventName === "onFormReady") {
-            const form = document.querySelector("form.hs-form") as HTMLFormElement;
-            form.addEventListener("submit", () => this.handleFormSubmission(form.getAttribute("data-form-id")));
+    // HubSpot form events are dispatched as window message events.
+    private onMessage(event: MessageEvent) {
+
+        // Ignore any non-HubSpot-form-related events.
+        if (event.data?.type !== "hsFormCallback") {
+            return;
+        }
+
+        const eventName: HubSpotFormEvent = event.data.eventName;
+        const utmData = this.getUTMCookieData();
+
+        // When the form is ready, update its hidden fields with UTM values.
+        if (eventName === "onFormReady") {
+            this.isLoading = false;
+            this.didLoad = true;
+
+            // Hidden form fields end up wrapped in divs with display:none, which leaves their parent
+            // fieldsets taking up vertical space for no reason. So we hide those as well.
+            const hiddenFields = this.el.querySelectorAll(`input[type="hidden"]`);
+            hiddenFields.forEach((field: HTMLInputElement) => {
+                const fieldset = field.closest("fieldset");
+                if (fieldset) {
+                    fieldset.style.display = "none";
+                }
+            });
+
+            const utmCampaignInput: HTMLInputElement = this.el.querySelector(`input[name="last_utm_campaign"]`);
+            if (utmCampaignInput) {
+                utmCampaignInput.value = utmData.campaign;
+            }
+
+            const utmSourceInput: HTMLInputElement = this.el.querySelector(`input[name="last_utm_source"]`);
+            if (utmSourceInput) {
+                utmSourceInput.value = utmData.source;
+            }
+
+            const utmMediumInput: HTMLInputElement = this.el.querySelector(`input[name="last_utm_medium"]`);
+            if (utmMediumInput) {
+                utmMediumInput.value = utmData.medium;
+            }
+        }
+
+        // When the form is submitted, notify Segment.
+        if (eventName === "onFormSubmit") {
+            const emailAddress: HTMLInputElement = this.el.querySelector(`input[name="email"]`);
+            this.notifySegment(emailAddress.value, utmData);
+        }
+
+        // When there are problems loading the form, show a failure message.
+        if (eventName === "onFormDefinitionFetchError") {
+            this.isLoading = false;
+            this.didLoad = false;
         }
     }
 
-    // When the form is submitted we also send an event to Segment with the relevant UTM tags.
-    private handleFormSubmission(formId: string) {
+    // Send a tracking event to Segment.
+    private notifySegment(emailAddress: string, utmData: UTMData) {
         const analytics = (window as any).analytics;
         const analyticsAvailable = analytics && analytics.track && (typeof analytics.track === "function");
 
         if (analyticsAvailable) {
-            const cookies = parseCookie();
-            const utmCookie: any = parseUTMCookieString(cookies["__utmzz"]);
-            const email = document.querySelector("form.hs-form input[name='email']") as HTMLInputElement;
-
             const submissionData = {
-                formId: formId,
-                email: email.value,
-                utmCampaign: utmCookie.utmccn || "(not set)",
-                utmSource: utmCookie.utmcsr || "(direct)",
-                utmMedium: utmCookie.utmcmd || "(none)",
+                formId: this.formId,
+                email: emailAddress,
+                utmCampaign: utmData.campaign,
+                utmSource: utmData.source,
+                utmMedium: utmData.medium,
             };
 
             analytics.track("form-submission", submissionData);
         }
     }
 
-    renderIsLoadingForm() {
-        return(
-            <div>
-                <i class="fa fa-spinner fa-spin mr-2"></i>
-                <span>Loading Form</span>
-            </div>
-        );
+    // Parse the current cookie and return any UTM fields.
+    private getUTMCookieData(): UTMData {
+        const cookies = parseCookie();
+        const utmCookie: any = parseUTMCookieString(cookies["__utmzz"]);
+
+        return {
+            campaign: utmCookie.utmccn || "(not set)",
+            source: utmCookie.utmcsr || "(direct)",
+            medium: utmCookie.utmcmd || "(none)",
+        };
     }
 
-    renderFailedToLoadForm() {
-        return(
-            <div>
-                There was an issue loading this form. Please try and refresh
-                your browser. If you continuing running into an issue please reach
-                out to support@pulumi.com.
-            </div>
-        );
+    private renderIsLoadingForm() {
+        return <p>
+            <i class="fa fa-spinner fa-spin mr-2"></i>
+        </p>;
+    }
+
+    private renderFailedToLoadForm() {
+        return <p>
+            There was an problem loading this form. Please try refreshing your
+            browser, and if you continue to see this message, let us know
+            at <a href="mailto:support@pulumi.com">support@pulumi.com</a>.
+        </p>;
     }
 
     render() {
-        return [
-            <script src="//js.hsforms.net/forms/v2.js"></script>,
-            <div id={`hubspotForm_${this.formId}`}>
-                { !this.didLoad && !this.isLoading ? this.renderFailedToLoadForm() : this.renderIsLoadingForm() }
-            </div>
-        ];
+        return <div id={this.hubspotFormTargetId}>
+            { !this.didLoad && !this.isLoading ? this.renderFailedToLoadForm() : this.renderIsLoadingForm() }
+        </div>;
     }
 }

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,6 +6,12 @@
 <script src="{{ getenv "REL_JS_BUNDLE" }}"></script>
 
 <!--
+    The HubSpot forms script exposes a global, `hbspt`, that our components use
+    to create and manage HubSpot forms dynamically.
+-->
+<script src="//js.hsforms.net/forms/v2.js"></script>
+
+<!--
     These two scripts are provided separately in order to allow browsers to decide which
     component bundle to load. Modern browsers that support web components will load the
     smaller bundle. Others will load the (much larger) polyfill. Because they're ultimately

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,12 +6,6 @@
 <script src="{{ getenv "REL_JS_BUNDLE" }}"></script>
 
 <!--
-    The HubSpot forms script exposes a global, `hbspt`, that our components use
-    to create and manage HubSpot forms dynamically.
--->
-<script src="//js.hsforms.net/forms/v2.js"></script>
-
-<!--
     These two scripts are provided separately in order to allow browsers to decide which
     component bundle to load. Modern browsers that support web components will load the
     smaller bundle. Others will load the (much larger) polyfill. Because they're ultimately


### PR DESCRIPTION
It looks like we get all the form-loading notifications we need from HubSpot in the form of message events, so this PR refactors the component to rely on those.

Fixes #4971. 