### PR TITLE
automatically approve PRs that were created by pulumi-bot

### DIFF
--- a/.github/workflows/auto-approve-for-auto-merge.yml
+++ b/.github/workflows/auto-approve-for-auto-merge.yml
@@ -1,6 +1,6 @@
 name: Auto approve
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   auto-approve:

--- a/.github/workflows/auto-approve-for-auto-merge.yml
+++ b/.github/workflows/auto-approve-for-auto-merge.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: (github.event.pull_request.user.login == 'pulumi-bot') && (github.event.pull_request.head.repo.full_name == github.repository) && (contains(github.event.pull_request.labels.*.name, 'automation/merge')
+    if: (github.event.pull_request.user.login == 'pulumi-bot') && (github.event.pull_request.head.repo.full_name == github.repository) && (contains(github.event.pull_request.labels.*.name, 'automation/merge'))
     steps:
       - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/auto-approve-for-auto-merge.yml
+++ b/.github/workflows/auto-approve-for-auto-merge.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: (github.event.pull_request.user.login == 'pulumi-bot') && (github.event.pull_request.head.repo.full_name == github.repository)
+    if: (github.event.pull_request.user.login == 'pulumi-bot') && (github.event.pull_request.head.repo.full_name == github.repository) && (contains(github.event.pull_request.labels.*.name, 'automation/merge')
     steps:
       - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/auto-approve-for-auto-merge.yml
+++ b/.github/workflows/auto-approve-for-auto-merge.yml
@@ -1,0 +1,12 @@
+name: Auto approve
+
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: (github.event.pull_request.user.login == 'pulumi-bot') && (github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - uses: hmarr/auto-approve-action@v4


### PR DESCRIPTION
pulumi-bot creates documentation update and version update PRs in this repo.  These should be auto-merged, but that's broken because we've set up branch protections, and the action we're using to auto-merge PRs won't go ahead and try to merge PRs if they are not approved (even if there are exceptions set up in the branch protections to allow these PRs through).

Auto-approve PRs that come from pulumi-bot.  This should make the auto-merge automation work again.

### Related issues (optional)
Fixes https://github.com/pulumi/docs/issues/12055
