### PR TITLE
Experiment with different docs nav structure

### DIFF
--- a/content/docs/cli/_index.md
+++ b/content/docs/cli/_index.md
@@ -6,9 +6,9 @@ h1: Pulumi CLI overview
 no_on_this_page: true
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  cli:
-    name: Overview
-    weight: 3
+  pulumiiac:
+    identifier: cli
+    weight: 8
 aliases:
 - /docs/reference/commands/
 - /docs/tour/basics-deploying/

--- a/content/docs/cli/command-line-completion.md
+++ b/content/docs/cli/command-line-completion.md
@@ -5,7 +5,8 @@ title: Command-line completion
 h1: Pulumi CLI command-line completion
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  cli:
+  pulumiiac:
+    parent: cli
     weight: 3
 ---
 

--- a/content/docs/cli/commands/_index.md
+++ b/content/docs/cli/commands/_index.md
@@ -5,7 +5,8 @@ title: Commands
 h1: Pulumi CLI commands
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  cli:
+  pulumiiac:
+    parent: cli
     weight: 1
     identifier: commands
 ---

--- a/content/docs/cli/environment-variables.md
+++ b/content/docs/cli/environment-variables.md
@@ -5,7 +5,8 @@ title: Environment variables
 h1: Pulumi CLI environment variables
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  cli:
+  pulumiiac:
+    parent: cli
     weight: 2
 aliases:
 - /docs/reference/cli/environment-variables/

--- a/content/docs/clouds/_index.md
+++ b/content/docs/clouds/_index.md
@@ -5,8 +5,8 @@ title: "Clouds"
 no_on_this_page: true
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  clouds:
-    name: Overview
+  pulumiiac:
+    identifier: clouds
     weight: 3
 ---
 

--- a/content/docs/clouds/aws/_index.md
+++ b/content/docs/clouds/aws/_index.md
@@ -5,7 +5,8 @@ title: "AWS"
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 h1: AWS & Pulumi
 menu:
-  clouds:
+  pulumiiac:
+    parent: clouds
     identifier: aws
     weight: 1
 cloud_overview: true

--- a/content/docs/clouds/aws/get-started/_index.md
+++ b/content/docs/clouds/aws/get-started/_index.md
@@ -4,7 +4,7 @@ title: Get started
 h1: Get started with Pulumi & AWS
 meta_desc: This page provides an overview and guide on how to get started with AWS.
 menu:
-  clouds:
+  pulumiiac:
     parent: aws
     identifier: aws-get-started
     weight: 1

--- a/content/docs/clouds/aws/get-started/begin.md
+++ b/content/docs/clouds/aws/get-started/begin.md
@@ -5,7 +5,7 @@ h1: "Pulumi & AWS: Before you begin"
 meta_desc: This page provides an overview on how to get started with Pulumi when starting an AWS project.
 weight: 2
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-get-started
     identifier: aws-get-started-begin
 

--- a/content/docs/clouds/aws/get-started/create-project.md
+++ b/content/docs/clouds/aws/get-started/create-project.md
@@ -5,7 +5,7 @@ h1: "Pulumi & AWS: Create new project"
 meta_desc: This page provides an overview of how to create a new AWS + Pulumi project.
 weight: 3
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-get-started
     identifier: aws-get-started-create-project
 

--- a/content/docs/clouds/aws/get-started/deploy-changes.md
+++ b/content/docs/clouds/aws/get-started/deploy-changes.md
@@ -5,7 +5,7 @@ h1: "Pulumi & AWS: Deploy changes"
 meta_desc: Learn how to deploy changes to an AWS project in this guide.
 weight: 7
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-get-started
     identifier: aws-get-started-deploy-changes
 aliases:

--- a/content/docs/clouds/aws/get-started/deploy-stack.md
+++ b/content/docs/clouds/aws/get-started/deploy-stack.md
@@ -5,7 +5,7 @@ h1: "Pulumi & AWS: Deploy stack"
 meta_desc: Learn how to deploy your stack to an AWS project in this guide.
 weight: 5
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-get-started
     identifier: aws-get-started-deploy-stack
 

--- a/content/docs/clouds/aws/get-started/destroy-stack.md
+++ b/content/docs/clouds/aws/get-started/destroy-stack.md
@@ -5,7 +5,7 @@ h1: "Pulumi & AWS: Destroy stack"
 meta_desc: This page provides an overview of how to destroy a Pulumi stack of an AWS project.
 weight: 8
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-get-started
     identifier: aws-get-started-destroy-stack
 

--- a/content/docs/clouds/aws/get-started/modify-program.md
+++ b/content/docs/clouds/aws/get-started/modify-program.md
@@ -5,7 +5,7 @@ h1: "Pulumi & AWS: Modify program"
 meta_desc: This page provides an overview on how to update an AWS project from a Pulumi program.
 weight: 6
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-get-started
     identifier: aws-get-started-modify-program
 

--- a/content/docs/clouds/aws/get-started/next-steps.md
+++ b/content/docs/clouds/aws/get-started/next-steps.md
@@ -6,7 +6,7 @@ meta_desc: This page provides a list of tutorials that take a deeper dive into
             AWS cloud resources.
 weight: 9
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-get-started
     identifier: aws-get-started-next-steps
 

--- a/content/docs/clouds/aws/get-started/review-project.md
+++ b/content/docs/clouds/aws/get-started/review-project.md
@@ -5,7 +5,7 @@ h1: "Pulumi & AWS: Review project"
 meta_desc: This page provides an overview on how to a review a new AWS project.
 weight: 4
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-get-started
 
 aliases:

--- a/content/docs/clouds/aws/guides/_index.md
+++ b/content/docs/clouds/aws/guides/_index.md
@@ -5,7 +5,7 @@ h1: AWS Guides
 meta_desc: Pulumi Crosswalk for AWS supports a simplified approach to defining and deploying cloud infrastructure.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     identifier: aws-guides
     parent: aws
     weight: 4

--- a/content/docs/clouds/aws/guides/api-gateway.md
+++ b/content/docs/clouds/aws/guides/api-gateway.md
@@ -5,7 +5,7 @@ h1: Amazon API Gateway
 meta_desc: Pulumi Crosswalk for AWS provides a significantly easier way of programming API Gateway. Here is how.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-api-gateway
     weight: 1

--- a/content/docs/clouds/aws/guides/autoscaling.md
+++ b/content/docs/clouds/aws/guides/autoscaling.md
@@ -6,7 +6,7 @@ meta_desc: Pulumi Crosswalk for AWS allows you to easily to define Auto Scaling 
            instances.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-auto-scaling
     weight: 2

--- a/content/docs/clouds/aws/guides/aws-index-of-services.md
+++ b/content/docs/clouds/aws/guides/aws-index-of-services.md
@@ -5,7 +5,7 @@ h1: Index of AWS services
 meta_desc: Pulumi Crosswalk for AWS supports all AWS services. This page provides a complete list of supported services.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-aws-services
     weight: 12

--- a/content/docs/clouds/aws/guides/cloudwatch.md
+++ b/content/docs/clouds/aws/guides/cloudwatch.md
@@ -5,7 +5,7 @@ h1: AWS CloudWatch
 meta_desc: Pulumi Crosswalk for AWS CloudWatch help you operationally understand and manage your AWS CloudWatch metrics, resources and applications.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-cloudwatch
     weight: 3

--- a/content/docs/clouds/aws/guides/ecr.md
+++ b/content/docs/clouds/aws/guides/ecr.md
@@ -5,7 +5,7 @@ h1: AWS Elastic Container Registry (ECR)
 meta_desc: Pulumi Crosswalk for AWS ECR makes the provisioning of new ECR repositories as simple as one line of code.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-ecr
     weight: 4

--- a/content/docs/clouds/aws/guides/ecs.md
+++ b/content/docs/clouds/aws/guides/ecs.md
@@ -6,7 +6,7 @@ meta_desc: Pulumi Crosswalk for AWS ECS simplifies deploying containerized appli
             associated resources.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-ecs
     weight: 5

--- a/content/docs/clouds/aws/guides/eks.md
+++ b/content/docs/clouds/aws/guides/eks.md
@@ -6,7 +6,7 @@ meta_desc: Pulumi Crosswalk for AWS simplifies the creation, configuration, and 
            offering a single programming model and deployment workflow.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-eks
     weight: 6

--- a/content/docs/clouds/aws/guides/elb.md
+++ b/content/docs/clouds/aws/guides/elb.md
@@ -6,7 +6,7 @@ meta_desc: Pulumi Crosswalk for AWS ELB provides easy provisioning Application a
            integrates with functionality of AWS other services.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-elb
     weight: 7

--- a/content/docs/clouds/aws/guides/iam.md
+++ b/content/docs/clouds/aws/guides/iam.md
@@ -6,7 +6,7 @@ meta_desc: Pulumi Crosswalk for AWS adds strongly typed IAM resource classes, fo
            otherwise managing AWS users, groups, and roles securely.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-iam
     weight: 8

--- a/content/docs/clouds/aws/guides/lambda.md
+++ b/content/docs/clouds/aws/guides/lambda.md
@@ -5,7 +5,7 @@ h1: AWS Lambda & Serverless Events
 meta_desc: Pulumi Crosswalk for AWS brings a more natural, and easier to use, way of building serverless applications using AWS Lambda.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-lambda
     weight: 9

--- a/content/docs/clouds/aws/guides/more.md
+++ b/content/docs/clouds/aws/guides/more.md
@@ -5,7 +5,7 @@ h1: More AWS examples
 meta_desc: More examples of common AWS resources to help you get the most out of Pulumi.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-more
     weight: 11

--- a/content/docs/clouds/aws/guides/vpc.md
+++ b/content/docs/clouds/aws/guides/vpc.md
@@ -6,7 +6,7 @@ meta_desc: Pulumi Crosswalk for AWS provides simple, out of the box VPC function
            practices.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: aws-guides
     identifier: aws-guides-vpc
     weight: 10

--- a/content/docs/clouds/azure/_index.md
+++ b/content/docs/clouds/azure/_index.md
@@ -5,7 +5,8 @@ title: "Azure"
 meta_image: /images/docs/meta-images/docs-clouds-azure-meta-image.png
 h1: Azure & Pulumi
 menu:
-  clouds:
+  pulumiiac:
+    parent: clouds
     identifier: azure
     weight: 1
 cloud_overview: true

