### PR TITLE
Add clause reminding people to create file from within project directory

### DIFF
--- a/content/docs/get-started/aws/modify-program.md
+++ b/content/docs/get-started/aws/modify-program.md
@@ -12,7 +12,7 @@ menu:
 aliases: ["/docs/quickstart/aws/modify-program/"]
 ---
 
-Now that your S3 bucket is provisioned, let's add an object to it. First, create a new `index.html` file with some content in it.
+Now that your S3 bucket is provisioned, let's add an object to it. First, from within your project directory, create a new `index.html` file with some content in it.
 
 {{< chooser os "macos,linux,windows" / >}}
 

--- a/content/docs/get-started/azure/modify-program.md
+++ b/content/docs/get-started/azure/modify-program.md
@@ -12,7 +12,7 @@ menu:
 aliases: ["/docs/quickstart/azure/modify-program/"]
 ---
 
-Now that your S3 bucket is provisioned, let's add an object to it. First, create a new `index.html` file with some content in it.
+Now that your S3 bucket is provisioned, let's add an object to it. First, from within your project directory, create a new `index.html` file with some content in it.
 
 {{< chooser os "macos,linux,windows" / >}}
 

--- a/content/docs/get-started/gcp/modify-program.md
+++ b/content/docs/get-started/gcp/modify-program.md
@@ -12,7 +12,7 @@ menu:
 aliases: ["/docs/quickstart/gcp/modify-program/"]
 ---
 
-Now that your storage bucket is provisioned, let's add an object to it. First, create a new `index.html` file with some content in it.
+Now that your storage bucket is provisioned, let's add an object to it. First, from within your project directory, create a new `index.html` file with some content in it.
 
 {{< chooser os "macos,linux,windows" / >}}
 


### PR DESCRIPTION
This change reminds folks to create `index.html` from within their project directory so that a new `FileAsset` object can be created (and used as a source) successfully in the tutorial.