### PR TITLE
pydocgen: Don't generate HTML permalinks

### DIFF
--- a/tools/pydocgen/pydocgen/templates/conf.py
+++ b/tools/pydocgen/pydocgen/templates/conf.py
@@ -72,6 +72,10 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Don't generate HTML permalinks because those are injected into the page
+# with Javascript separately.
+html_permalinks = False
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
sphinx_rtd_theme injects HTML permalinks in all pages by default,
using a FontAwesome based link icon.

This is not necessary on our website because we use Javascript
to inject header links client-side,
and instead leads to double-anchors on the website.
