### PR TITLE
enable cors to access rss feeds corss origin

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -247,6 +247,24 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         },
         {
             ...baseCacheBehavior,
+            targetOriginId: originBucket.arn,
+            pathPattern: "/*/rss.xml",
+            defaultTtl: oneHour,
+            maxTtl: oneHour,
+            forwardedValues: {
+                cookies: {
+                    forward: "none",
+                },
+                queryString: false,
+                headers: [
+                    "Origin",
+                    "Access-Control-Request-Headers",
+                    "Access-Control-Request-Method",
+                ],
+            },
+        },
+        {
+            ...baseCacheBehavior,
             pathPattern: "/css/styles.*.css",
             defaultTtl: oneYear,
             maxTtl: oneYear,

--- a/scripts/cors.json
+++ b/scripts/cors.json
@@ -1,0 +1,10 @@
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["https://*.pulumi.com"],
+      "AllowedHeaders": ["Authorization"],
+      "AllowedMethods": ["GET"],
+      "MaxAgeSeconds": 300
+    }
+  ]
+}

--- a/scripts/cors/cors.json
+++ b/scripts/cors/cors.json
@@ -3,7 +3,9 @@
     {
       "AllowedOrigins": [
         "https://*.pulumi.com",
-        "https://*.pulumi-dev.io"
+        "https://*.pulumi-dev.io",
+        "http://localhost:3000",
+        "http://localhost:4200"
       ],
       "AllowedMethods": ["GET"],
       "MaxAgeSeconds": 300

--- a/scripts/cors/cors.json
+++ b/scripts/cors/cors.json
@@ -5,7 +5,6 @@
         "https://*.pulumi.com",
         "https://*.pulumi-dev.io"
       ],
-      "AllowedHeaders": ["Authorization"],
       "AllowedMethods": ["GET"],
       "MaxAgeSeconds": 300
     }

--- a/scripts/cors/cors.json
+++ b/scripts/cors/cors.json
@@ -1,7 +1,10 @@
 {
   "CORSRules": [
     {
-      "AllowedOrigins": ["https://*.pulumi.com"],
+      "AllowedOrigins": [
+        "https://*.pulumi.com",
+        "https://*.pulumi-dev.io"
+      ],
       "AllowedHeaders": ["Authorization"],
       "AllowedMethods": ["GET"],
       "MaxAgeSeconds": 300

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -99,8 +99,10 @@ aws s3 cp "$metadata_file" "${destination_bucket_uri}/metadata.json" --region "$
 # Persist an association between the current commit and the bucket we just deployed to.
 set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$(aws_region)"
 
+pwd
+
 # Set cors configuration on bucket.
-aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration file://cors.json
+aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration file://scripts/cors.json
 
 # Finally, if it's a preview, post a comment to the PR that directs the user to the resulting bucket URL.
 if [ "$1" == "preview" ]; then

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -102,7 +102,7 @@ set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$(aws_region)"
 pwd
 
 # Set cors configuration on bucket.
-aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration file://scripts/cors.json
+aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration file://scripts/cors/cors.json
 
 # Finally, if it's a preview, post a comment to the PR that directs the user to the resulting bucket URL.
 if [ "$1" == "preview" ]; then

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -99,8 +99,6 @@ aws s3 cp "$metadata_file" "${destination_bucket_uri}/metadata.json" --region "$
 # Persist an association between the current commit and the bucket we just deployed to.
 set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$(aws_region)"
 
-pwd
-
 # Set cors configuration on bucket.
 aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration file://scripts/cors/cors.json
 

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -99,6 +99,9 @@ aws s3 cp "$metadata_file" "${destination_bucket_uri}/metadata.json" --region "$
 # Persist an association between the current commit and the bucket we just deployed to.
 set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$(aws_region)"
 
+# Set cors configuration on bucket.
+aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration file://cors.json
+
 # Finally, if it's a preview, post a comment to the PR that directs the user to the resulting bucket URL.
 if [ "$1" == "preview" ]; then
     pr_comment_api_url="$(cat "$GITHUB_EVENT_PATH" | jq -r ".pull_request._links.comments.href")"

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -100,7 +100,7 @@ aws s3 cp "$metadata_file" "${destination_bucket_uri}/metadata.json" --region "$
 set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$(aws_region)"
 
 # Set cors configuration on bucket.
-aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration file://scripts/cors/cors.json
+aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration "file://scripts/cors/cors.json" --region "$(aws_region)"
 
 # Finally, if it's a preview, post a comment to the PR that directs the user to the resulting bucket URL.
 if [ "$1" == "preview" ]; then


### PR DESCRIPTION
This PR enables us to access the rss feeds cross origin, since I need to access them from the console UI. I tried this out in a dev environment by standing up cloudfront and the bucket and confirming I can fetch from the browser console.  This will allow origins from any subdomain of pulumi.com or any subdomain of pulumi-dev.io