### PR TITLE
modify mobile table of contents (on this page) to appear on the correct breakpoint

### DIFF
--- a/theme/src/scss/docs/_docs-main.scss
+++ b/theme/src/scss/docs/_docs-main.scss
@@ -418,11 +418,11 @@ body.section-registry {
                 padding: 8px 0;
             }
 
-            @media (min-width: 1024px) {
+            @media (min-width: 1280px) {
                 width: 240px;
             }
 
-            @media (min-width: 1024px) {
+            @media (min-width: 1280px) {
                 min-width: 340px;
             }
         }
@@ -444,7 +444,7 @@ body.section-registry {
         }
 
 
-        @media (min-width: 1024px) {
+        @media (min-width: 1280px) {
             flex-direction: row;
             gap: 24px;
 
@@ -695,7 +695,7 @@ body.section-registry {
             }
         }
 
-        @media (min-width: 1024px) {
+        @media (min-width: 1280px) {
             display: flex;
             flex-direction: column;
             gap: 24px;
@@ -744,7 +744,7 @@ body.section-registry {
             }
         }
 
-        @media (min-width: 1024px) {
+        @media (min-width: 1280px) {
             .accordion-checkbox-table-of-contents,
             label {
                 pointer-events: none;


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
docs - adjust the breakpoint for the mobile version of the "on this page" table of contents to appear on the first breakpoint where the right side panel is hidden

### Related issues
Fixes https://github.com/pulumi/docs/issues/13772
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