--- a/content/docs/clouds/azure/get-started/_index.md
+++ b/content/docs/clouds/azure/get-started/_index.md
@@ -4,7 +4,7 @@ meta_desc: This page provides an overview and guide on how to get started with A
 title: Get started
 h1: Get started with Pulumi & Azure
 menu:
-  clouds:
+  pulumiiac:
     parent: azure
     identifier: azure-get-started
     weight: 2

--- a/content/docs/clouds/azure/get-started/begin.md
+++ b/content/docs/clouds/azure/get-started/begin.md
@@ -5,7 +5,7 @@ title: Before you begin
 h1: "Pulumi & Azure: Before you begin"
 weight: 2
 menu:
-  clouds:
+  pulumiiac:
     parent: azure-get-started
     identifier: azure-begin
 

--- a/content/docs/clouds/azure/get-started/create-project.md
+++ b/content/docs/clouds/azure/get-started/create-project.md
@@ -5,7 +5,7 @@ title: Create project
 h1: "Pulumi & Azure: Create project"
 weight: 3
 menu:
-  clouds:
+  pulumiiac:
     parent: azure-get-started
     identifier: azure-create-project
 

--- a/content/docs/clouds/azure/get-started/deploy-changes.md
+++ b/content/docs/clouds/azure/get-started/deploy-changes.md
@@ -5,7 +5,7 @@ title: Deploy changes
 h1: "Pulumi & Azure: Deploy changes"
 weight: 7
 menu:
-  clouds:
+  pulumiiac:
     parent: azure-get-started
     identifier: azure-deploy-changes
 

--- a/content/docs/clouds/azure/get-started/deploy-stack.md
+++ b/content/docs/clouds/azure/get-started/deploy-stack.md
@@ -5,7 +5,7 @@ title: Deploy stack
 h1: "Pulumi & Azure: Deploy stack"
 weight: 5
 menu:
-  clouds:
+  pulumiiac:
     parent: azure-get-started
     identifier: azure-deploy-stack
 

--- a/content/docs/clouds/azure/get-started/destroy-stack.md
+++ b/content/docs/clouds/azure/get-started/destroy-stack.md
@@ -5,7 +5,7 @@ title: Destroy stack
 h1: "Pulumi & Azure: Destroy stack"
 weight: 8
 menu:
-  clouds:
+  pulumiiac:
     parent: azure-get-started
     identifier: azure-destroy-stack
 

--- a/content/docs/clouds/azure/get-started/modify-program.md
+++ b/content/docs/clouds/azure/get-started/modify-program.md
@@ -5,7 +5,7 @@ title: Modify program
 h1: "Pulumi & Azure: Modify program"
 weight: 6
 menu:
-  clouds:
+  pulumiiac:
     parent: azure-get-started
     identifier: azure-modify-program
 

--- a/content/docs/clouds/azure/get-started/next-steps.md
+++ b/content/docs/clouds/azure/get-started/next-steps.md
@@ -6,7 +6,7 @@ title: Next steps
 h1: "Pulumi & Azure: Next steps"
 weight: 9
 menu:
-  clouds:
+  pulumiiac:
     parent: azure-get-started
     identifier: azure-next-steps
 

--- a/content/docs/clouds/azure/get-started/review-project.md
+++ b/content/docs/clouds/azure/get-started/review-project.md
@@ -5,7 +5,7 @@ title: Review project
 h1: "Pulumi & Azure: Review project"
 weight: 4
 menu:
-  clouds:
+  pulumiiac:
     parent: azure-get-started
     identifier: azure-review-project
 

--- a/content/docs/clouds/gcp/_index.md
+++ b/content/docs/clouds/gcp/_index.md
@@ -5,7 +5,8 @@ title: "Google Cloud"
 meta_image: /images/docs/meta-images/docs-clouds-google-cloud-meta-image.png
 h1: Google Cloud & Pulumi
 menu:
-  clouds:
+  pulumiiac:
+    parent: clouds
     identifier: google-cloud
     weight: 1
 cloud_overview: true

--- a/content/docs/clouds/gcp/get-started/_index.md
+++ b/content/docs/clouds/gcp/get-started/_index.md
@@ -4,7 +4,7 @@ meta_desc: This page provides an overview and guide on how to get started with G
 title: Get started
 h1: Get started with Pulumi & Google Cloud
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud
     identifier: google-cloud-get-started
     weight: 3

--- a/content/docs/clouds/gcp/get-started/begin.md
+++ b/content/docs/clouds/gcp/get-started/begin.md
@@ -5,7 +5,7 @@ title: Before you begin
 h1: "Pulumi & Google Cloud: Before you begin"
 weight: 2
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud-get-started
     identifier: gcp-begin
 

--- a/content/docs/clouds/gcp/get-started/create-project.md
+++ b/content/docs/clouds/gcp/get-started/create-project.md
@@ -5,7 +5,7 @@ title: Create project
 h1: "Pulumi & Google Cloud: Create project"
 weight: 3
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud-get-started
     identifier: gcp-create-project
 

--- a/content/docs/clouds/gcp/get-started/deploy-changes.md
+++ b/content/docs/clouds/gcp/get-started/deploy-changes.md
@@ -5,7 +5,7 @@ title: Deploy changes
 h1: "Pulumi & Google Cloud: Deploy changes"
 weight: 7
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud-get-started
     identifier: gcp-deploy-changes
 

--- a/content/docs/clouds/gcp/get-started/deploy-stack.md
+++ b/content/docs/clouds/gcp/get-started/deploy-stack.md
@@ -5,7 +5,7 @@ title: Deploy stack
 h1: "Pulumi & Google Cloud: Deploy stack"
 weight: 5
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud-get-started
     identifier: gcp-deploy-stack
 

--- a/content/docs/clouds/gcp/get-started/destroy-stack.md
+++ b/content/docs/clouds/gcp/get-started/destroy-stack.md
@@ -5,7 +5,7 @@ title: Destroy stack
 h1: "Pulumi & Google Cloud: Destroy stack"
 weight: 8
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud-get-started
     identifier: gcp-destroy-stack
 

--- a/content/docs/clouds/gcp/get-started/modify-program.md
+++ b/content/docs/clouds/gcp/get-started/modify-program.md
@@ -5,7 +5,7 @@ title: Modify program
 h1: "Pulumi & Google Cloud: Modify program"
 weight: 6
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud-get-started
     identifier: gcp-modify-program
 

--- a/content/docs/clouds/gcp/get-started/next-steps.md
+++ b/content/docs/clouds/gcp/get-started/next-steps.md
@@ -6,7 +6,7 @@ title: Next steps
 h1: "Pulumi & Google Cloud: Next steps"
 weight: 9
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud-get-started
     identifier: gcp-next-steps
 

--- a/content/docs/clouds/gcp/get-started/review-project.md
+++ b/content/docs/clouds/gcp/get-started/review-project.md
@@ -5,7 +5,7 @@ title: Review project
 h1: "Pulumi & Google Cloud: Review project"
 weight: 4
 menu:
-  clouds:
+  pulumiiac:
     parent: google-cloud-get-started
     identifier: gcp-review-project
 

--- a/content/docs/clouds/kubernetes/_index.md
+++ b/content/docs/clouds/kubernetes/_index.md
@@ -5,7 +5,8 @@ title: "Kubernetes"
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 h1: Kubernetes & Pulumi
 menu:
-  clouds:
+  pulumiiac:
+    parent: clouds
     identifier: kube
     weight: 4
 cloud_overview: true

--- a/content/docs/clouds/kubernetes/get-started/_index.md
+++ b/content/docs/clouds/kubernetes/get-started/_index.md
@@ -4,7 +4,7 @@ meta_desc: This page provides an overview and guide on how to get started with K
 title: Get started
 h1: Get Started with Kubernetes
 menu:
-  clouds:
+  pulumiiac:
     identifier: kubernetes-get-started
     parent: kube
     weight: 4

--- a/content/docs/clouds/kubernetes/get-started/begin.md
+++ b/content/docs/clouds/kubernetes/get-started/begin.md
@@ -5,7 +5,7 @@ title: Before you begin
 h1: "Pulumi & Kubernetes: Before you begin"
 weight: 2
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-get-started
     identifier: kubernetes-begin
 

--- a/content/docs/clouds/kubernetes/get-started/create-project.md
+++ b/content/docs/clouds/kubernetes/get-started/create-project.md
@@ -5,7 +5,7 @@ title: Create project
 h1: "Pulumi & Kubernetes: Create project"
 weight: 3
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-get-started
     identifier: kubernetes-get-started-create-project
 

--- a/content/docs/clouds/kubernetes/get-started/deploy-changes.md
+++ b/content/docs/clouds/kubernetes/get-started/deploy-changes.md
@@ -5,7 +5,7 @@ title: Deploy changes
 h1: "Pulumi & Kubernetes: Deploy changes"
 weight: 7
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-get-started
     identifier: kubernetes-deploy-changes
 

--- a/content/docs/clouds/kubernetes/get-started/deploy-stack.md
+++ b/content/docs/clouds/kubernetes/get-started/deploy-stack.md
@@ -5,7 +5,7 @@ title: Deploy stack
 h1: "Pulumi & Kubernetes: Deploy stack"
 weight: 5
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-get-started
     identifier: kubernetes-deploy-stack
 

--- a/content/docs/clouds/kubernetes/get-started/destroy-stack.md
+++ b/content/docs/clouds/kubernetes/get-started/destroy-stack.md
@@ -5,7 +5,7 @@ title: Destroy stack
 h1: "Pulumi & Kubernetes: Destroy stack"
 weight: 8
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-get-started
     identifier: kubernetes-destroy-stack
 

--- a/content/docs/clouds/kubernetes/get-started/modify-program.md
+++ b/content/docs/clouds/kubernetes/get-started/modify-program.md
@@ -5,7 +5,7 @@ title: Modify program
 h1: "Pulumi & Kubernetes: Modify program"
 weight: 6
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-get-started
     identifier: kubernetes-modify-program
 

--- a/content/docs/clouds/kubernetes/get-started/next-steps.md
+++ b/content/docs/clouds/kubernetes/get-started/next-steps.md
@@ -6,7 +6,7 @@ title: Next steps
 h1: "Pulumi & Kubernetes: Next steps"
 weight: 9
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-get-started
     identifier: kubernetes-next-steps
 

--- a/content/docs/clouds/kubernetes/get-started/review-project.md
+++ b/content/docs/clouds/kubernetes/get-started/review-project.md
@@ -5,7 +5,7 @@ title: Review project
 h1: "Pulumi & Kubernetes: Review project"
 weight: 4
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-get-started
     identifier: kubernetes-review-project-get-started
 

