### PR TITLE
Run pulumi previews against the production stack

### DIFF
--- a/scripts/run-pulumi.sh
+++ b/scripts/run-pulumi.sh
@@ -16,6 +16,10 @@ export PULUMI_ACTION=${1}
 
 case ${PULUMI_ACTION} in
     preview)
+        # Run previews against the production stack. On PR workflows we provision the bucket in the testing account
+        # but infrastructure previews should always run against the production stack since that is the stack
+        # they will get deployed to when merged(not the www-testing stack).
+        pulumi stack select pulumi/www-production
         pulumi -C infrastructure preview
         ;;
     update)

--- a/scripts/run-pulumi.sh
+++ b/scripts/run-pulumi.sh
@@ -19,7 +19,7 @@ case ${PULUMI_ACTION} in
         # Run previews against the production stack. On PR workflows we provision the bucket in the testing account
         # but infrastructure previews should always run against the production stack since that is the stack
         # they will get deployed to when merged(not the www-testing stack).
-        pulumi stack select pulumi/www-production
+        pulumi -C infrastructure stack select pulumi/www-production
         pulumi -C infrastructure preview
         ;;
     update)


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/13425

Runs the previews against the production stack. On PR workflows we provision the preview bucket in the testing account but infrastructure previews should always run against the production stack since that is the stack they will get deployed to when merged(not the www-testing stack).