### PR TITLE
Denote blog entries in Swiftype search result sets

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -78,7 +78,12 @@
         <meta class="swiftype" name="title" data-type="string" content="{{ .Params.title_tag }}" />
         <title>{{ .Params.title_tag }} | Pulumi</title>
     {{ else if .Title }}
-        <meta class="swiftype" name="title" data-type="string" content="{{ .Title }}" />
+        <!-- For blog posts that come up in Swiftype result sets, denote that the links are blog posts by adding a "Blog" prefix to the title. -->
+        {{ if and (eq .Type "blog") .IsPage }}
+            <meta class="swiftype" name="title" data-type="string" content="Blog: {{ .Title }}" />
+        {{ else }}
+            <meta class="swiftype" name="title" data-type="string" content="{{ .Title }}" />
+        {{ end }}
         <title>{{ .Title }} | Pulumi</title>
     {{ else if not (or .Params.redirect_to .Params.private) }}
         <!--


### PR DESCRIPTION
Our blog posts contain a lot of good information that hasn't been included in the core docs, yet. Because of this, our Swiftype engine currently crawls blog posts and includes them in relevant queries; however, when looking through the result set, you don't know when you're clicking on a blog post or a page in the documentation. Clicking on a blog post means you will travel outside of the core docs to the blogs section of the Pulumi corp site.

This change is a simple fix to append "Blog" as a prefix to the topic title. 