### PR TITLE
Follow redirects

### DIFF
--- a/scripts/validate-sitemap-urls.sh
+++ b/scripts/validate-sitemap-urls.sh
@@ -9,7 +9,7 @@ parse_urls() {
 }
 
 request_urls() {
-    cat site_urls.txt | xargs -I {} curl -s -o /dev/null -w "%{http_code} %{url_effective}\n" {} | grep -v '200\|301'
+    cat site_urls.txt | xargs -I {} curl -L -s -o /dev/null -w "%{http_code} %{url_effective}\n" {} | grep -v '200\|301'
 }
 
 request_and_format_sitemap


### PR DESCRIPTION
This adds the `-L` option to `curl` to instruct `curl` to follow redirects, which should ensure that redirect locations also exist. (Otherwise, we wouldn't notice we're redirecting to content that isn't there.)  

Context here: https://github.com/pulumi/docs/pull/6630/files#r729074862
