### PR TITLE
Update to latest docs templates

### DIFF
--- a/tools/resourcedocsgen/go.mod
+++ b/tools/resourcedocsgen/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220429220415-0a0f48e292b6
-	github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220429220415-0a0f48e292b6
+	github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220501172512-e462b78a7448
+	github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220501172512-e462b78a7448
 	github.com/spf13/cobra v1.4.0
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/tools/resourcedocsgen/go.sum
+++ b/tools/resourcedocsgen/go.sum
@@ -562,11 +562,11 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220429220415-0a0f48e292b6 h1:8LLsR5cGcom5am0tPd1kjynI//e6r3W8Y75CnRkKKng=
-github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220429220415-0a0f48e292b6/go.mod h1:bO/BHZJoG2Mm8C3dxP414vLPvjxFfsetPE3Ep7Ffgro=
+github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220501172512-e462b78a7448 h1:JMdpZ8sKjg/t7Pg6xOmiK808sINdWmQBiNBWuakB08A=
+github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220501172512-e462b78a7448/go.mod h1:bO/BHZJoG2Mm8C3dxP414vLPvjxFfsetPE3Ep7Ffgro=
 github.com/pulumi/pulumi/sdk/v3 v3.31.0/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
-github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220429220415-0a0f48e292b6 h1:l1FhZjsqOv/SXBH0MfVkNKg9d0Yn7o/NRCH9A6wOa6U=
-github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220429220415-0a0f48e292b6/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
+github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220501172512-e462b78a7448 h1:EI+cmXW1DRx7kvrCMJi3YLJZVmt8msngo8LX6lWhDvQ=
+github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220501172512-e462b78a7448/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=


### PR DESCRIPTION
Updates the site to use the template fixes in https://github.com/pulumi/pulumi/pull/9501.

Current:
https://www.pulumi.com/registry/packages/gcp/api-docs/accesscontextmanager/accesslevel/?language=nodejs

Fixed:
http://pulumi-docs-origin-pr-7438-aa747b0d.s3-website.us-west-2.amazonaws.com/registry/packages/gcp/api-docs/accesscontextmanager/accesslevel/?language=nodejs