### PR TITLE
Add answers redirects

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -30,8 +30,8 @@ export function getEdgeRedirectAssociation(): aws.types.input.cloudfront.Distrib
     };
 }
 
-export async function getAnswersEdgeRedirectAssociation(): Promise<aws.types.input.cloudfront.DistributionDefaultCacheBehaviorLambdaFunctionAssociation> {    
-    const response = await axios.get("https://www.pulumi-test.io/answers/redirects.json")
+export async function getAnswersEdgeRedirectAssociation(websiteDomain: string): Promise<aws.types.input.cloudfront.DistributionDefaultCacheBehaviorLambdaFunctionAssociation> {    
+    const response = await axios.get(`https://${websiteDomain}/answers/redirects.json`)
     const redirects = response.data;
     const edgeRedirectsLambda = new LambdaEdge("redirects-answers", {
         func: getAnswersRedirectsLambdaCallback(redirects),

--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -31,7 +31,10 @@ export function getEdgeRedirectAssociation(): aws.types.input.cloudfront.Distrib
 }
 
 export async function getAnswersEdgeRedirectAssociation(websiteDomain: string): Promise<aws.types.input.cloudfront.DistributionDefaultCacheBehaviorLambdaFunctionAssociation> {    
-    const response = await axios.get(`https://${websiteDomain}/answers/redirects.json`)
+    const response = await axios.get(`https://${websiteDomain}/answers/redirects.json`);
+    if (response.status !== 200) {
+        throw new pulumi.RunError(`Failed to fetch answers redirects: HTTP ${response.status}`);
+    }
     const redirects = response.data;
     const edgeRedirectsLambda = new LambdaEdge("redirects-answers", {
         func: getAnswersRedirectsLambdaCallback(redirects),

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -4,7 +4,7 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
 
-import { getAIAnswersRewriteAssociation, getEdgeRedirectAssociation } from "./cloudfrontLambdaAssociations";
+import { getAIAnswersRewriteAssociation, getAnswersEdgeRedirectAssociation, getEdgeRedirectAssociation } from "./cloudfrontLambdaAssociations";
 
 const stackConfig = new pulumi.Config();
 
@@ -650,7 +650,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             pathPattern: '/ai/*',
             originRequestPolicyId: allViewerExceptHostHeaderId,
             cachePolicyId: cachingDisabledId,
-            lambdaFunctionAssociations: config.doAIAnswersRewrites ? [getAIAnswersRewriteAssociation()] : [],
+            lambdaFunctionAssociations: config.doAIAnswersRewrites ? [getAnswersEdgeRedirectAssociation(),getAIAnswersRewriteAssociation()] : [],
             forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
         },
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -650,7 +650,10 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             pathPattern: '/ai/*',
             originRequestPolicyId: allViewerExceptHostHeaderId,
             cachePolicyId: cachingDisabledId,
-            lambdaFunctionAssociations: config.doAIAnswersRewrites ? [getAnswersEdgeRedirectAssociation(),getAIAnswersRewriteAssociation()] : [],
+            lambdaFunctionAssociations: [
+                ...config.doAIAnswersRewrites ? [getAIAnswersRewriteAssociation()] : [],
+                getAnswersEdgeRedirectAssociation(config.websiteDomain),
+            ],
             forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
         },
 

--- a/static/sitemap-index.xml
+++ b/static/sitemap-index.xml
@@ -6,4 +6,7 @@
   <sitemap>
     <loc>https://www.pulumi.com/registry/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://www.pulumi.com/answers/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
Now that we have the new version of some of the answers pages deployed, we need to redirect from the original ones. The new ones are genned based on the existing pages and we need to redirect from their old routes to the new route for pages that are being replaced. These redirects will continually get updated as we gradually port more and more of the pages over.

This PR adds the redirects from the old ai answers pages to the new ones that we are replacing by adding an edge lambda that gets invoked by the cloudfront distribution. We are gradually porting over the existing pages and will redirect once they are replaced. There is a file placed at the [pulumi.com/answers/redirects.json](https://pulumi.com/answers/redirects.json) route which contains a map of {oldURL: newURL}. This file is fetched when `pulumi up` is run so the fetch is not part of the serialized function that becomes part of the lambda code - only the resulting value is part of the code. This is so we are not invoking a fetch of this file whenever the lambda is invoked and it is instead precomputed at deployment time. This PR also adds the answers sitemap to the sitemap-index file as well.

This is currently deployed to test. Here is an example of a page we replaced that lived under the /ai/answers route and you should see it successfully redirects now to the new page in the test env: https://www.pulumi-test.io/ai/answers/hCy3E99tc5VjfUqFEGj2GU/adding-custom-headers-with-istio-envoyfilter-kubernetes-tutorial