### PR TITLE
Fix .NET link, add logging

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -44,6 +44,7 @@ disableKinds:
 sectionPagesMenu: main
 pygmentsCodeFences: true
 pygmentsUseClasses: true
+disablePathToLower: true
 
 # We always generate the robots.txt file. But based on the environment
 # built, it may disallow crawling.

--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -167,6 +167,10 @@ function getCloudProvidersRedirect(uri: string): string | undefined {
 }
 
 function getAPIDocsRedirect(uri: string): string | undefined {
+    console.log(`getAPIDocsRedirect uri: '${uri}'`);
+    console.log(uri.match(/\/docs\/reference\/pkg\/nodejs|python|dotnet|java\//));
+    console.log(uri.match(/\/docs\/reference\/pkg\/(nodejs|python|dotnet|java)\//));
+
     if (uri.match(/\/docs\/reference\/pkg\/nodejs|python|dotnet|java\//)) {
         return undefined;
     }


### PR DESCRIPTION
This should fix the .NET link, but I'm still not sure why the Java link should be failing, as the regex should match, and matches with my dev stack. So adding some logging to see if that sheds some light. (Perhaps the function isn't being redeployed?)