### PR TITLE
Post new issues to the Docs board instead

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,8 +8,8 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - name: Add to DevRel
+      - name: Add to Docs
         uses: actions/add-to-project@v0.4.0
         with:
-          project-url: https://github.com/orgs/pulumi/projects/47
+          project-url: https://github.com/orgs/pulumi/projects/79
           github-token: ${{ secrets.PULUMI_BOT_GHA_MARKETING }}


### PR DESCRIPTION
Updates the Add Issues to Project workflow to post new issues to the Docs board instead of Developer Relations.

Part of https://github.com/pulumi/devrel-team/issues/607.