### PR TITLE
Deploy registry independently

### DIFF
--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 permissions:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 permissions:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -1,9 +1,6 @@
-name: Build and deploy
-on:
+name: Build and deploy testing
+on: 
   push:
-    branches:
-      - master
-  pull_request:
     branches:
       - master
 permissions:
@@ -15,7 +12,7 @@ jobs:
       GOPATH: ${{ github.workspace }}/go
     name: Install deps and build site
     runs-on: ubuntu-22.04-8core
-    environment: production
+    environment: testing
     steps:
 
       - uses: actions/checkout@v2
@@ -36,11 +33,10 @@ jobs:
       - name: Configure Git
         run: |
           git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-to-assume: arn:aws:iam::571684982431:role/ContinuousDelivery
           role-session-name: docs-deploy
           role-duration-seconds: 7200
           aws-region: us-west-2
@@ -49,12 +45,12 @@ jobs:
         uses: pulumi/actions@v4
 
       - name: Build and deploy
-        run: make ci_${GITHUB_EVENT_NAME}
+        run: make ci_push
         env:
           CDN_PULUMI_URN: ${{ vars.CDN_PULUMI_URN }}
+          DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           PULUMI_STACK_NAME: ${{ vars.PULUMI_STACK_NAME }}
-          DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
@@ -82,7 +78,7 @@ jobs:
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:
-          SLACK_CHANNEL: docs-ops
+          SLACK_CHANNEL: docs-ops-test
           SLACK_COLOR: "#F54242"
           SLACK_MESSAGE: "build and deploy failure in pulumi/docs repo :meow_sad:"
           SLACK_USERNAME: docsbot

--- a/infrastructure/Pulumi.www-testing.yaml
+++ b/infrastructure/Pulumi.www-testing.yaml
@@ -1,7 +1,7 @@
 config:
   aws:region: us-west-2
   www.pulumi.com:addSecurityHeaders: "true"
-  www.pulumi.com:certificateArn: "arn:aws:acm:us-east-1:571684982431:certificate/35773c92-83c6-4196-9912-2c823883d252"
+  www.pulumi.com:certificateArn: "arn:aws:acm:us-east-1:571684982431:certificate/dacf95ab-d4dd-4370-9c93-6ce0b9dda7c0"
   www.pulumi.com:doEdgeRedirects: "true"
   www.pulumi.com:makeFallbackBucket: "false"
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json

--- a/infrastructure/Pulumi.www-testing.yaml
+++ b/infrastructure/Pulumi.www-testing.yaml
@@ -1,0 +1,12 @@
+config:
+  aws:region: us-west-2
+  www.pulumi.com:addSecurityHeaders: "true"
+  www.pulumi.com:certificateArn: "arn:aws:acm:us-east-1:571684982431:certificate/35773c92-83c6-4196-9912-2c823883d252"
+  www.pulumi.com:doEdgeRedirects: "true"
+  www.pulumi.com:makeFallbackBucket: "false"
+  www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
+  www.pulumi.com:websiteDomain: www.pulumi-test.io
+  www.pulumi.com:websiteLogsBucketName: pulumi-test-io-website-logs
+  www.pulumi.com:hostedZone: www.pulumi-test.io
+  www.pulumi.com:setRootRecord: true
+  www.pulumi.com:testingFlow: true

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -230,6 +230,15 @@ const lambdaFunctionAssociations = getLambdaFunctionAssociations(
     config.doEdgeRedirects,
 );
 
+
+// AllViewerExceptHostHeader passes all cookies, querystrings, and headers except the Host header.
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
+const allViewerExceptHostHeaderId = "b689b0a8-53d0-40ab-baf2-68738e2966ac";
+
+// CachingDisabled sets min, max, and default cache TTLs to 0.
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+const cachingDisabledId = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad";
+
 const baseCacheBehavior = {
     targetOriginId: originBucket.arn,
     compress: true,
@@ -335,17 +344,9 @@ if (config.testingFlow) {
             defaultTtl: 0,
             minTtl: 0,
             maxTtl: 0,
-            forwardedValues: {
-                queryString: true,
-                cookies: {
-                    forward: "all",
-                },
-                headers: [
-                    // CloudFront will not cache the objects associated with this cache behavior.
-                    // Instead, it will send every request to the origin.
-                    "*",
-                ],
-            },
+            originRequestPolicyId: allViewerExceptHostHeaderId,
+            cachePolicyId: cachingDisabledId,
+            forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
         },
     )
 }
