### PR TITLE
fix path for versions.md in pulumi-cli version update workflow

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Update version lists
         run: |
           NL=$'\n'
-          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/iac/install/versions.md
+          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/iac/download-install/versions.md
         working-directory: docs
       - name: git status
         run: git status && git diff


### PR DESCRIPTION
There was some reorganization of the docs in https://github.com/pulumi/docs/pull/12693, which adjusted a bunch of paths.  This path here was also updated both in the workflow and in the repo, but not quite correctly.  Fix that now.

Fixes https://github.com/pulumi/docs/issues/12814
Fixes https://github.com/pulumi/pulumi/issues/17282
