### PR TITLE
Skip PR workflows for forks

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -8,6 +8,8 @@ permissions:
       contents: read    # This is required for actions/checkout
 jobs:
   do_cleanup:
+    # Only run this job for events that originate on this repository.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: Do cleanup
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,8 @@ permissions:
       contents: read    # This is required for actions/checkout
 jobs:
   buildSite:
+    # Only run this job for events that originate on this repository.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Install deps and build site


### PR DESCRIPTION
Does what's on the label -- we skip these because we can't run them, as they depend on environment variables and secrets that aren't exposed to forks.
