### PR TITLE
wrap text to avoid platypus overlap on docs banner

### DIFF
--- a/layouts/partials/docs/special-pages/docs-home.html
+++ b/layouts/partials/docs/special-pages/docs-home.html
@@ -6,7 +6,9 @@
     <div id="docs-home-banner" class="header bg-blue-100 bg-right">
         {{ $h1 := split .Params.h1 " " }}
         <h1>{{ index $h1 0 }}<strong> {{ index $h1 1 }}</strong> docs</h1>
-        {{ .Params.description | safeHTML }}
+        <div class="w-full lg:w-2/3">
+            {{ .Params.description | safeHTML }}
+        </div>
         <div class="link-buttons">
             <a class="docs-primary-link-btn" href="{{ $primary_link_button.link }}">{{ $primary_link_button.label }}</a>
             <a class="docs-secondary-link-btn" href="{{ $secondary_link_button.link }}">{{ $secondary_link_button.label }}</a>


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
fixed the text wrap on the docs banners
