### PR TITLE
Update site banners and Intro workshop listings

### DIFF
--- a/content/pulumi-up/_index.md
+++ b/content/pulumi-up/_index.md
@@ -6,6 +6,9 @@ meta_desc: |
     On April 20th Pulumi presents PulumiUP, a 2 hour virtual event that will feature product updates, company news,
     and much more.
 
+aliases:
+    - /pulumiup
+
 countdown_date: 2021-04-20T09:00:00-08:00
 
 form:

--- a/content/resources/introduction-to-pulumi/index.md
+++ b/content/resources/introduction-to-pulumi/index.md
@@ -38,11 +38,14 @@ url_slug: "introduction-to-pulumi"
 
 # Webinar pages support multiple session via the 'multiple' property.
 multiple:
-    - datetime: 2021-03-09T09:00:00-08:00
-      hubspot_form_id: "e53ebeef-8f9b-4705-a137-8cf434b8b0c6"
-
     - datetime: 2021-03-23T09:00:00-07:00
       hubspot_form_id: "6a812c24-e2bd-4102-9c3c-c8a9f7178e29"
+
+    - datetime: 2021-04-08T10:00:00-07:00
+      hubspot_form_id: "64bd0999-63b9-4049-bdb4-c47686d3ffb3"
+
+    - datetime: 2021-05-18T10:00:00-07:00
+      hubspot_form_id: "4690007d-8ec6-4141-b050-d4b845f21e04"
 
 # The content of the hero section.
 hero:

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,13 +1,11 @@
-{{ $text := "Join us during re:Invent! Check out the latest news and workshops." }}
-{{ $url := relref . "/partner/aws" }}
+{{ $text := "We're cooking up something brand new for you. Be the first know what it is." }}
+{{ $url := relref . "/pulumi-up" }}
 {{ $color := "orange"}}
-
-<!-- No news to share right now.
 
 <div class="mx-auto mb-12">
     <div class="inline-block">
         <a href="{{ $url }}" class="block p-2 bg-purple-400 hover:bg-purple-300 transition-all items-center text-purple-100 leading-none rounded-full flex md:inline-flex shadow-xl">
-            <span class="alert-chicklet flex rounded-full bg-{{ $color }}-700 border-4 border-{{ $color }}-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">Now!</span>
+            <span class="alert-chicklet flex rounded-full bg-{{ $color }}-700 border-4 border-{{ $color }}-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New!</span>
             <span class="alert-content text-left flex-auto text-white text-sm md:text-base leading-normal">
                 {{ $text | safeHTML }}
             </span>
@@ -15,5 +13,3 @@
         </a>
     </div>
 </div>
-
--->

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,7 +1,7 @@
-{{ $name := "2021Q1-workshops" }}
-{{ $summary := "Ready to level-up your engineering skills? Join a Pulumi Workshop." }}
-{{ $url := relref . "/resources#upcoming" }}
-{{ $label := "Register Now"}}
+{{ $name := "snowflake-case-study" }}
+{{ $summary := "Learn how Snowflake uses Pulumi to dramatically decrease infrastructure deployment time 🚀" }}
+{{ $url := relref . "/case-studies/snowflake" }}
+{{ $label := "Read Now"}}
 {{ $external := false }}
 
 {{/* When a banner is dismissed, its `name` property is recorded in localStorage to

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,5 +1,5 @@
 {{ $name := "snowflake-case-study" }}
-{{ $summary := "Learn how Snowflake uses Pulumi to dramatically decrease infrastructure deployment time 🚀" }}
+{{ $summary := "Learn how Snowflake uses Pulumi to dramatically decrease infrastructure deployment time. 🚀" }}
 {{ $url := relref . "/case-studies/snowflake" }}
 {{ $label := "Read Now"}}
 {{ $external := false }}


### PR DESCRIPTION
This PR does a few things:

1. Updates the Introduction Workshop listings to remove an old one and add two new ones.
2. Updates the banners on the site to promote the Snowflake Case Study and PulumiUP
3. Updates `/pulumi-up` with an alias `/pulumiup`