### PR TITLE
temporarily disable search index generation

### DIFF
--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -7,7 +7,9 @@ source ./scripts/ci-login.sh
 ./scripts/build-site.sh
 ./scripts/sync-and-test-bucket.sh update
 
-./scripts/generate-search-index.sh
+# Temporarily removing the search index generation from the process until 
+# https://github.com/pulumi/docs/issues/12768 is resolved in order to unblock the pipeline.
+# ./scripts/generate-search-index.sh
 
 node ./scripts/await-in-progress.js
 


### PR DESCRIPTION
Temporarily disabling the search index generation until we can resolve: https://github.com/pulumi/docs/issues/12768. This means the algolia search index that powers our insite search will not be updated until then and will only reflect the current state of the site.

I also disabled the [cron job](https://github.com/pulumi/docs/actions/workflows/update-search-index.yml) that uploads the search index until we can fix this.