### PR TITLE
Automerge tutorials

### DIFF
--- a/.github/workflows/update-tutorials.yml
+++ b/.github/workflows/update-tutorials.yml
@@ -28,6 +28,7 @@ jobs:
           author: Pulumi Bot <bot@pulumi.com>
           committer: Pulumi Bot <bot@pulumi.com>
           title: Update tutorials
+          labels: "automation/merge"
           commit-message: Update tutorials
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           body: |


### PR DESCRIPTION
Adds the `automation/merge` label so we can have tutorials merge automatically (currently once a day, when there are some).

This is the way we do this _now_, but I think @stack72 was thinking of switching this up across all of our repos, so open to alternatives if someone could point me to the new/desired approach.