--- a/content/docs/clouds/kubernetes/guides/_index.md
+++ b/content/docs/clouds/kubernetes/guides/_index.md
@@ -6,7 +6,7 @@ title: Guides
 h1: Pulumi & Kubernetes guides
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kube
     identifier: kubernetes-guides
     weight: 5

--- a/content/docs/clouds/kubernetes/guides/app-services.md
+++ b/content/docs/clouds/kubernetes/guides/app-services.md
@@ -6,7 +6,7 @@ title: App services
 h1: Kubernetes App services
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-app-svcs
     weight: 8

--- a/content/docs/clouds/kubernetes/guides/apps.md
+++ b/content/docs/clouds/kubernetes/guides/apps.md
@@ -5,7 +5,7 @@ title: Apps
 h1: Kubernetes Apps
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-apps
     weight: 12

--- a/content/docs/clouds/kubernetes/guides/cluster-services.md
+++ b/content/docs/clouds/kubernetes/guides/cluster-services.md
@@ -5,7 +5,7 @@ title: Cluster services
 h1: Kubernetes cluster services
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-cluster-svcs
     weight: 7

--- a/content/docs/clouds/kubernetes/guides/configure-access-control.md
+++ b/content/docs/clouds/kubernetes/guides/configure-access-control.md
@@ -6,7 +6,7 @@ title: Access control
 h1: Kubernetes access control
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-configure-authorization
     weight: 6

--- a/content/docs/clouds/kubernetes/guides/configure-defaults.md
+++ b/content/docs/clouds/kubernetes/guides/configure-defaults.md
@@ -6,7 +6,7 @@ title: Cluster defaults
 h1: Kubernetes cluster defaults
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-defaults
     weight: 5

--- a/content/docs/clouds/kubernetes/guides/control-plane.md
+++ b/content/docs/clouds/kubernetes/guides/control-plane.md
@@ -6,7 +6,7 @@ title: Control Plane
 h1: Kubernetes Control Plane
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-control-plane
     weight: 2

--- a/content/docs/clouds/kubernetes/guides/faq.md
+++ b/content/docs/clouds/kubernetes/guides/faq.md
@@ -5,7 +5,7 @@ title: FAQ
 h1: Kubernetes FAQ
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     weight: 14
 aliases:

--- a/content/docs/clouds/kubernetes/guides/identity.md
+++ b/content/docs/clouds/kubernetes/guides/identity.md
@@ -5,7 +5,7 @@ title: IAM
 h1: Kubernetes identity and access management (IAM)
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-iam
     weight: 11

--- a/content/docs/clouds/kubernetes/guides/managed-infra.md
+++ b/content/docs/clouds/kubernetes/guides/managed-infra.md
@@ -6,7 +6,7 @@ title: Infra services
 h1: Kubernetes infrastructure services
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     weight: 13
 aliases:

--- a/content/docs/clouds/kubernetes/guides/playbooks.md
+++ b/content/docs/clouds/kubernetes/guides/playbooks.md
@@ -6,7 +6,7 @@ title: Playbooks
 h1: Kubernetes playbooks
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-playbooks
     weight: 1

--- a/content/docs/clouds/kubernetes/guides/try-out-the-cluster.md
+++ b/content/docs/clouds/kubernetes/guides/try-out-the-cluster.md
@@ -5,7 +5,7 @@ title: Access clusters
 h1: Accessing Kubernetes clusters
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-access-cluster
     weight: 4

--- a/content/docs/clouds/kubernetes/guides/update-worker-nodes.md
+++ b/content/docs/clouds/kubernetes/guides/update-worker-nodes.md
@@ -6,7 +6,7 @@ title: Updating worker nodes
 h1: Updating Kubernetes worker nodes
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-update-workers
     weight: 10

--- a/content/docs/clouds/kubernetes/guides/worker-nodes.md
+++ b/content/docs/clouds/kubernetes/guides/worker-nodes.md
@@ -6,7 +6,7 @@ title: Worker node creation
 h1: Creating Kubernetes worker nodes
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
 menu:
-  clouds:
+  pulumiiac:
     parent: kubernetes-guides
     identifier: kubernetes-guides-worker-nodes
     weight: 3

--- a/content/docs/concepts/_index.md
+++ b/content/docs/concepts/_index.md
@@ -5,8 +5,8 @@ title: Concepts
 h1: What is Pulumi?
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
-    name: Overview
+  pulumiiac:
+    identifier: concepts
     weight: 4
 
 aliases:

--- a/content/docs/concepts/assets-archives.md
+++ b/content/docs/concepts/assets-archives.md
@@ -5,7 +5,8 @@ title: Assets & archives
 h1: Assets & archives
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 13
 aliases:
 - /docs/intro/concepts/assets-archives/

--- a/content/docs/concepts/config.md
+++ b/content/docs/concepts/config.md
@@ -5,7 +5,8 @@ title: Configuration
 h1: Configuration
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 6
 aliases:
 - /docs/reference/config/

--- a/content/docs/concepts/environments.md
+++ b/content/docs/concepts/environments.md
@@ -4,7 +4,8 @@ title_tag: Environments, Secrets, and Configuration (ESC) | Pulumi Concepts
 h1: Pulumi ESC (Environments, Secrets, and Configuration)
 meta_desc: Pulumi ESC allows you to compose and manage hierarchical collections of configuration and secrets and consume them in various ways.
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 8
 search:
   boost: true

--- a/content/docs/concepts/function-serialization.md
+++ b/content/docs/concepts/function-serialization.md
@@ -10,7 +10,8 @@ keywords:
 - function serialization
 - pulumi sdk
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 14
 aliases:
 - /docs/reference/serializing-functions/

--- a/content/docs/concepts/glossary.md
+++ b/content/docs/concepts/glossary.md
@@ -5,7 +5,8 @@ title: Pulumi glossary
 h1: Pulumi glossary
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 15
 aliases:
 - /docs/reference/glossary/

--- a/content/docs/concepts/how-pulumi-works.md
+++ b/content/docs/concepts/how-pulumi-works.md
@@ -5,7 +5,8 @@ title: "How Pulumi works"
 h1: "How Pulumi works"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 1
 aliases:
 - /docs/reference/how/

--- a/content/docs/concepts/inputs-outputs/_index.md
+++ b/content/docs/concepts/inputs-outputs/_index.md
@@ -5,7 +5,8 @@ title: "Inputs & outputs"
 h1: "Inputs & outputs"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     identifier: inputs-outputs
     weight: 5
 aliases:

--- a/content/docs/concepts/inputs-outputs/all.md
+++ b/content/docs/concepts/inputs-outputs/all.md
@@ -5,7 +5,7 @@ title: Accessing multiple outputs with All
 h1: Accessing multiple outputs with All
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     weight: 3
     parent: inputs-outputs
 ---

--- a/content/docs/concepts/inputs-outputs/apply.md
+++ b/content/docs/concepts/inputs-outputs/apply.md
@@ -5,7 +5,7 @@ title: Accessing single outputs with Apply
 h1: Accessing single outputs with Apply
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     weight: 2
     parent: inputs-outputs
 ---

--- a/content/docs/concepts/logging.md
+++ b/content/docs/concepts/logging.md
@@ -5,7 +5,8 @@ title: "Logging"
 h1: "Logging"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 10
 aliases:
 - /docs/intro/concepts/logging/

--- a/content/docs/concepts/options/_index.md
+++ b/content/docs/concepts/options/_index.md
@@ -5,7 +5,8 @@ title: Resource options
 h1: Resource options
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     identifier: options
     weight: 4
 aliases:

--- a/content/docs/concepts/options/additionalsecretoutputs.md
+++ b/content/docs/concepts/options/additionalsecretoutputs.md
@@ -5,7 +5,7 @@ title: "additionalSecretOutputs"
 h1: "Resource option: additionalSecretOutputs"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: additionalSecretOutputs
     parent: options
     weight: 1

--- a/content/docs/concepts/options/aliases.md
+++ b/content/docs/concepts/options/aliases.md
@@ -5,7 +5,7 @@ title: "aliases"
 h1: "Resource option: aliases"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: aliases
     parent: options
     weight: 2

--- a/content/docs/concepts/options/customtimeouts.md
+++ b/content/docs/concepts/options/customtimeouts.md
@@ -5,7 +5,7 @@ title: "customTimeouts"
 h1: "Resource option: customTimeouts"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: customTimeouts
     parent: options
     weight: 3

--- a/content/docs/concepts/options/deletebeforereplace.md
+++ b/content/docs/concepts/options/deletebeforereplace.md
@@ -5,7 +5,7 @@ title: "deleteBeforeReplace"
 h1: "Resource option: deleteBeforeReplace"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: deleteBeforeReplace
     parent: options
     weight: 4

--- a/content/docs/concepts/options/deletedwith.md
+++ b/content/docs/concepts/options/deletedwith.md
@@ -5,7 +5,7 @@ title: "deletedWith"
 h1: "Resource option: deletedWith"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: deletedWith
     parent: options
     weight: 5

--- a/content/docs/concepts/options/dependson.md
+++ b/content/docs/concepts/options/dependson.md
@@ -5,7 +5,7 @@ title: "dependsOn"
 h1: "Resource option: dependsOn"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: dependsOn
     parent: options
     weight: 6

--- a/content/docs/concepts/options/ignorechanges.md
+++ b/content/docs/concepts/options/ignorechanges.md
@@ -5,7 +5,7 @@ title: "ignoreChanges"
 h1: "Resource option: ignoreChanges"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: ignoreChanges
     parent: options
     weight: 7

--- a/content/docs/concepts/options/import.md
+++ b/content/docs/concepts/options/import.md
@@ -5,7 +5,7 @@ title: "import"
 h1: "Resource option: import"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: import
     parent: options
     weight: 8

--- a/content/docs/concepts/options/parent.md
+++ b/content/docs/concepts/options/parent.md
@@ -5,7 +5,7 @@ title: "parent"
 h1: "Resource option: parent"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: parent
     parent: options
     weight: 9

--- a/content/docs/concepts/options/protect.md
+++ b/content/docs/concepts/options/protect.md
@@ -5,7 +5,7 @@ title: "protect"
 h1: "Resource option: protect"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: protect
     parent: options
     weight: 10

