### PR TITLE
Fix `pulumi env init` example

### DIFF
--- a/content/docs/iac/cli/commands/pulumi_env.md
+++ b/content/docs/iac/cli/commands/pulumi_env.md
@@ -19,7 +19,7 @@ Opening an environment may involve generating new dynamic data.
 To begin working with environments, run the `pulumi env init` command:
 
 ```
-    pulumi env init
+pulumi env init
 ```
 
 This will prompt you to create a new environment to hold secrets and configuration.

--- a/content/docs/iac/cli/commands/pulumi_env.md
+++ b/content/docs/iac/cli/commands/pulumi_env.md
@@ -16,9 +16,11 @@ An environment is a named collection of possibly-secret, possibly-dynamic data.
 Each environment has a definition and may be opened in order to access its contents.
 Opening an environment may involve generating new dynamic data.
 
-To begin working with environments, run the `env init` command:
+To begin working with environments, run the `pulumi env init` command:
 
-    env init
+```
+    pulumi env init
+```
 
 This will prompt you to create a new environment to hold secrets and configuration.
 


### PR DESCRIPTION
### Proposed changes

The first example in the [docs page](https://www.pulumi.com/docs/iac/cli/commands/pulumi_env/) for `pulumi env` has an example that says `env init` but it should be `pulumi env init`.

