### PR TITLE
Remove reference to marketing stack

### DIFF
--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -5,7 +5,6 @@ config:
   www.pulumi.com:doEdgeRedirects: "true"
   www.pulumi.com:hostedZone: www.pulumi.com
   www.pulumi.com:makeFallbackBucket: "false"
-  www.pulumi.com:marketingPortalStack: pulumi/marketing-db/production
   www.pulumi.com:originBucketNameOverride: ""
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
   www.pulumi.com:registryStack: "pulumi/registry/production"


### PR DESCRIPTION
I am going to tear down the marketing calendar stack and need to prevent this stack from referencing this first or this stack will fail to provision on the next deployment.