### PR TITLE
bump runner size for scheduled tests job

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - ubuntu-latest
+          - pulumi-service-ubuntu-22.04-16core
         go-version:
           - 1.21.x
         node-version:


### PR DESCRIPTION
We have been frequently running into disk space limitations on the current runner used for the job that runs the tests of our pulumi programs. This makes the change to use a larger runner.