### PR TITLE
Update trial length in a few places

### DIFF
--- a/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
+++ b/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
@@ -48,7 +48,7 @@ td {
 | For teams just getting started with cloud applications and infrastructure. | For medium to large teams using Pulumi for multiple projects or clouds. | For large organizations operating at scale or with advanced custom needs.
 | Includes<ul><li>Any Cloud<li>Includes 3 users<li>Up to 20 stacks<li>Basic secrets management<li>CI/CD Integrations</ul> | Everything in Team Starter plus...<ul><li>Up to 25 users<li>Unlimited projects and stacks<li>APIs and webhooks<li>Advanced secrets management<li>12x5 support available</ul> | Everything in Team Pro plus...<ul><li>Teams, roles, and policies<li>SAML/SSO<li>On-premeses/self-host available<li>24x7 support available</ul> |
 
-All editions offer a 14-day free trial, no credit card
+All editions offer a 30-day free trial, no credit card
 required. If you need a longer trial period, want to discuss potential proof of
 concept projects, or are interested in advanced capabilities, such as
 large numbers of seats, Training, or Support, please [contact

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -1049,7 +1049,7 @@
                             it's all there in the open source for you to use freely as you'd like.
                         </p>
                         <p>
-                            Finally, all paid editions offer a 14-day free trial. If this isn't a sufficient duration for
+                            Finally, all paid editions offer a 30-day free trial. If this isn't a sufficient duration for
                             your project, <a href="{{ relref . "/contact.md" }}">please contact us</a>, and we are happy to work
                             out a custom trial period for you that makes sense given your proof-of-concept timeline. After your
                             trial expires, no data will be lost, and there is a grace period with soft enforcement.


### PR DESCRIPTION
In [PR](https://github.com/pulumi/pulumi-service/pull/6220) we are changing the length of a trial from 14 days to 30 days. In this PR we are updating places on the website where we reference the trial length. I only found two places but it is probably worth it for someone else to take a look and ensure I didn't miss anything.