### PR TITLE
Set the working directory for `esc gen-docs`

### DIFF
--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Generate Markdown docs
         run: |
           esc gen-docs ./content/docs/esc-cli/commands
+        working-directory: docs
       - name: Update latest version
         run: |
           VERSION_TAG=${{ env.ESC_VERSION }}


### PR DESCRIPTION
The workflow checks out the repo into `docs`, so this adds a bit to change to that directory first before running `gen-docs`.