### PR TITLE
Update gke.md

### DIFF
--- a/content/docs/tutorials/kubernetes/gke.md
+++ b/content/docs/tutorials/kubernetes/gke.md
@@ -296,7 +296,7 @@ Next, we need to setup the `kubeconfig` file to configure `kubectl`. We can leve
 stack output in the CLI, as Pulumi facilitates exporting these objects for us.
 
 ```bash
-pulumi stack output kubeconfig > kubeconfig
+pulumi stack output kubeconfig --show-secrets > kubeconfig
 export KUBECONFIG=$PWD/kubeconfig
 
 kubectl version


### PR DESCRIPTION
Without `--show-secrets` the `pulumi stack output` command produces a kubeconfig file that is not usable.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
