### PR TITLE
Redirect Node.js EKS docs to the EKS resource docs

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -160,7 +160,6 @@ function nodeSDKRedirect(uri: string): string | undefined {
         "cloud",
         "policy",
         "awsx",
-        "eks",
         "kubernetesx",
         "terraform",
     ];


### PR DESCRIPTION
When these redirects were written, we didn't yet have resource docs for EKS. Now we do, so we can redirect Googlers to the new location at https://www.pulumi.com/docs/reference/pkg/eks.

We'll also want to remove these from Swiftype results; will look into what needs to be done for that and file follow-ups as needed.

Fixes #6282.
