### PR TITLE
fix(cloud-rest-api): remove continuationToken from List Teams

### DIFF
--- a/content/docs/pulumi-cloud/cloud-rest-api/_index.md
+++ b/content/docs/pulumi-cloud/cloud-rest-api/_index.md
@@ -1835,7 +1835,6 @@ GET /api/orgs/{organization}/teams
 | Parameter           | Type   | In    | Description                                                                                                  |
 |---------------------|--------|-------|--------------------------------------------------------------------------------------------------------------|
 | `organization`      | string | path  | organization name                                                                                            |
-| `continuationToken` | string | query | **Optional.** the continuation token to use for retrieving the next set of results if results were truncated |
 
 #### Example
 


### PR DESCRIPTION
Removes `continuationToken` from List Teams API docs - it is ignored in the backend.

### Related issues (optional)

Fixes #12156 
