### PR TITLE
Adjustments to prepare for search cutover

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -32,6 +32,8 @@ security:
       - PULUMI_CONVERT_URL
       - PULUMI_AI_WS_URL
       - GITHUB_TOKEN
+      - ALGOLIA_APP_ID
+      - ALGOLIA_APP_SEARCH_KEY
 
 disableKinds:
   - category

--- a/scripts/search/page.js
+++ b/scripts/search/page.js
@@ -89,12 +89,13 @@ module.exports = {
             // (as this means they probably aren't actual Hugo pages), and those with explicit
             // rankings of zero.
             .filter(item => {
-                const draft = !!item.params.draft;
-                const blockedFromSearch = item.block_external_search_index === true;
-                const missingObjectID = item.objectID === "";
-                const zeroRanked = this.getRank(item) === 0;
+                const isDraft = !!item.params.draft;
+                const isBlockedFromExternalSearch = item.block_external_search_index === true;
+                const isMissingObjectID = item.objectID === "";
+                const isZeroRanked = this.getRank(item) === 0;
+                const isRedirect = (item.params.redirect_to && item.params.redirect_to !== "");
 
-                if (draft || blockedFromSearch || missingObjectID || zeroRanked) {
+                if (isDraft || isBlockedFromExternalSearch || isRedirect || isMissingObjectID || isZeroRanked) {
                     return false;
                 }
 
@@ -104,7 +105,7 @@ module.exports = {
             // Convert Hugo page items into Algolia index objects.
             .map(item => {
                 return {
-                    objectID: item.objectID,
+                    objectID: this.getObjectID(item),
                     section: this.getTopLevelSection(item),
                     title: item.title,
                     description: item.params.meta_desc,
@@ -169,6 +170,6 @@ module.exports = {
     // If, at some point, we find that we need to have two records pointing to the same URL, we can
     // add another parameter to the list and hash both.
     getObjectID({ href }) {
-        return crypto.createHash('md5').update(href).digest('hex');
+        return crypto.createHash("md5").update(href).digest("hex");
     }
 };

--- a/scripts/search/rank.js
+++ b/scripts/search/rank.js
@@ -102,6 +102,14 @@ module.exports = {
             } else if (page.href.match(/installation-configuration/)) {
                 return 780;
             } else if (page.href.match(/api-docs/)) {
+
+                // Order Kubernetes API docs more recent first (e.g., v1 over v1beta1).
+                if (page.href.match(/\/kubernetes\/api-docs/)) {
+                    if (page.href.match(/\/v\d\//)) {
+                        return 775;
+                    }
+                }
+
                 return 770;
             } else if (page.href.match(/how-to-guides/)) {
                 return 760;

--- a/scripts/search/registry.js
+++ b/scripts/search/registry.js
@@ -38,6 +38,7 @@ module.exports = {
                             itemPath.concat(item.name).join("."),
                             itemPath.concat(item.name).join(":"),
                             itemPath.concat(item.name).join(" "),
+                            itemPath.concat(item.name).slice(1).join(" "),
                             `${providerTitle} ${item.name}`
                         ],
                         ancestors: [ "Registry", providerTitle, "API Docs" ],

--- a/scripts/search/settings.js
+++ b/scripts/search/settings.js
@@ -1,3 +1,5 @@
+const page = require("./page");
+
 // Algolia index settings.
 //
 // Changes to this file should be made with extreme care.
@@ -34,6 +36,7 @@ module.exports = {
             ["provider", "package"],
             ["pulumi service", "pulumi console", "pulumi cloud"],
             ["rbac", "role based access control"],
+            ["saml", "sso"],
             ["stack reference", "stackreference"],
             ["tf", "terraform"],
             ["vm", "virtual machine"],
@@ -57,10 +60,10 @@ module.exports = {
     // https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/setting-searchable-attributes/#set-searchable-attributes-with-the-api
     getSearchableAttributes() {
         return [
-            "title",
+            "unordered(title)",
             "keywords",
             "href",
-            "tags",
+            "unordered(tags)",
             "ancestors",
             "description",
             "section",
@@ -89,6 +92,7 @@ module.exports = {
     // https://www.algolia.com/doc/guides/managing-results/rules/rules-overview/
     getRules() {
         return [
+
             // When the query is for "cloud", deliver the Pulumi Cloud overview page as the top result.
             {
                 objectID: "is-cloud",
@@ -104,8 +108,7 @@ module.exports = {
                     promote: [
                         {
                             objectIDs: [
-                                // The Pulumi Cloud overview page.
-                                "a2074d4bcd83fa3d347dc9da4b8aa822"
+                                page.getObjectID({ href: "/docs/pulumi-cloud/" }),
                             ],
                             position: 0,
                         },


### PR DESCRIPTION
Adds a few things in preparation for cutover:

* Allow-list the environment variables needed by the UI (so the search boxes know which app and index to use)
* Rank non-beta Kubernetes APIs higher than beta ones
* Add a rule to return the Inputs & Outputs page as the top result for queries for "output" or "outputs"

Also writes settings locally as well. (These files aren't technically necessary, they just help with local debugging, and could be uploaded as release artifacts if we wanted to store them more permanently.)