### PR TITLE
Add working URLs to exceptions list

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -265,6 +265,10 @@ function getDefaultExcludedKeywords() {
         "https://www.reddit.com/r/pulumi/comments/130b4rn/ama_with_luke_hoban_cto_on_pulumi_insightsai_at/",
         "https://platform.openai.com/account/api-keys",
         "https://dash.cloudflare.com/sign-up/",
+        "https://www.sdxcentral.com/articles/news/pulumi-wants-to-piece-together-aws-lego-blocks/2019/06/",
+        "https://www.sdxcentral.com/articles/news/pulumi-code-dev-platform-adds-premium-team-tier-scores-15m-series-a/2018/10/",
+        "https://www.gartner.com/en/newsroom/press-releases/2023-11-29-gartner-says-cloud-will-become-a-business-necessity-by-2028",
+        "https://www.gartner.com/en/articles/what-is-platform-engineering",
     ];
 }
 


### PR DESCRIPTION
### Proposed changes

This PR adds a few URLs to the list of exceptions because they are working but continue to show up in the docs-ops due to some Cloudflare serving/filtering mechanism.
