### PR TITLE
Add pre-commit linting, version checking, and upgrade to Hugo latest (0.126.0)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.111.0'
+          hugo-version: '0.126.0'
           extended: true
 
       - name: Configure AWS Credentials

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.111.0'
+          hugo-version: '0.126.0'
           extended: true
       - name: Run make check_links
         run: make check_links

--- a/.github/workflows/customer-managed-deployment-agent-cli.yml
+++ b/.github/workflows/customer-managed-deployment-agent-cli.yml
@@ -54,7 +54,7 @@ jobs:
 #      - name: Install Hugo
 #        uses: peaceiris/actions-hugo@v2
 #        with:
-#          hugo-version: '0.111.0'
+#          hugo-version: '0.126.0'
 #          extended: true
 #      - name: Install node
 #        uses: actions/setup-node@v2

--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.111.0'
+          hugo-version: '0.126.0'
           extended: true
       - name: Install node
         uses: actions/setup-node@v2

--- a/.github/workflows/generate-provider-docs.yml
+++ b/.github/workflows/generate-provider-docs.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.111.0'
+          hugo-version: '0.126.0'
           extended: true
       - name: setup node
         uses: actions/setup-node@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.111.0'
+          hugo-version: '0.126.0'
           extended: true
 
       - name: Configure AWS Credentials

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.111.0'
+          hugo-version: '0.126.0'
           extended: true
       - name: Install node
         uses: actions/setup-node@v2

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.111.0"
+          hugo-version: "0.126.0"
           extended: true
 
       - name: Install Pulumi

--- a/.github/workflows/scheduled-upgrade-programs.yml
+++ b/.github/workflows/scheduled-upgrade-programs.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.111.0"
+          hugo-version: "0.126.0"
           extended: true
 
       - name: Install Pulumi

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.111.0'
+          hugo-version: '0.126.0'
           extended: true
 
       - name: Configure AWS Credentials

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+echo "Running pre-commit checks..."
+make lint

--- a/Makefile
+++ b/Makefile
@@ -142,4 +142,4 @@ lint:
 
 .PHONY: format
 format:
-	yarn prettier --write .
+	./scripts/format.sh

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ See also:
 
 We build the Pulumi website with Hugo, manage our dependencies with Node.js and Yarn, and write our documentation in Markdown. Below is a list of the tools you'll need if you'd like to work on the website (e.g., to contribute docs content, a blog post, etc.):
 
