### PR TITLE
Fix uv Pulumi.yaml example

### DIFF
--- a/content/docs/iac/languages-sdks/python/_index.md
+++ b/content/docs/iac/languages-sdks/python/_index.md
@@ -115,7 +115,7 @@ When using `uv` Pulumi will create a virtual environment in the `.venv` director
 runtime:
   name: python
   options:
-    toolchain: pip
+    toolchain: uv
     virtualenv: .venv
 ```
 


### PR DESCRIPTION
Follow up to https://github.com/pulumi/docs/pull/13292#pullrequestreview-2440774920, @justinvp caught an error I made in the Pulumi.yaml for `uv`, it should of course say `uv` and not `pip`.