### PR TITLE
add sdk docs to left nav of languages+sdks section

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -131,3 +131,27 @@ cli:
     url: /docs/cli/commands/pulumi_whoami/
     weight: 2
     parent: commands
+
+# -------------------------------------
+# Languages & SDKs Menus
+# -------------------------------------
+
+javascript:
+  - name: SDK docs
+    url: /docs/reference/pkg/nodejs/pulumi/pulumi
+    weight: 1
+
+python:
+  - name: SDK docs
+    url: /docs/reference/pkg/python/pulumi
+    weight: 1
+
+go:
+  - name: SDK docs
+    url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
+    weight: 1
+
+dotnet:
+  - name: SDK docs
+    url: /docs/reference/pkg/dotnet
+    weight: 1

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -137,19 +137,19 @@ cli:
 # -------------------------------------
 
 languages:
-  - javascript:
-    - name: SDK docs
-      url: /docs/reference/pkg/nodejs/pulumi/pulumi
-      weight: 1
-  - python:
-    - name: SDK docs
-      url: /docs/reference/pkg/python/pulumi
-      weight: 1
-  - go:
-    - name: SDK docs
-      url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
-      weight: 1
-  - dotnet:
-    - name: SDK docs
-      url: /docs/reference/pkg/dotnet
-      weight: 1
+  - name: SDK docs
+    parent: javascript
+    url: /docs/reference/pkg/nodejs/pulumi/pulumi
+    weight: 1
+  - name: SDK docs
+    parent: python
+    url: /docs/reference/pkg/python/pulumi
+    weight: 1
+  - name: SDK docs
+    parent: go
+    url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
+    weight: 1
+  - name: SDK docs
+    parent: dotnet
+    url: /docs/reference/pkg/dotnet
+    weight: 1

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -155,5 +155,5 @@ languages:
   - name: SDK docs
     identifier: sdk-docs-dotnet
     parent: dotnet
-    url: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
+    url: "/docs/reference/pkg/dotnet/Pulumi/Pulumi.html"
     weight: 1

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -137,25 +137,19 @@ cli:
 # -------------------------------------
 
 languages:
-  javascript:
-    - name: SDK docs
-      url: /docs/reference/pkg/nodejs/pulumi/pulumi
-      weight: 1
-
-languages:
-  python:
-    - name: SDK docs
-      url: /docs/reference/pkg/python/pulumi
-      weight: 1
-
-languages:
-  go:
-    - name: SDK docs
-      url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
-      weight: 1
-
-languages:
-  dotnet:
-    - name: SDK docs
-      url: /docs/reference/pkg/dotnet
-      weight: 1
+-javascript:
+  - name: SDK docs
+    url: /docs/reference/pkg/nodejs/pulumi/pulumi
+    weight: 1
+- python:
+  - name: SDK docs
+    url: /docs/reference/pkg/python/pulumi
+    weight: 1
+- go:
+  - name: SDK docs
+    url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
+    weight: 1
+- dotnet:
+  - name: SDK docs
+    url: /docs/reference/pkg/dotnet
+    weight: 1

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -136,22 +136,26 @@ cli:
 # Languages & SDKs Menus
 # -------------------------------------
 
-javascript:
-  - name: SDK docs
-    url: /docs/reference/pkg/nodejs/pulumi/pulumi
-    weight: 1
+languages:
+  javascript:
+    - name: SDK docs
+      url: /docs/reference/pkg/nodejs/pulumi/pulumi
+      weight: 1
 
-python:
-  - name: SDK docs
-    url: /docs/reference/pkg/python/pulumi
-    weight: 1
+languages:
+  python:
+    - name: SDK docs
+      url: /docs/reference/pkg/python/pulumi
+      weight: 1
 
-go:
-  - name: SDK docs
-    url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
-    weight: 1
+languages:
+  go:
+    - name: SDK docs
+      url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
+      weight: 1
 
