### PR TITLE
Revert "Update the module reference for pulumi/pulumi-hugo (#6383)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/pulumi/pulumi-docs
 
 go 1.16
 
-require github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210824213919-2d5dfd76ac2a
+require github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210822071724-eaf21715bb67

--- a/go.sum
+++ b/go.sum
@@ -258,5 +258,3 @@ github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210820195207-193b21dcf3e3 
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210820195207-193b21dcf3e3/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210822071724-eaf21715bb67 h1:Ga8XKVunL89Om1gPTWOYW1rfeKUxOyzoEDv7qSXLb7k=
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210822071724-eaf21715bb67/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
-github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210824213919-2d5dfd76ac2a h1:+cslZNqRMSSDUKBSthTP87ohjVCHzM077UVSbUh05m0=
-github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20210824213919-2d5dfd76ac2a/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=


### PR DESCRIPTION
This reverts commit 8d5d52f34bd8e4972d8eb353a0f8e03425995a52.

This commit introduces a breaking change to the main nav, so we should back it out.