### PR TITLE
Update pulumi-cli.yml

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           source_branch: "pulumi/${{ github.run_id }}-${{ github.run_number }}"
           destination_branch: "master"
-          pr_title: "Regen docs pulumi@${PULUMI_VERSION}"
+          pr_title: "Regen docs pulumi@${{ env.PULUMI_VERSION }}"
           pr_body: "Automated PR"
           pr_label: "automation/pulumi-cli-docs,automation/merge"
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}


### PR DESCRIPTION
docs PRs for new CLI releases were being opened as `Regen docs pulumi@${PULUMI_VERSION}` due to a change in the GitHub action: `repo-sync/pull-request@v2`

Fixes #8451 

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
