### PR TITLE
Adds a 'Contact Us' link to the Self-Hosted pages.

### DIFF
--- a/content/docs/guides/self-hosted/_index.md
+++ b/content/docs/guides/self-hosted/_index.md
@@ -49,7 +49,9 @@ Here are some examples of deployment topologies:
 | [Console]({{< relref "console" >}}) |	[https://hub.docker.com/r/pulumi/console/](https://hub.docker.com/r/pulumi/console/) |
 | Migrations | [https://hub.docker.com/r/pulumi/migrations/](https://hub.docker.com/r/pulumi/migrations/) |
 
-> **Note**: The above container image repositories are private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% notes type="info" %}}
+The above container image repositories are private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% /notes %}}
 
 ## Quickstart
 

--- a/content/docs/guides/self-hosted/_index.md
+++ b/content/docs/guides/self-hosted/_index.md
@@ -9,7 +9,10 @@ meta_desc: Pulumi Enterprise Edition gives you the option to self-host Pulumi wi
 
 <div class="note note-info" role="alert">
     <p>
-        Self-hosting is only available with the <strong>Pulumi Enterprise Edition</strong>.
+        Self-hosting is only available with the <strong>Pulumi Enterprise Edition</strong>. 
+    </p>
+    <p>
+        <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
     </p>
 </div>
 
@@ -26,7 +29,7 @@ There are two services that need to be hosted for the purposes of remote state m
 
 The self-hosted version of the Pulumi Service also offers some features that are not available with the managed version (i.e. [app.pulumi.com](https://app.pulumi.com)). The self-hosted installation of Pulumi provides full control of your data -- a requirement for enterprises in certain industries with specific security compliance requirements.
 
-If you are unsure about whether a self-hosted version of the Pulumi Service is right for your organization, [contact us]({{< relref "/about#contact" >}}) to learn more.
+If you are unsure about whether a self-hosted version of the Pulumi Service is right for your organization, [contact us]({{< relref "/contact.md" >}}) to learn more.
 
 ## Deployment Topology
 
@@ -52,6 +55,7 @@ Here are some examples of deployment topologies:
 | Migrations | [https://hub.docker.com/r/pulumi/migrations/](https://hub.docker.com/r/pulumi/migrations/) |
 
 > **Note**: The above container image repositories are private.
+> <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
 
 ## Quickstart
 

--- a/content/docs/guides/self-hosted/_index.md
+++ b/content/docs/guides/self-hosted/_index.md
@@ -7,14 +7,9 @@ menu:
 meta_desc: Pulumi Enterprise Edition gives you the option to self-host Pulumi within your organization's infrastructure.
 ---
 
-<div class="note note-info" role="alert">
-    <p>
-        Self-hosting is only available with the <strong>Pulumi Enterprise Edition</strong>. 
-    </p>
-    <p>
-        <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
-    </p>
-</div>
+{{% notes type="info" %}}
+Self-hosting is only available with the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% /notes %}}
 
 This guide walks you through the components that are required to get the Pulumi Service running in your own environment.
 
@@ -54,8 +49,7 @@ Here are some examples of deployment topologies:
 | [Console]({{< relref "console" >}}) |	[https://hub.docker.com/r/pulumi/console/](https://hub.docker.com/r/pulumi/console/) |
 | Migrations | [https://hub.docker.com/r/pulumi/migrations/](https://hub.docker.com/r/pulumi/migrations/) |
 
-> **Note**: The above container image repositories are private.
-> <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
+> **Note**: The above container image repositories are private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
 
 ## Quickstart
 

--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -36,7 +36,9 @@ The Pulumi API is one of the components required for self-hosting Pulumi in your
 
 ## What's In The Container?
 
-> **Note**: The container image repository is private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% notes type="info" %}}
+The container image repository is private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% /notes %}}
 
 The API service is a Go-based application. This is a single binary application that has all of the dependencies it needs in order to run.
 

--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -8,14 +8,9 @@ menu:
 meta_desc: Pulumi API is one of the components required for self-hosting Pulumi. Self-hosting is available as part of the Enterprise Edition.
 ---
 