@@ -366,14 +367,6 @@ if (!config.testingFlow) {
         domainAliases.push(config.redirectDomain);
     }
 }
-
-// AllViewerExceptHostHeader passes all cookies, querystrings, and headers except the Host header.
-// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
-const allViewerExceptHostHeaderId = "b689b0a8-53d0-40ab-baf2-68738e2966ac";
-
-// CachingDisabled sets min, max, and default cache TTLs to 0.
-// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
-const cachingDisabledId = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad";
 
 // distributionArgs configures the CloudFront distribution. Relevant documentation:
 // https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -333,16 +333,17 @@ if (config.testingFlow) {
             targetOriginId: registryCDN,
             pathPattern: "/registry/*",
             defaultTtl: 0,
+            minTtl: 0,
             maxTtl: 0,
             forwardedValues: {
+                queryString: true,
                 cookies: {
-                    forward: "none",
+                    forward: "all",
                 },
-                queryString: false,
                 headers: [
-                    "Origin",
-                    "Access-Control-Request-Headers",
-                    "Access-Control-Request-Method",
+                    // CloudFront will not cache the objects associated with this cache behavior.
+                    // Instead, it will send every request to the origin.
+                    "*",
                 ],
             },
         },

--- a/infrastructure/lambdaEdge.ts
+++ b/infrastructure/lambdaEdge.ts
@@ -115,7 +115,7 @@ export class LambdaEdge extends pulumi.ComponentResource {
                 memorySize: 128,
                 publish: true,
                 role: this.role,
-                runtime: "nodejs12.x",
+                runtime: "nodejs14.x",
                 // Note that Lambda@Edge functions have a different max timeout of 30 seconds
                 // than the regular Lambda functions.
                 timeout: 5,

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -41,7 +41,19 @@ if [ "$1" == "preview" ]; then
     export HUGO_BASEURL="http://$(origin_bucket_prefix)-$(build_identifier).s3-website.$(aws_region).amazonaws.com"
     GOGC=3 hugo --minify --buildFuture --templateMetrics -e "preview"
 else
-    GOGC=3 hugo --minify --buildFuture --templateMetrics -e production
+    case ${DEPLOYMENT_ENVIRONMENT} in
+    testing)
+        export HUGO_BASEURL="https://www.pulumi-test.io"
+        GOGC=3 hugo --minify --buildFuture --templateMetrics -e "preview"
+        ;;
+    production)
+        GOGC=3 hugo --minify --buildFuture --templateMetrics -e "production"
+        ;;
+    *)
+        echo "Unknown environment '${DEPLOYMENT_ENVIRONMENT}'"
+        exit 1
+        ;;
+    esac
 fi
 
 # Purge unused CSS.

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -26,11 +26,15 @@ make copy_static_prebuilt
 
 REGISTRY_COMMIT="$(go mod graph | grep pulumi/registry/themes/default | sed 's/.*-//')"
 
-printf "Generating API docs from registry commit %s...\n\n" "${REGISTRY_COMMIT}"
-pushd tools/resourcedocsgen
-go build -o "${GOPATH}/bin/resourcedocsgen" .
-resourcedocsgen docs registry --commitSha "${REGISTRY_COMMIT}" --logtostderr
-popd
+# In the testing environment this is done by the pulumi/registry repo. Once this moves to prod,
+# we can remove this altogether, since API docs generation will no longer be done here.
+if [[ "$DEPLOYMENT_ENVIRONMENT" != "testing" ]]; then
+    printf "Generating API docs from registry commit %s...\n\n" "${REGISTRY_COMMIT}"
+    pushd tools/resourcedocsgen
+    go build -o "${GOPATH}/bin/resourcedocsgen" .
+    resourcedocsgen docs registry --commitSha "${REGISTRY_COMMIT}" --logtostderr
+    popd
+fi
 
 printf "Running Hugo...\n\n"
 if [ "$1" == "preview" ]; then

