### PR TITLE
Include strict-transport-policy response headers

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -158,6 +158,9 @@ const baseCacheBehavior = {
     maxTtl: fiveMinutes,
 
     lambdaFunctionAssociations,
+
+    // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html#managed-response-headers-policies-security
+    responseHeadersPolicyId: "67f7725c-6f97-4210-82d7-5512b31e9d03", // SecurityHeadersPolicy
 };
 
 // domainAliases is a list of CNAMEs that accompany the CloudFront distribution. Any


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Refs https://github.com/pulumi/get.pulumi.com/pull/140 https://github.com/pulumi/home/issues/2490

We've seen an issue where users running old OSes or browsers will incorrectly flag our newly-rotated production certs as invalid, and we suspect adding security headers will address the issue.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
