### PR TITLE
Update Automation API getting started code to use BucketV2

### DIFF
--- a/content/docs/iac/packages-and-automation/automation-api/getting-started-automation-api.md
+++ b/content/docs/iac/packages-and-automation/automation-api/getting-started-automation-api.md
@@ -171,6 +171,7 @@ def pulumi_program():
     # Export the website URL.
     pulumi.export("website_url", website.website_endpoint)
 ```
+
 {{% /choosable %}}
 
 {{% choosable language go %}}


### PR DESCRIPTION
This change updates the code examples in the `Get started with Automation API` page.

Instead of using aws.s3.Bucket the examples now use aws.s3.BucketV2 as is recommended for our users.

In addition the code example is simplified to achieve a minimal static website wtihout manually setting up policy.

Fixes https://github.com/pulumi/home/issues/3735

