### PR TITLE
Allow CLI docs PRs to be merged automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 content/docs/ @pulumi/docs
+# Allow CLI docs PRs to be merged automatically.
+content/docs/iac/cli/commands/
+content/docs/esc/cli/commands/
+
 content/tutorials/ @pulumi/docs
 content/templates/ @pulumi/docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,9 @@
 content/docs/ @pulumi/docs
+
 # Allow CLI docs PRs to be merged automatically.
 content/docs/iac/cli/commands/
 content/docs/esc/cli/commands/
+content/docs/iac/download-install/versions.md
 
 content/tutorials/ @pulumi/docs
 content/templates/ @pulumi/docs


### PR DESCRIPTION
It looks like the current CODEOWNERS setting (which requires a review from the docs team for anything under /docs) is preventing CLI docs PRs from being merged automatically. This should fix things up.