### PR TITLE
aws account migration - add hosted zone and domain alias config

### DIFF
--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -8,4 +8,5 @@ config:
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
   www.pulumi.com:websiteDomain: www.pulumi.com
   www.pulumi.com:websiteLogsBucketName: www-prod.pulumi.com-website-logs
-  www.pulumi.com:newAccountRollout: true
+  www.pulumi.com:hostedZone: www.pulumi.com
+  www.pulumi.com:cloudfrontDomainAlias: "*.pulumi.com"

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -14,7 +14,7 @@ if [[ "$GITHUB_WORKFLOW" == "Build and deploy" ]]; then
 elif [[ "$GITHUB_WORKFLOW" == "Build and deploy new account" ]]; then
     # temporarily setting site to build in preview mode, to prevent search bots from indexing
     # until we cut over DNS to start routing to the new account.
-    ./scripts/build-site.sh preview
+    ./scripts/build-site.sh
     ./scripts/sync-and-test-bucket.sh
     node ./scripts/await-in-progress.js
     ./scripts/run-pulumi.sh update


### PR DESCRIPTION
Enable custom hosted zone and domain alias configuration to support aws migration to new account.