### PR TITLE
add redirect to kubecon roundup blog from '/blog/kubecon-2024-launces'

### DIFF
--- a/content/blog/kubecon-na-2024-roundup/index.md
+++ b/content/blog/kubecon-na-2024-roundup/index.md
@@ -11,6 +11,8 @@ tags:
     - kubecon
     - kubernetes
     - conferences
+aliases:
+    - /blog/kubecon-2024-launches
 ---
 
 Pulumi is excited to be at KubeCon North America this week, the premier event for all things Kubernetes and cloud-native. KubeCon is the gathering place for developers, enterprises, and cloud native experts to meet and further the education and advancement of Kubernetes and cloud native computing. At Pulumi, we are strongly committed to Kubernetes and continue to support the ecosystem with infrastructure management solutions that empower teams to automate, secure, and manage Kubernetes at scale.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
redirect `/blog/kubecon-2024-launches` to `/blog/kubecon-na-2024-roundup/` 


