### PR TITLE
Fix Error in "Embedding Pulumi" Tutorial

### DIFF
--- a/content/tutorials/embedding-pulumi/building-api/index.md
+++ b/content/tutorials/embedding-pulumi/building-api/index.md
@@ -158,7 +158,7 @@ if __name__ == "__main__":
         project="api",
         stackd="dev",
         dirname="api",
-        request="timezone",
+        req="timezone",
     )
     spin_venv(context["dirname"])
     stack = set_stack(context_var=context)


### PR DESCRIPTION
### Proposed changes

The proposed changes are to change a parameter from `request` to `req` on line 161.

Explanation:

The `set_context()`  function accepts the `req` parameter. 

```python
def set_context(org, project, stackd, dirname, req):
    config_obj = {
        "org": org,
        "project": project,
        "stack": stackd,
        "stack_name": auto.fully_qualified_stack_name(org, project, stackd),
        "dirname": dirname,
        "request": req,
    }
    return config_obj
```

However, on line 161 the `set_context` function is called and the `request` parameter is passed in instead of `req`, which is incorrect:

```python
    context = set_context(
        org="<org>",
        project="api",
        stackd="dev",
        dirname="api",
        request="timezone", # <-- this is incorrect
    )
```

In my experience, this did not interfere with the demo but I still think it's worth addressing this so there's no confusion. My IDE complained about this portion of the code and I wasn't sure if I was doing something wrong when going through this demo.