### PR TITLE
Turn off Goldmark auto-linking

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -86,7 +86,7 @@ markup:
     extensions:
       definitionList: true
       footnote: true
-      linkify: true
+      linkify: false
       strikethrough: true
       table: true
       taskList: true


### PR DESCRIPTION
This change disables [Goldmark's `linkify` extension](https://pkg.go.dev/github.com/yuin/goldmark#readme-linkify-extension), which converts strings that look like URLs into links. 

Today, given the following Markdown: 

```markdown
# Some Heading

Some text with http://example.com in it.  
```

you get this:

```html
<h1>Some Heading</h1>
<p>Some text with <a href="http://example.com">http://example.com</a> in it. </p>
```

However, we don't want this, for reasons described in https://github.com/pulumi/marketing/issues/124. With this change, we'll instead get this:

```html
<h1>Some Heading</h1>
<p>Some text with http://example.com in it.</p>
```

I feel okay about this change and I don't think authors will be surprised by it, as our practice has always been to encode links explicitly, whether with Markdown expressions, `<a href>`s, Hugo `{{< relref >}}`s, or the like.

We'll want to do this in module repos as well (pulumi-hugo, registry), but it's this repo'd config that manages how we build and deploy the website. (Module configs only apply to local development and PR previews.)

Fixes https://github.com/pulumi/marketing/issues/124.
