### PR TITLE
Restore the `rb` subcommand

### DIFF
--- a/scripts/remove-recent-buckets.sh
+++ b/scripts/remove-recent-buckets.sh
@@ -28,7 +28,7 @@ echo
 
 for bucket in $buckets_to_remove; do
     echo "Removing ${bucket}..."
-    aws s3  "s3://${bucket}" --force --region "$(aws_region)"
+    aws s3 rb "s3://${bucket}" --force --region "$(aws_region)"
     echo
 done
 


### PR DESCRIPTION
Took out this rather important subcommand to test, and then [forgot to put it back in](https://github.com/pulumi/docs/pull/7728/files#diff-64a53b35f4390e2e056b4a0ebe011cd78d9d0e1bdd7a36cdc163157095845e77L29) before submitting #7728. 🤦