### PR TITLE
use latest version of pipenv

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: ${{matrix.pythonversion}}
       - name: Install Pipenv
-        run:  pip3 install pipenv==2022.10.12
+        run:  pip3 install pipenv
       - name: Install dotnet
         uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
We currently pin pipenv to a specific version. This version no longer works with newer python versions however. Unpin pipenv, so we can install a version that works.
