### PR TITLE
Add Registry build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ _vendor/
 
 # Ignore Hugo build locks.
 .hugo_build.lock
+
+# Ignore registry-related build artifacts.
+/content/registry/packages/*/api-docs
+/static/registry


### PR DESCRIPTION
Things can get noisy when running `make build` locally:

```
$ git status

On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        content/registry/packages/aiven/
        content/registry/packages/akamai/
        content/registry/packages/alicloud/
        content/registry/packages/artifactory/
        content/registry/packages/auth0/
		...
        static/registry/
```

This change just adds these files to the ignore list.