### PR TITLE
Do not fail build on 404 checker failure

### DIFF
--- a/scripts/detect-new-404s.sh
+++ b/scripts/detect-new-404s.sh
@@ -10,4 +10,5 @@ destination_bucket="$(cat "$(origin_bucket_metadata_filepath)" | jq -r ".bucket"
 s3_website_url="http://${destination_bucket}.s3-website.$(aws_region).amazonaws.com"
 
 echo "Checking ${s3_website_url} for new 404s..."
-node scripts/detect-new-404s.js "https://pulumi.com" "${s3_website_url}"
+# For now we don't want this to fail the build due to lots of flakiness, so always exit successfully.
+node scripts/detect-new-404s.js "https://pulumi.com" "${s3_website_url}" || true


### PR DESCRIPTION
Do not fail the build on the 404 checker failure. This check has been very flaky lately and is currently providing minimal value, so swallowing failures for now as to not block PRs.