### PR TITLE
Replace some readFileSyncs with FileAsset

### DIFF
--- a/content/docs/get-started/aws/deploy-changes.md
+++ b/content/docs/get-started/aws/deploy-changes.md
@@ -126,7 +126,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
     acl: "public-read",
     contentType: "text/html",
     bucket: bucket,
-    content: fs.readFileSync("site/index.html").toString(),
+    source: new pulumi.asset.FileAsset("index.html"),
 });
 ```
 
@@ -157,7 +157,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
     acl: "public-read",
     contentType: "text/html",
     bucket: bucket,
-    content: fs.readFileSync("site/index.html").toString(),
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -188,7 +188,7 @@ bucketObject = s3.BucketObject(
     acl='public-read',
     content_type='text/html',
     bucket=bucket,
-    content=open('site/index.html').read(),
+    content=pulumi.FileAsset('index.html'),
 )
 ```
 
@@ -219,7 +219,7 @@ _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Acl:         pulumi.String("public-read"),
     ContentType: pulumi.String("text/html"),
     Bucket:      bucket.ID(),
-    Content:     pulumi.String(string(htmlContent)),
+    Source:      pulumi.NewFileAsset("index.html")
 })
 ```
 
@@ -258,7 +258,7 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
     Acl = "public-read",
     ContentType = "text/html",
     Bucket = bucket.BucketName,
-    Content = htmlString,
+    Source = new FileAsset("index.html")
 });
 ```
 

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -12,20 +12,14 @@ menu:
 aliases: ["/docs/quickstart/aws/modify-program/"]
 ---
 
-Now that your S3 bucket is provisioned, let's add an object to it. First, create a new directory called `site`.
-
-```bash
-mkdir site
-```
-
-Next, create a new `index.html` file with some content in it.
+Now that your S3 bucket is provisioned, let's add an object to it. First, create a new `index.html` file with some content in it.
 
 {{< chooser os "macos,linux,windows" / >}}
 
 {{% choosable os macos %}}
 
 ```bash
-cat <<EOT > site/index.html
+cat <<EOT > index.html
 <html>
     <body>
         <h1>Hello, Pulumi!</h1>
@@ -39,7 +33,7 @@ EOT
 {{% choosable os linux %}}
 
 ```bash
-cat <<EOT > site/index.html
+cat <<EOT > index.html
 <html>
     <body>
         <h1>Hello, Pulumi!</h1>
@@ -59,31 +53,25 @@ EOT
     <h1>Hello, Pulumi!</h1>
   </body>
 </html>
