### PR TITLE
ignore github 403s

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -306,6 +306,9 @@ function excludeAcceptable(links) {
         // intelligently, but we can come back to that in a follow up.
         .filter(b => !(b.reason === "HTTP_429" && b.destination.match(/github.com|npmjs.com/)))
 
+        // Ignore GitHub 403s
+        .filter(b => !(b.reason === "HTTP_403" && b.destination.match(/github.com/)))
+
         // Ignore remote disconnects.
         .filter(b => b.reason !== "ERRNO_ECONNRESET")
 


### PR DESCRIPTION
website notifications is full of these
can we ignore them for now?

to clarify, there is nothing wrong with the github links, but the link checker is reporting them as 403s in the website notifications channel because of how the link checker was written, 20 or something a day