### PR TITLE
Add back missing checksums

### DIFF
--- a/content/docs/get-started/install/versions.md
+++ b/content/docs/get-started/install/versions.md
@@ -18,8 +18,9 @@ The current stable version of Pulumi is **{{< latest-version >}}**.
         </tr>
     </thead>
     <tbody>
-        {{< changelog-table-row version="3.40.1" date="2022-09-19" >}}
-        {{< changelog-table-row version="3.40.0" date="2022-09-14" >}}
+        {{< changelog-table-row version="3.40.1" date="2022-09-19" showChecksum="true" >}}
+        {{< changelog-table-row version="3.40.0" date="2022-09-14" showChecksum="true" >}}
+        {{< changelog-table-row version="3.39.4" date="2022-09-14" showChecksum="true" >}}
         {{< changelog-table-row version="3.39.3" date="2022-09-08" showChecksum="true" >}}
         {{< changelog-table-row version="3.39.2" date="2022-09-07" showChecksum="true" >}}
         {{< changelog-table-row version="3.39.1" date="2022-09-02" showChecksum="true" >}}


### PR DESCRIPTION
We've manually published checksums for `3.39.4`, `3.40.0`, and `3.40.1`, so we can add a row for `3.39.4` and turn back on the checksum links for `3.40.0` and `3.40.1`.

Fixes #8043