### PR TITLE
Temporarily disable automerge for automated pulumi-hugo PRs

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -52,7 +52,7 @@ jobs:
           author: Pulumi Bot <bot@pulumi.com>
           committer: Pulumi Bot <bot@pulumi.com>
           title: Update Hugo modules
-          labels: "automation/tfgen-provider-docs,automation/merge"
+          labels: "automation/tfgen-provider-docs"
           commit-message: Update Hugo module references
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           body: |


### PR DESCRIPTION
This should prevent any automatic merging of content PRs. We can restore this label when we're ready to turn it back on again.