### PR TITLE
relax relref error level

### DIFF
--- a/config/production/config.yaml
+++ b/config/production/config.yaml
@@ -1,1 +1,2 @@
 baseURL: https://www.pulumi.com/
+refLinksErrorLevel: WARNING


### PR DESCRIPTION
Relref errors are occuring when a relref link becomes stale or is unable to resolve. This causes our entire build to fail and ends up blocking up the pipeline. This PR lowers the error level to warning so that we do not block deployments when this occurs. We have a link checker that runs on a daily cron to validate links on the site, so these issues are already being caught there.