### PR TITLE
Fix CSS caching rules

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -315,7 +315,13 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         },
         {
             ...baseCacheBehavior,
-            pathPattern: "/css/styles.*.css",
+            pathPattern: "/css/bundle.*.css",
+            defaultTtl: oneYear,
+            maxTtl: oneYear,
+        },
+        {
+            ...baseCacheBehavior,
+            pathPattern: "/css/marketing.*.css",
             defaultTtl: oneYear,
             maxTtl: oneYear,
         },


### PR DESCRIPTION
Somewhere along the way, our CSS caching rule fell out of sync with our filenames. This change updates those rules to align with the files we're shipping today. (See [this thread](https://pulumi.slack.com/archives/C85BS3LJZ/p1684438150667419) for context/discussion.)