### PR TITLE
fix incorrect query param in deployment logs endpoint docs

### DIFF
--- a/content/docs/pulumi-cloud/deployments/api.md
+++ b/content/docs/pulumi-cloud/deployments/api.md
@@ -1180,7 +1180,7 @@ The `token` is a string that contains the `job`, `offset` and `step` of the next
 
 The following query parameters are available:
 
-* **nextToken**: A string returned by the previous response, that can be used to get the next set of logs.
+* **continuationToken**: A string returned by the previous response, that can be used to get the next set of logs.
 
 ##### Example
 
@@ -1230,12 +1230,12 @@ Response
 }
 ```
 
-Following request (using `nextToken`)
+Following request (using the returned `nextToken`)
 
 ```shell
 curl -XGET -H "Content-Type: application/json" \
 -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
---location "https://api.pulumi.com/api/stacks/my-org/aws-ts-s3-folder/dev/deployments/6b1ec06b-4f41-4cce-a7c9-13ceded14db2/logs?nextToken=0.2.1"
+--location "https://api.pulumi.com/api/stacks/my-org/aws-ts-s3-folder/dev/deployments/6b1ec06b-4f41-4cce-a7c9-13ceded14db2/logs?continuationToken=0.2.1"
 ```
 
 Response

--- a/content/docs/pulumi-cloud/deployments/api.md
+++ b/content/docs/pulumi-cloud/deployments/api.md
@@ -1180,7 +1180,7 @@ The `token` is a string that contains the `job`, `offset` and `step` of the next
 
 The following query parameters are available:
 
-* **continuationToken**: A string returned by the previous response, that can be used to get the next set of logs.
+* **continuationToken**: The `nextToken` value from the previous response, that can be used to get the next set of logs.
 
 ##### Example
 


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
The deployment logs endpoint actually uses a [`continuationToken` query param](https://github.com/pulumi/pulumi-service/blob/31449fbea5f22e570b72a602202d7f02ccbcafd1/cmd/service/api/deployments.go#L582) instead of the documented `nextToken` one.  Unfortunately the api response returns `nextToken`, so it's a bit confusing :(

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes https://github.com/pulumi/pulumi-service/issues/24318
