### PR TITLE
Sean/fix bucket cleanup job

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Bucket cleanup
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,3 +43,4 @@ jobs:
             PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
             SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}

--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -41,6 +41,6 @@ jobs:
         run: make ci_bucket_cleanup
         env:
             PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+            PULUMI_STACK_NAME: ${{ vars.PULUMI_STACK_NAME }}
             SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/9818

Sets the pulumi stack name to use as an environment variable for this job. The stack name was abstracted out when we configured this docs workflows to start deploying to the test environment in the [ci-login](https://github.com/pulumi/docs/blob/master/scripts/ci-login.sh#L5) script so we could select stacks based on github environment.

![image](https://github.com/pulumi/docs/assets/16751381/0c4bd04b-1435-42d6-961a-754d52a09ddd)
