### PR TITLE
Finish updating get-started/aws to BucketV2

### DIFF
--- a/content/docs/iac/get-started/aws/destroy-stack.md
+++ b/content/docs/iac/get-started/aws/destroy-stack.md
@@ -23,12 +23,13 @@ You'll be prompted to make sure you really want to delete these resources. This 
 ```
 Previewing destroy (dev):
 
-     Type                               Name                 Plan
- -   pulumi:pulumi:Stack                quickstart-dev       delete
- -   ├─ aws:s3:BucketObject             index.html           delete
- -   ├─ aws:s3:BucketOwnershipControls  ownership-controls   delete
- -   ├─ aws:s3:BucketPublicAccessBlock  public-access-block  delete
- -   └─ aws:s3:Bucket                   my-bucket            delete
+     Type                                    Name                 Status
+ -   pulumi:pulumi:Stack                     quickstart-dev       delete
+ -   ├─ aws:s3:BucketObject                  index.html           delete
+ -   ├─ aws:s3:BucketOwnershipControls       ownership-controls   delete
+ -   ├─ aws:s3:BucketPublicAccessBlock       public-access-block  delete
+ -   ├─ aws:s3:BucketWebsiteConfigurationV2  website              delete
+ -   └─ aws:s3:BucketV2                      my-bucket            delete
 
 Outputs:
   - bucketEndpoint: "http://my-bucket-dfd6bd0.s3-website-us-east-1.amazonaws.com"
@@ -40,12 +41,13 @@ Resources:
 Do you want to perform this destroy? yes
 Destroying (dev):
 
-     Type                               Name                 Status
- -   pulumi:pulumi:Stack                quickstart-dev       deleted
- -   ├─ aws:s3:BucketObject             index.html           deleted (1s)
- -   ├─ aws:s3:BucketPublicAccessBlock  public-access-block  deleted (0.28s)
- -   ├─ aws:s3:BucketOwnershipControls  ownership-controls   deleted (0.47s)
- -   └─ aws:s3:Bucket                   my-bucket            deleted (0.39s)
+     Type                                    Name                 Status
+ -   pulumi:pulumi:Stack                     quickstart-dev       deleted (0.31s)
+ -   ├─ aws:s3:BucketObject                  index.html           deleted (1s)
+ -   ├─ aws:s3:BucketPublicAccessBlock       public-access-block  deleted (0.67s)
+ -   ├─ aws:s3:BucketWebsiteConfigurationV2  website              deleted (0.88s)
+ -   ├─ aws:s3:BucketOwnershipControls       ownership-controls   deleted (1s)
+ -   └─ aws:s3:BucketV2                      my-bucket            deleted (0.58s)
 
 Outputs:
   - bucketEndpoint: "http://my-bucket-dfd6bd0.s3-website-us-east-1.amazonaws.com"


### PR DESCRIPTION
With BucketV2 instead of using the `website` argument the recommended setup is to use a side-by-side BucketWebsiteConfigurationV2 resource. The AWS getting started guide is updated to follow this recommendation.

The changes are verified (pulumi up).

Fixes https://github.com/pulumi/home/issues/3733
Fixes https://github.com/pulumi/home/issues/3734
