### PR TITLE
Upload docs index to s3 bucket and configure cronjob

### DIFF
--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -1,0 +1,42 @@
+name: "Scheduled jobs: Update Seach Index"
+on:
+  schedule:
+    - cron:  '*/60 * * * *'
+  workflow_dispatch:
+jobs:
+  merge:
+    name: Update Algolia Search Index
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+
+      - name: Update search indexes
+        run: make update_search_indexes
+        env:
+          ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
+          ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
+          ALGOLIA_APP_ADMIN_KEY: ${{  secrets.ALGOLIA_APP_ADMIN_KEY }}
+
+  notify:
+    if: failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [merge]
+    steps:
+      - name: Slack Notification
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "update search index failure in pulumi/docs repo :meow_sad:"
+          SLACK_USERNAME: docsbot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
       - name: Update search indexes
-        run: make update_search_indexes
+        run: make ci_update_search_index
         env:
           ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
           ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}

--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -1,4 +1,4 @@
-name: "Scheduled jobs: Update Seach Index"
+name: "Scheduled jobs: Update Search Index"
 on:
   schedule:
     - cron:  '*/60 * * * *'
@@ -36,7 +36,7 @@ jobs:
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:
-          SLACK_CHANNEL: docs-ops
+          SLACK_CHANNEL: docs-ops-test
           SLACK_COLOR: "#F54242"
           SLACK_MESSAGE: "update search index failure in pulumi/docs repo :meow_sad:"
           SLACK_USERNAME: docsbot

--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -4,9 +4,10 @@ on:
     - cron:  '*/60 * * * *'
   workflow_dispatch:
 jobs:
-  merge:
+  update:
     name: Update Algolia Search Index
     runs-on: ubuntu-latest
+    environment: testing
     steps:
       - name: Install Node
         uses: actions/setup-node@v1
@@ -24,12 +25,13 @@ jobs:
           ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
           ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
           ALGOLIA_APP_ADMIN_KEY: ${{  secrets.ALGOLIA_APP_ADMIN_KEY }}
+          DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}
 
   notify:
     if: failure()
     name: Send slack notification
     runs-on: ubuntu-latest
-    needs: [merge]
+    needs: [update]
     steps:
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0

--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,9 @@ ci_pull_request_closed:
 ci_bucket_cleanup:
 	$(MAKE) banner
 	./scripts/ci-bucket-cleanup.sh
+
+.PHONY: ci_update_search_index
+ci_update_search_index:
+	$(MAKE) ensure
+	echo "Updating search index in testing..."
+	./scripts/ci-update-search-index.sh testing

--- a/Makefile
+++ b/Makefile
@@ -93,5 +93,5 @@ ci_bucket_cleanup:
 .PHONY: ci_update_search_index
 ci_update_search_index:
 	$(MAKE) ensure
-	echo "Updating search index in testing..."
-	./scripts/ci-update-search-index.sh testing
+	echo "Updating search index in ${DEPLOYMENT_ENVIRONMENT}..."
+	./scripts/ci-update-search-index.sh "${DEPLOYMENT_ENVIRONMENT}"

--- a/Makefile
+++ b/Makefile
@@ -93,5 +93,5 @@ ci_bucket_cleanup:
 .PHONY: ci_update_search_index
 ci_update_search_index:
 	$(MAKE) ensure
-	echo "Updating search index in ${DEPLOYMENT_ENVIRONMENT}..."
+	echo "Updating search index: ${DEPLOYMENT_ENVIRONMENT}..."
 	./scripts/ci-update-search-index.sh "${DEPLOYMENT_ENVIRONMENT}"

--- a/scripts/ci-update-search-index.sh
+++ b/scripts/ci-update-search-index.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This script downloads the search indexes for registry and docs from pulumi.com then combines
+# the two indexes and pushes them to Algolia.
+node ./scripts/search/update.js "$1"

--- a/scripts/search/main.js
+++ b/scripts/search/main.js
@@ -81,9 +81,9 @@ const indexRules = settings.getRules();
 
 // Write the results, just so we have them.
 console.log(" ↳ Writing results...");
-fs.writeFileSync("./public/search-index-docs.json", JSON.stringify(docsObjects, null, 4));
 fs.writeFileSync("./public/search-index.json", JSON.stringify(allObjects, null, 4));
 fs.writeFileSync("./public/search-index-settings.json", JSON.stringify({ indexSettings, indexSynonyms, indexRules }, null, 4));
+fs.writeFileSync("./public/search-index-docs.json", JSON.stringify(docsObjects, null, 4));
 console.log(" ↳ Done. ✨\n");
 
 // Update the Algolia index, including all page objects and index settings (like searchable

--- a/scripts/search/main.js
+++ b/scripts/search/main.js
@@ -56,6 +56,13 @@ let allObjects = [
     ...registryObjects,
 ];
 
