### PR TITLE
add new prod stack

### DIFF
--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: us-west-2

--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -6,12 +6,9 @@ set -o errexit -o pipefail
 if [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
     echo "Assuming the production CI role in **NEW** AWS account..."
     eval $(assume-role -duration "2h0m0s" "arn:aws:iam::388588623842:role/ContinuousIntegrationRole")
-    
-    # uncomment pulumi login code below when migration is complete and update stack selection
-    # to select the production stack that manages the new environment.
 
-    # pulumi login
-    # pulumi -C infrastructure stack select pulumi/production
+    pulumi login
+    pulumi -C infrastructure stack select pulumi/www-production
 else
     echo "Assuming the production CI role..."
     eval $(assume-role -duration "2h0m0s" "arn:aws:iam::058607598222:role/ContinuousIntegrationRole")


### PR DESCRIPTION
the workflow failed, because one of the functions pulls the [aws region from the stack config](https://github.com/pulumi/docs/blob/master/scripts/common.sh#L4). there is no stack for the new prod environment yet, so it is failing. I am adding a stack `www-production` with a stack config that only contains the region for now. There will be no pulumi updates run against the new account yet though. This is just to get things in a passing state and deploying to the new account.