### PR TITLE
add GH token env var

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -45,6 +45,8 @@ jobs:
             echo 'NEW_COMMITS<<EOF' >> $GITHUB_ENV
             node scripts/get-module-diff-details.js >> $GITHUB_ENV
             echo 'EOF' >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/8477

Adding the GITHUB_TOKEN env variable to workflow step. We saw another rate limitting error [here](https://github.com/pulumi/docs/actions/runs/4000780762/jobs/6866326356). It looks like the [script ](https://github.com/pulumi/docs/blob/master/scripts/get-module-diff-details.js#L8-L12)is set up to make the request with the GH token, but i'm guessing it wasnt set in the environment. Maybe it is already set by default though, so let me know if this makes sense. However, I do see us explicitly setting it like this in other workflows, so I am assuming this is the issue.