### PR TITLE
Remove schedule block from deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    # Every hour on the hour.
-    - cron:  '*/60 * * * *'
 jobs:
   buildSite:
     env:


### PR DESCRIPTION
This was mistakenly left in the `build-and-deploy` workflow. (I ended up doing the hourly jobs [in a different workflow](https://github.com/pulumi/docs/blob/135c63d1f3d08ae3df863c2f69aaa90fdea9b110/.github/workflows/update-theme.yml#L3-L4).)