### PR TITLE
Add H1s to the list of searchable attributes

### DIFF
--- a/scripts/search/main.js
+++ b/scripts/search/main.js
@@ -60,6 +60,7 @@ const allObjects = [
 const indexSettings = {
     searchableAttributes: settings.getSearchableAttributes(),
     attributesForFaceting: settings.getAttributesForFaceting(),
+    attributesToHighlight: settings.getAttributesToHighlight(),
     customRanking: settings.getCustomRanking(),
     ignorePlurals: true,
 };

--- a/scripts/search/page.js
+++ b/scripts/search/page.js
@@ -108,6 +108,7 @@ module.exports = {
                     objectID: this.getObjectID(item),
                     section: this.getTopLevelSection(item),
                     title: item.title,
+                    h1: item.params.h1,
                     description: item.params.meta_desc,
                     href: item.href,
                     authors: item.params.authors,

--- a/scripts/search/registry.js
+++ b/scripts/search/registry.js
@@ -35,10 +35,10 @@ module.exports = {
                         href: `/registry/packages/${providerName}/api-docs/${itemPath.concat(item.link).slice(1).join("/").toLowerCase()}/`,
                         keywords: [
                             item.name,
+                            itemPath.concat(item.name).slice(1).join(" ").toLowerCase(),
                             itemPath.concat(item.name).join("."),
                             itemPath.concat(item.name).join(":"),
                             itemPath.concat(item.name).join(" "),
-                            itemPath.concat(item.name).slice(1).join(" "),
                             `${providerTitle} ${item.name}`
                         ],
                         ancestors: [ "Registry", providerTitle, "API Docs" ],

--- a/scripts/search/settings.js
+++ b/scripts/search/settings.js
@@ -60,14 +60,24 @@ module.exports = {
     // https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/setting-searchable-attributes/#set-searchable-attributes-with-the-api
     getSearchableAttributes() {
         return [
-            "unordered(title)",
-            "keywords",
-            "href",
-            "unordered(tags)",
-            "ancestors",
+            "title,h1",            // Title and H1 are considered of equal relevance, so they're listed on the same level.
+            "keywords",            // Keywords are treated as ordered. Those higher up in the list are considered more relevant.
+            "href",                // Hrefs are considered searchable as well. (URLs often contain relevant keywords.)
+            "unordered(tags)",     // Tags are treated as unordered. Unlike keywords, their order has no significance.
+            "ancestors",           // Ancestors contains a list of the labels comprising a breadcrumb. (These often contain relevant keywords also.)
+            "description",         // Descriptions occasionally contain relevant keywords, but often don't, so we place them further down in the list.
+            "section",             // Section is the primary "facet" of a record -- Docs, Registry, Blog, Examples, etc.
+            "unordered(authors)",  // Blog-post authors are occasionally useful for searching, but their order is considered irrelevant.
+        ];
+    },
+
+    // Attributes to highlight contains the list of searchable attributes that might be used to highlight query matches in the UI.
+    // https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/
+    getAttributesToHighlight() {
+        return [
+            "title",
+            "h1",
             "description",
-            "section",
-            "authors",
         ];
     },
 


### PR DESCRIPTION
This change adds `h1` values to the list of Algolia searchable attributes and makes them equivalent to `title`s in terms of attribute relevance. 

Couple of things to note:

* Merging this PR will not yet result in us showing `h1` values in search results, as the UI has not yet been updated to handle displaying them conditionally, along with the relevant highlighting (most records do not contain `h1` parameter values). That work (the work to show and highlight `h1`s when we have them) exists in https://github.com/pulumi/pulumi-hugo/pull/3054 and will be merged shortly after this PR.

* Between the time this code is released and the accompanying front-end changes go out, users who issue queries that match _only_ on `h1` values (which should be rare) could see results that don't reflect highlights perfectly -- e.g., because the match would contain only `h1` highlight data, and the UI won't yet be updated to reflect anything having to do with the `h1` property. In this case, users will see titles without highlighting, which might look a bit strange, but should not cause any actual problems.   

Also bumps `namespace module` up in ranking to better account for queries like `s3 bucket` or `ec2 instance`, sets tags and authors as `unordered`, and adds a few comments explaining how these attributes are ranked and why.