### PR TITLE
fix: add missing pkg to GetAvailabilityZonesArgs

### DIFF
--- a/content/docs/reference/pkg/aws/getavailabilityzones/_index.md
+++ b/content/docs/reference/pkg/aws/getavailabilityzones/_index.md
@@ -77,7 +77,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		opt0 := "available"
-		available, err := aws.GetAvailabilityZones(ctx, &GetAvailabilityZonesArgs{
+		available, err := aws.GetAvailabilityZones(ctx, &aws.GetAvailabilityZonesArgs{
 			State: &opt0,
 		}, nil)
 		if err != nil {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Add missing package name (`aws`) to GetAvailabilityZonesArgs from Go library. 

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
