### PR TITLE
fix r53 a record

### DIFF
--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -10,3 +10,4 @@ config:
   www.pulumi.com:websiteLogsBucketName: www-prod.pulumi.com-website-logs
   www.pulumi.com:hostedZone: www.pulumi.com
   www.pulumi.com:cloudfrontDomainAlias: "*.pulumi.com"
+  www.pulumi.com:setRootRecord: true

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -439,10 +439,9 @@ if (!config.newAccountRollout) {
         const domainParts = getDomainAndSubdomain(targetDomain);
         const hostedZone = await aws.route53.getZone({ name: config.hostedZone || domainParts.parentDomain });
         return new aws.route53.Record(
-            "my-a-record.pulumi.com",
+            config.websiteDomain,
             {
-                // name: config.setRootRecord ? "" : domainParts.subdomain,
-                name: "",
+                name: config.setRootRecord ? "" : domainParts.subdomain,
                 zoneId: hostedZone.zoneId,
                 type: "A",
                 aliases: [

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -47,6 +47,10 @@ const config = {
     // cloudfrontDomainAlias is the domain alias to add to the CloudFront distribution.
     // If not set, will default the alias to the `websiteDomain` config value.
     cloudfrontDomainAlias: stackConfig.get("cloudfrontDomainAlias") || undefined,
+
+    // setRootRecord assumes the name of the hosted zone specified for the A record.
+    setRootRecord: stackConfig.get("setRootRecord") || undefined,
+
 };
 
 // originBucketName is the name of the S3 bucket to use as the CloudFront origin for the
@@ -437,7 +441,7 @@ if (!config.newAccountRollout) {
         return new aws.route53.Record(
             targetDomain,
             {
-                name: "",
+                name: config.setRootRecord ? "" : domainParts.subdomain,
                 zoneId: hostedZone.zoneId,
                 type: "A",
                 aliases: [
@@ -453,7 +457,7 @@ if (!config.newAccountRollout) {
             });
     }
 
-    createAliasRecord(config.websiteDomain, cdn);
+    [...new Set(domainAliases)].map(alias => createAliasRecord(alias, cdn));
 }
 
 export const uploadsBucketName = uploadsBucket.bucket;

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -437,7 +437,7 @@ if (!config.newAccountRollout) {
         return new aws.route53.Record(
             targetDomain,
             {
-                name: domainParts.subdomain,
+                name: "",
                 zoneId: hostedZone.zoneId,
                 type: "A",
                 aliases: [
@@ -453,7 +453,7 @@ if (!config.newAccountRollout) {
             });
     }
 
-    [...new Set(domainAliases)].map(alias => createAliasRecord(alias, cdn));
+    createAliasRecord(config.websiteDomain, cdn);
 }
 
 export const uploadsBucketName = uploadsBucket.bucket;

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -439,9 +439,10 @@ if (!config.newAccountRollout) {
         const domainParts = getDomainAndSubdomain(targetDomain);
         const hostedZone = await aws.route53.getZone({ name: config.hostedZone || domainParts.parentDomain });
         return new aws.route53.Record(
-            targetDomain,
+            "my-a-record.pulumi.com",
             {
-                name: config.setRootRecord ? "" : domainParts.subdomain,
+                // name: config.setRootRecord ? "" : domainParts.subdomain,
+                name: "",
                 zoneId: hostedZone.zoneId,
                 type: "A",
                 aliases: [


### PR DESCRIPTION
update route 53 record to use empty A record name, so it will take the name of the hosted zone if `setRoorRecord` is true.
