### PR TITLE
Match a wider set of .NET links

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -188,11 +188,13 @@ function pythonSDKRedirect(uri: string): string | undefined {
 }
 
 function dotnetSDKRedirect(uri: string): string | undefined {
-    const pattern = new URLPattern("/docs/reference/pkg/dotnet/Pulumi.(:provider)/Pulumi.(:providerAgain)(.(:service)).html");
+    const pattern = new URLPattern(
+        "/docs/reference/pkg/dotnet/Pulumi.:provider/Pulumi.:providerRepeated(.:service)(.*).html"
+    );
     const match = pattern.match(uri);
 
     if (match && match.provider) {
-        if (match.service) {
+        if (match.service && !match.service.match(/Types|Config/)) {
             // tslint:disable-next-line:max-line-length
             return `/docs/reference/pkg/${match.provider.toLowerCase()}/${match.service.toLowerCase()}/?language=csharp`;
         }
@@ -200,7 +202,7 @@ function dotnetSDKRedirect(uri: string): string | undefined {
 
     // If the URI matches /dotnet/anything-else, we'll just direct you to the GitHub repo.
     } else if (uri.startsWith("/docs/reference/pkg/dotnet/")) {
-        return "https://github.com/pulumi/pulumi/tree/master/sdk/dotnet";
+        return "/docs/reference/pkg";
     }
 
     return undefined;


### PR DESCRIPTION
This change widens the set of matches for the recently removed .NET docs in order to direct more users to the resource docs rather than GitHub. It also changes the fallback URL from GitHub to the resource-docs home page. 

```
[
    test("/docs/reference/pkg/dotnet/Pulumi.Aws/Pulumi.Aws.html"),
    test("/docs/reference/pkg/dotnet/Pulumi.DigitalOcean/Pulumi.DigitalOcean.html"),
    test("/docs/reference/pkg/dotnet/Pulumi.DigitalOcean/Pulumi.DigitalOcean.Droplet.html"),
    test("/docs/reference/pkg/dotnet/Pulumi/Pulumi.html"),
    test("/docs/reference/pkg/dotnet/Pulumi.Kubernetes/Pulumi.Kubernetes.Types.Outputs.Core.V1.PodAntiAffinity.html"),
    test("/docs/reference/pkg/dotnet/Pulumi.Gcp/Pulumi.Gcp.Apigee.Organization.html"),
    test("/docs/reference/pkg/dotnet/Pulumi.Gcp/Pulumi.Gcp.CloudRun.DomainMapping.html"),
    test("/docs/reference/pkg/dotnet/Pulumi.Gcp/Pulumi.Gcp.ContainerAnalysis.html"),
    test("/docs/reference/pkg/dotnet/Pulumi.Gcp/Pulumi.Gcp.html"),
    test("/docs/reference/pkg/dotnet/Pulumi.Gcp/Pulumi.Gcp.Compute.Network.html"),
].map(result => console.log(`https://pulumi.com${result}`));
```

```
https://pulumi.com/docs/reference/pkg/aws/?language=csharp
https://pulumi.com/docs/reference/pkg/digitalocean/?language=csharp
https://pulumi.com/docs/reference/pkg/digitalocean/droplet/?language=csharp
https://pulumi.com/docs/reference/pkg
https://pulumi.com/docs/reference/pkg/kubernetes/?language=csharp
https://pulumi.com/docs/reference/pkg/gcp/apigee/?language=csharp
https://pulumi.com/docs/reference/pkg/gcp/cloudrun/?language=csharp
https://pulumi.com/docs/reference/pkg/gcp/containeranalysis/?language=csharp
https://pulumi.com/docs/reference/pkg/gcp/?language=csharp
https://pulumi.com/docs/reference/pkg/gcp/compute/?language=csharp
```