--- a/content/docs/concepts/options/provider.md
+++ b/content/docs/concepts/options/provider.md
@@ -5,7 +5,7 @@ title: "provider"
 h1: "Resource option: provider"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: provider
     parent: options
     weight: 11

--- a/content/docs/concepts/options/providers.md
+++ b/content/docs/concepts/options/providers.md
@@ -5,7 +5,7 @@ title: "providers"
 h1: "Resource option: providers"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: providers
     parent: options
     weight: 12

--- a/content/docs/concepts/options/replaceonchanges.md
+++ b/content/docs/concepts/options/replaceonchanges.md
@@ -5,7 +5,7 @@ title: "replaceOnChanges"
 h1: "Resource option: replaceOnChanges"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: replaceOnChanges
     parent: options
     weight: 13

--- a/content/docs/concepts/options/retainOnDelete.md
+++ b/content/docs/concepts/options/retainOnDelete.md
@@ -5,7 +5,7 @@ title: "retainOnDelete"
 h1: "Resource option: retainOnDelete"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: retainOnDelete
     parent: options
     weight: 14

--- a/content/docs/concepts/options/transformations.md
+++ b/content/docs/concepts/options/transformations.md
@@ -5,7 +5,7 @@ title: "transformations"
 h1: "Resource option: transformations"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: transformations
     parent: options
     weight: 15

--- a/content/docs/concepts/options/transforms.md
+++ b/content/docs/concepts/options/transforms.md
@@ -5,7 +5,7 @@ title: "transforms"
 h1: "Resource option: transforms"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: transforms
     parent: options
     weight: 15

--- a/content/docs/concepts/options/version.md
+++ b/content/docs/concepts/options/version.md
@@ -5,7 +5,7 @@ title: "version"
 h1: "Resource option: version"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: version
     parent: options
     weight: 15

--- a/content/docs/concepts/projects/_index.md
+++ b/content/docs/concepts/projects/_index.md
@@ -5,7 +5,8 @@ title: Projects
 h1: Projects
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     identifier: projects
     weight: 1
 

--- a/content/docs/concepts/projects/project-file.md
+++ b/content/docs/concepts/projects/project-file.md
@@ -5,7 +5,7 @@ title: Project file reference
 h1: Pulumi project file reference
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: projects
     weight: 1
 

--- a/content/docs/concepts/resources/_index.md
+++ b/content/docs/concepts/resources/_index.md
@@ -5,7 +5,8 @@ title: Resources
 h1: Resources
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     identifier: resources
     weight: 3
 aliases:

--- a/content/docs/concepts/resources/components.md
+++ b/content/docs/concepts/resources/components.md
@@ -5,7 +5,7 @@ title: Components
 h1: Component resources
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: resources
     weight: 3
 aliases:

--- a/content/docs/concepts/resources/dynamic-providers.md
+++ b/content/docs/concepts/resources/dynamic-providers.md
@@ -5,7 +5,7 @@ title: Dynamic providers
 h1: Dynamic resource providers
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: resources
     weight: 6
 aliases:

--- a/content/docs/concepts/resources/functions.md
+++ b/content/docs/concepts/resources/functions.md
@@ -5,7 +5,7 @@ title: Provider functions
 h1: Provider functions
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: resources
     weight: 7
 aliases:

--- a/content/docs/concepts/resources/get.md
+++ b/content/docs/concepts/resources/get.md
@@ -5,7 +5,7 @@ title: Get functions
 h1: Get functions
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: resources
     weight: 7
 aliases:

--- a/content/docs/concepts/resources/names.md
+++ b/content/docs/concepts/resources/names.md
@@ -5,7 +5,7 @@ title: Names
 h1: Resource names
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: resources
     weight: 1
 aliases:

--- a/content/docs/concepts/resources/providers.md
+++ b/content/docs/concepts/resources/providers.md
@@ -5,7 +5,7 @@ title: Providers
 h1: Resource providers
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: resources
     weight: 4
 aliases:

--- a/content/docs/concepts/secrets.md
+++ b/content/docs/concepts/secrets.md
@@ -5,7 +5,8 @@ title: Secrets
 h1: Secrets
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 7
 aliases:
 - /docs/intro/concepts/secrets/

--- a/content/docs/concepts/stack.md
+++ b/content/docs/concepts/stack.md
@@ -5,7 +5,8 @@ title: Stacks
 h1: Stacks
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 2
 aliases:
 - /docs/reference/stack/

--- a/content/docs/concepts/state.md
+++ b/content/docs/concepts/state.md
@@ -9,7 +9,8 @@ keywords:
  - state backend
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 9
 
 aliases:

--- a/content/docs/concepts/update-plans.md
+++ b/content/docs/concepts/update-plans.md
@@ -5,7 +5,8 @@ title: Update plans
 h1: Update  plans
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     weight: 11
 aliases:
 - /updateplans/

--- a/content/docs/concepts/vs/_index.md
+++ b/content/docs/concepts/vs/_index.md
@@ -5,7 +5,8 @@ title: Compare to...
 h1: Compare Pulumi to other solutions
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
+    parent: concepts
     identifier: vs
     weight: 16
 aliases:

--- a/content/docs/concepts/vs/chef-puppet-etc.md
+++ b/content/docs/concepts/vs/chef-puppet-etc.md
@@ -5,7 +5,7 @@ title: Chef & Puppet
 h1: Chef, Puppet, Ansible, & Salt vs Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: vs
     weight: 9
 aliases:

--- a/content/docs/concepts/vs/cloud-sdks.md
+++ b/content/docs/concepts/vs/cloud-sdks.md
@@ -5,7 +5,7 @@ title: Cloud SDKs
 h1: Pulumi vs. AWS Boto and Cloud SDKs
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: vs
     weight: 4
 aliases:

--- a/content/docs/concepts/vs/cloud-template-transpilers/aws-cdk/_index.md
+++ b/content/docs/concepts/vs/cloud-template-transpilers/aws-cdk/_index.md
@@ -5,7 +5,7 @@ title: AWS CDK
 h1: Pulumi vs AWS Cloud Development Kit (CDK)
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: vs
     weight: 3
 aliases:

--- a/content/docs/concepts/vs/cloud-templates/cloudformation/_index.md
+++ b/content/docs/concepts/vs/cloud-templates/cloudformation/_index.md
@@ -5,7 +5,7 @@ title: AWS CloudFormation
 h1: Pulumi vs AWS CloudFormation
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: vs
     weight: 2
 aliases:

--- a/content/docs/concepts/vs/terraform/_index.md
+++ b/content/docs/concepts/vs/terraform/_index.md
@@ -5,7 +5,7 @@ title: Terraform
 h1: Terraform vs. Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     identifier: vs-terraform
     parent: vs
     weight: 1

--- a/content/docs/concepts/vs/terraform/opentofu.md
+++ b/content/docs/concepts/vs/terraform/opentofu.md
@@ -5,7 +5,7 @@ title: Terraform vs. OpenTofu
 h1: Terraform vs. OpenTofu
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: vs-terraform
     weight: 2
 ---

--- a/content/docs/concepts/vs/terraform/terminology.md
+++ b/content/docs/concepts/vs/terraform/terminology.md
@@ -5,7 +5,7 @@ title: Pulumi equivalents
 h1: Pulumi terms & command equivalents
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  concepts:
+  pulumiiac:
     parent: vs-terraform
     weight: 1
 aliases:

--- a/content/docs/esc-cli/_index.md
+++ b/content/docs/esc-cli/_index.md
@@ -6,8 +6,11 @@ h1: Pulumi ESC CLI overview
 no_on_this_page: true
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  esc_cli:
-    name: Overview
+  pulumiesc:
+    identifier: esc_cli
+    weight: 8
+    name: Pulumi ESC CLI
+
 ---
 
 Pulumi ESC is controlled primarily using the command line interface (CLI). It works in conjunction with the Pulumi Cloud

--- a/content/docs/esc-cli/command-line-completion.md
+++ b/content/docs/esc-cli/command-line-completion.md
@@ -5,7 +5,8 @@ title: Command-line completion
 h1: Pulumi CLI command-line completion
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  esc_cli:
+  pulumiesc:
+    parent: esc_cli
     weight: 3
 ---
 

--- a/content/docs/esc-cli/commands/_index.md
+++ b/content/docs/esc-cli/commands/_index.md
@@ -5,7 +5,8 @@ title: Commands
 h1: Pulumi ESC CLI commands
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  esc_cli:
+  pulumiesc:
+    parent: esc_cli
     weight: 1
     identifier: commands
 ---

--- a/content/docs/esc/environments.md
+++ b/content/docs/esc/environments.md
@@ -6,7 +6,7 @@ meta_desc: Pulumi ESC allows you to compose and manage hierarchical collections 
 menu:
   pulumiesc:
     identifier: environments
-    weight: 2
+    weight: 3
 search:
   boost: true
   keywords:

--- a/content/docs/esc/faq.md
+++ b/content/docs/esc/faq.md
@@ -6,7 +6,7 @@ h1: Pulumi ESC FAQs
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   pulumiesc:
-    weight: 7
+    weight: 9
     identifier: faq
 aliases:
   - /docs/pulumi-cloud/esc/faq

--- a/content/docs/esc/get-started/_index.md
+++ b/content/docs/esc/get-started/_index.md
@@ -5,8 +5,8 @@ h1: Get Started with Pulumi ESC (Environments, Secrets, and Configuration)
 meta_desc: Learn how to manage secrets and hierarchical configuration with Pulumi.
 menu:
   pulumiesc:
-    identifier: esc-get-started
-    weight: 1
+    identifier: esc_get_started
+    weight: 2
 aliases:
   - /docs/pulumi-cloud/esc/get-started/
 ---

--- a/content/docs/esc/get-started/begin.md
+++ b/content/docs/esc/get-started/begin.md
@@ -6,8 +6,8 @@ meta_desc: This page provides an overview on how to get started with Pulumi ESC.
 weight: 2
 menu:
   pulumiesc:
-    parent: esc-get-started
-    identifier: esc-get-started-begin
+    parent: esc_get_started
+    identifier: esc_get_started_begin
 ---
 
 Before you get started using Pulumi ESC, let's run through a few quick steps to ensure your environment is set up correctly.

--- a/content/docs/esc/get-started/create-environment.md
+++ b/content/docs/esc/get-started/create-environment.md
@@ -6,8 +6,8 @@ meta_desc: This page provides an overview on how to create a new Pulumi ESC envi
 weight: 3
 menu:
   pulumiesc:
