### PR TITLE
Bump automerge retires from 30 to 50

### DIFF
--- a/.github/workflows/automerge-workflow.yml
+++ b/.github/workflows/automerge-workflow.yml
@@ -12,7 +12,7 @@ jobs:
           MERGE_LABELS: automation/merge
           MERGE_METHOD: squash
           MERGE_REMOVE_LABELS: automation/merge
-          MERGE_RETRIES: "30"
+          MERGE_RETRIES: "50"
           MERGE_RETRY_SLEEP: "60000"
           UPDATE_LABELS: automation/update
           UPDATE_METHOD: rebase


### PR DESCRIPTION
We have seen some PRs where the automerge workflow didn't run and from the logs it looks like this is likely a race condition where the automerge workflow stops polling before the checks have completed. This PR bumps the retries for the automerge step to 50, which increases the time window from 30 minutes to 50 minutes.