### PR TITLE
Do not recommend using a `-native` suffix for native providers

### DIFF
--- a/content/docs/using-pulumi/pulumi-packages/how-to-author.md
+++ b/content/docs/using-pulumi/pulumi-packages/how-to-author.md
@@ -43,7 +43,7 @@ To get started, click the link for the boilerplate repository template that you 
 You should name your repository (and thus, your Pulumi Package) using the following guidelines:
 
 - The name should start with `pulumi-`, like our [`pulumi-aws-native`](/registry/packages/aws-native) AWS Native Provider and our [`pulumi-eks`](/registry/packages/eks) Component for AWS Elastic Kubernetes Service (EKS)
-- If you're naming a **native provider**, use the cloud provider's name and the suffix `-native`, like our [`pulumi-azure-native`](/registry/packages/azure-native) Azure Native Provider
+- If you're naming a **native provider**, use the cloud provider's name, like our [`pulumi-kubernetes`](/registry/packages/kubernetes) Kubernetes Provider
 - If you're naming a **bridged provider**, re-use the Terraform provider's name but replace the `terraform-provider-` prefix with `pulumi-`
 - If you're naming a **component**, name your package using both the cloud provider whose resources you're building on top of and the resources, like our [`pulumi-aws-apigateway`](/registry/packages/aws-apigateway) Component for AWS API Gateway
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

My understanding was that we were moving away from `-native` naming schemes. If so, we shouldn't recommend it to others.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
