### PR TITLE
deploy registry split to prod

### DIFF
--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -10,3 +10,4 @@ config:
   www.pulumi.com:websiteLogsBucketName: www-prod.pulumi.com-website-logs
   www.pulumi.com:hostedZone: www.pulumi.com
   www.pulumi.com:setRootRecord: true
+  www.pulumi.com:registryStack: "pulumi/registry/production"

--- a/infrastructure/Pulumi.www-testing.yaml
+++ b/infrastructure/Pulumi.www-testing.yaml
@@ -9,4 +9,4 @@ config:
   www.pulumi.com:websiteLogsBucketName: pulumi-test-io-website-logs
   www.pulumi.com:hostedZone: www.pulumi-test.io
   www.pulumi.com:setRootRecord: true
-  www.pulumi.com:testingFlow: true
+  www.pulumi.com:registryStack: "pulumi/registry/testing"


### PR DESCRIPTION
This PR will cut over the traffic from /registry to the registry cdn and the bundles for /css and /js will be routed to the new bundles bucket (the bundles bucket is already provisioned and bundles have been pushed there over the last week, this just routes the traffic there)

must go in after: https://github.com/pulumi/registry/pull/3183

Note: we are continuing to build the registry here in the docs workflows for now, so that we can continue producing the aloglia search indexes for registry.

prod preview: https://app.pulumi.com/pulumi/www.pulumi.com/www-production/previews/d7261ea2-0d4c-4ab1-bc5d-66f827bfd62b