### PR TITLE
Rewrite how Pulumi works page to use BucketV2

### DIFF
--- a/content/docs/iac/concepts/how-pulumi-works.md
+++ b/content/docs/iac/concepts/how-pulumi-works.md
@@ -63,6 +63,9 @@ Let's walk through a simple example. Suppose we have the following Pulumi progra
 {{% choosable language javascript %}}
 
 ```javascript
+"use strict";
+const aws = require("@pulumi/aws");
+
 const mediaBucket = new aws.s3.BucketV2("media-bucket");
 const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```
@@ -71,6 +74,8 @@ const contentBucket = new aws.s3.BucketV2("content-bucket");
 {{% choosable language typescript %}}
 
 ```typescript
+import * as aws from "@pulumi/aws";
+
 const mediaBucket = new aws.s3.BucketV2("media-bucket");
 const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```
@@ -79,6 +84,8 @@ const contentBucket = new aws.s3.BucketV2("content-bucket");
 {{% choosable language python %}}
 
 ```python
+from pulumi_aws import s3
+
 media_bucket = s3.BucketV2('media-bucket')
 content_bucket = s3.BucketV2('content-bucket')
 ```
@@ -87,31 +94,42 @@ content_bucket = s3.BucketV2('content-bucket')
 {{% choosable language go %}}
 
 ```go
-mediaBucket, _ := s3.NewBucketV2(ctx, "media-bucket", nil)
-contentBucket, _ := s3.NewBucketV2(ctx, "content-bucket", nil)
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		mediaBucket, err := s3.NewBucketV2(ctx, "media-bucket", nil)
+		if err != nil {
+			return err
+		}
+		contentBucket, err := s3.NewBucketV2(ctx, "content-bucket", nil)
+		if err != nil {
+			return err
+		}
+		ctx.Export("contentBucket", contentBucket.ID())
+		ctx.Export("mediaBucket", mediaBucket.ID())
+		return nil
+	})
+}
 ```
 
 {{% /choosable %}}
 {{% choosable language csharp %}}
 
 ```csharp
-using System.Threading.Tasks;
 using Pulumi;
 using Aws = Pulumi.Aws;
 
-class Program
+return await Deployment.RunAsync(() =>
 {
-    static Task<int> Main() => Deployment.RunAsync<MyStack>();
-}
-
-public MyStack : Stack
-{
-    public MyStack()
-    {
-        var mediaBucket = new Aws.S3.BucketV2("media-bucket");
-        var contentBucket = new Aws.S3.BucketV2("content-bucket");
-    }
-}
+    var mediaBucket = new Aws.S3.BucketV2("media-bucket");
+    var contentBucket = new Aws.S3.BucketV2("content-bucket");
+});
 ```
 
 {{% /choosable %}}
@@ -120,20 +138,15 @@ public MyStack : Stack
 ```java
 package myproject;
 
-import com.pulumi.Context;
-import com.pulumi.Exports;
 import com.pulumi.Pulumi;
-import com.pulumi.aws.s3.Bucket;
-
+import com.pulumi.aws.s3.BucketV2;
 
 public class App {
     public static void main(String[] args) {
-        Pulumi.run(App::stack);
-    }
-
-    public static void stack(Context ctx) {
-        var mediaBucket = new BucketV2("media-bucket");
-        var contentBucket = new BucketV2("content-bucket");
+        Pulumi.run(ctx -> {
+            var mediaBucket = new BucketV2("media-bucket");
+            var contentBucket = new BucketV2("content-bucket");
+        });
     }
 }
 ```
