### PR TITLE
Add the date to the versions list

### DIFF
--- a/data/versions.json
+++ b/data/versions.json
@@ -1,6 +1,7 @@
 [
   {
     "version": "v3.3.1",
+    "date": "2021-05-25T08:35:31Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.3.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.3.1-linux-arm64.tar.gz",

--- a/data/versions.json
+++ b/data/versions.json
@@ -13,6 +13,7 @@
   },
   {
     "version": "v3.3.0",
+    "date": "2021-05-20T13:52:49Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.3.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.3.0-linux-arm64.tar.gz",
@@ -24,6 +25,7 @@
   },
   {
     "version": "v3.2.1",
+    "date": "2021-05-06T16:23:58Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.2.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.2.1-linux-arm64.tar.gz",
@@ -35,6 +37,7 @@
   },
   {
     "version": "v3.2.0",
+    "date": "2021-05-05T17:28:59Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.2.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.2.0-linux-arm64.tar.gz",
@@ -46,6 +49,7 @@
   },
   {
     "version": "v3.1.0",
+    "date": "2021-04-22T18:34:31Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.1.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.1.0-linux-arm64.tar.gz",
@@ -57,6 +61,7 @@
   },
   {
     "version": "v3.0.0",
+    "date": "2021-04-19T08:14:31Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.0.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.0.0-linux-arm64.tar.gz",
@@ -68,6 +73,7 @@
   },
   {
     "version": "v3.0.0-rc.1",
+    "date": "2021-04-16T08:00:09Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.0.0-rc.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.0.0-rc.1-linux-arm64.tar.gz",
@@ -79,6 +85,7 @@
   },
   {
     "version": "v3.0.0-beta.2",
+    "date": "2021-04-08T17:10:39Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.0.0-beta.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.0.0-beta.2-linux-arm64.tar.gz",
@@ -90,6 +97,7 @@
   },
   {
     "version": "v3.0.0-beta.1",
+    "date": "2021-04-01T12:19:24Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v3.0.0-beta.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v3.0.0-beta.1-linux-arm64.tar.gz",
@@ -101,6 +109,7 @@
   },
   {
     "version": "v2.25.2",
+    "date": "2021-04-17T12:03:38Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.25.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.25.2-linux-arm64.tar.gz",
@@ -112,6 +121,7 @@
   },
   {
     "version": "v2.25.1",
+    "date": "2021-04-15T18:42:00Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.25.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.25.1-linux-arm64.tar.gz",
@@ -123,6 +133,7 @@
   },
   {
     "version": "v2.25.0",
+    "date": "2021-04-14T16:22:27Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.25.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.25.0-linux-arm64.tar.gz",
@@ -134,6 +145,7 @@
   },
   {
     "version": "v2.24.1",
+    "date": "2021-04-01T21:02:52Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.24.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.24.1-linux-arm64.tar.gz",
@@ -145,6 +157,7 @@
   },
   {
     "version": "v2.24.0",
+    "date": "2021-03-31T20:27:02Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.24.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.24.0-linux-arm64.tar.gz",
@@ -156,6 +169,7 @@
   },
   {
     "version": "v2.23.2",
+    "date": "2021-03-25T17:39:55Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.23.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.23.2-linux-arm64.tar.gz",
@@ -167,6 +181,7 @@
   },
   {
     "version": "v2.23.1",
+    "date": "2021-03-18T04:14:20Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.23.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.23.1-linux-arm64.tar.gz",
@@ -178,6 +193,7 @@
   },
   {
     "version": "v2.23.0",
+    "date": "2021-03-17T18:08:56Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.23.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.23.0-linux-arm64.tar.gz",
@@ -189,6 +205,7 @@
   },
   {
     "version": "v2.22.0",
+    "date": "2021-03-03T18:45:26Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.22.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.22.0-linux-arm64.tar.gz",
@@ -200,6 +217,7 @@
   },
   {
     "version": "v2.21.2",
+    "date": "2021-02-22T10:41:13Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.21.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.21.2-linux-arm64.tar.gz",
@@ -211,6 +229,7 @@
   },
   {
     "version": "v2.21.1",
+    "date": "2021-02-18T18:50:12Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.21.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.21.1-linux-arm64.tar.gz",
@@ -222,6 +241,7 @@
   },
   {
     "version": "v2.21.0",
+    "date": "2021-02-17T20:42:48Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.21.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.21.0-linux-arm64.tar.gz",
@@ -233,6 +253,7 @@
   },
   {
     "version": "v2.20.0",
+    "date": "2021-02-03T20:40:11Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.20.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.20.0-linux-arm64.tar.gz",
@@ -244,6 +265,7 @@
   },
   {
     "version": "v2.19.0",
+    "date": "2021-01-28T01:40:21Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.19.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.19.0-linux-arm64.tar.gz",
@@ -255,6 +277,7 @@
   },
   {
     "version": "v2.18.2",
+    "date": "2021-01-22T20:18:24Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.18.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.18.2-linux-arm64.tar.gz",
@@ -266,6 +289,7 @@
   },
   {
     "version": "v2.18.1",
+    "date": "2021-01-21T21:40:15Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.18.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.18.1-linux-arm64.tar.gz",
@@ -277,6 +301,7 @@
   },
   {
     "version": "v2.18.0",
+    "date": "2021-01-20T17:30:06Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.18.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.18.0-linux-arm64.tar.gz",
@@ -288,6 +313,7 @@
   },
   {
     "version": "v2.17.2",
+    "date": "2021-01-14T22:39:33Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.17.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.17.2-linux-arm64.tar.gz",
@@ -299,6 +325,7 @@
   },
   {
     "version": "v2.17.1",
+    "date": "2021-01-13T14:48:16Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.17.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.17.1-linux-arm64.tar.gz",
@@ -310,6 +337,7 @@
   },
   {
     "version": "v2.17.0",
+    "date": "2021-01-06T20:13:34Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.17.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.17.0-linux-arm64.tar.gz",
@@ -321,6 +349,7 @@
   },
   {
     "version": "v2.16.2",
+    "date": "2020-12-23T22:02:13Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.16.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.16.2-linux-arm64.tar.gz",
@@ -332,6 +361,7 @@
   },
   {
     "version": "v2.16.1",
+    "date": "2020-12-22T20:53:16Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.16.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.16.1-linux-arm64.tar.gz",
@@ -343,6 +373,7 @@
   },
   {
     "version": "v2.16.0",
+    "date": "2020-12-21T17:52:24Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.16.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.16.0-linux-arm64.tar.gz",
@@ -354,6 +385,7 @@
   },
   {
     "version": "v2.15.6",
+    "date": "2020-12-12T21:04:38Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.6-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.6-linux-arm64.tar.gz",
@@ -365,6 +397,7 @@
   },
   {
     "version": "v2.15.5",
+    "date": "2020-12-11T11:49:50Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.5-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.5-linux-arm64.tar.gz",
@@ -376,6 +409,7 @@
   },
   {
     "version": "v2.15.4",
+    "date": "2020-12-08T14:32:15Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.4-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.4-linux-arm64.tar.gz",
@@ -387,6 +421,7 @@
   },
   {
     "version": "v2.15.3",
+    "date": "2020-12-07T18:34:46Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.3-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.3-linux-arm64.tar.gz",
@@ -398,6 +433,7 @@
   },
   {
     "version": "v2.15.2",
+    "date": "2020-12-07T12:48:25Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.2-linux-arm64.tar.gz",
@@ -409,6 +445,7 @@
   },
   {
     "version": "v2.15.1",
+    "date": "2020-12-04T20:06:10Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.1-linux-arm64.tar.gz",
@@ -420,6 +457,7 @@
   },
   {
     "version": "v2.15.0",
+    "date": "2020-12-02T20:15:29Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.15.0-linux-arm64.tar.gz",
@@ -431,6 +469,7 @@
   },
   {
     "version": "v2.14.0",
+    "date": "2020-11-18T16:56:26Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.14.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.14.0-linux-arm64.tar.gz",
@@ -442,6 +481,7 @@
   },
   {
     "version": "v2.13.2",
+    "date": "2020-11-07T10:14:03Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.13.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.13.2-linux-arm64.tar.gz",
@@ -453,6 +493,7 @@
   },
   {
     "version": "v2.13.1",
+    "date": "2020-11-06T20:49:20Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.13.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.13.1-linux-arm64.tar.gz",
@@ -464,6 +505,7 @@
   },
   {
     "version": "v2.13.0",
+    "date": "2020-11-04T21:55:05Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.13.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.13.0-linux-arm64.tar.gz",
@@ -475,6 +517,7 @@
   },
   {
     "version": "v2.12.1",
+    "date": "2020-10-23T12:30:31Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.12.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.12.1-linux-arm64.tar.gz",
@@ -486,6 +529,7 @@
   },
   {
     "version": "v2.12.0",
+    "date": "2020-10-14T17:26:34Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.12.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.12.0-linux-arm64.tar.gz",
@@ -497,6 +541,7 @@
   },
   {
     "version": "v2.11.2",
+    "date": "2020-10-01T22:09:23Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.11.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.11.2-linux-arm64.tar.gz",
@@ -508,6 +553,7 @@
   },
   {
     "version": "v2.11.1",
+    "date": "2020-10-01T00:13:03Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.11.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.11.1-linux-arm64.tar.gz",
@@ -519,6 +565,7 @@
   },
   {
     "version": "v2.11.0",
+    "date": "2020-09-30T18:00:47Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.11.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.11.0-linux-arm64.tar.gz",
@@ -530,6 +577,7 @@
   },
   {
     "version": "v2.10.2",
+    "date": "2020-09-21T18:51:56Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.10.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.10.2-linux-arm64.tar.gz",
@@ -541,6 +589,7 @@
   },
   {
     "version": "v2.10.1",
+    "date": "2020-09-16T15:02:33Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.10.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.10.1-linux-arm64.tar.gz",
@@ -552,6 +601,7 @@
   },
   {
     "version": "v2.10.0",
+    "date": "2020-09-10T18:30:56Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.10.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.10.0-linux-arm64.tar.gz",
@@ -563,6 +613,7 @@
   },
   {
     "version": "v2.9.2",
+    "date": "2020-08-31T16:15:42Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.9.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.9.2-linux-arm64.tar.gz",
@@ -574,6 +625,7 @@
   },
   {
     "version": "v2.9.1",
+    "date": "2020-08-27T22:07:46Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.9.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.9.1-linux-arm64.tar.gz",
@@ -585,6 +637,7 @@
   },
   {
     "version": "v2.9.0",
+    "date": "2020-08-19T19:00:57Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.9.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.9.0-linux-arm64.tar.gz",
@@ -596,6 +649,7 @@
   },
   {
     "version": "v2.8.2",
+    "date": "2020-08-07T20:36:09Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.8.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.8.2-linux-arm64.tar.gz",
@@ -607,6 +661,7 @@
   },
   {
     "version": "v2.8.1",
+    "date": "2020-08-05T21:33:55Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.8.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.8.1-linux-arm64.tar.gz",
@@ -618,6 +673,7 @@
   },
   {
     "version": "v2.8.0",
+    "date": "2020-08-04T18:13:33Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.8.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.8.0-linux-arm64.tar.gz",
@@ -629,6 +685,7 @@
   },
   {
     "version": "v2.7.1",
+    "date": "2020-07-22T20:36:01Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.7.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.7.1-linux-arm64.tar.gz",
@@ -640,6 +697,7 @@
   },
   {
     "version": "v2.7.0",
+    "date": "2020-07-21T19:03:09Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.7.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.7.0-linux-arm64.tar.gz",
@@ -651,6 +709,7 @@
   },
   {
     "version": "v2.6.1",
+    "date": "2020-07-09T14:51:23Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.6.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.6.1-linux-arm64.tar.gz",
@@ -662,6 +721,7 @@
   },
   {
     "version": "v2.6.0",
+    "date": "2020-07-08T21:05:43Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.6.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.6.0-linux-arm64.tar.gz",
@@ -673,6 +733,7 @@
   },
   {
     "version": "v2.5.0",
+    "date": "2020-06-25T09:00:45Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.5.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.5.0-linux-arm64.tar.gz",
@@ -684,6 +745,7 @@
   },
   {
     "version": "v2.4.0",
+    "date": "2020-06-10T17:58:05Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.4.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.4.0-linux-arm64.tar.gz",
@@ -695,6 +757,7 @@
   },
   {
     "version": "v2.3.0",
+    "date": "2020-05-27T19:30:22Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.3.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.3.0-linux-arm64.tar.gz",
@@ -706,6 +769,7 @@
   },
   {
     "version": "v2.2.1",
+    "date": "2020-05-14T03:52:44Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.2.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.2.1-linux-arm64.tar.gz",
@@ -717,6 +781,7 @@
   },
   {
     "version": "v2.2.0",
+    "date": "2020-05-13T20:49:00Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.2.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.2.0-linux-arm64.tar.gz",
@@ -728,6 +793,7 @@
   },
   {
     "version": "v2.1.1",
+    "date": "2020-05-11T22:05:43Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.1.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.1.1-linux-arm64.tar.gz",
@@ -739,6 +805,7 @@
   },
   {
     "version": "v2.1.0",
+    "date": "2020-04-29T20:45:35Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.1.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.1.0-linux-arm64.tar.gz",
@@ -750,6 +817,7 @@
   },
   {
     "version": "v2.0.0",
+    "date": "2020-04-16T16:58:16Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.0.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.0.0-linux-arm64.tar.gz",
@@ -761,6 +829,7 @@
   },
   {
     "version": "v2.0.0-beta.3",
+    "date": "2020-04-09T20:30:05Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.0.0-beta.3-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.0.0-beta.3-linux-arm64.tar.gz",
@@ -772,6 +841,7 @@
   },
   {
     "version": "v2.0.0-beta.2",
+    "date": "2020-04-01T12:28:34Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.0.0-beta.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.0.0-beta.2-linux-arm64.tar.gz",
@@ -783,6 +853,7 @@
   },
   {
     "version": "v2.0.0-beta.1",
+    "date": "2020-03-30T23:34:40Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v2.0.0-beta.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v2.0.0-beta.1-linux-arm64.tar.gz",
@@ -794,6 +865,7 @@
   },
   {
     "version": "v1.14.1",
+    "date": "2020-04-13T21:51:31Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.14.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.14.1-linux-arm64.tar.gz",
@@ -805,6 +877,7 @@
   },
   {
     "version": "v1.14.0",
+    "date": "2020-04-01T16:54:16Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.14.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.14.0-linux-arm64.tar.gz",
@@ -816,6 +889,7 @@
   },
   {
     "version": "v1.13.1",
+    "date": "2020-03-27T20:16:07Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.13.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.13.1-linux-arm64.tar.gz",
@@ -827,6 +901,7 @@
   },
   {
     "version": "v1.13.0",
+    "date": "2020-03-18T23:25:30Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.13.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.13.0-linux-arm64.tar.gz",
@@ -838,6 +913,7 @@
   },
   {
     "version": "v1.12.1",
+    "date": "2020-03-11T22:43:37Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.12.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.12.1-linux-arm64.tar.gz",
@@ -849,6 +925,7 @@
   },
   {
     "version": "v1.12.0",
+    "date": "2020-03-04T21:35:45Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.12.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.12.0-linux-arm64.tar.gz",
@@ -860,6 +937,7 @@
   },
   {
     "version": "v1.11.1",
+    "date": "2020-02-26T18:42:45Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.11.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.11.1-linux-arm64.tar.gz",
@@ -871,6 +949,7 @@
   },
   {
     "version": "v1.11.0",
+    "date": "2020-02-20T18:11:12Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.11.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.11.0-linux-arm64.tar.gz",
@@ -882,6 +961,7 @@
   },
   {
     "version": "v1.10.1",
+    "date": "2020-02-06T18:05:45Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.10.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.10.1-linux-arm64.tar.gz",
@@ -893,6 +973,7 @@
   },
   {
     "version": "v1.10.0",
+    "date": "2020-02-05T20:56:10Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.10.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.10.0-linux-arm64.tar.gz",
@@ -904,6 +985,7 @@
   },
   {
     "version": "v1.9.1",
+    "date": "2020-01-27T19:47:51Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.9.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.9.1-linux-arm64.tar.gz",
@@ -915,6 +997,7 @@
   },
   {
     "version": "v1.9.0",
+    "date": "2020-01-22T19:56:40Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.9.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.9.0-linux-arm64.tar.gz",
@@ -926,6 +1009,7 @@
   },
   {
     "version": "v1.8.1",
+    "date": "2019-12-20T22:05:00Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.8.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.8.1-linux-arm64.tar.gz",
@@ -937,6 +1021,7 @@
   },
   {
     "version": "v1.8.0",
+    "date": "2019-12-20T02:43:06Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.8.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.8.0-linux-arm64.tar.gz",
@@ -948,6 +1033,7 @@
   },
   {
     "version": "v1.7.1",
+    "date": "2019-12-13T23:37:16Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.7.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.7.1-linux-arm64.tar.gz",
@@ -959,6 +1045,7 @@
   },
   {
     "version": "v1.7.0",
+    "date": "2019-12-11T17:36:18Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.7.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.7.0-linux-arm64.tar.gz",
@@ -970,6 +1057,7 @@
   },
   {
     "version": "v1.6.1",
+    "date": "2019-11-26T22:52:32Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.6.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.6.1-linux-arm64.tar.gz",
@@ -981,6 +1069,7 @@
   },
   {
     "version": "v1.6.0",
+    "date": "2019-11-20T18:53:04Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.6.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.6.0-linux-arm64.tar.gz",
@@ -992,6 +1081,7 @@
   },
   {
     "version": "v1.5.2",
+    "date": "2019-11-13T16:11:22Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.5.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.5.2-linux-arm64.tar.gz",
@@ -1003,6 +1093,7 @@
   },
   {
     "version": "v1.5.1",
+    "date": "2019-11-07T15:36:50Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.5.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.5.1-linux-arm64.tar.gz",
@@ -1014,6 +1105,7 @@
   },
   {
     "version": "v1.5.0",
+    "date": "2019-11-06T20:57:36Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.5.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.5.0-linux-arm64.tar.gz",
@@ -1025,6 +1117,7 @@
   },
   {
     "version": "v1.4.1",
+    "date": "2019-11-01T21:17:55Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.4.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.4.1-linux-arm64.tar.gz",
@@ -1036,6 +1129,7 @@
   },
   {
     "version": "v1.4.0",
+    "date": "2019-10-24T17:11:44Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-linux-arm64.tar.gz",
@@ -1047,6 +1141,7 @@
   },
   {
     "version": "v1.3.4",
+    "date": "2019-10-18T20:47:35Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.4-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.4-linux-arm64.tar.gz",
@@ -1058,6 +1153,7 @@
   },
   {
     "version": "v1.3.3",
+    "date": "2019-10-17T22:10:30Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.3-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.3-linux-arm64.tar.gz",
@@ -1069,6 +1165,7 @@
   },
   {
     "version": "v1.3.2",
+    "date": "2019-10-15T22:47:40Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.2-linux-arm64.tar.gz",
@@ -1080,6 +1177,7 @@
   },
   {
     "version": "v1.3.1",
+    "date": "2019-10-10T17:33:50Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.1-linux-arm64.tar.gz",
@@ -1091,6 +1189,7 @@
   },
   {
     "version": "v1.3.0",
+    "date": "2019-10-09T18:50:21Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.3.0-linux-arm64.tar.gz",
@@ -1102,6 +1201,7 @@
   },
   {
     "version": "v1.2.0",
+    "date": "2019-09-26T20:27:57Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.2.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.2.0-linux-arm64.tar.gz",
@@ -1113,6 +1213,7 @@
   },
   {
     "version": "v1.1.0",
+    "date": "2019-09-11T20:56:48Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.1.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.1.0-linux-arm64.tar.gz",
@@ -1124,6 +1225,7 @@
   },
   {
     "version": "v1.0.0",
+    "date": "2019-09-03T22:28:51Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-linux-arm64.tar.gz",
@@ -1135,6 +1237,7 @@
   },
   {
     "version": "v1.0.0-rc.1",
+    "date": "2019-08-28T20:54:57Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-rc.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-rc.1-linux-arm64.tar.gz",
@@ -1146,6 +1249,7 @@
   },
   {
     "version": "v1.0.0-beta.4",
+    "date": "2019-08-22T18:55:02Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-beta.4-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-beta.4-linux-arm64.tar.gz",
@@ -1157,6 +1261,7 @@
   },
   {
     "version": "v1.0.0-beta.3",
+    "date": "2019-08-21T17:33:33Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-beta.3-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-beta.3-linux-arm64.tar.gz",
@@ -1168,6 +1273,7 @@
   },
   {
     "version": "v1.0.0-beta.2",
+    "date": "2019-08-13T22:40:25Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-beta.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-beta.2-linux-arm64.tar.gz",
@@ -1179,6 +1285,7 @@
   },
   {
     "version": "v1.0.0-beta.1",
+    "date": "2019-08-13T18:41:32Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-beta.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v1.0.0-beta.1-linux-arm64.tar.gz",
@@ -1190,6 +1297,7 @@
   },
   {
     "version": "v0.17.28",
+    "date": "2019-08-05T18:46:51Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.28-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.28-linux-arm64.tar.gz",
@@ -1201,6 +1309,7 @@
   },
   {
     "version": "v0.17.27",
+    "date": "2019-07-29T19:01:10Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.27-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.27-linux-arm64.tar.gz",
@@ -1212,6 +1321,7 @@
   },
   {
     "version": "v0.17.26",
+    "date": "2019-07-26T15:54:53Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.26-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.26-linux-arm64.tar.gz",
@@ -1223,6 +1333,7 @@
   },
   {
     "version": "v0.17.25",
+    "date": "2019-07-19T20:31:40Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.25-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.25-linux-arm64.tar.gz",
@@ -1234,6 +1345,7 @@
   },
   {
     "version": "v0.17.24",
+    "date": "2019-07-16T19:12:21Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.24-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.24-linux-arm64.tar.gz",
@@ -1245,6 +1357,7 @@
   },
   {
     "version": "v0.17.23",
+    "date": "2019-07-16T18:05:29Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.23-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.23-linux-arm64.tar.gz",
@@ -1256,6 +1369,7 @@
   },
   {
     "version": "v0.17.22",
+    "date": "2019-06-28T16:40:21Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.22-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.22-linux-arm64.tar.gz",
@@ -1267,6 +1381,7 @@
   },
   {
     "version": "v0.17.21",
+    "date": "2019-06-27T04:49:31Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.21-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.21-linux-arm64.tar.gz",
@@ -1278,6 +1393,7 @@
   },
   {
     "version": "v0.17.20",
+    "date": "2019-06-23T23:56:09Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.20-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.20-linux-arm64.tar.gz",
@@ -1289,6 +1405,7 @@
   },
   {
     "version": "v0.17.19",
+    "date": "2019-06-23T16:49:04Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.19-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.19-linux-arm64.tar.gz",
@@ -1300,6 +1417,7 @@
   },
   {
     "version": "v0.17.18",
+    "date": "2019-06-20T23:47:24Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.18-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.18-linux-arm64.tar.gz",
@@ -1311,6 +1429,7 @@
   },
   {
     "version": "v0.17.17",
+    "date": "2019-06-11T23:57:37Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.17-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.17-linux-arm64.tar.gz",
@@ -1322,6 +1441,7 @@
   },
   {
     "version": "v0.17.16",
+    "date": "2019-06-06T17:35:24Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.16-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.16-linux-arm64.tar.gz",
@@ -1333,6 +1453,7 @@
   },
   {
     "version": "v0.17.15",
+    "date": "2019-06-05T16:39:11Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.15-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.15-linux-arm64.tar.gz",
@@ -1344,6 +1465,7 @@
   },
   {
     "version": "v0.17.14",
+    "date": "2019-05-28T17:54:56Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.14-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.14-linux-arm64.tar.gz",
@@ -1355,6 +1477,7 @@
   },
   {
     "version": "v0.17.13",
+    "date": "2019-05-22T02:20:18Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.13-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.13-linux-arm64.tar.gz",
@@ -1366,6 +1489,7 @@
   },
   {
     "version": "v0.17.12",
+    "date": "2019-05-15T23:20:25Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.12-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.12-linux-arm64.tar.gz",
@@ -1377,6 +1501,7 @@
   },
   {
     "version": "v0.17.11",
+    "date": "2019-05-14T00:38:19Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.11-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.11-linux-arm64.tar.gz",
@@ -1388,6 +1513,7 @@
   },
   {
     "version": "v0.17.10",
+    "date": "2019-05-02T23:53:35Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.10-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.10-linux-arm64.tar.gz",
@@ -1399,6 +1525,7 @@
   },
   {
     "version": "v0.17.9",
+    "date": "2019-04-30T18:01:58Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.9-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.9-linux-arm64.tar.gz",
@@ -1410,6 +1537,7 @@
   },
   {
     "version": "v0.17.8",
+    "date": "2019-04-23T20:21:56Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.8-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.8-linux-arm64.tar.gz",
@@ -1421,6 +1549,7 @@
   },
   {
     "version": "v0.17.7",
+    "date": "2019-04-17T15:19:52Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.7-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.7-linux-arm64.tar.gz",
@@ -1443,6 +1572,7 @@
   },
   {
     "version": "v0.17.5",
+    "date": "2019-04-08T16:44:05Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.5-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.5-linux-arm64.tar.gz",
@@ -1454,6 +1584,7 @@
   },
   {
     "version": "v0.17.4",
+    "date": "2019-03-26T23:36:43Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.4-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.4-linux-arm64.tar.gz",
@@ -1465,6 +1596,7 @@
   },
   {
     "version": "v0.17.3",
+    "date": "2019-03-26T21:45:09Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.3-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.3-linux-arm64.tar.gz",
@@ -1476,6 +1608,7 @@
   },
   {
     "version": "v0.17.2",
+    "date": "2019-03-15T22:21:34Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.2-linux-arm64.tar.gz",
@@ -1487,6 +1620,7 @@
   },
   {
     "version": "v0.17.1",
+    "date": "2019-03-06T09:53:58Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.1-linux-arm64.tar.gz",
@@ -1498,6 +1632,7 @@
   },
   {
     "version": "v0.17.0",
+    "date": "2019-03-06T01:06:57Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.0-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.17.0-linux-arm64.tar.gz",
@@ -1509,6 +1644,7 @@
   },
   {
     "version": "v0.16.19",
+    "date": "2019-03-04T20:03:18Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.19-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.19-linux-arm64.tar.gz",
@@ -1520,6 +1656,7 @@
   },
   {
     "version": "v0.16.18",
+    "date": "2019-03-02T01:43:26Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.18-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.18-linux-arm64.tar.gz",
@@ -1531,6 +1668,7 @@
   },
   {
     "version": "v0.16.17",
+    "date": "2019-02-27T20:31:57Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.17-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.17-linux-arm64.tar.gz",
@@ -1542,6 +1680,7 @@
   },
   {
     "version": "v0.16.16",
+    "date": "2019-02-24T20:14:16Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.16-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.16-linux-arm64.tar.gz",
@@ -1553,6 +1692,7 @@
   },
   {
     "version": "v0.16.15",
+    "date": "2019-02-22T04:18:29Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.15-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.15-linux-arm64.tar.gz",
@@ -1564,6 +1704,7 @@
   },
   {
     "version": "v0.16.14",
+    "date": "2019-01-31T20:00:32Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.14-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.14-linux-arm64.tar.gz",
@@ -1575,6 +1716,7 @@
   },
   {
     "version": "v0.16.13",
+    "date": "2019-01-31T05:17:34Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.13-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.13-linux-arm64.tar.gz",
@@ -1586,6 +1728,7 @@
   },
   {
     "version": "v0.16.12",
+    "date": "2019-01-25T23:26:01Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.12-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.12-linux-arm64.tar.gz",
@@ -1608,6 +1751,7 @@
   },
   {
     "version": "v0.16.10",
+    "date": "2019-01-11T23:18:34Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.10-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.10-linux-arm64.tar.gz",
@@ -1652,6 +1796,7 @@
   },
   {
     "version": "v0.16.6",
+    "date": "2018-11-28T18:02:13Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.6-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.16.6-linux-arm64.tar.gz",
@@ -2378,6 +2523,7 @@
   },
   {
     "version": "v0.11.1-dev",
+    "date": "2018-03-27T22:29:10Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.11.1-dev-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.11.1-dev-linux-arm64.tar.gz",
@@ -2422,6 +2568,7 @@
   },
   {
     "version": "v0.11.0-dev",
+    "date": "2018-02-09T21:42:16Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.11.0-dev-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.11.0-dev-linux-arm64.tar.gz",
@@ -2444,6 +2591,7 @@
   },
   {
     "version": "v0.10.0-rc6",
+    "date": "2018-02-22T15:51:26Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc6-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc6-linux-arm64.tar.gz",
@@ -2466,6 +2614,7 @@
   },
   {
     "version": "v0.10.0-rc4",
+    "date": "2018-02-16T01:14:35Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc4-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc4-linux-arm64.tar.gz",
@@ -2477,6 +2626,7 @@
   },
   {
     "version": "v0.10.0-rc3",
+    "date": "2018-02-14T03:19:42Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc3-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc3-linux-arm64.tar.gz",
@@ -2488,6 +2638,7 @@
   },
   {
     "version": "v0.10.0-rc2",
+    "date": "2018-02-09T22:08:20Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc2-linux-arm64.tar.gz",
@@ -2499,6 +2650,7 @@
   },
   {
     "version": "v0.10.0-rc1",
+    "date": "2018-02-06T19:22:10Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.10.0-rc1-linux-arm64.tar.gz",
@@ -2510,6 +2662,7 @@
   },
   {
     "version": "v0.9.13",
+    "date": "2018-02-06T20:56:44Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.13-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.13-linux-arm64.tar.gz",
@@ -2521,6 +2674,7 @@
   },
   {
     "version": "v0.9.12",
+    "date": "2018-02-03T06:52:37Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.12-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.12-linux-arm64.tar.gz",
@@ -2532,6 +2686,7 @@
   },
   {
     "version": "v0.9.11",
+    "date": "2018-01-22T22:21:08Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.11-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.11-linux-arm64.tar.gz",
@@ -2543,6 +2698,7 @@
   },
   {
     "version": "v0.9.10",
+    "date": "2018-01-22T20:28:35Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.10-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.10-linux-arm64.tar.gz",
@@ -2554,6 +2710,7 @@
   },
   {
     "version": "v0.9.9",
+    "date": "2018-01-10T03:15:17Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.9-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.9-linux-arm64.tar.gz",
@@ -2565,6 +2722,7 @@
   },
   {
     "version": "v0.9.8",
+    "date": "2017-12-29T01:47:10Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.8-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.8-linux-arm64.tar.gz",
@@ -2576,6 +2734,7 @@
   },
   {
     "version": "v0.9.7",
+    "date": "2017-12-27T14:35:52Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.7-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.7-linux-arm64.tar.gz",
@@ -2587,6 +2746,7 @@
   },
   {
     "version": "v0.9.6",
+    "date": "2017-12-22T14:58:31Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.6-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.6-linux-arm64.tar.gz",
@@ -2598,6 +2758,7 @@
   },
   {
     "version": "v0.9.5",
+    "date": "2017-12-18T22:51:23Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.5-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.5-linux-arm64.tar.gz",
@@ -2609,6 +2770,7 @@
   },
   {
     "version": "v0.9.4",
+    "date": "2017-12-15T16:40:17Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.4-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.4-linux-arm64.tar.gz",
@@ -2631,6 +2793,7 @@
   },
   {
     "version": "v0.9.2",
+    "date": "2017-12-12T20:31:09Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9.2-linux-arm64.tar.gz",
@@ -2664,6 +2827,7 @@
   },
   {
     "version": "v0.9-rc1",
+    "date": "2017-12-10T15:44:11Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9-rc1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.9-rc1-linux-arm64.tar.gz",
@@ -2675,6 +2839,7 @@
   },
   {
     "version": "v0.8.3",
+    "date": "2017-11-16T21:11:58Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.8.3-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.8.3-linux-arm64.tar.gz",
@@ -2686,6 +2851,7 @@
   },
   {
     "version": "v0.8.2",
+    "date": "2017-11-08T22:37:01Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.8.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.8.2-linux-arm64.tar.gz",
@@ -2697,6 +2863,7 @@
   },
   {
     "version": "v0.8.1",
+    "date": "2017-11-07T22:24:49Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.8.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.8.1-linux-arm64.tar.gz",
@@ -2708,6 +2875,7 @@
   },
   {
     "version": "v0.8",
+    "date": "2017-11-06T23:18:35Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.8-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.8-linux-arm64.tar.gz",
@@ -2719,6 +2887,7 @@
   },
   {
     "version": "v0.7",
+    "date": "2017-10-10T15:52:04Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.7-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.7-linux-arm64.tar.gz",
@@ -2730,6 +2899,7 @@
   },
   {
     "version": "v0.6.1-rc1",
+    "date": "2017-09-23T18:38:07Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.6.1-rc1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.6.1-rc1-linux-arm64.tar.gz",
@@ -2741,6 +2911,7 @@
   },
   {
     "version": "v0.6",
+    "date": "2017-09-18T22:16:30Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.6-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.6-linux-arm64.tar.gz",
@@ -2752,6 +2923,7 @@
   },
   {
     "version": "v0.4",
+    "date": "2017-07-31T18:44:34Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.4-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.4-linux-arm64.tar.gz",
@@ -2763,6 +2935,7 @@
   },
   {
     "version": "v0.3",
+    "date": "2017-06-25T20:59:26Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.3-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.3-linux-arm64.tar.gz",
@@ -2774,6 +2947,7 @@
   },
   {
     "version": "v0.2",
+    "date": "2017-06-06T23:42:14Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.2-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.2-linux-arm64.tar.gz",
@@ -2785,6 +2959,7 @@
   },
   {
     "version": "v0.1",
+    "date": "2017-01-26T01:22:35Z",
     "downloads": {
       "linux-x64": "https://get.pulumi.com/releases/sdk/pulumi-v0.1-linux-x64.tar.gz",
       "linux-arm64": "https://get.pulumi.com/releases/sdk/pulumi-v0.1-linux-arm64.tar.gz",

--- a/scripts/get-versions.js
+++ b/scripts/get-versions.js
@@ -68,6 +68,7 @@ const main = async () => {
     .filter((tag) => !tag.name.match(/sdk|pkg/))
     .map((tag) => ({
       version: tag.name,
+      date: tag.target.committedDate,
       downloads: createDownloadLinks(tag.name),
       checksums: `${baseUrl}/pulumi-${tag.name.slice(1)}-checksums.txt`,
       latest: latestVersion === tag.name.slice(1) ? true : undefined,


### PR DESCRIPTION
Builds on https://github.com/pulumi/docs/pull/5923 to add release date to the dataset, which will allow us to use the same data to build the Available Versions page that lives at https://www.pulumi.com/docs/get-started/install/versions.