### PR TITLE
changed CTA on the ESC page to docs

### DIFF
--- a/layouts/product/secrets-management.html
+++ b/layouts/product/secrets-management.html
@@ -12,7 +12,7 @@
             </h5>
         </div>
         <div class="container mx-auto text-center pt-8 w-9/12">
-            <a href="https://app.pulumi.com/" class="btn-primary">Get Started with Pulumi ESC</a>
+            <a href="https://www.pulumi.com/docs/esc/get-started/" class="btn-primary">Get Started with Pulumi ESC</a>
         </div>
     </section>
 


### PR DESCRIPTION
Updated the CTA on the Pulumi ESC page to point to the ESC get started in docs.