### PR TITLE
[tools/resourcedocsgen] Read the displayName, publisher, category and kind from the Pulumi schema

### DIFF
--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -357,8 +357,9 @@ func getCategoryFromKeywords(keywords []string) (pkg.PackageCategory, error) {
 		return defaultPackageCategory, nil
 	}
 
+	categoryName := strings.Replace(*categoryTag, "category/", "", -1)
 	var category pkg.PackageCategory
-	if n, ok := categoryNameMap[*categoryTag]; !ok {
+	if n, ok := categoryNameMap[categoryName]; !ok {
 		return defaultPackageCategory, errors.New(fmt.Sprintf("invalid category tag %s", *categoryTag))
 	} else {
 		category = n


### PR DESCRIPTION
### Proposed changes

This PR updates the docs driver tool to use the Pulumi schema as the fallback if an override is not passed to it for the fields mentioned in the title.

### Unreleased product version (optional)

N/A

### Related issues (optional)

https://github.com/pulumi/pulumi/issues/7813
