### PR TITLE
Adjust import cron cadence

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -1,7 +1,7 @@
 name: "Scheduled jobs: Update Hugo modules"
 on:
   schedule:
-    - cron:  '*/60 * * * *'
+    - cron:  '*/30 * * * *'
   workflow_dispatch:
 jobs:
   merge:


### PR DESCRIPTION
Now that we've shaved off around 40 mins of the deployment time by yanking out registry, we can probably run the update hugo modules cron on a tighter cadence. This will move it from hourly to every half hour.