-    parent: esc-get-started
-    identifier: esc-get-started-create-environment
+    parent: esc_get_started
+    identifier: esc_get_started_create_environment
 
 ---
 

--- a/content/docs/esc/get-started/esc-run-command.md
+++ b/content/docs/esc/get-started/esc-run-command.md
@@ -6,8 +6,8 @@ meta_desc: This page provides an overview on how to run commands without using l
 weight: 6
 menu:
   pulumiesc:
-    parent: esc-get-started
-    identifier: esc-get-started-esc-run-command
+    parent: esc_get_started
+    identifier: esc_get_started_esc_run_command
 ---
 
 ## Overview

--- a/content/docs/esc/get-started/import-environments.md
+++ b/content/docs/esc/get-started/import-environments.md
@@ -6,8 +6,8 @@ meta_desc: This page provides an overview on how to import environments in Pulum
 weight: 5
 menu:
   pulumiesc:
-    parent: esc-get-started
-    identifier: esc-get-started-import-environments
+    parent: esc_get_started
+    identifier: esc_get_started_import_environments
 ---
 
 ## Overview

--- a/content/docs/esc/get-started/integrate-with-pulumi-iac.md
+++ b/content/docs/esc/get-started/integrate-with-pulumi-iac.md
@@ -6,8 +6,8 @@ meta_desc: This page provides an overview on how to use Pulumi ESC with Pulumi I
 weight: 8
 menu:
   pulumiesc:
-    parent: esc-get-started
-    identifier: esc-get-started-integrate-with-pulumi-iac
+    parent: esc_get_started
+    identifier: esc_get_started_integrate_with_pulumi_iac
 ---
 
 ## Overview

--- a/content/docs/esc/get-started/retrieve-external-secrets.md
+++ b/content/docs/esc/get-started/retrieve-external-secrets.md
@@ -6,8 +6,8 @@ meta_desc: This page provides an overview on how to retrieve secrets from extern
 weight: 7
 menu:
   pulumiesc:
-    parent: esc-get-started
-    identifier: esc-get-started-retrieve-external-secrets
+    parent: esc_get_started
+    identifier: esc_get_started_retrieve_external_secrets
 ---
 
 ## Overview

--- a/content/docs/esc/get-started/store-and-retrieve-secrets.md
+++ b/content/docs/esc/get-started/store-and-retrieve-secrets.md
@@ -6,8 +6,8 @@ meta_desc: This page provides an overview on how to store and retrieve secrets i
 weight: 4
 menu:
   pulumiesc:
-    parent: esc-get-started
-    identifier: esc-get-started-store-retrieve-secrets
+    parent: esc_get_started
+    identifier: esc_get_started_store_retrieve_secrets
 
 ---
 

--- a/content/docs/esc/install.md
+++ b/content/docs/esc/install.md
@@ -1,18 +1,22 @@
 ---
 title_tag: Download & Install Pulumi ESC
 meta_desc: Detailed instructions for downloading and installing Pulumi ESC (Environments, Secrets and Configuration).
-title: Pulumi ESC
+title: Download & install
 h1: Download & Install Pulumi ESC
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  install:
-    weight: 2
+  pulumiesc:
+    identifier: esc-install
+    weight: 1
 search:
    boost: true
    keywords:
       - install
       - homebrew
       - cli
+aliases:
+- /install/esc/
+
 ---
 
 ## Select an Operating System

--- a/content/docs/get-started/_index.md
+++ b/content/docs/get-started/_index.md
@@ -7,8 +7,8 @@ h1: Get started with Pulumi
 no_on_this_page: true
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  getstarted:
-    name: Overview
+  pulumiiac:
+    identifier: getstarted
     weight: 2
 
 aliases:

--- a/content/docs/iac/_index.md
+++ b/content/docs/iac/_index.md
@@ -1,0 +1,94 @@
+---
+title: Pulumi IaC
+meta_desc: Learn how to create, deploy, and manage infrastructure on any cloud using Pulumi's open source infrastructure as code SDK.
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+  pulumiiac:
+    name: Overview
+    identifier: iac
+    weight: 1
+aliases:
+- /docs/reference/
+notitle: true
+docs_home: true
+h1: Pulumi Docs
+description: <p>Pulumi is an <a href="https://github.com/pulumi/pulumi" target="_blank">open source</a> infrastructure as code tool for creating, deploying, and managing cloud infrastructure.</p>
+link_buttons:
+  primary:
+    label: Get Started
+    link: /docs/get-started/
+  secondary:
+    label: Install
+    link: /docs/install/
+sections:
+- type: cards-logo-label-link
+  heading: Clouds
+  description: <p>Pulumi supports AWS, Azure, Google Cloud, Kubernetes, and <a href="/registry/">120+ packages</a>.</p>
+  cards:
+  - label: AWS & Pulumi
+    icon: aws-40
+    link: /docs/clouds/aws/
+  - label: Azure & Pulumi
+    icon: azure-40
+    link: /docs/clouds/azure/
+  - label: Google Cloud & Pulumi
+    icon: google-cloud-40
+    link: /docs/clouds/gcp/
+  - label: Kubernetes & Pulumi
+    icon: kubernetes-40
+    link: /docs/clouds/kubernetes/
+- type: full-width-cards
+  heading: Featured docs
+  cards:
+  - icon: lightbulb-blue-21-21
+    heading: Concepts
+    description: Dive deeper into what Pulumi is and how it works.
+    link: /docs/concepts/
+  - icon: cloud-blue-21-21
+    heading: Pulumi Cloud
+    description: Learn about Pulumi’s secure cloud service for individuals and teams.
+    link: /docs/pulumi-cloud/
+  - icon: swap-blue-21-21
+    heading: Adopting Pulumi
+    description: Migrate any infrastructure to Pulumi with comprehensive guides.
+    link: /docs/using-pulumi/adopting-pulumi/
+- type: blue-sparkle
+  heading: Why Pulumi?
+  description: Pulumi enables developers to deploy infrastructure in any cloud environment with one common approach. Leverage familiar languages to make the most of abstractions and reuse while enjoying access in your favorite IDEs, and testing tools!
+- type: cards-logo-label-link
+  heading: Languages
+  description: Build infrastructure intuitively on any cloud using familiar languages.
+  cards:
+  - label: Node.js
+    icon: icon-32-32 node-color-32-32
+    link: /docs/languages-sdks/javascript/
+  - label: Python
+    icon: icon-32-32 python-color-32-32
+    link: /docs/languages-sdks/python/
+  - label: Go
+    icon: icon-32-32 go-color-32-32
+    link: /docs/languages-sdks/go/
+  - label: .NET
+    icon: icon-32-32 dotnet-color-32-32
+    link: /docs/languages-sdks/dotnet/
+  - label: Java
+    icon: icon-32-32 java-color-32-32
+    link: /docs/languages-sdks/java/
+  - label: YAML
+    icon: icon-32-32 yaml-color-32-32
+    link: /docs/languages-sdks/yaml/
+- type: full-width-cards
+  heading: Reference
+  cards:
+    - icon: code-tree-blue-21-21
+      heading: Pulumi Cloud REST API docs
+      description: Leverage automation with the Pulumi Cloud REST API.
+      link: /docs/pulumi-cloud/cloud-rest-api/
+    - icon: terminal-blue-21-21
+      heading: Pulumi CLI docs
+      description: Browse the complete documentation of available CLI commands.
+      link: /docs/cli/
+- type: flat
+  heading: Have questions?
+  description: <p>For questions or feedback, reach out on <a href="https://slack.pulumi.com" target="_blank">community Slack</a>, <a href="https://github.com/pulumi" target="_blank">GitHub</a>, or <a href="/support/">contact support</a>.</p>
+---

--- a/content/docs/install/_index.md
+++ b/content/docs/install/_index.md
@@ -5,8 +5,8 @@ title: "Download & install"
 h1: Download & install Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  install:
-    name: Overview
+  pulumiiac:
+    identifier: install
     weight: 1
 
 aliases:

--- a/content/docs/install/versions.md
+++ b/content/docs/install/versions.md
@@ -2,7 +2,8 @@
 title: Pulumi CLI versions
 meta_desc: This page provides an list of available versions of the Pulumi CLI.
 menu:
-  install:
+  pulumiiac:
+    parent: install
     weight: 1
 aliases:
 - /docs/reference/changelog/

--- a/content/docs/languages-sdks/_index.md
+++ b/content/docs/languages-sdks/_index.md
@@ -5,8 +5,8 @@ title: Languages & SDKs
 h1: Pulumi languages & SDKs
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  languages:
-    name: Overview
+  pulumiiac:
+    identifier: languages
     weight: 7
 
 aliases:

--- a/content/docs/languages-sdks/dotnet/_index.md
+++ b/content/docs/languages-sdks/dotnet/_index.md
@@ -5,7 +5,8 @@ title: C#, VB, F# (.NET)
 h1: Pulumi & C#, VB, F# (.NET)
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  languages:
+  pulumiiac:
+    parent: languages
     identifier: dotnet
     weight: 3
 aliases:

--- a/content/docs/languages-sdks/go/_index.md
+++ b/content/docs/languages-sdks/go/_index.md
@@ -5,7 +5,8 @@ title: Go
 h1: Pulumi & Go
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    languages:
+    pulumiiac:
+        parent: languages
         identifier: go
         weight: 4
 aliases:

--- a/content/docs/languages-sdks/java/_index.md
+++ b/content/docs/languages-sdks/java/_index.md
@@ -5,7 +5,8 @@ title: Java
 h1: Pulumi & Java
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    languages:
+    pulumiiac:
+        parent: languages
         identifier: java
         weight: 5
 aliases:

--- a/content/docs/languages-sdks/javascript/_index.md
+++ b/content/docs/languages-sdks/javascript/_index.md
@@ -5,7 +5,8 @@ title: TypeScript (Node.js)
 h1: Pulumi & TypeScript & JavaScript (Node.js)
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  languages:
+  pulumiiac:
+    parent: languages
     identifier: javascript
     weight: 1
 aliases:

--- a/content/docs/languages-sdks/python/_index.md
+++ b/content/docs/languages-sdks/python/_index.md
@@ -5,7 +5,8 @@ title: Python
 h1: Pulumi & Python
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  languages:
+  pulumiiac:
+    parent: languages
     identifier: python
     weight: 2
 aliases:

--- a/content/docs/languages-sdks/python/python-blocking-async.md
+++ b/content/docs/languages-sdks/python/python-blocking-async.md
@@ -5,7 +5,7 @@ title: Blocking and Async
 h1: Blocking and Async Python with Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  languages:
