### PR TITLE
update action docker image

### DIFF
--- a/.github/workflows/check-lighthouse.yml
+++ b/.github/workflows/check-lighthouse.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [all]
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: docker://sholung/action-slack-notify:v2.3.0
         env:
           SLACK_CHANNEL: docs-ops
           SLACK_COLOR: "#F54242"


### PR DESCRIPTION
update docker image to use fix for action url link. it's the same as what is bein done in this [PR](https://github.com/pulumi/docs/pull/8540), i just somehow missed updating this one.