### PR TITLE
Feat: add devbox integration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -43,3 +43,7 @@ origin-bucket-metadata.json
 
 # Ignore js scripts added to the static folder
 static/js
+
+# Ignore files installed with devbox
+devbox.json
+.devbox

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Additionally, to build the SDK and CLI documentation, you'll also need:
 * [Pulumi](https://www.pulumi.com/docs/install)
 * [Pulumi ESC](https://www.pulumi.com/docs/install/esc)
 
+Alternatively, you can quickly launch a shell environment with all the required dependencies using [devbox](https://www.jetpack.io/devbox/):
+```
+# Install devbox if needed
+$ which devbox || curl -fsSL https://get.jetpack.io/devbox | bash
+$ devbox shell
+```
+
 ### Repository layout
 
 * **Documentation and page content**: We generally follow Hugo's [directory-structure conventions](https://gohugo.io/getting-started/directory-structure/), with Markdown files in `./content`, layout files (including partials and shortcodes) in `./layout`, and data files in `./data`. There are also several [Hugo templates](https://gohugo.io/content-management/archetypes/) available in `./archetypes` for bootstrapping common content types like blog posts and Learn modules.

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.6/.schema/devbox.schema.json",
+  "packages": [
+    "go@1.21",
+    "python@3.7",
+    "hugo@0.126",
+    "nodejs@18",
+    "dotnet-sdk@6",
+    "pulumi@3.99",
+    "pulumi-esc@latest"
+  ],
+  "env": {
+    "DEVBOX_COREPACK_ENABLED": "true",
+    "VENV_DIR": "venv"
+  },
+  "shell": {
+    "init_hook": [
+      ". $VENV_DIR/bin/activate"
+    ]
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,367 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "dotnet-sdk@6": {
+      "last_modified": "2024-11-16T04:25:12Z",
+      "resolved": "github:NixOS/nixpkgs/34a626458d686f1b58139620a8b2793e9e123bba#dotnet-sdk",
+      "source": "devbox-search",
+      "version": "6.0.427",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/p1m94qjsxr6jkzagj1r83wyllrw8wj2b-dotnet-sdk-6.0.427",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/p1m94qjsxr6jkzagj1r83wyllrw8wj2b-dotnet-sdk-6.0.427"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mi8lk7f9aqwakmb793wq1cn8q6z5iqjh-dotnet-sdk-6.0.427",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/mi8lk7f9aqwakmb793wq1cn8q6z5iqjh-dotnet-sdk-6.0.427"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cg7f6ni6p44ykzpghp4p03vwqbr2dgm0-dotnet-sdk-6.0.427",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/cg7f6ni6p44ykzpghp4p03vwqbr2dgm0-dotnet-sdk-6.0.427"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2ashk2ig3vb8s54mpyc2w5dgr4saqcvj-dotnet-sdk-6.0.427",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/2ashk2ig3vb8s54mpyc2w5dgr4saqcvj-dotnet-sdk-6.0.427"
+        }
+      }
+    },
+    "go@1.21": {
+      "last_modified": "2024-09-10T15:01:03Z",
+      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#go_1_21",
+      "source": "devbox-search",
+      "version": "1.21.13",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/59bymri4pr8mq5zh678smrf381i3fmy2-go-1.21.13",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/59bymri4pr8mq5zh678smrf381i3fmy2-go-1.21.13"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7dqbqicx8szqnyzag6l41gwbjmh1xdk0-go-1.21.13",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7dqbqicx8szqnyzag6l41gwbjmh1xdk0-go-1.21.13"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ws9bs446vgwmxchqnpjp9503x420iz75-go-1.21.13",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ws9bs446vgwmxchqnpjp9503x420iz75-go-1.21.13"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yij3vkkjv7ghn055v0rqhbjzyh0dy4nq-go-1.21.13",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/yij3vkkjv7ghn055v0rqhbjzyh0dy4nq-go-1.21.13"
+        }
+      }
+    },
+    "hugo@0.126": {
+      "last_modified": "2024-06-04T00:03:09Z",
+      "resolved": "github:NixOS/nixpkgs/3b01abcc24846ae49957b30f4345bab4b3f1d14b#hugo",
+      "source": "devbox-search",
+      "version": "0.126.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vkg3fy81l6p2g0fmgc0wvgjhmjk97ghy-hugo-0.126.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vkg3fy81l6p2g0fmgc0wvgjhmjk97ghy-hugo-0.126.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wvay2iwdsxvr481c70k98xfrr669bywz-hugo-0.126.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/wvay2iwdsxvr481c70k98xfrr669bywz-hugo-0.126.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jfps3j0w7h9y6xsn8aryrpl948ycpnm7-hugo-0.126.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/jfps3j0w7h9y6xsn8aryrpl948ycpnm7-hugo-0.126.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/dsazc5gd0i0923vimsvy30xya7nhi22b-hugo-0.126.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/dsazc5gd0i0923vimsvy30xya7nhi22b-hugo-0.126.3"
+        }
+      }
+    },
+    "nodejs@18": {
+      "last_modified": "2024-12-03T12:40:06Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/566e53c2ad750c84f6d31f9ccb9d00f823165550#nodejs_18",
+      "source": "devbox-search",
+      "version": "18.20.5",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6dlw5588gs7whckfx2l0iyd8xi4gklq6-nodejs-18.20.5",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/a40q0j0m27m1dxy9i94accm5zaknpx2k-nodejs-18.20.5-libv8"
+            }
+          ],
+          "store_path": "/nix/store/6dlw5588gs7whckfx2l0iyd8xi4gklq6-nodejs-18.20.5"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qa34xfgbvrpdymlr31ai4vjym7pmvapn-nodejs-18.20.5",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/wqi5b71jkvyw2lv81j2ydgchhywdrn1q-nodejs-18.20.5-libv8"
+            }
+          ],
+          "store_path": "/nix/store/qa34xfgbvrpdymlr31ai4vjym7pmvapn-nodejs-18.20.5"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/211dnaznay3942xf2gykgshcflcsr4f8-nodejs-18.20.5",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/cc6k5wryplskfs7bbmcnzwvv2c3nh219-nodejs-18.20.5-libv8"
+            }
+          ],
+          "store_path": "/nix/store/211dnaznay3942xf2gykgshcflcsr4f8-nodejs-18.20.5"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nmmgwk1a0cakhmhwgf1v2b5ws3zf899h-nodejs-18.20.5",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/3kp2j4w0k9cb7r29wq2iv8kyp7hw1dqs-nodejs-18.20.5-libv8"
+            }
+          ],
+          "store_path": "/nix/store/nmmgwk1a0cakhmhwgf1v2b5ws3zf899h-nodejs-18.20.5"
+        }
+      }
+    },
+    "pulumi-esc@latest": {
+      "last_modified": "2024-11-28T07:51:56Z",
+      "resolved": "github:NixOS/nixpkgs/226216574ada4c3ecefcbbec41f39ce4655f78ef#pulumi-esc",
+      "source": "devbox-search",
+      "version": "0.11.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gpqqsmjhjn17k16vmkrn8a4lip9qw0ja-pulumi-esc-0.11.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gpqqsmjhjn17k16vmkrn8a4lip9qw0ja-pulumi-esc-0.11.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/s4gn62k0in5kiaplgiawvvmqa36xj8v9-pulumi-esc-0.11.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/s4gn62k0in5kiaplgiawvvmqa36xj8v9-pulumi-esc-0.11.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ih1y8kgfr8wkdh0qqbla1fz0h4ipyc40-pulumi-esc-0.11.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ih1y8kgfr8wkdh0qqbla1fz0h4ipyc40-pulumi-esc-0.11.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rk9y1i4bm905f9smsw6d8qf108x4xlfz-pulumi-esc-0.11.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/rk9y1i4bm905f9smsw6d8qf108x4xlfz-pulumi-esc-0.11.0"
+        }
+      }
+    },
+    "pulumi@3.99": {
+      "last_modified": "2024-07-07T07:43:47Z",
+      "resolved": "github:NixOS/nixpkgs/b60793b86201040d9dee019a05089a9150d08b5b#pulumi",
+      "source": "devbox-search",
+      "version": "3.99.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f4lfi4fas8pm0ad6qyqlb8h8r19ka2mb-pulumi-3.99.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/f4lfi4fas8pm0ad6qyqlb8h8r19ka2mb-pulumi-3.99.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8jcd9chg00wb9m3lsw7vkcfpwpfwb43x-pulumi-3.99.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8jcd9chg00wb9m3lsw7vkcfpwpfwb43x-pulumi-3.99.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nv4gwssvvscq1y7i3bjk6llbv2bmwxlv-pulumi-3.99.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nv4gwssvvscq1y7i3bjk6llbv2bmwxlv-pulumi-3.99.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i43skxbhsfry9f97gjdygzgsmchlfj7q-pulumi-3.99.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i43skxbhsfry9f97gjdygzgsmchlfj7q-pulumi-3.99.0"
+        }
+      }
+    },
+    "python@3.7": {
+      "last_modified": "2022-12-17T09:19:40Z",
+      "plugin_version": "0.0.4",
+      "resolved": "github:NixOS/nixpkgs/80c24eeb9ff46aa99617844d0c4168659e35175f#python37",
+      "source": "devbox-search",
+      "version": "3.7.16",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/a89sd5jwn01cdg97lkspl8cpf75y5142-python3-3.7.16",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/a89sd5jwn01cdg97lkspl8cpf75y5142-python3-3.7.16"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ymrbxfmljyl73rmh5cfk0bzk3ydcbqg8-python3-3.7.16",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/3x7736j3fyw6j9fzn1y9fc0iqyf1rncc-python3-3.7.16-debug"
+            }
+          ],
+          "store_path": "/nix/store/ymrbxfmljyl73rmh5cfk0bzk3ydcbqg8-python3-3.7.16"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i028a4nf177g23ksa7kc63ld9nys17nb-python3-3.7.16",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i028a4nf177g23ksa7kc63ld9nys17nb-python3-3.7.16"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ik7s754pwxhiky396mjagzmjs1kp0wzq-python3-3.7.16",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/l0xi13a88d4vjn8ada3a58zkwm88hq7h-python3-3.7.16-debug"
+            }
+          ],
+          "store_path": "/nix/store/ik7s754pwxhiky396mjagzmjs1kp0wzq-python3-3.7.16"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
   "devDependencies": {
     "husky": "^9.0.11",
     "prettier": "^2.6.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/ci-bucket-cleanup.sh
+++ b/scripts/ci-bucket-cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/ci-login.sh
+++ b/scripts/ci-login.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/ci-pull-request-closed.sh
+++ b/scripts/ci-pull-request-closed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/ci-pull-request.sh
+++ b/scripts/ci-pull-request.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/ci-update-search-index.sh
+++ b/scripts/ci-update-search-index.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script downloads the search indexes for registry and docs from pulumi.com then combines
 # the two indexes and pushes them to Algolia.

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 yarn cache clean
 hugo mod clean

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 aws_region() {
     echo "$(pulumi -C infrastructure config get 'aws:region')"

--- a/scripts/create-dev-stack.sh
+++ b/scripts/create-dev-stack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/deploy-dev-stack.sh
+++ b/scripts/deploy-dev-stack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/destroy-dev-stack.sh
+++ b/scripts/destroy-dev-stack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/detect-new-404s.sh
+++ b/scripts/detect-new-404s.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/ensure.sh
+++ b/scripts/ensure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/gen_all_resource_docs.sh
+++ b/scripts/gen_all_resource_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A script to generate the schema-based resource docs for all of the providers for which we can generate
 # a Pulumi schema.

--- a/scripts/gen_component_docs.sh
+++ b/scripts/gen_component_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o nounset -o errexit -o pipefail
 

--- a/scripts/gen_package_metadata.sh
+++ b/scripts/gen_package_metadata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A script that facilitates generating package metadata files using the tools/resourcedocsgen Go-based
 # tool. This script optionally allows passing the provider name (without the "pulumi-" prefix.)

--- a/scripts/gen_resource_docs.sh
+++ b/scripts/gen_resource_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # A script that facilitates generating resource docs using the tools/resourcedocsgen Go-based
 # tool. This script optionally allows passing the provider name (without the "pulumi-" prefix.)
 

--- a/scripts/generate-search-index.sh
+++ b/scripts/generate-search-index.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/laptop-deploy.sh
+++ b/scripts/laptop-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/list-recent-buckets.sh
+++ b/scripts/list-recent-buckets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/make-s3-redirects.sh
+++ b/scripts/make-s3-redirects.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/normalize-video.sh
+++ b/scripts/normalize-video.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script takes an input video path (relative is fine) and converts it to H.264 MP4 format with AAC audio,
 # downscaling to 1200-pixel max-width where necessary. Converted files are written to ${filename}-${video_codec}.${extension}.

--- a/scripts/on-demand-build-sync-test.sh
+++ b/scripts/on-demand-build-sync-test.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/remove-recent-buckets.sh
+++ b/scripts/remove-recent-buckets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/resource_docs_common.sh
+++ b/scripts/resource_docs_common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script contains common functions used in the scripts for API docs generation.
 

--- a/scripts/run-browser-tests.sh
+++ b/scripts/run-browser-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MAX_RETRIES=3
 RETRY_COUNT=0

--- a/scripts/run-pulumi.sh
+++ b/scripts/run-pulumi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run Pulumi to update the stack targeted by the given branch.
 

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 yarn --cwd components test

--- a/scripts/run_docfx.sh
+++ b/scripts/run_docfx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: run_docfx
 
 set -o nounset -o errexit -o pipefail

--- a/scripts/run_typedoc.sh
+++ b/scripts/run_typedoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Runs typedoc on various Pulumi repos and copies them to
 # the /libraries folder.

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o pipefail
 

--- a/scripts/update_repos.sh
+++ b/scripts/update_repos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: update_repos
 
 set -o nounset -o errexit -o pipefail

--- a/scripts/validate-sitemap-urls.sh
+++ b/scripts/validate-sitemap-urls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 request_and_format_sitemap() {
     curl https://www.pulumi.com/sitemap.xml > sitemap.xml && xmllint --format sitemap.xml > temp_sitemap.xml && mv temp_sitemap.xml sitemap.xml


### PR DESCRIPTION
### Proposed changes

Adds a devbox configuration to install all the repo's requirements for contributing.

Pulumi uses [devbox](https://www.jetify.com/devbox/) for most providers to give contributors a quick way to get their development environment set up.

It also removes some hurdles for NixOS users if they want to contribute (they don't have `/bin/bash`)

Pulumi is currently stuck at 3.99, [later versions are not building properly](https://github.com/NixOS/nixpkgs/issues/351955).