### PR TITLE
Swap registry and pulumi-hugo module imports

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -3,14 +3,6 @@ title: Pulumi - Universal Infrastructure as Code
 
 module:
   imports:
-    - path: github.com/pulumi/registry/themes/default
-      mounts:
-        - source: content
-          target: content
-        - source: layouts
-          target: layouts
-        - source: data
-          target: data
     - path: github.com/pulumi/pulumi-hugo/themes/default
       mounts:
         - source: content
@@ -19,6 +11,14 @@ module:
           target: assets
         - source: static
           target: static
+        - source: layouts
+          target: layouts
+        - source: data
+          target: data
+    - path: github.com/pulumi/registry/themes/default
+      mounts:
+        - source: content
+          target: content
         - source: layouts
           target: layouts
         - source: data


### PR DESCRIPTION
This change swaps the order of the `registry` and `pulumi-hugo` modules to ensure the imported files from `pulumi-hugo` take precedence over those in `registry`. This is necessary because https://github.com/pulumi/registry/pull/3267 adds a file called `assets.html` that also exists in `pulumi-hugo`, so if we didn't do this, the Registry version would take precedence and cause the build to fail:

![image](https://github.com/pulumi/docs/assets/274700/aa0f47b5-20ef-49a0-bf1d-90648606b220)
