### PR TITLE
Adds tooltip text to expand/shrink content widget

### DIFF
--- a/layouts/partials/docs/search.html
+++ b/layouts/partials/docs/search.html
@@ -12,7 +12,7 @@
         ></div>
     </div>
     <div class="content-width-controls">
-        <div id="expand-content-button" class="icon icon-18-18 width-expand-18-18 expand-content"></div>
-        <div id="collapse-content-button" class="icon icon-18-18 width-collapse-18-18 collapse-content hide"></div>
+        <div id="expand-content-button" class="icon icon-18-18 width-expand-18-18 expand-content" title="Expand content width"></div>
+        <div id="collapse-content-button" class="icon icon-18-18 width-collapse-18-18 collapse-content hide" title="Shrink content width"></div>
     </div>
 </div>


### PR DESCRIPTION
Fixes #11436

Per feedback, here: https://github.com/pulumi/pulumi-hugo/pull/3115#issuecomment-1612102996

This technique of adding `title="tooltip text"` will enable a system-default style tooltip when hovering over the widget and will show different text depending on which div is hidden at the moment. Simple, and should not run into the problems with placement @sean1588 described with a more sophisticated tooltip. 