### PR TITLE
Update runner references to ubuntu-latest

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,13 +5,13 @@ on:
       - master
 permissions:
       id-token: write   # This is required for requesting the JWT
-      contents: read    # This is required for actions/checkout
+      contents: read   # This is required for actions/checkout
 jobs:
   buildSite:
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Install deps and build site
-    runs-on: ubuntu-22.04-8core
+    runs-on: ubuntu-latest
     environment: production
     steps:
 

--- a/.github/workflows/check-lighthouse.yml
+++ b/.github/workflows/check-lighthouse.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   all:
     name: Lighthouse
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Run Lighthouse
         uses: treosh/lighthouse-ci-action@v8

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Install deps and build site
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: testing
     steps:
 

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Install deps and build site
-    runs-on: ubuntu-22.04-8core
+    runs-on: ubuntu-latest
     environment: testing
     steps:
 


### PR DESCRIPTION
The `ubuntu-22.04-8core` runner seems no longer valid (causing jobs to get stuck in the queue). This updates all of our runners to use `ubuntu-latest`.


Fixes https://github.com/pulumi/docs/issues/12074.