### PR TITLE
Fix broken link and a few style nits

### DIFF
--- a/content/docs/pulumi-cloud/admin/organizations.md
+++ b/content/docs/pulumi-cloud/admin/organizations.md
@@ -36,7 +36,7 @@ Organizations are a space for you to collaborate on shared projects and stacks.
 | Policies | Lists of organization policies and policy groups. Policies allow you to set guardrails to enforce best practices and compliance. |
 | Settings | Organization settings including subscription and payment information and history, Billing Managers, stack permissions, and links to Pulumi's [continuous delivery guides](/docs/using-pulumi/continuous-delivery/). |
 
-## Creating an Organization
+## Creating an organization
 
 Creating an organization will start a free trial that has access to all features.
 At the end of the trial, you can choose to move to the Pulumi Team Edition, the Pulumi Enterprise Edition or the Pulumi Business Critical Edition.
@@ -48,7 +48,7 @@ To create an organization:
 1. Provide an organization name, and agree to the terms of service and privacy policy.
 1. Select **Start free trial**.
 
-## Joining an Organization
+## Joining an organization
 
 To become a member of a Pulumi organization, you must be invited by an existing Pulumi
 organization administrator or submit a request to the administrator for approval.
@@ -58,7 +58,7 @@ For example, to become a member of a Pulumi organization backed by a GitLab Grou
 you must associate a GitLab identity with your Pulumi account, and also
 be a member of that GitLab group.
 
-## Inviting Members to an Organization
+## Inviting members to an organization
 
 Pulumi organization administrators can invite new members to an organization.
 
@@ -72,7 +72,7 @@ New member invitation links never expire and may only be used one time.
 
 Pulumi organization administrators can monitor current organization members and pending invitations on the Members console page. For pending invitations, administrators can re-send email invitations, copy links for both email and link generated invitations, and revoke invitations. The invitation status column in the members table includes the date an invitation was sent, and will note if a potential member encountered an error while attempting to accept an invitation. In this case, a tooltip will share the exact error that was encountered.
 
-## Switching Between Organizations
+## Switching between organizations
 
 The organization menu displays your individual account and all of the organizations you belong.
 
@@ -81,7 +81,7 @@ To switch to a different organization:
 1. Select the organization menu at the top of the navigation.
 1. Select your organization name.
 
-## Organization Roles
+## Organization roles
 
 | Role | Description |
 |--------|--------|
@@ -89,20 +89,20 @@ To switch to a different organization:
 | Member | Members are able to view and edit stacks they have access to and view members and teams. |
 | Billing Manager | Billing Managers are able to adjust billing information and view other Billing Managers. They do not have read or write access to stacks, teams, or policies. |
 
-## Organization Identity Providers
+## Organization identity providers
 
 A Pulumi organization can use the Pulumi identity provider or a third-party identity provider.
 If using a third-party identity provider all members need to belong to the third-party
 identity provider in order to join a Pulumi organization.
 
 For example, if a Pulumi organization, is backed by a GitHub organization, then only members
-of that GitHub organization may be added to the Pulumi organization. Similarly, as soon as
+of that GitHub organization may be added to the Pulumi organization. As soon as
 someone loses access to the GitHub organization, they will no longer have access to the
 Pulumi organization.
 
-In addition, a Pulumi organization can be backed by a [SAML 2.0 identity provider](/docs/pulumi-cloud/access-management/saml/).
+A Pulumi organization can also be backed by a [SAML 2.0 identity provider](/docs/pulumi-cloud/access-management/saml/).
 
-### Changing Identity Providers
+### Changing identity providers
 
 Every organization is backed by an identity that governs the membership to your organization.
 By default, when you create a new Pulumi organization, it uses the Pulumi identity provider.
@@ -116,7 +116,7 @@ To change an organization's identity provider:
 1. Navigate to **Settings** > **Access Management**.
 1. Select **Change requirements**.
 
-### Disconnecting Identity Providers
+### Disconnecting identity providers
 
 In order to disconnect an identity provider you need to select another identity provider. This is also true for SAML SSO. To remove SAML SSO configuration, selected a new identity provider.
 
@@ -126,7 +126,7 @@ Organization members must first add the new identity provider to their individua
 1. Select **Change requirements**.
 1. Select a new identity provider.
 
-### GitHub Identity Provider
+### GitHub identity provider
 
 [Setting up a GitHub Organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch)
 
@@ -135,7 +135,7 @@ must first grant the Pulumi OAuth app the [`read:org` scope](https://github.com/
 This is required to verify memberships within the GitHub organization.
 Pulumi will not have access to any of the organization's source code, issues, or other data.
 
-### GitLab Identity Provider
+### GitLab identity provider
 
 [GitLab Groups](https://docs.gitlab.com/ce/user/group/)
 
@@ -147,9 +147,9 @@ expiration value. In order to invite those members to Pulumi, their membership i
 GitLab group must still be active. As soon as their GitLab group membership expires,
 those users will lose access to Pulumi organization.
 
-### Bitbucket Identity Provider
+### Bitbucket identity provider
 
-[BitBucket Workspaces](https://bitbucket.org/blog/introducing-workspaces)
+[BitBucket Workspaces](https://support.atlassian.com/bitbucket-cloud/docs/what-is-a-workspace/)
 
 To add a Bitbucket-backed organization to Pulumi, an admin of the Atlassian
 Bitbucket workspace


### PR DESCRIPTION
Primary purpose is to fix the (newly) broken link to the Bitbucket Workspaces blog. While here, I also updated the headings to match our casing standards and tightened up the language in one of the sections to reduce unnecessary verbiage.