-<div class="note note-info" role="alert">
-    <p>
-        Self-hosting is only available with the <strong>Pulumi Enterprise Edition</strong>.
-    </p>
-    <p>
-        <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
-    </p>
-</div>
+{{% notes type="info" %}}
+Self-hosting is only available with the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% /notes %}}
 
 The Pulumi API is one of the components required for self-hosting Pulumi in your organization's environment. It provides the necessary APIs for both the CLI and the [Console]({{< relref "console" >}}).
 
@@ -41,8 +36,7 @@ The Pulumi API is one of the components required for self-hosting Pulumi in your
 
 ## What's In The Container?
 
-> **Note**: The container image repository is private.
-> <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
+> **Note**: The container image repository is private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
 
 The API service is a Go-based application. This is a single binary application that has all of the dependencies it needs in order to run.
 

--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -12,6 +12,9 @@ meta_desc: Pulumi API is one of the components required for self-hosting Pulumi.
     <p>
         Self-hosting is only available with the <strong>Pulumi Enterprise Edition</strong>.
     </p>
+    <p>
+        <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
+    </p>
 </div>
 
 The Pulumi API is one of the components required for self-hosting Pulumi in your organization's environment. It provides the necessary APIs for both the CLI and the [Console]({{< relref "console" >}}).
@@ -37,6 +40,9 @@ The Pulumi API is one of the components required for self-hosting Pulumi in your
 > **Note**: The storage recommendations for the Object Storage can be lesser than 200GB depending on your organization size and the expected usage.
 
 ## What's In The Container?
+
+> **Note**: The container image repository is private.
+> <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
 
 The API service is a Go-based application. This is a single binary application that has all of the dependencies it needs in order to run.
 

--- a/content/docs/guides/self-hosted/console.md
+++ b/content/docs/guides/self-hosted/console.md
@@ -12,6 +12,9 @@ meta_desc: Pulumi Console is one of the components required for self-hosting Pul
     <p>
         Self-hosting is only available with the <strong>Pulumi Enterprise Edition</strong>.
     </p>
+    <p>
+        <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
+    </p>
 </div>
 
 The Pulumi Console allows users to view the stacks they have created, see any past activities recorded for those stacks. It also allows you to manage RBAC for your users.
@@ -35,6 +38,9 @@ You can run this container on the same host that your API container is running o
 | Compute | 1 CPU core w/ 1 GB memory | |
 
 ## What's In The Container?
+
+> **Note**: The container image repository is private.
+> <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
 
 The Console container runs a web server using a Node 10-based image.
 

--- a/content/docs/guides/self-hosted/console.md
+++ b/content/docs/guides/self-hosted/console.md
@@ -8,14 +8,9 @@ menu:
 meta_desc: Pulumi Console is one of the components required for self-hosting Pulumi. Self-hosting is available as part of the Enterprise Edition.
 ---
 
-<div class="note note-info" role="alert">
-    <p>
-        Self-hosting is only available with the <strong>Pulumi Enterprise Edition</strong>.
-    </p>
-    <p>
-        <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
-    </p>
-</div>
+{{% notes type="info" %}}
+Self-hosting is only available with the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% /notes %}}
 
 The Pulumi Console allows users to view the stacks they have created, see any past activities recorded for those stacks. It also allows you to manage RBAC for your users.
 
@@ -39,8 +34,7 @@ You can run this container on the same host that your API container is running o
 
 ## What's In The Container?
 
-> **Note**: The container image repository is private.
-> <a href="/contact/">Contact us</a> if you would like to evaluate the Self-Hosted Enterprise Edition.
+> **Note**: The container image repository is private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
 
 The Console container runs a web server using a Node 10-based image.
 

--- a/content/docs/guides/self-hosted/console.md
+++ b/content/docs/guides/self-hosted/console.md
@@ -34,7 +34,9 @@ You can run this container on the same host that your API container is running o
 
 ## What's In The Container?
 
-> **Note**: The container image repository is private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% notes type="info" %}}
+The container image repository is private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% /notes %}}
 
 The Console container runs a web server using a Node 10-based image.
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/docs/issues/5202.

Used `<a href>...</a>` in all places to be consistent with the `div` at the top of the page, where `relref` doesn't seem to work.
