### PR TITLE
Add details to module-update PRs

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -12,6 +12,11 @@ jobs:
         with:
           go-version: 1.16.x
 
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
@@ -30,6 +35,11 @@ jobs:
       - name: Update the pulumi-hugo module
         run: hugo mod get -u
 
+      - name: Identify relevant commits
+        id: diffdetails
+        run: |
+            echo "::set-output name=message::$(node scripts/get-module-diff-details.js)"
+
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v3
         with:
@@ -40,4 +50,6 @@ jobs:
           commit-message: Update the module reference for pulumi/pulumi-hugo
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           body: |
-            Updates the Hugo module reference to bring the latest from https://github.com/pulumi/pulumi-hugo.
+            Brings in the latest from https://github.com/pulumi/pulumi-hugo, including:
+
+            ${{ steps.diffdetails.outputs.message }}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "http-server": "^0.12.1",
     "js-yaml": "^3.13.1",
     "markdownlint": "^0.17.2",
+    "parse-diff": "^0.8.1",
     "typedoc": "^0.15.3"
   }
 }

--- a/scripts/get-module-diff-details.js
+++ b/scripts/get-module-diff-details.js
@@ -1,0 +1,64 @@
+const { Octokit } = require("@octokit/rest");
+const parseDiff = require("parse-diff");
+const execSync = require("child_process").execSync;
+
+// Find the commits that occurred between the two commits provided
+// and return a bulleted list of their GitHub links.
+async function getCommitsBetween(base, head) {
+    const githubToken = process.env.GITHUB_TOKEN;
+    const [ owner ] = process.env.GITHUB_REPOSITORY.split("/");
+    const repo = "pulumi-hugo";
+
+    const octokit = new Octokit({
+        auth: githubToken,
+    });
+
+    const commits = await octokit.repos.compareCommits({
+        owner,
+        repo,
+        base,
+        head,
+    });
+
+    console.log(`${commits.data.commits.map(commit => `* ${commit.html_url}`).join("\n")}`);
+}
+
+const diff = execSync("git diff").toString("utf-8");
+const files = parseDiff(diff);
+
+// Loop through the files of the diff (if any) looking for changes to go.mod specifically.
+files.forEach(file => {
+    if (file.from === file.to && file.to === "go.mod") {
+        let deletion, addition;
+
+        file.chunks.map(chunk => {
+            chunk.changes.map(change => {
+                if (change.del) {
+                    deletion = change.content;
+                } else if (change.add) {
+                    addition = change.content;
+                }
+            });
+        });
+
+        if (deletion && addition) {
+            // Extract the Git SHA from the go.mod reference line -- e.g.,
+            // "github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210409102228-8b0e4c5741cb // indirect"
+            const re = /github\.com\/pulumi\/pulumi-hugo\/themes\/default [v\.0]+-[\d]+-([\w]+)/;
+
+            const base = deletion.match(re)[1];
+            const head = addition.match(re)[1];
+
+            if (base && head) {
+                getCommitsBetween(base, head);
+            }
+        }
+    }
+});
+
+// Unhandled errors that happen within Promises yield warnings, but do not yet cause the
+// process to exit nonzero.
+// https://nodejs.org/api/process.html#process_event_unhandledrejection
+process.on("unhandledRejection", (error) => {
+    throw error;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,6 +1920,11 @@ p-retry@^4.0.0:
     "@types/retry" "^0.12.0"
     retry "^0.12.0"
 
+parse-diff@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/parse-diff/-/parse-diff-0.8.1.tgz#d8d3d11a97da7a0dc6c657bbb72024c0738359cd"
+  integrity sha512-0QG0HqwXCC/zMohOlaxkQmV1igZq1LQ6xsv/ziex6TDbY0GFxr3TDJN+/aHjWH3s2WTysSW3Bhs9Yfh6DOelFA==
+
 parse-domain@~0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/parse-domain/-/parse-domain-0.2.2.tgz#188989b1e2e7398bff3c4f4fd7dca157eb51fac1"


### PR DESCRIPTION
One problem we have today is that PRs resulting from pulumi-hugo updates (e.g., [here](https://github.com/pulumi/docs/pull/5689)) don't contain enough information about the changes that would be incorporated if the PR were merged. This change adds a step to the `update-theme` workflow that attempts to convert the `go.mod` diff (via the GitHub API) into a bulleted list of GitHub links to the relevant pulumi-hugo commits, like this:

* https://github.com/pulumi/pulumi-hugo/commit/6952590c6e5f385c9b001a1dcae8611f96f85b5e
* https://github.com/pulumi/pulumi-hugo/commit/514ef32c841f9e98e6b5069c1e0b69aab7d0f858
* https://github.com/pulumi/pulumi-hugo/commit/31fdf2d2fa3392b28d6a45092c6412c261b3a2a4