### PR TITLE
Fix link to the Policy Violations docs

### DIFF
--- a/content/blog/centralized-policy-violations/index.md
+++ b/content/blog/centralized-policy-violations/index.md
@@ -64,4 +64,4 @@ Centralizing and surfacing policy violations is just the beginning. Future updat
 
 The Centralized Policy Violations Page to Pulumi is a significant step forward in simplifying policy management and enhancing compliance. By bringing all violations into a single, easily accessible view, we’re making it easier for admins to maintain control and ensure their infrastructure remains secure and compliant.
 
-Try out this new feature today and experience the benefits of streamlined compliance management. For more information, visit our [Policy Violations documentation](/docs/guides/crossguard/policy-violations/). To use this feature, [start a trial](https://app.pulumi.com/signup) or [contact sales](/contact/) to get a demo or to trial Policy as Code.
+Try out this new feature today and experience the benefits of streamlined compliance management. For more information, visit our [Policy Violations documentation](/docs/using-pulumi/crossguard/policy-violations/). To use this feature, [start a trial](https://app.pulumi.com/signup) or [contact sales](/contact/) to get a demo or to trial Policy as Code.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Blog article for Policy Violations points to the Policy Violations documentation, but the link is not correct.