### PR TITLE
Don't default the title to the package name in the script

### DIFF
--- a/scripts/gen_package_metadata.sh
+++ b/scripts/gen_package_metadata.sh
@@ -35,10 +35,6 @@ COMPONENT=${7:-}
 METADATA_OUT_DIR=../../../registry/themes/default/data/registry/packages
 TOOL_RESDOCGEN="./tools/resourcedocsgen/"
 
-if [ -z "${TITLE:-}" ]; then
-    TITLE=${REPO_OVERRIDE}
-fi
-
 if [ -z "${REPO_OVERRIDE:-}" ]; then
   echo "Specify the repo name. Usage is gen_package_metadata.sh <METADATA_OUT_DIR> <REPO_OVERRIDE> <VERSION> [PUBLISHER] [TITLE] [CATEGORY]."
   exit 1


### PR DESCRIPTION
### Proposed changes

In PR https://github.com/pulumi/docs/pull/6710 I updated the `resourcedocsgen` tool to use its `title` flag truly as an override and always defaulting to the information from the schema. With that we should not default the title to the package name in the script anymore.

### Unreleased product version (optional)

N/A

### Related issues (optional)

Related to PR https://github.com/pulumi/docs/pull/6710
