### PR TITLE
Add check for empty email form submissions

### DIFF
--- a/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
+++ b/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
@@ -148,7 +148,7 @@ export class HubspotForm {
                 utmSource: utmData.source,
                 utmMedium: utmData.medium,
             };
-            if(emailAddress !== ""){
+            if(emailAddress !== ""){ // Don't track empty email addresses
                 analytics.track("form-submission", submissionData);
             }
         }

--- a/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
+++ b/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
@@ -148,8 +148,9 @@ export class HubspotForm {
                 utmSource: utmData.source,
                 utmMedium: utmData.medium,
             };
-
-            analytics.track("form-submission", submissionData);
+            if(emailAddress !== ""){
+                analytics.track("form-submission", submissionData);
+            }
         }
     }
 

--- a/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
+++ b/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
@@ -140,7 +140,7 @@ export class HubspotForm {
         const analytics = (window as any).analytics;
         const analyticsAvailable = analytics && analytics.track && typeof analytics.track === "function";
 
-        if (analyticsAvailable) {
+        if (analyticsAvailable && emailAddress !== "") { // Don't track empty email addresses
             const submissionData = {
                 formId: this.formId,
                 email: emailAddress,
@@ -148,9 +148,7 @@ export class HubspotForm {
                 utmSource: utmData.source,
                 utmMedium: utmData.medium,
             };
-            if(emailAddress !== ""){ // Don't track empty email addresses
-                analytics.track("form-submission", submissionData);
-            }
+            analytics.track("form-submission", submissionData);
         }
     }
 


### PR DESCRIPTION
## Description

This PR addresses issue https://github.com/pulumi/marketing/issues/864 by adding a check to make sure events generated from Hubspot's callback do not generate fake form submission events to Segment, polluting metrics with empty form fills.
