### PR TITLE
update/fix the Type field documentation for Servicev1Condition in golang

### DIFF
--- a/content/docs/reference/pkg/fastly/servicev1.md
+++ b/content/docs/reference/pkg/fastly/servicev1.md
@@ -6603,7 +6603,7 @@ see [Fastly's Documentation on Conditionals][fastly-conditionals].
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>{{% md %}}The location in generated VCL where the snippet should be placed (can be one of `init`, `recv`, `hit`, `miss`, `pass`, `fetch`, `error`, `deliver`, `log` or `none`).
+    <dd>{{% md %}}The classification type for the condition (can be one of `REQUEST`, `RESPONSE`, `CACHE`, or `PREFETCH`).
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="priority_go">


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
I've been using the `golang` `fastly` provider to manage services and the documentation for `Servicev1Condition` looks like it may have been pasted from somewhere else. This updates the `golang` documentation to specify the proper accepted values.

The other languages should probably be updated too, but since I've only used the `golang` implementation, I'm only updating the documentation with values for this implementation.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
