### PR TITLE
Remove erroneous "v" prefix in esc-cli workflow

### DIFF
--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           repository: pulumi/esc
           path: esc
-          ref: v${{ github.event.client_payload.ref }}
+          ref: ${{ github.event.client_payload.ref }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
See previous failure at https://github.com/pulumi/docs/actions/runs/6567039870/job/17838995547#step:4:53
<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
