### PR TITLE
Set testing workflow to deploy testing branch

### DIFF
--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -1,8 +1,8 @@
 name: Build and deploy testing
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - testing/hugo-retirement
 permissions:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/11292

I created a testing branch, `testing/hugo-retirement`, to deploy to the testing environment for our pulumi-hugo migration workstream. This PR sets the branch to deploy on push there, so we can deploy whenever we merge to the `testing/hugo-retirement` branch.