### PR TITLE
docs iac menu fix for project file reference page

### DIFF
--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -5,7 +5,7 @@ title: Project file reference
 h1: Pulumi project file reference
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    iad:
+    iac:
         name: Project file reference
         parent: iac-concepts-projects
         weight: 1


### PR DESCRIPTION
fixing a typo for the menu on this page:
https://github.com/pulumi/docs/edit/master/content/docs/iac/concepts/projects/project-file.md
