### PR TITLE
Re-add bucket policy

### DIFF
--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -1,6 +1,6 @@
 name: Build and deploy testing
 on:
-  push:
+  pull_request:
     branches:
       - master
 permissions:

--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -3,11 +3,12 @@ config:
   www.pulumi.com:addSecurityHeaders: "true"
   www.pulumi.com:certificateArn: "arn:aws:acm:us-east-1:388588623842:certificate/9db6a76b-f7ba-465b-ab96-ce1d3b8ae02c"
   www.pulumi.com:doEdgeRedirects: "true"
+  www.pulumi.com:hostedZone: www.pulumi.com
   www.pulumi.com:makeFallbackBucket: "false"
+  www.pulumi.com:marketingPortalStack: pulumi/marketing-db/production
   www.pulumi.com:originBucketNameOverride: ""
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
+  www.pulumi.com:registryStack: "pulumi/registry/production"
+  www.pulumi.com:setRootRecord: "true"
   www.pulumi.com:websiteDomain: www.pulumi.com
   www.pulumi.com:websiteLogsBucketName: www-prod.pulumi.com-website-logs
-  www.pulumi.com:hostedZone: www.pulumi.com
-  www.pulumi.com:setRootRecord: true
-  www.pulumi.com:registryStack: "pulumi/registry/production"

--- a/infrastructure/Pulumi.www-testing.yaml
+++ b/infrastructure/Pulumi.www-testing.yaml
@@ -3,10 +3,11 @@ config:
   www.pulumi.com:addSecurityHeaders: "true"
   www.pulumi.com:certificateArn: "arn:aws:acm:us-east-1:571684982431:certificate/dacf95ab-d4dd-4370-9c93-6ce0b9dda7c0"
   www.pulumi.com:doEdgeRedirects: "true"
+  www.pulumi.com:hostedZone: www.pulumi-test.io
   www.pulumi.com:makeFallbackBucket: "false"
+  www.pulumi.com:marketingPortalStack: pulumi/marketing-db/staging
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
+  www.pulumi.com:registryStack: "pulumi/registry/testing"
+  www.pulumi.com:setRootRecord: "true"
   www.pulumi.com:websiteDomain: www.pulumi-test.io
   www.pulumi.com:websiteLogsBucketName: pulumi-test-io-website-logs
