### PR TITLE
Add bucket ACL to enable cloudfront logging

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -212,6 +212,31 @@ const logsBucketACL = new aws.s3.BucketAclV2("logs-bucket-acl", {
     dependsOn: [logsBucketOwnershipControls],
 });
 
+// The canonical user ID for the account.
+const owner = aws.s3.getCanonicalUserId({});
+// Grant the CloudFront log delivery account permission to write to the bucket.
+const logsBucketDeliveryACL = new aws.s3.BucketAclV2("logs-bucket-delivery-acl", {
+    bucket: websiteLogsBucket.id,
+    accessControlPolicy: {
+        grants: [
+            {
+                grantee: {
+                    // The canconical ID for the `awslogsdelivery` account.
+                    // see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsOverview
+                    id: "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0",
+                    type: "CanonicalUser",
+                },
+                permission: "WRITE",
+            },
+        ],
+        owner: {
+            id: owner.then(owner => owner.id),
+        },
+    },
+}, {
+    dependsOn: [logsBucketOwnershipControls],
+});
+
 
 
 const fiveMinutes = 60 * 5;


### PR DESCRIPTION
fixes: https://github.com/pulumi/home/issues/2873

AWS changed their policy with regards to cloudfront logging, now requiring you to explicitly specify an ACL to grant the `awslogsdelivery` role write access to the logs bucket. This PR adds that ACL. I ran the update against the test account and logs are now being delivered in the testing environment :tada:

see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsOverview