### PR TITLE
Exclude API docs pages from the link checker

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -245,7 +245,9 @@ async function onComplete(brokenLinks) {
 */
 function getDefaultExcludedKeywords() {
     return [
+        "example.com",
         "/docs/reference/pkg",
+        "/registry/packages/*/api-docs",
         "/docs/get-started/install/versions",
         "https://api.pulumi.com/",
         "https://github.com/pulls?",


### PR DESCRIPTION
We've ~always excluded these, but when we moved them from `/docs/reference/pkg` to the Registry, we (er, I) forgot to add an exclusion for them at the new location as well. This change does that, and also adds `example.com` (just happened to notice it in the logs).