### PR TITLE
Add better support for deploying dev stacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,7 @@ lint:
 .PHONY: format
 format:
 	./scripts/format.sh
+
+.PHONY: deploy-dev-stack
+deploy-dev-stack:
+	./scripts/deploy-dev-stack.sh $1

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The `Makefile` exposes a number of useful helpers for authoring:
 * `make generate` builds the TypeScript, Python, and Pulumi CLI documentation
 * `make new-blog-post` scaffolds a new, bare-bones blog post with placeholder content
 * `make new-example-program` generates a new multi-language set of examples at `./static/programs`
+* `make deploy-dev-stack` runs a build, deploys to S3, runs the tests, and deploys to the selected dev stack
 
 As a content contributor, the commands you'll use most often are these:
 

--- a/scripts/deploy-dev-stack.sh
+++ b/scripts/deploy-dev-stack.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+source ./scripts/common.sh
+
+# This script runs a full site build, deploys to a unique S3 bucket, and runs Pulumi to deploy the specified stack.
+#
+# Usage:
+#
+#   ./scripts/deploy-dev-stack.sh                               # Runs a full build. Prompts for stack name and before update.
+#   ./scripts/deploy-dev-stack.sh pulumi/stackname              # Runs a full build, skipping the prompt for stack name.
+#   STACK_NAME=pulumi/stackname ./scripts/deploy-dev-stack.sh   # Same as above.
+#   SKIP_BUILD=true ./scripts/deploy-dev-stack.sh               # Skips the build step and goes straight to deployment, but still prompts before update.
+#   SKIP_PREVIEW=true ./scripts/deploy-dev-stack.sh             # Skips the preview before updating. (Is the same as passing --yes.)
+
+echo
+echo "Listing available stacks for this project..."
+echo
+pulumi -C infrastructure stack ls | grep -v "production" | grep -v "staging" | grep -v "testing"
+
+stack_name="${STACK_NAME:=$1}"
+
+if [ -z "$stack_name" ]; then
+    echo
+    read -p "Which stack would you like to deploy? " stack_name
+fi
+
+if [[ "$stack_name" == *production* || "$stack_name" == *staging* || "$stack_name" == *testing* ]]; then
+    echo
+    echo "Refusing to deploy the $stack_name stack with this script. Exiting."
+    exit 0
+fi
+
+echo
+echo "Selecting the $stack_name stack..."
+pulumi -C infrastructure stack select "$stack_name"
+
+if [[ -z "$SKIP_BUILD" || "$SKIP_BUILD" == false ]]; then
+    echo
+    echo "Running a build and deploying to S3..."
+
+    # This environment variable doesn't actually correspond to any real environment; it just populates a variable
+    # we use to name the S3 bucket. (In GHA, we use it to target a GHA environment, but in this context, it has no effect.)
+    DEPLOYMENT_ENVIRONMENT="dev" ./scripts/on-demand-build-sync-test.sh
+else
+    echo
+    echo "Skipping build..."
+fi
+
+echo
+echo "Deploying..."
+echo
+
+if [[ "$SKIP_PREVIEW" == true ]]; then
+    pulumi -C infrastructure up --skip-preview
+else
+    pulumi -C infrastructure up
+fi
+
+echo "Done!"
+echo
+echo "https://$(pulumi -C infrastructure stack output websiteDomain)"
+echo


### PR DESCRIPTION
Adds a script and Makefile target to make it easier to deploy to a dev stack. Assumes the target dev stack already exists, and filters out stacks named `production`, `staging`, or `testing`.

Usage:

```bash
# Prompt for all values (stack name, update approval)
make deploy-dev-stack

# Optionally set the stack name, skip build, or skip previews
STACK_NAME=pulumi/christian SKIP_BUILD=true SKIP_PREVIEW=true make deploy-dev-stack
```