### PR TITLE
Only run the automerge workflow when a token is present

### DIFF
--- a/.github/workflows/automerge-workflow.yml
+++ b/.github/workflows/automerge-workflow.yml
@@ -4,7 +4,8 @@ jobs:
     name: Automerge Workflow
     runs-on: ubuntu-18.04
     steps:
-      - env:
+      - if: env.GITHUB_TOKEN != null
+        env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
           MERGE_COMMIT_MESSAGE: pull-request-title
           MERGE_FORKS: "false"

--- a/.github/workflows/automerge-workflow.yml
+++ b/.github/workflows/automerge-workflow.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - if: env.GITHUB_TOKEN != null
         env:
-          GITHUB_TOKEN: ${{ secrets.NOPE }}
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
           MERGE_COMMIT_MESSAGE: pull-request-title
           MERGE_FORKS: "false"
           MERGE_LABELS: automation/merge

--- a/.github/workflows/automerge-workflow.yml
+++ b/.github/workflows/automerge-workflow.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - if: env.GITHUB_TOKEN != null
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NOPE }}
           MERGE_COMMIT_MESSAGE: pull-request-title
           MERGE_FORKS: "false"
           MERGE_LABELS: automation/merge


### PR DESCRIPTION
The automerge workflow fails when GITHUB_TOKEN is missing, so this change just skips the workflow when that's the case.