### PR TITLE
Remove redirects for ai answers

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -10,7 +10,6 @@ import {
 } from "aws-lambda";
 import * as URLPattern from "url-pattern";
 import { LambdaEdge } from "./lambdaEdge";
-import axios from "axios";
 import { getResources } from "@pulumi/aws/resourcegroupstaggingapi/getResources";
 
 // Edge functions must be defined in us-east-1.
@@ -29,24 +28,6 @@ export function getEdgeRedirectAssociation(): aws.types.input.cloudfront.Distrib
         lambdaArn: edgeRedirectsLambda.getLambdaEdgeArn(),
         eventType: "origin-request",
     };
-}
-
-export async function getAnswersEdgeRedirectAssociation(websiteDomain: string): Promise<aws.types.input.cloudfront.DistributionDefaultCacheBehaviorLambdaFunctionAssociation> {
-    const response = await axios.get(`https://${websiteDomain}/answers/redirects.json`);
-    if (response.status !== 200) {
-        throw new pulumi.RunError(`Failed to fetch answers redirects: HTTP ${response.status}`);
-    }
-    const redirects = response.data;
-    const edgeRedirectsLambda = new LambdaEdge("redirects-answers", {
-        func: getAnswersRedirectsLambdaCallback(redirects),
-        funcDescription: "Lambda function that conditionally redirects based on a path-matching expression.",
-    }, { provider: usEast1Provider });
-    return {
-        includeBody: false,
-        lambdaArn: edgeRedirectsLambda.getLambdaEdgeArn(),
-        eventType: "origin-request",
-    };
-
 }
 
 export function getAIAnswersRewriteAssociation(): aws.types.input.cloudfront.DistributionDefaultCacheBehaviorLambdaFunctionAssociation {
@@ -118,42 +99,6 @@ function getAIAnswersRewritesLambdaCallback(): aws.lambda.Callback<CloudFrontReq
 
         callback(null, response);
         return;
-    };
-}
-
-function getAnswersRedirectsLambdaCallback(redirects: Record<string, string>): aws.lambda.Callback<CloudFrontRequestEvent, CloudFrontRequest | CloudFrontResponse> {
-
-    return (event: CloudFrontRequestEvent, context, callback) => {
-        const request = event.Records[0].cf.request;
-        // Check for a redirect that matches the request URL.
-        const redirect = redirects[request.uri];
-
-        // If there isn't one, just return with the original request.
-        if (!redirect) {
-            callback(null, request);
-            return;
-        }
-
-        // Return with a redirect.
-        const modifiedResponse = {
-            status: "301",
-            statusDescription: "Moved Permanently",
-            headers: {
-                "location": [
-                    {
-                        key: "Location",
-                        value: redirect,
-                    },
-                ],
-                "cache-control": [
-                    {
-                        key: "Cache-Control",
-                        value: "max-age=1800", /* half hour in seconds */
-                    },
-                ],
-            },
-        };
-        callback(null, modifiedResponse);
     };
 }
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -4,7 +4,7 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
 
-import { getAIAnswersRewriteAssociation, getAnswersEdgeRedirectAssociation, getEdgeRedirectAssociation } from "./cloudfrontLambdaAssociations";
+import { getAIAnswersRewriteAssociation, getEdgeRedirectAssociation } from "./cloudfrontLambdaAssociations";
 
 const stackConfig = new pulumi.Config();
 
@@ -650,10 +650,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             pathPattern: '/ai/*',
             originRequestPolicyId: allViewerExceptHostHeaderId,
             cachePolicyId: cachingDisabledId,
-            lambdaFunctionAssociations: [
-                ...config.doAIAnswersRewrites ? [getAIAnswersRewriteAssociation()] : [],
-                getAnswersEdgeRedirectAssociation(config.websiteDomain),
-            ],
+            lambdaFunctionAssociations: config.doAIAnswersRewrites ? [getAIAnswersRewriteAssociation()] : [],
             forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
         },
 


### PR DESCRIPTION
This code reverts the redirects added to redirect traffic from old ai answers app to the new one. This was tested and verified to be working in the testing environment at pulumi-test.io.