### PR TITLE
Add `pulumi env` to left nav of cli docs

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -37,6 +37,11 @@ cli:
     weight: 2
     parent: commands
 
+  - name: env
+    url: /docs/cli/commands/pulumi_env/
+    weight: 2
+    parent: commands
+
   - name: gen-completion
     url: /docs/cli/commands/pulumi_gen-completion/
     weight: 2


### PR DESCRIPTION
Adds `pulumi env` menu item to left nav of cli docs.

<img width="154" alt="Screen Shot 2023-10-10 at 1 49 32 PM" src="https://github.com/pulumi/docs/assets/16751381/7625fde4-cd77-4110-9d6b-5f657c8257e6">
