### PR TITLE
pulumi-stacks provide example

### DIFF
--- a/content/docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks.md
+++ b/content/docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks.md
@@ -30,11 +30,26 @@ values:
     privateSubnetIds: ${stackRefs.vpcInfra.privateSubnetIds}
 ```
 
+Where your stack file is for e.g.
+```py
+# __main__.py
+import pulumi
+import pulumi_awsx as awsx
+
+# Fetch the default VPC for the current AWS region.
+vpc = awsx.ec2.DefaultVpc("default-vpc")
+
+# Export a few properties to make them easy to use.
+pulumi.export("vpcId", vpc.vpc_id)
+pulumi.export("publicSubnetIds", vpc.public_subnet_ids)
+pulumi.export("privateSubnetIds", vpc.private_subnet_ids)
+```
+
 ## Inputs
 
-| Property | Type                                   | Description                                   |
-|----------|----------------------------------------|-----------------------------------------------|
-| `stacks` | map[string][PulumiStack](#pulumistack) | A map of names to stacks to get outputs from. |
+| Property | Type                                   | Description                                                                                 |
+|----------|----------------------------------------|---------------------------------------------------------------------------------------------|
+| `stacks` | map[string][PulumiStack](#pulumistack) | A map of names to stacks to get outputs from. The names contains all outputs from the stack |
 
 ### PulumiStack
 

--- a/content/docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks.md
+++ b/content/docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks.md
@@ -30,26 +30,12 @@ values:
     privateSubnetIds: ${stackRefs.vpcInfra.privateSubnetIds}
 ```
 
-Where your stack file is for e.g.
-```py
-# __main__.py
-import pulumi
-import pulumi_awsx as awsx
-
-# Fetch the default VPC for the current AWS region.
-vpc = awsx.ec2.DefaultVpc("default-vpc")
-
-# Export a few properties to make them easy to use.
-pulumi.export("vpcId", vpc.vpc_id)
-pulumi.export("publicSubnetIds", vpc.public_subnet_ids)
-pulumi.export("privateSubnetIds", vpc.private_subnet_ids)
-```
 
 ## Inputs
 
-| Property | Type                                   | Description                                                                                 |
-|----------|----------------------------------------|---------------------------------------------------------------------------------------------|
-| `stacks` | map[string][PulumiStack](#pulumistack) | A map of names to stacks to get outputs from. The names contains all outputs from the stack |
+| Property | Type                                   | Description                                                                                  |
+|----------|----------------------------------------|----------------------------------------------------------------------------------------------|
+| `stacks` | map[string][PulumiStack](#pulumistack) | A map of names to stacks to get outputs from. The names contains all outputs from the stack. |
 
 ### PulumiStack
 

--- a/content/docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks.md
+++ b/content/docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks.md
@@ -30,7 +30,6 @@ values:
     privateSubnetIds: ${stackRefs.vpcInfra.privateSubnetIds}
 ```
 
-
 ## Inputs
 
 | Property | Type                                   | Description                                                                                  |


### PR DESCRIPTION
A little example how the stack and stacks work together

### Proposed changes

The pulumi-stacks documentation was not directly clear to me. The variables `stacks` and `stack` made it a little bit confusing. 

### Comment
I am a beginner in Pulumi so I came across this documentation. 
For a maintainer or a experiences user I would also like an example how you could use different stacks together. Now `vpcInfra` is linked to the `vpc-infra` project on the `dev` stack. But I guess its use is to set the `vpcId` based on the current `stack` and not hard to the `vpc-infra/dev`. 

So something like
```yaml
values:
  stackRefs:
    fn::open::pulumi-stacks:
       stacks:
        vpcInfra:
          stack: vpc-infra/{current-stack}
```
or is there a better way to do this?