### PR TITLE
Add redirect exceptions for types and config

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -159,7 +159,7 @@ function nodeSDKRedirect(uri: string): string | undefined {
     ];
 
     if (match && match.provider && !exceptions.includes(match.provider)) {
-        if (match.service) {
+        if (match.service && !match.service.match(/types|config/)) {
             return `/docs/reference/pkg/${match.provider}/${match.service}/?language=nodejs`;
         }
         return `/docs/reference/pkg/${match.provider}/?language=nodejs`;


### PR DESCRIPTION
Our redirect rule is currently matching on `types` and `config`, which were subdirectories of some providers and aren't covered in the resource docs. This just adds a rule that prevents users still navigating to these URLs from experiencing 404s, by redirecting to the top-level provider. (We'll hide these sections client-side and remove their respective sections from doc-gen templates in separate PRs.)

Part of #5156.