### PR TITLE
Change "Project ID" to "Project Number" for GCP OIDC for deployments …

### DIFF
--- a/content/docs/pulumi-cloud/access-management/oidc/provider/gcp.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/provider/gcp.md
@@ -146,7 +146,7 @@ In addition to the Pulumi Console, deployment settings including OIDC can be con
 2. Open the stack's "Settings" tab.
 3. Choose the "Deploy" panel.
 4. Under the "OpenID Connect" header, toggle "Enable Google Cloud Integration".
-5. Enter the numerical ID of your Google Cloud project in the "Project ID" field.
+5. Enter the numerical ID of your Google Cloud project in the "Project Number" field.
 6. Enter the workload pool ID, identity provider ID, and service account email address in the "Workload Pool ID", "Identity Provider ID", and "Service Account Email Address" fields.
 7. If desired, enter the stack's Google Cloud region in the "Region" field. This is typically unnecessary.
 8. If you would like to constrain the duration of the temporary Google Cloud credentials, enter a duration in the form "XhYmZs" in the "Session Duration" field.


### PR DESCRIPTION
The UI for adding GCP OIDC to deployment settings is being updated to refer to the GCP `Project Number` instead of the `Project ID` to better match GCP terminology.
This update reflects this change in the UI.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
