### PR TITLE
Enable testing for the azure examples

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -8,6 +8,10 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   AWS_REGION: "us-west-2"
+  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
 jobs:
   test:

--- a/scripts/programs/test.sh
+++ b/scripts/programs/test.sh
@@ -58,10 +58,6 @@ pushd "$programs_dir"
         if [[ "$project" == "aws-import-iac-iam-role-"* ]]; then
             continue
         fi
-        # Skipping the 6 azure examples temporarily until we get azure creds configured.
-        if [[ "$project" == "azure-"* ]]; then
-            continue
-        fi
 
         echo
         echo "***"


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/13261

Enables testing for the azure examples. It turns out all we needed to do was set the environment variables based on our azure org level secrets. I also verified this works, see this run: https://github.com/pulumi/docs/actions/runs/11751276481/job/32741012915