### PR TITLE
Fix PR closed job

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -38,3 +38,4 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOYMENT_ENVIRONMENT: ${{ vars.DEPLOYMENT_ENVIRONMENT }}

--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -22,11 +22,12 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
         pr_comment_api_url="$(echo $event | jq -r ".pull_request._links.comments.href")"
 
         # List s3 buckets and filter all buckets associated with this PR. 
-        buckets=$(aws s3 ls | grep "$(origin_bucket_prefix)-pr-${pr_number}")
+        buckets=$(aws s3 ls | grep "$(origin_bucket_prefix)-pr-${pr_number}" | awk '{print $3}')
 
         if [ ! -z "$buckets" ]; then
             for bucket in $buckets; do
-                aws s3 rb "s3://${pr_bucket_name}" --force --region "$(aws_region)"
+                echo "removing s3://${bucket}..."
+                aws s3 rb "s3://${bucket}" --force --region "$(aws_region)"
             done
         else
             echo "No buckets found for PR: 'https://github.com/pulumi/docs/pulls/${pr_number}'"

--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -21,33 +21,16 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
     if [[ "$pr_action" == "closed" ]]; then
         pr_comment_api_url="$(echo $event | jq -r ".pull_request._links.comments.href")"
 
-        # Find all commits associated with the PR.
-        pr_commits="$(curl \
-            -s \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/commits")"
+        # List s3 buckets and filter all buckets associated with this PR. 
+        buckets=$(aws s3 ls | grep "$(origin_bucket_prefix)-pr-${pr_number}")
 
-        # For each PR commit, if a bucket exists for it, delete it.
-        for commit in $(echo $pr_commits | jq -r ".[].sha"); do
-            pr_bucket_name="$(get_bucket_for_commit $commit)"
-
-            if [ ! -z "$pr_bucket_name" ]; then
-                echo "Found bucket ${pr_bucket_name} associated with commit ${commit}."
-                echo "Attempting to delete..."
-
-                # aws s3api head-bucket is a quick way to determine whether the bucket exists
-                # and we have access to it.
-                if aws s3api head-bucket --bucket "$pr_bucket_name" --region "$(aws_region)" 2>/dev/null; then
-                    aws s3 rb "s3://${pr_bucket_name}" --force --region "$(aws_region)"
-                    remove_param_for_commit "$(git_sha)" "$(aws_region)"
-                else
-                    echo "Unable to delete ${pr_bucket_name}. Skipping."
-                fi
-            else
-                echo "No bucket found for commit ${commit}. Skipping."
-            fi
-        done
+        if [ ! -z "$buckets" ]; then
+            for bucket in $buckets; do
+                aws s3 rb "s3://${pr_bucket_name}" --force --region "$(aws_region)"
+            done
+        else
+            echo "No buckets found for PR: 'https://github.com/pulumi/docs/pulls/${pr_number}'"
+        fi
 
         # Post a PR comment that any links to previously built previews will no longer work.
         post_github_pr_comment \

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -97,38 +97,6 @@ build_identifier() {
     echo "$identifier"
 }
 
-# Get the AWS SSM Parameter Store key for the specified commit SHA. Used for mapping a
-# commit to a previously created bucket.
-ssm_parameter_key_for_commit() {
-    echo "/docs/commits/$1/bucket"
-}
-
-# Get the S3 bucket associated with a specific commit.
-get_bucket_for_commit() {
-    aws ssm get-parameter \
-        --name "$(ssm_parameter_key_for_commit $1)" \
-        --query Parameter.Value \
-        --region "$(aws_region)" \
-        --output text || echo ""
-}
-
-# Set the S3 bucket associated with a specific commit.
-set_bucket_for_commit() {
-    aws ssm put-parameter \
-        --name "$(ssm_parameter_key_for_commit $1)" \
-        --value "$2" \
-        --type String \
-        --region $3 \
-        --overwrite
-}
-
-# Remove the parameter key associated with a specific commit.
-remove_param_for_commit() {
-    aws ssm delete-parameter \
-        --name "$(ssm_parameter_key_for_commit $1)" \
-        --region $2
-}
-
 # List the 100 most recent bucket in the current account, sorted descendingly by
 # CreationDate, matching the prefix we use to name website buckets. Supports an optional
 # suffix to filter by (e.g., "pr" or "push").

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -108,9 +108,6 @@ printf "$metadata" "$(current_time_in_ms)" "$(git_sha)" "$destination_bucket" "$
 # Copy the file to the destination bucket, for future reference.
 aws s3 cp "$metadata_file" "${destination_bucket_uri}/metadata.json" --region "$(aws_region)" --acl public-read
 
-# Persist an association between the current commit and the bucket we just deployed to.
-set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$(aws_region)"
-
 # Set cors configuration on bucket.
 aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration "file://scripts/cors/cors.json" --region "$(aws_region)"
 


### PR DESCRIPTION
Our PR closed jobs have not been cleaning up and of the buckets associated with their PRs and have been failing silently since it thinks there were no buckets to delete. 

I made some adjustments to the job to fix this as well as remove the dependency we had on the SSM parameter store. We used to use the store to persist each commit for a PR and then find buckets based on that. I have simplified this a bit to remove this dependency altogether as it doesn't look like this complexity is needed and instead just remove all buckets via `<origin_bucket_prefits>-pr-<pr-number>`, since we do want to delete all buckets associated with that PR anyway.