### PR TITLE
update uploads and logging buckets

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -80,6 +80,10 @@ const uploadsBucket = new aws.s3.Bucket("uploads-bucket", {
     }],
 });
 
+// This needs to be set in order to allow the use of ACLs. This was added to update our infrastructure to be
+// compatible with the default S3 settings from AWS' April update. `ObjectWriter` was the prior default, so
+// changing it to that here to match the configuration prior to the update.
+// https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/
 const uploadsBucketOwnershipControls = new aws.s3.BucketOwnershipControls("uploads-bucket-ownership-controls", {
     bucket: uploadsBucket.id,
     rule: {
@@ -151,6 +155,10 @@ const websiteLogsBucket = new aws.s3.Bucket(
     },
 );
 
+// This needs to be set in order to allow the use of ACLs. This was added to update our infrastructure to be
+// compatible with the default S3 settings from AWS' April update. `ObjectWriter` was the prior default, so
+// changing it to that here to match the configuration prior to the update.
+// https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/
 const logsBucketOwnershipControls = new aws.s3.BucketOwnershipControls("logs-bucket-ownership-controls", {
     bucket: websiteLogsBucket.id,
     rule: {


### PR DESCRIPTION
fixes: https://github.com/pulumi/home/issues/2776

This PR updates the uploads and logging bucket configurations to match the previous default settings prior to the [AWS change made on 4/17/2023](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/). This is currently fine and functioning in production at this point because these buckets already exist and we do not re-create or update them when we deploy like we do for the website content bucket.  However, if we happened to need to re-provision the docs infrastructure again from scratch, these changes would be needed to run the pulumi update successfully. 

We can get this buttoned down a bit further in the future if we choose. Right now this is just to get parity with the previous defaults the infrastructure was originally provisioned with

This PR does the following:
-  explicitly sets the bucket ownership to be `ObjectWriter` (previous AWS default) for uplloads and logging buckets.
- explicitly sets the private acl on the logging bucket (this used to be set on bucket creation, but with AWS' new update this is no longer possible since ACLing is not enabled by default anymore)
- explicitly sets the  public read acl on the uploads bucket (this used to be set on bucket creation, but with AWS' new update this is no longer possible since ACLing is not enabled by default anymore)
- turns off the public access block from the uploads bucket (the new default is to block all public access).

Production Preview of Changes here: https://app.pulumi.com/pulumi/www.pulumi.com/production/previews/84192dbd-080f-4dd7-b054-23f299de6fca


Here are their configurations on my dev stack. If someone with production access can compare these to the current uploads and logging buckets in production that would be awesome just to verify there isn't any diffs we should be concerned about.

(need to be in sandbox console to view the following links)
https://s3.console.aws.amazon.com/s3/buckets/uploads-bucket-c02f93f/?region=us-west-2&tab=permissions
https://s3.console.aws.amazon.com/s3/buckets/www-sean-build.pulumi-dev.io-logs?region=us-west-2&tab=permissions