@@ -142,6 +155,8 @@ public class App {
 {{% choosable language yaml %}}
 
 ```yaml
+name: my-yaml-project
+runtime: yaml
 resources:
     mediaBucket:
         type: aws:s3:BucketV2
@@ -178,6 +193,9 @@ Now, let's make a change to one of resources and run `pulumi up` again.  Since P
 {{% choosable language javascript %}}
 
 ```javascript
+"use strict";
+const aws = require("@pulumi/aws");
+
 const mediaBucket = new aws.s3.BucketV2("media-bucket", {
     tags: {"owner": "media-team"},
 });
@@ -188,6 +206,8 @@ const contentBucket = new aws.s3.BucketV2("content-bucket");
 {{% choosable language typescript %}}
 
 ```typescript
+import * as aws from "@pulumi/aws";
+
 const mediaBucket = new aws.s3.BucketV2("media-bucket", {
     tags: {"owner": "media-team"},
 });
@@ -198,6 +218,8 @@ const contentBucket = new aws.s3.BucketV2("content-bucket");
 {{% choosable language python %}}
 
 ```python
+from pulumi_aws import s3
+
 media_bucket = s3.BucketV2('media-bucket', tags={'owner': 'media-team'})
 content_bucket = s3.BucketV2('content-bucket')
 ```
@@ -206,36 +228,51 @@ content_bucket = s3.BucketV2('content-bucket')
 {{% choosable language go %}}
 
 ```go
-mediaBucket, _ := s3.NewBucketV2(ctx, "mediaBucket", &s3.BucketV2Args{
-        Tags: pulumi.StringMap{
-                "owner": pulumi.String("media-team"),
-        },
-})
-contentBucket, _ := s3.NewBucketV2(ctx, "contentBucket", nil)
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		mediaBucket, err := s3.NewBucketV2(ctx, "mediaBucket", &s3.BucketV2Args{
+			Tags: pulumi.StringMap{
+				"owner": pulumi.String("media-team"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		contentBucket, err := s3.NewBucketV2(ctx, "contentBucket", nil)
+		if err != nil {
+			return err
+		}
+		ctx.Export("contentBucket", contentBucket.ID())
+		ctx.Export("mediaBucket", mediaBucket.ID())
+		return nil
+	})
+}
 ```
 
 {{% /choosable %}}
 {{% choosable language csharp %}}
 
 ```csharp
-
-using System.Collections.Generic;
-using System.Linq;
 using Pulumi;
 using Aws = Pulumi.Aws;
 
 return await Deployment.RunAsync(() =>
 {
-    var mediaBucket = new Aws.S3.BucketV2("mediaBucket", new()
+    var mediaBucket = new Aws.S3.BucketV2("media-bucket", new()
     {
         Tags =
         {
             { "owner", "media-team" },
         },
-    });
-
-    var contentBucket = new Aws.S3.BucketV2("contentBucket");
-
+    }););
+    var contentBucket = new Aws.S3.BucketV2("content-bucket");
 });
 ```
 
@@ -243,33 +280,21 @@ return await Deployment.RunAsync(() =>
 {{% choosable language java %}}
 
 ```java
-
 package myproject;
 
-import com.pulumi.Context;
+import java.util.Map;
 import com.pulumi.Pulumi;
-import com.pulumi.core.Output;
 import com.pulumi.aws.s3.BucketV2;
 import com.pulumi.aws.s3.BucketV2Args;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 public class App {
     public static void main(String[] args) {
-        Pulumi.run(App::stack);
-    }
-
-    public static void stack(Context ctx) {
-        var mediaBucket = new BucketV2("mediaBucket", BucketV2Args.builder()
-            .tags(Map.of("owner", "media-team"))
-            .build());
-
-        var contentBucket = new BucketV2("contentBucket");
-
+        Pulumi.run(ctx -> {
+            var mediaBucket = new BucketV2("mediaBucket", BucketV2Args.builder()
+                .tags(Map.of("owner", "media-team"))
+                .build());
+            var contentBucket = new BucketV2("content-bucket");
+        });
     }
 }
 ```
@@ -278,6 +303,8 @@ public class App {
 {{% choosable language yaml %}}
 
 ```yaml
+name: my-yaml-project
+runtime: yaml
 resources:
   mediaBucket:
     type: aws:s3:BucketV2
@@ -285,7 +312,7 @@ resources:
       tags:
         owner: media-team
   contentBucket:
-    type: aws:s3:Bucket
+    type: aws:s3:BucketV2
 ```
 
 {{% /choosable %}}
@@ -303,6 +330,8 @@ Now, suppose we rename `content-bucket` to `app-bucket`.
 {{% choosable language javascript %}}
 
 ```javascript
+"use strict";
+const aws = require("@pulumi/aws");
 const mediaBucket = new aws.s3.BucketV2("media-bucket", {
     tags: {"owner": "media-team"},
 });
@@ -313,6 +342,8 @@ const appBucket = new aws.s3.BucketV2("app-bucket");
 {{% choosable language typescript %}}
 
 ```typescript
+import * as aws from "@pulumi/aws";
+
 const mediaBucket = new aws.s3.BucketV2("media-bucket", {
     tags: {"owner": "media-team"},
 });
@@ -323,6 +354,8 @@ const appBucket = new aws.s3.BucketV2("app-bucket");
 {{% choosable language python %}}
 
 ```python
