### PR TITLE
Update blog template

### DIFF
--- a/archetypes/blog-post/index.md
+++ b/archetypes/blog-post/index.md
@@ -34,6 +34,13 @@ authors:
 tags:
     - change-me
 
+
+# The social copy used to promote this post on Twitter and Linkedin. These
+# properties do not actually create the post and have no effect on the
+# generated blog page. They are here strictly for reference.
+social_twitter: "social copy to post on Twitter"
+social_linkedin: "social copy to post on Linkedin"
+
 # See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.
 ---

--- a/archetypes/blog-post/index.md
+++ b/archetypes/blog-post/index.md
@@ -38,8 +38,18 @@ tags:
 # The social copy used to promote this post on Twitter and Linkedin. These
 # properties do not actually create the post and have no effect on the
 # generated blog page. They are here strictly for reference.
-social_twitter: "social copy to post on Twitter"
-social_linkedin: "social copy to post on Linkedin"
+
+# Here are some examples of posts we have made in the past for inspiration:
+# https://www.linkedin.com/feed/update/urn:li:activity:7171191945841561601
+# https://www.linkedin.com/feed/update/urn:li:activity:7169021002394296320
+# https://www.linkedin.com/feed/update/urn:li:activity:7155606616455737345
+# https://twitter.com/PulumiCorp/status/1763265391042654623
+# https://twitter.com/PulumiCorp/status/1762900472489185492
+# https://twitter.com/PulumiCorp/status/1755637618631405655
+
+social:
+    twitter:
+    linkedin:
 
 # See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -13,7 +13,8 @@ security:
       - ALGOLIA_APP_SEARCH_KEY
 
 disableKinds:
-  - taxonomy
+  - taxonomyTerm
+  - category
 
 sectionPagesMenu: main
 pygmentsCodeFences: true

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -13,8 +13,7 @@ security:
       - ALGOLIA_APP_SEARCH_KEY
 
 disableKinds:
-  - taxonomyTerm
-  - category
+  - taxonomy
 
 sectionPagesMenu: main
 pygmentsCodeFences: true


### PR DESCRIPTION
Updates the blog template to include properties to house the social copies to be posted on twitter and linkedin. I also updated the `disabledKinds` config to update it to `taxonomyTerm` from `taxonomy`. This term was updated to this after hugo 0.73 from my understanding and also matches the config we were running in pulumi-hugo. I also added the `category` kind as well, since pulumi-hugo had this listed. It was giving me an error before I updated this when running the `hugo new` command to generate the blog files. 

We _could_ add linting here to enforce this, but it would fail unless we add these props to all the blog files. It also will presumably just pass for new blog posts going forward as these would already be filled out when generated from the template. Maybe we can do something like only running linting against newly added files in the commit, but I think this should be good enough for now.
