### PR TITLE
Delete provider resource docs before generating new ones

### DIFF
--- a/tools/resourcedocsgen/main.go
+++ b/tools/resourcedocsgen/main.go
@@ -76,8 +76,10 @@ func main() {
 	}
 
 	// Delete existing docs before generating new ones.
-	fmt.Printf("Deleting %s", outDir)
-	os.RemoveAll(outDir)
+	if err := os.RemoveAll(outDir); err != nil {
+		glog.Infof("error deleting provider directory %v: %v", outDir, err)
+		os.Exit(1)
+	}
 
 	if err := generateDocsFromSchema(outDir, mainSpec); err != nil {
 		glog.Infof("error generating docs from schema: %v", err)

--- a/tools/resourcedocsgen/main.go
+++ b/tools/resourcedocsgen/main.go
@@ -18,11 +18,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"path"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
 
 	docsgen "github.com/pulumi/pulumi/pkg/v3/codegen/docs"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
@@ -73,6 +74,10 @@ func main() {
 
 		mergeOverlaySchemaSpec(mainSpec, overlaySpec)
 	}
+
+	// Delete existing docs before generating new ones.
+	fmt.Printf("Deleting %s", outDir)
+	os.RemoveAll(outDir)
 
 	if err := generateDocsFromSchema(outDir, mainSpec); err != nil {
 		glog.Infof("error generating docs from schema: %v", err)


### PR DESCRIPTION
### Proposed changes

This change adds a step to `resourcedocsgen` to remove existing provider docs before generating new ones (which should be safe, since we always generate all of them). 

Related to:
* https://github.com/pulumi/pulumi/pull/7450
* https://github.com/pulumi/docs/pull/6209, 

We should merge this PR before https://github.com/pulumi/pulumi/pull/7450, as that PR changes the way we name these files. (Otherwise, we'd end up with ~2x the number of files per provider.) 

