### PR TITLE
Don't update Hugo modules on every ensure

### DIFF
--- a/scripts/ensure.sh
+++ b/scripts/ensure.sh
@@ -15,5 +15,4 @@ yarn install
 yarn --cwd infrastructure install
 
 # Fetch Hugo modules.
-hugo mod get -u github.com/pulumi/pulumi-hugo/themes/default
 hugo mod vendor


### PR DESCRIPTION
Currently, `make ensure` also updates the website's Hugo module references, which can lead to unnecessary `go.mod` and `go.sum` diffs and cause downstream PR merge conflicts. Since we should only be updating those references when we want to pull in changes from pulumi/pulumi-hugo (and we're already running [a scheduled workflow to do that](https://github.com/pulumi/docs/blob/5c1c9dfc2d9692f685326cb93c91b6e3c67c5303/.github/workflows/update-theme.yml#L31)), this change removes that line from the `ensure` script.