### PR TITLE
Add z-index override for chat widget

### DIFF
--- a/assets/sass/_hubspot.scss
+++ b/assets/sass/_hubspot.scss
@@ -1,3 +1,7 @@
+#hubspot-messages-iframe-container {
+    z-index: 100000000 !important;
+}
+
 .hs-form {
     @apply text-sm;
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/docs/issues/5438

The HubSpot chat widget overlaps with the cookie banner so this change overrides the z-index of the chat widget so it will end up beneath the cookie banner.