### PR TITLE
add exclusions to link checker

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -247,6 +247,9 @@ function getDefaultExcludedKeywords() {
         "https://data-flair.training",
         "https://opensource.org/licenses",
         "https://console.eventstore.cloud/authentication-tokens",
+        "https://telecomreseller.com/2019/03/20/crossing-cloud-chasms-avoiding-catastrophic-cloud-calamities",
+        "https://www.enterprisetech.com/2018/10/23/startup-pulumi-rolls-cloud-native-tools",
+        "http://optout.networkadvertising.org/?c=1",
     ];
 }
 


### PR DESCRIPTION
we regularly get 403s on these links, but they work just fine for us
so adding them to the exclude list