### PR TITLE
Add some link exemptions

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -292,6 +292,9 @@ function getDefaultExcludedKeywords() {
         "https://github.com/marketplace",
         "https://bard.google.com/",
         "https://cloud.getdbt.com/api",
+        "https://dutchie.com/",
+        "https://www.gartner.com/en/newsroom/press-releases/2024-04-11-gartner-says-75-percent-of-enterprise-software-engineers-will-use-ai-code-assistants-by-2028",
+        "https://www.gartner.com/en/webinar/445864/1051166",
     ];
 }
 


### PR DESCRIPTION
These links (two Gartner links and the customer website Dutchie) are consistently a `403` to our link checker, for some reason*. This is probably something to look into long-term, but for now, adding these exemptions because these links work fine. 

*I did a little digging and this seems related to the use of Cloudflare, and its firewall rules that detect bots and then 403 them intentionally. No real way around that.

