### PR TITLE
Pulumi currently supports Python >=3.7. 3.6 is no longer supported.

### DIFF
--- a/content/docs/reference/pkg/python/pulumi/_index.md
+++ b/content/docs/reference/pkg/python/pulumi/_index.md
@@ -14,7 +14,7 @@ that you’ll need in order to interact with Pulumi resource providers and expre
 Pulumi resource providers all depend on this library and express their resources in terms of the types defined in this
 module.</p>
 <blockquote class="epigraph">
-<div><p><strong>Note</strong>: The Pulumi Python SDK requires Python version 3.6 or greater. Please see the
+<div><p><strong>Note</strong>: The Pulumi Python SDK requires Python version 3.7 or greater. Please see the
 <a class="reference external" href="/docs/reference/python/#getting-started">Python getting started</a> documentation for details on how to get started with
 Python.</p>
 </div></blockquote>


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR changes the supported Python version to 3.7, since 3.6 is no longer supported by Pulumi.
This change brings the reference page into parity with the Getting Started page, which lists 3.7 as the minimum version.

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
