### PR TITLE
Notify docs-ops slack channel on code example failures

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -104,3 +104,19 @@ jobs:
         run: make test
         env:
           TEST_MODE: ${{ github.event_name }}
+  notify:
+    # Only send slack notifications for failures during scheduled cron runs.
+    if: (failure() && github.event_name == 'schedule')
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - name: Slack Notification
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "Failing code example tests in `pulumi/docs` :meow_sad:"
+          SLACK_USERNAME: docsbot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/13931

Send alerts to docs-ops slack channel when cron job that runs code example tests fail.