### PR TITLE
Stop building draft and future-dated pages in PRs

### DIFF
--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -35,7 +35,7 @@ popd
 printf "Running Hugo...\n\n"
 if [ "$1" == "preview" ]; then
     export HUGO_BASEURL="http://$(origin_bucket_prefix)-$(build_identifier).s3-website.$(aws_region).amazonaws.com"
-    GOGC=5 hugo --minify --templateMetrics --buildDrafts --buildFuture -e "preview"
+    GOGC=5 hugo --minify --templateMetrics -e "preview"
 else
     GOGC=5 hugo --minify --templateMetrics -e production
 fi


### PR DESCRIPTION
Now that all of our hand-written content happens in pulumi-hugo, and we build drafts and future-dated pages for PR previews there, we no longer need to do the same thing here (and indeed, it's somewhat confusing that we do). This change just removes those two `hugo` options.
