### PR TITLE
hide (unlist) github actions workshop from resources list

### DIFF
--- a/content/resources/getting-started-with-ci-cd-for-aws-pulumi-github-actions/index.md
+++ b/content/resources/getting-started-with-ci-cd-for-aws-pulumi-github-actions/index.md
@@ -8,7 +8,7 @@ meta_image:
 featured: false
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Unlist https://www.pulumi.com/resources/getting-started-with-ci-cd-for-aws-pulumi-github-actions/ to remove it from resources list (url still accessible)

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
