### PR TITLE
Latest AzureNextGen uses Enumerations instead of strings on DefaultCo…

### DIFF
--- a/content/docs/reference/pkg/azure-nextgen/documentdb/databaseaccount.md
+++ b/content/docs/reference/pkg/azure-nextgen/documentdb/databaseaccount.md
@@ -45,7 +45,7 @@ class MyStack : Stack
             },
             ConsistencyPolicy = new AzureNextGen.DocumentDB.Latest.Inputs.ConsistencyPolicyArgs
             {
-                DefaultConsistencyLevel = DefaultConsistencyLevel.BoundedStaleness,
+                DefaultConsistencyLevel = AzureNextGen.DocumentDB.Latest.DefaultConsistencyLevel.BoundedStaleness,
                 MaxIntervalInSeconds = 10,
                 MaxStalenessPrefix = 200,
             },
@@ -56,7 +56,7 @@ class MyStack : Stack
                     AllowedOrigins = "https://test",
                 },
             },
-            DatabaseAccountOfferType = DatabaseAccountOfferType.Standard,
+            DatabaseAccountOfferType = AzureNextGen.DocumentDB.Latest.DatabaseAccountOfferType.Standard,
             EnableAnalyticalStorage = true,
             EnableFreeTier = false,
             IpRules = 

--- a/content/docs/reference/pkg/azure-nextgen/documentdb/databaseaccount.md
+++ b/content/docs/reference/pkg/azure-nextgen/documentdb/databaseaccount.md
@@ -45,7 +45,7 @@ class MyStack : Stack
             },
             ConsistencyPolicy = new AzureNextGen.DocumentDB.Latest.Inputs.ConsistencyPolicyArgs
             {
-                DefaultConsistencyLevel = "BoundedStaleness",
+                DefaultConsistencyLevel = DefaultConsistencyLevel.BoundedStaleness,
                 MaxIntervalInSeconds = 10,
                 MaxStalenessPrefix = 200,
             },
@@ -56,7 +56,7 @@ class MyStack : Stack
                     AllowedOrigins = "https://test",
                 },
             },
-            DatabaseAccountOfferType = "Standard",
+            DatabaseAccountOfferType = DatabaseAccountOfferType.Standard,
             EnableAnalyticalStorage = true,
             EnableFreeTier = false,
             IpRules = 


### PR DESCRIPTION
### Proposed changes

Latest AzureNextGen.DocumentDB changed `DatabaseAccountOfferType` and `DefaultConsistencyLevel` from strings to Enumerations on `DatabaseAccountArgs`. The C#-Documentation should do the same.
