### PR TITLE
Send production deploy failures to docs-ops-critical

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:
-          SLACK_CHANNEL: docs-ops
+          SLACK_CHANNEL: docs-ops-critical
           SLACK_COLOR: "#F54242"
           SLACK_MESSAGE: "build and deploy failure in pulumi/docs repo :meow_sad:"
           SLACK_USERNAME: docsbot


### PR DESCRIPTION
part of: https://github.com/pulumi/devrel-team/issues/893

As a way to help differentiate more critical alerts that need to be addressed with immediacy from those that are less urgent, this will send the production build and deploy pipeline failures (indicating a blockage of our prod pipeline) to the #docs-ops critical channel. Let me know what you think.