### PR TITLE
Update outdated template in AWS Lambda guide

### DIFF
--- a/content/docs/tutorials/aws/rest-api.md
+++ b/content/docs/tutorials/aws/rest-api.md
@@ -13,7 +13,7 @@ In this tutorial, we'll show you how to write a Pulumi program that creates a se
 
 ### Step 1: Create a new project from a template
 
-Create a project directory, `ahoy-pulumi`, and change into it. Run [`pulumi new aws-javascript --name myproject`]({{< relref "/docs/reference/cli/pulumi_new" >}}) to create a new project using the AWS template for JavaScript. Replace `myproject` with your desired project name.
+Create a project directory, `ahoy-pulumi`, and change into it. Run [`pulumi new hello-aws-javascript --name myproject`]({{< relref "/docs/reference/cli/pulumi_new" >}}) to create a new project using the AWS template for JavaScript. Replace `myproject` with your desired project name.
 
 ```bash
 $ mkdir ahoy-pulumi && cd ahoy-pulumi


### PR DESCRIPTION
The template name previously mentioned does not generate the correct boilerplate for this guide.

Label suggestions:
* `area/docs`
* `docs/guide`

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

I corrected an oversight/typo in the guide for a serverless app with AWS API Gateway and Lambdas where an incorrect template name is indicated in the steps.