### PR TITLE
Exclude local Jaeger endpoint in troubleshooting guide from BLC

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -283,6 +283,7 @@ function getDefaultExcludedKeywords() {
         "https://twitter.com",
         "https://t.co",
         "https://www.akamai.com",
+        "http://localhost:16686/search", // Local Jaeger endpoint presented in troubleshooting guide.
     ];
 }
 


### PR DESCRIPTION
Ignore the local Jaeger endpoint that's in the troubleshooting guide from the broken link checking