### PR TITLE
Document new PULUMI_DATABASE_USER_* env vars

### DIFF
--- a/content/docs/guides/self-hosted/api.md
+++ b/content/docs/guides/self-hosted/api.md
@@ -61,6 +61,8 @@ This container runs an HTTP server which provides the APIs needed by the Console
 
 | Variable Name | Description |
 | ------------- | ----------- |
+| PULUMI_DATABASE_USER_NAME | Name of the database user the Pulumi Service connects as. Leave default unless you are having trouble connecting to your database.
+| PULUMI_DATABASE_USER_PASSWORD | Password of the database user the Pulumi Service connects as. Leave default unless you are having troubles connecting to your database.
 | PULUMI_OBJECTS_BUCKET | S3 bucket name for persisting state for stacks.<br><br>**Note**: Only used if hosted on AWS. |
 | RECAPTCHA_SECRET_KEY | reCAPTCHA secret key for self-service password reset. Create a [site key and a secret key from Google](https://www.google.com/recaptcha/admin). |
 | SAML_CERTIFICATE_PUBLIC_KEY | Public key used by the [IdP]({{< relref "../saml/sso#terminology" >}}) to sign SAML assertions. Learn how to [set SAML_CERTIFICATE_PUBLIC_KEY]({{< relref "saml-sso" >}}). |


### PR DESCRIPTION
### Proposed changes

The Pulumi Service recently added support for customizing the database user the service connects as. This PR documents it.

Screencap of the page edit. I am not sure if there is a better way to phrase this. Since things should "just work" out of the box, I didn't want to mention the defaults. (Also, since that would require going into some of the technical details when really it's just an escape hatch for problematic database systems or customization of the install.) But LMK what you think.

<img width="843" alt="image" src="https://user-images.githubusercontent.com/4029847/110384356-5fcd7880-8012-11eb-9f87-14815a97f87b.png">

### Unreleased product version (optional)

I believe the change has already been deployed, so any recent build of the on-prem Pulumi Service will have this.

### Related issues (optional)

https://github.com/pulumi/pulumi-service/pull/6289