-* [Hugo](https://gohugo.io) (>= 0.111.0)
-  * Hugo 0.111.0 is highly recommended. This is the version we use in our deployment pipelines.
-* [Node.js](https://nodejs.org/en/) (>= 18)
-* [Yarn](https://classic.yarnpkg.com/en/) (1.x)
+* [Hugo](https://gohugo.io/installation/) (>= 0.126.0)
+  * Hugo 0.126.0 is highly recommended. This is the version we use in our deployment pipelines.
+* [Node.js](https://nodejs.org/en/download/package-manager) (>= 18)
+* [Yarn](https://classic.yarnpkg.com/lang/en/docs/install) (1.x)
 
 Additionally, to build the SDK and CLI documentation, you'll also need:
 
@@ -65,12 +65,12 @@ The `Makefile` exposes a number of useful helpers for authoring:
 * `make new-blog-post` scaffolds a new, bare-bones blog post with placeholder content
 * `make new-example-program` generates a new multi-language set of examples at `./static/programs`
 
-As a content contributor, the commands you'll most often use are these:
+As a content contributor, the commands you'll use most often are these:
 
 ```bash
 make ensure    # Install or update dependencies.
 make serve     # Run the development server locally on http://localhost:1313.
-make lint      # Identify any Markdown or code-formatting issues so you an fix them.
+make lint      # Identify any Markdown or code-formatting issues so you can fix them.
 ```
 
 ## Generating SDK and CLI documentation

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -13,8 +13,7 @@ security:
       - ALGOLIA_APP_SEARCH_KEY
 
 disableKinds:
-  - category
-  - taxonomyTerm
+  - taxonomy
 
 sectionPagesMenu: main
 pygmentsCodeFences: true

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -6,17 +6,19 @@
         {{ $ancestors = $ancestors | append $a.LinkTitle }}
     {{- end -}}
 
-    {{-
-        $index = $index | append (
-            dict
-                "objectID" $page.File.UniqueID
-                "title" $page.Title
-                "section" $page.Section
-                "href" $page.RelPermalink
-                "params" $page.Params
-                "kind" $page.Kind
-                "ancestors" (after 1 $ancestors)
-        )
-    -}}
+    {{- if ne $page.File nil -}}
+        {{-
+            $index = $index | append (
+                dict
+                    "objectID" $page.File.UniqueID
+                    "title" $page.Title
+                    "section" $page.Section
+                    "href" $page.RelPermalink
+                    "params" $page.Params
+                    "kind" $page.Kind
+                    "ancestors" (after 1 $ancestors)
+            )
+        -}}
+    {{- end -}}
 {{- end -}}
 {{- $index | jsonify (dict "indent" "    ") -}}

--- a/layouts/page/about.html
+++ b/layouts/page/about.html
@@ -57,7 +57,7 @@
         <h3 class="font-medium text-6xl">Our purpose</h3>
         <h4 class="font-medium text-4-xl">To democratize the cloud for every engineer.</h4>
         <p class="text-gray-700 text-xl mb-10">We help engineers ship infrastructure faster with Infrastructure as Code in general-purpose languages.</p>
-        <a href="{{ relref . " /leadership" }}" class="btn-primary">Meet our leaders</a>
+        <a href="{{ relref . "/leadership" }}" class="btn-primary">Meet our leaders</a>
     </section>
 
     <section id="what-we-believe" class="text-center text-lg py-8 relative">
@@ -98,7 +98,7 @@
             </div>
         </div>
         <div class="careers-cta py-6 w-full mt-28 bg-white">
-            <h4>Like what we stand for? <a href="{{ relref . " /careers" }}" class="font-bold text-blue-600">Join us.</a></h4>
+            <h4>Like what we stand for? <a href="{{ relref . "/careers" }}" class="font-bold text-blue-600">Join us.</a></h4>
             <p>We are looking for new teammates who want to build the future of cloud infrastructure together.</p>
         </div>
     </section>
@@ -119,7 +119,7 @@
                 <img src="/images/mascot/victory-medal-pulumipus.svg" alt="Pulumipus wearing a medal with two hands raised" />
                 <div class="header mt-6 mb-1.5 text-medium text-2xl">The Puluminaries</div>
                 <p class="text-left flex-grow">A group for stellar Pulumi community members who have made "above and beyond" contributions to the community.</p>
-                <a href="{{ relref . " /community/puluminaries" }}" class="btn-primary">Meet our Puluminaries</a>
+                <a href="{{ relref . "/community/puluminaries" }}" class="btn-primary">Meet our Puluminaries</a>
             </div>
             <div class="community-spotlight mx-auto flex flex-col justify-cetner items-center w-72 md:w-1/3 my-6 px-3">
                 <img src="/images/mascot/rocketpus.svg" alt="Pulumipus wearing a medal with two hands raised" />
@@ -129,9 +129,9 @@
             </div>
             <div class="community-spotlight mx-auto flex flex-col justify-cetner items-center w-72 md:w-1/3 my-6 px-3">
                 <img src="/images/mascot/hoodie-pulumipus.svg" alt="Pulumipus wearing a Pulumi hoodie" />
-                <div class="header mt-6 mb-1.5 text-medium text-2xl">Pulumi users</div>
+                <div class="header  /leadershipt-6 mb-1.5 text-medium text-2xl">Pulumi users</div>
                 <p class="text-left flex-grow">Engineers love Pulumi! Don’t believe us? Check out what our users have to say.</p>
-                <a href="{{ relref . " /testimonials" }}" class="btn-primary ">Read user quotes</a>
+                <a href="{{ relref . "/testimonials" }}" class="btn-primary ">Read user quotes</a>
             </div>
         </div>
     </section>
@@ -226,7 +226,7 @@
                 {{ end }}
             </ul>
             <div>
-                <a class="inline-block mt-6 text-bold text-blue-600 mt-12 font-bold" href="{{ relref . " /awards" }}">View all achievements</a>
+                <a class="inline-block mt-6 text-bold text-blue-600 mt-12 font-bold" href="{{ relref . "/awards" }}">View all achievements</a>
             </div>
         </div>
     </section>
@@ -248,7 +248,7 @@
                         </li>
                     {{ end }}
                 </ul>
-                <a class="text-blue-600 font-bold" href="{{ relref . " /newsroom" }}">View all press releases</a>
+                <a class="text-blue-600 font-bold" href="{{ relref . "/newsroom" }}">View all press releases</a>
             </div>
             <div class="md:w/1-2 md:px-8">
                 <h3 class="text-center md:text-left font-medium text-6xl">Recent News</h3>
@@ -262,7 +262,7 @@
                         </li>
                     {{ end }}
                 </ul>
-                <a class="text-blue-600 font-bold" href="{{ relref . " /newsroom" }}">View all recent news</a>
+                <a class="text-blue-600 font-bold" href="{{ relref . "/newsroom" }}">View all recent news</a>
             </div>
         </div>
     </section>
@@ -275,6 +275,6 @@
         <h3 class="font-medium text-6xl">Join our team</h3>
         <h4>We are fully remote and hiring!</h4>
         <p class="mb-9">Our team is a diverse and talented group of individuals from all walks of life.</p>
-        <a href="{{ relref . " /careers" }}" class="btn-primary">Browse open positions</a>
+        <a href="{{ relref . "/careers" }}" class="btn-primary">Browse open positions</a>
     </section>
 {{ end }}

--- a/layouts/page/leadership.html
+++ b/layouts/page/leadership.html
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
     <div class="container mx-auto mt-12  max-w-7xl">
-        <a class="text-blue-600 text-xl font-body ml-9 hidden sm:block" href="{{ relref . " /about" }}">
+        <a class="text-blue-600 text-xl font-body ml-9 hidden sm:block" href="{{ relref . "/about" }}">
             <i class="fas fa-arrow-left mr-4"></i>
             About
         </a>

--- a/layouts/product/pulumi-cloud.html
+++ b/layouts/product/pulumi-cloud.html
@@ -151,7 +151,7 @@
             <h2>{{ .title }}</h2>
             <p class="max-w-xl mx-auto">{{ .description | markdownify }}</p>
             <div class="mt-12">
-                <a href="{{ relref $pageContext " /pricing" }}" class="btn-secondary">Pricing</a>
+                <a href="{{ relref $pageContext "/pricing" }}" class="btn-secondary">Pricing</a>
             </div>
         {{ end }}
     </section>

--- a/layouts/product/pulumi-insights.html
+++ b/layouts/product/pulumi-insights.html
@@ -120,7 +120,7 @@
             <h2>{{ .title }}</h2>
             <p class="max-w-2xl mx-auto">{{ .description | markdownify }}</p>
             <div class="mt-12">
-                <a href="{{ relref $pageContext " /pricing" }}" class="btn-secondary">View Pricing</a>
+                <a href="{{ relref $pageContext "/pricing" }}" class="btn-secondary">View Pricing</a>
             </div>
         {{ end }}
     </section>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "minify-css": "node scripts/minify-css.js"
+    "minify-css": "node scripts/minify-css.js",
+    "prepare": "husky"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.427.0",
@@ -34,6 +35,7 @@
     "typescript": "^4.9.5"
   },
   "devDependencies": {
+    "husky": "^9.0.11",
     "prettier": "^2.6.2"
   }
 }

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+yarn prettier --write .

--- a/yarn.lock
+++ b/yarn.lock
@@ -2894,6 +2894,11 @@ humanize-duration@^3.9.1:
   resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.27.3.tgz#db654e72ebf5ccfe232c7f56bc58aa3a6fe4df88"
   integrity sha512-iimHkHPfIAQ8zCDQLgn08pRqSVioyWvnGfaQ8gond2wf7Jq2jJ+24ykmnRyiz3fIldcn4oUuQXpjqKLhSVR7lw==
 
+husky@^9.0.11:
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
+  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
+
 iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"


### PR DESCRIPTION
Adds the pre-commit hook (to run the linter) that we were using in pulumi-hugo, and also adds a bit of scripting to ensure required tools and versions are installed, warning on differences. Also upgrades to the latest version of Hugo (0.126.0).

Fixes #11855.