### PR TITLE
Chain minify functions instead of running the side by side

### DIFF
--- a/scripts/minify-css.js
+++ b/scripts/minify-css.js
@@ -9,7 +9,7 @@ function minifyCSS(filePath) {
 
     // If there is no matching bundle then we will skip minifying things.
     if (bundlePath === undefined) {
-        return;
+        return Promise.resolve();
     }
 
     const css = fs.readFileSync(bundlePath);

--- a/scripts/minify-css.js
+++ b/scripts/minify-css.js
@@ -14,7 +14,7 @@ function minifyCSS(filePath) {
 
     const css = fs.readFileSync(bundlePath);
 
-    postcss([
+    return postcss([
 
         // PurgeCSS removes unused CSS by analyzing the files of the built website.
         // https://purgecss.com/
@@ -74,10 +74,11 @@ function minifyCSS(filePath) {
     });
 }
 
-Promise.all([
-    minifyCSS("public/css/bundle.*.css"),
-    minifyCSS("public/css/marketing.*.css"),
-]);
+minifyCSS("public/css/bundle.*.css").then(() => {
+    minifyCSS("public/css/marketing.*.css").then(() => {
+        console.log("CSS bundles minified successfully!");
+    });
+});
 
 // Exit non-zero when something goes wrong in the promise chain.
 process.on("unhandledRejection", error => {


### PR DESCRIPTION
In https://github.com/pulumi/docs/pull/7262 we introduced a way to support a marketing bundle with modification. Unfortunately Github Actions runs out memory when we run them in `Promise.all()`. [Failed Build](https://github.com/pulumi/docs/runs/5746354567?check_suite_focus=true#step:9:1217)

This PR chains the promises so that we won't hit those limits. 