### PR TITLE
Add keywords to assets-archives.md

### DIFF
--- a/content/docs/iac/concepts/assets-archives.md
+++ b/content/docs/iac/concepts/assets-archives.md
@@ -11,6 +11,14 @@ menu:
         weight: 13
     concepts:
         weight: 13
+search:
+   keywords:
+      - FileAsset
+      - StringAsset
+      - RemoteAsset
+      - FileArchive
+      - RemoteArchive
+      - AssetArchive
 aliases:
 - /docs/intro/concepts/assets-archives/
 - /docs/concepts/inputs-outputs/assets-archives/


### PR DESCRIPTION
I was looking at the Algolia dashboard recently and noticed that some of the more common cases of no results were for FileAsset and FileArchive. I think this is the best docs we have for those so adding them as keywords should help folks find what they are looking for more easily.