--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -2,7 +2,6 @@
 
 set -o errexit -o pipefail
 
-echo "Selecting the pulumi/www-production stack"
+echo "Selecting the ${PULUMI_STACK_NAME} stack"
 pulumi login
-pulumi -C infrastructure stack select pulumi/www-production
-
+pulumi -C infrastructure stack select "${PULUMI_STACK_NAME}"

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -5,10 +5,12 @@ set -o errexit -o pipefail
 source ./scripts/ci-login.sh
 
 ./scripts/build-site.sh
-./scripts/sync-and-test-bucket.sh
+./scripts/sync-and-test-bucket.sh update
 
 node ./scripts/await-in-progress.js
 
 ./scripts/run-pulumi.sh update
-./scripts/update-search-index.sh production
+if [[ "$DEPLOYMENT_ENVIRONMENT" != "testing" ]]; then
+    ./scripts/update-search-index.sh production
+fi
 ./scripts/make-s3-redirects.sh

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -60,7 +60,7 @@ origin_bucket_prefix() {
     # S3 buckets. We are adding a `www` prefix to the buckets being deployed
     # to the new account, in order to account for collisions in the global
     # bucket namespace.
-    echo "www-pulumi-docs-origin"
+    echo "www-${DEPLOYMENT_ENVIRONMENT}-pulumi-docs-origin"
 }
 
 # Returns the name of the metadata file we expect to exist locally before running Pulumi.

--- a/scripts/run-pulumi.sh
+++ b/scripts/run-pulumi.sh
@@ -22,7 +22,7 @@ case ${PULUMI_ACTION} in
         # Given how frequently we update the CloudFront distribution, and how easy it can
         # be for our checkpointed CloudFront Etag to fall out of sync with what's current,
         # we refresh the distribution on every update.
-        pulumi -C infrastructure refresh -t "urn:pulumi:www-production::www.pulumi.com::aws:cloudfront/distribution:Distribution::cdn" --yes
+        pulumi -C infrastructure refresh -t "${CDN_PULUMI_URN}" --yes
 
         pulumi -C infrastructure up --yes
         ;;

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -66,7 +66,7 @@ aws s3 website $destination_bucket_uri --index-document index.html --error-docum
 echo "Synchronizing to $destination_bucket_uri..."
 aws s3 sync "$build_dir" "$destination_bucket_uri" --acl public-read --delete --quiet --region "$(aws_region)"
 
-if [[ "$1" == "update" ]]; then
+if [[ "$1" == "update" && "$DEPLOYMENT_ENVIRONMENT" == "testing" ]]; then
     # We host the bundle files in a separate bucket that `/css` and `js` routes to to enable managing the bundles
     # generated from both the docs and hugo repos.
     bundleBucket=$(pulumi -C infrastructure stack output bundlesS3BucketName)


### PR DESCRIPTION
This PR is part of phase 1 of the docs build separation. There is a [PR](https://github.com/pulumi/registry/pull/2963) also open in the registry repo that goes along with this. The registry PR should merge first.  This will enable registry to deploy independently and manage its own infrastructure. 

This PR adds some extra infrastructure configuration that will get deployed to the testing account whenever a pull request is merged into master.  It also sets up a workflow that will run in parallel, alongside the current deployment workflow that deploys to production today, which will deploy with the new infrastructure configuration to the test environment.

- **adds a bundles bucket and cloudfront origin to manage css/js files** - this bucket will manage the bundle files for both the registry build and the docs build. All /js and /css routes will resolve here. The new bundles produced by each build will get added to this bucket. This will not be in effect for production yet. This PR will only provision the bundles bucket in the production account, but not hook it up to cloudfront, so the current flow will continue to function as it does today.
- **adds a cloudfront origin for registry**  - routes requests under /registry to the registry CDN being managed in the registry PR.

Note: once these changes get applied to production we can remove the `resourcedocsgen` tool from this repo as well as the stage of the script which generates the registry files, since this will all now live in registry


testing env cdn endpoint: d298m5mqqr8wsc.cloudfront.net

production preview: https://app.pulumi.com/pulumi/www.pulumi.com/www-production/previews/462e222e-33b5-41da-9a98-0398dc0654b1
