### PR TITLE
Add SDK docs to Algolia search

### DIFF
--- a/scripts/search/main.js
+++ b/scripts/search/main.js
@@ -16,10 +16,91 @@ const primaryPageObjects = page.getPrimaryObjects(hugoPageItems);
 console.log(" ↳ Building secondary page objects...");
 const secondaryPageObjects = page.getSecondaryObjects(primaryPageObjects);
 
+// Incorporate any additional objects. This list is provided as a hand-crafted list for now, because pragmatism,
+// but it should probably be pulled out into a proper module at some point.
+const additionalObjects = [
+    {
+        "section": "Docs",
+        "title": "Pulumi Node.js SDK Documentation",
+        "description": "Documentation for the Pulumi Node.js SDK.",
+        "href": "/docs/reference/pkg/nodejs/pulumi/pulumi/",
+        "keywords": [
+            "@pulumi/pulumi",
+            "javascript sdk",
+            "typescript sdk",
+            "sdk",
+        ],
+        "ancestors": [
+            "Docs",
+            "Languages & SDKs",
+            "TypeScript (Node.js)"
+        ],
+    },
+    {
+        "section": "Docs",
+        "title": "Pulumi Python SDK Documentation",
+        "description": "Documentation for the Pulumi Python SDK.",
+        "href": "/docs/reference/pkg/python/pulumi/",
+        "keywords": [
+            "pulumi_pulumi",
+            "python sdk",
+            "sdk",
+        ],
+        "ancestors": [
+            "Docs",
+            "Languages & SDKs",
+            "Python"
+        ],
+    },
+    {
+        "section": "Docs",
+        "title": "Pulumi Go SDK Documentation",
+        "description": "Documentation for the Pulumi Go SDK.",
+        "href": "https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi",
+        "rank": 860, // The default ranking for docs. (See rank.js.)
+        "keywords": [
+            "go sdk",
+            "golang sdk",
+            "sdk",
+        ],
+        "ancestors": [
+            "Docs",
+            "Languages & SDKs",
+            "Go"
+        ],
+    },
+    {
+
+        "section": "Docs",
+        "title": "Pulumi .NET SDK Documentation (C#, VB, F#)",
+        "description": "Documentation for the Pulumi .NET SDK.",
+        "href": "/docs/reference/pkg/dotnet/Pulumi/Pulumi.html",
+        "keywords": [
+            "Pulumi.Pulumi",
+            ".net sdk",
+            "c# sdk",
+            "vb sdk",
+            "f# sdk",
+            "sdk"
+        ],
+        "ancestors": [
+            "Docs",
+            "Languages & SDKs",
+            ".NET (C#, VB, F#)"
+        ],
+    },
+].map(item => {
+    return {
+        "objectID": page.getObjectID({ href: item.href }),
+        ...item,
+    };
+});
+
 // Stitch these lists together into one tidy bundle.
 let allObjects = [
     ...primaryPageObjects,
     ...secondaryPageObjects,
+    ...additionalObjects,
 ];
 
 // Temporary hack: Remove any references to `azure-native-v1`. This line can be

--- a/scripts/search/main.js
+++ b/scripts/search/main.js
@@ -28,6 +28,8 @@ const additionalObjects = [
             "@pulumi/pulumi",
             "javascript sdk",
             "typescript sdk",
+            "nodejs sdk",
+            "node sdk",
             "sdk",
         ],
         "ancestors": [


### PR DESCRIPTION
Adds four records to Algolia for the Node, Python, Go, and .NET SDK docs.

![image](https://github.com/pulumi/docs/assets/274700/392e8cd2-1545-4e04-bd24-6abb5801477b)
