### PR TITLE
Remove Pulumi AI sitemap from sitemap-index

### DIFF
--- a/static/sitemap-index.xml
+++ b/static/sitemap-index.xml
@@ -6,7 +6,4 @@
   <sitemap>
     <loc>https://www.pulumi.com/registry/sitemap.xml</loc>
   </sitemap>
-  <sitemap>
-    <loc>https://www.pulumi.com/ai/sitemap.xml</loc>
-  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
Now that we have a sitemap index for Pulumi AI that's been indexed by Google (and now referenced by https://pulumi.com/robots.txt), we can remove this entry.

See also https://github.com/pulumi/pulumi-hugo/issues/3938.
