### PR TITLE
add job to update latest-dev-version file

### DIFF
--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -22,7 +22,7 @@ jobs:
           pr_body: "Automated PR"
           pr_label: "automation/pulumi-cli-docs,automation/merge"
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
-  build-pulumi-cli-docs:
+  update-latest-dev-version:
     runs-on: ubuntu-latest
     steps:
       - name: checkout docs repo

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -1,0 +1,57 @@
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+
+name: Update latest-dev-version
+on:
+  repository_dispatch:
+    types:
+      - pulumi-cli-dev-version
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    needs: update-latest-dev-version
+    steps:
+      - name: checkout docs repo
+        uses: actions/checkout@v2
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "pulumi/${{ github.run_id }}-${{ github.run_number }}"
+          destination_branch: "master"
+          pr_title: "Regen dev version pulumi@${{ github.event.client_payload.dev_version}}"
+          pr_body: "Automated PR"
+          pr_label: "automation/pulumi-cli-docs,automation/merge"
+          github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+  build-pulumi-cli-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout docs repo
+        uses: actions/checkout@v2
+      - name: Update latest version
+        run: |
+          echo -n "${{ github.event.client_payload.dev_version }}" > ./static/latest-dev-version
+      - name: git status
+        run: git status && git diff
+      - name: commit changes
+        run: |
+          git config --local user.email "bot@pulumi.com"
+          git config --local user.name "pulumi-bot"
+          git checkout -b pulumi/${{ github.run_id }}-${{ github.run_number }}
+          git add static/
+          git commit -m "Updating latest pulumi dev version@${{ github.event.client_payload.dev_version }}"
+          git push origin pulumi/${{ github.run_id }}-${{ github.run_number }}
+  notify:
+    if: failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [pull-request, build-pulumi-cli-docs]
+    steps:
+      - name: Slack Notification
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "cli docs build failure in pulumi/docs repo :meow_sad:"
+          SLACK_USERNAME: docsbot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -36,7 +36,7 @@ jobs:
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b pulumi/${{ github.run_id }}-${{ github.run_number }}
-          git add static/
+          git add static/latest-dev-version
           git commit -m "Updating latest pulumi dev version@${{ github.event.client_payload.dev_version }}"
           git push origin pulumi/${{ github.run_id }}-${{ github.run_number }}
   notify:

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -20,7 +20,6 @@ jobs:
           destination_branch: "master"
           pr_title: "Regen dev version pulumi@${{ github.event.client_payload.dev_version}}"
           pr_body: "Automated PR"
-          pr_label: "automation/pulumi-cli-docs,automation/merge"
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
   update-latest-dev-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -43,7 +43,7 @@ jobs:
     if: failure()
     name: Send slack notification
     runs-on: ubuntu-latest
-    needs: [pull-request, build-pulumi-cli-docs]
+    needs: [pull-request, update-latest-dev-version]
     steps:
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0


### PR DESCRIPTION
Add a workflow that updates the `latest-dev-version` file and publishes it.

For background, we want to start publishing dev releases for pulumi/pulumi at every merge.  Users will be able to download them via `get.pulumi.com`, or the pulumi GitHub action.  To be able to do this, we need to know the latest version that has been merged and published to the S3 bucket that the `get.pulumi.com` script reads from.  We'll use the `latest-dev-version` file added here to do that, similar to how we use the `latest-version` file to download the latest pulumi version currently.

### Related issues (optional)

https://github.com/pulumi/pulumi/issues/14623
https://github.com/pulumi/pulumictl/pull/78 is the corresponding PR to add a `pulumictl` command for this.
