### PR TITLE
Add ESC SDK docs with examples

### DIFF
--- a/content/docs/esc/sdk/_index.md
+++ b/content/docs/esc/sdk/_index.md
@@ -1,0 +1,51 @@
+---
+title_tag: "Pulumi ESC SDK"
+meta_desc: An overview of how to use Node.js, Go, and Python when using Pulumi ESC in your application and infrastructure code. 
+title: Pulumi ESC SDK
+h1: Pulumi ESC SDK Languages
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+  pulumiesc:
+    identifier: sdk
+    weight: 6
+---
+
+Pulumi ESC SDKs support multiple languages. Each language is as capable as the
+other and supports the entire capability of [Pulumi ESC](/docs/esc).
+
+The following language runtimes are currently supported in Pulumi ESC. Select one to go the respective documentation:  
+
+<div class="tiles flex-wrap mt-4">
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <a class="tile p-8 pb-16 text-center" href="./javascript">
+            <p class="mx-auto text-xl font-semibold link">
+                Node.js
+                <span class="text-xs font-light">(JavaScript, TypeScript)</span>
+            </p>
+            <img class="h-12 mx-auto inline" src="/logos/tech/node.svg" alt="Node.js">
+            <img class="h-12 mx-auto inline" src="/logos/tech/javascript.svg" alt="JavaScript">
+            <img class="h-12 mx-auto inline" src="/logos/tech/typescript.svg" alt="TypeScript">
+        </a>
+    </div>
+    <div class="pb-4 md:w-1/2">
+        <a class="tile p-8 pb-16 text-center" href="./python">
+            <p class="mx-auto text-xl font-semibold link">
+                Python
+            </p>
+            <img class="h-12 mx-auto inline" src="/logos/tech/python.svg" alt="Python">
+        </a>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <a class="tile p-8 pb-16 text-center" href="./go">
+            <p class="mx-auto text-xl font-semibold link">
+                Go
+            </p>
+            <img class="h-12 mx-auto inline" src="/logos/tech/go.svg" alt="Go">
+        </a>
+    </div>
+    
+
+If your favorite language isn't listed, open a new issue on our [GitHub repository](https://github.com/pulumi/esc/issues/new/choose).
+
+For further questions, [contact us](/docs/support/troubleshooting#contact-us) and let us
+know what you're looking for.

--- a/content/docs/esc/sdk/_index.md
+++ b/content/docs/esc/sdk/_index.md
@@ -43,9 +43,9 @@ The following language runtimes are currently supported in Pulumi ESC. Select on
             <img class="h-12 mx-auto inline" src="/logos/tech/go.svg" alt="Go">
         </a>
     </div>
-    
+</div>
 
-If your favorite language isn't listed, open a new issue on our [GitHub repository](https://github.com/pulumi/esc/issues/new/choose).
+If your favorite language isn't listed, open a new issue on our [GitHub repository](https://github.com/pulumi/esc-sdk/issues/new/choose).
 
 For further questions, [contact us](/docs/support/troubleshooting#contact-us) and let us
 know what you're looking for.

--- a/content/docs/esc/sdk/go.md
+++ b/content/docs/esc/sdk/go.md
@@ -1,0 +1,168 @@
+---
+title_tag: Go SDK | Pulumi ESC
+title: Go
+h1: "Pulumi ESC: Go SDK"
+meta_desc: This page provides an overview on how to use Pulumi ESC Go SDK.
+weight: 2
+menu:
+  pulumiesc:
+    parent: sdk
+    identifier: go-sdk
+---
+
+The [Go SDK](https://github.com/pulumi/esc-sdk) for [Pulumi ESC (Environments, Secrets, and Configuration)](/product/esc/) allows you to automate Pulumi ESC.
+
+Here are some of the scenarios the SDK can automate:
+
+* List environments and read environment definitions
+* Open enviroments to access config and resolve secrets
+* Create, update, decrypt, and delete environment definitions
+    * Supports both structured types and yaml text
+* List environment revisions and create new revision tags
+* Check environment definitions for errors
+
+## Install the SDK package
+
+Run `go get github.com/pulumi/esc-sdk/sdk` to install the SDK package.
+
+## Examples
+
+These samples show how to create an `EscClient` with an access token and use it to perform varias ESC tasks.
+
+All of these example expects a `PULUMI_ACCESS_TOKEN` and `PULUMI_ORG` environment variable to be set.
+
+### Manage environment example
+
+This example creates a new environment, opens that environment to access a secret, and the list the environments.
+
+{{< chooser language "go" >}}
+
+{{% choosable language "go" %}}
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	esc "github.com/pulumi/esc-sdk/sdk/go"
+)
+
+func main() {
+	accessToken := os.Getenv("PULUMI_ACCESS_TOKEN")
+	orgName := os.Getenv("PULUMI_ORG")
+	configuration := esc.NewConfiguration()
+	escClient := esc.NewClient(configuration)
+	authCtx := esc.NewAuthContext(accessToken)
+
+	envName := "sdk-go-example"
+	// Create Environment
+	err := escClient.CreateEnvironment(authCtx, orgName, envName)
+	if err != nil {
+		log.Fatalf("Failed to create environment: %v", err)
+	}
+
+	// Update Environment with Secrets
+	updatePayload := &esc.EnvironmentDefinition{
+		Values: &esc.EnvironmentDefinitionValues{
+			AdditionalProperties: map[string]interface{}{
+				"my_secret": map[string]string{
+					"fn::secret": "shh! don't tell anyone",
+				},
+			},
+		},
+	}
+
+	_, err = escClient.UpdateEnvironment(authCtx, orgName, envName, updatePayload)
+	if err != nil {
+		log.Fatalf("Failed to update environment: %v", err)
+	}
+
+	// Open and View Secrets
+	_, values, err := escClient.OpenAndReadEnvironment(authCtx, orgName, envName)
+	if err != nil {
+		log.Fatalf("Failed to open environment: %v", err)
+	}
+
+	mySecret, ok := values["my_secret"]
+	if !ok {
+		log.Fatalf("Secret 'my_secret' not found in environment %s", envName)
+	}
+
+	log.Printf("my_secret: %v\n", mySecret)
+
+	orgEnvs, err := escClient.ListEnvironments(authCtx, orgName, nil)
+	if err != nil {
+		log.Fatalf("Failed to list environments: %v", err)
+	}
+
+	for _, orgEnv := range orgEnvs.Environments {
+		log.Printf("Environment: %v\n", orgEnv.Name)
+	}
+
+}
+
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+
+### Tag revision example
+
+This example lists revisions for an environment, tags a revision, and lists revision tags.
+
+{{< chooser language "go" >}}
+
+{{% choosable language "go" %}}
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	esc "github.com/pulumi/esc-sdk/sdk/go"
+)
+
+func main() {
+	accessToken := os.Getenv("PULUMI_ACCESS_TOKEN")
+	orgName := os.Getenv("PULUMI_ORG")
+	configuration := esc.NewConfiguration()
+	escClient := esc.NewClient(configuration)
+	authCtx := esc.NewAuthContext(accessToken)
+
+	envName := "sdk-go-example"
+	revs, err := escClient.ListEnvironmentRevisions(authCtx, orgName, envName)
+	if err != nil {
+		log.Fatalf("Failed to list environment revisions: %v", err)
+	}
+
+	if len(revs) < 2 {
+		return
+	}
+
+	// get the second latest revision
+	secondLatestRev := revs[1]
+	err = escClient.CreateEnvironmentRevisionTag(authCtx, orgName, envName, "stable", secondLatestRev.Number)
+	if err != nil {
+		log.Fatalf("Failed to tag environment revision: %v", err)
+	}
+
+	log.Printf("Tagged revision %d as 'stable'", secondLatestRev.Number)
+
+	tags, err := escClient.ListEnvironmentRevisionTags(authCtx, orgName, envName)
+	if err != nil {
+		log.Fatalf("Failed to list environment revision tags: %v", err)
+	}
+
+	for _, tag := range tags.Tags {
+		log.Printf("Tag %s at revision %d", tag.Name, tag.Revision)
+	}
+}
+
+```
+
+{{% /choosable %}}
+{{< /chooser >}}

--- a/content/docs/esc/sdk/javascript.md
+++ b/content/docs/esc/sdk/javascript.md
@@ -1,0 +1,151 @@
+---
+title_tag: TypeScript/JavaScript SDK | Pulumi ESC
+title: TypeScript (Node.js)
+h1: "Pulumi ESC: TypeScript/JavaScript SDK"
+meta_desc: This page provides an overview on how to use Pulumi ESC TypeScript/JavaScript SDK.
+weight: 2
+menu:
+  pulumiesc:
+    parent: sdk
+    identifier: typescript-sdk
+---
+
+The [JavaScript/TypeScript SDK](https://www.npmjs.com/package/@pulumi/esc-sdk) for [Pulumi ESC (Environments, Secrets, and Configuration)](/product/esc/) allows you to automate Pulumi ESC.
+
+Here are some of the scenarios the SDK can automate:
+
+* List environments and read environment definitions
+* Open enviroments to access config and resolve secrets
+* Create, update, decrypt, and delete environment definitions
+    * Supports both structured types and yaml text
+* List environment revisions and create new revision tags
+* Check environment definitions for errors
+
+## Install the SDK package
+
+Run `npm install @pulumi/esc-sdk` or `yarn add @pulumi/esc-sdk` to install the SDK package.
+
+## Examples
+
+These samples show how to create an `EscApi` client with an access token and use it to perform varias ESC tasks.
+
+All of these example expects a `PULUMI_ACCESS_TOKEN` and `PULUMI_ORG` environment variable to be set.
+
+### Manage environment example
+
+This example creates a new environment, opens that environment to access a secret, and the list the environments.
+
+{{< chooser language "typescript" >}}
+
+{{% choosable language "typescript" %}}
+
+```typescript
+import * as esc from "@pulumi/esc-sdk";
+
+async function main() {
+    const PULUMI_ACCESS_TOKEN = process.env.PULUMI_ACCESS_TOKEN!;
+    const orgName = process.env.PULUMI_ORG!;
+    const config = new esc.Configuration({ accessToken: PULUMI_ACCESS_TOKEN });
+    const client = new esc.EscApi(config);
+
+    const envName = "sdk-typescript-example";
+
+    // Create a new environment
+    await client.createEnvironment(orgName, envName);
+
+    const envDef: esc.EnvironmentDefinition = {
+        values: {
+            my_secret: {
+                "fn::secret": "shh! don't tell anyone",
+            },
+        },
+    };
+
+    // Update the environment with the new definition
+    await client.updateEnvironment(orgName, envName, envDef);
+
+    // Open and read the environment
+    const openEnv = await client.openAndReadEnvironment(orgName, envName);
+
+    if (!openEnv) {
+        console.error("Failed to open and read the environment");
+        return;
+    }
+
+    // Acces the value of the secret
+    const secretValue = openEnv.values?.my_secret;
+    console.log(`Secret value: ${secretValue}\n`);
+
+    // List all the environments in the organization
+    const orgEnvs = await client.listEnvironments(orgName);
+    if (!orgEnvs || !orgEnvs.environments) {
+        console.log("No environments found");
+        return;
+    }
+
+    for (const env of orgEnvs.environments) {
+        console.log(`Environment: ${env.name}`);
+    }
+}
+
+(async ()=>{
+    await main();
+})();
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+
+### Tag revision example
+
+This example lists revisions for an environment, tags a revision, and lists revision tags.
+
+{{< chooser language "typescript" >}}
+
+{{% choosable language "typescript" %}}
+
+```typescript
+
+import * as esc from "@pulumi/esc-sdk";
+
+async function main() {
+    const PULUMI_ACCESS_TOKEN = process.env.PULUMI_ACCESS_TOKEN!;
+    const orgName = process.env.PULUMI_ORG!;
+    const config = new esc.Configuration({ accessToken: PULUMI_ACCESS_TOKEN });
+    const client = new esc.EscApi(config);
+
+    const envName = "sdk-typescript-example";
+
+    // List environment revisions
+    const revisions = await client.listEnvironmentRevisions(orgName, envName);
+
+    if (!revisions || revisions.length < 2) {
+        throw new Error(`Expected at least 2 revisions for environment ${envName}`);
+    }
+
+    // Get the second latest revision
+    const revision = revisions[1];
+    await client.createEnvironmentRevisionTag(orgName, envName, "stable", revision.number);
+
+    console.log(`Tagged revision ${revision.number} as 'stable'`);
+
+    // List tags
+    const tags = await client.listEnvironmentRevisionTags(orgName, envName);
+    if (!tags || !tags.tags) {
+        throw new Error(`Expected tags for environment ${envName}`);
+    }
+
+    for (const tag of tags?.tags) {
+        console.log(`Tag ${tag.name} at revision ${tag.revision}`);
+    }
+}
+
+(async ()=>{
+    await main();
+})();
+
+
+```
+
+{{% /choosable %}}
+{{< /chooser >}}

--- a/content/docs/esc/sdk/python.md
+++ b/content/docs/esc/sdk/python.md
@@ -1,0 +1,134 @@
+---
+title_tag: Python SDK | Pulumi ESC
+title: Python
+h1: "Pulumi ESC: Python SDK"
+meta_desc: This page provides an overview on how to use Pulumi ESC Python SDK.
+weight: 2
+menu:
+  pulumiesc:
+    parent: sdk
+    identifier: python-sdk
+---
+
+The [Python SDK](https://pypi.org/project/pulumi-esc-sdk/) for [Pulumi ESC (Environments, Secrets, and Configuration)](/product/esc/) allows you to automate Pulumi ESC.
+
+Here are some of the scenarios the SDK can automate:
+
+* List environments and read environment definitions
+* Open enviroments to access config and resolve secrets
+* Create, update, decrypt, and delete environment definitions
+    * Supports both structured types and yaml text
+* List environment revisions and create new revision tags
+* Check environment definitions for errors
+
+## Install the SDK package
+
+Run `pip install pulumi-esc-sdk` to install the SDK package.
+
+## Examples
+
+These samples show how to create an `EscClient` with an access token and use it to perform varias ESC tasks.
+
+All of these example expects a `PULUMI_ACCESS_TOKEN` and `PULUMI_ORG` environment variable to be set.
+
+### Manage environment example
+
+This example creates a new environment, opens that environment to access a secret, and the list the environments.
+
+{{< chooser language "python" >}}
+
+{{% choosable language "python" %}}
+
+```python
+import pulumi_esc_sdk as esc
+import os
+
+accessToken = os.getenv("PULUMI_ACCESS_TOKEN")
+
+orgName = os.getenv("PULUMI_ORG")
+
+configuration = esc.Configuration(access_token=accessToken)
+client = esc.EscClient(configuration)
+
+envName = "sdk-python-example"
+
+# Create environment
+client.create_environment(orgName, envName)
+
+# create a new EnvironmentDefinition with "my_secret" as a secret in values additional_properties
+envDef = esc.EnvironmentDefinition(
+    imports=[],
+    values=esc.EnvironmentDefinitionValues(
+        additional_properties={
+            "my_secret": {
+                "fn::secret": "shh! don't tell anyone"
+            }
+        }
+    )
+)
+
+# Update environment
+client.update_environment(orgName, envName, envDef)
+
+# Open and read the environment
+
+env, values, yaml = client.open_and_read_environment(orgName, envName)
+
+secret = values["my_secret"]
+print(f'Secret: {secret}\n')
+
+# List environments
+
+environments = client.list_environments(orgName)
+
+for env in environments.environments:
+    print(f'Environment: {env.name}')
+
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+
+### Tag revision example
+
+This example lists revisions for an environment, tags a revision, and lists revision tags.
+
+{{< chooser language "python" >}}
+
+{{% choosable language "python" %}}
+
+```python
+import pulumi_esc_sdk as esc
+import os
+
+accessToken = os.getenv("PULUMI_ACCESS_TOKEN")
+
+orgName = os.getenv("PULUMI_ORG")
+
+configuration = esc.Configuration(access_token=accessToken)
+client = esc.EscClient(configuration)
+
+envName = "sdk-python-example"
+
+# list environment revisions
+
+revisions = client.list_environment_revisions(orgName, envName)
+
+# get second latest revision
+second_latest_revision = revisions[1]
+
+# create a new environment revision tag
+client.create_environment_revision_tag(orgName, envName, "stable", second_latest_revision.number)
+
+print(f'Tagged revision {second_latest_revision.number} as stable')
+
+# list environment revision tags
+tags = client.list_environment_revision_tags(orgName, envName)
+
+for tag in tags.tags:
+    print(f'Tag {tag.name} at revision {tag.revision}')
+
+```
+
+{{% /choosable %}}
+{{< /chooser >}}


### PR DESCRIPTION
SDK Docs with examples for python, typescript, go.

I do not have reference docs yet, that will be a fast follow with the new build that includes jsdoc, pydoc comments.
