### PR TITLE
Set margin for hubspot forms inside label so autohide will not leave margins between fields

### DIFF
--- a/theme/src/scss/_hubspot.scss
+++ b/theme/src/scss/_hubspot.scss
@@ -12,7 +12,6 @@
 
     fieldset {
         @apply block;
-        margin: 1rem 0 !important;
 
         &:not(.form-columns-1) > .field:first-child {
             @apply pr-2;
@@ -20,6 +19,7 @@
 
         label {
             @apply block mb-2 font-normal;
+            margin: 1rem 0 !important;
         }
 
         .hs-input {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/ffcebe12-1a93-4cd0-ad4b-930604f3de7f)
![image](https://github.com/user-attachments/assets/8207828f-a590-4d59-9d55-1434f2567509)

After:
<img width="672" alt="image" src="https://github.com/user-attachments/assets/e5b8c012-4946-45e2-ba34-44b155603d6f">
<img width="675" alt="image" src="https://github.com/user-attachments/assets/588e880d-49c0-466b-b44d-4772a5fa2e11">
