### PR TITLE
Add a button for ad-hoc triggering module-update PRs

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -2,6 +2,7 @@ name: "Scheduled jobs: Update Hugo modules"
 on:
   schedule:
     - cron:  '*/60 * * * *'
+  workflow_dispatch:
 jobs:
   merge:
     name: Update Hugo theme


### PR DESCRIPTION
Occasionally it's helpful to be able to kick off the hourly PR job manually. This little GHA trick surfaces a button in the Actions Workflow tab to make it easier (and a bit more intuitive) to do that.

![image](https://user-images.githubusercontent.com/274700/165388753-efdf6ddb-aa51-4256-9fe8-14c54574ba12.png)