+// Generate array of objects related to docs. The primary objects are included here instead of the filtered objects,
+// since these will be filtered by the job that stiches the registry and docs objects together.
+let docsObjects = [
+    ...primaryPageObjects,
+    ...secondaryPageObjects,
+]
+
 // Temporary hack: Remove any references to `azure-native-v1`. This line can be
 // removed once the azure-native-v1 package is removed from the Registry.
 // https://github.com/pulumi/registry/issues/2879
@@ -74,6 +81,7 @@ const indexRules = settings.getRules();
 
 // Write the results, just so we have them.
 console.log(" ↳ Writing results...");
+fs.writeFileSync("./public/search-index-docs.json", JSON.stringify(docsObjects, null, 4));
 fs.writeFileSync("./public/search-index.json", JSON.stringify(allObjects, null, 4));
 fs.writeFileSync("./public/search-index-settings.json", JSON.stringify({ indexSettings, indexSynonyms, indexRules }, null, 4));
 console.log(" ↳ Done. ✨\n");

--- a/scripts/search/update-search-index.js
+++ b/scripts/search/update-search-index.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const settings = require("./settings");
+const algoliasearch = require("algoliasearch");
 
 // URL of the JSON file
 const registrySearchIndexUrl = "https://www.pulumi.com/registry/search-index.json";
