### PR TITLE
Hide the Supporting Types note

### DIFF
--- a/assets/config/postcss.config.js
+++ b/assets/config/postcss.config.js
@@ -64,6 +64,7 @@ module.exports = {
             whitelist: [
                 "supported-cicd-platforms", ":not", ":target", "md:max-w-lg", "blink", "typing",
                 "char", "resource-deprecated", "btn-scroll-top", "lg:btn-purple-transparent", "section-docs",
+                "supporting-types"
             ],
 
             // Whitelist custom parent selectors and their children.

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -247,9 +247,15 @@ main {
     }
 }
 
-// Hide the language-specific SDK-docs tables until we've removed them from the provider builds.
-.section-docs main .container dl.package-details + p + dl.tabular {
-    @apply hidden;
+.section-docs {
+    // Hide the language-specific SDK-docs tables until we've removed them from the provider builds.
+    main .container dl.package-details + p + dl.tabular {
+        @apply hidden;
+    }
+    // Hide input and output type notes as well.
+    #supporting-types ~ h4 ~ div pulumi-choosable .active blockquote {
+        @apply hidden;
+    }
 }
 
 @tailwind utilities;


### PR DESCRIPTION
These links have no proper destination as of #5133, so this PR hides them with CSS until we can get them removed from the doc-gen templates in pulumi/pulumi.

Compare:

http://pulumi-docs-origin-pr-5166-29c6d07b.s3-website.us-west-2.amazonaws.com/docs/reference/pkg/aws/eks/cluster/#supporting-types

https://www.pulumi.com/docs/reference/pkg/aws/eks/cluster/#supporting-types

Part of #5156.