### PR TITLE
Only run automerge if pulumi-bot

### DIFF
--- a/.github/workflows/automerge-workflow.yml
+++ b/.github/workflows/automerge-workflow.yml
@@ -1,6 +1,6 @@
 jobs:
   automerge:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: (github.event.pull_request.user.login == 'pulumi-bot') && (github.event.pull_request.head.repo.full_name == github.repository)
     name: Automerge Workflow
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We have been getting quite a few failures from the automerge workflow due to github ratelimitting. This is likely happening now that there are more PRs being submitted to docs after the migration. This adds a condition to only run when the author is pulumi-bot, since that is the main reason we have this workflow.
