### PR TITLE
Add EKS to package documentation section for all languages

### DIFF
--- a/content/docs/reference/pkg/_index.md
+++ b/content/docs/reference/pkg/_index.md
@@ -98,9 +98,9 @@ SDK reference documentation, organized by language.
 </dl>
 {{% /choosable %}}
 
-{{% choosable language "javascript,typescript" %}}
 ### Extension Packages
 
+{{% choosable language "javascript,typescript" %}}
 <dl class="tabular">
     <dt>AWS Extensions</dt>
     <dd>
@@ -109,7 +109,7 @@ SDK reference documentation, organized by language.
     </dd>
     <dt>AWS EKS Cluster</dt>
     <dd>
-        <a href="{{< relref "/docs/reference/pkg/nodejs/pulumi/eks" >}}">@pulumi/eks</a>
+        <a href="{{< relref "/docs/reference/pkg/eks" >}}">@pulumi/eks</a>
         <p>Simpler interfaces for working with AWS EKS.</p>
     </dd>
     <dt>Kubernetes Extensions</dt>
@@ -117,6 +117,36 @@ SDK reference documentation, organized by language.
         <a href="{{< relref "/docs/reference/pkg/nodejs/pulumi/kubernetesx" >}}">@pulumi/kubernetesx</a>
         <span class="ml-2 badge badge-preview">Preview</span>
         <p>Simpler interfaces for working with Kubernetes.</p>
+    </dd>
+</dl>
+{{% /choosable %}}
+
+{{% choosable language python %}}
+<dl class="tabular">
+    <dt>AWS EKS Cluster</dt>
+    <dd>
+        <a href="{{< relref "/docs/reference/pkg/eks" >}}">pulumi_eks</a>
+        <p>Simpler interfaces for working with AWS EKS.</p>
+    </dd>
+</dl>
+{{% /choosable %}}
+
+{{% choosable language go %}}
+<dl class="tabular">
+    <dt>AWS EKS Cluster</dt>
+    <dd>
+        <a href="{{< relref "/docs/reference/pkg/eks" >}}">eks</a>
+        <p>Simpler interfaces for working with AWS EKS.</p>
+    </dd>
+</dl>
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+<dl class="tabular">
+    <dt>AWS EKS Cluster</dt>
+    <dd>
+        <a href="{{< relref "/docs/reference/pkg/eks" >}}">Pulumi.Eks</a>
+        <p>Simpler interfaces for working with AWS EKS.</p>
     </dd>
 </dl>
 {{% /choosable %}}


### PR DESCRIPTION
Fixes pulumi/pulumi-eks#533

I thought about adding a new "Extensions" section under "Utilities" on the page and simply referencing this as another "resource provider" similar to the others. But I think it makes more sense to have this show up next to AWSX/KX in JavaScript/TypeScript, so I went with this structure instead.