### PR TITLE
Workflow fixes

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,9 +12,15 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Install Node
+        uses: actions/setup-node@v1
         with:
           node-version: '14.x'
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.82.0'
+          extended: true
       - name: Run make check_links
         run: make check_links
         env:

--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -1,4 +1,4 @@
-name: Update pulumi-hugo
+name: "Scheduled jobs: Update pulumi-hugo"
 on:
   schedule:
     - cron:  '*/60 * * * *'


### PR DESCRIPTION
* Rename the scheduled pulumi-hugo workflow for consistency with other scheduled jobs
* Add Hugo the the link-checking workflow (it's required by `make ensure`) to re-enable it