### PR TITLE
add redirect banners to old EKS and k8s operator blogs

### DIFF
--- a/content/blog/amazon-eks-anywhere-bare-metal/index.md
+++ b/content/blog/amazon-eks-anywhere-bare-metal/index.md
@@ -15,6 +15,9 @@ tags:
 # See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.
 ---
+{{% notes type="info" %}}
+Check out version 3.0 of the [Pulumi EKS Provider](/blog/eks-v3-release/).
+{{% /notes %}}
 
 Some of the largest and most complex deployments that teams manage are hybrid and multi-cloud deployments. Kubernetes is a common component in these deployments because it enables platform teams to provide a common set of services across cloud and on-premises infrastructure and simplifies the process of migrating and scaling workloads as demand fluctuates. Pulumi simplifies these deployment scenarios but teams often need to manage different flavors of Kubernetes for on-premises deployments versus cloud deployments.
 

--- a/content/blog/create-eks-clusters-in-your-favorite-language/index.md
+++ b/content/blog/create-eks-clusters-in-your-favorite-language/index.md
@@ -15,6 +15,10 @@ tags:
     - typescript
 ---
 
+{{% notes type="info" %}}
+Check out version 3.0 of the [Pulumi EKS Provider](/blog/eks-v3-release/).
+{{% /notes %}}
+
 Pulumi's [infrastructure as code](/what-is/what-is-infrastructure-as-code/) tooling combines the programming languages and tools you already know with the full power of cloud
 infrastructure. But until now, some Pulumi components for cloud infrastructure, like our popular [EKS package] for Amazon's Elastic
 Kubernetes Service, were only available in a subset of the languages supported by Pulumi.

--- a/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
+++ b/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
@@ -22,7 +22,7 @@ package](https://github.com/pulumi/pulumi-eks). Let's see how.
 <!--more-->
 
 {{% notes type="info" %}}
-Updated January 2021 to include Python, .NET, and Go support.
+Updated October 2024 to [version 3.0](/blog/eks-v3-release/)
 {{% /notes %}}
 
 To get started, download the free and open source

--- a/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
+++ b/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
@@ -22,7 +22,9 @@ package](https://github.com/pulumi/pulumi-eks). Let's see how.
 <!--more-->
 
 {{% notes type="info" %}}
-Updated October 2024 to [version 3.0](/blog/eks-v3-release/)
+Updated January 2021 to include Python, .NET, and Go support.
+
+Updated October 2024 to [Version 3.0](/blog/eks-v3-release/)
 {{% /notes %}}
 
 To get started, download the free and open source

--- a/content/blog/improving-gitops-with-pulumi-operator/index.md
+++ b/content/blog/improving-gitops-with-pulumi-operator/index.md
@@ -8,6 +8,10 @@ authors: ["david-flanagan"]
 tags: ["continuous-delivery", "gitops", "kubernetes"]
 ---
 
+{{% notes type="info" %}}
+Check out version 2.0 of the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator-2-0/).
+{{% /notes %}}
+
 This time last year, I presented [Applying the Law of Demeter to GitOps](https://www.youtube.com/watch?v=gLZpt8a9YuA) at [GitOps Days 2020](https://www.gitopsdays.com/). The [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter) is a design principle, proposed in 1988, which encourages loose coupling between systems. During this session, I wanted the audience to understand and be able to identify when their applications and continuous delivery pipelines have too much knowledge of the platform in which they're going to run. As an industry, we're seeing a great deal of momentum towards Platform Engineering and with this comes a Broca divide, a strict division of responsibilities: to build a platform and to consume a platform.
 
 Instead, the platform will provide everything the application needs to function. We've seen a lot of this before, notably via the [12-factor manifesto](https://12factor.net/).

--- a/content/blog/pulumi-kubernetes-new-2022/index.md
+++ b/content/blog/pulumi-kubernetes-new-2022/index.md
@@ -13,6 +13,10 @@ Kubernetes is one of the most used platforms in Pulumi, second only to AWS, with
 
 <!--more-->
 
+{{% notes type="info" %}}
+Check out version 2.0 of the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator-2-0/).
+{{% /notes %}}
+
 Today we are announcing a set of major updates which deepen and extend Pulumi’s support for Kubernetes and the Kubernetes ecosystem. In this post, we’ll highlight a few of these exciting enhancements:
 
 * [Pulumi Kubernetes Operator v1.10](https://github.com/pulumi/pulumi-kubernetes-operator/#readme): New integration with Flux for richer GitOps support, and ability to deploy Pulumi stacks from directly within the Kubernetes resource model

--- a/content/blog/pulumi-kubernetes-operator-1-0/index.md
+++ b/content/blog/pulumi-kubernetes-operator-1-0/index.md
@@ -7,7 +7,7 @@ meta_desc: "Pulumi Kubernetes Operator 1.0: GitOps, Automation API, State Backen
 meta_image: operator.png
 ---
 {{% notes type="info" %}}
-Check out the version 2.0 beta of the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator-2-0/).
+Check out version 2.0 of the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator-2-0/).
 {{% /notes %}}
 
 Last year we released the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator/), a new cloud-native way to manage and deploy cloud infrastructure using Pulumi from within your Kubernetes environment. Since then, we’ve worked with many Pulumi users who have adopted the Pulumi Kubernetes Operator at increasingly larger scales and for a wide variety of use cases. Today, we’re excited to make the [1.0 release](https://github.com/pulumi/pulumi-kubernetes-operator/releases/tag/v1.0.0) of the Pulumi Kubernetes Operator available.

--- a/content/blog/pulumi-kubernetes-operator-1-0/index.md
+++ b/content/blog/pulumi-kubernetes-operator-1-0/index.md
@@ -6,6 +6,9 @@ tags: ["Kubernetes", "Continuous-Delivery", "operators"]
 meta_desc: "Pulumi Kubernetes Operator 1.0: GitOps, Automation API, State Backends, Safe Upgrades and Metrics"
 meta_image: operator.png
 ---
+{{% notes type="info" %}}
+Check out the version 2.0 beta of the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator-2-0/).
+{{% /notes %}}
 
 Last year we released the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator/), a new cloud-native way to manage and deploy cloud infrastructure using Pulumi from within your Kubernetes environment. Since then, we’ve worked with many Pulumi users who have adopted the Pulumi Kubernetes Operator at increasingly larger scales and for a wide variety of use cases. Today, we’re excited to make the [1.0 release](https://github.com/pulumi/pulumi-kubernetes-operator/releases/tag/v1.0.0) of the Pulumi Kubernetes Operator available.
 

--- a/content/blog/pulumi-kubernetes-operator/index.md
+++ b/content/blog/pulumi-kubernetes-operator/index.md
@@ -7,7 +7,7 @@ meta_desc: "Introducing the Pulumi Kubernetes Operator: Deploy infrastructure in
 meta_image: operator.png
 ---
 {{% notes type="info" %}}
-Check out the version 2.0 beta of the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator-2-0/).
+Check out version 2.0 of the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator-2-0/).
 {{% /notes %}}
 
 Kubernetes developers and operators work together to manage workloads

