### PR TITLE
Update getting started guides to use dictionary literals in Python

### DIFF
--- a/content/docs/iac/get-started/aws/deploy-changes.md
+++ b/content/docs/iac/get-started/aws/deploy-changes.md
@@ -144,9 +144,9 @@ const bucket = new aws.s3.Bucket("my-bucket", {
 
 ```python
 bucket = s3.Bucket("my-bucket",
-    website=s3.BucketWebsiteArgs(
-        index_document="index.html",
-    ),
+    website={
+        "index_document": "index.html",
+    },
 )
 ```
 
@@ -249,9 +249,9 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 ownership_controls = s3.BucketOwnershipControls(
     'ownership-controls',
     bucket=bucket.id,
-    rule=s3.BucketOwnershipControlsRuleArgs(
-        object_ownership='ObjectWriter',
-    ),
+    rule={
+        "object_ownership": 'ObjectWriter',
+    },
 )
 
 public_access_block = s3.BucketPublicAccessBlock(

--- a/content/docs/iac/get-started/azure/review-project.md
+++ b/content/docs/iac/get-started/azure/review-project.md
@@ -99,9 +99,9 @@ resource_group = resources.ResourceGroup("resource_group")
 account = storage.StorageAccount(
     "sa",
     resource_group_name=resource_group.name,
-    sku=storage.SkuArgs(
-        name=storage.SkuName.STANDARD_LRS,
-    ),
+    sku={
+        "name": storage.SkuName.STANDARD_LRS,
+    },
     kind=storage.Kind.STORAGE_V2,
 )
 

--- a/content/docs/iac/get-started/gcp/deploy-changes.md
+++ b/content/docs/iac/get-started/gcp/deploy-changes.md
@@ -187,7 +187,9 @@ To do that, update the bucket definition to configure its `website` property. Th
 bucket = storage.Bucket(
     "my-bucket",
     location="US",
-    website=storage.BucketWebsiteArgs(main_page_suffix="index.html"),
+    website={
+        "main_page_suffix": "index.html"
+    },
     uniform_bucket_level_access=True,
 )
 ```

--- a/content/docs/iac/get-started/kubernetes/review-project.md
+++ b/content/docs/iac/get-started/kubernetes/review-project.md
@@ -109,14 +109,14 @@ app_labels = { "app": "nginx" }
 
 deployment = Deployment(
     "nginx",
-    spec=DeploymentSpecArgs(
-        selector=LabelSelectorArgs(match_labels=app_labels),
-        replicas=1,
-        template=PodTemplateSpecArgs(
-            metadata=ObjectMetaArgs(labels=app_labels),
-            spec=PodSpecArgs(containers=[ContainerArgs(name="nginx", image="nginx")])
-        ),
-    ))
+    spec={
+        "selector": { "match_labels": app_labels },
+        "replicas": 1,
+        "template": {
+            "metadata": { "labels": app_labels },
+            "spec": { "containers": [{ "name": "nginx", "image": "nginx" }] }
+        },
+    })
 
 pulumi.export("name", deployment.metadata["name"])
 ```


### PR DESCRIPTION
### Proposed changes

We prefer (the now typed) dictionary literals for Python inputs, over the `Args` classes.

### Related issues (optional)

https://github.com/pulumi/docs/issues/12229