### PR TITLE
Do not fetch master if already on master

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Fetch master branch
+        if: github.ref != 'refs/heads/master'
         run: git fetch origin master:master
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
The job that tests our example code is failing when triggered from the cron. Since the cron runs on master, the fetch command is failing. We should only run this if the current branch is not master.

https://github.com/pulumi/docs/actions/runs/13130938858/job/36635784348