### PR TITLE
Fix SCHEMA_FILE location

### DIFF
--- a/scripts/gen_resource_docs.sh
+++ b/scripts/gen_resource_docs.sh
@@ -82,7 +82,7 @@ generate_docs() {
     fi
 
     # This path should be relative to the tools/resourcedocsgen tool.
-    SCHEMA_FILE="../../${EXISTING_SCHEMA_FILE}"
+    SCHEMA_FILE="${EXISTING_SCHEMA_FILE}"
 
     echo "Running docs generator from schema for ${provider}..."
 
@@ -92,8 +92,6 @@ generate_docs() {
       --version "${plugin_version}" \
       --logtostderr \
       --packageTreeJSONOutDir "${PACKAGE_TREE_OUT_DIR}" || exit 3
-
-    popd
 
     echo "Done generating resource docs for ${provider}"
     echo ""


### PR DESCRIPTION
In https://github.com/pulumi/docs/pull/10053/files we removed the `pushd <resourcedocsgen-directory>` command, however didn't remove the corresponding popd, and neither updated the `SCHEMA_FILE` variable correctly.  This results in this script not working properly.  Fix that up.

### Related issues (optional)

Corrects a bug introduced in https://github.com/pulumi/docs/pull/10053, so we can get the CI job in pulumi/pulumi building correctly again.
