### PR TITLE
Disable auto merge of update PRs

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -53,7 +53,7 @@ jobs:
           author: Pulumi Bot <bot@pulumi.com>
           committer: Pulumi Bot <bot@pulumi.com>
           title: Update Hugo modules
-          labels: "automation/tfgen-provider-docs,automation/merge"
+          labels: "automation/tfgen-provider-docs"
           commit-message: Update Hugo module references
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           body: |


### PR DESCRIPTION
Temporarily disabling auto-merging while we move `theme` back into `pulumi-hugo`.