+from pulumi_aws import s3
+
 media_bucket = s3.BucketV2('media-bucket', tags={'owner': 'media-team'})
 app_bucket = s3.BucketV2('app-bucket')
 ```
@@ -331,36 +364,51 @@ app_bucket = s3.BucketV2('app-bucket')
 {{% choosable language go %}}
 
 ```go
-mediaBucket, _ := s3.NewBucketV2(ctx, "mediaBucket", &s3.BucketV2Args{
-        Tags: pulumi.StringMap{
-                "owner": pulumi.String("media-team"),
-        },
-})
-appBucket, _ := s3.NewBucketV2(ctx, "appBucket", nil)
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		mediaBucket, err := s3.NewBucketV2(ctx, "mediaBucket", &s3.BucketV2Args{
+			Tags: pulumi.StringMap{
+				"owner": pulumi.String("media-team"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		appBucket, err := s3.NewBucketV2(ctx, "appBucket", nil)
+		if err != nil {
+			return err
+		}
+		ctx.Export("appBucket", appBucket.ID())
+		ctx.Export("mediaBucket", mediaBucket.ID())
+		return nil
+	})
+}
 ```
 
 {{% /choosable %}}
 {{% choosable language csharp %}}
 
 ```csharp
-
-using System.Collections.Generic;
-using System.Linq;
 using Pulumi;
 using Aws = Pulumi.Aws;
 
 return await Deployment.RunAsync(() =>
 {
-    var mediaBucket = new Aws.S3.BucketV2("mediaBucket", new()
+    var mediaBucket = new Aws.S3.BucketV2("media-bucket", new()
     {
         Tags =
         {
             { "owner", "media-team" },
         },
-    });
-
-    var appBucket = new Aws.S3.BucketV2("appBucket");
-
+    }););
+    var appBucket = new Aws.S3.BucketV2("app-bucket");
 });
 ```
 
@@ -368,33 +416,21 @@ return await Deployment.RunAsync(() =>
 {{% choosable language java %}}
 
 ```java
-
 package myproject;
 
-import com.pulumi.Context;
+import java.util.Map;
 import com.pulumi.Pulumi;
-import com.pulumi.core.Output;
 import com.pulumi.aws.s3.BucketV2;
 import com.pulumi.aws.s3.BucketV2Args;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 public class App {
     public static void main(String[] args) {
-        Pulumi.run(App::stack);
-    }
-
-    public static void stack(Context ctx) {
-        var mediaBucket = new BucketV2("mediaBucket", BucketV2Args.builder()
-            .tags(Map.of("owner", "media-team"))
-            .build());
-
-        var appBucket = new BucketV2("appBucket");
-
+        Pulumi.run(ctx -> {
+            var mediaBucket = new BucketV2("mediaBucket", BucketV2Args.builder()
+                .tags(Map.of("owner", "media-team"))
+                .build());
+            var appBucket = new BucketV2("appBucket");
+        });
     }
 }
 ```
@@ -403,6 +439,8 @@ public class App {
 {{% choosable language yaml %}}
 
 ```yaml
+name: my-yaml-project
+runtime: yaml
 resources:
   mediaBucket:
     type: aws:s3:BucketV2
@@ -410,7 +448,7 @@ resources:
       tags:
         owner: media-team
   appBucket:
-    type: aws:s3:Bucket
+    type: aws:s3:BucketV2
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/how-pulumi-works.md
+++ b/content/docs/iac/concepts/how-pulumi-works.md
@@ -63,32 +63,32 @@ Let's walk through a simple example. Suppose we have the following Pulumi progra
 {{% choosable language javascript %}}
 
 ```javascript
-const mediaBucket = new aws.s3.Bucket("media-bucket");
-const contentBucket = new aws.s3.Bucket("content-bucket");
+const mediaBucket = new aws.s3.BucketV2("media-bucket");
+const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```
 
 {{% /choosable %}}
 {{% choosable language typescript %}}
 
 ```typescript
-const mediaBucket = new aws.s3.Bucket("media-bucket");
-const contentBucket = new aws.s3.Bucket("content-bucket");
+const mediaBucket = new aws.s3.BucketV2("media-bucket");
+const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```
 
 {{% /choosable %}}
 {{% choosable language python %}}
 
 ```python
-media_bucket = s3.Bucket('media-bucket')
-content_bucket = s3.Bucket('content-bucket')
+media_bucket = s3.BucketV2('media-bucket')
+content_bucket = s3.BucketV2('content-bucket')
 ```
 
 {{% /choosable %}}
 {{% choosable language go %}}
 
 ```go
-mediaBucket, _ := s3.NewBucket(ctx, "media-bucket", nil)
-contentBucket, _ := s3.NewBucket(ctx, "content-bucket", nil)
+mediaBucket, _ := s3.NewBucketV2(ctx, "media-bucket", nil)
+contentBucket, _ := s3.NewBucketV2(ctx, "content-bucket", nil)
 ```
 
 {{% /choosable %}}
