### PR TITLE
add new account prod stack

### DIFF
--- a/.github/workflows/build-and-deploy-new-acct.yml
+++ b/.github/workflows/build-and-deploy-new-acct.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:
-          SLACK_CHANNEL: sean-ops-test
+          SLACK_CHANNEL: docs-ops-test
           SLACK_COLOR: "#F54242"
-          SLACK_MESSAGE: "[new account] build and deploy failure in pulumi/docs repo :meow_sad:"
+          SLACK_MESSAGE: "[NEW ACCOUNT] build and deploy failure in pulumi/docs repo :meow_sad:"
           SLACK_USERNAME: docsbot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/.github/workflows/build-and-deploy-new-acct.yml
+++ b/.github/workflows/build-and-deploy-new-acct.yml
@@ -1,0 +1,74 @@
+# temporary workflow to start deploying to the new prod account.
+name: Build and deploy new account
+on:
+  push:
+    branches:
+      - master
+jobs:
+  buildSite:
+    env:
+      GOPATH: ${{ github.workspace }}/go
+    name: Install deps and build site
+    runs-on: buildjet-4vcpu-ubuntu-2004
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.19.x
+
+      - uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.96.0'
+          extended: true
+
+      - name: Configure Git
+        run: |
+          git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
+      - name: Install assume-role
+        run: go install github.com/remind101/assume-role@latest
+
+      - name: Install Pulumi CLI
+        uses: pulumi/setup-pulumi@v2
+
+      - name: Build and deploy
+        run: make ci_${GITHUB_EVENT_NAME}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID_NEW }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY_NEW }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: "--max_old_space_size=4096"
+
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: browser-test-results
+          path: cypress/videos
+
+      - name: Archive bucket metadata
+        uses: actions/upload-artifact@v2
+        with:
+          name: origin-bucket-metadata
+          path: origin-bucket-metadata.json
+  notify:
+    if: (github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'pulumi-bot')) && failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [buildSite]
+    steps:
+      - name: Slack Notification
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: sean-ops-test
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "[new account] build and deploy failure in pulumi/docs repo :meow_sad:"
+          SLACK_USERNAME: docsbot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: us-west-2

--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -2,21 +2,21 @@
 
 set -o errexit -o pipefail
 
