### PR TITLE
Install Hugo in docs workflows

### DIFF
--- a/.github/workflows/generate-provider-docs.yml
+++ b/.github/workflows/generate-provider-docs.yml
@@ -62,6 +62,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.82.0'
+          extended: true
       - name: setup node
         uses: actions/setup-node@v2-beta
       - name: Setup Python

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -50,19 +50,24 @@ jobs:
         uses: pulumi/action-install-pulumi-cli@v1.0.1
         with:
           pulumi-version: ${{ env.PULUMI_VERSION }}
-      - name: setup go
+      - name: Install go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
-      - name: setup node
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.82.0'
+          extended: true
+      - name: Install node
         uses: actions/setup-node@v2-beta
-      - name: setup python
+      - name: Install python
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
       - name: Install Pipenv
         run:  pip3 install pipenv
-      - name: setup dotnet
+      - name: Install dotnet
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{matrix.dotnetverson}}


### PR DESCRIPTION
With the change to start using Hugo modules, the `ensure` and `clean` Make targets were updated to use `hugo mod` subcommands, which requires that Hugo be installed. This change installs Hugo in the two workflows that need it (and tweaks a few step names for consistency). 