### PR TITLE
Only have Swiftype crawl the main content on docs and blogs

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -19,7 +19,7 @@
                             {{ partial "blog/authors.html" (dict "context" . "authors" .Params.authors) }}
                         </span>
                     </div>
-                    <section>
+                    <section data-swiftype-index="true">
                         {{ .Content }}
                     </section>
                     <div>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -10,8 +10,9 @@
                 {{ else if and (ne .Title "") (not .Params.notitle) }}
                     <h1>{{ .Title }}</h1>
                 {{ end }}
-
-                {{ .Content }}
+                <section data-swiftype-index="true">
+                    {{ .Content }}
+                </section>
             </div>
 
             <div class="md:w-3/12 md:pl-8 mt-2">


### PR DESCRIPTION
Currently, Swiftype is crawling every section on the page (e.g. submenus, footers, etc.). This change restricts the crawled area to the body of a given topic or blog post (hopefully).