### PR TITLE
Update file size of index.html

### DIFF
--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -104,7 +104,7 @@ $ aws s3 ls $(pulumi stack output BucketName)
 Notice that your `index.html` file has been added to the bucket:
 
 ```bash
-2020-08-27 12:30:24         68 index.html
+2020-08-27 12:30:24         70 index.html
 ```
 
 {{% choosable language javascript %}}


### PR DESCRIPTION
The file size for index.html is actually 70 B and not 68 B

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
