### PR TITLE
Add 'esc env version' to CLI overview references

### DIFF
--- a/content/docs/esc-cli/_index.md
+++ b/content/docs/esc-cli/_index.md
@@ -33,10 +33,7 @@ The most common commands in the CLI that you'll be using are as follows:
 * [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment
 * [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment
 * [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment
-* [esc env version history](/docs/esc-cli/commands/esc_env_version_history/) - Show revision history of an environment
 * [esc env version tag](/docs/esc-cli/commands/esc_env_version_tag/) - Manage tagged versions
-* [esc env version tag ls](/docs/esc-cli/commands/esc_env_version_tag_ls/) - List tagged versions
-* [esc env version tag rm](/docs/esc-cli/commands/esc_env_version_tag_rm/) - Remove a tagged version
 * [esc login](/docs/esc-cli/commands/esc_login/) - Log in to the Pulumi Cloud
 * [esc open](/docs/esc-cli/commands/esc_open/) - Open the environment with the given name
 * [esc run](/docs/esc-cli/commands/esc_run/) - Open the environment with the given name and run a command

--- a/content/docs/esc-cli/_index.md
+++ b/content/docs/esc-cli/_index.md
@@ -23,14 +23,15 @@ The Pulumi ESC CLI is open source and free to use:
 
 The most common commands in the CLI that you'll be using are as follows:
 
-* [esc env](/docs/esc-cli/commands/esc_env/)	 - Manage environments
-* [esc env edit](/docs/esc-cli/commands/esc_env_edit/)	 - Edit an environment definition
-* [esc env get](/docs/esc-cli/commands/esc_env_get/)	 - Get a value within an environment.
-* [esc env init](/docs/esc-cli/commands/esc_env_init/)	 - Create an empty environment with the given name.
-* [esc env ls](/docs/esc-cli/commands/esc_env_ls/)	 - List environments.
-* [esc env rm](/docs/esc-cli/commands/esc_env_rm/)	 - Remove an environment or a value from an environment.
-* [esc env set](/docs/esc-cli/commands/esc_env_set/)	 - Set a value within an environment.
-* [esc login](/docs/esc-cli/commands/esc_login/)	 - Log in to the Pulumi Cloud
-* [esc open](/docs/esc-cli/commands/esc_open/)	 - Open the environment with the given name.
-* [esc run](/docs/esc-cli/commands/esc_run/)	 - Open the environment with the given name and run a command.
-* [esc version](/docs/esc-cli/commands/esc_version/)	 - Print esc's version number
+* [esc env](/docs/esc-cli/commands/esc_env/) - Manage environments
+* [esc env edit](/docs/esc-cli/commands/esc_env_edit/) - Edit an environment definition
+* [esc env get](/docs/esc-cli/commands/esc_env_get/) - Get a value within an environment.
+* [esc env init](/docs/esc-cli/commands/esc_env_init/) - Create an empty environment with the given name.
+* [esc env ls](/docs/esc-cli/commands/esc_env_ls/) - List environments.
+* [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment.
+* [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment.
+* [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment.
+* [esc login](/docs/esc-cli/commands/esc_login/) - Log in to the Pulumi Cloud
+* [esc open](/docs/esc-cli/commands/esc_open/) - Open the environment with the given name.
+* [esc run](/docs/esc-cli/commands/esc_run/) - Open the environment with the given name and run a command.
+* [esc version](/docs/esc-cli/commands/esc_version/) - Print esc's version number

--- a/content/docs/esc-cli/_index.md
+++ b/content/docs/esc-cli/_index.md
@@ -24,14 +24,20 @@ The Pulumi ESC CLI is open source and free to use:
 The most common commands in the CLI that you'll be using are as follows:
 
 * [esc env](/docs/esc-cli/commands/esc_env/) - Manage environments
+* [esc env diff](/docs/esc-cli/commands/esc_env_diff/) - Show the difference between versions of an environment
 * [esc env edit](/docs/esc-cli/commands/esc_env_edit/) - Edit an environment definition
-* [esc env get](/docs/esc-cli/commands/esc_env_get/) - Get a value within an environment.
-* [esc env init](/docs/esc-cli/commands/esc_env_init/) - Create an empty environment with the given name.
-* [esc env ls](/docs/esc-cli/commands/esc_env_ls/) - List environments.
-* [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment.
-* [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment.
-* [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment.
+* [esc env get](/docs/esc-cli/commands/esc_env_get/) - Get a value within an environment
+* [esc env init](/docs/esc-cli/commands/esc_env_init/) - Create an empty environment with the given name
+* [esc env ls](/docs/esc-cli/commands/esc_env_ls/) - List environments
+* [esc env rollback](/docs/esc-cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version.
+* [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment
+* [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment
+* [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment
+* [esc env version history](/docs/esc-cli/commands/esc_env_version_history/) - Show revision history of an environment
+* [esc env version tag](/docs/esc-cli/commands/esc_env_version_tag/) - Manage tagged versions
+* [esc env version tag ls](/docs/esc-cli/commands/esc_env_version_tag_ls/) - List tagged versions
+* [esc env version tag rm](/docs/esc-cli/commands/esc_env_version_tag_rm/) - Remove a tagged version
 * [esc login](/docs/esc-cli/commands/esc_login/) - Log in to the Pulumi Cloud
-* [esc open](/docs/esc-cli/commands/esc_open/) - Open the environment with the given name.
-* [esc run](/docs/esc-cli/commands/esc_run/) - Open the environment with the given name and run a command.
+* [esc open](/docs/esc-cli/commands/esc_open/) - Open the environment with the given name
+* [esc run](/docs/esc-cli/commands/esc_run/) - Open the environment with the given name and run a command
 * [esc version](/docs/esc-cli/commands/esc_version/) - Print esc's version number

--- a/content/docs/esc-cli/_index.md
+++ b/content/docs/esc-cli/_index.md
@@ -29,7 +29,7 @@ The most common commands in the CLI that you'll be using are as follows:
 * [esc env get](/docs/esc-cli/commands/esc_env_get/) - Get a value within an environment
 * [esc env init](/docs/esc-cli/commands/esc_env_init/) - Create an empty environment with the given name
 * [esc env ls](/docs/esc-cli/commands/esc_env_ls/) - List environments
-* [esc env rollback](/docs/esc-cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version.
+* [esc env rollback](/docs/esc-cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version
 * [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment
 * [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment
 * [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment

--- a/content/docs/esc-cli/commands/_index.md
+++ b/content/docs/esc-cli/commands/_index.md
@@ -14,14 +14,15 @@ menu:
 
 The most common commands in the CLI that you'll be using are as follows:
 
-* [esc env](/docs/esc-cli/commands/esc_env/)	 - Manage environments
-* [esc env edit](/docs/esc-cli/commands/esc_env_edit/)	 - Edit an environment definition
-* [esc env get](/docs/esc-cli/commands/esc_env_get/)	 - Get a value within an environment.
-* [esc env init](/docs/esc-cli/commands/esc_env_init/)	 - Create an empty environment with the given name.
-* [esc env ls](/docs/esc-cli/commands/esc_env_ls/)	 - List environments.
-* [esc env rm](/docs/esc-cli/commands/esc_env_rm/)	 - Remove an environment or a value from an environment.
-* [esc env set](/docs/esc-cli/commands/esc_env_set/)	 - Set a value within an environment.
-* [esc login](/docs/esc-cli/commands/esc_login/)	 - Log in to the Pulumi Cloud
-* [esc open](/docs/esc-cli/commands/esc_open/)	 - Open the environment with the given name.
-* [esc run](/docs/esc-cli/commands/esc_run/)	 - Open the environment with the given name and run a command.
-* [esc version](/docs/esc-cli/commands/esc_version/)	 - Print esc's version number
+* [esc env](/docs/esc-cli/commands/esc_env/) - Manage environments
+* [esc env edit](/docs/esc-cli/commands/esc_env_edit/) - Edit an environment definition
+* [esc env get](/docs/esc-cli/commands/esc_env_get/) - Get a value within an environment.
+* [esc env init](/docs/esc-cli/commands/esc_env_init/) - Create an empty environment with the given name.
+* [esc env ls](/docs/esc-cli/commands/esc_env_ls/) - List environments.
+* [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment.
+* [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment.
+* [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment.
+* [esc login](/docs/esc-cli/commands/esc_login/) - Log in to the Pulumi Cloud
+* [esc open](/docs/esc-cli/commands/esc_open/) - Open the environment with the given name.
+* [esc run](/docs/esc-cli/commands/esc_run/) - Open the environment with the given name and run a command.
+* [esc version](/docs/esc-cli/commands/esc_version/) - Print esc's version number

--- a/content/docs/esc-cli/commands/_index.md
+++ b/content/docs/esc-cli/commands/_index.md
@@ -24,10 +24,7 @@ The most common commands in the CLI that you'll be using are as follows:
 * [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment
 * [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment
 * [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment
-* [esc env version history](/docs/esc-cli/commands/esc_env_version_history/) - Show revision history of an environment
 * [esc env version tag](/docs/esc-cli/commands/esc_env_version_tag/) - Manage tagged versions
-* [esc env version tag ls](/docs/esc-cli/commands/esc_env_version_tag_ls/) - List tagged versions
-* [esc env version tag rm](/docs/esc-cli/commands/esc_env_version_tag_rm/) - Remove a tagged version
 * [esc login](/docs/esc-cli/commands/esc_login/) - Log in to the Pulumi Cloud
 * [esc open](/docs/esc-cli/commands/esc_open/) - Open the environment with the given name
 * [esc run](/docs/esc-cli/commands/esc_run/) - Open the environment with the given name and run a command

--- a/content/docs/esc-cli/commands/_index.md
+++ b/content/docs/esc-cli/commands/_index.md
@@ -15,14 +15,20 @@ menu:
 The most common commands in the CLI that you'll be using are as follows:
 
 * [esc env](/docs/esc-cli/commands/esc_env/) - Manage environments
+* [esc env diff](/docs/esc-cli/commands/esc_env_diff/) - Show the difference between versions of an environment
 * [esc env edit](/docs/esc-cli/commands/esc_env_edit/) - Edit an environment definition
-* [esc env get](/docs/esc-cli/commands/esc_env_get/) - Get a value within an environment.
-* [esc env init](/docs/esc-cli/commands/esc_env_init/) - Create an empty environment with the given name.
-* [esc env ls](/docs/esc-cli/commands/esc_env_ls/) - List environments.
-* [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment.
-* [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment.
-* [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment.
+* [esc env get](/docs/esc-cli/commands/esc_env_get/) - Get a value within an environment
+* [esc env init](/docs/esc-cli/commands/esc_env_init/) - Create an empty environment with the given name
+* [esc env ls](/docs/esc-cli/commands/esc_env_ls/) - List environments
+* [esc env rollback](/docs/esc-cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version.
+* [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment
+* [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment
+* [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment
+* [esc env version history](/docs/esc-cli/commands/esc_env_version_history/) - Show revision history of an environment
+* [esc env version tag](/docs/esc-cli/commands/esc_env_version_tag/) - Manage tagged versions
+* [esc env version tag ls](/docs/esc-cli/commands/esc_env_version_tag_ls/) - List tagged versions
+* [esc env version tag rm](/docs/esc-cli/commands/esc_env_version_tag_rm/) - Remove a tagged version
 * [esc login](/docs/esc-cli/commands/esc_login/) - Log in to the Pulumi Cloud
-* [esc open](/docs/esc-cli/commands/esc_open/) - Open the environment with the given name.
-* [esc run](/docs/esc-cli/commands/esc_run/) - Open the environment with the given name and run a command.
+* [esc open](/docs/esc-cli/commands/esc_open/) - Open the environment with the given name
+* [esc run](/docs/esc-cli/commands/esc_run/) - Open the environment with the given name and run a command
 * [esc version](/docs/esc-cli/commands/esc_version/) - Print esc's version number

--- a/content/docs/esc-cli/commands/_index.md
+++ b/content/docs/esc-cli/commands/_index.md
@@ -20,7 +20,7 @@ The most common commands in the CLI that you'll be using are as follows:
 * [esc env get](/docs/esc-cli/commands/esc_env_get/) - Get a value within an environment
 * [esc env init](/docs/esc-cli/commands/esc_env_init/) - Create an empty environment with the given name
 * [esc env ls](/docs/esc-cli/commands/esc_env_ls/) - List environments
-* [esc env rollback](/docs/esc-cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version.
+* [esc env rollback](/docs/esc-cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version
 * [esc env rm](/docs/esc-cli/commands/esc_env_rm/) - Remove an environment or a value from an environment
 * [esc env set](/docs/esc-cli/commands/esc_env_set/) - Set a value within an environment
 * [esc env version](/docs/esc-cli/commands/esc_env_version/) - Manage the versions of an environment


### PR DESCRIPTION
Since these two pages are hand-crafted, these lines need to be added manually.