-  www.pulumi.com:hostedZone: www.pulumi-test.io
-  www.pulumi.com:setRootRecord: true
-  www.pulumi.com:registryStack: "pulumi/registry/testing"

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -100,25 +100,26 @@ if (pulumi.getStack() === "www-testing") {
 
     const uploadsBucketPolicy = new aws.s3.BucketPolicy("uploads-bucket-policy", {
         bucket: uploadsBucket.bucket,
-        policy: JSON.stringify({
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "Example permissions",
-                    "Effect": "Allow",
-                    "Principal": {
-                        "AWS": `arn:aws:iam::${marketingAppAccountId}:root`
-                    },
-                    "Action": [
-                        "s3:GetLifecycleConfiguration",
-                        "s3:ListBucket"
-                    ],
-                    "Resource": [
-                        `arn:aws:s3:::${uploadsBucket.bucket}`
-                    ]
-                }
-            ]
-        }),
+        policy: pulumi.all([uploadsBucket.bucket, marketingAppAccountId])
+            .apply(([bucket, accountId]) => JSON.stringify({
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "Example permissions",
+                        "Effect": "Allow",
+                        "Principal": {
+                            "AWS": `arn:aws:iam::${accountId}:root`
+                        },
+                        "Action": [
+                            "s3:GetLifecycleConfiguration",
+                            "s3:ListBucket"
+                        ],
+                        "Resource": [
+                            `arn:aws:s3:::${bucket}`
+                        ]
+                    }
+                ]
+            })),
     });
 }
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -100,8 +100,8 @@ if (pulumi.getStack() === "www-testing") {
 
     const uploadsBucketPolicy = new aws.s3.BucketPolicy("uploads-bucket-policy", {
         bucket: uploadsBucket.bucket,
-        policy: pulumi.all([uploadsBucket.bucket, ecsRoleArn])
-            .apply(([bucket, roleArn]) => JSON.stringify({
+        policy: pulumi.all([uploadsBucket.arn, ecsRoleArn])
+            .apply(([bucketArn, roleArn]) => JSON.stringify({
                 "Version": "2012-10-17",
                 "Statement": [
                     {
@@ -113,9 +113,7 @@ if (pulumi.getStack() === "www-testing") {
                             "AWS": roleArn,
                          },
                         "Effect": "Allow",
-                        "Resource": [
-                            `arn:aws:s3:::${bucket}`
-                        ]
+                        "Resource": bucketArn,
                     },
                     {
                         "Effect": "Allow",
@@ -126,9 +124,7 @@ if (pulumi.getStack() === "www-testing") {
                             "s3:GetObject",
                             "s3:PutObject"
                         ],
-                        "Resource": [
-                            `arn:aws:s3:::${bucket}/*`
-                        ]
+                        "Resource": `${bucketArn}/*`,
                     },
                 ]
             })),

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -112,7 +112,8 @@ if (pulumi.getStack() === "www-testing") {
                         },
                         "Action": [
                             "s3:GetLifecycleConfiguration",
-                            "s3:ListBucket"
+                            "s3:ListBucket",
+                            "s3:PutObject"
                         ],
                         "Resource": [
                             `arn:aws:s3:::${bucket}`

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -111,12 +111,11 @@ if (pulumi.getStack() === "www-testing") {
                             "AWS": `arn:aws:iam::${accountId}:root`
                         },
                         "Action": [
-                            "s3:GetLifecycleConfiguration",
-                            "s3:ListBucket",
-                            "s3:PutObject"
+                            "s3:PutObject",
+                            "s3:PutObjectAcl"
                         ],
                         "Resource": [
-                            `arn:aws:s3:::${bucket}`
+                            `arn:aws:s3:::${bucket}/*`
                         ]
                     }
                 ]

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -49,6 +49,10 @@ const config = {
 
     // the registry stack to reference to route traffic to for `/registry` routes.
     registryStack: stackConfig.get("registryStack"),
+
+    // the marketing portal stack to reference to allow the marketing portal
+    // to add items to the uploads bucket.
+    marketingPortalStack: stackConfig.get("marketingPortalStack"),
 };
 
 const aiAppStack = new pulumi.StackReference('pulumi/pulumi-ai-app-infra/prod');
@@ -94,8 +98,8 @@ const uploadsBucket = new aws.s3.Bucket("uploads-bucket", {
     }],
 });
 
-if (pulumi.getStack() === "www-testing") {
-    const marketingAppStack = new pulumi.StackReference("pulumi/marketing-db/staging");
+if (config.marketingPortalStack) {
+    const marketingAppStack = new pulumi.StackReference(config.marketingPortalStack);
     const ecsRoleArn = marketingAppStack.getOutput("ecsRoleArn");
 
     const uploadsBucketPolicy = new aws.s3.BucketPolicy("uploads-bucket-policy", {
@@ -111,7 +115,7 @@ if (pulumi.getStack() === "www-testing") {
                         ],
                         "Principal": {
                             "AWS": roleArn,
-                         },
+                            },
                         "Effect": "Allow",
                         "Resource": bucketArn,
                     },

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -100,7 +100,7 @@ const uploadsBucket = new aws.s3.Bucket("uploads-bucket", {
 
 if (config.marketingPortalStack) {
     const marketingAppStack = new pulumi.StackReference(config.marketingPortalStack);
-    const ecsRoleArn = marketingAppStack.getOutput("ecsRoleArn");
+    const ecsRoleArn = marketingAppStack.requireOutput("ecsRoleArn");
 
     const uploadsBucketPolicy = new aws.s3.BucketPolicy("uploads-bucket-policy", {
         bucket: uploadsBucket.bucket,


### PR DESCRIPTION
### Proposed changes

This re-adds the bucket policy, allowing uploads from the marketing portal.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
