### PR TITLE
Add a script to check search URLs

### DIFF
--- a/.github/workflows/check-search-urls.yml
+++ b/.github/workflows/check-search-urls.yml
@@ -1,0 +1,30 @@
+name: "Scheduled jobs: Check search URLs"
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string.
+    # Run every day at 3:00PM UTC.
+    - cron:  '0 15 * * *'
+  workflow_dispatch:
+jobs:
+  all:
+    env:
+      GOPATH: ${{ github.workspace }}/go
+    name: Check search URLs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+
+      - uses: algolia/setup-algolia-cli@master
+
+      - name: Run make check_search_urls
+        run: make check_search_urls
+        env:
+            SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}
+            ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
+            ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
+            ALGOLIA_APP_ADMIN_KEY: ${{  secrets.ALGOLIA_APP_ADMIN_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ check_links:
 	$(MAKE) ensure
 	./scripts/link-checker/check-links.sh "https://www.pulumi.com"
 
+.PHONY: check_search_urls
+check_search_urls:
+	$(MAKE) banner
+	$(MAKE) ensure
+	./scripts/search/check-urls.sh production "https://www.pulumi.com"
+
 .PHONY: new_learn_module
 new_learn_module:
 	./scripts/new-learn-module.sh

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@octokit/rest": "^18.5.3",
     "@slack/web-api": "^5.12.0",
     "algoliasearch": "^4.17.0",
+    "axios": "^1.4.0",
+    "axios-retry": "^3.5.1",
     "broken-link-checker": "^0.7.8",
     "concurrently": "^6.0.0",
     "cssnano": "^5.0.8",

--- a/scripts/link-checker/check-links.sh
+++ b/scripts/link-checker/check-links.sh
@@ -6,6 +6,4 @@ source ./scripts/common.sh
 echo "Checking links..."
 
 base_url="$1"
-this_path="scripts/link-checker"
-
-node "$this_path/check-links.js" "$base_url" 2
+node "./scripts/link-checker/check-links.js" "$base_url" 2

--- a/scripts/search/check-urls.js
+++ b/scripts/search/check-urls.js
@@ -1,0 +1,81 @@
+const fs = require("fs");
+const axios = require("axios").default;
+const retry = require("axios-retry");
+
+async function checkSearchURLs(baseURL) {
+
+    // We operate on the result of a call to the Algolia CLI to fetch the full index, which is
+    // returned as a newline-delimited list of JSON strings. So we join turn that list into a
+    // JavaScript array to make it easier to work with.
+    const objects = fs.readFileSync("./public/search-index.json", "utf-8").split("\n").filter(o => !!o).map(s => JSON.parse(s));
+    console.log(`Checking ${objects.length} search URLs...`);
+
+    // Since we end up checking tens of thousands of URLs here, we chunk them up into groups
+    // of a thousand to process them more efficiently.
+    const chunkSize = 1000;
+    const chunks = [];
+    const results = [];
+
+    for (let i = 0; i < objects.length; i += chunkSize) {
+        chunks.push({ chunk: i / chunkSize, objects: objects.slice(i, i + chunkSize) });
+    }
+
+    // Retry failed requests up to three times.
+    retry(axios, {
+        retries: 3,
+        shouldResetTimeout: true,
+        onRetry: (count, error, config) => console.log(`    ↳ ${config.url} failed (${error.message}). Retrying...`),
+    });
+
+    for await (const chunk of chunks) {
+        console.log(` ↳ Checking group ${chunk.chunk + 1} of ${chunks.length} (${chunk.objects.length} URLs)...`);
+
+        const result = await Promise.allSettled(chunk.objects.map(obj => {
+            const url = `${baseURL}${obj.href}`;
+
+            return new Promise(async (resolve, reject) => {
+                try {
+                    // Make a HEAD request for the URL.
+                    const res = await axios.head(url, { timeout: 60000 });
+                    const status = `${url} ${res.status}`;
+
+                    // Anything less than 400 is considered OK.
+                    if (res.status < 400) {
+                        resolve(status);
+                    } else {
+                        reject(status);
+                    }
+                }
+                catch (error) {
+                    reject(`${url} ERROR: ${error}`);
+                }
+            });
+        }));
+
+        results.push(...result);
+    }
+
+    return results;
+}
+
+checkSearchURLs(process.argv[2] || "https://www.pulumi.com")
+    .then(results => {
+
+        const summary = {
+            checked: results.length,
+            fulfilled: results.filter(r => r.status === "fulfilled").map(r => r.value) || [],
+            rejected: results.filter(r => r.status === "rejected").map(r => r.reason) || [],
+        };
+
+        fs.writeFileSync(`./public/search-check-results.json`, JSON.stringify(summary, null, 4));
+        console.log(" ↳ Done. ✨\n");
+
+        if (summary.rejected.length > 0) {
+            throw new Error(`One or more URLs failed: \n\n${summary.rejected.join("\n")}\n`);
+        }
+    });
+
+// Exit non-zero when something goes wrong in the promise chain.
+process.on("unhandledRejection", error => {
+    throw new Error(error);
+});

--- a/scripts/search/check-urls.sh
+++ b/scripts/search/check-urls.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+source ./scripts/common.sh
+
+index="$1"
+base_url="$2"
+
+mkdir -p public
+
+echo "Downloading the '$index' index..."
+algolia objects browse "$index" \
+    --admin-api-key "$ALGOLIA_APP_ADMIN_KEY" \
+    --application-id "$ALGOLIA_APP_ID" > ./public/search-index.json
+
+node "./scripts/search/check-urls.js" "$base_url"

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,13 @@
     "@algolia/logger-common" "4.17.0"
     "@algolia/requester-common" "4.17.0"
 
+"@babel/runtime@^7.15.4":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
+  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@cypress/listr-verbose-renderer@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
@@ -577,12 +584,29 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios-retry@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.5.1.tgz#d902f69fe1b2a71902e29605318f887bef0981c6"
+  integrity sha512-mQRJ4IyAUnYig14BQ4MnnNHHuH1cNH7NW4JxEUD6mNJwK6pwOY66wKLCwZ6Y0o3POpfStalqRC+J4+Hnn6Om7w==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    is-retry-allowed "^2.2.0"
+
 axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1525,7 +1549,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -2009,6 +2033,11 @@ is-promise@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -2921,6 +2950,11 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -3049,6 +3083,11 @@ rechoir@^0.6.2:
   integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
   dependencies:
     resolve "^1.1.6"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 request-progress@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This change adds a script (and runs it daily) to that the URLs we send to Algolia are valid:

```
Downloading the 'production' index...
Checking 30062 search URLs...
 ↳ Checking group 1 of 31 (1000 URLs)...
 ...
 ↳ Checking group 8 of 31 (1000 URLs)...
   ↳ https://www.pulumi.com/registry/packages/azure-native/api-docs/databoxedge/getkubernetesrole/ failed (read ECONNRESET). Retrying...
   ↳ https://www.pulumi.com/registry/packages/azure/api-docs/armmsi/ failed (read ECONNRESET). Retrying...
   ...
```

Fixes https://github.com/pulumi/docs/issues/9391.
