### PR TITLE
Add the 'b' page to the link checker

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -367,6 +367,9 @@ async function getURLsToCheck(base) {
                 // Tack on any additional pages we'd like to check.
                 .concat([
                     "https://github.com/pulumi/pulumi",
+
+                    // Alternative version of the home page for Google ads.
+                    "https://www.pulumi.com/b/",
                 ])
 
                 // Sort everything alphabetically.


### PR DESCRIPTION
Adds https://www.pulumi.com/b to the link checker to alert on accidental deletion.
