### PR TITLE
fix(insights):  use correct env var name for OCI insights esc setup

### DIFF
--- a/content/docs/pulumi-cloud/insights/accounts.md
+++ b/content/docs/pulumi-cloud/insights/accounts.md
@@ -201,7 +201,7 @@ values:
     OCI_TENANCY_OCID: "ocid1.tenancy.oc1..tenancyidnumbers"
     OCI_USER_OCID: "user_ocid"
   files:
-    OCI_PRIVATE_KEY: "PRIVATE_KEY_CONTENT"
+    OCI_PRIVATE_KEY_PATH: "<PRIVATE_KEY_CONTENT>"
 ```
 
 Once the ESC environment is set up with the proper credentials, assign it to your insights account during the account creation phase.

--- a/content/docs/pulumi-cloud/insights/accounts.md
+++ b/content/docs/pulumi-cloud/insights/accounts.md
@@ -191,6 +191,7 @@ The OCI scanner for Pulumi Cloud requires access to your Oracle Cloud account. T
 * **OCI_FINGERPRINT**: Fingerprint for the key pair being used. See [How to Get the Key's Fingerprint](https://docs.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#four).
 * **OCI_REGION**: The OCI region where your resources are located. See [Regions and Availability Domains](https://docs.oracle.com/iaas/Content/General/Concepts/regions.htm).
 * **OCI_PRIVATE_KEY_PATH**: The private key is required to be listed as an ESC file. To create a private key and integrate it with ESC, see [How to Generate an API Signing Key](https://docs.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#two) and [how to upload the public key](https://docs.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#three)
+
 Use the following ESC configuration to provide the required credentials:
 
 ```yaml


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Update the onboarding docs to use the right env variable name.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