--- a/content/blog/pulumi-kubernetes-operator/index.md
+++ b/content/blog/pulumi-kubernetes-operator/index.md
@@ -6,6 +6,9 @@ tags: ["Kubernetes", "Continuous-Delivery", "operators"]
 meta_desc: "Introducing the Pulumi Kubernetes Operator: Deploy infrastructure in Pulumi Stacks"
 meta_image: operator.png
 ---
+{{% notes type="info" %}}
+Check out the version 2.0 beta of the [Pulumi Kubernetes Operator](/blog/pulumi-kubernetes-operator-2-0/).
+{{% /notes %}}
 
 Kubernetes developers and operators work together to manage workloads
 and to continuously ship software through CI/CD. These users

--- a/content/blog/simplify-kubernetes-rbac-in-amazon-eks-with-open-source-pulumi-packages/index.md
+++ b/content/blog/simplify-kubernetes-rbac-in-amazon-eks-with-open-source-pulumi-packages/index.md
@@ -7,6 +7,10 @@ date: "2019-04-24"
 meta_desc: "This post contrasts the traditional approach with Pulumi's modern method for simplifying Kubernetes RBAC in Amazon EKS."
 ---
 
+{{% notes type="info" %}}
+Check out version 3.0 of the [Pulumi EKS Provider](/blog/eks-v3-release/).
+{{% /notes %}}
+
 One of the most common areas Kubernetes operators struggle with in
 production involves creating and managing role-based access control
 (RBAC). This is so daunting that RBAC is often not implemented, or


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Added redirect banners to:
https://www.pulumi.com/blog/amazon-eks-anywhere-bare-metal/
https://www.pulumi.com/blog/pulumi-kubernetes-operator-1-0/
https://www.pulumi.com/blog/pulumi-kubernetes-operator/

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
