### PR TITLE
🌿 add missing top-level `values:` to various ESC reference examples

### DIFF
--- a/content/docs/esc/get-started/integrate-with-pulumi-iac.md
+++ b/content/docs/esc/get-started/integrate-with-pulumi-iac.md
@@ -35,8 +35,8 @@ This command will walk you through creating a new Pulumi project.
 Enter a value or leave blank to accept the (default), and press <ENTER>.
 Press ^C at any time to quit.
 
-project name (pulumi-esc-iac):  
-project description (A minimal Python Pulumi program):  
+project name (pulumi-esc-iac):
+project description (A minimal Python Pulumi program):
 Created project 'pulumi-esc-iac'
 
 Please enter your desired stack name.

--- a/content/docs/esc/integrations/dynamic-login-credentials/azure-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/azure-login.md
@@ -19,6 +19,7 @@ The `azure-login` provider enables you to log in to Azure using OpenID Connect o
 ## Example
 
 ```yaml
+values:
   azure:
     login:
       fn::open::azure-login:

--- a/content/docs/esc/integrations/dynamic-login-credentials/gcp-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/gcp-login.md
@@ -19,15 +19,15 @@ The `gcp-login` provider enables you to log in to Google Cloud using OpenID Conn
 ## Example
 
 ```yaml
-  values:
-    gcp:
-      login:
-        fn::open::gcp-login:
-          project: 123456789
-          oidc:
-            workloadPoolId: pulumi-esc
-            providerId: pulumi-esc
-            serviceAccount: pulumi-esc@foo-bar-123456.iam.gserviceaccount.com
+values:
+  gcp:
+    login:
+      fn::open::gcp-login:
+        project: 123456789
+        oidc:
+          workloadPoolId: pulumi-esc
+          providerId: pulumi-esc
+          serviceAccount: pulumi-esc@foo-bar-123456.iam.gserviceaccount.com
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/integrations/dynamic-login-credentials/vault-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/vault-login.md
@@ -19,6 +19,7 @@ The `vault-login` provider enables you to log in to HashiCorp Vault using OpenID
 ## Examples
 
 ```yaml
+values:
   vault:
     login:
       fn::open::vault-login:
@@ -28,6 +29,7 @@ The `vault-login` provider enables you to log in to HashiCorp Vault using OpenID
 ```
 
 ```yaml
+values:
   vault:
     login:
       fn::open::vault-login:

--- a/content/docs/esc/integrations/dynamic-secrets/1password-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/1password-secrets.md
@@ -23,6 +23,7 @@ This provider is currently in **preview**.
 ## Example
 
 ```yaml
+values:
   1password:
     secrets:
       fn::open::1password-secrets:

--- a/content/docs/esc/integrations/dynamic-secrets/aws-parameter-store.md
+++ b/content/docs/esc/integrations/dynamic-secrets/aws-parameter-store.md
@@ -18,29 +18,29 @@ The `aws-parameter-store` provider enables you to dynamically import parameters 
 ## Example
 
 ```yaml
-aws:
-  login:
-    fn::open::aws-login:
-      oidc:
-        roleArn: arn:aws:iam::123456789:role/esc-oidc
-        sessionName: pulumi-environments-session
-  params:
-    fn::open::aws-parameter-store:
-      region: us-west-1
-      login: ${aws.login}
-      get:
-        myKey:
-          name: /myNamespace/myKey
-        myKeyByVersion:
-          name: /myNamespace/myKey:1
-        myKeyByVersionLabel:
-          name: /myNamespace/myKey:stable
-        secureKey:
-          name: /myNamespace/secureKey
-          decrypt: true
-        myList:
-          name: /myNamespace/myList
-
+values:
+  aws:
+    login:
+      fn::open::aws-login:
+        oidc:
+          roleArn: arn:aws:iam::123456789:role/esc-oidc
+          sessionName: pulumi-environments-session
+    params:
+      fn::open::aws-parameter-store:
+        region: us-west-1
+        login: ${aws.login}
+        get:
+          myKey:
+            name: /myNamespace/myKey
+          myKeyByVersion:
+            name: /myNamespace/myKey:1
+          myKeyByVersionLabel:
+            name: /myNamespace/myKey:stable
+          secureKey:
+            name: /myNamespace/secureKey
+            decrypt: true
+          myList:
+            name: /myNamespace/myList
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/integrations/dynamic-secrets/aws-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/aws-secrets.md
@@ -18,22 +18,23 @@ The `aws-secrets` provider enables you to dynamically import Secrets from AWS Se
 ## Example
 
 ```yaml
-aws:
-  login:
-    fn::open::aws-login:
-      oidc:
-        roleArn: arn:aws:iam::123456789:role/esc-oidc
-        sessionName: pulumi-environments-session
-  secrets:
-    fn::open::aws-secrets:
-      region: us-west-1
-      login: ${aws.login}
-      get:
-        api-key:
-          # Secret name as shown in the AWS Console, or secret ARN:
-          secretId: api-key
-        app-secret:
-          secretId: app-secret
+values:
+  aws:
+    login:
+      fn::open::aws-login:
+        oidc:
+          roleArn: arn:aws:iam::123456789:role/esc-oidc
+          sessionName: pulumi-environments-session
+    secrets:
+      fn::open::aws-secrets:
+        region: us-west-1
+        login: ${aws.login}
+        get:
+          api-key:
+            # Secret name as shown in the AWS Console, or secret ARN:
+            secretId: api-key
+          app-secret:
+            secretId: app-secret
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/integrations/dynamic-secrets/azure-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/azure-secrets.md
@@ -18,6 +18,7 @@ The `azure-secrets` provider enables you to dynamically import Secrets and Confi
 ## Example
 
 ```yaml
+values:
   azure:
     login:
       fn::open::azure-login:

--- a/content/docs/esc/integrations/dynamic-secrets/gcp-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/gcp-secrets.md
@@ -19,6 +19,7 @@ The `gcp-secrets` provider enables you to dynamically import Secrets from Google
 ## Example
 
 ```yaml
+values:
   gcp:
     login:
       fn::open::gcp-login:

--- a/content/docs/esc/integrations/dynamic-secrets/vault-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/vault-secrets.md
@@ -18,6 +18,7 @@ The `vault-secrets` provider enables you to dynamically import Secrets from Hash
 ## Example
 
 ```yaml
+values:
   vault:
     login:
       fn::open::vault-login:

--- a/content/docs/esc/integrations/infrastructure/cloudflare.md
+++ b/content/docs/esc/integrations/infrastructure/cloudflare.md
@@ -137,7 +137,7 @@ There are two options for managing the `.dev.vars` definition.
   ```bash
   esc run -i ${ESC_ENV} -- sh -c 'cat $DEV_VARS > .dev.vars'
   ```
-  
+
   For additional options and details, see `esc run --help`.
 
 ### 4. Use ESC with `wrangler secret put`


### PR DESCRIPTION
### Proposed changes

Some ESC reference examples were missing the top-level `values:` key. This could confuse the reader into thinking `values:` is not required but where in fact it's required. As ESC doesn't complain about such syntax it's even harder to identify the problem.

This PR adds those missing top-level `values:` for the relevant ESC reference examples and makes indentation consistent.

Additionally, a few trailing spaces have been removed.
