### PR TITLE
Enabling Scheduled posts in blog

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,9 +3,12 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # Run at 6 AM Eastern (11:00 UTC)
+    - cron: '0 11 * * *'
 permissions:
-      id-token: write   # This is required for requesting the JWT
-      contents: read   # This is required for actions/checkout
+  id-token: write   # This is required for requesting the JWT
+  contents: read   # This is required for actions/checkout
 jobs:
   buildSite:
     env:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The `Makefile` exposes a number of useful helpers for authoring:
 * `make ensure` resolves and installs all dependencies
 * `make lint` checks all Markdown files for correctness
 * `make format` formats all applicable files to ensure they conform to style guidelines
-* `make serve` runs the Hugo server locally at http://localhost:1313 and watches for changes
+* `make serve` runs the Hugo server locally at http://localhost:1313 and watches for changes. You can set `BUILD_FUTURE=false` to simulate production behavior by excluding future-dated content (e.g., `BUILD_FUTURE=false make serve`)
 * `make serve-all` does the same as `make serve`, but also watches for changes to CSS and JS source files
 * `make build` generates the website and writes it to `./public`
 * `make build-assets` builds only the CSS and JavaScript asset bundles
@@ -237,7 +237,7 @@ Engage with our community to elevate your developer experience:
 Delve deeper into Pulumi with additional resources:
 
 - [Get Started with Pulumi](https://www.pulumi.com/docs/get-started/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources): Deploy a simple application in AWS, Azure, Google Cloud, or Kubernetes using Pulumi.
-- [Registry](https://www.pulumi.com/registry/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources): Search for packages and learn about the supported resources you need. Install the package directly into your project, browse the API documentation, and start building.
+- [Registry](https://www.pulumi.com/registry/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Search for packages and learn about the supported resources you need. Install the package directly into your project, browse the API documentation, and start building.
 - [Pulumi Blog](https://www.pulumi.com/blog/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Stay in the loop with our latest tech announcements, insightful articles, and updates.
 - [Try Pulumi AI](https://www.pulumi.com/ai/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Use natural-language prompts to generate Pulumi infrastructure-as-code programs in any language.
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Engage with our community to elevate your developer experience:
 Delve deeper into Pulumi with additional resources:
 
 - [Get Started with Pulumi](https://www.pulumi.com/docs/get-started/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources): Deploy a simple application in AWS, Azure, Google Cloud, or Kubernetes using Pulumi.
-- [Registry](https://www.pulumi.com/registry/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Search for packages and learn about the supported resources you need. Install the package directly into your project, browse the API documentation, and start building.
+- [Registry](https://www.pulumi.com/registry/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources): Search for packages and learn about the supported resources you need. Install the package directly into your project, browse the API documentation, and start building.
 - [Pulumi Blog](https://www.pulumi.com/blog/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Stay in the loop with our latest tech announcements, insightful articles, and updates.
 - [Try Pulumi AI](https://www.pulumi.com/ai/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Use natural-language prompts to generate Pulumi infrastructure-as-code programs in any language.
 

--- a/content/blog/pulumi-year-in-review/index.md
+++ b/content/blog/pulumi-year-in-review/index.md
@@ -8,7 +8,7 @@ allow_long_title: true
 # published. To influence the ordering of posts published on the same date, use
 # the time portion of the date value; posts are sorted in descending order by
 # date/time.
-date: 2024-12-20T06:11:09Z
+date: 2025-12-20T06:11:09Z
 
 # The draft setting determines whether a post is published. Set it to true if
 # you want to be able to merge the post without publishing it.

--- a/content/blog/pulumi-year-in-review/index.md
+++ b/content/blog/pulumi-year-in-review/index.md
@@ -8,7 +8,7 @@ allow_long_title: true
 # published. To influence the ordering of posts published on the same date, use
 # the time portion of the date value; posts are sorted in descending order by
 # date/time.
-date: 2025-12-20T06:11:09Z
+date: 2024-12-20T06:11:09Z
 
 # The draft setting determines whether a post is published. Set it to true if
 # you want to be able to merge the post without publishing it.

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -39,7 +39,7 @@ else
         export HUGO_BASEURL="https://www.pulumi-test.io"
         GOGC=3 hugo --minify --buildFuture --templateMetrics -e "preview"
     else
-        GOGC=3 hugo --minify --buildFuture --templateMetrics -e "production"
+        GOGC=3 hugo --minify --templateMetrics -e "production"
     fi
 fi
 

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -19,4 +19,10 @@ export REL_JS_BUNDLE="/js/bundle.min.${ASSET_BUNDLE_ID}.js"
 # URL to the Pulumi conversion service.
 export PULUMI_CONVERT_URL="${PULUMI_CONVERT_URL:-$(pulumi stack output --stack pulumi/tf2pulumi-service/production url)}"
 
-HUGO_BASEURL=http://localhost:1313 hugo server --renderToMemory --disableFastRender --buildDrafts --buildFuture
+# Default to building future content unless explicitly disabled
+BUILD_FUTURE_FLAG="--buildFuture"
+if [ "${BUILD_FUTURE:-true}" = "false" ]; then
+    BUILD_FUTURE_FLAG=""
+fi
+
+HUGO_BASEURL=http://localhost:1313 hugo server --renderToMemory --disableFastRender --buildDrafts ${BUILD_FUTURE_FLAG}


### PR DESCRIPTION
- For a production build, turn off `--buildFuture`
- We run a build each morning, to publish anything scheduled
- No one has to merge things on release day manually