### PR TITLE
Update supported version of macOS

### DIFF
--- a/content/blog/configuring-your-dev-environment/index.md
+++ b/content/blog/configuring-your-dev-environment/index.md
@@ -568,7 +568,7 @@ $ brew install --cask goland
 
 {{% choosable os macos %}}
 
-macOS Sierra (10.12) or later is required.
+macOS Ventura (13) or later is required.
 
 ### Homebrew
 

--- a/content/docs/esc/download-install/_index.md
+++ b/content/docs/esc/download-install/_index.md
@@ -36,7 +36,7 @@ aliases:
 <a class="btn btn-secondary mx-2" href="https://get.pulumi.com/esc/releases/esc-v{{< latest-version-esc >}}-darwin-x64.tar.gz">amd64</a>
 <a class="btn btn-secondary mx-2" href="https://get.pulumi.com/esc/releases/esc-v{{< latest-version-esc >}}-darwin-arm64.tar.gz">arm64</a></p>
 
-macOS Sierra (10.12) or later is required.
+macOS Ventura (13) or later is required.
 
 The latest version of Pulumi ESC is {{< latest-version-esc >}}.
 

--- a/content/docs/iac/download-install/_index.md
+++ b/content/docs/iac/download-install/_index.md
@@ -48,7 +48,7 @@ The latest version of Pulumi is **{{< latest-version >}}**. For previous version
 <a class="btn btn-secondary mx-2" href="https://get.pulumi.com/releases/sdk/pulumi-v{{< latest-version >}}-darwin-x64.tar.gz">amd64</a>
 <a class="btn btn-secondary mx-2" href="https://get.pulumi.com/releases/sdk/pulumi-v{{< latest-version >}}-darwin-arm64.tar.gz">arm64</a></p>
 
-macOS Sierra (10.12) or later is required.
+macOS Ventura (13) or later is required.
 
 {{< get-started-note >}}
 


### PR DESCRIPTION
The docs are referring to a _very_ old version of macOS. Apple isn't forthcoming with official supported dates, but Apple usually provides security updates for the latest 3 releases only. The oldest supported version we can use to test on GitHub Actions is macOS 13, so this is the version we officially support. More info: https://endoflife.date/macos.

This change updates the docs to reflect this.