### PR TITLE
remove parameter from store on bucket delete

### DIFF
--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -41,6 +41,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
                 # and we have access to it.
                 if aws s3api head-bucket --bucket "$pr_bucket_name" --region "$(aws_region)" 2>/dev/null; then
                     aws s3 rb "s3://${pr_bucket_name}" --force --region "$(aws_region)"
+                    remove_param_for_commit "$(git_sha)" "$(aws_region)"
                 else
                     echo "Unable to delete ${pr_bucket_name}. Skipping."
                 fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -126,6 +126,13 @@ set_bucket_for_commit() {
         --overwrite
 }
 
+# Remove the parameter key associated with a specific commit.
+remove_param_for_commit() {
+    aws ssm delete-parameter \
+        --name "$(ssm_parameter_key_for_commit $1)" \
+        --region $2
+}
+
 # List the 100 most recent bucket in the current account, sorted descendingly by
 # CreationDate, matching the prefix we use to name website buckets. Supports an optional
 # suffix to filter by (e.g., "pr" or "push").


### PR DESCRIPTION
fixes: https://github.com/pulumi/home/issues/2779

This PR removes the parameters used to track the preview buckets associated with PR commits once the PR. We have a limit for how many parameters we can store, so this will clean up the parameter used to track that particular bucket once the bucket gets deleted, since it is no longer needed at that point. 