### PR TITLE
fix: Automatically update Python docs

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -109,9 +109,10 @@ jobs:
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b pulumi/${{ github.run_id }}-${{ github.run_number }}
-          git add static/
           git add content/
           git add data/
+          git add static-prebuilt/
+          git add static/
           git commit -m "Regenerating docs for Pulumi@${{ env.PULUMI_VERSION}}"
           git push origin pulumi/${{ github.run_id }}-${{ github.run_number }}
         working-directory: docs


### PR DESCRIPTION
When a new version of the CLI and Node.js and Python SDKs are released, we kick off a workflow to regenerate docs for these. However, the regenerated Python docs were not being included in the PR that is opened with the changes. This fixes that, by including the updated Python docs in the commit for the PR.

The Python docs are generated under `static-prebuilt/`: https://github.com/pulumi/docs/actions/runs/7925776275/job/21639491629#step:21:117

Fixes #10594