### PR TITLE
Change PR runner

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Install deps and build site
-    runs-on: ubuntu-22.04-8core
+    runs-on: ubuntu-22.04
     environment: testing
     steps:
 


### PR DESCRIPTION
Changes to using the "standard" ubuntu runner for PR builds. Now that this flow has been broken off, I don't think the larger ones are necessary for this. It's likely we can also back down the runner size for the deployment job as well, since I believe this was a relic from when we used to build everything here, along with registry and needed more beefy machinery.