### PR TITLE
Fixed redirects for Azure Native + AWS Native how to guides

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -196,13 +196,13 @@ function getTutorialsRedirect(uri: string): string | undefined {
         const isAWSNativeGuide = AWS_NATIVE_TUTORIALS.some((awsNativeGuide) => uri.includes(awsNativeGuide))
         if (isAWSNativeGuide) {
             return uri.replace("docs/tutorials/aws", "registry/packages/aws-native/how-to-guides")
-            .replace("docs/reference/tutorials/aws", "registry/packages/aws-native/how-to-guides");
+                .replace("docs/reference/tutorials/aws", "registry/packages/aws-native/how-to-guides");
         }
 
         const isAzureNativeGuide = AZURE_NATIVE_TUTORIALS.some((azureNativeGuide) => uri.includes(azureNativeGuide))
         if (isAzureNativeGuide) {
             return uri.replace("docs/tutorials/azure", "registry/packages/azure-native/how-to-guides")
-            .replace("docs/reference/tutorials/azure", "registry/packages/azure-native/how-to-guides");
+                .replace("docs/reference/tutorials/azure", "registry/packages/azure-native/how-to-guides");
         }
 
         return uri.replace("docs/tutorials", "registry/packages")
@@ -296,7 +296,7 @@ function dotnetSDKRedirect(uri: string): string | undefined {
     return undefined;
 }
 
-// these are how-to guides that have the improper package because our template-creating script was not parsing classic-azure or aws-native correctly
+// These are how-to guides that have the improper package because our template-creating script was not parsing classic-azure or aws-native correctly
 const AZURE_NATIVE_TUTORIALS = [
     "azure-cs-aks-cosmos-helm",
     "azure-cs-credential-rotation-one-set",


### PR DESCRIPTION
Some of the how to guides (those for Azure Native and AWS Native) were incorrectly parsed and thus everything lived at `docs/tutorials/aws|azure` instead of these guides living at `docs/tutorials/azure-native|aws-native`. Thus, our redirect rules were failing for these guides because they were redirecting to the classic packages instead of the native ones. Since we have fixed the paths of these guides, they now live in the correct locations `registry/aws-native|azure-native/how-to-guides`.

This PR fixes these specific links in question, as well as adding redirects for 3 AWS guides that were renamed to have the proper naming conention (language in article title).

## Issue
Fixes #6657