### PR TITLE
Handle AWS CLI v2

### DIFF
--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -48,17 +48,17 @@ aws s3 mb $destination_bucket_uri --region "$(aws_region)" || true
 
 # Tag the bucket with ownership information for production buckets.
 if [ "$(pulumi -C infrastructure stack --show-name)" == "production" ]; then
-    aws s3api put-bucket-tagging --bucket $destination_bucket --tagging file://$(pwd)/scripts/bucket-tagging.json
+    aws s3api put-bucket-tagging --bucket $destination_bucket --tagging file://$(pwd)/scripts/bucket-tagging.json --region "$(aws_region)"
 fi
 
 # Make the bucket an S3 website.
-aws s3 website $destination_bucket_uri --index-document index.html --error-document 404.html
+aws s3 website $destination_bucket_uri --index-document index.html --error-document 404.html --region "$(aws_region)"
 
 # Sync the local build directory to the bucket. Note that we do pass the --delete option
 # here, since in most cases, we'll be continually updating a bucket associated with a PR;
 # passing this option keeps the destination bucket clean.
 echo "Synchronizing to $destination_bucket_uri..."
-aws s3 sync "$build_dir" "$destination_bucket_uri" --acl public-read --delete --quiet
+aws s3 sync "$build_dir" "$destination_bucket_uri" --acl public-read --delete --quiet --region "$(aws_region)"
 
 echo "Sync complete."
 s3_website_url="http://${destination_bucket}.s3-website.$(aws_region).amazonaws.com"
@@ -66,7 +66,7 @@ echo "$s3_website_url"
 
 # Set the content-type of latest-version explicitly. (Otherwise, it'll be set as binary/octet-stream.)
 aws s3 cp "$build_dir/latest-version" "${destination_bucket_uri}/latest-version" \
-    --content-type "text/plain" --acl public-read --metadata-directive REPLACE
+    --content-type "text/plain" --acl public-read --region "$(aws_region)" --metadata-directive REPLACE
 
 # Smoke test the deployed website. Specs are in ../cypress/integration.
 echo "Running tests..."


### PR DESCRIPTION
Noticed some failing deployments today, and it looks like GitHub is in the process of rolling this out (i.e., upgrading AWS CLI from V1 to V2): https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-Readme.md

This change makes the appropriate adjustments to get us back to 🟢.