### PR TITLE
Update Azure GS tutorial to be static site and to use native provider

### DIFF
--- a/content/docs/get-started/aws/_index.md
+++ b/content/docs/get-started/aws/_index.md
@@ -13,6 +13,4 @@ aliases: ["/docs/quickstart/aws/"]
 
 {{< cloud-intro "AWS" >}}
 
-To get started we will walk through installing Pulumi, installing your preferred language runtime (if needed), and configuring Pulumi with AWS. Click the button below to get started.
-
 {{< get-started-stepper >}}

--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -18,7 +18,7 @@ Now let's deploy your changes.
 $ pulumi up
 ```
 
-First, Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
+Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
 Previewing update (dev):

--- a/content/docs/get-started/azure/_index.md
+++ b/content/docs/get-started/azure/_index.md
@@ -11,8 +11,6 @@ menu:
 aliases: ["/docs/quickstart/azure/"]
 ---
 
-{{< cloud-intro "Azure" >}}
-
-To get started we will walk through installing Pulumi, installing your preferred language runtime (if needed), and setting up the Azure CLI. Click the button below to get started.
+{{< cloud-intro "Microsoft Azure" >}}
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/azure/begin.md
+++ b/content/docs/get-started/azure/begin.md
@@ -58,9 +58,13 @@ Finally, configure Pulumi with Microsoft Azure.
 
 ### Configure Pulumi to access your Microsoft Azure account
 
-Pulumi requires cloud credentials to manage and provision resources. Pulumi can authenticate to Azure using an IAM user or service principal that has **Programmatic access** with rights to deploy and manage your Azure resources.
+Pulumi requires cloud credentials to manage and provision resources. Pulumi can authenticate to Azure using a user account or service principal that has **Programmatic access** with rights to deploy and manage your Azure resources.
 
-In this guide, you will need an IAM user account with permissions to create and populate Blob storage containers and provide anonymous access to a Blob file.
+{{% notes type="info" %}}
+Pulumi relies on the Azure SDK to authenticate requests from your computer to Azure. Your credentials are never sent to pulumi.com.
+{{% /notes %}}
+
+In this guide, you will need a user account with permissions to create and populate Blob storage containers and provide anonymous access to a Blob file.
 
 When developing locally, we recommend that you install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and then authorize access with a user account.
 

--- a/content/docs/get-started/azure/begin.md
+++ b/content/docs/get-started/azure/begin.md
@@ -20,7 +20,7 @@ aliases: [
 ]
 ---
 
-Before we get started using Pulumi, let's run through a few quick steps to ensure our environment is setup correctly.
+Before you get started using Pulumi, let's run through a few quick steps to ensure your environment is set up correctly.
 
 ### Install Pulumi
 
@@ -30,15 +30,15 @@ All Windows examples in this tutorial assume you are running in PowerShell.
 {{% /notes %}}
 {{< /install-pulumi >}}
 
-Next, we'll install the required language runtime.
+Next, install the required language runtime, if you have not already.
 
 ### Install Language Runtime
 
 #### Choose Your Language
 
-{{< chooser language "javascript,typescript,python,go,csharp" / >}}
+{{< chooser language "typescript,python,go,csharp" / >}}
 
-{{% choosable language "javascript,typescript" %}}
+{{% choosable language "typescript" %}}
 {{< install-node >}}
 {{% /choosable %}}
 
@@ -54,12 +54,28 @@ Next, we'll install the required language runtime.
 {{< install-dotnet >}}
 {{% /choosable %}}
 
-Next, we'll configure Azure.
+Finally, configure Pulumi with Microsoft Azure.
 
-### Configure Azure
+### Configure Pulumi to access your Microsoft Azure account
 
-<a href="{{< relref "/docs/intro/cloud-providers/azure/setup" >}}" target="_blank">Configure Azure</a> so the Pulumi CLI can connect to Azure. If you have previously configured the <a href="https://docs.microsoft.com/en-us/cli/azure/" target="_blank">Azure CLI</a>, `az`, Pulumi will respect and use your configuration settings.
+Pulumi requires cloud credentials to manage and provision resources. Pulumi can authenticate to Azure using an IAM user or service principal that has **Programmatic access** with rights to deploy and manage your Azure resources.
 
-Next, we'll create a new project.
+In this guide, you will need an IAM user account with permissions to create and populate Blob storage containers and provide anonymous access to a Blob file.
+
+When developing locally, we recommend that you install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and then authorize access with a user account.
+
+```bash
+az login
+```
+
+After successfully logging in, you are ready to go.
+
+{{% notes type="info" %}}
+The Azure CLI, and thus Pulumi, will use the default subscription for the account. You can change the active subscription with the [`az account set`](https://docs.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az_account_set) command.
+{{% /notes %}}
+
+For additional information on authenticating with Azure, or to login with a service principal, see [Azure Setup]({{< relref "/docs/intro/cloud-providers/azure/setup" >}}).
+
+Next, you'll create a new project.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/azure/create-project.md
+++ b/content/docs/get-started/azure/create-project.md
@@ -12,18 +12,20 @@ menu:
 aliases: ["/docs/quickstart/azure/create-project/"]
 ---
 
-Let's get started with a new project in a new directory.
+Now that you have set up your environment by installing Pulumi, installing your preferred language runtime, and configuring your AWS credentials, let's get started with creating your first Pulumi program.
 
-{{< chooser language "javascript,typescript,python,go,csharp" / >}}
+In this guide you will:
 
-{{% choosable language javascript %}}
+- Create a new Pulumi project.
+- Provision a new Blob storage container.
+- Add an `index.html` file to your container.
+- Serve the `index.html` as a static website.
+- Destroy the resources you've provisioned.
 
-```bash
-$ mkdir quickstart && cd quickstart
-$ pulumi new azure-javascript
-```
+To get started, first create a new directory and project.
 
-{{% /choosable %}}
+{{< chooser language "typescript,python,go,csharp" / >}}
+
 {{% choosable language typescript %}}
 
 ```bash
@@ -58,40 +60,25 @@ $ pulumi new azure-go
 
 {{% /choosable %}}
 
+The [`pulumi new`]({{< relref "/docs/reference/cli/pulumi_new" >}}) command creates a new Pulumi project with some basic scaffolding based on the cloud and language specified.
+
 {{< cli-note >}}
 
 After logging in, the CLI will proceed with walking you through creating a new project.
