### PR TITLE
Fix Docker image reference in tutorials

### DIFF
--- a/content/tutorials/importing/getting-started/index.md
+++ b/content/tutorials/importing/getting-started/index.md
@@ -40,7 +40,7 @@ resource "docker_image" "frontend" {
 }
 
 resource "docker_image" "mongo" {
-  name         = "pulumi/tutorial-pulumi-fundamentals-database-local:latest"
+  name         = "pulumi/tutorial-pulumi-fundamentals-database:latest"
   keep_locally = false
 }
 

--- a/content/tutorials/pulumi-fundamentals/configure-and-provision/index.md
+++ b/content/tutorials/pulumi-fundamentals/configure-and-provision/index.md
@@ -79,7 +79,7 @@ const frontend = new docker.RemoteImage(`${frontendImageName}Image`, {
 
 // Pull the MongoDB image
 const mongoImage = new docker.RemoteImage("mongoImage", {
-    name: "pulumi/tutorial-pulumi-fundamentals-database-local:latest",
+    name: "pulumi/tutorial-pulumi-fundamentals-database:latest",
 });
 ```
 
@@ -115,7 +115,7 @@ frontend = docker.RemoteImage(
 
 # Pull the MongoDB image
 mongo_image = docker.RemoteImage(
-    "mongo_image", name="pulumi/tutorial-pulumi-fundamentals-database-local:latest"
+    "mongo_image", name="pulumi/tutorial-pulumi-fundamentals-database:latest"
 )
 ```
 
@@ -439,7 +439,7 @@ const frontend = new docker.RemoteImage(`${frontendImageName}Image`, {
 
 // Pull the MongoDB image
 const mongoImage = new docker.RemoteImage("mongoImage", {
-    name: "pulumi/tutorial-pulumi-fundamentals-database-local:latest",
+    name: "pulumi/tutorial-pulumi-fundamentals-database:latest",
 });
 
 // Create a Docker network
@@ -546,7 +546,7 @@ frontend = docker.RemoteImage(
 
 # Pull the MongoDB image
 mongo_image = docker.RemoteImage(
-    "mongo_image", name="pulumi/tutorial-pulumi-fundamentals-database-local:latest"
+    "mongo_image", name="pulumi/tutorial-pulumi-fundamentals-database:latest"
 )
 
 # Create a Docker network

--- a/content/tutorials/pulumi-fundamentals/create-docker-images/index.md
+++ b/content/tutorials/pulumi-fundamentals/create-docker-images/index.md
@@ -380,7 +380,7 @@ const frontend = new docker.RemoteImage(`${frontendImageName}Image`, {
 
 // Pull the MongoDB image
 const mongoImage = new docker.RemoteImage("mongoImage", {
-    name: "pulumi/tutorial-pulumi-fundamentals-database-local:latest",
+    name: "pulumi/tutorial-pulumi-fundamentals-database:latest",
 });
 ```
 
@@ -398,7 +398,7 @@ frontend = docker.RemoteImage(
 
 # Pull the MongoDB image
 mongo_image = docker.RemoteImage(
-    "mongo_image", name="pulumi/tutorial-pulumi-fundamentals-database-local:latest"
+    "mongo_image", name="pulumi/tutorial-pulumi-fundamentals-database:latest"
 )
 ```
 
@@ -421,7 +421,7 @@ ctx.Export("frontendDockerImage", frontendImage.Name)
 
 // Pull the MongoDB image
 mongoImage, err := docker.NewRemoteImage(ctx, "mongo-image", &docker.RemoteImageArgs{
-	Name: pulumi.String("pulumi/tutorial-pulumi-fundamentals-database-local:latest"),
+	Name: pulumi.String("pulumi/tutorial-pulumi-fundamentals-database:latest"),
 })
 if err != nil {
 	return err
@@ -447,7 +447,7 @@ final var frontendImage = new RemoteImage(
 final var mongoImage = new RemoteImage(
         "mongoImage",
         RemoteImageArgs.builder()
-                .name("pulumi/tutorial-pulumi-fundamentals-database-local:latest")
+                .name("pulumi/tutorial-pulumi-fundamentals-database:latest")
                 .build()
 );
 ```
@@ -467,7 +467,7 @@ frontend-image:
 mongo-image:
     type: docker:index:RemoteImage
     properties:
-      name: pulumi/tutorial-pulumi-fundamentals-database-local:latest
+      name: pulumi/tutorial-pulumi-fundamentals-database:latest
 ```
 
 {{% /choosable %}}
@@ -500,7 +500,7 @@ const frontend = new docker.RemoteImage(`${frontendImageName}Image`, {
 
 // Pull the MongoDB image
 const mongoImage = new docker.RemoteImage("mongoImage", {
-    name: "pulumi/tutorial-pulumi-fundamentals-database-local:latest",
+    name: "pulumi/tutorial-pulumi-fundamentals-database:latest",
 });
 ```
 
@@ -530,7 +530,7 @@ frontend = docker.RemoteImage(
 
 # Pull the MongoDB image
 mongo_image = docker.RemoteImage(
-    "mongo_image", name="pulumi/tutorial-pulumi-fundamentals-database-local:latest"
+    "mongo_image", name="pulumi/tutorial-pulumi-fundamentals-database:latest"
 )
 ```
 


### PR DESCRIPTION
The image references here appear to be wrong. The `-local` image referenced in the Fundamentals tutorial [isn't available in multiple architectures](https://hub.docker.com/r/pulumi/tutorial-pulumi-fundamentals-database-local/tags), which means Linux users aren't able to finish the tutorial. We do, however, seem to build this image for multiple architectures (as [pulumi/tutorial-pulumi-fundamentals-database](https://hub.docker.com/r/pulumi/tutorial-pulumi-fundamentals-database/tags)), so it looks like all we have to do to fix this issue is point to that one instead. (The fix also seems to be confirmed by [this user's comment](https://github.com/pulumi/tutorial-pulumi-fundamentals/issues/11#issuecomment-1741806057).)

Fixes https://github.com/pulumi/tutorial-pulumi-fundamentals/issues/11.