### PR TITLE
Route new issues to Docs project board

### DIFF
--- a/.github/workflows/new-issues-to-triage.yml
+++ b/.github/workflows/new-issues-to-triage.yml
@@ -1,0 +1,18 @@
+name: New Issues to Triage
+
+on:
+  issues:
+    types: [ opened ]
+
+jobs:
+  new-issue-to-triage:
+    runs-on: ubuntu-latest
+    name: New Issue to Triage
+    steps:
+    - name: New issues to Service Triage
+      uses: alex-page/github-project-automation-plus@v0.3.0
+      if: "! (contains(github.event.issue.labels.*.name, 'Epic') || contains(github.event.issue.labels.*.name, 'kind/epic'))"
+      with:
+        project: Docs
+        column:  Triage 🔀
+        repo-token:  ${{ secrets.PULUMI_BOT_ACTIONS_ORG_ACCESS }} 


### PR DESCRIPTION
Similar to some other internal automation we use, let's route new issues to the Docs project board so that we can see and act on them.
