### PR TITLE
[tools/resourcedocsgen] Continue to use the attribution as a hint for native providers

### DIFF
--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -256,7 +256,12 @@ func packageMetadataCmd() *cobra.Command {
 				}
 			}
 
-			native := isNative(mainSpec.Keywords)
+			native := mainSpec.Attribution == ""
+			// If native is false, check if the schema has the "kind/native" tag in the Keywords
+			// array.
+			if !native {
+				native = isNative(mainSpec.Keywords)
+			}
 
 			if !component {
 				component = isComponent(mainSpec.Keywords)


### PR DESCRIPTION
### Proposed changes

I was a bit eager with the removal of the fallback mechanism for determining if a package is native or not. I am in the process of getting the labels added to the respective native packages and until new versions of those packages containing the appropriate tag in the `keywords` array is available, we should continue to use the old way.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A
