### PR TITLE
add note style 'tip'

### DIFF
--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -36,6 +36,7 @@ Our docs currently support two kinds of note: `info`-level and `warning`-level.
 * Use notes in general to communicate important information.
 * Try to limit the number of notes within a single page.
 * Use `info`-level notes to convey general information.
+* Use `tip`-level notes to convey helpful ideas.
 * Use `warning`-level notes for information that, if missed, could lead to negative or unexpected consequences.
 
 ### Examples
@@ -43,6 +44,10 @@ Our docs currently support two kinds of note: `info`-level and `warning`-level.
 ```go
 {{% notes type="info" %}}
 This bit of info is important enough to call out, but not critical.
+{{% /notes %}}
+
+{{% notes type="tip" %}}
+This bit of info is a great idea, that might be really helpful.
 {{% /notes %}}
 
 {{% notes type="warning" %}}

--- a/layouts/shortcodes/notes.html
+++ b/layouts/shortcodes/notes.html
@@ -1,6 +1,10 @@
 {{ $type := default "info" (.Get "type") }}
 {{ $icon := "info-circle" }}
 
+{{ if eq $type "tip" }}
+    {{ $icon = "lightbulb" }}
+{{ end }}
+
 {{ if eq $type "warning" }}
     {{ $icon = "exclamation-triangle" }}
 {{ end }}

--- a/theme/src/scss/_notes.scss
+++ b/theme/src/scss/_notes.scss
@@ -74,6 +74,26 @@
         }
     }
 
+    &.note-tip {
+        background: #f1feea;
+
+        a {
+            color: #338d72;
+        }
+
+        i {
+            color: #25a78b;
+        }
+
+        div.line {
+            background-color: #4ce1b4;
+        }
+
+        code {
+            background-color: #b2fbe0;
+        }
+    }
+
     &.note-warning {
         background: #fcf2e9;
 


### PR DESCRIPTION
Fixes #11724 to add a `tip` style note.

Example: test out all three note styles
```
{{< notes type="info" >}}
Note: The Go SDK requires Go 1.16 or greater. Check out [this link](https://www.pulumi.com/pricing/) to learn more about all the things you are interested in.
{{< /notes >}}

{{< notes type="tip" >}}
Tip: To bypass the prompt, you can also pass the `-y` option. Check out [this link](https://www.pulumi.com/pricing/) to learn more about all the things you are interested in.
{{< /notes >}}

{{< notes type="warning" >}}
Warning: Never do this! It's a trap. Check out [this link](https://www.pulumi.com/pricing/) to learn more about all the things you are interested in.
{{< /notes >}}
```

Which renders like this:
<img width="727" alt="Screenshot 2024-11-13 at 4 34 52 AM" src="https://github.com/user-attachments/assets/c1319077-49d8-4950-bd37-c3eb5d402ace">

