### PR TITLE
Explain how update plans are executed

### DIFF
--- a/content/docs/concepts/update-plans.md
+++ b/content/docs/concepts/update-plans.md
@@ -32,6 +32,12 @@ To generate an update plan run `pulumi preview --save-plan=plan.json`. The plan 
 
 To use an update plan run `pulumi up --plan=plan.json`, this will constrain the update to only the operations that were saved to the plan.
 
+An update plan constrains the pulumi up operation to allow only the changes described in the plan. No other changes will be applied.
+
+It's important to note that the plan is not evaluated in an all-or-nothing fashion before changes are applied. Instead, update operations run in batches as the program execution progresses and resources resolve their input values. At any point, if any discrepancy between the plan and the actual execution is detected, the `pulumi up` operation will immediately fail, preventing any unexpected updates.
+
+This approach ensures that only planned changes are applied while allowing for the natural resolution of resource dependencies during execution.
+
 ## Limitations
 
 Update plans can only record information that is available at preview time. This means there are some program


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

A customer asked a question why their update plans were failing _after_ some changes were applied to the stack. I tried to reflect my answer to them in the docs.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
