### PR TITLE
Update deploy with pulumi button references

### DIFF
--- a/content/blog/how-to-create-and-share-a-pulumi-template/index.md
+++ b/content/blog/how-to-create-and-share-a-pulumi-template/index.md
@@ -285,18 +285,18 @@ Be sure to tidy up as before with `pulumi destroy` when you're done.
 
 In addition to the CLI, your users can also create new projects in the Pulumi Service with the [Deploy with Pulumi button](/docs/pulumi-cloud/pulumi-button/). This is a great option for making your project installable from GitHub READMEs and other team docs. Here, for example, is a Deploy button that creates a new project using my version of the gist we created above:
 
-[![Deploy with Pulumi](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://gist.github.com/cnunciato/b331efae6a4740c237a0364d17fe220f)
+[![Deploy with Pulumi](/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://gist.github.com/cnunciato/b331efae6a4740c237a0364d17fe220f)
 
 Embedding these buttons yourself is easy --- just use one of the snippets below, swapping the values of `{template-url}` for the URL of your template's gist or Git repository:
 
 ```html
 <a href="https://app.pulumi.com/new?template={template-url}">
-    <img src="https://get.pulumi.com/new/button.svg" title="Deploy with Pulumi">
+    <img src="/images/deploy-with-pulumi/dark.svg" title="Deploy with Pulumi">
 </a>
 ```
 
 ```markdown
-[![Deploy with Pulumi](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template={template-url})
+[![Deploy with Pulumi](/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template={template-url})
 ```
 
 Project creators who go down this path will be prompted in the browser for the same configuration values as they would with the CLI, and afterward, they'll be able to deploy the project either with the Pulumi CLI or with [Pulumi Deployments](https://www.pulumi.com/docs/pulumi-cloud/deployments/).

--- a/content/docs/pulumi-cloud/pulumi-button.md
+++ b/content/docs/pulumi-cloud/pulumi-button.md
@@ -23,7 +23,7 @@ The "Deploy with Pulumi" button lets you easily create new Pulumi projects from 
 
 For example, select the `Deploy` button to configure and create a new empty JavaScript project:
 
-[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/templates/javascript)
+[![Deploy](/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/templates/javascript)
 
 To create a _Deploy with Pulumi_ button:
 
@@ -65,23 +65,28 @@ After you've verified your project template works as expected, you can add a but
 Here's an example in Markdown:
 
 ```markdown
-[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/aws-js-s3-folder)
+[![Deploy](/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/aws-js-s3-folder)
 ```
 
 Or, the equivalent HTML:
 
 ```html
 <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/aws-js-s3-folder">
-  <img src="https://get.pulumi.com/new/button.svg" alt="Deploy">
+  <img src="/images/deploy-with-pulumi/dark.svg" alt="Deploy">
 </a>
 ```
 
 ### Button Image
 
-Pulumi provides both SVG and PNG versions of the button image at the following URLs:
+Pulumi provides both SVG and PNG versions of the button image at the following URLs in both light and dark themes:
 
-- `https://get.pulumi.com/new/button.svg`
-- `https://get.pulumi.com/new/button.png`
+**Dark Theme**
+- `https://pulumi.com/images/deploy-with-pulumi/dark.svg`
+- `https://pulumi.com/images/deploy-with-pulumi/dark.png`
+
+**Light Theme**
+- `https://pulumi.com/images/deploy-with-pulumi/light.svg`
+- `https://pulumi.com/images/deploy-with-pulumi/light.png`
 
 ## Custom Git Branches
 

--- a/content/docs/pulumi-cloud/pulumi-button.md
+++ b/content/docs/pulumi-cloud/pulumi-button.md
@@ -81,10 +81,12 @@ Or, the equivalent HTML:
 Pulumi provides both SVG and PNG versions of the button image at the following URLs in both light and dark themes:
 
 **Dark Theme**
+
 - `https://pulumi.com/images/deploy-with-pulumi/dark.svg`
 - `https://pulumi.com/images/deploy-with-pulumi/dark.png`
 
 **Light Theme**
+
 - `https://pulumi.com/images/deploy-with-pulumi/light.svg`
 - `https://pulumi.com/images/deploy-with-pulumi/light.png`
 

--- a/layouts/shortcodes/templates/pulumi-new.html
+++ b/layouts/shortcodes/templates/pulumi-new.html
@@ -42,7 +42,7 @@
         </div>
         <div class="mt-4 md:mt-0 md:ml-2">
             <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/templates/tree/master/{{ $templateName }}" target="_blank">
-                <img src="https://get.pulumi.com/new/button.svg" title="Create a new {{ $templateName }} project in the Pulumi Service">
+                <img src="/images/deploy-with-pulumi/dark.svg" title="Create a new {{ $templateName }} project in the Pulumi Service">
             </a>
         </div>
     </div>


### PR DESCRIPTION
Part of: https://github.com/pulumi/docs/issues/13881

We have been having issues with the "Deploy with Pulumi" button rendering, seemingly due to issues being able to reliably fetch it at its location at get.pulumi.com/new/button.svg. 

Turns out we actually have had those buttons also hosted in this repo. This updates our site pages to reference the asset directly from there. 

I also update the docs page where we have this documented: https://pulumi.com/docs/pulumi-cloud/pulumi-button/