### PR TITLE
Add missing C# file content for new project

### DIFF
--- a/content/learn/pulumi-fundamentals/create-a-pulumi-project/index.md
+++ b/content/learn/pulumi-fundamentals/create-a-pulumi-project/index.md
@@ -260,7 +260,7 @@ For YAML, your {{< langfile >}} is also your program's main entrypoint file.
 Use the command <code>cat</code>{{< langfile >}} to explore the contents of your
 project's empty program:
 
-{{< chooser language "typescript,python,go,java,yaml" / >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language typescript %}}
 
@@ -294,6 +294,27 @@ func main() {
 		return nil
 	})
 }
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+using System.Collections.Generic;
+using Pulumi;
+
+return await Deployment.RunAsync(() =>
+{
+    // Add your resources here
+    // e.g. var resource = new Resource("name", new ResourceArgs { });
+
+    // Export outputs here
+    return new Dictionary<string, object?>
+    {
+        ["outputKey"] = "outputValue"
+    };
+});
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
Fixes #12017

The bug was caused because not all language checkers had a `csharp` entry, and since the language checker is global it doesn't make sense to display a language that can't be selected for one checker.

Ideally, we would introduce a lint failure to make this mistake impossible (and catch other places where we made the mistake). That is out of scope for this PR.