### PR TITLE
Update to use testing account for PR closed

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-to-assume: arn:aws:iam::571684982431:role/ContinuousDelivery
           role-session-name: docs-cleanup
           role-duration-seconds: 7200
           aws-region: us-west-2


### PR DESCRIPTION
updates job to use testing account for PR closed, since that is where the PR buckets are being created. 

See: https://github.com/pulumi/docs/blob/master/.github/workflows/pull-request.yml#L36