### PR TITLE
set content-type for latest-dev-version explicitly

### DIFF
--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -85,6 +85,8 @@ echo "$s3_website_url"
 # Set the content-type of latest-version explicitly. (Otherwise, it'll be set as binary/octet-stream.)
 aws s3 cp "$build_dir/latest-version" "${destination_bucket_uri}/latest-version" \
     --content-type "text/plain" --acl public-read --region "$(aws_region)" --metadata-directive REPLACE
+aws s3 cp "$build_dir/latest-dev-version" "${destination_bucket_uri}/latest-dev-version" \
+    --content-type "text/plain" --acl public-read --region "$(aws_region)" --metadata-directive REPLACE
 aws s3 cp "$build_dir/esc/latest-version" "${destination_bucket_uri}/esc/latest-version" \
     --content-type "text/plain" --acl public-read --region "$(aws_region)" --metadata-directive REPLACE
 


### PR DESCRIPTION
Set the content-type for the latest-dev-version to "text/plain" explicitly.  The file will be uploaded anyway, but have the "binary/octet-stream" content type.  This still works just fine, but it looks better in a browser to have "text/plain", so the text will be shown, instead of downloading a file.

This was added in https://github.com/pulumi/docs/pull/10365, and https://github.com/pulumi/docs/pull/10423


