### PR TITLE
Stop pushing CSS and JS bundles to a separate bucket

### DIFF
--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -1,5 +1,5 @@
 name: Build and deploy testing
-on: 
+on:
   push:
     branches:
       - master

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -66,18 +66,6 @@ aws s3 website $destination_bucket_uri --index-document index.html --error-docum
 echo "Synchronizing to $destination_bucket_uri..."
 aws s3 sync "$build_dir" "$destination_bucket_uri" --acl public-read --delete --quiet --region "$(aws_region)"
 
-if [[ "$1" == "update" ]]; then
-    # We host the bundle files in a separate bucket that `/css` and `js` routes to to enable managing the bundles
-    # generated from both the docs and hugo repos.
-    bundleBucket=$(pulumi -C infrastructure stack output bundlesS3BucketName)
-    # Upload the CSS/JS bundle files to the bundles bucket.
-    echo "Syncing CSS files to the bundles bucket"
-    aws s3 cp "${build_dir}/css/" "s3://${bundleBucket}/css/" --acl public-read  --content-type "text/css" --region "$(aws_region)" --recursive
-
-    echo "Syncing JS files to the bundles bucket"
-    aws s3 cp "${build_dir}/js/" "s3://${bundleBucket}/js/" --acl public-read  --content-type "text/javascript" --region "$(aws_region)" --recursive
-fi
-
 echo "Sync complete."
 s3_website_url="http://${destination_bucket}.s3-website.$(aws_region).amazonaws.com"
 echo "$s3_website_url"


### PR DESCRIPTION
Follow-up to https://github.com/pulumi/registry/pull/3397, this change stops pushing CSS and JS bundles to a separate S3 bucket and instead serves them out of the same bucket as the website build. 

This is the first of two PRs: The first sets the bucket to `forceDestroy: true`, so it can be deleted later, and the second will actually delete the bucket. Verifying first in the test environment to make sure all looks well before merging.