-dotnet:
-  - name: SDK docs
-    url: /docs/reference/pkg/dotnet
-    weight: 1
+languages:
+  dotnet:
+    - name: SDK docs
+      url: /docs/reference/pkg/dotnet
+      weight: 1

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -153,11 +153,6 @@ languages:
     url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
     weight: 1
   - name: SDK docs
-    identifier: sdk-docs-dotnet
-    parent: dotnet
-    pageRef: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
-    weight: 1
-  - name: SDK docs
     identifier: sdk-docs-java
     parent: java
     url: https://github.com/pulumi/pulumi-java/tree/main/sdk/java

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -157,3 +157,8 @@ languages:
     parent: dotnet
     url: "/docs/reference/pkg/dotnet/Pulumi/Pulumi.html"
     weight: 1
+  - name: SDK docs
+    identifier: sdk-docs-java
+    parent: java
+    url: https://github.com/pulumi/pulumi-java/tree/main/sdk/java
+    weight: 1

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -138,18 +138,22 @@ cli:
 
 languages:
   - name: SDK docs
+    identifier: sdk-docs-javascript
     parent: javascript
     url: /docs/reference/pkg/nodejs/pulumi/pulumi
     weight: 1
   - name: SDK docs
+    identifier: sdk-docs-python
     parent: python
     url: /docs/reference/pkg/python/pulumi
     weight: 1
   - name: SDK docs
+    identifier: sdk-docs-go
     parent: go
     url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
     weight: 1
   - name: SDK docs
+    identifier: sdk-docs-dotnet
     parent: dotnet
-    url: /docs/reference/pkg/dotnet
+    url: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
     weight: 1

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -137,19 +137,19 @@ cli:
 # -------------------------------------
 
 languages:
--javascript:
-  - name: SDK docs
-    url: /docs/reference/pkg/nodejs/pulumi/pulumi
-    weight: 1
-- python:
-  - name: SDK docs
-    url: /docs/reference/pkg/python/pulumi
-    weight: 1
-- go:
-  - name: SDK docs
-    url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
-    weight: 1
-- dotnet:
-  - name: SDK docs
-    url: /docs/reference/pkg/dotnet
-    weight: 1
+  - javascript:
+    - name: SDK docs
+      url: /docs/reference/pkg/nodejs/pulumi/pulumi
+      weight: 1
+  - python:
+    - name: SDK docs
+      url: /docs/reference/pkg/python/pulumi
+      weight: 1
+  - go:
+    - name: SDK docs
+      url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
+      weight: 1
+  - dotnet:
+    - name: SDK docs
+      url: /docs/reference/pkg/dotnet
+      weight: 1

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -140,12 +140,12 @@ languages:
   - name: SDK docs
     identifier: sdk-docs-javascript
     parent: javascript
-    url: /docs/reference/pkg/nodejs/pulumi/pulumi
+    pageRef: /docs/reference/pkg/nodejs/pulumi/pulumi
     weight: 1
   - name: SDK docs
     identifier: sdk-docs-python
     parent: python
-    url: /docs/reference/pkg/python/pulumi
+    pageRef: /docs/reference/pkg/python/pulumi
     weight: 1
   - name: SDK docs
     identifier: sdk-docs-go
@@ -155,7 +155,7 @@ languages:
   - name: SDK docs
     identifier: sdk-docs-dotnet
     parent: dotnet
-    url: "/docs/reference/pkg/dotnet/Pulumi/Pulumi.html"
+    pageRef: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
     weight: 1
   - name: SDK docs
     identifier: sdk-docs-java


### PR DESCRIPTION
this adds the sdk docs to node, go, python, and java to the left nav in docs. dotnet will come in a separate pr as its a unique snowflakes causing me issues.

go opens in a new tab.
java opens in a new tab.

python and node close the tab, but its better than nothing so would like to go ahead for now.

preview link: https://www-pulumi-docs-origin-pr-9138-bd4eb6c1.s3-website-us-west-2.amazonaws.com/

<img width="271" alt="Screenshot 2023-05-23 at 2 24 23 PM" src="https://github.com/pulumi/docs/assets/5489125/6717cf8c-d8eb-4a9f-bea1-4d997a0b5771">


