### PR TITLE
Add support for overriding package metadata fields when generating metadata using resourcedocsgen

### DIFF
--- a/scripts/gen_package_metadata.sh
+++ b/scripts/gen_package_metadata.sh
@@ -10,20 +10,28 @@ METADATA_OUT_DIR=${1:-}
 # The second argument is the override for the package for which this script will generate the metadata.
 # Must not be passed without the "pulumi-" prefix.
 REPO_OVERRIDE=${2:-}
-# Pass a 3rd argument that is a non-empty string to override the package version used by this script.
+# Pass a non-empty string as the 3rd arg to override the package version used by this script.
 VERSION=${3:-}
-# Pass a 4th argument that is a non-empty string to override the default publisher name for the package.
+# Pass a non-empty string as the 4th arg to override the default publisher name for the package.
 PUBLISHER=${4:-Pulumi}
+# Pass a non-empty string as the 5th arg to set the display name of the package.
+TITLE=${5:-}
+# Pass a non-empty string as the 6th arg to set the category of the package.
+CATEGORY=${6:-cloud}
+
+if [ -z "${TITLE:-}" ]; then
+    TITLE=${REPO_OVERRIDE}
+fi
 
 TOOL_RESDOCGEN="./tools/resourcedocsgen/"
 
 if [ -z "${METADATA_OUT_DIR:-}" ]; then
-  echo "Specify an out dir for the metadata files. Usage is gen_package_metadata.sh <METADATA_OUT_DIR> <REPO_OVERRIDE> <VERSION>."
+  echo "Specify an out dir for the metadata files. Usage is gen_package_metadata.sh <METADATA_OUT_DIR> <REPO_OVERRIDE> <VERSION> [PUBLISHER] [TITLE] [CATEGORY]."
   exit 1
 fi
 
 if [ -z "${REPO_OVERRIDE:-}" ]; then
-  echo "Specify the repo name. Usage is gen_package_metadata.sh <METADATA_OUT_DIR> <REPO_OVERRIDE> <VERSION>."
+  echo "Specify the repo name. Usage is gen_package_metadata.sh <METADATA_OUT_DIR> <REPO_OVERRIDE> <VERSION> [PUBLISHER] [TITLE] [CATEGORY]."
   exit 1
 fi
 
@@ -53,7 +61,7 @@ generate_metadata() {
     provider=$1
     repository="pulumi-${provider}"
 
-    echo -e "\033[0;95m--- Updating repo pulumi/${repository} ---\033[0m"
+    echo -e "\033[0;95m--- Updating repo ${repository} ---\033[0m"
     pushd "../${repository}"
     git fetch --tags
 
@@ -73,7 +81,7 @@ generate_metadata() {
     # See https://git-scm.com/docs/git-for-each-ref#_field_names (search for `creatordate`).
     PKG_UPDATED_ON=$(git for-each-ref --format="%(creatordate:unix)" "refs/tags/${plugin_version}")
 
-    echo -e "\033[0;93mCheckout pulumi/${repository} at tag $plugin_version\033[0m"
+    echo -e "\033[0;93mCheckout ${repository} at tag $plugin_version\033[0m"
     git -c advice.detachedHead=false checkout "$plugin_version" >/dev/null
 
     # Go back to the docs repo.
@@ -124,6 +132,8 @@ generate_metadata() {
       --version "${plugin_version}" \
       --publisher "${PUBLISHER}" \
       --updatedOn "${PKG_UPDATED_ON}" \
+      --title "${TITLE}" \
+      --category "${CATEGORY}" \
       --logtostderr ${featured_flag} || exit 3
 
     popd

--- a/scripts/gen_package_metadata.sh
+++ b/scripts/gen_package_metadata.sh
@@ -12,12 +12,13 @@ METADATA_OUT_DIR=${1:-}
 REPO_OVERRIDE=${2:-}
 # Pass a non-empty string as the 3rd arg to override the package version used by this script.
 VERSION=${3:-}
-# Pass a non-empty string as the 4th arg to override the default publisher name for the package.
+# Pass a non-empty string as the 4th arg to override the publisher name for the package.
+# Default is Pulumi.
 PUBLISHER=${4:-Pulumi}
-# Pass a non-empty string as the 5th arg to set the display name of the package.
+# Pass a non-empty string as the 5th arg to override the display name of the package.
 TITLE=${5:-}
-# Pass a non-empty string as the 6th arg to set the category of the package.
-CATEGORY=${6:-cloud}
+# Pass a non-empty string as the 6th arg to override the category of the package.
+CATEGORY=${6:-}
 
 if [ -z "${TITLE:-}" ]; then
     TITLE=${REPO_OVERRIDE}

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -156,6 +156,8 @@ var titleLookup = map[string]string{
 func packageMetadataCmd() *cobra.Command {
 	var metadataOutDir string
 	var featured bool
+	var publisher string
+	var updatedOn int64
 
 	cmd := &cobra.Command{
 		Use:   "metadata <metadataOutDir> [featured]",
@@ -177,8 +179,8 @@ func packageMetadataCmd() *cobra.Command {
 			}
 			pm := pkg.PackageMeta{
 				Name:          mainSpec.Name,
-				UpdatedOn:     time.Now().Unix(),
-				Publisher:     "Pulumi",
+				UpdatedOn:     updatedOn,
+				Publisher:     publisher,
 				Title:         title,
 				Description:   mainSpec.Description,
 				Category:      category,
@@ -204,6 +206,8 @@ func packageMetadataCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&metadataOutDir, "metadataOutDir", "", "The directory path to where the docs will be written to")
 	cmd.Flags().BoolVar(&featured, "featured", false, "Whether or not this package should be marked as featured in its metadata")
+	cmd.Flags().StringVar(&publisher, "publisher", "Pulumi", "The publisher's display name to be shown in the package")
+	cmd.Flags().Int64Var(&updatedOn, "updatedOn", time.Now().Unix(), "The timestamp (epoch) to use for when the package was last updated")
 
 	cmd.MarkFlagRequired("metadataOutDir")
 

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -173,7 +173,7 @@ func packageMetadataCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "metadata <metadataOutDir> [featured]",
-		Short: "Generate package metadata only",
+		Short: "Generate package metadata from Pulumi schema",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			status := pkg.PackageStatusGA
 			if strings.HasPrefix(version, "v0.") {


### PR DESCRIPTION
### Proposed changes

Pretty much what the title states...the one thing I'll mention is about using the git tag timestamp as the `Last Updated On` value for which I have added a comment inline in the changes.

### Unreleased product version (optional)

N/A

### Related issues (optional)

https://github.com/pulumi/pulumi-service/issues/7463
