### PR TITLE
Remove references to pulumi/theme, use pulumi-hugo for CSS and JS

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Update Hugo modules
         run: |
           hugo mod get github.com/pulumi/pulumi-hugo/themes/default
-          hugo mod get github.com/pulumi/theme@release
           hugo mod get github.com/pulumi/registry/themes/default
 
       - name: Identify relevant commits

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -15,20 +15,14 @@ module:
       mounts:
         - source: content
           target: content
-        - source: static
-          target: static
-        - source: layouts
-          target: layouts
-        - source: data
-          target: data
-    - path: github.com/pulumi/theme
-      mounts:
         - source: assets
           target: assets
         - source: static
           target: static
         - source: layouts
           target: layouts
+        - source: data
+          target: data
 
 security:
   funcs:

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,4 @@ go 1.16
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20230309215742-35d2caee7d7c // indirect
 	github.com/pulumi/registry/themes/default v0.0.0-20230309195752-50056b430735 // indirect
-	github.com/pulumi/theme v0.0.0-20230119195349-58fee7fe1379 // indirect
 )


### PR DESCRIPTION
A while back, we moved our CSS and JS into pulumi-hugo, but it looks like we kept the references to pulumi/theme, so we've since been building the site using pulumi/theme's CSS and JS and not pulumi-hugo's as we presumably expected. 

This change drops all references to pulumi/theme and adjusts the Hugo config to use the built `assets` from the pulumi-hugo module going forward. 