### PR TITLE
Fix embedded Youtube video

### DIFF
--- a/content/blog/tour-pulumi-equinix-provider/index.md
+++ b/content/blog/tour-pulumi-equinix-provider/index.md
@@ -33,11 +33,8 @@ Detailed documentation for the Equinix provider can be found in the [Pulumi Regi
 
 In order to demonstrate the power and utility of Pulumi and the Equinix provider, Equinix Labs has produced a codebase that [creates a Kubernetes cluster on Equinix Metal](https://github.com/equinix-labs/pulumi-equinix-kubernetes-cluster/). The codebase is available in both [TypeScript](https://github.com/equinix-labs/pulumi-equinix-kubernetes-cluster/tree/main/nodejs) and [Python](https://github.com/equinix-labs/pulumi-equinix-kubernetes-cluster/tree/main/python).
 
-{{% notes type="info" %}}
-For an overview of how Pulumi works along with a guided tour of the codebase and deploying a workload onto the Kubernetes cluster, check out [Pulumi's presentation at Equinix Demo Day 2023](https://youtu.be/-siv1ga0l_o). (Pulumi's presentation begins at 3:30:00 below, or click the preceding link to jump directly to Pulumi's presentation on YouTube.):
-
-{{< youtube "-siv1ga0l_o?t=12576&rel=0" >}}
-{{% /notes %}}
+> **NOTE**: For an overview of how Pulumi works along with a guided tour of the codebase and deploying a workload onto the Kubernetes cluster, check out [Pulumi's presentation at Equinix Demo Day 2023](https://youtu.be/-siv1ga0l_o). (Pulumi's presentation begins at 3:30:00 below, or click the preceding link to jump directly to Pulumi's presentation on YouTube.):
+> {{< youtube id=-siv1ga0l_o start=12576 >}}
 
 The codebase gives an excellent example of one of Pulumi's most compelling features: the ability to manage and orchestrate many different kinds of resources in real programming languages with a single tool. In addition to the Equinix provider which is used to manage the bare metal compute resources, the codebase also uses the following providers:
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/docs/issues/11600

The issue here was multivariate:
- Previous version of Hugo (>1.25.0) did not support deep linking to a timestamp in a video, so the shortcode was stripping out the parameter from the URL and linking to the beginning of the video. We've since upgraded to a new version of Hugo (1.35.0) and now the shortcode includes the ability to link to a specific time stamp, but not via the url param, rather via the `start` parameter in the shortcode. 
- Previous version of Hugo's shortcode seemed to work fine with nesting the embedding inside of the the `{{% note %}}` shortcode, but now, with the new version, it breaks and renders the youtube shortcode in a `<pre>` block. I tried various ways to remediate that, but had no luck. Instead, removed the note shortcode and instead just formatted with an indexed block which works. 

So, now the video renders as expected and links to the correct time.