### PR TITLE
enable cors on uploads bucket

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -70,6 +70,12 @@ const uploadsBucket = new aws.s3.Bucket("uploads-bucket", {
     website: {
         indexDocument: "index.html",
     },
+    corsRules: [{
+        allowedMethods: [
+            "GET",
+        ],
+        allowedOrigins: ["*"],
+    }],
 });
 
 // Optionally create a fallback bucket for serving the website directly out of S3 when necessary.

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -221,6 +221,10 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
 
     defaultCacheBehavior: {
         ...baseCacheBehavior,
+        // the policy ID of the AWS managed policy, CORS-S3-Origin, it includes the headers that enable cross-origin
+        // resource sharing (CORS) requests when the content origin is an S3 bucket.
+        // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
+        originRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf",
     },
 
     orderedCacheBehaviors: [

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -221,10 +221,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
 
     defaultCacheBehavior: {
         ...baseCacheBehavior,
-        // the policy ID of the AWS managed policy, CORS-S3-Origin, it includes the headers that enable cross-origin
-        // resource sharing (CORS) requests when the content origin is an S3 bucket.
-        // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
-        originRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf",
     },
 
     orderedCacheBehaviors: [
@@ -234,6 +230,17 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             pathPattern: "/uploads/*",
             defaultTtl: oneHour,
             maxTtl: oneHour,
+            forwardedValues: {
+                cookies: {
+                    forward: "none",
+                },
+                queryString: false,
+                headers: [
+                    "Origin",
+                    "Access-Control-Request-Headers",
+                    "Access-Control-Request-Method",
+                ],
+            },
         },
         {
             ...baseCacheBehavior,


### PR DESCRIPTION
This will allow us to access non-media related assets locally and in previews that are hosted in the uploads bucket. On the actual site `pulumi.com` this is not an issue since everything is referenced under the same origin via `pulumi.com/uploads`. However when developing locally or using a preview the origin is different, e.g. localhost