### PR TITLE
Make update_repos.sh resilient to differing default branch names

### DIFF
--- a/scripts/update_repos.sh
+++ b/scripts/update_repos.sh
@@ -74,8 +74,9 @@ update_repo() {
     mkdir -p "../${repo}" && cd "../${repo}"
     git remote -v || git clone "git@github.com:pulumi/${repo}.git" .
     echo -e "\033[0;93mPulling changes\033[0m"
-    git checkout master >/dev/null
-    git pull origin master >/dev/null
+    default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | cut -d'/' -f4)
+    git checkout ${default_branch} >/dev/null
+    git pull origin ${default_branch} >/dev/null
     git fetch --tags >/dev/null
     echo -e "\033[0;93mChecking out latest release\033[0m"
     LATEST_RELEASE=$(git describe --tags `git rev-list --max-count=1 --tags --not --tags='*-dev'`)


### PR DESCRIPTION
### Proposed changes

Fixes repo updating by deriving the default branch name from the repo vs assuming a default branch named `master`. 

Previously, `update_repos.sh` would break at `pulumi-tls` repo and stop, because that repo uses `main` for the default branch name, not `master`. 

Example Output (broken):
```
--- Updating repo pulumi/pulumi-tls ---
fatal: not a git repository (or any of the parent directories): .git
Cloning into '.'...
remote: Enumerating objects: 5268, done.
remote: Counting objects: 100% (2522/2522), done.
remote: Compressing objects: 100% (824/824), done.
remote: Total 5268 (delta 1701), reused 2198 (delta 1543), pack-reused 2746
Receiving objects: 100% (5268/5268), 13.80 MiB | 2.56 MiB/s, done.
Resolving deltas: 100% (3613/3613), done.
Pulling changes
error: pathspec 'master' did not match any file(s) known to git
```
Notice the error when it fails to execute `git checkout` on the non-existent `master` branch. This also means the script would stop here and not continue on to pull/update the remaining five API docs repos (e.g. `pulumi-vault`..`pulumi-yandex`).

Example Output (fixed):
```
--- Updating repo pulumi/pulumi-tls ---
origin git@github.com:pulumi/pulumi-tls.git (fetch)
origin git@github.com:pulumi/pulumi-tls.git (push)
Pulling changes
Already on 'main'
From github.com:pulumi/pulumi-tls
 * branch            main       -> FETCH_HEAD
Checking out latest release
HEAD is now at 6d079c7 Upgrade pulumi-terraform-bridge to v3.79.0 (#464)
sdk/v5.0.2
--- Updating repo pulumi/pulumi-vault ---

```
Here, the script executes successfully against the `pulumi-tls` repo, and continues on to process the other repos in the list, completing the pull/update for all repos prior to API docs generation.

### Related issues (optional)

Fixes #11255 