### PR TITLE
Update YAML capitalization

### DIFF
--- a/content/docs/clouds/azure/get-started/review-project.md
+++ b/content/docs/clouds/azure/get-started/review-project.md
@@ -296,11 +296,9 @@ resources:
       kind: StorageV2
 variables:
   storageAccountKeys:
-    Fn::Invoke:
-      Function: azure-native:storage:listStorageAccountKeys
-      Arguments:
-        resourceGroupName: ${resourceGroup.name}
-        accountName: ${sa.name}
+    fn::azure-native:storage:listStorageAccountKeys:
+      resourceGroupName: ${resourceGroup.name}
+      accountName: ${sa.name}
 outputs:
   primaryStorageKey: ${storageAccountKeys.keys[0].value}
 ```

--- a/content/docs/concepts/assets-archives.md
+++ b/content/docs/concepts/assets-archives.md
@@ -85,11 +85,11 @@ final var remoteAsset = new com.pulumi.asset.RemoteAsset("http://worldclockapi.c
 ```yaml
 variables:
   fileAsset:
-    Fn::FileAsset: ./file.txt
+    fn::fileAsset: ./file.txt
   stringAsset:
-    Fn::StringAsset: Hello, world!
+    fn::stringAsset: Hello, world!
   remoteAsset:
-    Fn::RemoteAsset: http://worldclockapi.com/api/json/est/now
+    fn::remoteAsset: http://worldclockapi.com/api/json/est/now
 ```
 
 {{% /choosable %}}
@@ -273,15 +273,15 @@ var assetArchive = new com.pulumi.asset.AssetArchive(
 ```yaml
 variables:
   fileArchive:
-    Fn::FileArchive: ./file.zip
+    fn::fileArchive: ./file.zip
   remoteArchive:
-    Fn::RemoteArchive: http://contoso.com/file.zip
+    fn::remoteArchive: http://contoso.com/file.zip
   assetArchive:
-    Fn::AssetArchive:
+    fn::assetArchive:
       file:
-        Fn::StringAsset: Hello, World!
+        fn::stringAsset: Hello, World!
       folder:
-        Fn::FileArchive: ./folder
+        fn::fileArchive: ./folder
 ```
 
 {{% /choosable %}}

--- a/content/docs/concepts/resources/functions.md
+++ b/content/docs/concepts/resources/functions.md
@@ -121,10 +121,8 @@ const example = pulumi.output(aws.apigateway.getDomainName({
 ```yaml
 variables:
   example:
-    Fn::Invoke:
-      Function: aws:apigateway:getDomainName
-      Arguments:
-        domainName: api.example.com
+    fn::aws:apigateway:getDomainName:
+      domainName: api.example.com
 ```
 
 </pulumi-choosable>

--- a/content/docs/concepts/secrets.md
+++ b/content/docs/concepts/secrets.md
@@ -80,7 +80,7 @@ There are two ways to programmatically create secret values:
 {{% choosable language yaml %}}
 
 - Setting `configuration.${KEY}.Secret: true` when reading a value from the config.
-- Calling `Fn::Secret` to construct a secret from an existing value.
+- Calling `fn::secret` to construct a secret from an existing value.
 
 {{% /choosable %}}
 

--- a/content/what-is/what-is-yaml.md
+++ b/content/what-is/what-is-yaml.md
@@ -119,7 +119,7 @@ resources:
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::StringAsset: <h1>Hello, world!</h1>
+        fn::stringAsset: <h1>Hello, world!</h1>
       acl: public-read
       contentType: text/html
 outputs:
@@ -147,7 +147,7 @@ resources:
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::StringAsset: <h1>Hello, world!</h1>
+        fn::stringAsset: <h1>Hello, world!</h1>
       acl: public-read
       contentType: text/html
 ```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Pulumi Yaml has been standardized to use camelCase capitalization in pulumi/pulumi-yaml#355. This PR updates a number of documentation pages to use this standard in their code samples.

The current samples will trigger warnings which is not a great first impression:
```
Warning: ‘Fn::FileAsset’ looks like a miscapitalization of ‘fn::fileAsset’
   on Pulumi.yaml line 93:
   93:     Fn::FileAsset: ./Pulumi.yaml
  A future version of Pulumi YAML will enforce camelCase fields. See https://github.com/pulumi/pulumi-yaml/issues/355 for details.
```
