### PR TITLE
stop trying to build resourcedocsgen in scripts

### DIFF
--- a/scripts/gen_resource_docs.sh
+++ b/scripts/gen_resource_docs.sh
@@ -86,16 +86,6 @@ generate_docs() {
 
     echo "Running docs generator from schema for ${provider}..."
 
-    pushd ${TOOL_RESDOCGEN}
-
-    go mod tidy
-
-    if [ -z "${GOPATH:-}" ]; then
-        echo "GOPATH is empty. Defaulting to ${HOME}/go"
-        GOPATH="${HOME}/go"
-    fi
-
-    go build -o "${GOPATH}/bin/resourcedocsgen" .
     resourcedocsgen docs \
       --docsOutDir "${ABSOLUTEPACKDIR}/${provider}/api-docs" \
       --schemaFile "${SCHEMA_FILE}" \


### PR DESCRIPTION
resourcedocsgen no longer lives in this repository, so we shouldn't try to build it from here any longer (it was removed in https://github.com/pulumi/docs/pull/10009).