### PR TITLE
Use bot token only for posting previews

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -49,7 +49,7 @@ jobs:
           PULUMI_STACK_NAME: ${{ vars.PULUMI_STACK_NAME }}
           DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
           ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
           ALGOLIA_APP_ADMIN_KEY: ${{  secrets.ALGOLIA_APP_ADMIN_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,7 +45,8 @@ jobs:
           PULUMI_STACK_NAME: ${{ vars.PULUMI_STACK_NAME }}
           DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
           ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
           ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
           ALGOLIA_APP_ADMIN_KEY: ${{  secrets.ALGOLIA_APP_ADMIN_KEY }}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -30,7 +30,7 @@ post_github_pr_comment() {
 
     curl -s \
          -X POST \
-         -H "Authorization: token ${GITHUB_TOKEN}" \
+         -H "Authorization: token ${PULUMI_BOT_TOKEN}" \
          -d "$pr_comment_body" \
          $pr_comment_api_url > /dev/null
 }


### PR DESCRIPTION
We are running into rate limitting issues with the PULUMI_BOT_TOKEN, so using it only to post the preview links as this is what it was needed for and using the default GITHUB_TOKEN everywhere else. The default GITHUB_TOKEN is ephemeral and a new one is generated for each run, so less likely it will run into the rate limit.