-if [[ "$GITHUB_WORKFLOW" == "Build and deploy" ]]; then
+# if being run by the new account workflow, then assume role in new account.
+if [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
+    echo "Assuming the production CI role in **NEW** AWS account..."
+    eval $(assume-role -duration "2h0m0s" "arn:aws:iam::388588623842:role/ContinuousIntegrationRole")
+    
+    # uncomment pulumi login code below when migration is complete and update stack selection
+    # to select the production stack that manages the new environment.
+
+    # pulumi login
+    # pulumi -C infrastructure stack select pulumi/production
+else
     echo "Assuming the production CI role..."
     eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
     echo "Selecting the pulumi/production stack"
     pulumi login
     pulumi -C infrastructure stack select pulumi/production
-elif [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
-    echo "Assuming the production CI role in new AWS account..."
-    eval $(assume-role -duration "2h0m0s" "arn:aws:iam::388588623842:role/ContinuousIntegrationRole")
-    # uncomment below when migration is complete and update stack selection to select the production stack
-    # that manages the new environment.
-    # pulumi login
-    # pulumi -C infrastructure stack select pulumi/production
-else
-    echo "the workflow, ${GITHUB_WORKFLOW}, is not recognized"
-    exit 1
 fi
 

--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -2,9 +2,17 @@
 
 set -o errexit -o pipefail
 
-echo "Assuming the production CI role..."
-eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
+if [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
+    echo "Assuming the production CI role in new AWS account..."
+    # change this ARN to reference CI Role in new account.
+    eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
+    # pulumi login
+    # pulumi -C infrastructure stack select pulumi/production
+else
+    echo "Assuming the production CI role..."
+    eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
+    echo "Selecting the pulumi/production stack"
+    pulumi login
+    pulumi -C infrastructure stack select pulumi/production
+fi
 
-echo "Selecting the pulumi/production stack"
-pulumi login
-pulumi -C infrastructure stack select pulumi/production

--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -6,12 +6,9 @@ set -o errexit -o pipefail
 if [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
     echo "Assuming the production CI role in **NEW** AWS account..."
     eval $(assume-role -duration "2h0m0s" "arn:aws:iam::388588623842:role/ContinuousIntegrationRole")
-    
-    # uncomment pulumi login code below when migration is complete and update stack selection
-    # to select the production stack that manages the new environment.
 
-    # pulumi login
-    # pulumi -C infrastructure stack select pulumi/production
+    pulumi login
+    pulumi -C infrastructure stack select pulumi/www-production
 else
     echo "Assuming the production CI role..."
     eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")

--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -2,17 +2,22 @@
 
 set -o errexit -o pipefail
 
-if [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
-    echo "Assuming the production CI role in new AWS account..."
-    # change this ARN to reference CI Role in new account.
-    eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
-    # pulumi login
-    # pulumi -C infrastructure stack select pulumi/production
-else
+if [[ "$GITHUB_WORKFLOW" == "Build and deploy" ]]; then
     echo "Assuming the production CI role..."
     eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
     echo "Selecting the pulumi/production stack"
     pulumi login
     pulumi -C infrastructure stack select pulumi/production
+elif [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
+    echo "Assuming the production CI role in new AWS account..."
+    # change this ARN to reference CI Role in new account.
+    eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
+    # uncomment below when migration is complete and update stack selection to select the production stack
+    # that manages the new environment.
+    # pulumi login
+    # pulumi -C infrastructure stack select pulumi/production
+else
+    echo "the workflow, ${GITHUB_WORKFLOW}, is not recognized"
+    exit 1
 fi
 

--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -10,8 +10,7 @@ if [[ "$GITHUB_WORKFLOW" == "Build and deploy" ]]; then
     pulumi -C infrastructure stack select pulumi/production
 elif [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
     echo "Assuming the production CI role in new AWS account..."
-    # change this ARN to reference CI Role in new account.
-    eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")
+    eval $(assume-role -duration "2h0m0s" "arn:aws:iam::388588623842:role/ContinuousIntegrationRole")
     # uncomment below when migration is complete and update stack selection to select the production stack
     # that manages the new environment.
     # pulumi login

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -16,5 +16,8 @@ elif [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
     # until we cut over DNS to start routing to the new account.
     ./scripts/build-site.sh preview
     ./scripts/sync-and-test-bucket.sh
+else
+    echo "the workflow, ${GITHUB_WORKFLOW}, is not recognized"
+    exit 1
 fi
 ./scripts/make-s3-redirects.sh

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -7,8 +7,9 @@ source ./scripts/ci-login.sh
 ./scripts/build-site.sh
 ./scripts/sync-and-test-bucket.sh
 
-# Wait for in-progress jobs to complete before proceeding.
-node ./scripts/await-in-progress.js
-
-./scripts/run-pulumi.sh update
+if [[ "$GITHUB_WORKFLOW" == "Build and deploy" ]]; then
+    # Wait for in-progress jobs to complete before proceeding.
+    node ./scripts/await-in-progress.js
+    ./scripts/run-pulumi.sh update
+fi
 ./scripts/make-s3-redirects.sh

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -4,12 +4,17 @@ set -o errexit -o pipefail
 
 source ./scripts/ci-login.sh
 
-./scripts/build-site.sh
-./scripts/sync-and-test-bucket.sh
 
 if [[ "$GITHUB_WORKFLOW" == "Build and deploy" ]]; then
     # Wait for in-progress jobs to complete before proceeding.
+    ./scripts/build-site.sh
+    ./scripts/sync-and-test-bucket.sh
     node ./scripts/await-in-progress.js
     ./scripts/run-pulumi.sh update
+elif [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
+    # temporarily setting site to build in preview mode, to prevent search bots from indexing
+    # until we cut over DNS to start routing to the new account.
+    ./scripts/build-site.sh preview
+    ./scripts/sync-and-test-bucket.sh
 fi
 ./scripts/make-s3-redirects.sh

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -56,7 +56,15 @@ current_time_in_ms() {
 }
 
 origin_bucket_prefix() {
-    echo "pulumi-docs-origin"
+    # This function returns the bucket name prefix to be used when naming the
+    # S3 buckets. We are adding a `www` prefix to the buckets being deployed
+    # to the new account, in order to account for collisions in the global
+    # bucket namespace.
+    if [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
+        echo "www-pulumi-docs-origin"
+    else
+        echo "pulumi-docs-origin"
+    fi
 }
 
 # Returns the name of the metadata file we expect to exist locally before running Pulumi.

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -31,17 +31,7 @@ fi
 
 # For previews, name the destination bucket with the PR number, to reduce the number of
 # buckets we create and to facilitate shorter sync times.
-destination_bucket=""
-if [[ "$GITHUB_WORKFLOW" == "Build and deploy" ]]; then
-    echo "configuring bucket in production account"
-    destination_bucket="$(origin_bucket_prefix)-$(build_identifier)"
-elif [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
-    echo "configuring bucket in new production account"
-    destination_bucket="www-$(origin_bucket_prefix)-$(build_identifier)"
-else
-    echo "the workflow, ${GITHUB_WORKFLOW}, is not recognized"
-    exit 1
-fi
+destination_bucket="$(origin_bucket_prefix)-$(build_identifier)"
 destination_bucket_uri="s3://${destination_bucket}"
 
 # Translate Hugo redirects into a file we'll use for making 301 redirects later. Note that

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -31,10 +31,16 @@ fi
 
 # For previews, name the destination bucket with the PR number, to reduce the number of
 # buckets we create and to facilitate shorter sync times.
-destination_bucket="$(origin_bucket_prefix)-$(build_identifier)"
-if [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
-    echo "setting bucket in new account"
+destination_bucket=""
+if [[ "$GITHUB_WORKFLOW" == "Build and deploy" ]]; then
+    echo "configuring bucket in production account"
+    destination_bucket="$(origin_bucket_prefix)-$(build_identifier)"
+elif [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
+    echo "configuring bucket in new production account"
     destination_bucket="www-$(origin_bucket_prefix)-$(build_identifier)"
+else
+    echo "the workflow, ${GITHUB_WORKFLOW}, is not recognized"
+    exit 1
 fi
 destination_bucket_uri="s3://${destination_bucket}"
 

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -32,6 +32,10 @@ fi
 # For previews, name the destination bucket with the PR number, to reduce the number of
 # buckets we create and to facilitate shorter sync times.
 destination_bucket="$(origin_bucket_prefix)-$(build_identifier)"
+if [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
+    echo "setting bucket in new account"
+    destination_bucket="www-$(origin_bucket_prefix)-$(build_identifier)"
+fi
 destination_bucket_uri="s3://${destination_bucket}"
 
 # Translate Hugo redirects into a file we'll use for making 301 redirects later. Note that


### PR DESCRIPTION
the workflow failed, because one of the functions pulls the aws region from the stack config. there is no stack for the new prod environment yet, so it is failing. I am adding a stack `www-production` with a stack config that only contains the region for now. There will be no pulumi updates run against the new account yet though. This is just to get things in a passing state and deploying to the new account.