### PR TITLE
Patch Javadocs search error

### DIFF
--- a/static-prebuilt/docs/reference/pkg/java/search.js
+++ b/static-prebuilt/docs/reference/pkg/java/search.js
@@ -314,6 +314,10 @@ $(function() {
                 } else if (ui.item.category === catSearchTags) {
                     url += ui.item.u;
                 }
+
+                // Nastiest hack ever, but it works.
+                url = url.replace("undefined/", "");
+
                 if (top !== window) {
                     parent.classFrame.location = pathtoroot + url;
                 } else {

--- a/static-prebuilt/docs/reference/pkg/java/search.js
+++ b/static-prebuilt/docs/reference/pkg/java/search.js
@@ -315,7 +315,8 @@ $(function() {
                     url += ui.item.u;
                 }
 
-                // Nastiest hack ever, but it works.
+                // Nastiest (temporary) hack ever, but it works.
+                // https://github.com/pulumi/pulumi-java/issues/595
                 url = url.replace("undefined/", "");
 
                 if (top !== window) {


### PR DESCRIPTION
The Javadocs are being generated in a way that's leaving the `url` variable prefixed with `undefined`. This "fix" swaps out that string while we investigate how to configure the Javadocs build script to set this stuff up properly.