-"@ | Out-File -FilePath site\index.html
+"@ | Out-File -FilePath index.html
 ```
 
 {{% /choosable %}}
 
 Now that you have your new `index.html` with some content, open your program file and modify it to add the contents of your `index.html` file to your S3 bucket.
 
-To accomplish this, you will use your chosen programming language's native libraries to read the content of the file and assign it as an input to a new  `BucketObject`.
+To accomplish this, you will use Pulumi's `FileAsset` class to assign the content of the file to a new  `BucketObject`.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
 {{% choosable language javascript %}}
 
-In `index.js`, add the following:
-
-```javascript
-const fs = require("fs");
-```
-
-Next you will create a new bucket object right after creating the bucket itself.
+In `index.ts`, create a new bucket object right after creating the bucket itself.
 
 ```javascript
 const bucketObject = new aws.s3.BucketObject("index.html", {
     bucket: bucket,
-    content: fs.readFileSync("site/index.html").toString(),
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -91,18 +79,12 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 
 {{% choosable language typescript %}}
 
-In `index.ts`, add the following:
-
-```typescript
-import * as fs from "fs";
-```
-
-Next you will create a new bucket object right after creating the bucket itself.
+In `index.ts`, create a new bucket object right after creating the bucket itself.
 
 ```typescript
 const bucketObject = new aws.s3.BucketObject("index.html", {
     bucket: bucket,
-    content: fs.readFileSync("site/index.html").toString(),
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -116,7 +98,7 @@ In `__main__.py`, create a new bucket object by adding the following right after
 bucketObject = s3.BucketObject(
     'index.html',
     bucket=bucket,
-    content=open('site/index.html').read(),
+    source=pulumi.FileAsset('index.html')
 )
 ```
 
@@ -124,26 +106,12 @@ bucketObject = s3.BucketObject(
 
 {{% choosable language go %}}
 
-In `main.go`, add the following:
+In `main.go`, create a new bucket object on the lines right after creating the bucket itself.
 
 ```go
-import (
-    "io/ioutil"
-    // Existing imports...
-)
-```
-
-Next you will create a new bucket object on the lines right after creating the bucket itself.
-
-```go
-htmlContent, err := ioutil.ReadFile("site/index.html")
-if err != nil {
-    return err
-}
-
 _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Bucket:  bucket.ID(),
-    Content: pulumi.String(string(htmlContent)),
+    Source: pulumi.NewFileAsset("index.html")
 })
 if err != nil {
     return err
@@ -154,22 +122,13 @@ if err != nil {
 
 {{% choosable language csharp %}}
 
-In `MyStack.cs`, add the following:
-
-```csharp
-using System.IO;
-```
-
 Next you will create a new bucket object right after creating the bucket itself.
 
 ```csharp
-var filePath = Path.GetFullPath("./site/index.html");
-var htmlString = File.ReadAllText(filePath);
-
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.BucketName,
-    Content = htmlString,
+    Source = new FileAsset("index.html")
 });
 ```
 

--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -66,7 +66,7 @@ To accomplish this, you will use Pulumi's `FileAsset` class to assign the conten
 
 {{% choosable language javascript %}}
 
-In `index.ts`, create a new bucket object right after creating the bucket itself.
+In `index.js`, create the `BucketObject` right after creating the bucket itself.
 
 ```javascript
 const bucketObject = new aws.s3.BucketObject("index.html", {
@@ -79,7 +79,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 
 {{% choosable language typescript %}}
 
-In `index.ts`, create a new bucket object right after creating the bucket itself.
+In `index.ts`, create the `BucketObject` right after creating the bucket itself.
 
 ```typescript
 const bucketObject = new aws.s3.BucketObject("index.html", {
@@ -106,7 +106,7 @@ bucketObject = s3.BucketObject(
 
 {{% choosable language go %}}
 
-In `main.go`, create a new bucket object on the lines right after creating the bucket itself.
+In `main.go`, create the `BucketObject` right after creating the bucket itself.
 
 ```go
 _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
@@ -122,7 +122,7 @@ if err != nil {
 
 {{% choosable language csharp %}}
 
-Next you will create a new bucket object right after creating the bucket itself.
+In `MyStack.cs`, create the `BucketObject` right after creating the bucket itself.
 
 ```csharp
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs

--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -12,20 +12,14 @@ menu:
 aliases: ["/docs/quickstart/azure/modify-program/"]
 ---
 
-Now that your storage account is provisioned, let's add a file to it. First, create a new directory called `site`.
-
-```bash
-mkdir site
-```
-
-Next, create a new `index.html` file with some content in it.
+Now that your S3 bucket is provisioned, let's add an object to it. First, create a new `index.html` file with some content in it.
 
 {{< chooser os "macos,linux,windows" / >}}
 
 {{% choosable os macos %}}
 
 ```bash
-cat <<EOT > site/index.html
+cat <<EOT > index.html
 <html>
     <body>
         <h1>Hello, Pulumi!</h1>
@@ -39,7 +33,7 @@ EOT
 {{% choosable os linux %}}
 
 ```bash
-cat <<EOT > site/index.html
+cat <<EOT > index.html
 <html>
     <body>
         <h1>Hello, Pulumi!</h1>
@@ -59,7 +53,7 @@ EOT
     <h1>Hello, Pulumi!</h1>
   </body>
 </html>
-"@ | Out-File -FilePath site\index.html
+"@ | Out-File -FilePath index.html
 ```
 
 {{% /choosable %}}
@@ -140,7 +134,7 @@ const indexHtml = new storage.Blob("index.html", {
     resourceGroupName: resourceGroup.name,
     accountName: storageAccount.name,
     containerName: staticWebsite.containerName,
-    source: new pulumi.asset.FileAsset("./site/index.html"),
+    source: new pulumi.asset.FileAsset("index.html"),
     contentType: "text/html",
 });
 ```
@@ -155,7 +149,7 @@ index_html = storage.Blob("index.html",
     resource_group_name=resource_group.name,
     account_name=account.name,
     container_name=static_website.container_name,
-    source=pulumi.FileAsset("./site/index.html"),
+    source=pulumi.FileAsset("index.html"),
     content_type="text/html")
 ```
 
@@ -168,7 +162,7 @@ _, err = storage.NewBlob(ctx, "index.html", &storage.BlobArgs{
     ResourceGroupName: resourceGroup.Name,
     AccountName:       account.Name,
     ContainerName:     staticWebsite.ContainerName,
-    Source:            pulumi.NewFileAsset("./site/index.html"),
+    Source:            pulumi.NewFileAsset("index.html"),
     ContentType:       pulumi.String("text/html"),
 })
 if err != nil {
@@ -186,7 +180,7 @@ var index_html = new Blob("index.html", new BlobArgs
     ResourceGroupName = resourceGroup.Name,
     AccountName = storageAccount.Name,
     ContainerName = staticWebsite.ContainerName,
-    Source = new FileAsset("./site/index.html"),
+    Source = new FileAsset("index.html"),
     ContentType = "text/html",
 });
 ```

--- a/content/docs/get-started/gcp/deploy-changes.md
+++ b/content/docs/get-started/gcp/deploy-changes.md
@@ -140,7 +140,7 @@ Also, change the content type of your `index.html` object so that it is served a
 const bucketObject = new gcp.storage.BucketObject("index.html", {
     bucket: bucket.name,
     contentType: "text/html",
-    content: fs.readFileSync("site/index.html").toString(),
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -182,7 +182,7 @@ Also, change the content type of your `index.html` object so that it is served a
 const bucketObject = new gcp.storage.BucketObject("index.html", {
     bucket: bucket.name,
     contentType: "text/html",
-    content: fs.readFileSync("site/index.html").toString(),
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -224,7 +224,7 @@ bucketObject = storage.BucketObject(
     'index.html',
     bucket=bucket,
     content_type='text/html',
-    content=open('site/index.html').read(),
+    source=pulumi.FileAsset('index.html')
 )
 ```
 
@@ -272,8 +272,8 @@ Also, change the content type of your `index.html` object so that it is served a
 
 ```go
 bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketObjectArgs{
-    Bucket:  bucket.Name,
-    Content: pulumi.String(string(htmlContent)),
+    Bucket: bucket.Name,
+    Source: pulumi.NewFileAsset("index.html")
 })
 if err != nil {
     return err
@@ -327,7 +327,7 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.Name,
     ContentType = "text/html",
-    Content = htmlString,
+    Source = new FileAsset("index.html")
 });
 ```
 

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -66,7 +66,7 @@ To accomplish this, you will use Pulumi's `FileAsset` class to assign the conten
 
 {{% choosable language javascript %}}
 
-Create a new bucket object on the lines right after creating the bucket itself.
+In `index.js`, create the `BucketObject` right after creating the bucket itself.
 
 ```javascript
 const bucketObject = new gcp.storage.BucketObject("index.html", {
@@ -79,7 +79,7 @@ const bucketObject = new gcp.storage.BucketObject("index.html", {
 
 {{% choosable language typescript %}}
 
-Create a new bucket object on the lines right after creating the bucket itself.
+In `index.ts`, create the `BucketObject` right after creating the bucket itself.
 
 ```typescript
 const bucketObject = new gcp.storage.BucketObject("index.html", {
@@ -106,7 +106,7 @@ bucketObject = storage.BucketObject(
 
 {{% choosable language go %}}
 
-Create a new bucket object on the lines right after creating the bucket itself.
+In `main.go`, create the `BucketObject` right after creating the bucket itself.
 
 ```go
 bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketObjectArgs{
@@ -122,7 +122,7 @@ if err != nil {
 
 {{% choosable language csharp %}}
 
-Create a new bucket object on the lines right after creating the bucket itself.
+In `MyStack.cs`, create the `BucketObject` right after creating the bucket itself.
 
 ```csharp
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -12,20 +12,14 @@ menu:
 aliases: ["/docs/quickstart/gcp/modify-program/"]
 ---
 
-Now that your storage bucket is provisioned, let's add an object to it. First, create a new directory called `site`.
-
-```bash
-mkdir site
-```
-
-Next, create a new `index.html` file with some content in it.
+Now that your storage bucket is provisioned, let's add an object to it. First, create a new `index.html` file with some content in it.
 
 {{< chooser os "macos,linux,windows" / >}}
 
 {{% choosable os macos %}}
 
 ```bash
-cat <<EOT > site/index.html
+cat <<EOT > index.html
 <html>
     <body>
         <h1>Hello, Pulumi!</h1>
@@ -39,7 +33,7 @@ EOT
 {{% choosable os linux %}}
 
 ```bash
-cat <<EOT > site/index.html
+cat <<EOT > index.html
 <html>
     <body>
         <h1>Hello, Pulumi!</h1>
@@ -59,31 +53,25 @@ EOT
     <h1>Hello, Pulumi!</h1>
   </body>
 </html>
-"@ | Out-File -FilePath site\index.html
+"@ | Out-File -FilePath index.html
 ```
 
 {{% /choosable %}}
 
 Now that you have your new `index.html` with some content, open your program file and modify it to add the contents of your `index.html` file to your storage bucket.
 
-To accomplish this, you will use your chosen programming language's native libraries to read the content of the file and assign it as an input to a new  `BucketObject`.
+To accomplish this, you will use Pulumi's `FileAsset` class to assign the content of the file to a new  `BucketObject`.
 
 {{< chooser language "javascript,typescript,python,go,csharp" / >}}
 
 {{% choosable language javascript %}}
 
-In `index.js`, add the following:
-
-```javascript
-const fs = require("fs");
-```
-
-Next you will create a new bucket object on the lines right after creating the bucket itself.
+Create a new bucket object on the lines right after creating the bucket itself.
 
 ```javascript
 const bucketObject = new gcp.storage.BucketObject("index.html", {
     bucket: bucket.name,
-    content: fs.readFileSync("site/index.html").toString(),
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -91,18 +79,12 @@ const bucketObject = new gcp.storage.BucketObject("index.html", {
 
 {{% choosable language typescript %}}
 
-In `index.ts`, add the following:
-
-```typescript
-import * as fs from "fs";
-```
-
-Next you will create a new bucket object on the lines right after creating the bucket itself.
+Create a new bucket object on the lines right after creating the bucket itself.
 
 ```typescript
 const bucketObject = new gcp.storage.BucketObject("index.html", {
     bucket: bucket.name,
-    content: fs.readFileSync("site/index.html").toString(),
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -116,7 +98,7 @@ In `__main__.py`, create a new bucket object by adding the following right after
 bucketObject = storage.BucketObject(
     'index.html',
     bucket=bucket,
-    content=open('site/index.html').read(),
+    source=pulumi.FileAsset('index.html')
 )
 ```
 
@@ -124,26 +106,12 @@ bucketObject = storage.BucketObject(
 
 {{% choosable language go %}}
 
-In `main.go`, add the following:
+Create a new bucket object on the lines right after creating the bucket itself.
 
 ```go
-import (
-    "io/ioutil"
-    // Existing imports...
-)
-```
-
-Next you will create a new bucket object on the lines right after creating the bucket itself.
-
-```go
-htmlContent, err := ioutil.ReadFile("site/index.html")
-if err != nil {
-    return err
-}
-
 bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketObjectArgs{
-    Bucket:  bucket.Name,
-    Content: pulumi.String(string(htmlContent)),
+    Bucket: bucket.Name,
+    Source: pulumi.NewFileAsset("index.html")
 })
 if err != nil {
     return err
@@ -154,22 +122,13 @@ if err != nil {
 
 {{% choosable language csharp %}}
 
-In `MyStack.cs`, add the following:
+Create a new bucket object on the lines right after creating the bucket itself.
 
 ```csharp
-using System.IO;
-```
-
-Next you will create a new bucket object on the lines right after creating the bucket itself.
-
-```csharp
-var filePath = Path.GetFullPath("./site/index.html");
-var htmlString = File.ReadAllText(filePath);
-
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.Name,
-    Content = htmlString,
+    Source = new FileAsset("index.html")
 });
 ```
 

--- a/layouts/migrate/terraform.html
+++ b/layouts/migrate/terraform.html
@@ -83,7 +83,7 @@
 
                     <!-- Example 1 -->
                     {{ $code := `import * as aws from "@pulumi/aws";
-import { readFileSync, readdirSync } from "fs";
+import { readdirSync } from "fs";
 import { join as pathjoin } from "path";
 
 const bucket = new aws.s3.Bucket("mybucket");
@@ -93,7 +93,7 @@ let files = readdirSync(folder);
 for (let file of files) {
     const object = new aws.s3.BucketObject(file, {
         bucket: bucket,
-        content: readFileSync(pathjoin(folder, file)).toString("utf8")
+        source: new pulumi.FileAsset(pathjoin(folder, file))
     });
 }
 


### PR DESCRIPTION
### Proposed changes

The get-started tutorials for AWS and GCP still used the `content: readFileSync`
(or equivalent in other languages) way of reading contents for uploading
to cloud storage. There was also an instance in the Terraform migration
example.  All examples on these pages, for all languages, have been changed
to use the equivalent `source: new FileAsset` version.

The examples have all been changed to not use a subdirectory in order to
avoid the other potential issue pointed out by Joe in #4903.

This may be of interest to @davidwrede 

### Related issues (optional)

#4903 