@@ -16,6 +17,10 @@ const config = {
 if (!config.appID || !config.searchAPIKey || !config.adminAPIKey || !config.indexName) {
     throw new Error(`Missing one or more required configuration values. (Provided keys: [${Object.keys(config)}])`);
 }
+
+// Initialize the Algolia search client.
+const client = algoliasearch(config.appID, config.adminAPIKey);
+const algoliaIndex = client.initIndex(config.indexName);
 
 async function publishIndex() {
 

--- a/scripts/search/update-search-index.js
+++ b/scripts/search/update-search-index.js
@@ -1,0 +1,85 @@
+const axios = require('axios');
+
+// URL of the JSON file
+const registrySearchIndexUrl = "https://www.pulumi.com/registry/search-index.json";
+const docsSearchIndexUrl = "https://www.pulumi.com/search-index.json";
+const indexSettingsUrl = "https://www.pulumi.com/search-index-settings.json";
+
+// Configuration values required for updating the Algolia index.
+const config = {
+    appID: process.env.ALGOLIA_APP_ID,
+    searchAPIKey: process.env.ALGOLIA_APP_SEARCH_KEY,
+    adminAPIKey: process.env.ALGOLIA_APP_ADMIN_KEY,
+    indexName: process.argv[2],
+};
+
+if (!config.appID || !config.searchAPIKey || !config.adminAPIKey || !config.indexName) {
+    throw new Error(`Missing one or more required configuration values. (Provided keys: [${Object.keys(config)}])`);
+}
+
+async function publishIndex() {
+
+    let registryIndex = [];
+    let docsIndex = [];
+    let indexSettings = [];
+
+    async function fetchIndexFiles() {
+        return Promise.all([
+            axios.get(registrySearchIndexUrl)
+                .then((response) => {
+                    registryIndex = response.data;
+                }),    
+            axios.get(docsSearchIndexUrl)
+                .then((response) => {
+                    docsIndex = response.data;
+                }),
+            axios.get(indexSettingsUrl)
+                .then((response) => {
+                    indexSettings = response.data;
+                })
+            ]);
+    }
+
+    await fetchIndexFiles().catch((error) => {
+        console.error("error retrieving index file:", error);
+    });
+
+    // De-dupe any registry objects that also may exist in the docs index.
+    const filteredDocsObjects = docsIndex.filter(o => registryIndex.find(ro => ro.href === o.href) === undefined);
+
+    // Combine search index objects from both docs and registry.
+    let allObjects = [
+        ...filteredDocsObjects,
+        ...registryIndex,
+    ];
+
+    // Update the Algolia index, including all page objects and index settings (like searchable
+    // attributes, custom ranking, synonyms, etc.).
+    async function updateIndex(objects) {
+        console.log("Updating search index...");
+
+        try {
+            console.log(` ↳ Replacing all records in the '${ config.indexName }' index...`);
+            const result = await algoliaIndex.replaceAllObjects(objects, { safe: true });
+            console.log(`   ↳ ${result.objectIDs.length} records updated.`);
+
+            console.log(` ↳ Updating index settings...`)
+            await algoliaIndex.setSettings(indexSettings);
+
+            console.log(" ↳ Updating synonyms...")
+            await algoliaIndex.saveSynonyms(indexSynonyms, { replaceExistingSynonyms: true });
+
+            console.log(" ↳ Updating rules...")
+            await algoliaIndex.replaceAllRules(indexRules);
+
+            console.log(" ↳ Done. ✨\n");
+        }
+        catch (error) {
+            console.error(error);
+        }
+    }
+
+    await updateIndex(allObjects);
+}
+
+publishIndex();

--- a/scripts/search/update-search-index.js
+++ b/scripts/search/update-search-index.js
@@ -1,9 +1,9 @@
 const axios = require('axios');
+const settings = require("./settings");
 
 // URL of the JSON file
 const registrySearchIndexUrl = "https://www.pulumi.com/registry/search-index.json";
 const docsSearchIndexUrl = "https://www.pulumi.com/search-index.json";
-const indexSettingsUrl = "https://www.pulumi.com/search-index-settings.json";
 
 // Configuration values required for updating the Algolia index.
 const config = {
@@ -21,7 +21,6 @@ async function publishIndex() {
 
     let registryIndex = [];
     let docsIndex = [];
-    let indexSettings = [];
 
     async function fetchIndexFiles() {
         return Promise.all([
@@ -33,10 +32,6 @@ async function publishIndex() {
                 .then((response) => {
                     docsIndex = response.data;
                 }),
-            axios.get(indexSettingsUrl)
-                .then((response) => {
-                    indexSettings = response.data;
-                })
             ]);
     }
 
@@ -52,6 +47,18 @@ async function publishIndex() {
         ...filteredDocsObjects,
         ...registryIndex,
     ];
+
+    // Gather up index settings, synonyms, and rules.
+    const indexSettings = {
+        searchableAttributes: settings.getSearchableAttributes(),
+        attributesForFaceting: settings.getAttributesForFaceting(),
+        attributesToHighlight: settings.getAttributesToHighlight(),
+        customRanking: settings.getCustomRanking(),
+        ignorePlurals: true,
+    };
+
+    const indexSynonyms = settings.getSynonyms();
+    const indexRules = settings.getRules();
 
     // Update the Algolia index, including all page objects and index settings (like searchable
     // attributes, custom ranking, synonyms, etc.).

--- a/scripts/update-search-index.sh
+++ b/scripts/update-search-index.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+set -o errexit -o pipefail
+
+source ./scripts/common.sh
+
 # Run the script that updates the Algolia search index. The value passed into this script denotes
 # the name of the index to be updated (e.g., 'preview' or 'production').
 node ./scripts/search/main.js "$1"
+
+# Fetch the name of the bucket from the metadata file.
+docs_bucket="$(cat "$(origin_bucket_metadata_filepath)" | jq -r ".bucket")"
+
+# Upload the `search-index.json` file to S3 where it can be accessed by the update search index cron.
+aws s3 cp "./public/search-index-docs.json" "s3://${docs_bucket}/search-index.json" --acl public-read --region "$(aws_region)"
+
+# Upload the `search-index-settings.json` file to S3 where it can be accessed by the update search index cron.
+aws s3 cp "./public/search-index-settings.json" "s3://${docs_bucket}/search-index-settings.json" --acl public-read --region "$(aws_region)"

--- a/scripts/update-search-index.sh
+++ b/scripts/update-search-index.sh
@@ -13,6 +13,3 @@ destination_bucket="$(cat "$(origin_bucket_metadata_filepath)" | jq -r ".bucket"
 
 # Upload the `search-index.json` file to S3 where it can be accessed by the update search index cron.
 aws s3 cp "./public/search-index-docs.json" "s3://${destination_bucket}/search-index.json" --acl public-read --region "$(aws_region)"
-
-# Upload the `search-index-settings.json` file to S3 where it can be accessed by the update search index cron.
-aws s3 cp "./public/search-index-settings.json" "s3://${destination_bucket}/search-index-settings.json" --acl public-read --region "$(aws_region)"

--- a/scripts/update-search-index.sh
+++ b/scripts/update-search-index.sh
@@ -9,10 +9,10 @@ source ./scripts/common.sh
 node ./scripts/search/main.js "$1"
 
 # Fetch the name of the bucket from the metadata file.
-docs_bucket="$(cat "$(origin_bucket_metadata_filepath)" | jq -r ".bucket")"
+destination_bucket="$(cat "$(origin_bucket_metadata_filepath)" | jq -r ".bucket")"
 
 # Upload the `search-index.json` file to S3 where it can be accessed by the update search index cron.
-aws s3 cp "./public/search-index-docs.json" "s3://${docs_bucket}/search-index.json" --acl public-read --region "$(aws_region)"
+aws s3 cp "./public/search-index-docs.json" "s3://${destination_bucket}/search-index.json" --acl public-read --region "$(aws_region)"
 
 # Upload the `search-index-settings.json` file to S3 where it can be accessed by the update search index cron.
-aws s3 cp "./public/search-index-settings.json" "s3://${docs_bucket}/search-index-settings.json" --acl public-read --region "$(aws_region)"
+aws s3 cp "./public/search-index-settings.json" "s3://${destination_bucket}/search-index-settings.json" --acl public-read --region "$(aws_region)"


### PR DESCRIPTION
This PR writes a file containing the docs specific search index and uploads it to s3 under the root directory and configures a cron job to access these files and combine the index with the one in registry then push to Algolia. The job will only push to the `testing` index in algolia for now. In prod we will continue to push the indexes to algolia as we are currently until we can confirm the testing index looks right. This PR should not change anything we are currently doing, it is only writing a separate index file specifically containing the non-registry related objects and pushing it to the s3 bucket and configuring a cron job which will only push to the testing index for now.

related registry [PR](https://github.com/pulumi/registry/pull/3215) to push registry indexes.