### PR TITLE
Add a fallback bucket

### DIFF
--- a/infrastructure/Pulumi.christian.yaml
+++ b/infrastructure/Pulumi.christian.yaml
@@ -1,9 +1,10 @@
 config:
   aws:region: us-west-2
-  www.pulumi.com:addSecurityHeaders: true
-  www.pulumi.com:doEdgeRedirects: true
+  www.pulumi.com:addSecurityHeaders: "true"
   www.pulumi.com:certificateArn: arn:aws:acm:us-east-1:372027080554:certificate/54d0431c-2cf9-4c40-bd3c-324cfb8b7d32
-  www.pulumi.com:originBucketNameOverride:
+  www.pulumi.com:doEdgeRedirects: "true"
+  www.pulumi.com:makeFallbackBucket: "true"
+  www.pulumi.com:originBucketNameOverride: ""
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
   www.pulumi.com:websiteDomain: www-christian.pulumi-dev.io
   www.pulumi.com:websiteLogsBucketName: www-christian.pulumi-dev.io-logs

--- a/infrastructure/Pulumi.production.yaml
+++ b/infrastructure/Pulumi.production.yaml
@@ -1,9 +1,10 @@
 config:
   aws:region: us-west-2
-  www.pulumi.com:addSecurityHeaders: true
-  www.pulumi.com:doEdgeRedirects: true
+  www.pulumi.com:addSecurityHeaders: "true"
   www.pulumi.com:certificateArn: arn:aws:acm:us-east-1:058607598222:certificate/a3f72a2b-e715-4639-b126-1e4efc0b634b
-  www.pulumi.com:originBucketNameOverride:
+  www.pulumi.com:doEdgeRedirects: "true"
+  www.pulumi.com:makeFallbackBucket: "true"
+  www.pulumi.com:originBucketNameOverride: ""
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
   www.pulumi.com:websiteDomain: www.pulumi.com
   www.pulumi.com:websiteLogsBucketName: www-prod.pulumi.com-logs


### PR DESCRIPTION
Adds a new, named S3 bucket to use as a fallback for website content.

Part of https://github.com/pulumi/home/issues/1478.