### PR TITLE
Adjust the default PurgeCSS extractor

### DIFF
--- a/scripts/minify-css.js
+++ b/scripts/minify-css.js
@@ -39,8 +39,8 @@ postcss([
         // We need to extract the Tailwind screen size selectors (e.g. sm, md, lg)
         // so that we do not strip them out. As long as a class name appears in the HTML
         // in its entirety, PurgeCSS will not remove it.
-        // Ex. https://tailwindcss.com/docs/controlling-file-size/#writing-purgeable-html
-        defaultExtractor: content => content.match(/[\w-/:]*[\w-/:]/g) || [],
+        // Ex. https://tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html
+        defaultExtractor: content => content.match(/[\w-/.:]+(?<!:)/g) || [],
     }),
 
     // CSSNano minifies our rendered CSS by removing whitespace, comments, etc.


### PR DESCRIPTION
Adjusts the PurgeCSS `defaultExtractor` regex to allow for decimal points in utility classnames (a Tailwind feature introduced after this regex was written).

Fixes https://github.com/pulumi/registry/issues/119 and a few of the others we've identified. Verified with a full docs build:

![image](https://user-images.githubusercontent.com/274700/136619468-2e155442-895e-43fc-901b-ae6daaff6626.png)

![image](https://user-images.githubusercontent.com/274700/136619486-617cc4d9-7346-40ac-994f-b82c4e160d80.png)

![image](https://user-images.githubusercontent.com/274700/136619518-0ca611bf-a6a4-4e00-8d92-3cd0246a4598.png)

Final bundle size still comes in at ~31K gzipped.