### PR TITLE
Update docs saying wildcards can be used

### DIFF
--- a/content/docs/pulumi-cloud/access-management/oidc/client/_index.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/client/_index.md
@@ -62,6 +62,11 @@ To prevent a range of security attacks, Pulumi stores the provider's TLS certifi
 
 ### Configure the authorization policies
 
+{{< notes type="info" >}}
+The max amount of policies is limited to 20 policies per OIDC Issuer.
+{{< /notes >}}
+
+
 When a new OIDC issuer is registered, a default authorization policy is provisioned denying any token exchange. Explicitly configuring **allow** policies is required.
 
 When configuring a policy, it is required to explicitly state what kind of token can be requested and what team or user the token should be scoped to.

--- a/content/docs/pulumi-cloud/access-management/oidc/client/_index.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/client/_index.md
@@ -90,7 +90,7 @@ You can target the pod name by defining the path as `"kubernetes.io".pod.name`.
 
 Note the use of quotes to escape dots in the object keys.
 
-For the claim values, it is possible to use the following wildcard notation for flexible matching:
+It is possible to use the following wildcard notation for flexible matching for the claim values and team name:
 
 - `*`: match zero or more characters
 - `?`: match zero or one character

--- a/content/docs/pulumi-cloud/access-management/oidc/client/_index.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/client/_index.md
@@ -66,7 +66,6 @@ To prevent a range of security attacks, Pulumi stores the provider's TLS certifi
 The max amount of policies is limited to 20 policies per OIDC Issuer.
 {{< /notes >}}
 
-
 When a new OIDC issuer is registered, a default authorization policy is provisioned denying any token exchange. Explicitly configuring **allow** policies is required.
 
 When configuring a policy, it is required to explicitly state what kind of token can be requested and what team or user the token should be scoped to.


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi-service/issues/25464

Update doc to explain that wildcard notation can me used for team matching when configuring oidc policies