### PR TITLE
Exclude Akamai from the link checker

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -262,6 +262,7 @@ function getDefaultExcludedKeywords() {
         "https://codepen.io",
         "https://twitter.com",
         "https://t.co",
+        "https://www.akamai.com",
     ];
 }
 


### PR DESCRIPTION
The HTTP library used by broken-link-checker fails to resolve or reject the promise returned by calls to Akamai, causing our daily link-checking process to hang and eventually time out. This change adds Akamai to the list of excluded URLs.

Fixes #5045.