### PR TITLE
Remove exclusion from link checker

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -79,7 +79,6 @@ function getChecker(brokenLinks) {
         excludeLinksToSamePage: true,
         excludedKeywords: [
             ...getDefaultExcludedKeywords(),
-            "https://www*"
         ]
     };
 


### PR DESCRIPTION
I'm not sure why this was put here (goes all the way back to when the file was first added), but I can't think of a good reason to be excluding everything matching `https://www*`. Will likely reveal more broken links, but hey -- that's what we want, right?