### PR TITLE
Improves the dynamic providers docs page examples to reflect how to pass creds via env variables and configuration.

### DIFF
--- a/content/docs/iac/concepts/resources/dynamic-providers.md
+++ b/content/docs/iac/concepts/resources/dynamic-providers.md
@@ -309,7 +309,7 @@ class MyResource(Resource):
 
 ### configure(ConfigureRequest)
 
-The `configure` method is invoked after a dynamic resource provider is loaded. This method is optional and is called exactly for each provider. The `configure` method receives a `ConfigureRequest` object as argument, which contains the configuration of the current stack. This method can be used to perform any necessary setup for the provider, and allows you to read configuration values and store them for later use in the other provider methods.
+The `configure` method is invoked after a dynamic resource provider is loaded. This method is optional and is called exactly once for each provider instance. The `configure` method receives a `ConfigureRequest` object as its argument, which contains the configuration of the current stack. This method can be used to perform any necessary setup for the provider, and allows you to read configuration values and store them for later use in other provider methods.
 
 ### check(olds, news)
 

--- a/content/docs/iac/concepts/resources/dynamic-providers.md
+++ b/content/docs/iac/concepts/resources/dynamic-providers.md
@@ -307,6 +307,10 @@ class MyResource(Resource):
 
 {{< /chooser >}}
 
+### configure(ConfigureRequest)
+
+The `configure` method is invoked after a dynamic resource provider is loaded. This method is optional and is called exactly for each provider. The `configure` method receives a `ConfigureRequest` object as argument, which contains the configuration of the current stack. This method can be used to perform any necessary setup for the provider, and allows you to read configuration values and store them for later use in the other provider methods.
+
 ### check(olds, news)
 
 The `check` method is invoked before any other methods. The resolved input properties that were originally provided to the resource constructor by the user are passed to it. The operation is passed both the old input properties that were stored in the *state file* after the previous update to the resource, as well as the new inputs from the current deployment. It has two jobs:
@@ -834,6 +838,96 @@ export("label_url", label.url)
 ```
 
 {{% /choosable %}}
+{{< /chooser >}}
+
+### Example: Using Stack Configuration
+
+The `configure` method allows dynamic providers to access the current stack's configuration and use it to configure the provider.
+
+{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+class ProviderWithConfigure implements pulumi.dynamic.ResourceProvider {
+    private accessToken: string;
+
+    async configure(req: pulumi.dynamic.ConfigureRequest): Promise<void> {
+        this.accessToken = req.config.require("access-token");
+    }
+
+    async create(props: any): Promise<pulumi.dynamic.CreateResult> {
+        const res = await fetch(`https://api.example.com/v1/resources?token=${this.accessToken}`);
+        ...
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language javascript %}}
+
+```javascript
+class ProviderWithConfigure {
+    async configure(req) {
+        this.accessToken = req.config.require("access-token");
+    }
+
+    async create(props)
+        const res = await fetch(`https://api.example.com/v1/resources?token=${this.accessToken}`);
+        ...
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+class ProviderWithConfigure(ResourceProvider):
+    access_token: str
+
+    def configure(self, req: ConfigureRequest):
+        self.access_token = req.config.require("access-token")
+
+    def create(self, props):
+        res = http.get(f"https://api.example.com/v1/resources?token={self.access_token}")
+        ...
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+// Dynamic Providers are not currently supported in Go.
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```csharp
+// Dynamic Providers are currently not supported in .NET.
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```yaml
+# Dynamic Providers are not supported in YAML.
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+// Dynamic Providers are currently not supported in Java.
+```
+
+{{% /choosable %}}
+
 {{< /chooser >}}
 
 ### Additional Examples


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

The dynamic providers page has examples that do not show best practices for passing in secrets. This update modifies the github example to use the (new) `configure()` interface.
It also removes the simple `configure()` example that was added with the docs update to add the interface.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
