### PR TITLE
remove testing gate from pushing bundles to bundles bucket

### DIFF
--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -66,7 +66,7 @@ aws s3 website $destination_bucket_uri --index-document index.html --error-docum
 echo "Synchronizing to $destination_bucket_uri..."
 aws s3 sync "$build_dir" "$destination_bucket_uri" --acl public-read --delete --quiet --region "$(aws_region)"
 
-if [[ "$1" == "update" && "$DEPLOYMENT_ENVIRONMENT" == "testing" ]]; then
+if [[ "$1" == "update" ]]; then
     # We host the bundle files in a separate bucket that `/css` and `js` routes to to enable managing the bundles
     # generated from both the docs and hugo repos.
     bundleBucket=$(pulumi -C infrastructure stack output bundlesS3BucketName)


### PR DESCRIPTION
This gate was originally in place, because this would fail until the bundles bucket was actually provisioned in the prod account (i.e. we can't get the stack output for the bucket if the bucket has not yet been provisioned). The bundles bucket now exists, so we can remove this condition and start pushing the built bundles to that bucket in production. They will still not be referenced yet, until the cloudfront distribution is updated to add the bucket as an origin, whcih we will do separately when we cut over the registry split work to prod.