### PR TITLE
Clean up a few more references to pulumi-hugo

### DIFF
--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           go-version: 1.20.x
 
-      - name: Configure Git
-        run: |
-          git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,10 +33,6 @@ jobs:
           hugo-version: '0.111.0'
           extended: true
 
-      - name: Configure Git
-        run: |
-          git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -23,10 +23,6 @@ jobs:
         with:
           go-version: 1.20.x
 
-      - name: Configure Git
-        run: |
-          git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -73,7 +73,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-duration-seconds: 14400 # 4 hours
-          role-session-name: pulumi-hugo-examples@githubActions
+          role-session-name: pulumi-docs-examples@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
 
       - name: Run the tests

--- a/.github/workflows/scheduled-upgrade-programs.yml
+++ b/.github/workflows/scheduled-upgrade-programs.yml
@@ -75,7 +75,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-duration-seconds: 14400 # 4 hours
-          role-session-name: pulumi-hugo-examples@githubActions
+          role-session-name: pulumi-docs-examples@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
 
       - name: Upgrade and test example programs

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -30,9 +30,6 @@ jobs:
           hugo-version: '0.111.0'
           extended: true
 
-      - name: Configure Git
-        run: |
-          git config --global url."https://${{ secrets.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/pulumi-hugo-internal".insteadOf "https://github.com/pulumi/pulumi-hugo-internal"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/BLOGGING.md
+++ b/BLOGGING.md
@@ -6,7 +6,7 @@ steps to make it happen.
 ## Set Up Your Development Environment
 
 If you haven't already, clone this repository and