+  pulumiiac:
     parent: python
     weight: 5
 aliases:

--- a/content/docs/languages-sdks/yaml/_index.md
+++ b/content/docs/languages-sdks/yaml/_index.md
@@ -5,7 +5,8 @@ title: YAML
 h1: Pulumi & YAML
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  languages:
+  pulumiiac:
+    parent: languages
     identifier: yaml-language
     weight: 6
 

--- a/content/docs/languages-sdks/yaml/yaml-language-reference.md
+++ b/content/docs/languages-sdks/yaml/yaml-language-reference.md
@@ -5,7 +5,7 @@ title: Reference
 h1: Pulumi YAML reference
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  languages:
+  pulumiiac:
     parent: yaml-language
     weight: 1
 aliases:

--- a/content/docs/pulumi-cloud/_index.md
+++ b/content/docs/pulumi-cloud/_index.md
@@ -9,7 +9,6 @@ menu:
   pulumicloud:
     name: Overview
     identifier: pulumi-cloud
-
 aliases:
 - /docs/reference/service/
 - /docs/intro/console/accounts-and-organizations/editions/

--- a/content/docs/support/_index.md
+++ b/content/docs/support/_index.md
@@ -5,8 +5,8 @@ title: Support
 h1: Pulumi support overview
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  support:
-    name: Overview
+  pulumiiac:
+    identifier: support
     weight: 9
 aliases:
 - /docs/troubleshooting/overview/

--- a/content/docs/support/faq.md
+++ b/content/docs/support/faq.md
@@ -5,7 +5,8 @@ title: FAQ
 h1: Pulumi CLI & Pulumi Cloud FAQ
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  support:
+  pulumiiac:
+    parent: support
     weight: 2
     identifier: all-faqs
 

--- a/content/docs/support/troubleshooting.md
+++ b/content/docs/support/troubleshooting.md
@@ -5,7 +5,8 @@ title: Troubleshooting
 h1: Pulumi troubleshooting
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  support:
+  pulumiiac:
+    parent: support
     weight: 1
 search:
   keywords:

--- a/content/docs/using-pulumi/_index.md
+++ b/content/docs/using-pulumi/_index.md
@@ -5,9 +5,9 @@ title: Using Pulumi
 h1: Using Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     weight: 6
-    name: Overview
+    identifier: usingpulumi
 aliases:
 - /docs/guides/
 ---

--- a/content/docs/using-pulumi/adopting-pulumi/_index.md
+++ b/content/docs/using-pulumi/adopting-pulumi/_index.md
@@ -5,7 +5,8 @@ title: Adopting Pulumi
 h1: Adopting Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
+    parent: usingpulumi
     identifier: adopting-pulumi
     weight: 1
 ---

--- a/content/docs/using-pulumi/adopting-pulumi/converters.md
+++ b/content/docs/using-pulumi/adopting-pulumi/converters.md
@@ -5,7 +5,7 @@ title: Convert code
 h1: Convert code to Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     identifier: converters
     parent: adopting-pulumi
     weight: 4

--- a/content/docs/using-pulumi/adopting-pulumi/import/_index.md
+++ b/content/docs/using-pulumi/adopting-pulumi/import/_index.md
@@ -5,7 +5,7 @@ title: "Import resources"
 h1: "Importing resources"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: adopting-pulumi
     weight: 3
 aliases:

--- a/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/_index.md
+++ b/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/_index.md
@@ -5,7 +5,7 @@ title: "Migrate from..."
 h1: Migrating from other solutions to Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     identifier: migrating
     parent: adopting-pulumi
     weight: 2

--- a/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/from-aws.md
+++ b/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/from-aws.md
@@ -5,7 +5,7 @@ title: AWS CloudFormation
 h1: "Migrating from AWS CloudFormation to Pulumi"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     identifier: from-aws-cloudformation
     parent: migrating
     weight: 3

--- a/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/from-azure.md
+++ b/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/from-azure.md
@@ -5,7 +5,7 @@ title: Azure Resource Manager
 h1: Migrating from Azure Resource Manager to Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: migrating
     weight: 4
 aliases:

--- a/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/from-kubernetes.md
+++ b/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/from-kubernetes.md
@@ -5,7 +5,7 @@ title: Kubernetes YAML & Helm Charts
 h1: Migrating from Kubernetes YAML or Helm Charts to Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: migrating
     weight: 5
 aliases:

--- a/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/from-terraform.md
+++ b/content/docs/using-pulumi/adopting-pulumi/migrating-to-pulumi/from-terraform.md
@@ -5,7 +5,7 @@ title: Terraform
 h1: Migrating from Terraform to Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     identifier: from-terraform
     parent: migrating
     weight: 2

--- a/content/docs/using-pulumi/automation-api/_index.md
+++ b/content/docs/using-pulumi/automation-api/_index.md
@@ -5,7 +5,8 @@ title: Automation API
 h1: Automation API
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
+        parent: usingpulumi
         identifier: automation-api
         weight: 3
 aliases:

--- a/content/docs/using-pulumi/automation-api/concepts-terminology.md
+++ b/content/docs/using-pulumi/automation-api/concepts-terminology.md
@@ -6,7 +6,7 @@ h1: Automation API concepts & terminology
 weight: 2
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: automation-api
 aliases:
 - /docs/guides/automation-api/concepts-terminology/

--- a/content/docs/using-pulumi/automation-api/getting-started-automation-api.md
+++ b/content/docs/using-pulumi/automation-api/getting-started-automation-api.md
@@ -6,7 +6,7 @@ h1: Get started with Automation API
 weight: 1
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: automation-api
 aliases:
 - /docs/guides/automation-api/getting-started-automation-api/

--- a/content/docs/using-pulumi/continuous-delivery/_index.md
+++ b/content/docs/using-pulumi/continuous-delivery/_index.md
@@ -5,7 +5,8 @@ title: Continuous Delivery
 h1: Pulumi & Continuous delivery
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
+        parent: usingpulumi
         name: Continuous Delivery
         identifier: cont_delivery
         weight: 5

--- a/content/docs/using-pulumi/continuous-delivery/add-support-for-cicd-systems.md
+++ b/content/docs/using-pulumi/continuous-delivery/add-support-for-cicd-systems.md
@@ -6,7 +6,7 @@ title: Adding CI/CD support
 h1: Adding Pulumi support for CI/CD systems
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 2
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/aws-code-services.md
+++ b/content/docs/using-pulumi/continuous-delivery/aws-code-services.md
@@ -6,7 +6,7 @@ title: AWS Code Services
 h1: Pulumi CI/CD & AWS Code Services
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 

--- a/content/docs/using-pulumi/continuous-delivery/azure-devops.md
+++ b/content/docs/using-pulumi/continuous-delivery/azure-devops.md
@@ -6,7 +6,7 @@ title: Azure DevOps
 h1: Pulumi CI/CD & Azure DevOps
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 

--- a/content/docs/using-pulumi/continuous-delivery/circleci.md
+++ b/content/docs/using-pulumi/continuous-delivery/circleci.md
@@ -5,7 +5,7 @@ title: CircleCI
 h1: Pulumi CI/CD & CircleCI
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 

--- a/content/docs/using-pulumi/continuous-delivery/codefresh.md
+++ b/content/docs/using-pulumi/continuous-delivery/codefresh.md
@@ -5,7 +5,7 @@ title: Codefresh
 h1: Pulumi CI/CD & Codefresh
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 

--- a/content/docs/using-pulumi/continuous-delivery/github-actions.md
+++ b/content/docs/using-pulumi/continuous-delivery/github-actions.md
@@ -6,7 +6,7 @@ title: GitHub Actions
 h1: GitHub Actions for Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/github-app.md
+++ b/content/docs/using-pulumi/continuous-delivery/github-app.md
@@ -6,7 +6,7 @@ title: Pulumi GitHub App
 h1: Pulumi Github App
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 

--- a/content/docs/using-pulumi/continuous-delivery/gitlab-app.md
+++ b/content/docs/using-pulumi/continuous-delivery/gitlab-app.md
@@ -6,7 +6,7 @@ title: GitLab integration
 h1: Pulumi CI/CD & GitLab integration
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
+++ b/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
@@ -6,7 +6,7 @@ title: GitLab CI
 h1: Pulumi CI/CD & GitLab
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 

--- a/content/docs/using-pulumi/continuous-delivery/google-cloud-build.md
+++ b/content/docs/using-pulumi/continuous-delivery/google-cloud-build.md
@@ -5,7 +5,7 @@ title: Google Cloud Build
 h1: Pulumi CI/CD & Google Cloud Build
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/jenkins.md
+++ b/content/docs/using-pulumi/continuous-delivery/jenkins.md
@@ -5,7 +5,7 @@ title: Jenkins
 h1: Pulumi CI/CD & Jenkins Pipelines
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/octopus-deploy.md
+++ b/content/docs/using-pulumi/continuous-delivery/octopus-deploy.md
@@ -5,7 +5,7 @@ title: Octopus Deploy
 h1: Pulumi CI/CD & Octopus Deploy
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/pulumi-kubernetes-operator.md
+++ b/content/docs/using-pulumi/continuous-delivery/pulumi-kubernetes-operator.md
@@ -6,7 +6,7 @@ title: Pulumi Kubernetes Operator
 h1: Pulumi Kubernetes Operator
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/spinnaker.md
+++ b/content/docs/using-pulumi/continuous-delivery/spinnaker.md
@@ -5,7 +5,7 @@ title: Spinnaker
 h1: Pulumi CI/CD & Spinnaker
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/teamcity.md
+++ b/content/docs/using-pulumi/continuous-delivery/teamcity.md
@@ -5,7 +5,7 @@ title: JetBrains TeamCity
 h1: Pulumi CI/CD & JetBrains TeamCity
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/travis.md
+++ b/content/docs/using-pulumi/continuous-delivery/travis.md
@@ -6,7 +6,7 @@ title: Travis CI
 h1: Pulumi CI/CD & Travis CI
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 1
 aliases:

--- a/content/docs/using-pulumi/continuous-delivery/troubleshooting-guide.md
+++ b/content/docs/using-pulumi/continuous-delivery/troubleshooting-guide.md
@@ -5,7 +5,7 @@ title: Troubleshooting
 h1: Troubleshooting Pulumi CI/CD
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: cont_delivery
         weight: 2
 aliases:

