### PR TITLE
turn off auto merge on cli docs prs

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -23,7 +23,7 @@ jobs:
           destination_branch: "master"
           pr_title: "Regen docs pulumi@${{ env.PULUMI_VERSION }}"
           pr_body: "Automated PR"
-          pr_label: "automation/pulumi-cli-docs,automation/merge"
+          pr_label: "automation/pulumi-cli-docs"
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
   build-pulumi-cli-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
turning this off for the next cli docs release
so we can manually review ahead of merge
to make sure everything is working correctly

assuming it works well for the next cli docs release, we can add this label back
@sean1588 will also be addressing #9087 this week