### PR TITLE
Detach from pulumi-hugo-internal

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -3,7 +3,7 @@ title: Pulumi - Modern Infrastructure as Code
 
 module:
   imports:
-    - path: github.com/pulumi/pulumi-hugo-internal/themes/default
+    - path: github.com/pulumi/pulumi-hugo/themes/default
       mounts:
         - source: content
           target: content
@@ -25,16 +25,6 @@ module:
           target: assets
         - source: yarn.lock
           target: assets
-    - path: github.com/pulumi/pulumi-hugo/themes/default
-      mounts:
-        - source: content
-          target: content
-        - source: static
-          target: static
-        - source: layouts
-          target: layouts
-        - source: data
-          target: data
 
 disableKinds:
   - category

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,7 @@ require (
 	github.com/pelletier/go-toml v1.9.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/polyfloyd/go-errorlint v0.0.0-20210418123303-74da32850375 // indirect
-	github.com/pulumi/pulumi-hugo-internal/themes/default v0.0.0-20210420051511-254e60382661 // indirect
-	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210420015507-f4d9a5ebea36 // indirect
+	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210420073726-96c6fd914ff9 // indirect
 	github.com/quasilyte/go-ruleguard v0.3.4 // indirect
 	github.com/quasilyte/regex/syntax v0.0.0-20200805063351-8f842688393c // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -770,6 +770,8 @@ github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210419225943-3431f32ed55e 
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210419225943-3431f32ed55e/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210420015507-f4d9a5ebea36 h1:4EGtl93d5IWuuSOygbbH0EiUgK8nmfcmktY0QqoaGUM=
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210420015507-f4d9a5ebea36/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
+github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210420073726-96c6fd914ff9 h1:8py4bePg+fw9QsKNfmZH+xoHhwPeUIa3ZQoeMXiwFhI=
+github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210420073726-96c6fd914ff9/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c h1:JoUA0uz9U0FVFq5p4LjEq4C0VgQ0El320s3Ms0V4eww=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1:CGFX09Ci3pq9QZdj86B+VGIdNj4VyCo2iPOGS9esB/k=

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -148,5 +148,5 @@ retry() {
 }
 
 hugo_theme_path() {
-    echo "github.com/pulumi/pulumi-hugo-internal/themes/default"
+    echo "github.com/pulumi/pulumi-hugo/themes/default"
 }


### PR DESCRIPTION
Now that the new website is live, this change removes this repository's dependency on pulumi-hugo-internal.