--- a/content/docs/using-pulumi/crossguard/_index.md
+++ b/content/docs/using-pulumi/crossguard/_index.md
@@ -6,7 +6,8 @@ title: Policy as code
 h1: Pulumi policy as code
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
+        parent: usingpulumi
         identifier: crossguard
         weight: 6
 aliases:

--- a/content/docs/using-pulumi/crossguard/api-policy-manager.md
+++ b/content/docs/using-pulumi/crossguard/api-policy-manager.md
@@ -6,7 +6,7 @@ h1: Policy Manager
 weight: 1
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard-compliance-ready-policies
     weight: 1
 ---

--- a/content/docs/using-pulumi/crossguard/awsguard.md
+++ b/content/docs/using-pulumi/crossguard/awsguard.md
@@ -7,7 +7,7 @@ h1: AWSGuard policies
 weight: 3
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard
 aliases:
 - /docs/guides/crossguard/awsguard/

--- a/content/docs/using-pulumi/crossguard/best-practices.md
+++ b/content/docs/using-pulumi/crossguard/best-practices.md
@@ -6,7 +6,7 @@ h1: Policy pack best practices
 weight: 5
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard
 aliases:
 - /docs/guides/crossguard/best-practices/

--- a/content/docs/using-pulumi/crossguard/compliance-ready-policies-aws.md
+++ b/content/docs/using-pulumi/crossguard/compliance-ready-policies-aws.md
@@ -5,7 +5,7 @@ title: Compliance Ready Aws Policies
 h1: List of Compliance Ready Policies for Aws
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard-compliance-ready-policies
 ---
 There's a total of 93 Compliance Ready Policies for the Aws provider.

--- a/content/docs/using-pulumi/crossguard/compliance-ready-policies-awsnative.md
+++ b/content/docs/using-pulumi/crossguard/compliance-ready-policies-awsnative.md
@@ -5,7 +5,7 @@ title: Compliance Ready Awsnative Policies
 h1: List of Compliance Ready Policies for Awsnative
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard-compliance-ready-policies
 ---
 There's a total of 54 Compliance Ready Policies for the Awsnative provider.

--- a/content/docs/using-pulumi/crossguard/compliance-ready-policies-azure.md
+++ b/content/docs/using-pulumi/crossguard/compliance-ready-policies-azure.md
@@ -5,7 +5,7 @@ title: Compliance Ready Azure Policies
 h1: List of Compliance Ready Policies for Azure
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard-compliance-ready-policies
     identifier: crossguard-compliance-ready-policies-azure
 ---

--- a/content/docs/using-pulumi/crossguard/compliance-ready-policies-azurenative.md
+++ b/content/docs/using-pulumi/crossguard/compliance-ready-policies-azurenative.md
@@ -6,7 +6,7 @@ h1: List of Compliance Ready Policies for Azurenative
 weight: 2
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard-compliance-ready-policies
     identifier: crossguard-compliance-ready-policies-azurenative
 ---

--- a/content/docs/using-pulumi/crossguard/compliance-ready-policies-gcp.md
+++ b/content/docs/using-pulumi/crossguard/compliance-ready-policies-gcp.md
@@ -5,7 +5,7 @@ title: Compliance Ready Gcp Policies
 h1: List of Compliance Ready Policies for Gcp
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard-compliance-ready-policies
 ---
 There's a total of 1 Compliance Ready Policies for the Gcp provider.

--- a/content/docs/using-pulumi/crossguard/compliance-ready-policies-googlenative.md
+++ b/content/docs/using-pulumi/crossguard/compliance-ready-policies-googlenative.md
@@ -5,7 +5,7 @@ title: Compliance Ready Googlenative Policies
 h1: List of Compliance Ready Policies for Googlenative
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard-compliance-ready-policies
 aliases:
 - /docs/guides/crossguard/compliance-ready-policies-googlenative/

--- a/content/docs/using-pulumi/crossguard/compliance-ready-policies-kubernetes.md
+++ b/content/docs/using-pulumi/crossguard/compliance-ready-policies-kubernetes.md
@@ -5,7 +5,7 @@ title: Compliance Ready Kubernetes Policies
 h1: List of Compliance Ready Policies for Kubernetes
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard-compliance-ready-policies
 ---
 There's a total of 237 Compliance Ready Policies for the Kubernetes provider.

--- a/content/docs/using-pulumi/crossguard/compliance-ready-policies.md
+++ b/content/docs/using-pulumi/crossguard/compliance-ready-policies.md
@@ -6,7 +6,7 @@ h1: Compliance Ready Policies
 weight: 3
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard
     identifier: crossguard-compliance-ready-policies
 ---

--- a/content/docs/using-pulumi/crossguard/configuration.md
+++ b/content/docs/using-pulumi/crossguard/configuration.md
@@ -6,7 +6,7 @@ h1: Configuring policy packs
 weight: 4
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard
 aliases:
 - /docs/guides/crossguard/configuration/

--- a/content/docs/using-pulumi/crossguard/core-concepts.md
+++ b/content/docs/using-pulumi/crossguard/core-concepts.md
@@ -7,7 +7,7 @@ h1: Pulumi policy as code concepts
 weight: 2
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard
     identifier: crossguard-core-concepts
 aliases:

--- a/content/docs/using-pulumi/crossguard/faq.md
+++ b/content/docs/using-pulumi/crossguard/faq.md
@@ -6,7 +6,7 @@ h1: Policy as code FAQ
 weight: 6
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard
 aliases:
 - /docs/guides/crossguard/faq/

--- a/content/docs/using-pulumi/crossguard/get-started.md
+++ b/content/docs/using-pulumi/crossguard/get-started.md
@@ -7,7 +7,7 @@ h1: Get started with Pulumi policy as code
 weight: 1
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard
     identifier: policy-as-code-get-started
 aliases:

--- a/content/docs/using-pulumi/crossguard/snyk-policy.md
+++ b/content/docs/using-pulumi/crossguard/snyk-policy.md
@@ -6,7 +6,7 @@ h1: Snyk Container Scanning
 weight: 3
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: crossguard
 aliases:
 - /docs/guides/crossguard/snyk-container-scanning/

--- a/content/docs/using-pulumi/debugging/_index.md
+++ b/content/docs/using-pulumi/debugging/_index.md
@@ -5,7 +5,8 @@ title: Debugging
 h1: Debugging Pulumi programs
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
+        parent: usingpulumi
         identifier: debugging
         weight: 9
 ---

--- a/content/docs/using-pulumi/organizing-projects-stacks/_index.md
+++ b/content/docs/using-pulumi/organizing-projects-stacks/_index.md
@@ -5,7 +5,8 @@ title: Organizing projects
 h1: Organizing Pulumi projects & stacks
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  usingpulumi:
+  pulumiiac:
+    parent: usingpulumi
     weight: 2
 
 aliases:

--- a/content/docs/using-pulumi/pulumi-packages/_index.md
+++ b/content/docs/using-pulumi/pulumi-packages/_index.md
@@ -5,7 +5,8 @@ title: Pulumi packages
 h1: Pulumi packages
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
+        parent: usingpulumi
         identifier: pulumi-packages
         weight: 7
 aliases:

--- a/content/docs/using-pulumi/pulumi-packages/contribute-to-pulumi-registry.md
+++ b/content/docs/using-pulumi/pulumi-packages/contribute-to-pulumi-registry.md
@@ -5,7 +5,7 @@ title: Contribute packages
 h1: Contribute packages to Pulumi Registry
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: pulumi-packages
         identifier: contribute-to-pulumi-registry
         weight: 1

--- a/content/docs/using-pulumi/pulumi-packages/debugging-provider-packages.md
+++ b/content/docs/using-pulumi/pulumi-packages/debugging-provider-packages.md
@@ -5,7 +5,7 @@ title: Debug provider packages
 h1: Debug Pulumi provider packages
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: pulumi-packages
         identifier: how-to-debug-providers
         weight: 2

--- a/content/docs/using-pulumi/pulumi-packages/how-to-author.md
+++ b/content/docs/using-pulumi/pulumi-packages/how-to-author.md
@@ -5,7 +5,7 @@ title: Author packages
 h1: Author packages in Pulumi Registry
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: pulumi-packages
         identifier: how-to-author
         weight: 2

--- a/content/docs/using-pulumi/pulumi-packages/schema.md
+++ b/content/docs/using-pulumi/pulumi-packages/schema.md
@@ -6,7 +6,7 @@ title: Schema
 h1: Pulumi package schema
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
         parent: pulumi-packages
         weight: 3
 aliases:

--- a/content/docs/using-pulumi/testing/_index.md
+++ b/content/docs/using-pulumi/testing/_index.md
@@ -5,7 +5,8 @@ title: Testing
 h1: Testing Pulumi programs
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    usingpulumi:
+    pulumiiac:
+        parent: usingpulumi
         identifier: testing
         weight: 8
 aliases:

--- a/content/docs/using-pulumi/testing/integration.md
+++ b/content/docs/using-pulumi/testing/integration.md
@@ -6,7 +6,7 @@ h1: Integration testing for Pulumi programs
 meta_image: /images/docs/meta-images/docs-meta.png
 weight: 3
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: testing
 aliases:
 - /docs/guides/testing/integration/

--- a/content/docs/using-pulumi/testing/property-testing.md
+++ b/content/docs/using-pulumi/testing/property-testing.md
@@ -6,7 +6,7 @@ h1: Property testing for Pulumi programs
 meta_image: /images/docs/meta-images/docs-meta.png
 weight: 2
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: testing
 aliases:
 - /docs/guides/testing/property-testing/

--- a/content/docs/using-pulumi/testing/unit.md
+++ b/content/docs/using-pulumi/testing/unit.md
@@ -6,7 +6,7 @@ h1: Unit testing Pulumi programs
 meta_image: /images/docs/meta-images/docs-meta.png
 weight: 1
 menu:
-  usingpulumi:
+  pulumiiac:
     parent: testing
 aliases:
 - /docs/guides/testing/unit/

--- a/layouts/partials/docs/main-nav.html
+++ b/layouts/partials/docs/main-nav.html
@@ -2,15 +2,45 @@
     {{ if hasPrefix .RelPermalink "/docs/" }}
         {{/* Render a top-level menu for our major docs sections */}}
         {{ $toc_page := . }}