-
-```
-This command will walk you through creating a new Pulumi project.
-
-Enter a value or leave blank to accept the (default), and press <ENTER>.
-Press ^C at any time to quit.
-
-project name: (quickstart)
-project description: (A minimal Azure Pulumi program)
-Created project 'quickstart'
-
-stack name: (dev)
-Created stack 'dev'
-
-azure:environment: The Azure environment to use (`public`, `usgovernment`, `german`, `china`): (public)
-azure:location: The Azure location to use: (WestUS)
-Saved config
-```
 
 First, you will be asked for a project name and description. Hit `ENTER` to accept the default values or specify new values.
 
 Next, you will be asked for the name of a stack. Hit `ENTER` to accept the default value of `dev`.
 
+For Azure projects, the default region is `WestUS`; however, you can change the region for your stack by using the `pulumi config set` command as shown below:
+
+```bash
+pulumi config set azure-native:location EastUS
+```
+
 > What are [projects]({{< relref "/docs/intro/concepts/project" >}}) and [stacks]({{< relref "/docs/intro/concepts/stack" >}})? Pulumi projects and stacks let you organize Pulumi code. Consider a Pulumi _project_ to be analogous to a GitHub repo---a single place for code---and a _stack_ to be an instance of that code with a separate configuration. For instance, _Project Foo_ may have multiple stacks for different development environments (Dev, Test, or Prod), or perhaps for different cloud configurations (geographic region for example). See [Organizing Projects and Stacks]({{< relref "/docs/guides/organizing-projects-stacks" >}}) for some best practices on organizing your Pulumi projects and stacks.
 
-Next, you will be prompted for some configuration values for the stack.
-
-For Azure projects, you will be prompted for the Azure environment and location. You can accept the default values or
-provide your own.
-
-{{% choosable language "javascript,typescript" %}}
+{{% choosable language "typescript" %}}
 After some dependency installations from `npm`, the project and stack will be ready.
 {{% /choosable %}}
 

--- a/content/docs/get-started/azure/deploy-changes.md
+++ b/content/docs/get-started/azure/deploy-changes.md
@@ -12,24 +12,28 @@ menu:
 aliases: ["/docs/quickstart/azure/deploy-changes/"]
 ---
 
-Now let's deploy our changes.
+Deploy your changes by using `pulumi up` again.
 
 ```bash
 $ pulumi up
 ```
 
-Pulumi computes the minimally disruptive change to achieve the desired state described by the program.
+Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
 Previewing update (dev):
 
-     Type                      Name                     Plan       Info
-     pulumi:pulumi:Stack       quickstart-dev
- ~   └─ azure:storage:Account  storage                  update     [diff: ~tags]
+     Type                                                         Name                     Plan
+     pulumi:pulumi:Stack                                          quickstart-dev
+ +   ├─ azure-native:storage/latest:StorageAccountStaticWebsite   staticWebsite            create
+ +   └─ azure-native:storage/latest:Blob                          index.html               create
+
+Outputs:
+  + staticEndpoint   : "https://mystorageaccount.z22.web.core.windows.net/"
 
 Resources:
-    ~ 1 to update
-    2 unchanged
+    + 2 to create
+    3 unchanged
 
 Do you want to perform this update?
   yes
@@ -37,28 +41,72 @@ Do you want to perform this update?
   details
 ```
 
-Pulumi will update the storage account to add the tag. The resource group hasn't changed so it remains as-is.
-
-Choosing `yes` will proceed with the update.
+Choosing `yes` will proceed with the update by uploading the `index.html` file to a storage container in your account and enabling static website support on the container.
 
 ```
 Do you want to perform this update? yes
 Updating (dev):
 
-     Type                      Name                     Status      Info
-     pulumi:pulumi:Stack       quickstart-dev
- ~   └─ azure:storage:Account  storage                  updated     [diff: ~tags]
+     Type                                                         Name                     Status
+     pulumi:pulumi:Stack                                          quickstart-dev
+ +   ├─ azure-native:storage/latest:StorageAccountStaticWebsite   staticWebsite            created
+ +   └─ azure-native:storage/latest:Blob                          index.html               created
 
 Outputs:
-    connectionString: "[secret]"
+    primaryStorageKey: "<key_value>"
+  + staticEndpoint   : "https://mystorageaccount.z22.web.core.windows.net/"
 
 Resources:
