### PR TITLE
feat: support GH style alert blockquotes

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.126.0"
+          hugo-version: "0.135.0"
           extended: true
 
       - name: Install Pulumi

--- a/.github/workflows/scheduled-upgrade-programs.yml
+++ b/.github/workflows/scheduled-upgrade-programs.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.126.0"
+          hugo-version: "0.135.0"
           extended: true
 
       - name: Install Pulumi

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -74,7 +74,7 @@ markup:
       autoHeadingID: true
       autoHeadingIDType: "github"
       attribute:
-        block: false
+        block: true
         title: true
     renderer:
       hardWraps: false

--- a/layouts/_default/_markup/render-blockquote-alert.html
+++ b/layouts/_default/_markup/render-blockquote-alert.html
@@ -1,0 +1,19 @@
+{{ $emojis := dict
+"caution" ":exclamation:"
+"important" ":zap:"
+"note" ":information_source:"
+"tip" ":bulb:"
+"warning" ":warning:"
+}}
+
+<blockquote class="alert alert-{{ .AlertType }}">
+    <p class="alert-heading">
+        {{ transform.Emojify (index $emojis .AlertType) }}
+        {{ with .AlertTitle }}
+            {{ . }}
+        {{ else }}
+            {{ or (i18n .AlertType) (title .AlertType) }}
+        {{ end }}
+    </p>
+    {{ .Text }}
+</blockquote>

--- a/layouts/_default/_markup/render-blockquote-alert.html
+++ b/layouts/_default/_markup/render-blockquote-alert.html
@@ -1,19 +1,18 @@
-{{ $emojis := dict
-"caution" ":exclamation:"
-"important" ":zap:"
-"note" ":information_source:"
-"tip" ":bulb:"
-"warning" ":warning:"
+{{ $icon := dict
+"caution" "exclamation-triangle"
+"important" "star"
+"note" "pencil-alt"
+"info" "info-circle"
+"tip" "lightbulb"
+"warning" "exclamation-triangle"
 }}
 
-<blockquote class="alert alert-{{ .AlertType }}">
-    <p class="alert-heading">
-        {{ transform.Emojify (index $emojis .AlertType) }}
-        {{ with .AlertTitle }}
-            {{ . }}
-        {{ else }}
-            {{ or (i18n .AlertType) (title .AlertType) }}
-        {{ end }}
-    </p>
-    {{ .Text }}
-</blockquote>
+<div class="note note-{{ .AlertType }}">
+    <div class="icon-and-line">
+        <i class="fas fa-{{ index $icon .AlertType }}"></i>
+        <div class="line"></div>
+    </div>
+    <div class="content">
+        {{- .Text -}}
+    </div>
+</div>

--- a/layouts/_default/_markup/render-blockquote-regular.html
+++ b/layouts/_default/_markup/render-blockquote-regular.html
@@ -1,0 +1,3 @@
+<blockquote>
+    {{ .Text }}
+</blockquote>


### PR DESCRIPTION
This PR adds support for GH style alert blockquotes. See https://gohugo.io/render-hooks/blockquotes/#alerts for details

![image](https://github.com/user-attachments/assets/5d558467-be53-4e8c-b6c3-28a5ef40b519)
