### PR TITLE
remove azure native v2 beta docs

### DIFF
--- a/scripts/minify-css.js
+++ b/scripts/minify-css.js
@@ -26,7 +26,6 @@ function minifyCSS(filePath) {
             // should not affect the minified bundle, since there isn't any new css being
             // used for this package that wouldn't already be in the bundle.
             skippedContentGlobs: [
-                "public/registry/packages/azure-native-v2/**/*",
                 "public/registry/packages/azure-native-v1/**/*",
             ],
             css: [

--- a/tools/resourcedocsgen/cmd/docs/docs.go
+++ b/tools/resourcedocsgen/cmd/docs/docs.go
@@ -59,10 +59,6 @@ func getPulumiPackageFromSchema(docsOutDir string) (*pschema.Package, error) {
 	// schema.json file will have `azure-native` as the package name. Without this, the files genned
 	// will be overwritten by the second version of the package, since they will end up being written
 	// to the same azure-native directory.
-	if strings.Contains(docsOutDir, "azure-native-v2") {
-		pulPkg.Name = "azure-native-v2"
-	}
-
 	if strings.Contains(docsOutDir, "azure-native-v1") {
 		pulPkg.Name = "azure-native-v1"
 	}


### PR DESCRIPTION
Remove the azure v2 beta docs from being genned. Now that the redirect is in place and confirmed to be working these can go away now.