### PR TITLE
publish APAC workshop for 1/22

### DIFF
--- a/content/events/platform-engineering-done-right/index.md
+++ b/content/events/platform-engineering-done-right/index.md
@@ -1,0 +1,101 @@
+---
+# Name of the event, <= 60 characters
+title: "Platform Engineering Done Right: Steps to Success"
+meta_desc: Implement Platform Engineering practices. Learn the 7 essential steps to success, avoid common pitfalls and save costs with expert tips and real-world examples.
+meta_image:
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: platform-engineering-done-right
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "Platform Engineering Done Right: Steps to Success"
+
+    event_type: workshop # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url: 
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2025-01-22T13:00:00+11:00
+
+    # Duration of the webinar.
+    duration: 90 minutes
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: virtual
+
+    # Description of the webinar.
+    description: |
+       Is your organization developing an Internal Developer Platform (IDP)? How do you ensure your efforts are on the right track?
+
+       Join us for a comprehensive session to explore when and why organizations need a platform and share practical strategies to adopt platform engineering successfully. You'll learn how to assess your platform efforts, identify the right indicators of success, and avoid costly missteps that can derail your efforts.
+
+       This webinar will take you through the seven essential steps to successfully implementing platform engineering best practices, offering actionable guidance at every stage of implementation.
+
+       The core webinar is pre-recorded to ensure a polished and focused presentation, but our live Q&A session at the end will allow you to interact directly with experts, get your questions answered, and address challenges you are facing in your organization.
+
+    learn:
+        - The key indicators that signal the need for an IDP in your organization.
+        - Best practices for adopting platform engineering as a discipline.
+        - Using infrastructure as code, automated controls, reporting, and self-service infrastructure in your platform engineering efforts.
+        - Strategies to avoid common pitfalls and maximize the value of your platform investment.
+
+    # The webinar presenters
+    presenters:
+        - name: Aurélien Requiem
+          role: Customer Engineer, Pulumi
+          photo: /images/team/aurelien-requiem.jpg
+        - name: Josh Kodroff 
+          role: Principal Solutions Architect, Pulumi
+          photo: /images/team/josh-kodroff.jpg
+
+    # case-sensitive
+    tags:
+        level: Intermediate # Beginner, Intermediate, Advanced
+        topics: ["Platform Engineering", "DevOps", "Automation"]
+        languages: []
+        clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: d7728975-26ec-4372-9520-89bc1c1e75a8
+    salesforce_campaign_id: 701PQ00000QSoKiYAL
+
+event_data:
+  name: "Platform Engineering Done Right: Steps to Success"
+  start_date: 2025-01-22T13:00:00+11:00
+  end_date: 2025-01-22T14:30:00+11:00
+  url: "https://www.pulumi.com/events/platform-engineering-done-right/"
+  description: |
+       Is your organization developing an Internal Developer Platform (IDP)? How do you ensure your efforts are on the right track?
+
+       Join us for a comprehensive session to explore when and why organizations need a platform and share practical strategies to adopt platform engineering successfully. You'll learn how to assess your platform efforts, identify the right indicators of success, and avoid costly missteps that can derail your efforts.
+
+       This webinar will take you through the seven essential steps to successfully implementing platform engineering best practices, offering actionable guidance at every stage of implementation.
+
+       The core webinar is pre-recorded to ensure a polished and focused presentation, but our live Q&A session at the end will allow you to interact directly with experts, get your questions answered, and address challenges you are facing in your organization.
+---


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Workshop added for https://github.com/pulumi/marketing/issues/1243

Known bug for APAC workshops (we're looking to fix this next week): Hugo doesn't support date displays over a date line without some extra configuration that we need to determine the blast radius of, so 1/22 will display in locations where it's actually 1/21

