### PR TITLE
fix slack alert to notify on pulumi-hugo/refresh branch

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Configure Git
         run: |
           git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
-
       - name: Install assume-role
         run: go install github.com/remind101/assume-role@latest
 
@@ -61,7 +60,7 @@ jobs:
           name: origin-bucket-metadata
           path: origin-bucket-metadata.json
   notify:
-    if: github.ref == 'refs/heads/master' && failure()
+    if: (github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'pulumi-bot')) && failure()
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [buildSite]


### PR DESCRIPTION
Fix slack notification to notify on branch pulumi-hugo/refresh. We missed a notification recently, because the notification was only alerting on master build failures. We also need to be notifying for failures on the pulumi-hugo/refresh branch, since that is the branch that the [scheduled Update Hugo Modules cron uses when auto opening PRs](https://github.com/pulumi/docs/blob/master/.github/workflows/update-theme.yml#L54). So we need to be alerted as things can get blocked at this stage before the PR gets automerged.


NOTE: I changed this to just notify on all PRs opened by the `pulumi-bot`, since we want to know about any failures caused by any automated PRs