### PR TITLE
fix blank line at end of redirects file

### DIFF
--- a/scripts/make-s3-redirects.sh
+++ b/scripts/make-s3-redirects.sh
@@ -26,7 +26,10 @@ rm "$redirects_file"
 ls -l "./scripts/redirects/" | tail -n +2 | awk '{print $9}' | while read line; do
     redirect_file="./scripts/redirects/$line"
     while read key location; do
-        echo "Redirecting $key to $location"
-        aws s3api put-object --key "$key" --website-redirect-location "$location" --bucket "$destination_bucket" --acl public-read --region "$(aws_region)"
+        # skip empty lines
+        if [[ ! -z "$key" ]]; then
+            echo "Redirecting $key to $location"
+            aws s3api put-object --key "$key" --website-redirect-location "$location" --bucket "registry-origin-pr-2963-5e4873c3" --acl public-read --region "us-west-2"
+        fi
     done < "$redirect_file"
 done

--- a/scripts/redirects/aws-v6-redirects.txt
+++ b/scripts/redirects/aws-v6-redirects.txt
@@ -45,4 +45,3 @@ registry/packages/aws/api-docs/macie/s3bucketassociation/index.html|https://www.
 registry/packages/aws/api-docs/rds/securitygroup/index.html|https://www.pulumi.com/registry/packages/aws/api-docs/rds/
 registry/packages/aws/api-docs/redshift/securitygroup/index.html|https://www.pulumi.com/registry/packages/aws/api-docs/redshift/
 registry/packages/aws/api-docs/ses/confgurationset/index.html|https://www.pulumi.com/registry/packages/aws/api-docs/ses/configurationset/
-


### PR DESCRIPTION
removes blank line that was causing error at end of redirects file. also adds a check to skip blank lines in case we do this again in the future.