### PR TITLE
ESC environment syntax reference: Add a multiline value example.

### DIFF
--- a/content/docs/esc/reference.md
+++ b/content/docs/esc/reference.md
@@ -54,6 +54,12 @@ values:
     # Array elements are "app.items[0]" and "app.items[1]"
     items: [ "config-a", "config-b" ]
 
+    # Path is "app.multiline"
+    # If the value needs to be a multiline value, use YAML pipe.
+    multilineValue: |
+      The quick brown fox
+      jumped over the lazy dog
+
     # Values within the environment and its imports may be referenced
     # Path is "app.settingCopy"
     settingCopy: ${app.setting}
@@ -73,6 +79,23 @@ values:
     # Path is "app.password"
     password:
       fn::secret: YQ!r24kdF7
+
+    # Multiline private key stored as a secret using YAML multiline pipe.
+    # The value will be encrypted and
+    # stored as ciphertext when the environment is saved.
+    # Path is "app.sshKey"
+    sshKey:
+      fn::secret: |
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        blahblahblahblahblahblahblabhablhablahkldfldsfjdlsfdlfjdslfjlladsklfll
+        dfdsafdsadfsadsfadshblahblabhablhablahkldfldsfjdlsfdlfjdslfjlladsklfll
+        dfdsafdsadfsadsfadshblahblabhablhablahkldfldsfjdlsfdlfjdslfjlladsklfll
+        dfdsafdsadfsadsfadshblahblabhablhablahkldfldsfjdlsfdlfjdslfjlladsklfll
+        dfdsafdsadfsadsfadshblahblabhablhablahkldfldsfjdlsfdlfjdslfjlladsklfll
+        dfdsafdsadfsadsfadshblahblabhablhablahkldfldsfjdlsfdlfjdslfjlladsklfll
+        dfdsafdsadfsadsfadshblahblabhablhablahkldfldsfjdlsfdlfjdslfjlladsklfll
+        dfdsafdsadfsadsfadshblahblabhablhablahkldfldsfjdlsfdlfjdslfjlladsklfll
+        -----END OPENSSH PRIVATE KEY-----
 
     # Join array elements with the given delimiter
     # Path is "app.url"
@@ -208,8 +231,9 @@ values:
       stacks:
         k8-cluster:
           stack: k8-cluster-1/dev
-    kubeconfig:
-      fn::toJSON: ${app.k8-cluster.kubeconfig}
+  kubeconfig:
+    # The referenced stack has a stack output named "kconfig"
+    fn::toJSON: ${app.k8-cluster.kconfig}
 
   # ---------------------------------------------------------------------------------------
   # Exports -- expose configuration values to particular consumers


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
This change is to make it easier to discover that the YAML pipe (i.e. "|") can be used to create values that are multiline text.

- Added a basic example for creating a multiline text value.
- Added another multiline example that uses `fn::secret` for an SSH key.
- Also noticed that the stack reference example had an indent issue, so fixed that.


### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
