### PR TITLE
retry cypress tests on failure

### DIFF
--- a/cypress/integration/site_spec.js
+++ b/cypress/integration/site_spec.js
@@ -6,7 +6,7 @@ describe("www.pulumi.com", () => {
             cy.visit("/");
         });
 
-        it("loads and applies CSS", { retries: 3 }, () => {
+        it("loads and applies CSS", () => {
             // Checking the computed background-color value validates that the CSS bundle
             // was properly loaded and applied.
             cy.get(".header-container")
@@ -14,7 +14,7 @@ describe("www.pulumi.com", () => {
                 .should("equal", "rgb(255, 255, 255)");
         });
 
-        it("loads and applies JavaScript", { retries: 3 }, () => {
+        it("loads and applies JavaScript", () => {
             // Checking the carousel validates that the JS bundle was loaded and applied
             // (excluding Stencil components, which are bundled separately).
             cy.get(".header-container")

--- a/scripts/run-browser-tests.sh
+++ b/scripts/run-browser-tests.sh
@@ -1,3 +1,26 @@
 #!/bin/bash
 
-CYPRESS_BASE_URL="$1" yarn run cypress run --headless
+MAX_RETRIES=3
+RETRY_COUNT=0
+
+# Retry on errors up to `MAX_RETRIES` with a 10 second sleep in between.
+run_tests() {
+    while true; do
+        CYPRESS_BASE_URL="$1" yarn run cypress run --headless
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+            RETRY_COUNT=$((RETRY_COUNT+1))
+            if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+                echo "Error: Browser tests failed after ${MAX_RETRIES} retries"
+                exit $exit_code
+            else
+                echo "Error: Retrying browser tests in 10 seconds..."
+                sleep 10
+            fi
+        else
+            break
+        fi
+    done
+}
+
+trap 'run_tests $1' EXIT


### PR DESCRIPTION
fixes: #8627 

The cypress retry logic does not seem to actually be working for some reason and I cannot seem to get it to work. I'm not sure why exactly. I have reverted this to doing the retry purely in bash by trapping the exit code from the failed tests and triggering the retry.
