### PR TITLE
Fix `esc --help` example in documentation

### DIFF
--- a/content/docs/esc/cli/_index.md
+++ b/content/docs/esc/cli/_index.md
@@ -46,7 +46,7 @@ The most common commands in the CLI that you'll be using are as follows:
 To see a full list of Pulumi ESC CLI commands, you can run the following command:
 
 ```bash
-pulumi esc --help
+esc --help
 ```
 
 For more detailed help on a specific command, you can append `--help` to any command.


### PR DESCRIPTION
### Proposed changes

The [ESC docs](https://www.pulumi.com/docs/esc/cli/) state that you can run `pulumi esc --help` to see a full list of `esc` commands, but the command should really be `esc --help`.