-        {{ $toc_sections := slice "Download & install" "Get started" "Clouds" "Concepts" "Pulumi Cloud" "Pulumi ESC" "Using Pulumi" "Languages & SDKs" "Pulumi CLI" "Pulumi ESC CLI" "Support" }}
-        {{ $toc_menus := dict "Download & install" .Site.Menus.install "Get started" .Site.Menus.getstarted "Clouds" .Site.Menus.clouds "Concepts" .Site.Menus.concepts "Pulumi Cloud" .Site.Menus.pulumicloud "Pulumi ESC" .Site.Menus.pulumiesc "Using Pulumi" .Site.Menus.usingpulumi "Languages & SDKs" .Site.Menus.languages "Pulumi CLI" .Site.Menus.cli "Pulumi ESC CLI" .Site.Menus.esc_cli "Support" .Site.Menus.support }}
+        {{ $toc_sections := slice }}
+        {{ $toc_urls := dict }}
+        {{ $toc_menus := dict }}
+
+        {{ if or (hasPrefix .RelPermalink "/docs/esc/") (hasPrefix .RelPermalink "/docs/esc-cli/") }}
+            {{ range .Site.Menus.pulumiesc }}
+                {{ if ne .Name "Overview" }}
+                    {{ $toc_sections = $toc_sections | append .Name }}
+                    {{ $toc_urls = merge $toc_urls (dict .Name .URL) }}
+                    {{ $toc_menus = merge $toc_menus (dict .Name .Children) }}
+                {{ end }}
+            {{ end }}
+        {{ else if hasPrefix .RelPermalink "/docs/pulumi-cloud/" }}
+            {{ range .Site.Menus.pulumicloud }}
+                {{ if ne .Name "Overview" }}
+                    {{ $toc_sections = $toc_sections | append .Name }}
+                    {{ $toc_urls = merge $toc_urls (dict .Name .URL) }}
+                    {{ $toc_menus = merge $toc_menus (dict .Name .Children) }}
+                {{ end }}
+            {{ end }}
+        {{ else if ne .RelPermalink "/docs/" }}
+            {{ range .Site.Menus.pulumiiac }}
+                {{ if ne .Name "Overview" }}
+                    {{ $toc_sections = $toc_sections | append .Name }}
+                    {{ $toc_urls = merge $toc_urls (dict .Name .URL) }}
+                    {{ $toc_menus = merge $toc_menus (dict .Name .Children) }}
+                {{ end }}
+            {{ end }}
+        {{ else }}
+            {{ $toc_sections = slice "Pulumi IaC" "Pulumi ESC" "Pulumi Cloud" }}
+            {{ $toc_menus = dict "Pulumi IaC" .Site.Menus.pulumiiac "Pulumi ESC" .Site.Menus.pulumiesc "Pulumi Cloud" .Site.Menus.pulumicloud }}
+        {{ end }}
 
         {{ range $index, $element := $toc_sections }}
             {{ $sidenav_selected := "" }}
             {{ $toc_name := . }}
             {{ $toc_menu := (index $toc_menus $toc_name) }}
 
-            {{ $toc_section_link := "" }}
+            {{ $toc_section_link := (index $toc_urls $toc_name) }}
             {{ range $toc_menu }}
                 {{ if (eq .Name "Overview") }}
                     {{ $toc_section_link = .URL }}
@@ -30,7 +60,7 @@
             {{ end }}
             <div id="toc-menu-{{ $toc_name }}" class="{{ $sidenav_selected }} no-anchor toc-header toggle-topLevel {{ $toggle_class }}" id="{{ $toc_name | urlize }}-toc-header">
                 <a href="{{ $toc_section_link }}">{{ $toc_name }}</a>
-                {{ if and ($toc_section_link) (ne $toc_name "Get started") }}
+                {{ if and ($toc_section_link) (gt (len $toc_menu) 0) }}
                     <span class="toggleButton-topLevel down">
                         <div class="icon icon-14-14 keyboard-arrow-down-gray-14-14"></div>
                     </span>

--- a/layouts/partials/docs/search.html
+++ b/layouts/partials/docs/search.html
@@ -3,22 +3,112 @@
         <div class="inline-flex items-center">
             {{ $mode := .Scratch.Get "mode" }}
             {{ if eq "docs" $mode }}
-                <a class="tab-selected" href="/docs/">
-                    <img class="tab-icon" src="/icons/docs.svg" />
-                    <span>Docs</span>
-                </a>
-                <a class="tab" href="/registry/">
-                    <img class="tab-icon" src="/icons/registry-light.svg" />
-                    <span>Packages</span>
-                </a>
-                <a class="tab" href="/tutorials/">
-                    <img class="tab-icon" src="/icons/graduation-cap.svg" />
-                    <span>Tutorials</span>
-                </a>
+                {{ $docsKind := "docs" }}
+                {{ if or (hasPrefix .RelPermalink "/docs/esc/") (hasPrefix .RelPermalink "/docs/esc-cli/") }}
+                    {{ $docsKind = "docs-esc" }}
+                {{ else if hasPrefix .RelPermalink "/docs/pulumi-cloud/" }}
+                    {{ $docsKind = "docs-cloud" }}
+                {{ else if ne .RelPermalink "/docs/" }}
+                    {{ $docsKind = "docs-iac" }}
+                {{ end }}
+
+                {{ if eq "docs-iac" $docsKind }}
+                    <a class="tab-selected" href="/docs/iac/">
+                        <img class="tab-icon" src="/icons/docs.svg" />
+                        <span>IaC</span>
+                    </a>
+                    <a class="tab" href="/docs/esc/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>ESC</span>
+                    </a>
+                    <a class="tab" href="/docs/pulumi-cloud/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>Cloud</span>
+                    </a>
+                    <a class="tab" href="/registry/">
+                        <img class="tab-icon" src="/icons/registry-light.svg" />
+                        <span>Packages</span>
+                    </a>
+                    <a class="tab" href="/tutorials/">
+                        <img class="tab-icon" src="/icons/graduation-cap.svg" />
+                        <span>Tutorials</span>
+                    </a>
+                {{ else if eq "docs-esc" $docsKind }}
+                    <a class="tab" href="/docs/iac/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>IaC</span>
+                    </a>
+                    <a class="tab-selected" href="/docs/esc/">
+                        <img class="tab-icon" src="/icons/docs.svg" />
+                        <span>ESC</span>
+                    </a>
+                    <a class="tab" href="/docs/pulumi-cloud/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>Cloud</span>
+                    </a>
+                    <a class="tab" href="/registry/">
+                        <img class="tab-icon" src="/icons/registry-light.svg" />
+                        <span>Packages</span>
+                    </a>
+                    <a class="tab" href="/tutorials/">
+                        <img class="tab-icon" src="/icons/graduation-cap.svg" />
+                        <span>Tutorials</span>
+                    </a>
+                {{ else if eq "docs-cloud" $docsKind }}
+                    <a class="tab" href="/docs/iac/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>IaC</span>
+                    </a>
+                    <a class="tab" href="/docs/esc/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>ESC</span>
+                    </a>
+                    <a class="tab-selected" href="/docs/pulumi-cloud/">
+                        <img class="tab-icon" src="/icons/docs.svg" />
+                        <span>Cloud</span>
+                    </a>
+                    <a class="tab" href="/registry/">
+                        <img class="tab-icon" src="/icons/registry-light.svg" />
+                        <span>Packages</span>
+                    </a>
+                    <a class="tab" href="/tutorials/">
+                        <img class="tab-icon" src="/icons/graduation-cap.svg" />
+                        <span>Tutorials</span>
+                    </a>
+                {{ else }}
+                    <a class="tab" href="/docs/iac/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>IaC</span>
+                    </a>
+                    <a class="tab" href="/docs/esc/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>ESC</span>
+                    </a>
+                    <a class="tab" href="/docs/pulumi-cloud/">
+                        <img class="tab-icon" src="/icons/docs-light.svg" />
+                        <span>Cloud</span>
+                    </a>
+                    <a class="tab" href="/registry/">
+                        <img class="tab-icon" src="/icons/registry-light.svg" />
+                        <span>Packages</span>
+                    </a>
+                    <a class="tab" href="/tutorials/">
+                        <img class="tab-icon" src="/icons/graduation-cap.svg" />
+                        <span>Tutorials</span>
+                    </a>
+                {{ end }}
             {{ else if (or (eq "tutorials" $mode) (eq "providers" $mode) (eq "collections" $mode)) }}
-                <a class="tab" href="/docs/">
-                    <img class="tab-icon" src="/icons/docs.svg" />
-                    <span>Docs</span>
+                <a class="tab" href="/docs/iac/">
+                    <img class="tab-icon" src="/icons/docs-light.svg" />
+                    <span>IaC</span>
+                </a>
+                <a class="tab" href="/docs/esc/">
+                    <img class="tab-icon" src="/icons/docs-light.svg" />
+                    <span>ESC</span>
+                </a>
+                <a class="tab" href="/docs/pulumi-cloud/">
+                    <img class="tab-icon" src="/icons/docs-light.svg" />
+                    <span>Cloud</span>
                 </a>
                 <a class="tab" href="/registry/">
                     <img class="tab-icon" src="/icons/registry-light.svg" />
@@ -29,9 +119,17 @@
                     <span>Tutorials</span>
                 </a>
             {{ else }}
-                <a class="tab" href="/docs/">
+                <a class="tab" href="/docs/iac/">
                     <img class="tab-icon" src="/icons/docs-light.svg" />
-                    <span>Docs</span>
+                    <span>IaC</span>
+                </a>
+                <a class="tab" href="/docs/esc/">
+                    <img class="tab-icon" src="/icons/docs-light.svg" />
+                    <span>ESC</span>
+                </a>
+                <a class="tab" href="/docs/pulumi-cloud/">
+                    <img class="tab-icon" src="/icons/docs-light.svg" />
+                    <span>Cloud</span>
                 </a>
                 <a class="tab-selected" href="/registry/">
                     <img class="tab-icon" src="/icons/registry.svg" />


### PR DESCRIPTION
This splits out IaC, ESC, and Cloud into their own independent top level nav structures. This simplifies and focuses the left nav for each one of these. There are some gray areas, like conceptual topics in IaC (or Cloud) that do apply to one or the other, but I personally find this to be way more usable than the current mammoth combined left nav. As you go between the products, the left nav drops the "Pulumi IaC", "Pulumi ESC", and "Pulumi Cloud" headers in the nav since they're superfluous given the top level tabs.

This is not final and we've certainly not built consensus as a team on this yet -- just pushing the branch so we have something to discuss!
