### PR TITLE
Add a test for Python SDK styling

### DIFF
--- a/cypress/integration/site_spec.js
+++ b/cypress/integration/site_spec.js
@@ -47,4 +47,18 @@ describe("www.pulumi.com", () => {
             });
         });
     });
+
+    describe("python SDK docs", () => {
+        beforeEach(() => {
+            cy.visit("/docs/reference/pkg/python/pulumi");
+        });
+
+        // Regression test for https://github.com/pulumi/docs/issues/1396, which has happened multiple times.
+        // The CSS is applied by targeting specific node structures due to the way our Python docs are generated.
+        describe("is styled correctly", () => {
+            cy.get("#pulumi-python-sdk")
+                .invoke("css", "--pulumi-python-sdk")
+                .should("equal", "true");
+        });
+    });
 });

--- a/cypress/integration/site_spec.js
+++ b/cypress/integration/site_spec.js
@@ -55,7 +55,7 @@ describe("www.pulumi.com", () => {
 
         // Regression test for https://github.com/pulumi/docs/issues/1396, which has happened multiple times.
         // The CSS is applied by targeting specific node structures due to the way our Python docs are generated.
-        describe("is styled correctly", () => {
+        it("is styled correctly", () => {
             cy.get("#pulumi-python-sdk")
                 .invoke("css", "--pulumi-python-sdk")
                 .should("equal", "true");


### PR DESCRIPTION
Our Python SDK styling [has regressed more than once now](
https://github.com/pulumi/docs/issues/1396), because of the subtle way
that the CSS is targeting very specific layouts in the generated docs.
This change adds a test to ensure that it doesn't break in the future.

Dependent on https://github.com/pulumi/pulumi-hugo/pull/352.
