### PR TITLE
Add missing keyword

### DIFF
--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -203,7 +203,7 @@ public class MyStack : Stack
     }
 
     // 'url' is the output name. By default, it would take the property name 'Url'.
-    [Output("url")] Output<string> Url { get; set; }
+    [Output("url")] public Output<string> Url { get; set; }
 }
  ```
 


### PR DESCRIPTION
The C# code example was missing a `public` keyword. Fixes [#13348](https://github.com/pulumi/docs/issues/13348)