### PR TITLE
Add ignore rule for 404ing link in dbtcloud provider docs

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -291,6 +291,7 @@ function getDefaultExcludedKeywords() {
         "https://openai.com/",
         "https://github.com/marketplace",
         "https://bard.google.com/",
+        "https://cloud.getdbt.com/api",
     ];
 }
 


### PR DESCRIPTION
This URL is correct, but is a deeplink into the dbtcloud app and requires a login, hence failing the link checker.