### PR TITLE
Fix request a change link

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -81,7 +81,7 @@ markup:
 
 params:
     canonicalURL: https://www.pulumi.com
-    contentRepositoryURL: https://github.com/pulumi/pulumi-hugo
+    contentRepositoryURL: https://github.com/pulumi/docs
     contentRepositoryBaseBranch: master
     registryRepositoryURL: https://github.com/pulumi/registry
     registryRepositoryBaseBranch: master

--- a/layouts/partials/docs/table-of-contents.html
+++ b/layouts/partials/docs/table-of-contents.html
@@ -63,7 +63,7 @@
             <a
                 data-track="edit-page"
                 class="text-gray-600 hover:text-gray-700 text-xs"
-                href="{{ $repoURL }}/edit/{{ $.Site.Params.contentRepositoryBaseBranch }}/{{ getenv "REPO_THEME_PATH" }}content/{{ .Path }}"
+                href="{{ $repoURL }}/edit/{{ $.Site.Params.contentRepositoryBaseBranch }}/content/{{ .Path }}"
                 target="_blank"
             >
                 <i class="fas fa-edit mr-2" style="width: 14px"></i>Edit this Page
@@ -74,7 +74,7 @@
         <a
             data-track="request-change"
             class="text-gray-600 hover:text-gray-700 text-xs"
-            href="{{ $.Site.Params.contentRepositoryURL }}/issues/new?body=File: [{{ getenv "REPO_THEME_PATH" }}content/{{ .Path }}]({{ $.Page.Permalink }})"
+            href="{{ $.Site.Params.contentRepositoryURL }}/issues/new?body=File: [content/{{ .Path }}]({{ $.Page.Permalink }})"
             target="_blank"
         >
             <i class="far fa-check-square mr-2" style="width: 14px"></i>Request a Change


### PR DESCRIPTION
I had addressed this [here](https://github.com/pulumi/pulumi-hugo/pull/4249) prior to the migration, but looks like for some reason the config file in docs always had `pulumi-hugo` as the content repository :shrug:, so it is was using that.