### PR TITLE
Override default title string used by Swiftype

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -74,8 +74,11 @@
     {{ if .IsHome }}
         <title>{{ .Site.Title }}</title>
     {{ else if .Params.title_tag }}
+        <!-- Using the title frontmatter value to override the default title string that Swiftype pulls in. -->
+        <meta class="swiftype" name="title" data-type="string" content="{{ .Params.title_tag }}" />
         <title>{{ .Params.title_tag }} | Pulumi</title>
     {{ else if .Title }}
+        <meta class="swiftype" name="title" data-type="string" content="{{ .Title }}" />
         <title>{{ .Title }} | Pulumi</title>
     {{ else if not (or .Params.redirect_to .Params.private) }}
         <!--


### PR DESCRIPTION
Swiftype will pull in the HTML <title> tag by default. We append `| Pulumi` to the end of every title for external search SEO; however, that's not needed in a site search experience. 

Unfortunately, the current POC uses Swiftype to crawl the prod site, so we'll need to get this PR merged in before we can do local testing of the new Swiftype title change.