### PR TITLE
Remove form for Feb 2021 EKS workshop

### DIFF
--- a/content/resources/building-a-kubernetes-platform-in-amazon-eks/index.md
+++ b/content/resources/building-a-kubernetes-platform-in-amazon-eks/index.md
@@ -7,7 +7,7 @@ meta_desc: "In this workshop, you will examine how Pulumi interacts with Kuberne
 featured: true
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
@@ -20,7 +20,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars


### PR DESCRIPTION
As the title states, this PR removes the form and replaces it with the On-Demand version of the workshop.