### PR TITLE
azure native v2 redirect

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -163,6 +163,10 @@ function getCloudProvidersRedirect(uri: string): string | undefined {
             .replace("setup", "installation-configuration");
     }
 
+    if (uri.includes("/registry/packages/azure-native-v2")) {
+        return uri.replace("azure-native-v2", "azure-native")
+    }
+
     return undefined;
 }
 


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/9469

Configures redirect for azure-native-v2 to route to azure-native. We can remove the azure-native-v2 package files once this gets in and is confirmed to be working.