### PR TITLE
Fix bucket cleanup

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -44,3 +44,4 @@ jobs:
             PULUMI_STACK_NAME: ${{ vars.PULUMI_STACK_NAME }}
             SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/9890

The bucket clean up script is now passing, but was finding 0 buckets to delete. This is because it was missing an [environment variable](https://github.com/pulumi/docs/blob/master/scripts/common.sh#L63) that we use to generate the bucket name now, which it uses to look up the buckets to delete.

https://github.com/pulumi/docs/actions/runs/6314574721/job/17145163104#step:7:31

