### PR TITLE
Adjust redirect batch size

### DIFF
--- a/scripts/make-s3-redirects.sh
+++ b/scripts/make-s3-redirects.sh
@@ -14,7 +14,7 @@ redirects_file="./redirects.txt"
 aws s3 cp "s3://${destination_bucket}/redirects.txt" "$redirects_file" --region "$(aws_region)"
 
 echo "Processing S3 redirects ${destination_bucket}..."
-batch_size=50
+batch_size=5
 command_count=0
 IFS="|"
 while read key location; do


### PR DESCRIPTION
Looks like the runner just exited after processing one of the redirects... I'm wondering if the Github runners have some sort of process limit on them. So I'm bringing down the batch size to see if it will run now.