### PR TITLE
Skip a couple troublesome domains from broken link checks

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -284,6 +284,8 @@ function getDefaultExcludedKeywords() {
         "https://t.co",
         "https://www.akamai.com",
         "http://localhost:16686/search", // Local Jaeger endpoint presented in troubleshooting guide.
+        "https://ceph.io",
+        "https://www.pagerduty.com",
     ];
 }
 


### PR DESCRIPTION
There are two domains that consistently fail the broken link check. They're fairly well-known domains that I don't expect to stop working anytime soon, so let's skip them for now.