### PR TITLE
Disable 404 checker

### DIFF
--- a/scripts/ci-pull-request.sh
+++ b/scripts/ci-pull-request.sh
@@ -21,4 +21,5 @@ source ./scripts/ci-login.sh
 ./scripts/run-pulumi.sh preview
 ./scripts/make-s3-redirects.sh
 
-./scripts/detect-new-404s.sh
+# Temporarily disable 404 detection (too many false positives)
+# ./scripts/detect-new-404s.sh


### PR DESCRIPTION
The 404 checker has been creating false positives which interrupt the PR workflow. Disabling this temporarily until we can figure out better logic for this.