### PR TITLE
Configure Git access to pulumi-hugo-internal

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           go-version: 1.16.x
 
+      - name: Configure Git
+        run: |
+          git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
+
       - name: Install assume-role
         run: go get -u github.com/remind101/assume-role
 

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           go-version: 1.16.x
 
+      - name: Configure Git
+        run: |
+          git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
+
       - name: Install assume-role
         run: go get -u github.com/remind101/assume-role
 


### PR DESCRIPTION
In #5845, we added a Hugo module that's managed in a private repo. In that PR, I added a few lines of GHA workflow configuration to enable Git access to that private repo for PR and push jobs, but overlooked adding it to the cleanup jobs that run, for example, when a PR is closed. This change adds that bit of additional configuration to the daily and PR-closed workflows as well.

cc @stack72 who may want to add this to some of the other workflows in this repository.