### PR TITLE
Remove the link-check step from the build-and-deploy script

### DIFF
--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -71,9 +71,6 @@ aws s3 cp "$build_dir/latest-version" "${destination_bucket_uri}/latest-version"
 # Smoke test the deployed website. Specs are in ../cypress/integration.
 echo "Running tests..."
 
-echo "Checking links on $s3_website_url..."
-./scripts/check-links.sh "url" "$s3_website_url"
-
 echo "Running browser tests on $s3_website_url..."
 ./scripts/run-browser-tests.sh "$s3_website_url"
 


### PR DESCRIPTION
This step has been timing out sporadically lately, causing backups in the deployment queue. I'm not sure why that's happening -- we may just be outgrowing broken-link-checker -- but while I investigate, I'd like to remove it in order to keep from blocking deployments that would otherwise pass.

@stack72 I'd most like to hear from you on this. Do you believe it'd be risky to do this? Given the way our automated docs-generation processes work today, how plausible is it that we'd ship a docs update adding a link to a Pulumi archive or checksum that didn't exist on get.pulumi.com?   