### PR TITLE
Revert "allow manually dispatching the workflow"

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -6,12 +6,7 @@ on:
   repository_dispatch:
     types:
       - pulumi-cli
-  workflow_dispatch:
-    inputs:
-      ref:
-        required: true
-        description: "Git Tag"
-        type: string
+
 jobs:
   pull-request:
     runs-on: ubuntu-latest
@@ -21,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
       - name: set the pulumi version
         run: |
-          echo "PULUMI_VERSION=${{ inputs.ref }}" >> $GITHUB_ENV
+          echo "PULUMI_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
       - name: pull-request
         uses: repo-sync/pull-request@v2
         with:
@@ -36,7 +31,7 @@ jobs:
     steps:
       - name: set the pulumi version
         run: |
-          echo "PULUMI_VERSION=${{ inputs.ref }}" >> $GITHUB_ENV
+          echo "PULUMI_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
       - name: checkout docs repo
         uses: actions/checkout@v2
         with:
@@ -46,7 +41,7 @@ jobs:
         with:
           repository: pulumi/pulumi
           path: pulumi
-          ref: v${{ inputs.ref }}
+          ref: v${{ github.event.client_payload.ref }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:


### PR DESCRIPTION
This reverts commit 80c184cd372564a2a9e5f624923f4956dafd612f.  We no longer need to manually dispatch this after the workflow has been fixed, so return that part to its original state.
