### PR TITLE
Fix Javadoc redirect, SDK menu items

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -114,7 +114,7 @@ reference:
 
   - name: Java
     parent: Pulumi SDK
-    url: /docs/reference/pkg/java
+    url: /docs/reference/pkg/java/
     weight: 5
 
   - name: Pulumi YAML

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -91,3 +91,33 @@ reference:
     parent: cli
     url: /docs/reference/cli/pulumi_whoami/
     weight: 18
+
+  - name: Node.js
+    parent: Pulumi SDK
+    url: /docs/reference/pkg/nodejs/pulumi/pulumi
+    weight: 1
+
+  - name: Python
+    parent: Pulumi SDK
+    url: /docs/reference/pkg/python/pulumi
+    weight: 2
+
+  - name: Go
+    parent: Pulumi SDK
+    url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
+    weight: 3
+
+  - name: .NET Core
+    parent: Pulumi SDK
+    url: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
+    weight: 4
+
+  - name: Java
+    parent: Pulumi SDK
+    url: /docs/reference/pkg/java
+    weight: 5
+
+  - name: Pulumi YAML
+    parent: Pulumi SDK
+    url: https://github.com/pulumi/pulumi-yaml#spec
+    weight: 5

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -120,4 +120,4 @@ reference:
   - name: Pulumi YAML
     parent: Pulumi SDK
     url: https://github.com/pulumi/pulumi-yaml#spec
-    weight: 5
+    weight: 6

--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -167,7 +167,7 @@ function getCloudProvidersRedirect(uri: string): string | undefined {
 }
 
 function getAPIDocsRedirect(uri: string): string | undefined {
-    if (uri.match(/\/docs\/reference\/pkg\/nodejs|python|dotnet\//)) {
+    if (uri.match(/\/docs\/reference\/pkg\/nodejs|python|dotnet|java\//)) {
         return undefined;
     }
 
@@ -184,7 +184,7 @@ function getAPIDocsRedirect(uri: string): string | undefined {
 
 function getTutorialsRedirect(uri: string): string | undefined {
     const tutorialsPage = uri.match(/\/docs\/(?:reference\/)?tutorials\/([^\/]+)/);
-    
+
     if (tutorialsPage) {
         const packageName = tutorialsPage[1];
 


### PR DESCRIPTION
Fixes a currently-404ing link to our statically built Javadocs:

pulumi.com/docs/reference/pkg/java/

Also fixes https://github.com/pulumi/pulumi-hugo/issues/591.