### PR TITLE
Forward cookies and headers to /ai and /ai-preview

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -432,8 +432,11 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             forwardedValues: {
                 queryString: true,
                 cookies: {
-                    forward: "none",
+                    forward: "all",
                 },
+                headers: [
+                    "*"
+                ],
             },
             defaultTtl: 0,
             minTtl: 0,
@@ -451,8 +454,11 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             forwardedValues: {
                 queryString: true,
                 cookies: {
-                    forward: "none",
+                    forward: "all",
                 },
+                headers: [
+                    "*"
+                ],
             },
             defaultTtl: 0,
             minTtl: 0,
@@ -472,8 +478,11 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             forwardedValues: {
                 queryString: true,
                 cookies: {
-                    forward: "none",
+                    forward: "all",
                 },
+                headers: [
+                    "*"
+                ],
             },
             defaultTtl: 0,
             minTtl: 0,
@@ -491,8 +500,11 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             forwardedValues: {
                 queryString: true,
                 cookies: {
-                    forward: "none",
+                    forward: "all",
                 },
+                headers: [
+                    "*"
+                ],
             },
             defaultTtl: 0,
             minTtl: 0,

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -235,6 +235,14 @@ if (config.redirectDomain) {
     domainAliases.push(config.redirectDomain);
 }
 
+// AllViewerExceptHostHeader passes all cookies, querystrings, and headers except the Host header.
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
+const allViewerExceptHostHeaderId = "b689b0a8-53d0-40ab-baf2-68738e2966ac";
+
+// CachingDisabled sets min, max, and default cache TTLs to 0.
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+const cachingDisabledId = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad";
+
 // distributionArgs configures the CloudFront distribution. Relevant documentation:
 // https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html
@@ -429,15 +437,9 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ],
             targetOriginId: previewAiAppDomain,
             pathPattern: '/ai-preview',
-            forwardedValues: {
-                queryString: true,
-                cookies: {
-                    forward: "all",
-                },
-            },
-            defaultTtl: 0,
-            minTtl: 0,
-            maxTtl: 0,
+            originRequestPolicyId: allViewerExceptHostHeaderId,
+            cachePolicyId: cachingDisabledId,
+            forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
         },
         {
             ...baseCacheBehavior,
@@ -448,15 +450,9 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ],
             targetOriginId: previewAiAppDomain,
             pathPattern: '/ai-preview/*',
-            forwardedValues: {
-                queryString: true,
-                cookies: {
-                    forward: "all",
-                },
-            },
-            defaultTtl: 0,
-            minTtl: 0,
-            maxTtl: 0,
+            originRequestPolicyId: allViewerExceptHostHeaderId,
+            cachePolicyId: cachingDisabledId,
+            forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
         },
 
         // AI app, live, with caching handled by the app
@@ -469,15 +465,9 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ],
             targetOriginId: aiAppDomain,
             pathPattern: '/ai',
-            forwardedValues: {
-                queryString: true,
-                cookies: {
-                    forward: "all",
-                },
-            },
-            defaultTtl: 0,
-            minTtl: 0,
-            maxTtl: 0,
+            originRequestPolicyId: allViewerExceptHostHeaderId,
+            cachePolicyId: cachingDisabledId,
+            forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
         },
         {
             ...baseCacheBehavior,
@@ -488,15 +478,9 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ],
             targetOriginId: aiAppDomain,
             pathPattern: '/ai/*',
-            forwardedValues: {
-                queryString: true,
-                cookies: {
-                    forward: "all",
-                },
-            },
-            defaultTtl: 0,
-            minTtl: 0,
-            maxTtl: 0,
+            originRequestPolicyId: allViewerExceptHostHeaderId,
+            cachePolicyId: cachingDisabledId,
+            forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
         }
     ],
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -434,9 +434,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
                 cookies: {
                     forward: "all",
                 },
-                headers: [
-                    "*"
-                ],
             },
             defaultTtl: 0,
             minTtl: 0,
@@ -456,9 +453,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
                 cookies: {
                     forward: "all",
                 },
-                headers: [
-                    "*"
-                ],
             },
             defaultTtl: 0,
             minTtl: 0,
@@ -480,9 +474,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
                 cookies: {
                     forward: "all",
                 },
-                headers: [
-                    "*"
-                ],
             },
             defaultTtl: 0,
             minTtl: 0,
@@ -502,9 +493,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
                 cookies: {
                     forward: "all",
                 },
-                headers: [
-                    "*"
-                ],
             },
             defaultTtl: 0,
             minTtl: 0,


### PR DESCRIPTION
Adds support for passing cookies and headers to Pulumi AI origins.