### PR TITLE
Ignore data-flair.training

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -300,6 +300,7 @@ function getDefaultExcludedKeywords() {
         "https://linen.dev/",
         "https://cloud.yandex.com/",
         "http://localhost:3000",
+        "https://data-flair.training",
     ];
 }
 


### PR DESCRIPTION
Took a quick look at the 403 report for this one, and it's not clear how to work around it; I'm guessing it's due to Cloudflare's [browser-integrity check](https://support.cloudflare.com/hc/en-us/articles/200170086-What-does-the-Browser-Integrity-Check-do-). So this change adds this particular domain to the ignore list.