### PR TITLE
Forward querystrings to /ai

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -429,6 +429,12 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ],
             targetOriginId: previewAiAppDomain,
             pathPattern: '/ai-preview',
+            forwardedValues: {
+                queryString: true,
+                cookies: {
+                    forward: "none",
+                },
+            },
             defaultTtl: 0,
             minTtl: 0,
             maxTtl: 0,
@@ -442,6 +448,12 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ],
             targetOriginId: previewAiAppDomain,
             pathPattern: '/ai-preview/*',
+            forwardedValues: {
+                queryString: true,
+                cookies: {
+                    forward: "none",
+                },
+            },
             defaultTtl: 0,
             minTtl: 0,
             maxTtl: 0,
@@ -457,6 +469,12 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ],
             targetOriginId: aiAppDomain,
             pathPattern: '/ai',
+            forwardedValues: {
+                queryString: true,
+                cookies: {
+                    forward: "none",
+                },
+            },
             defaultTtl: 0,
             minTtl: 0,
             maxTtl: 0,
@@ -470,6 +488,12 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ],
             targetOriginId: aiAppDomain,
             pathPattern: '/ai/*',
+            forwardedValues: {
+                queryString: true,
+                cookies: {
+                    forward: "none",
+                },
+            },
             defaultTtl: 0,
             minTtl: 0,
             maxTtl: 0,


### PR DESCRIPTION
In order to properly redirect conversations shared via the previous version of pulumi.com/ai (which used querystring values to pass conversation IDs), we need to configure CloudFront to forward querystrings to the new AI app. This PR adds querystring support to both /ai and /ai-preview. 

Fixes https://github.com/pulumi/docs/issues/9739.