### PR TITLE
Add an exception for support.pulumi.com

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -286,6 +286,7 @@ function getDefaultExcludedKeywords() {
         "http://localhost:16686/search", // Local Jaeger endpoint presented in troubleshooting guide.
         "https://ceph.io",
         "https://www.pagerduty.com",
+        "https://support.pulumi.com",
     ];
 }
 


### PR DESCRIPTION
Requests from the link checker (and from `curl`) are returning 403s for this URL as of a few days ago ([convo here](https://pulumi.slack.com/archives/C8FNQFZQQ/p1634230284049800)), so this change just adds an exception for it.