@@ -108,8 +108,8 @@ public MyStack : Stack
 {
     public MyStack()
     {
-        var mediaBucket = new Aws.S3.Bucket("media-bucket");
-        var contentBucket = new Aws.S3.Bucket("content-bucket");
+        var mediaBucket = new Aws.S3.BucketV2("media-bucket");
+        var contentBucket = new Aws.S3.BucketV2("content-bucket");
     }
 }
 ```
@@ -132,8 +132,8 @@ public class App {
     }
 
     public static void stack(Context ctx) {
-        var mediaBucket = new Bucket("media-bucket");
-        var contentBucket = new Bucket("content-bucket");
+        var mediaBucket = new BucketV2("media-bucket");
+        var contentBucket = new BucketV2("content-bucket");
     }
 }
 ```
@@ -144,9 +144,9 @@ public class App {
 ```yaml
 resources:
     mediaBucket:
-        type: aws:s3:Bucket
+        type: aws:s3:BucketV2
     contentBucket:
-        type: aws:s3:Bucket
+        type: aws:s3:BucketV2
 ```
 
 {{% /choosable %}}
@@ -165,87 +165,98 @@ After both operations have completed, the language host exits as the program has
 
 ```
 stack mystack
-   - aws.s3.Bucket "media-bucket653a4"
-   - aws.s3.Bucket "content-bucket125ce"
+   - aws.s3.BucketV2 "media-bucket653a4"
+   - aws.s3.BucketV2 "content-bucket125ce"
 ```
 
 Note the extra suffixes on the end of these bucket names. This is due to a process called [auto-naming](/docs/concepts/resources#autonaming), which Pulumi uses by default in order to allow you to deploy multiple copies of your infrastructure without creating name collisions for resources. This behavior can be disabled if desired.
 
-Now, let's make a change to one of resources and run `pulumi up` again.  Since Pulumi operates on a desired state model, it will use the last deployed state to compute the minimal set of changes needed to update your deployed infrastructure. For example, imagine that we wanted to make the S3 `media-bucket` publicly readable.  We change our program to express this new desired state:
+Now, let's make a change to one of resources and run `pulumi up` again.  Since Pulumi operates on a desired state model, it will use the last deployed state to compute the minimal set of changes needed to update your deployed infrastructure. For example, imagine that we wanted to add tags to the S3 `media-bucket`.  We change our program to express this new desired state:
 
 {{< chooser language "javascript,typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language javascript %}}
 
 ```javascript
-const mediaBucket = new aws.s3.Bucket("media-bucket", {
-    acl: "public-read",   // add acl
+const mediaBucket = new aws.s3.BucketV2("media-bucket", {
+    tags: {"owner": "media-team"},
 });
-const contentBucket = new aws.s3.Bucket("content-bucket");
+const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```
 
 {{% /choosable %}}
 {{% choosable language typescript %}}
 
 ```typescript
-const mediaBucket = new aws.s3.Bucket("media-bucket", {
-    acl: "public-read",   // add acl
+const mediaBucket = new aws.s3.BucketV2("media-bucket", {
+    tags: {"owner": "media-team"},
 });
-const contentBucket = new aws.s3.Bucket("content-bucket");
+const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```
 
 {{% /choosable %}}
 {{% choosable language python %}}
 
 ```python
-media_bucket = s3.Bucket('media-bucket', acl="public-read") # add acl
-content_bucket = s3.Bucket('content-bucket')
+media_bucket = s3.BucketV2('media-bucket', tags={'owner': 'media-team'})
+content_bucket = s3.BucketV2('content-bucket')
 ```
 
 {{% /choosable %}}
 {{% choosable language go %}}
 
 ```go
-mediaBucket, _ := s3.NewBucket(ctx, "media-bucket", &s3.BucketArgs{Acl: "public-read"}) // add acl
-contentBucket, _ := s3.NewBucket(ctx, "content-bucket", nil)
+mediaBucket, _ := s3.NewBucketV2(ctx, "mediaBucket", &s3.BucketV2Args{
+        Tags: pulumi.StringMap{
+                "owner": pulumi.String("media-team"),
+        },
+})
+contentBucket, _ := s3.NewBucketV2(ctx, "contentBucket", nil)
 ```
 
 {{% /choosable %}}
 {{% choosable language csharp %}}
 
 ```csharp
-using System.Threading.Tasks;
+
+using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 using Aws = Pulumi.Aws;
 
-class Program
+return await Deployment.RunAsync(() =>
 {
-    static Task<int> Main() => Deployment.RunAsync<MyStack>();
-}
-
-public MyStack : Stack
-{
-    public MyStack()
+    var mediaBucket = new Aws.S3.BucketV2("mediaBucket", new()
     {
-        var mediaBucket = new Aws.S3.Bucket("media-bucket", new Aws.S3.BucketArgs
+        Tags =
         {
-            Acl = "public-read",   // add acl
-        });
-        var contentBucket = new Aws.S3.Bucket("content-bucket");
-    }
-}
+            { "owner", "media-team" },
+        },
+    });
+
+    var contentBucket = new Aws.S3.BucketV2("contentBucket");
+
+});
 ```
 
 {{% /choosable %}}
 {{% choosable language java %}}
 
 ```java
+
 package myproject;
 
 import com.pulumi.Context;
-import com.pulumi.Exports;
 import com.pulumi.Pulumi;
-import com.pulumi.aws.s3.Bucket;
+import com.pulumi.core.Output;
+import com.pulumi.aws.s3.BucketV2;
+import com.pulumi.aws.s3.BucketV2Args;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class App {
     public static void main(String[] args) {
@@ -253,11 +264,12 @@ public class App {
     }
 
     public static void stack(Context ctx) {
-        var mediaBucket = new Bucket("media-bucket",
-            BucketArgs.builder()
-                .acl("public-read")   // add acl
-                .build());
-        var contentBucket = new Bucket("content-bucket");
+        var mediaBucket = new BucketV2("mediaBucket", BucketV2Args.builder()
+            .tags(Map.of("owner", "media-team"))
+            .build());
+
+        var contentBucket = new BucketV2("contentBucket");
+
     }
 }
 ```
@@ -268,9 +280,10 @@ public class App {
 ```yaml
 resources:
   mediaBucket:
-    type: aws:s3:Bucket
+    type: aws:s3:BucketV2
     properties:
-      acl: public-read # add acl
+      tags:
+        owner: media-team
   contentBucket:
     type: aws:s3:Bucket
 ```
@@ -279,7 +292,7 @@ resources:
 
 {{< /chooser >}}
 
-When you run `pulumi preview` or `pulumi up`, the entire process starts over.  The language host starts running your program and the call to aws.s3.Bucket causes a new resource registration request to be sent to the engine. This time, however, our state already contains a resource named `media-bucket`, so engine asks the resource provider to compare the existing state from our previous run of `pulumi up` with the desired state expressed by the program. The process detects that the `acl` property has changed from `private` (the default value) to `public-read`. By again consulting the resource provider the engine determines that it is able to update this property without creating a new bucket, and so it tells the provider to update the acl property to `public-read`. When this operation completes, the current state is updated to reflect the change that had been made.
+When you run `pulumi preview` or `pulumi up`, the entire process starts over.  The language host starts running your program and the call to aws.s3.BucketV2 causes a new resource registration request to be sent to the engine. This time, however, our state already contains a resource named `media-bucket`, so engine asks the resource provider to compare the existing state from our previous run of `pulumi up` with the desired state expressed by the program. The process detects that the `tags` property has changed from empty to a map assigning the `owner` tag. By again consulting the resource provider the engine determines that it is able to update this property without creating a new bucket, and so it tells the provider to update the `tags` property to set the `owner` tag. When this operation completes, the current state is updated to reflect the change that had been made.
 
 The engine also receives a resource registration request for "content-bucket".  However, since there are no changes between the current state and the desired state, the engine does not need to make any changes to the resource.
 
@@ -290,74 +303,85 @@ Now, suppose we rename `content-bucket` to `app-bucket`.
 {{% choosable language javascript %}}
 
 ```javascript
-const mediaBucket = new aws.s3.Bucket("media-bucket", {
-    acl: "public-read",   // add acl
+const mediaBucket = new aws.s3.BucketV2("media-bucket", {
+    tags: {"owner": "media-team"},
 });
-const appBucket = new aws.s3.Bucket("app-bucket");
+const appBucket = new aws.s3.BucketV2("app-bucket");
 ```
 
 {{% /choosable %}}
 {{% choosable language typescript %}}
 
 ```typescript
-const mediaBucket = new aws.s3.Bucket("media-bucket", {
-    acl: "public-read",   // add acl
+const mediaBucket = new aws.s3.BucketV2("media-bucket", {
+    tags: {"owner": "media-team"},
 });
-const appBucket = new aws.s3.Bucket("app-bucket");
+const appBucket = new aws.s3.BucketV2("app-bucket");
 ```
 
 {{% /choosable %}}
 {{% choosable language python %}}
 
 ```python
-media_bucket = s3.Bucket('media-bucket', acl="public-read") # add acl
-app_bucket = s3.Bucket('app-bucket')
+media_bucket = s3.BucketV2('media-bucket', tags={'owner': 'media-team'})
+app_bucket = s3.BucketV2('app-bucket')
 ```
 
 {{% /choosable %}}
 {{% choosable language go %}}
 
 ```go
-mediaBucket, _ := s3.NewBucket(ctx, "media-bucket", &s3.BucketArgs{Acl: "public-read"}) // add acl
-appBucket, _ := s3.NewBucket(ctx, "app-bucket", nil)
+mediaBucket, _ := s3.NewBucketV2(ctx, "mediaBucket", &s3.BucketV2Args{
+        Tags: pulumi.StringMap{
+                "owner": pulumi.String("media-team"),
+        },
+})
+appBucket, _ := s3.NewBucketV2(ctx, "appBucket", nil)
 ```
 
 {{% /choosable %}}
 {{% choosable language csharp %}}
 
 ```csharp
-using System.Threading.Tasks;
+
+using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 using Aws = Pulumi.Aws;
 
-class Program
+return await Deployment.RunAsync(() =>
 {
-    static Task<int> Main() => Deployment.RunAsync<MyStack>();
-}
-
-public MyStack : Stack
-{
-    public MyStack()
+    var mediaBucket = new Aws.S3.BucketV2("mediaBucket", new()
     {
-        var mediaBucket = new Aws.S3.Bucket("media-bucket", new Aws.S3.BucketArgs
+        Tags =
         {
-            Acl = "public-read",   // add acl
-        });
-        var appBucket = new Aws.S3.Bucket("app-bucket");
-    }
-}
+            { "owner", "media-team" },
+        },
+    });
+
+    var appBucket = new Aws.S3.BucketV2("appBucket");
+
+});
 ```
 
 {{% /choosable %}}
 {{% choosable language java %}}
 
 ```java
+
 package myproject;
 
 import com.pulumi.Context;
-import com.pulumi.Exports;
 import com.pulumi.Pulumi;
-import com.pulumi.aws.s3.Bucket;
+import com.pulumi.core.Output;
+import com.pulumi.aws.s3.BucketV2;
+import com.pulumi.aws.s3.BucketV2Args;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class App {
     public static void main(String[] args) {
@@ -365,10 +389,12 @@ public class App {
     }
 
     public static void stack(Context ctx) {
-        var mediaBucket = new Bucket("media-bucket", BucketArgs.builder()
-            .acl("public-read")   // add acl
+        var mediaBucket = new BucketV2("mediaBucket", BucketV2Args.builder()
+            .tags(Map.of("owner", "media-team"))
             .build());
-        var contentBucket = new Bucket("app-bucket");
+
+        var appBucket = new BucketV2("appBucket");
+
     }
 }
 ```
@@ -379,9 +405,10 @@ public class App {
 ```yaml
 resources:
   mediaBucket:
-    type: aws:s3:Bucket
+    type: aws:s3:BucketV2
     properties:
-      acl: public-read # add acl
+      tags:
+        owner: media-team
   appBucket:
     type: aws:s3:Bucket
 ```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Bucket is going to be deprecated and BucketV2 is recommended. IN addition to that, bucket.acl is deprecated. Unfortunately these resources were selected to demonstrate how Pulumi works. The page itself does not need to concern itself with Bucket per se, but needs a good example. To avoid the difficulty with deprecated resources and attributes, this rewrite of how-pulumi-works uses BucketV2 and tags modification as the example, instead of using Bucket and acl.


### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

Relates: https://github.com/pulumi/home/issues/3583