-    ~ 1 updated
-    2 unchanged
+    + 2 created
+    3 unchanged
 
 Duration: 4s
 ```
 
-Next, we'll destroy the stack.
+You can check out your new static website at the URL in the `Outputs` section of your update or you can make a `curl` request and see the contents of your `index.html` object printed out in your terminal.
+
+{{% choosable language typescript %}}
+
+```bash
+$ curl $(pulumi stack output staticEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ curl $(pulumi stack output static_endpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ curl $(pulumi stack output staticEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ curl $(pulumi stack output StaticEndpoint)
+```
+
+{{% /choosable %}}
+
+And you should see:
+
+```bash
+<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>
+```
+
+Now that you have deployed your site, you will destroy the resources.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/azure/deploy-changes.md
+++ b/content/docs/get-started/azure/deploy-changes.md
@@ -25,8 +25,8 @@ Previewing update (dev):
 
      Type                                                         Name                     Plan
      pulumi:pulumi:Stack                                          quickstart-dev
- +   ├─ azure-native:storage:StorageAccountStaticWebsite   staticWebsite            create
- +   └─ azure-native:storage:Blob                          index.html               create
+ +   ├─ azure-native:storage:StorageAccountStaticWebsite          staticWebsite            create
+ +   └─ azure-native:storage:Blob                                 index.html               create
 
 Outputs:
   + staticEndpoint   : "https://sa8dd8af62.z22.web.core.windows.net/"
@@ -49,8 +49,8 @@ Updating (dev):
 
      Type                                                         Name                     Status
      pulumi:pulumi:Stack                                          quickstart-dev
- +   ├─ azure-native:storage:StorageAccountStaticWebsite   staticWebsite            created
- +   └─ azure-native:storage:Blob                          index.html               created
+ +   ├─ azure-native:storage:StorageAccountStaticWebsite          staticWebsite            created
+ +   └─ azure-native:storage:Blob                                 index.html               created
 
 Outputs:
     primaryStorageKey: "<key_value>"

--- a/content/docs/get-started/azure/deploy-changes.md
+++ b/content/docs/get-started/azure/deploy-changes.md
@@ -25,11 +25,11 @@ Previewing update (dev):
 
      Type                                                         Name                     Plan
      pulumi:pulumi:Stack                                          quickstart-dev
- +   ├─ azure-native:storage/latest:StorageAccountStaticWebsite   staticWebsite            create
- +   └─ azure-native:storage/latest:Blob                          index.html               create
+ +   ├─ azure-native:storage:StorageAccountStaticWebsite   staticWebsite            create
+ +   └─ azure-native:storage:Blob                          index.html               create
 
 Outputs:
-  + staticEndpoint   : "https://mystorageaccount.z22.web.core.windows.net/"
+  + staticEndpoint   : "https://sa8dd8af62.z22.web.core.windows.net/"
 
 Resources:
     + 2 to create
@@ -49,12 +49,12 @@ Updating (dev):
 
      Type                                                         Name                     Status
      pulumi:pulumi:Stack                                          quickstart-dev
- +   ├─ azure-native:storage/latest:StorageAccountStaticWebsite   staticWebsite            created
- +   └─ azure-native:storage/latest:Blob                          index.html               created
+ +   ├─ azure-native:storage:StorageAccountStaticWebsite   staticWebsite            created
+ +   └─ azure-native:storage:Blob                          index.html               created
 
 Outputs:
     primaryStorageKey: "<key_value>"
-  + staticEndpoint   : "https://mystorageaccount.z22.web.core.windows.net/"
+  + staticEndpoint   : "https://sa8dd8af62.z22.web.core.windows.net/"
 
 Resources:
     + 2 created

--- a/content/docs/get-started/azure/deploy-stack.md
+++ b/content/docs/get-started/azure/deploy-stack.md
@@ -12,21 +12,21 @@ menu:
 aliases: ["/docs/quickstart/azure/deploy-stack/"]
 ---
 
-Let's go ahead and deploy the stack:
+Let's go ahead and deploy your stack:
 
 ```bash
 $ pulumi up
 ```
 
-This command instructs Pulumi to determine the resources needed to create the stack. First, a preview is shown of the changes that will be made:
+This command evaluates your program and determines the resource updates to make. First, a preview is shown that outlines the changes that will be made when you run the update:
 
 ```
 Previewing update (dev):
 
-     Type                         Name            Plan
- +   pulumi:pulumi:Stack          quickstart-dev  create
- +   ├─ azure:core:ResourceGroup  resourceGroup   create
- +   └─ azure:storage:Account     storage         create
+    Type                                              Name             Plan
+ +   pulumi:pulumi:Stack                              quickstart-dev   create
+ +   ├─ azure-native:resources/latest:ResourceGroup   resourceGroup    create
+ +   └─ azure-native:storage/latest:StorageAccount    sa               create
 
 Resources:
     + 3 to create
@@ -37,19 +37,19 @@ Do you want to perform this update?
   details
 ```
 
-Choosing `yes` will create resources in Azure.
+Once the preview has finished, you are given three options to choose from. Choosing `details` will show you a rich diff of the changes to be made. Choosing `yes` will create your new Blob storage account in Azure. Choosing `no` will return you to the user prompt without performing the update operation.
 
 ```
 Do you want to perform this update? yes
 Updating (dev):
 
-     Type                         Name            Status
- +   pulumi:pulumi:Stack          quickstart-dev  created
- +   ├─ azure:core:ResourceGroup  resourceGroup   created
- +   └─ azure:storage:Account     storage         created
+     Type                                             Name             Status
+ +   pulumi:pulumi:Stack                              quickstart-dev   created
+ +   ├─ azure-native:resources/latest:ResourceGroup   resourceGroup    created
+ +   └─ azure-native:storage/latest:StorageAccount    sa               created
 
 Outputs:
-    connectionString: "[secret]"
+    primaryStorageKey: "<key_value>"
 
 Resources:
     + 3 created
@@ -57,10 +57,44 @@ Resources:
 Duration: 26s
 ```
 
-The storage account's connection string that we exported is shown as a [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}).
+Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the primary key of your bucket with the following command:
+
+{{% choosable language typescript %}}
+
+```bash
+$ pulumi stack output primaryStorageKey
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ pulumi stack output primary_storage_key
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ pulumi stack output primaryStorageKey
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ pulumi stack output PrimaryStorageKey
+```
+
+{{% /choosable %}}
+
+Running that command will print out the storage account's primary key.
 
 {{< console-note >}}
 
-Next, we'll make some modifications to the program.
+Now that your storage account has been provisioned, let's modify it to host a static website.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/azure/deploy-stack.md
+++ b/content/docs/get-started/azure/deploy-stack.md
@@ -25,8 +25,8 @@ Previewing update (dev):
 
     Type                                              Name             Plan
  +   pulumi:pulumi:Stack                              quickstart-dev   create
- +   ├─ azure-native:resources/latest:ResourceGroup   resourceGroup    create
- +   └─ azure-native:storage/latest:StorageAccount    sa               create
+ +   ├─ azure-native:resources:ResourceGroup          resourceGroup    create
+ +   └─ azure-native:storage:StorageAccount           sa               create
 
 Resources:
     + 3 to create
@@ -45,8 +45,8 @@ Updating (dev):
 
      Type                                             Name             Status
  +   pulumi:pulumi:Stack                              quickstart-dev   created
- +   ├─ azure-native:resources/latest:ResourceGroup   resourceGroup    created
- +   └─ azure-native:storage/latest:StorageAccount    sa               created
+ +   ├─ azure-native:resources:ResourceGroup          resourceGroup    created
+ +   └─ azure-native:storage:StorageAccount           sa               created
 
 Outputs:
     primaryStorageKey: "<key_value>"

--- a/content/docs/get-started/azure/destroy-stack.md
+++ b/content/docs/get-started/azure/destroy-stack.md
@@ -12,7 +12,7 @@ menu:
 aliases: ["/docs/quickstart/azure/destroy-stack/"]
 ---
 
-Now that we've seen how to deploy changes to our program, let's clean up and tear down the resources that are part of our stack.
+Now that you've seen how to deploy changes to our program, let's clean up and tear down the resources that are part of your stack.
 
 To destroy resources, run the following:
 
@@ -20,35 +20,41 @@ To destroy resources, run the following:
 $ pulumi destroy
 ```
 
-You'll be prompted to make sure you really want to delete these resources. Pulumi deletes the storage account and the resource group before it considers the destroy operation to be complete.
+You'll be prompted to make sure you really want to delete these resources. This can take a minute or two; Pulumi waits until all resources are shut down and deleted before it considers the destroy operation to be complete.
 
 ```
 Previewing destroy (dev):
 
-     Type                         Name                     Plan
- -   pulumi:pulumi:Stack          quickstart-dev           delete
- -   ├─ azure:storage:Account     storage                  delete
- -   └─ azure:core:ResourceGroup  resourceGroup            delete
+     Type                                                         Name                     Plan
+ -   pulumi:pulumi:Stack                                          quickstart-dev           delete
+ -   ├─ azure-native:storage/latest:Blob                          index.html               delete
+ -   ├─ azure-native:storage/latest:StorageAccountStaticWebsite   staticWebsite            delete
+ -   ├─ azure-native:storage/latest:StorageAccount                sa                       delete
+ -   └─ azure-native:resources/latest:ResourceGroup               resourceGroup            delete
 
 Outputs:
-  - connectionString: "[secret]"
+  - primaryStorageKey: "<key_value>"
+  - staticEndpoint   : "https://mystorageaccount.z22.web.core.windows.net/"
 
 Resources:
-    - 3 to delete
+    - 5 to delete
 
 Do you want to perform this destroy? yes
 Destroying (dev):
 
-     Type                         Name                     Status
- -   pulumi:pulumi:Stack          quickstart-dev           deleted
- -   ├─ azure:storage:Account     storage                  deleted
- -   └─ azure:core:ResourceGroup  resourceGroup            deleted
+     Type                                                         Name                     Status
+ -   pulumi:pulumi:Stack                                          quickstart-dev           deleted
+ -   ├─ azure-native:storage/latest:Blob                          index.html               deleted
+ -   ├─ azure-native:storage/latest:StorageAccountStaticWebsite   staticWebsite            deleted
+ -   ├─ azure-native:storage/latest:StorageAccount                sa                       deleted
+ -   └─ azure-native:resources/latest:ResourceGroup               resourceGroup            deleted
 
 Outputs:
-  - connectionString: "[secret]"
+  - primaryStorageKey: "<key_value>"
+  - staticEndpoint   : "https://mystorageaccount.z22.web.core.windows.net/"
 
 Resources:
-    - 3 deleted
+    - 5 deleted
 
 Duration: 53s
 ```
@@ -57,6 +63,14 @@ To delete the stack itself, run [`pulumi stack rm`]({{< relref
 "/docs/reference/cli/pulumi_stack_rm" >}}). Note that this removes the stack
 entirely from the Pulumi Service, along with all of its update history.
 
-Next, we'll look at some next steps.
+Congratulations! You've successfully provisioned some cloud resources using Pulumi. By completing this guide you have successfully:
+
+- Created a Pulumi new project.
+- Provisioned a new Azure Blob storage account and container.
+- Added an `index.html` file to your container.
+- Served the `index.html` as a static website.
+- Destroyed the resources you've provisioned.
+
+On the next page, we have a collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/azure/destroy-stack.md
+++ b/content/docs/get-started/azure/destroy-stack.md
@@ -27,14 +27,14 @@ Previewing destroy (dev):
 
      Type                                                         Name                     Plan
  -   pulumi:pulumi:Stack                                          quickstart-dev           delete
- -   ├─ azure-native:storage/latest:Blob                          index.html               delete
- -   ├─ azure-native:storage/latest:StorageAccountStaticWebsite   staticWebsite            delete
- -   ├─ azure-native:storage/latest:StorageAccount                sa                       delete
- -   └─ azure-native:resources/latest:ResourceGroup               resourceGroup            delete
+ -   ├─ azure-native:storage:Blob                                 index.html               delete
+ -   ├─ azure-native:storage:StorageAccountStaticWebsite          staticWebsite            delete
+ -   ├─ azure-native:storage:StorageAccount                       sa                       delete
+ -   └─ azure-native:resources:ResourceGroup                      resourceGroup            delete
 
 Outputs:
   - primaryStorageKey: "<key_value>"
-  - staticEndpoint   : "https://mystorageaccount.z22.web.core.windows.net/"
+  - staticEndpoint   : "https://sa8dd8af62.z22.web.core.windows.net/"
 
 Resources:
     - 5 to delete
@@ -44,14 +44,14 @@ Destroying (dev):
 
      Type                                                         Name                     Status
  -   pulumi:pulumi:Stack                                          quickstart-dev           deleted
- -   ├─ azure-native:storage/latest:Blob                          index.html               deleted
- -   ├─ azure-native:storage/latest:StorageAccountStaticWebsite   staticWebsite            deleted
- -   ├─ azure-native:storage/latest:StorageAccount                sa                       deleted
- -   └─ azure-native:resources/latest:ResourceGroup               resourceGroup            deleted
+ -   ├─ azure-native:storage:Blob                                 index.html               deleted
+ -   ├─ azure-native:storage:StorageAccountStaticWebsite          staticWebsite            deleted
+ -   ├─ azure-native:storage:StorageAccount                       sa                       deleted
+ -   └─ azure-native:resources:ResourceGroup                      resourceGroup            deleted
 
 Outputs:
   - primaryStorageKey: "<key_value>"
-  - staticEndpoint   : "https://mystorageaccount.z22.web.core.windows.net/"
+  - staticEndpoint   : "https://sa8dd8af62.z22.web.core.windows.net/"
 
 Resources:
     - 5 deleted

--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -130,17 +130,13 @@ Now use all of these cloud resources, and a local `FileAsset` resource, to uploa
 
 ```typescript
 // Upload the file
-["index.html"].map(name =>
-    new storage.Blob(name, {
-        blobName: name,
-        resourceGroupName: resourceGroup.name,
-        accountName: account.name,
-        containerName: staticWebsite.containerName,
-        type: storage.BlobType.Block,
-        source: new pulumi.asset.FileAsset(`./site/${name}`),
-        contentType: "text/html",
-    }),
-);
+const indexHtml = new storage.Blob("index.html", {
+    resourceGroupName: resourceGroup.name,
+    accountName: storageAccount.name,
+    containerName: staticWebsite.containerName,
+    source: new pulumi.asset.FileAsset("./site/index.html"),
+    contentType: "text/html",
+});
 ```
 
 {{% /choosable %}}
@@ -149,12 +145,10 @@ Now use all of these cloud resources, and a local `FileAsset` resource, to uploa
 
 ```python
 # Upload the file
-index_html = storage.Blob("index_html",
-    blob_name="index.html",
+index_html = storage.Blob("index.html",
     resource_group_name=resource_group.name,
     account_name=account.name,
     container_name=static_website.container_name,
-    type=storage.BlobType.BLOCK,
     source=pulumi.FileAsset("./site/index.html"),
     content_type="text/html")
 ```
@@ -164,12 +158,10 @@ index_html = storage.Blob("index_html",
 
 ```go
 // Upload the file
-_, err = storage.NewBlob(ctx, "index_html", &storage.BlobArgs{
-    BlobName:          pulumi.String("index.html"),
+_, err = storage.NewBlob(ctx, "index.html", &storage.BlobArgs{
     ResourceGroupName: resourceGroup.Name,
     AccountName:       account.Name,
     ContainerName:     staticWebsite.ContainerName,
-    Type:              storage.BlobTypeBlock,
     Source:            pulumi.NewFileAsset("./site/index.html"),
     ContentType:       pulumi.String("text/html"),
 })
@@ -183,13 +175,11 @@ if err != nil {
 
 ```csharp
 // Upload the file
-var index_html = new Blob("index_html", new BlobArgs
+var index_html = new Blob("index.html", new BlobArgs
 {
-    BlobName = "index.html",
     ResourceGroupName = resourceGroup.Name,
     AccountName = storageAccount.Name,
     ContainerName = staticWebsite.ContainerName,
-    Type = BlobType.Block,
     Source = new FileAsset("./site/index.html"),
     ContentType = "text/html",
 });

--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -12,120 +12,98 @@ menu:
 aliases: ["/docs/quickstart/azure/modify-program/"]
 ---
 
-Now that we have an instance of our Pulumi program deployed, let's add a tag to our storage account.
+Now that your Blob storage account is provisioned, let's add a file to it. First, create a new directory called `site`.
 
-Replace the entire contents of {{< langfile >}} with the following:
+```bash
+mkdir site
+```
 
-{{< chooser language "javascript,typescript,python,go,csharp" / >}}
+Next, create a new `index.html` file with some content in it.
 
-{{% choosable language javascript %}}
+{{< chooser os "macos,linux,windows" / >}}
 
-```javascript
-"use strict";
-const pulumi = require("@pulumi/pulumi");
-const azure = require("@pulumi/azure");
+{{% choosable os macos %}}
 
-// Create an Azure Resource Group
-const resourceGroup = new azure.core.ResourceGroup("resourceGroup");
-
-// Create an Azure resource (Storage Account)
-const account = new azure.storage.Account("storage", {
-    resourceGroupName: resourceGroup.name,
-    accountTier: "Standard",
-    accountReplicationType: "LRS",
-    tags: {
-        "Environment": "Dev",
-    },
-});
-
-// Export the connection string for the storage account
-exports.connectionString = account.primaryConnectionString;
+```bash
+cat <<EOT > site/index.html
+<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>
+EOT
 ```
 
 {{% /choosable %}}
+
+{{% choosable os linux %}}
+
+```bash
+cat <<EOT > site/index.html
+<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>
+EOT
+```
+
+{{% /choosable %}}
+
+{{% choosable os windows %}}
+
+```powershell
+@"
+<html>
+  <body>
+    <h1>Hello, Pulumi!</h1>
+  </body>
+</html>
+"@ | Out-File -FilePath site\index.html
+```
+
+{{% /choosable %}}
+
+Now that you have your new `index.html` with some content, you can enable static website support, upload `index.html` to a storage container, and retrieve a public URL through the use of resource properties. These properties can be used to define dependencies between related resources or to retrieve property values for further processing.
+
+To see how this all works, open the program file in your IDE or text editor and add the following the lines right after the storage account creation.
+
+{{< chooser language "typescript,python,go,csharp" / >}}
+
 {{% choosable language typescript %}}
 
 ```typescript
-import * as pulumi from "@pulumi/pulumi";
-import * as azure from "@pulumi/azure";
-
-// Create an Azure Resource Group
-const resourceGroup = new azure.core.ResourceGroup("resourceGroup");
-
-// Create an Azure resource (Storage Account)
-const account = new azure.storage.Account("storage", {
+// Enable static website support
+const staticWebsite = new storage.StorageAccountStaticWebsite("staticWebsite", {
+    accountName: storageAccount.name,
     resourceGroupName: resourceGroup.name,
-    accountTier: "Standard",
-    accountReplicationType: "LRS",
-    tags: {
-        "Environment": "Dev",
-    },
+    indexDocument: "index.html",
 });
-
-// Export the connection string for the storage account
-export const connectionString = account.primaryConnectionString;
 ```
 
 {{% /choosable %}}
 {{% choosable language python %}}
 
 ```python
-import pulumi
-from pulumi_azure import core, storage
-
-# Create an Azure Resource Group
-resource_group = core.ResourceGroup("resource_group")
-
-# Create an Azure resource (Storage Account)
-account = storage.Account("storage",
+# Enable static website support
+static_website = storage.StorageAccountStaticWebsite("staticWebsite",
+    account_name=account.name,
     resource_group_name=resource_group.name,
-    account_tier='Standard',
-    account_replication_type='LRS',
-    tags={"Environment": "Dev"})
-
-# Export the connection string for the storage account
-pulumi.export('connection_string', account.primary_connection_string)
+    index_document="index.html")
 ```
 
 {{% /choosable %}}
 {{% choosable language go %}}
 
 ```go
-package main
-
-import (
-    "github.com/pulumi/pulumi-azure/sdk/v3/go/azure/core"
-    "github.com/pulumi/pulumi-azure/sdk/v3/go/azure/storage"
-    "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
-)
-
-func main() {
-    pulumi.Run(func(ctx *pulumi.Context) error {
-        // Create an Azure Resource Group
-        resourceGroup, err := core.NewResourceGroup(ctx, "resourceGroup", &core.ResourceGroupArgs{
-            Location: pulumi.String("WestUS"),
-        })
-        if err != nil {
-            return err
-        }
-
-        // Create an Azure resource (Storage Account)
-        account, err := storage.NewAccount(ctx, "storage", &storage.AccountArgs{
-            ResourceGroupName:      resourceGroup.Name,
-            AccountTier:            pulumi.String("Standard"),
-            AccountReplicationType: pulumi.String("LRS"),
-            Tags: pulumi.StringMap{
-                "Environment": pulumi.String("Dev"),
-            },
-        })
-        if err != nil {
-            return err
-        }
-
-        // Export the connection string for the storage account
-        ctx.Export("connectionString", account.PrimaryConnectionString)
-        return nil
-    })
+// Enable static website support
+staticWebsite, err := storage.NewStorageAccountStaticWebsite(ctx, "staticWebsite", &storage.StorageAccountStaticWebsiteArgs{
+    AccountName:       account.Name,
+    ResourceGroupName: resourceGroup.Name,
+    IndexDocument:     pulumi.String("index.html"),
+})
+if err != nil {
+    return err
 }
 ```
 
@@ -133,40 +111,136 @@ func main() {
 {{% choosable language csharp %}}
 
 ```csharp
-using Pulumi;
-using Pulumi.Azure.Core;
-using Pulumi.Azure.Storage;
-
-class MyStack : Stack
+// Enable static website support
+var staticWebsite = new StorageAccountStaticWebsite("staticWebsite", new StorageAccountStaticWebsiteArgs
 {
-    public MyStack()
-    {
-        // Create an Azure Resource Group
-        var resourceGroup = new ResourceGroup("resourceGroup");
-
-        // Create an Azure Storage Account
-        var storageAccount = new Account("storage", new AccountArgs
-        {
-            ResourceGroupName = resourceGroup.Name,
-            AccountReplicationType = "LRS",
-            AccountTier = "Standard",
-            Tags =
-            {
-                { "Environment", "Dev" }
-            }
-        });
-
-        // Export the connection string for the storage account
-        this.ConnectionString = storageAccount.PrimaryConnectionString;
-    }
-
-    [Output]
-    public Output<string> ConnectionString { get; set; }
-}
+    AccountName = storageAccount.Name,
+    ResourceGroupName = resourceGroup.Name,
+    IndexDocument = "index.html",
+});
 ```
 
 {{% /choosable %}}
 
-Next, we'll deploy the changes.
+The static website resource leverages the storage account and resource group names defined previously in your program.
+
+Now use all of these cloud resources, and a local `FileAsset` resource, to upload `index.html` into your storage container.
+
+{{% choosable language typescript %}}
+
+```typescript
+// Upload the file
+["index.html"].map(name =>
+    new storage.Blob(name, {
+        blobName: name,
+        resourceGroupName: resourceGroup.name,
+        accountName: account.name,
+        containerName: staticWebsite.containerName,
+        type: storage.BlobType.Block,
+        source: new pulumi.asset.FileAsset(`./site/${name}`),
+        contentType: "text/html",
+    }),
+);
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+# Upload the file
+index_html = storage.Blob("index_html",
+    blob_name="index.html",
+    resource_group_name=resource_group.name,
+    account_name=account.name,
+    container_name=static_website.container_name,
+    type=storage.BlobType.BLOCK,
+    source=pulumi.FileAsset("./site/index.html"),
+    content_type="text/html")
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```go
+// Upload the file
+_, err = storage.NewBlob(ctx, "index_html", &storage.BlobArgs{
+    BlobName:          pulumi.String("index.html"),
+    ResourceGroupName: resourceGroup.Name,
+    AccountName:       account.Name,
+    ContainerName:     staticWebsite.ContainerName,
+    Type:              storage.BlobTypeBlock,
+    Source:            pulumi.NewFileAsset("./site/index.html"),
+    ContentType:       pulumi.String("text/html"),
+})
+if err != nil {
+    return err
+}
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```csharp
+// Upload the file
+var index_html = new Blob("index_html", new BlobArgs
+{
+    BlobName = "index.html",
+    ResourceGroupName = resourceGroup.Name,
+    AccountName = storageAccount.Name,
+    ContainerName = staticWebsite.ContainerName,
+    Type = BlobType.Block,
+    Source = new FileAsset("./site/index.html"),
+    ContentType = "text/html",
+});
+```
+
+{{% /choosable %}}
+
+Finally, at the end of the program file, export the resulting storage container's endpoint URL to stdout for easy access:
+
+{{% choosable language typescript %}}
+
+```typescript
+// Web endpoint to the website
+export const staticEndpoint = storageAccount.primaryEndpoints.web;
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+# Web endpoint to the website
+pulumi.export("staticEndpoint", account.primary_endpoints.web)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+// Web endpoint to the website
+ctx.Export("staticEndpoint", account.PrimaryEndpoints.Web())
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+// Web endpoint to the website
+this.StaticEndpoint = storageAccount.PrimaryEndpoints.Apply(
+        primaryEndpoints => primaryEndpoints.Web);
+```
+
+```csharp
+[Output]
+public Output<string> StaticEndpoint { get; set; }
+```
+
+{{% /choosable %}}
+
+Now that you have declared how you want your resources to be provisioned, it is time to deploy these remaining changes.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/azure/review-project.md
+++ b/content/docs/get-started/azure/review-project.md
@@ -57,8 +57,8 @@ export const primaryStorageKey = storageAccountKeys.keys[0].value;
 
 ```python
 import pulumi
-from pulumi_azure_native.storage import latest as storage
-from pulumi_azure_native.resources import latest as resources
+from pulumi_azure_native import storage
+from pulumi_azure_native import resources
 
 # Create an Azure Resource Group
 resource_group = resources.ResourceGroup("resource_group")
@@ -142,9 +142,9 @@ func main() {
 ```csharp
 using System.Threading.Tasks;
 using Pulumi;
-using Pulumi.AzureNative.Resources.Latest;
-using Pulumi.AzureNative.Storage.Latest;
-using Pulumi.AzureNative.Storage.Latest.Inputs;
+using Pulumi.AzureNative.Resources;
+using Pulumi.AzureNative.Storage;
+using Pulumi.AzureNative.Storage.Inputs;
 
 class MyStack : Stack
 {

--- a/content/docs/get-started/azure/review-project.md
+++ b/content/docs/get-started/azure/review-project.md
@@ -15,7 +15,7 @@ aliases: ["/docs/quickstart/azure/review-project/"]
 Let's review some of the generated project files:
 
 - `Pulumi.yaml` defines the [project]({{< relref "/docs/intro/concepts/project" >}}).
-- `Pulumi.dev.yaml` contains [configuration]({{< relref "/docs/intro/concepts/config" >}}) values for the [stack]({{< relref "/docs/intro/concepts/stack" >}}) we initialized.
+- `Pulumi.dev.yaml` contains [configuration]({{< relref "/docs/intro/concepts/config" >}}) values for the [stack]({{< relref "/docs/intro/concepts/stack" >}}) you initialized.
 
 {{% choosable language csharp %}}
 
@@ -23,50 +23,33 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-- {{< langfile >}} is the Pulumi program that defines our stack resources. Let's examine it.
+- {{< langfile >}} is the Pulumi program that defines your stack resources. Let's examine it.
 
-{{< chooser language "javascript,typescript,python,go,csharp" / >}}
+{{< chooser language "typescript,python,go,csharp" / >}}
 
-{{% choosable language javascript %}}
-
-```javascript
-"use strict";
-const pulumi = require("@pulumi/pulumi");
-const azure = require("@pulumi/azure");
-
-// Create an Azure Resource Group
-const resourceGroup = new azure.core.ResourceGroup("resourceGroup");
-
-// Create an Azure resource (Storage Account)
-const account = new azure.storage.Account("storage", {
-    resourceGroupName: resourceGroup.name,
-    accountTier: "Standard",
-    accountReplicationType: "LRS",
-});
-
-// Export the connection string for the storage account
-exports.connectionString = account.primaryConnectionString;
-```
-
-{{% /choosable %}}
 {{% choosable language typescript %}}
 
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
-import * as azure from "@pulumi/azure";
+import * as resources from "@pulumi/azure-native/resources";
+import * as storage from "@pulumi/azure-native/storage";
 
 // Create an Azure Resource Group
-const resourceGroup = new azure.core.ResourceGroup("resourceGroup");
+const resourceGroup = new resources.ResourceGroup("resourceGroup");
 
 // Create an Azure resource (Storage Account)
-const account = new azure.storage.Account("storage", {
+const storageAccount = new storage.StorageAccount("sa", {
     resourceGroupName: resourceGroup.name,
-    accountTier: "Standard",
-    accountReplicationType: "LRS",
+    sku: {
+        name: storage.SkuName.Standard_LRS,
+    },
+    kind: storage.Kind.StorageV2,
 });
 
-// Export the connection string for the storage account
-export const connectionString = account.primaryConnectionString;
+// Export the primary key of the Storage Account
+const storageAccountKeys = pulumi.all([resourceGroup.name, storageAccount.name]).apply(([resourceGroupName, accountName]) =>
+    storage.listStorageAccountKeys({ resourceGroupName, accountName }));
+export const primaryStorageKey = storageAccountKeys.keys[0].value;
 ```
 
 {{% /choosable %}}
@@ -74,19 +57,28 @@ export const connectionString = account.primaryConnectionString;
 
 ```python
 import pulumi
-from pulumi_azure import core, storage
+from pulumi_azure_native.storage import latest as storage
+from pulumi_azure_native.resources import latest as resources
 
 # Create an Azure Resource Group
-resource_group = core.ResourceGroup("resource_group")
+resource_group = resources.ResourceGroup("resource_group")
 
 # Create an Azure resource (Storage Account)
-account = storage.Account("storage",
+account = storage.StorageAccount('sa',
     resource_group_name=resource_group.name,
-    account_tier='Standard',
-    account_replication_type='LRS')
+    sku=storage.SkuArgs(
+        name=storage.SkuName.STANDARD_LRS,
+    ),
+    kind=storage.Kind.STORAGE_V2)
 
-# Export the connection string for the storage account
-pulumi.export('connection_string', account.primary_connection_string)
+# Export the primary key of the Storage Account
+primary_key = pulumi.Output.all(resource_group.name, account.name) \
+    .apply(lambda args: storage.list_storage_account_keys(
+        resource_group_name=args[0],
+        account_name=args[1]
+    )).apply(lambda accountKeys: accountKeys.keys[0].value)
+
+pulumi.export("primary_storage_key", primary_key)
 ```
 
 {{% /choosable %}}
@@ -96,33 +88,49 @@ pulumi.export('connection_string', account.primary_connection_string)
 package main
 
 import (
-    "github.com/pulumi/pulumi-azure/sdk/v3/go/azure/core"
-    "github.com/pulumi/pulumi-azure/sdk/v3/go/azure/storage"
+    "github.com/pulumi/pulumi-azure-native/sdk/go/azure/resources"
+	"github.com/pulumi/pulumi-azure-native/sdk/go/azure/storage"
     "github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
 func main() {
     pulumi.Run(func(ctx *pulumi.Context) error {
         // Create an Azure Resource Group
-        resourceGroup, err := core.NewResourceGroup(ctx, "resourceGroup", &core.ResourceGroupArgs{
-            Location: pulumi.String("WestUS"),
-        })
+        resourceGroup, err := resources.NewResourceGroup(ctx, "resourceGroup")
         if err != nil {
             return err
         }
 
         // Create an Azure resource (Storage Account)
-        account, err := storage.NewAccount(ctx, "storage", &storage.AccountArgs{
-            ResourceGroupName:      resourceGroup.Name,
-            AccountTier:            pulumi.String("Standard"),
-            AccountReplicationType: pulumi.String("LRS"),
+        account, err := storage.NewStorageAccount(ctx, "sa", &storage.StorageAccountArgs{
+			ResourceGroupName: resourceGroup.Name,
+			AccessTier:        storage.AccessTierHot,
+			Sku: &storage.SkuArgs{
+				Name: storage.SkuName_Standard_LRS,
+			},
+			Kind: storage.KindStorageV2,
         })
         if err != nil {
             return err
         }
 
-        // Export the connection string for the storage account
-        ctx.Export("connectionString", account.PrimaryConnectionString)
+        // Export the primary key of the Storage Account
+		ctx.Export("primaryStorageKey", pulumi.All(resourceGroup.Name, account.Name).ApplyT(
+			func(args []interface{}) (string, error) {
+				resourceGroupName := args[0].(string)
+				accountName := args[1].(string)
+				accountKeys, err := storage.ListStorageAccountKeys(ctx, &storage.ListStorageAccountKeysArgs{
+					ResourceGroupName: resourceGroupName,
+					AccountName:       accountName,
+				})
+				if err != nil {
+					return "", err
+				}
+
+				return accountKeys.Keys[0].Value, nil
+			},
+		))
+
         return nil
     })
 }
@@ -132,9 +140,11 @@ func main() {
 {{% choosable language csharp %}}
 
 ```csharp
+using System.Threading.Tasks;
 using Pulumi;
-using Pulumi.Azure.Core;
-using Pulumi.Azure.Storage;
+using Pulumi.AzureNative.Resources.Latest;
+using Pulumi.AzureNative.Storage.Latest;
+using Pulumi.AzureNative.Storage.Latest.Inputs;
 
 class MyStack : Stack
 {
@@ -143,29 +153,43 @@ class MyStack : Stack
         // Create an Azure Resource Group
         var resourceGroup = new ResourceGroup("resourceGroup");
 
-        // Create an Azure Storage Account
-        var storageAccount = new Account("storage", new AccountArgs
+        // Create an Azure resource (Storage Account)
+        var storageAccount = new StorageAccount("sa", new StorageAccountArgs
         {
             ResourceGroupName = resourceGroup.Name,
-            AccountReplicationType = "LRS",
-            AccountTier = "Standard"
+            Sku = new SkuArgs
+            {
+                Name = SkuName.Standard_LRS
+            },
+            Kind = Kind.StorageV2
         });
 
-        // Export the connection string for the storage account
-        this.ConnectionString = storageAccount.PrimaryConnectionString;
+        // Export the primary key of the Storage Account
+        this.PrimaryStorageKey = Output.Tuple(resourceGroup.Name, storageAccount.Name).Apply(names =>
+            Output.CreateSecret(GetStorageAccountPrimaryKey(names.Item1, names.Item2)));
     }
 
     [Output]
-    public Output<string> ConnectionString { get; set; }
+    public Output<string> PrimaryStorageKey { get; set; }
+
+    private static async Task<string> GetStorageAccountPrimaryKey(string resourceGroupName, string accountName)
+    {
+        var accountKeys = await ListStorageAccountKeys.InvokeAsync(new ListStorageAccountKeysArgs
+        {
+            ResourceGroupName = resourceGroupName,
+            AccountName = accountName
+        });
+        return accountKeys.Keys[0].Value;
+    }
 }
 ```
 
 {{% /choosable %}}
 
-This Pulumi program creates an Azure resource group and storage account and exports the storage account's connection string.
+This Pulumi program creates an Azure resource group and storage account and then exports the storage account's primary key.
 
-**Note**: In this program, the location of the resource group is set in the configuration setting `azure:location` (check the `Pulumi.dev.yaml` file). This is an easy way to set a global location for your program so you don't have to specify the location for each resource manually. The location for the storage account is automatically derived from the location of the resource group. To override the location for a resource, simply set the location property to one of Azure's [supported locations](https://azure.microsoft.com/en-us/global-infrastructure/locations/).
+**Note**: In this program, the location of the resource group is set in the configuration setting `azure-native:location` (check the `Pulumi.dev.yaml` file). This is an easy way to set a global location for your program so you don't have to specify the location for each resource manually. The location for the storage account is automatically derived from the location of the resource group. To override the location for a resource, simply set the location property to one of Azure's [supported locations](https://azure.microsoft.com/en-us/global-infrastructure/locations/).
 
-Next, we'll deploy the stack.
+Next, you'll deploy your stack, which will provision a resource group and your Blob storage account.
 
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/_index.md
+++ b/content/docs/get-started/gcp/_index.md
@@ -13,6 +13,4 @@ aliases: ["/docs/quickstart/gcp/"]
 
 {{< cloud-intro "Google Cloud" >}}
 
-To get started, we will walk through installing Pulumi, installing your preferred language runtime (if needed), and configuring Pulumi with Google Cloud. Click the button below to get started.
-
 {{< get-started-stepper >}}

--- a/content/docs/get-started/gcp/begin.md
+++ b/content/docs/get-started/gcp/begin.md
@@ -20,7 +20,7 @@ aliases: [
 ]
 ---
 
-Before you get started using Pulumi, let's run through a few quick steps to ensure your environment is setup correctly.
+Before you get started using Pulumi, let's run through a few quick steps to ensure your environment is set up correctly.
 
 ### Install Pulumi
 

--- a/content/docs/get-started/gcp/deploy-changes.md
+++ b/content/docs/get-started/gcp/deploy-changes.md
@@ -18,7 +18,7 @@ Now let's deploy your changes.
 $ pulumi up
 ```
 
-First, Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
+Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
 Previewing update (dev):

--- a/layouts/shortcodes/cloud-intro.html
+++ b/layouts/shortcodes/cloud-intro.html
@@ -9,4 +9,8 @@
         This guide will have you quickly provisioning infrastructure on {{ .Get 0 }} with Pulumi in your
         favorite language.
     </p>
+    <p>
+        To get started we will walk through installing Pulumi, installing your preferred language runtime (if needed),
+        and configuring Pulumi with {{ .Get 0 }}. Click the button below to get started.
+    </p>
 </div>


### PR DESCRIPTION
Fixes #5344. 

Update: I've tested the TypeScript, Python, and .NET versions. I'll test out Go when the package is available.

Also, I changed the flow of the tutorial a little bit compared to AWS and Google Cloud. This was largely due to resource ordering issues when provisioning on Azure (e.g. creating the StaticWebsite resource before uploading the index.html file).