### PR TITLE
Remove make ensure_tools

### DIFF
--- a/.github/workflows/generate-provider-docs.yml
+++ b/.github/workflows/generate-provider-docs.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{matrix.dotnetverson}}
-      - run: make ensure ensure_tools
+      - run: make ensure
         working-directory: docs
       - if: github.event.action == 'non-resource-provider'
         name: run yarn install in nodejs sdk

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{matrix.dotnetverson}}
-      - run: make ensure ensure_tools
+      - run: make ensure
         working-directory: docs
       - name: run yarn install in nodejs sdk
         run: yarn install && yarn run tsc

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,6 @@ clean:
 ensure: clean
 	./scripts/ensure.sh
 
-.PHONY: ensure_tools
-ensure_tools:
-	echo "Restoring resourcedocsgen deps..."
-	cd tools/resourcedocsgen && go mod download
-
 .PHONY: serve
 serve:
 	./scripts/serve.sh


### PR DESCRIPTION
Removing dependency on make ensure_tools. These workflows do not require this tool and the tool itself has been relocated to the registry repo.
