### PR TITLE
customize heights with media breakpoints to bypass tailwind

### DIFF
--- a/layouts/page/awards.html
+++ b/layouts/page/awards.html
@@ -12,10 +12,10 @@
                             <div class="md:w-1/3 p-4">
                                 {{ if .url }}
                                     <a data-track="{{ .title | urlize }}-img" class="block text-center" href="{{ .url }}">
-                                        <img class="text-center inline-block rounded shadow p-1 h-52 md:h-28" src="{{ .img }}" />
+                                        <img class="text-center inline-block rounded shadow p-1 medium-auto-height" src="{{ .img }}" />
                                     </a>
                                 {{ else }}
-                                    <img class="text-center inline-block rounded shadow p-1 h-52 md:h-28" src="{{ .img }}" />
+                                    <img class="text-center inline-block rounded shadow p-1 medium-auto-height" src="{{ .img }}" />
                                 {{ end }}
                             </div>
                             <div class="md:w-2/3 p-4 text-left">

--- a/theme/src/scss/_awards.scss
+++ b/theme/src/scss/_awards.scss
@@ -1,0 +1,11 @@
+@media (min-width: 0px) {
+    .medium-auto-height {
+        height: 13rem;
+    }
+}
+
+@media (min-width: 768px) {
+    .medium-auto-height {
+        height: auto;
+    }
+}

--- a/theme/src/scss/main.scss
+++ b/theme/src/scss/main.scss
@@ -11,6 +11,7 @@
 @import "api-nodejs";
 @import "api-python";
 @import "api-symbol";
+@import "awards";
 @import "marketing/automation-api";
 @import "badges";
 @import "benefits";


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Bypass the tailwind media breakpoints with custom height behavior for awards images

<!--Give us a brief description of what you've done and what it solves. -->


