### PR TITLE
Remove `disablePathToLower`

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -44,7 +44,6 @@ disableKinds:
 sectionPagesMenu: main
 pygmentsCodeFences: true
 pygmentsUseClasses: true
-disablePathToLower: true
 
 # We always generate the robots.txt file. But based on the environment
 # built, it may disallow crawling.


### PR DESCRIPTION
I added this line to fix a broken link in the left-hand menu of the docs, which had been pointing to the .NET SDK docs using the wrong casing (all-lowercase, whereas many resources in those docs are PascalCased). I thought this setting was used only for controlling the URL casing of menu links, but I was wrong -- apparently it's also used for managing the URL casing of content pages as well, which is causing pages that had been getting forcibly downcased (like this one: 
https://www.pulumi.com/registry/packages/azuredevops/api-docs/agent/, which is "natively" `Agent`) to be left alone -- causing us to return 404s from previously indexed search results. So this is change removes that setting.

Note that this does return us to having a broken link in the Docs > Reference menu (under Pulumi SDK > .NET), so we'll need to come back to that as a follow-up. But it should restore access to these Azure pages and any others that may have been named with uppercase, but built and indexed with lowercase.

Internal convo for additional context:
https://pulumi.slack.com/archives/C011EMDQ8JE/p1652721644833569