### PR TITLE
Reduce the cron time to every 15 minutes

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -1,7 +1,7 @@
 name: "Scheduled jobs: Update Hugo modules"
 on:
   schedule:
-    - cron:  '*/30 * * * *'
+    - cron:  '*/15 * * * *'
   workflow_dispatch:
 jobs:
   merge:


### PR DESCRIPTION
Now that PR builds are down to about 6 minutes and deployments are down to about 10, we should be able to drop this job to every 15 minutes.
