### PR TITLE
Separate pull request flow

### DIFF
--- a/.github/workflows/bucket-cleanup-testing.yml
+++ b/.github/workflows/bucket-cleanup-testing.yml
@@ -22,10 +22,6 @@ jobs:
         with:
           node-version: '18.x'
 
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.19.x
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/bucket-cleanup-testing.yml
+++ b/.github/workflows/bucket-cleanup-testing.yml
@@ -1,9 +1,10 @@
-name: "Scheduled jobs: Bucket cleanup"
+name: "Scheduled jobs: Bucket cleanup testing"
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string.
     # Run every day at 3:00PM UTC.
     - cron:  '0 15 * * *'
+  workflow_dispatch:
 permissions:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
@@ -12,7 +13,7 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Bucket cleanup
-    environment: production
+    environment: testing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,13 +24,13 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.20.x
+          go-version: 1.19.x
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
-          role-session-name: docs-cleanup
+          role-to-assume: arn:aws:iam::571684982431:role/ContinuousDelivery
+          role-session-name: docs-deploy
           role-duration-seconds: 7200
           aws-region: us-west-2
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         uses: pulumi/actions@v4
 
       - name: Build and deploy
-        run: make ci_${GITHUB_EVENT_NAME}
+        run: make ci_push
         env:
           CDN_PULUMI_URN: ${{ vars.CDN_PULUMI_URN }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,10 +21,6 @@ jobs:
         with:
           node-version: '18.x'
 
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.20.x
-
       - uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.111.0'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
-name: Build and deploy
+name: Pull Request
 on:
-  push:
+  pull_request:
     branches:
       - master
 permissions:
@@ -12,7 +12,7 @@ jobs:
       GOPATH: ${{ github.workspace }}/go
     name: Install deps and build site
     runs-on: ubuntu-22.04-8core
-    environment: production
+    environment: testing
     steps:
 
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-to-assume: arn:aws:iam::571684982431:role/ContinuousDelivery
           role-session-name: docs-deploy
           role-duration-seconds: 7200
           aws-region: us-west-2
@@ -42,7 +42,7 @@ jobs:
         uses: pulumi/actions@v4
 
       - name: Build and deploy
-        run: make ci_${GITHUB_EVENT_NAME}
+        run: make ci_pull_request
         env:
           CDN_PULUMI_URN: ${{ vars.CDN_PULUMI_URN }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/scripts/list-recent-buckets.sh
+++ b/scripts/list-recent-buckets.sh
@@ -49,8 +49,14 @@ if [ "$bucket_count" == "0" ]; then
     exit
 fi
 
+# Check if WEBSITE_URL is set
+if [ -z "$WEBSITE_URL" ]; then
+  echo "WEBSITE_URL is not set."
+  exit 1
+fi
+
 # Query for the bucket currently serving pulumi.com.
-currently_deployed_bucket="$(curl -s https://www.pulumi.com/metadata.json | jq -r '.bucket' || echo '')"
+currently_deployed_bucket="$(curl -s ${WEBSITE_URL}/metadata.json | jq -r '.bucket' || echo '')"
 
 maybe_echo "Found ${bucket_count} recent buckets matching the prefix $(origin_bucket_prefix)-${bucket_prefix}:"
 


### PR DESCRIPTION
Separates pull request flow from the build and deploy workflow and stand up a separate cleanup job for the testing environment, since that is where previews will live.

This separation will enable us to turn add the sync job to `docs-private`. It will only run the PR workflows and we can jsut disable the build-and-deploy workflow there so there will be no deploys from that repo, only PR builds. That repo does not have access to the prod environment, so can't really mess up anything there.