### PR TITLE
Fix .NET menu link

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -109,7 +109,7 @@ reference:
 
   - name: .NET Core
     parent: Pulumi SDK
-    url: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
+    url: /docs/reference/pkg/dotnet
     weight: 4
 
   - name: Java


### PR DESCRIPTION
Our current Hugo config settings automatically downcase all relative URLs (or at least those accessed through certain Hugo properties, like the `.URL` property exposed for menu items). This breaks the .NET Core link in the left-hand menu in the docs, however, because it points to `pulumi/pulumi.html` rather than its actual path, `Pulumi/Pulumi.html`.

This PR changes that link to point to a page one level up in the hierarchy -- which works because the path to _that_ page _is_ all lowercase, and the links _from_ that page to the DocFX docs themselves are expressed as simple Markdown links (as they have to be, because Hugo doesn't manage them). This is probably an overall better place to link to as well, as it provides access not just to the core docs, but also to those for F# and Automation API.