### PR TITLE
use the latest python version for cli docs build

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -123,7 +123,7 @@ jobs:
         goversion:
           - 1.16.x
         pythonversion:
-          - "3.7"
+          - "3.14"
         nodeversion:
           - "18.x"
   notify:

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -6,6 +6,14 @@ on:
   repository_dispatch:
     types:
       - pulumi-cli
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        description: "Git Tag"
+        type: string
 jobs:
   pull-request:
     runs-on: ubuntu-latest
@@ -15,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
       - name: set the pulumi version
         run: |
-          echo "PULUMI_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+          echo "PULUMI_VERSION=${{ inputs.ref }}" >> $GITHUB_ENV
       - name: pull-request
         uses: repo-sync/pull-request@v2
         with:
@@ -30,7 +38,7 @@ jobs:
     steps:
       - name: set the pulumi version
         run: |
-          echo "PULUMI_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+          echo "PULUMI_VERSION=${{ inputs.ref }}" >> $GITHUB_ENV
       - name: checkout docs repo
         uses: actions/checkout@v2
         with:
@@ -40,7 +48,7 @@ jobs:
         with:
           repository: pulumi/pulumi
           path: pulumi
-          ref: v${{ github.event.client_payload.ref }}
+          ref: v${{ inputs.ref }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -131,7 +131,7 @@ jobs:
         goversion:
           - 1.16.x
         pythonversion:
-          - "3.14"
+          - "3.13"
         nodeversion:
           - "18.x"
   notify:


### PR DESCRIPTION
Since the CI image has been upgraded to ubuntu 24.04, python 3.7 is no longer available.  Upgrade to the latest version to make the docs build work again.