### PR TITLE
temporarily turn off pr workflow for new account

### DIFF
--- a/.github/workflows/build-and-deploy-new-acct.yml
+++ b/.github/workflows/build-and-deploy-new-acct.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 jobs:
   buildSite:
     env:


### PR DESCRIPTION
temporarily turning this off prior to launch just in case the new account workflow has a random failure on PR and blocks merging things up.