### PR TITLE
Install Node deps during theme-update workflow

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Identify relevant commits
         id: diffdetails
         run: |
+            make ensure
             echo "::set-output name=message::$(node scripts/get-module-diff-details.js)"
 
       - name: Create a pull request


### PR DESCRIPTION
The script we run in the `diffdetails` step relies on Octokit, so we just need to install it first. 