-[follow the instructions in the README](https://github.com/pulumi/pulumi-hugo#running-hugo-locally)
+[follow the instructions in the README](https://github.com/pulumi/docs)
 to set up your environment and run the development web server.
 
 Once you're able to run:
@@ -32,7 +32,7 @@ including all the required frontmatter parameters.
 
    This will prompt you for a "slug" (a URL-friendly path) for your post and create a
    minimal post that you can browse to at http://localhost:1313/blog/. You'll find the new
-   post's source file at `themes/default/content/blog/[your-slug]/_index.md` containing the set of
+   post's source file at `content/blog/[your-slug]/_index.md` containing the set of
    [Hugo front matter](https://gohugo.io/content-management/front-matter/) properties you'll need to get started:
 
    ```
@@ -75,7 +75,7 @@ including all the required frontmatter parameters.
    **Canonical link**
    If you are posting a blog that originated somewhere else (for example, a syndicated community post) you will want to add the setting `canonical_url` for the URL where the blog post originated.
 
-1. If you don't already have a [TOML](https://github.com/toml-lang/toml) file [in the `team` directory](https://github.com/pulumi/pulumi-hugo/tree/master/themes/default/data/team/team) of the repo, create one now. For Pulumi employees, that file should look something like this (your `id` can be any string, but we recommend `firstname-lastname`):
+1. If you don't already have a [TOML](https://github.com/toml-lang/toml) file [in the `team` directory](https://github.com/pulumi/docs/tree/master/data/team/team) of the repo, create one now. For Pulumi employees, that file should look something like this (your `id` can be any string, but we recommend `firstname-lastname`):
 
    ```toml
    id = "christian-nunciato"
@@ -101,7 +101,7 @@ including all the required frontmatter parameters.
 
    The `social` section, and the items within it, are optional.
 
-   Once your team-member file's been created, add your author image at [`themes/default/static/images/team`](https://github.com/pulumi/pulumi-hugo/tree/master/themes/default/static/images/team). The image should be a square JPG (400x400 max) named with your author `id` (e.g., `christian-nunciato.jpg`).
+   Once your team-member file's been created, add your author image at [`static/images/team`](https://github.com/pulumi/docs/tree/master/static/images/team). The image should be a square JPG (400x400 max) named with your author `id` (e.g., `christian-nunciato.jpg`).
 
    Update the new post's `authors` property to use your author `id`. If you're still running the development server, you should see the change reflected in the browser immediately.
 
@@ -155,7 +155,7 @@ To add images to the body of your post, first place them within the folder conta
 #### Social ("Meta") Images
 
 > [!IMPORTANT]
-> If you are adding _any_ logos to the meta image, you must absolutely ensure these are current. Using a wrong or outdated logo can have a severe negative impact on social sharing timelines due caching. 
+> If you are adding _any_ logos to the meta image, you must absolutely ensure these are current. Using a wrong or outdated logo can have a severe negative impact on social sharing timelines due caching.
 
 When you generate a new post, an [OpenGraph](http://ogp.me/) placeholder image is included for you, and a reference to that image is added to the post's frontmatter as well, as its `meta_image`. The `meta_image` is meant to accompany the post in social previews (Twitter cards, unfurled Slack links, etc.) and on the Pulumi blog home page. It's optional, but recommended, as it can help to make your post more attractive and informative.
 
@@ -211,7 +211,7 @@ Because the website is deployed in response to a commit to pulumi/docs `master`,
 
 ## Publishing Check List
 
-- [ ] As mentioned, use the Hugo blog-post generator instead of copying another post: `make new-blog-post` (or alternatively, the more verbose but equivalent `hugo new --kind blog-post "themes/default/content/blog/[your-slug]"`)
+- [ ] As mentioned, use the Hugo blog-post generator instead of copying another post: `make new-blog-post` (or alternatively, the more verbose but equivalent `hugo new --kind blog-post "content/blog/[your-slug]"`)
 - [ ] Spell and grammar check. Consider using a service such as [Grammarly](http://grammarly.com).
 - [ ] Check for a break `<!--more-->` after the first paragraph, and ensure that your post's introduction looks right on the blog home page.
 - [ ] Check that your meta_image appears properly on the blog home page. Do not use animated GIFs for preview images.

--- a/LEARN.md
+++ b/LEARN.md
@@ -6,8 +6,8 @@ steps to make it happen.
 ## Setting up your development environment
 
 If you haven't done so already, clone this repository and
-[follow the instructions in the README](https://github.com/pulumi/pulumi-hugo)
-to set up your `pulumi/pulumi-hugo` development environment and run the development web server.
+[follow the instructions in the README](https://github.com/pulumi/docs)
+to set up your `pulumi/docs` development environment and run the development web server.
 
 Once you're able to run:
 
@@ -19,7 +19,7 @@ $ make serve
 
 ## How Learn content is organized
 
-All content lives under `./themes/default/content/learn`. Modules, which appear as cards on the Learn home page, sit at the top level of the `learn` folder, and each of the topics that comprise a given module live as siblings underneath their parent module. There are only these two levels in the hierarchy; no further nesting is supported as of today.
+All content lives under `./content/learn`. Modules, which appear as cards on the Learn home page, sit at the top level of the `learn` folder, and each of the topics that comprise a given module live as siblings underneath their parent module. There are only these two levels in the hierarchy; no further nesting is supported as of today.
 
 Both modules and topics can have their own meta images as well.
 
@@ -72,7 +72,7 @@ We have a couple of helpers that make it easy to create new modules and topics. 
 
 ### Creating a new module
 
-When you know what you want to call the new module, make sure you're at the root of the `pulumi-hugo` repository, then run the new-module helper as below. (You can do this anytime; you don't have to be running the development server first.)
+When you know what you want to call the new module, make sure you're at the root of the `docs` repository, then run the new-module helper as below. (You can do this anytime; you don't have to be running the development server first.)
 
 ```
 $ make new-learn-module
@@ -85,7 +85,7 @@ $ make new-learn-module
 ...
 
 Module name (e.g., pulumi-101-aws): pulumi-101-azure
-themes/default/content/learn/pulumi-101-azure created
+content/learn/pulumi-101-azure created
 ```
 
 Hugo will do its best to convert the slug to a proper title -- e.g., `pulumi-101-aws` becomes `Pulumi 101 Aws`. If you find that the conversion looks a bit weird, or if you just want to change it to something else, you can do that by editing the module file's YAML frontmatter directly.
@@ -97,11 +97,11 @@ $ make new-learn-module
 ...
 
 Module name (e.g., pulumi-101-aws): pulumi-101-azure
-themes/default/content/learn/pulumi-101-azure created
+content/learn/pulumi-101-azure created
 
 ...
 Topic name (e.g., basics): basics
-themes/default/content/learn/pulumi-101-azure/basics created
+content/learn/pulumi-101-azure/basics created
 ```
 
 When you want to create a topic for a module that already exists, use the topic-specific helper:
@@ -118,7 +118,7 @@ $ make new-learn-topic
 
 Module name (e.g., pulumi-101-aws): pulumi-101-azure
 Topic name (e.g., basics): advanced-basics
-themes/default/content/learn/pulumi-101-azure/advanced-basics created
+content/learn/pulumi-101-azure/advanced-basics created
 ```
 
 At this point, your new topic is created and you're ready to start writing. Each file should contain annotated frontmatter explaining how each property works, and if you find you don't have something you need, feel free to reach out in the #docs channel.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ First, be sure to read our [contributing guide](CONTRIBUTING.md) and review our 
 
 ## About this repository
 
-This repository hosts the documentation that we **generate** for the Pulumi CLI, SDK, and tutorials sourced from https://github.com/pulumi/examples. It's also responsible for building and deploying the https://www.pulumi.com website.
+This repository hosts all of our hand-crafted documentation, including, guides, tutorials, blogs, and landing pages, as well as all of the assets and templates we use to render the Pulumi website. It also houses the documentation that we generate for the Pulumi CLI and SDK, and it's responsible for building and deploying the https://www.pulumi.com website.
 
-If you're interested in contributing a blog post or other documentation, **you'll likely want to consult [pulumi/pulumi-hugo](https://github.com/pulumi/pulumi-hugo) instead**. There, you'll find all of our hand-crafted documentation, including, guides, tutorials, blogs, and landing pages, along with all of the assets and templates we use to render the Pulumi website. You'll also find all of the instructions you need to get going.
 ## Toolchain
 
 We build the Pulumi website statically with Hugo, manage our dependencies with Node.js and Yarn, and write our documentation in Markdown. Below is a list of the tools you'll need if you'd like to work on the project:

--- a/archetypes/blog-post/index.md
+++ b/archetypes/blog-post/index.md
@@ -34,7 +34,7 @@ authors:
 tags:
     - change-me
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 
@@ -48,7 +48,7 @@ Either way, avoid using images or code samples [in the first 70 words](https://g
 
 ## Writing the Post
 
-For help assembling the content of your post, see [BLOGGING.md](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md). For general formatting guidelines, see the [Style Guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
+For help assembling the content of your post, see [BLOGGING.md](https://github.com/pulumi/docs/blob/master/BLOGGING.md). For general formatting guidelines, see the [Style Guide](https://github.com/pulumi/docs/blob/master/STYLE-GUIDE.md).
 
 ## Code Samples
 

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -6,7 +6,6 @@ security:
   funcs:
     getenv:
       - ASSET_BUNDLE_ID
-      - REPO_THEME_PATH
       - PULUMI_CONVERT_URL
       - PULUMI_AI_WS_URL
       - GITHUB_TOKEN

--- a/content/blog/advanced-aws-networking-part-2/index.md
+++ b/content/blog/advanced-aws-networking-part-2/index.md
@@ -38,7 +38,7 @@ tags:
     - hub-and-spoke
     - python
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details,
 # and please remove these comments before submitting for review.
 ---

--- a/content/blog/ai-assist-improvements/index.md
+++ b/content/blog/ai-assist-improvements/index.md
@@ -36,7 +36,7 @@ tags:
     - ai
     - data-and-analytics
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/amazon-eks-anywhere-bare-metal/index.md
+++ b/content/blog/amazon-eks-anywhere-bare-metal/index.md
@@ -12,7 +12,7 @@ tags:
     - eks
     - aws
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/announcing-pulumiup-conference-2024/index.md
+++ b/content/blog/announcing-pulumiup-conference-2024/index.md
@@ -34,7 +34,7 @@ authors:
 tags:
     - pulumi-events
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 
@@ -57,7 +57,7 @@ One exciting addition to this year's event is the call for speakers. We invite y
 - CFP opens: Thursday, April 25, 2024.
 - CFP closes: Monday, June 17, 2024.
 - CFP Notifications: Monday, July 22, 2024.
-  
+
 ### Selection Criteria
 
 At PulumiUP, diversity and originality are celebrated. We welcome proposals from all corners of the tech community and prioritize fresh perspectives and solutions. Regardless of where you are in the world, we want to hear from you. Whether you're a seasoned speaker or a first-timer, we encourage you to submit your ideas. Just remember, no vendor pitches allowed!

--- a/content/blog/aws-enterprise-container-management/index.md
+++ b/content/blog/aws-enterprise-container-management/index.md
@@ -29,7 +29,7 @@ tags:
     - containers
     - kubernetes
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/aws-lambda-response-streaming/index.md
+++ b/content/blog/aws-lambda-response-streaming/index.md
@@ -11,7 +11,7 @@ date: 2023-04-06
 # of the content of the post, which is useful for targeting search results or social-media
 # previews. This field is required or the build will fail the linter test.
 # Max length is 160 characters.
-meta_desc: Pulumi support for the newly announced Lambda Response Streaming from AWS 
+meta_desc: Pulumi support for the newly announced Lambda Response Streaming from AWS
 
 # The meta_image appears in social-media previews and on the blog home page.
 # A placeholder image representing the recommended format, dimensions and aspect
@@ -30,7 +30,7 @@ tags:
     - aws
     - lambda
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/aws-lambda-snapstart/index.md
+++ b/content/blog/aws-lambda-snapstart/index.md
@@ -31,7 +31,7 @@ tags:
     - aws
     - lambda
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/aws-proton-pulumi/index.md
+++ b/content/blog/aws-proton-pulumi/index.md
@@ -30,7 +30,7 @@ tags:
     - aws
     - devops
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/building-developer-portals/index.md
+++ b/content/blog/building-developer-portals/index.md
@@ -40,7 +40,7 @@ tags:
 - platform-engineering
 
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/community-aws-iam-package/index.md
+++ b/content/blog/community-aws-iam-package/index.md
@@ -29,7 +29,7 @@ tags:
     - aws
     - iam
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/continue-on-error/index.md
+++ b/content/blog/continue-on-error/index.md
@@ -35,7 +35,7 @@ tags:
     - error-handling
     - announcement
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/crosswalk-for-aws-1-0/index.md
+++ b/content/blog/crosswalk-for-aws-1-0/index.md
@@ -29,7 +29,7 @@ tags:
     - features
     - aws
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/crosswalk-for-aws-all-languages/index.md
+++ b/content/blog/crosswalk-for-aws-all-languages/index.md
@@ -28,7 +28,7 @@ tags:
     - features
     - aws
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/developer-portal-gallery/index.md
+++ b/content/blog/developer-portal-gallery/index.md
@@ -36,7 +36,7 @@ tags:
     - developer-portals
     - platform-engineering
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/devops-ai-developer-future--pulumi-user-group-tech-talks/index.md
+++ b/content/blog/devops-ai-developer-future--pulumi-user-group-tech-talks/index.md
@@ -40,7 +40,7 @@ tags:
     - community
     - platform-engineering
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/extending-pulumi-languages-with-yaml-cue-jsonnet-rust/index.md
+++ b/content/blog/extending-pulumi-languages-with-yaml-cue-jsonnet-rust/index.md
@@ -28,7 +28,7 @@ authors:
 tags:
     - languages
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/finops-with-pulumi/index.md
+++ b/content/blog/finops-with-pulumi/index.md
@@ -32,7 +32,7 @@ tags:
     - cloud-engineering
     - automation-api
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 
@@ -68,13 +68,13 @@ Financial optimization can also come in the form of strategic sourcing; most clo
 
 Using cloud engineering practices with Pulumi, you have the opportunity to implement both proactive and reactive models to control your cloud spend.
 
-As an [infrastructure as code platform](/product/), **Pulumi is in the unique position to be proactive about managing your costs**.  
+As an [infrastructure as code platform](/product/), **Pulumi is in the unique position to be proactive about managing your costs**.
 
 - You can design guardrails on your provisioning to limit expensive resource types or quantities,
 - Direct resources to reserved allocations,
 - Ensure resources are tagged and traceable to the correct cost center,
 - Connect resources to your observability and dedicated FinOps platforms,
-- Provide preventative visibility and control.  
+- Provide preventative visibility and control.
 
 Consider uses for CrossGuard Policy as Code, multi-language components for defining resource abstractions, and Automation API to package up orchestration into web service endpoints, as described in Pulumi Features below.
 

--- a/content/blog/five-years-of-infrastructure-as-code-part-one/index.md
+++ b/content/blog/five-years-of-infrastructure-as-code-part-one/index.md
@@ -27,7 +27,7 @@ authors:
 tags:
     - infrastructure-as-code
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/five-years-of-infrastructure-as-code/index.md
+++ b/content/blog/five-years-of-infrastructure-as-code/index.md
@@ -27,7 +27,7 @@ authors:
 tags:
     - infrastructure-as-code
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/future-cloud-infrastructure-10-trends-shaping-2024-and-beyond/index.md
+++ b/content/blog/future-cloud-infrastructure-10-trends-shaping-2024-and-beyond/index.md
@@ -40,7 +40,7 @@ tags:
     - platform-engineering
     - devops
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/how-a-bank-modernized-its-software-engineering-with-infrastructure-as-code-automation/index.md
+++ b/content/blog/how-a-bank-modernized-its-software-engineering-with-infrastructure-as-code-automation/index.md
@@ -39,16 +39,16 @@ tags:
     - crossguard
     - policy-as-code
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 {{% notes type="info" %}}
 This blog post summarizes a presentation by Dennis Sauvé at [PulumiUP 2023](/pulumi-up/).
 {{% /notes %}}
 
-[Washington Trust Bank](https://www.watrust.com), the largest independently-owned full-service commercial bank in the Northwest, has served personal, private, commercial and wealth management clients throughout the region since 1902. It has assets exceeding $11 billion and currently has 42 branches and offices in Idaho, Oregon, and Washington. 
+[Washington Trust Bank](https://www.watrust.com), the largest independently-owned full-service commercial bank in the Northwest, has served personal, private, commercial and wealth management clients throughout the region since 1902. It has assets exceeding $11 billion and currently has 42 branches and offices in Idaho, Oregon, and Washington.
 
-As an FDIC-governed financial institution, it is imperative for the bank to maintain secure, reliable, and compliant cloud resources to protect clients’ personal data. On the other hand, it also aimed to create more agile development teams as it modernized its software development and infrastructure. [Dennis Sauvé](https://github.com/dengsauve), the bank's first DevOps Engineer, recognized [Infrastructure as Code (IaC)](/what-is/what-is-infrastructure-as-code/) as the solution to these challenges. 
+As an FDIC-governed financial institution, it is imperative for the bank to maintain secure, reliable, and compliant cloud resources to protect clients’ personal data. On the other hand, it also aimed to create more agile development teams as it modernized its software development and infrastructure. [Dennis Sauvé](https://github.com/dengsauve), the bank's first DevOps Engineer, recognized [Infrastructure as Code (IaC)](/what-is/what-is-infrastructure-as-code/) as the solution to these challenges.
 
 Embracing an Infrastructure as Code approach would allow them to automate building and deploying their cloud infrastructure, eliminate infrastructure provisioning as a bottleneck, and empower developers to self-service infrastructure and increase productivity.
 
@@ -56,9 +56,9 @@ Embracing an Infrastructure as Code approach would allow them to automate buildi
 
 ## Background
 
-The main challenge was managing Azure infrastructure in an efficient and secure way that kept pace with the bank's rapid growth. Previously, they ran on-premise infrastructure and deployed with BAT and Powershell scripts. Now, they had migrated to Azure and wanted to increase development speed through CI/CD for cloud infrastructure. 
+The main challenge was managing Azure infrastructure in an efficient and secure way that kept pace with the bank's rapid growth. Previously, they ran on-premise infrastructure and deployed with BAT and Powershell scripts. Now, they had migrated to Azure and wanted to increase development speed through CI/CD for cloud infrastructure.
 
-In addition, cloud resources' security and reliability were paramount. They needed a way for the infrastructure and information security teams to work together to implement security best practices for infrastructure, including how to prevent insecure resources from being provisioned. 
+In addition, cloud resources' security and reliability were paramount. They needed a way for the infrastructure and information security teams to work together to implement security best practices for infrastructure, including how to prevent insecure resources from being provisioned.
 
 The bank decided to adopt IaC to create reliable and rapid deployments while ensuring that its cloud infrastructure stayed compliant and secure.
 
@@ -74,9 +74,9 @@ Pulumi helped Washington Trust Bank improve efficiency by maintaining its infras
 
 ### Improved Development Speed with Reusable Infrastructure Packages and CI/CD
 
-Pulumi's automation capabilities played a transformational role. By freeing the infrastructure team from handling manual deployments, it could focus on improving developer productivity. The team created reusable and repeatable [infrastructure components](/docs/concepts/resources/components/) built around strict IT security standards in the form of Frazure, an internal NPM package. 
+Pulumi's automation capabilities played a transformational role. By freeing the infrastructure team from handling manual deployments, it could focus on improving developer productivity. The team created reusable and repeatable [infrastructure components](/docs/concepts/resources/components/) built around strict IT security standards in the form of Frazure, an internal NPM package.
 
-Frazure allows the bank’s developers to easily provision out-of-the-box resources for cloud services and covers the necessary Azure resource groups, vnets, and other resources. The package encapsulates best practices, such as how resource groups and their virtual networks can be created, including subnet IP spaces, peerings to and from the hub virtual network, user-defined routes and more. 
+Frazure allows the bank’s developers to easily provision out-of-the-box resources for cloud services and covers the necessary Azure resource groups, vnets, and other resources. The package encapsulates best practices, such as how resource groups and their virtual networks can be created, including subnet IP spaces, peerings to and from the hub virtual network, user-defined routes and more.
 
 To deploy, developers open a pull request which kicks off a [CI/CD pipeline in GitHub Actions](/docs/pulumi-cloud/deployments/ci-cd-integration-assistant/) and provisions testing environments and tests. Once the PR is reviewed and approved, the changes are automatically deployed to staging and live environments. This automated process enabled the bank to accelerate the building, testing, and deployment of new applications, translating into rapid value delivery to their customers.
 
@@ -86,11 +86,11 @@ Pulumi also gave the bank total confidence in being able to rapidly recover its 
 
 ###  Policy as Code Guardrails with Pulumi CrossGuard
 
-[Pulumi CrossGuard](/docs/using-pulumi/crossguard/) adds an extra layer of security and control and is used in conjunction with Azure Policies, which are used for auditing purposes. CrossGuard prevents the deployment of undesired, insecure, or expensive resources during the preview and deployment stage, thus preventing developers from even reaching Azure to provision resources. Custom error messages give developers context on why their deployment was not allowed. 
+[Pulumi CrossGuard](/docs/using-pulumi/crossguard/) adds an extra layer of security and control and is used in conjunction with Azure Policies, which are used for auditing purposes. CrossGuard prevents the deployment of undesired, insecure, or expensive resources during the preview and deployment stage, thus preventing developers from even reaching Azure to provision resources. Custom error messages give developers context on why their deployment was not allowed.
 
 [Pulumi Cloud Policy Packs](/docs/using-pulumi/crossguard/configuration/) allow them to group and deploy many policies simultaneously. The Policy Packs prevent specified resources from being deployed into staging and live environments. For example, one policy requires all SQL databases to use TLS 1.2 by default and another ensures all storage buckets have public access disabled by default. These capabilities helped bolster the security of the bank's cloud infrastructure.
 
-## Financial services cloud modernization with Pulumi 
+## Financial services cloud modernization with Pulumi
 
 The DevOps and development teams at Washington Trust Bank rely on Pulumi as a key tool in their cloud modernization, while maintaining high security and quality standards. Pulumi played a vital role in streamlining their cloud infrastructure management, enabling their developers to be more productive, and improving the security and reliability of its cloud infrastructure.
 

--- a/content/blog/how-starburst-data-creates-infrastructure-automation-magic-with-code/index.md
+++ b/content/blog/how-starburst-data-creates-infrastructure-automation-magic-with-code/index.md
@@ -40,7 +40,7 @@ tags:
     - community
     - pulumi-events
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 {{% notes type="info" %}}

--- a/content/blog/ill-just-update-my-bucket-object-what-could-go-wrong/index.md
+++ b/content/blog/ill-just-update-my-bucket-object-what-could-go-wrong/index.md
@@ -29,7 +29,7 @@ tags:
     - aws
     - static-website
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/introducing-the-puluminaries/index.md
+++ b/content/blog/introducing-the-puluminaries/index.md
@@ -27,7 +27,7 @@ authors:
 tags:
     - community
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/managing-multi-cloud-open-data-noaa/index.md
+++ b/content/blog/managing-multi-cloud-open-data-noaa/index.md
@@ -34,7 +34,7 @@ tags:
     - infrastructure-as-code
     - community
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/multi-factor-auth-mfa-in-pulumi-cloud/index.md
+++ b/content/blog/multi-factor-auth-mfa-in-pulumi-cloud/index.md
@@ -34,7 +34,7 @@ authors:
 tags:
     - features
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/new-improved-pulumi-service-console/index.md
+++ b/content/blog/new-improved-pulumi-service-console/index.md
@@ -29,7 +29,7 @@ tags:
     - pulumi-service
     - user-experience
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/next-level-iac-pulumi-runtime-logic/index.md
+++ b/content/blog/next-level-iac-pulumi-runtime-logic/index.md
@@ -367,7 +367,7 @@ Hopefully this first post has given you a few new ways to think about how to do 
 
 You'll find the full source for the examples above on GitHub:
 
-* [TypeScript version](https://github.com/pulumi/pulumi-hugo/tree/master/themes/default/static/programs/aws-static-website-with-runtime-logic-typescript)
-* [Python version](https://github.com/pulumi/pulumi-hugo/tree/master/themes/default/static/programs/aws-static-website-with-runtime-logic-python)
+* [TypeScript version](https://github.com/pulumi/docs/tree/master/static/programs/aws-static-website-with-runtime-logic-typescript)
+* [Python version](https://github.com/pulumi/docs/tree/master/static/programs/aws-static-website-with-runtime-logic-python)
 
 Happy coding!

--- a/content/blog/nx-monorepo/index.md
+++ b/content/blog/nx-monorepo/index.md
@@ -36,7 +36,7 @@ tags:
     - monorepo
     - nx
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/oidc-blog/index.md
+++ b/content/blog/oidc-blog/index.md
@@ -30,7 +30,7 @@ tags:
     - features
     - pulumi-releases
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/oidc-trust-relationships/index.md
+++ b/content/blog/oidc-trust-relationships/index.md
@@ -37,7 +37,7 @@ tags:
     - openid-connect
     - feature
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/org-admin-tokens/index.md
+++ b/content/blog/org-admin-tokens/index.md
@@ -35,7 +35,7 @@ authors:
 tags:
     - features
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/organization-access-tokens/index.md
+++ b/content/blog/organization-access-tokens/index.md
@@ -28,7 +28,7 @@ tags:
     - features
     - pulumi-enterprise
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 As enterprise adoption of the Pulumi Service has grown 350% over the last year, we've seen a strong customer demand for tools to manage automated Pulumi use cases such as CI/CD and Automation API at scale. Today we are launching Organization Access Tokens to empower our largest customers to manage automated workloads in a secure and collaborative manner.

--- a/content/blog/patterns-drift-detection/index.md
+++ b/content/blog/patterns-drift-detection/index.md
@@ -28,7 +28,7 @@ authors:
 tags:
     - continuous-delivery
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 {{% notes type="warning" %}}

--- a/content/blog/post-mortem-2023-10-06/index.md
+++ b/content/blog/post-mortem-2023-10-06/index.md
@@ -34,7 +34,7 @@ authors:
 tags:
     - postmortem
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/pricing-calculator-blog/index.md
+++ b/content/blog/pricing-calculator-blog/index.md
@@ -35,7 +35,7 @@ tags:
     - features
     - pricing
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/property-search/index.md
+++ b/content/blog/property-search/index.md
@@ -35,7 +35,7 @@ tags:
     - pulumi-cloud
     - features
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details,
 # and please remove these comments before submitting for review.
 ---

--- a/content/blog/pulumi-release-notes-70/index.md
+++ b/content/blog/pulumi-release-notes-70/index.md
@@ -29,7 +29,7 @@ tags:
     - features
     - pulumi-releases
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/pulumi-release-notes-74/index.md
+++ b/content/blog/pulumi-release-notes-74/index.md
@@ -29,7 +29,7 @@ tags:
     - features
     - pulumi-releases
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/pulumi-release-notes-77/index.md
+++ b/content/blog/pulumi-release-notes-77/index.md
@@ -29,7 +29,7 @@ tags:
    - features
    - pulumi-releases
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/pulumi-release-notes-80/index.md
+++ b/content/blog/pulumi-release-notes-80/index.md
@@ -1,35 +1,35 @@
 ---
 title: "Pulumi Release Notes: CED Launches, Skip Checkpoints flag, Automation API NodeJS parallel inline programs, and much more!"
 allow_long_title: true
- 
+
 # The date represents the post's publish date, and by default corresponds with
 # the date this file was generated. Posts with future dates are visible in development,
 # but excluded from production builds. Use the time and timezone-offset portions of
 # of this value to schedule posts for publishing later.
 date: 2022-11-08
- 
+
 # Use the meta_desc property to provide a brief summary (one or two sentences)
 # of the content of the post, which is useful for targeting search results or social-media
 # previews. This field is required or the build will fail the linter test.
 meta_desc: The latest Pulumi updates include our providers updates, enhancements made in the CLI and any Pulumi Service features released in the last two months.
- 
+
 # The meta_image appears in social-media previews and on the blog home page.
 # A placeholder image representing the recommended format, dimensions and aspect
 # ratio has been provided for you.
 meta_image: meta.png
- 
+
 # At least one author is required. The values in this list correspond with the `id`
 # properties of the team member files at /data/team/team. Create a file for yourself
 # if you don't already have one.
 authors:
    - meagan-cojocar
- 
+
 # At least one tag is required. Lowercase, hyphen-delimited is recommended.
 tags:
    - features
    - pulumi-releases
- 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 
@@ -78,7 +78,7 @@ In October we announced a set of major updates which deepen and extend Pulumi’
 - [Pulumi Kubernetes Operator v1.10](https://github.com/pulumi/pulumi-kubernetes-operator/#readme): New integration with Flux for richer GitOps support, and ability to deploy Pulumi stacks from directly within the Kubernetes resource model
 - [New Pulumi Provider for Flux](https://www.pulumi.com/registry/packages/flux/): Manage Flux with Infrastructure as Code
 - [Pulumi Kubernetes Provider v3.22](/registry/packages/kubernetes): Server Side Apply Option and Resource Patch
-  
+
 👉  Learn more in the [Pulumi+Kubernetes: New Flux Integration and Inline Programs blog](/blog/pulumi-kubernetes-new-2022).
 
 ## Pulumi CLI and core technologies
@@ -109,10 +109,10 @@ Previewing destroy (demo/dev)
 
 View Live: https://app.pulumi.com/meagan/demo/dev/previews/632658ed-41e0-411d-b8a8-f41cc6122ef4
 
-     Type                 Name                  Plan       
- -   pulumi:pulumi:Stack  dev                   delete     
- -   └─ aws:s3:Bucket     my-bucket             delete     
- 
+     Type                 Name                  Plan
+ -   pulumi:pulumi:Stack  dev                   delete
+ -   └─ aws:s3:Bucket     my-bucket             delete
+
 Outputs:
   - bucketName: "my-bucket-ad305ba"
 

--- a/content/blog/pulumi-release-notes-85/index.md
+++ b/content/blog/pulumi-release-notes-85/index.md
@@ -30,7 +30,7 @@ tags:
    - features
    - pulumi-releases
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/resource-search/index.md
+++ b/content/blog/resource-search/index.md
@@ -14,7 +14,7 @@ date: 2023-05-19
 # which is useful for targeting search results or social-media previews.
 # This field is required or the build will fail the linter test.
 # Max length is 160 characters.
-meta_desc: Pulumi Cloud recently launched Resource Search. Today we are announcing two new improvements to the feature- advanced filtering and Pulumi Teams support. 
+meta_desc: Pulumi Cloud recently launched Resource Search. Today we are announcing two new improvements to the feature- advanced filtering and Pulumi Teams support.
 
 # The meta_image appears in social-media previews and on the blog home page.
 # A placeholder image representing the recommended format, dimensions and aspect ratio
@@ -33,7 +33,7 @@ authors:
 tags:
     - features
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details,
 # and please remove these comments before submitting for review.
 ---

--- a/content/blog/restore-stacks/index.md
+++ b/content/blog/restore-stacks/index.md
@@ -34,7 +34,7 @@ authors:
 tags:
     - features
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details,
 # and please remove these comments before submitting for review.
 ---

--- a/content/blog/sam-cogan-testing-best-practices/index.md
+++ b/content/blog/sam-cogan-testing-best-practices/index.md
@@ -39,7 +39,7 @@ tags:
     - azure
     - testing
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/software-developer-experience-devex-devx-devops-culture/index.md
+++ b/content/blog/software-developer-experience-devex-devx-devops-culture/index.md
@@ -39,13 +39,13 @@ tags:
     - developer-portals
     - software-development
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 
 "Developer experience is hard to sell," said Cleve Littlefield, Engineering Manager at Pulumi, during a casual meeting. With experience as both an end-user developer and a lead in self-service platform implementation, Cleve's observation stuck with me.
 
-Though I have expertise in leading implementations and upgrades for internal platforms, none were specifically for developers. However, experience remains vital across departments, addressing tools, processes, systems, and best practices, aiming to reduce cognitive load, increase productivity, enhance collaboration, boost communication and much more. 
+Though I have expertise in leading implementations and upgrades for internal platforms, none were specifically for developers. However, experience remains vital across departments, addressing tools, processes, systems, and best practices, aiming to reduce cognitive load, increase productivity, enhance collaboration, boost communication and much more.
 
 Intriguingly, engineering teams may perceive its value differently. Therefore, we will dive into the concept of developer experience, aka DevEx, which, in truth, should translate into a competitive advantage.
 

--- a/content/blog/stack-readme/index.md
+++ b/content/blog/stack-readme/index.md
@@ -34,7 +34,7 @@ tags:
 
 draft: false
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/stack-transfers/index.md
+++ b/content/blog/stack-transfers/index.md
@@ -29,7 +29,7 @@ tags:
     - features
     - pulumi-service
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/unlocking-your-data-with-metabase-and-aws/index.md
+++ b/content/blog/unlocking-your-data-with-metabase-and-aws/index.md
@@ -29,7 +29,7 @@ tags:
     - aws
     - metabase
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/update-page-improvements/index.md
+++ b/content/blog/update-page-improvements/index.md
@@ -37,7 +37,7 @@ tags:
     - features
     - pulumi-cloud
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---
 

--- a/content/blog/url-shortener-cloudflare-worker/index.md
+++ b/content/blog/url-shortener-cloudflare-worker/index.md
@@ -29,7 +29,7 @@ tags:
     - cloudflare
     - serverless
 
-# See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
+# See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
 

--- a/layouts/community/section.html
+++ b/layouts/community/section.html
@@ -87,7 +87,7 @@
                                     <a href="https://twitter.com/pulumicorp" class="w-full block btn-secondary">Twitter</a>
                                 </div>
                                 <div class="my-2 mx-2 w-full lg:w-auto">
-                                    <a href="https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md" class="w-full block btn-secondary">Blog</a>
+                                    <a href="https://github.com/pulumi/docs/blob/master/BLOGGING.md" class="w-full block btn-secondary">Blog</a>
                                 </div>
                             </div>
                         </div>

--- a/layouts/partials/docs/table-of-contents.html
+++ b/layouts/partials/docs/table-of-contents.html
@@ -55,7 +55,7 @@
     {{ $isCLICommand := hasPrefix .Path "docs/cli/commands" }}
     {{ $isAPIDoc := and (hasPrefix .Path "docs/reference/pkg/") (ne .Path "docs/reference/pkg/_index.md") }}
     {{ if not (or $isCLICommand $isAPIDoc $.Page.Params.no_edit_this_page) }}
-        {{ $repoURL := "https://github.com/pulumi/pulumi-hugo" }}
+        {{ $repoURL := "https://github.com/pulumi/docs" }}
         {{ if (hasPrefix .Path "registry/") }}
             {{ $repoURL = "https://github.com/pulumi/registry" }}
         {{ end }}

--- a/layouts/partials/example-program.html
+++ b/layouts/partials/example-program.html
@@ -76,7 +76,7 @@
                 </div>
                 <div class="example-program-footer bg-white">
                     <pulumi-tooltip>
-                        <a href="https://github.com/pulumi/pulumi-hugo/tree/master/{{ getenv "REPO_THEME_PATH" }}static/programs/{{ $path }}-{{ $language }}" target="_blank">
+                        <a href="https://github.com/pulumi/docs/tree/master/static/programs/{{ $path }}-{{ $language }}" target="_blank">
                             <i class="fab fa-github"></i>
                         </a>
                         <span slot="content">View full example on GitHub</span>

--- a/layouts/shortcodes/example-program.html
+++ b/layouts/shortcodes/example-program.html
@@ -76,7 +76,7 @@
                 </div>
                 <div class="example-program-footer bg-white">
                     <pulumi-tooltip>
-                        <a href="https://github.com/pulumi/pulumi-hugo/tree/{{ $.Site.Params.contentRepositoryBaseBranch }}/{{ getenv "REPO_THEME_PATH" }}static/programs/{{ $path }}-{{ $language }}" target="_blank">
+                        <a href="https://github.com/pulumi/docs/tree/{{ $.Site.Params.contentRepositoryBaseBranch }}/static/programs/{{ $path }}-{{ $language }}" target="_blank">
                             <i class="fab fa-github"></i>
                         </a>
                         <span slot="content">View full example on GitHub</span>

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -19,7 +19,6 @@ export JS_BUNDLE="static/js/bundle.min.${ASSET_BUNDLE_ID}.js"
 # Relative paths to those same files, read by Hugo templates.
 export REL_CSS_BUNDLE="/css/styles.${ASSET_BUNDLE_ID}.css"
 export REL_JS_BUNDLE="/js/bundle.min.${ASSET_BUNDLE_ID}.js"
-export REPO_THEME_PATH="themes/default/"
 
 printf "Copying prebuilt docs...\n\n"
 make copy_static_prebuilt

--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -199,8 +199,6 @@ function getDefaultExcludedKeywords() {
         "https://github.com/pulumi/docs/issues/new",
         "https://github.com/pulumi/registry/edit/master",
         "https://github.com/pulumi/registry/issues/new",
-        "https://github.com/pulumi/pulumi-hugo/edit/master",
-        "https://github.com/pulumi/pulumi-hugo/issues/new",
         "https://www.linkedin.com/",
         "https://linkedin.com/",
         "https://marketplace.visualstudio.com/items?itemName=pulumi.build-and-release-task",


### PR DESCRIPTION
Fixes some links to point to the right places in the docs repo and removes a few references to `pulumi-hugo` et. al. that are no longer needed.

Also fixes up the README's About section to better reflect the current reality. 😄 
