### PR TITLE
Compilation fix for Apply/Outputs and Strings Go example

### DIFF
--- a/content/docs/concepts/inputs-outputs/apply.md
+++ b/content/docs/concepts/inputs-outputs/apply.md
@@ -988,7 +988,7 @@ pulumi.export("InstanceUrl", url)
 {{< example-program-snippet path="aws-ec2-instance-with-sg" language="go" from="24" to="26" >}}
 {{< example-program-snippet path="aws-ec2-instance-with-sg" language="go" from="28" to="31" >}}
 
-        url := server.PublicDns.ApplyT(func(dns string) (string, error) {
+        url := server.PublicDns.ApplyT(func(dns string) string {
 			return "https://" + dns
 		}).(pulumi.StringOutput)
 


### PR DESCRIPTION
### Proposed changes

The Go example [Outputs and Strings](https://www.pulumi.com/docs/concepts/inputs-outputs/apply/#accessing-single-outputs-with-apply) doesn't compile due to mismatch between return value (1) and expected return values (2) in `ApplyT`. This PR fixes that. 
