### PR TITLE
Add new runtime options

### DIFF
--- a/content/docs/concepts/projects/project-file.md
+++ b/content/docs/concepts/projects/project-file.md
@@ -57,9 +57,11 @@ The runtime attribute has an additional property called `options` where you can 
 | - | - | - |
 | `typescript` | Only applies to the `nodejs` runtime | Boolean indicating whether to use `ts-node` or not. |
 | `nodeargs` | Only applies to the `nodejs` runtime | Arguments to pass to `node`. |
+| `packagemanager` | Only applies to the `nodejs` runtime | Packagemanager to use for installing dependencies, `npm` (default), `pnpm` or `yarn`. |
 | `buildTarget` | Only applies to the `go` runtime | Path to save the compiled go binary to. |
 | `binary` | applies to the `go`, `dotnet`, and `java` runtimes | Path to a pre-built executable. |
-| `virtualenv` | Only applies to the `python` runtime | Virtual environment path. |
+| `toolchain` | Only applies to the `python` runtime | Toolchain to use for managing virtual environments, `pip` (default) or `poetry`. |
+| `virtualenv` | Only applies to the `python` runtime with the `pip` toolchain. | Virtual environment path. |
 | `typechecker` | Only applies to the `python` runtime | Type checker library to use. |
 | `compiler` | Only applies to the `yaml` runtime | Executable and arguments issued to standard out. |
 


### PR DESCRIPTION
The python runtime has a new `toolchain` option.
The nodejs runtime has a new `packagemanager` option.

[Preview](http://www-testing-pulumi-docs-origin-pr-12110-ddc9bf77.s3-website.us-west-2.amazonaws.com/docs/concepts/projects/project-file/#runtime-options)

Fixes https://github.com/pulumi/docs/issues/12109
Ref https://github.com/pulumi/pulumi/issues/15937

I'll follow up with a PR to explain the toolchain option, and the poetry choice, in the python SDK docs.