### PR TITLE
Allow more scheduled workflows to be triggered on demand

### DIFF
--- a/.github/workflows/check-lighthouse.yml
+++ b/.github/workflows/check-lighthouse.yml
@@ -4,6 +4,7 @@ on:
     # * is a special character in YAML so you have to quote this string.
     # Run every day at 3:00PM UTC.
     - cron:  '0 15 * * *'
+  workflow_dispatch:
 jobs:
   all:
     name: Lighthouse
@@ -21,4 +22,3 @@ jobs:
             https://www.pulumi.com/registry/
             https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucket/
           uploadArtifacts: true
-

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -4,6 +4,7 @@ on:
     # * is a special character in YAML so you have to quote this string.
     # Run every day at 3:00PM UTC.
     - cron:  '0 15 * * *'
+  workflow_dispatch:
 jobs:
   all:
     env:

--- a/.github/workflows/update-tutorials.yml
+++ b/.github/workflows/update-tutorials.yml
@@ -2,6 +2,7 @@ name: "Scheduled jobs: Update tutorials"
 on:
   schedule:
     - cron:  '0 15 * * *'
+  workflow_dispatch:
 jobs:
   merge:
     name: Update tutorials


### PR DESCRIPTION
This change allows us to run the check-links, check-lighthouse, and update-tutorials workflows on demand as an additional convenience.