### PR TITLE
Add an automerge workflow for provider and cli docs

### DIFF
--- a/.github/workflows/automerge-workflow.yml
+++ b/.github/workflows/automerge-workflow.yml
@@ -1,0 +1,37 @@
+jobs:
+  automerge:
+    name: Automerge Workflow
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          MERGE_COMMIT_MESSAGE: pull-request-title
+          MERGE_FORKS: "false"
+          MERGE_LABELS: automation/merge
+          MERGE_METHOD: squash
+          MERGE_REMOVE_LABELS: automation/merge
+          MERGE_RETRIES: "30"
+          MERGE_RETRY_SLEEP: "60000"
+          UPDATE_LABELS: automation/update
+          UPDATE_METHOD: rebase
+        name: Automerge
+        uses: pascalgn/automerge-action@v0.13.1
+name: Automerge workflow
+"on":
+  check_suite:
+    types:
+      - completed
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  status: {}

--- a/.github/workflows/generate-provider-docs.yml
+++ b/.github/workflows/generate-provider-docs.yml
@@ -27,7 +27,7 @@ jobs:
           destination_branch: "master"
           pr_title: "Regen docs ${{ env.PROVIDER_SHORT_NAME }}@${{ env.PROVIDER_VERSION }}"
           pr_body: ""
-          pr_label: "automation/tfgen-provider-docs"
+          pr_label: "automation/tfgen-provider-docs,automation/merge"
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
   build-tfgen-provider-docs:

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -23,7 +23,7 @@ jobs:
           destination_branch: "master"
           pr_title: "Regen docs pulumi@${PULUMI_VERSION}"
           pr_body: ""
-          pr_label: "automation/pulumi-cli-docs"
+          pr_label: "automation/pulumi-cli-docs,automation/merge"
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
   build-pulumi-cli-docs:


### PR DESCRIPTION
Fixes: #5298

This new automerge functionality will mean that provider docs PRs
+ CLI docs PRs will get a new tag added `automation/merge` that if
present AND the checks for the PR pass, then the PR will be automerged

This workflow will work for *any* PR that is tagged with
`automation/merge` - the nice point here is that a non-pulumiam
cannot add labels to PRs


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->