### PR TITLE
Reduce the GOGC threshold

### DIFF
--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -34,7 +34,7 @@ popd
 printf "Running Hugo...\n\n"
 if [ "$1" == "preview" ]; then
     export HUGO_BASEURL="http://$(origin_bucket_prefix)-$(build_identifier).s3-website.$(aws_region).amazonaws.com"
-    GOGC=5 hugo --minify --templateMetrics -e "preview"
+    GOGC=4 hugo --minify --templateMetrics -e "preview"
 else
     GOGC=5 hugo --minify --templateMetrics -e production
 fi

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -36,7 +36,7 @@ if [ "$1" == "preview" ]; then
     export HUGO_BASEURL="http://$(origin_bucket_prefix)-$(build_identifier).s3-website.$(aws_region).amazonaws.com"
     GOGC=4 hugo --minify --templateMetrics -e "preview"
 else
-    GOGC=5 hugo --minify --templateMetrics -e production
+    GOGC=4 hugo --minify --templateMetrics -e production
 fi
 
 # Purge unused CSS.


### PR DESCRIPTION
It appears with our current setting, we're exceeding available memory on GitHub Actions runners. This change reduces the GC threshold to bring us back down below the [apparent 7GB ceiling](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources). 

This probably isn't a super-sustainable solution, however; it'd be good to explore other options for reducing the amount of memory we actually need to produce a website build.

Fixes https://github.com/pulumi/docs/issues/7403.