### PR TITLE
disable 404 checker

### DIFF
--- a/scripts/ci-pull-request.sh
+++ b/scripts/ci-pull-request.sh
@@ -20,4 +20,6 @@ source ./scripts/ci-login.sh
 
 ./scripts/run-pulumi.sh preview
 ./scripts/make-s3-redirects.sh
-./scripts/detect-new-404s.sh
+
+# temporarily disable 404 checker.
+# ./scripts/detect-new-404s.sh


### PR DESCRIPTION
temporarily disabling 404 checker to not block PRs that have links to pages that do not yet exist (but will soon).