### PR TITLE
Generate CLI docs w/ PULUMI_EXPERIMENTAL flag

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -85,7 +85,7 @@ jobs:
         working-directory: docs
       - name: generate markdown
         run: |
-          pulumi gen-markdown ./content/docs/iac/cli/commands
+          PULUMI_EXPERIMENTAL=true pulumi gen-markdown ./content/docs/iac/cli/commands
         working-directory: docs
       - name: Update latest version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ generate:
 	@echo -e "\033[0;32mGENERATE:\033[0m"
 	NOBUILD=true ./scripts/run_typedoc.sh
 	./scripts/generate_python_docs.sh
-	pulumi gen-markdown ./content/docs/cli/commands
+	PULUMI_EXPERIMENTAL=true pulumi gen-markdown ./content/docs/cli/commands
 
 .PHONY: build
 build:


### PR DESCRIPTION
With this flag set, we will get docs generated for CLI commands like `pulumi ai web`. Fixes #9972