### PR TITLE
fix link in config docs

### DIFF
--- a/content/docs/iac/concepts/config.md
+++ b/content/docs/iac/concepts/config.md
@@ -621,7 +621,7 @@ Stack tags applied by Pulumi CLI are listed in the `Tags` section of the Overvie
 
 Often there is common configuration and secrets you do not want to duplicate in various stack configuration files. Pulumi ESC can help with that!
 
-Once you have an [environment](/docs/esc/concepts/) set up and you are [projecting pulumi configuration](/docs/esc/environments/working-with-environments/#projecting-pulumi-config), you can import that environment(/docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks/) (or multiple environments) into your Pulumi stack.
+Once you have an [environment](/docs/esc/concepts/) set up and you are [projecting pulumi configuration](/docs/esc/environments/working-with-environments/#projecting-pulumi-config), you can [import that environment](/docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks/) (or multiple environments) into your Pulumi stack.
 
 ```yaml
 # import the test environment and all of its configuration


### PR DESCRIPTION
It looks like this should be a link, but is currently missing some square brackets.  Add those to fix that.
