### PR TITLE
Document Python output lifting's use of `__getattr__`

### DIFF
--- a/content/docs/iac/concepts/inputs-outputs/apply.md
+++ b/content/docs/iac/concepts/inputs-outputs/apply.md
@@ -865,6 +865,10 @@ record = aws.route53.Record('validation',
 ...
 ```
 
+{{< notes type="warning" >}}
+Note that in Python, output lifting is implemented by overriding the special `__getattr__` method on resources so that the expression `resource.output` (which results in a call to `resource.__getattr__("output")`) becomes `resource.apply(lambda r: r.output)`. This means that using `hasattr`, which calls `__getattr__` under the hood and looks for an `AttributeError` to determine whether or not a property exists, will not work as expected on resource outputs.
+{{< /notes >}}
+
 {{% /choosable %}}
 
 {{% choosable language go %}}


### PR DESCRIPTION
The Pulumi Python SDK lifts output properties by overriding the special `__getattr__` method. This is designed to improve the ergonomics of writing Pulumi programs in Python, but technically violates some of the contracts Python expects of this method, particularly in relation to `hasattr`. This commit warns of this potential gotcha when mentioning output lifting to give users a reference point should they bump into this issue.

Fixes pulumi/pulumi#16743