### PR TITLE
Fix up duplicate meta descriptions issues

### DIFF
--- a/content/blog/advanced-aws-networking-part-1/index.md
+++ b/content/blog/advanced-aws-networking-part-1/index.md
@@ -14,7 +14,7 @@ date: 2023-04-05
 # which is useful for targeting search results or social-media previews.
 # This field is required or the build will fail the linter test.
 # Max length is 160 characters.
-meta_desc: Learn how to create a hub-and-spoke architecture in AWS in Python with Pulumi.
+meta_desc: Learn how to create a hub-and-spoke architecture in AWS in Python with Pulumi. This is Part 1 of a 2 Part series.
 
 # The meta_image appears in social-media previews and on the blog home page.
 # A placeholder image representing the recommended format, dimensions and aspect ratio

--- a/content/blog/advanced-aws-networking-part-1/index.md
+++ b/content/blog/advanced-aws-networking-part-1/index.md
@@ -14,7 +14,7 @@ date: 2023-04-05
 # which is useful for targeting search results or social-media previews.
 # This field is required or the build will fail the linter test.
 # Max length is 160 characters.
-meta_desc: Learn how to create a hub-and-spoke architecture in AWS in Python with Pulumi. This is Part 1 of a 2 Part series.
+meta_desc: Learn how to create a hub-and-spoke architecture in AWS using Pulumi with Python. This is Part 1 of a 2 Part series.
 
 # The meta_image appears in social-media previews and on the blog home page.
 # A placeholder image representing the recommended format, dimensions and aspect ratio

--- a/content/blog/advanced-aws-networking-part-2/index.md
+++ b/content/blog/advanced-aws-networking-part-2/index.md
@@ -14,7 +14,7 @@ date: 2023-04-20
 # which is useful for targeting search results or social-media previews.
 # This field is required or the build will fail the linter test.
 # Max length is 160 characters.
-meta_desc: Learn how to create a hub-and-spoke architecture in AWS in Python with Pulumi.
+meta_desc: Learn how to create a hub-and-spoke architecture in AWS using Pulumi with Python. This is Part 2 of a 2 part series.
 
 # The meta_image appears in social-media previews and on the blog home page.
 # A placeholder image representing the recommended format, dimensions and aspect ratio

--- a/content/blog/esc-automation-api-pulumi-service-provider-launch/index.md
+++ b/content/blog/esc-automation-api-pulumi-service-provider-launch/index.md
@@ -3,7 +3,7 @@ title: "Introducing Pulumi ESC Support in Automation API and the Pulumi Service 
 allow_long_title: true
 date: 2024-06-05T00:00:00-05:00
 draft: false
-meta_desc: "The new enhancements to Pulumi ESC Editor streamlines the authoring experience of environments for developers"
+meta_desc: "Supercharge how you manage your infrastructure and application secrets and configurations using the Pulumi Service Provider and Automation API."
 meta_image: "meta.png"
 authors:
   - arun-loganathan

--- a/content/blog/esc-key-value-table-editor-launch/index.md
+++ b/content/blog/esc-key-value-table-editor-launch/index.md
@@ -2,7 +2,7 @@
 title: "Introducing the Key-Value Table Editor for Pulumi ESC"
 date: 2024-03-26T00:00:00-07:00
 draft: false
-meta_desc: "The new enhancements to Pulumi ESC Editor streamlines the authoring experience of environments for developers"
+meta_desc: "The Key-Value Table Editor introduces a new visual interface for managing configuration and secrets using Pulumi ESC."
 meta_image: "meta.png"
 authors:
   - arun-loganathan

--- a/content/blog/october-23-roundup/index.md
+++ b/content/blog/october-23-roundup/index.md
@@ -3,7 +3,7 @@ title: "A recap of October 2023 - A big month at Pulumi!"
 allow_long_title: True
 authors: ["joe-duffy"]
 tags: ["pulumi-news"]
-meta_desc: "Today we announced a $41M Series C to build the best infrastructure as code and tackle more of our customers' toughest cloud challenges."
+meta_desc: "In October 2023 we announced a $41M Series C to build the best infrastructure as code and tackle more of our customers' toughest cloud challenges."
 date: "2023-10-16"
 meta_image: "oct-23.png"
 ---


### PR DESCRIPTION
This PR fixes up some issues we are having with duplicate meta descriptions. These seem to have been copy/pasted from similar blog posts, so I made some alterations to them to make them different and more relevant.