### PR TITLE
[concepts/options/deleteBeforeReplace] Typo fix + consistency warnings

### DIFF
--- a/content/docs/iac/concepts/options/deletebeforereplace.md
+++ b/content/docs/iac/concepts/options/deletebeforereplace.md
@@ -16,7 +16,7 @@ aliases:
 
 A resource may need to be replaced if an immutable property changes. In these cases, cloud providers do not support updating an existing resource so a new instance will be created and the old one deleted. By default, to minimize downtime, Pulumi creates new instances of resources before deleting old ones.
 
-While Setting the `deleteBeforeReplace` option may be necessary for some resources that manage scarce resources behind the scenes, and/or resources that cannot exist side-by-side, be aware that it introduces some risks. Since this behavior has a cascading impact on dependents so more resources may be replaced, it can lead to downtime. Separately, consider the consistency guarantees offered by your Cloud Providers. For example, AWS's APIs are all eventually consistent. In some scenarios, it is possible to create corrupted dependent resources because the dependency deletion has not propagated before the dependent's creation is executed.
+Setting the `deleteBeforeReplace` option to true means that Pulumi will delete the existing resource before creating its replacement. This option may be necessary for resources that manage scarce resources or resources that cannot exist side-by-side. However, it's important to note that it can cascade to dependent resources, potentially causing more replacements and downtime. Additionally, eventual consistency in cloud APIs (like AWS) may lead to corrupted dependent resources if deletion hasn't fully propagated before creation begins.
 
 This example deletes a database entirely before its replacement is created:
 

--- a/content/docs/iac/concepts/options/deletebeforereplace.md
+++ b/content/docs/iac/concepts/options/deletebeforereplace.md
@@ -16,7 +16,7 @@ aliases:
 
 A resource may need to be replaced if an immutable property changes. In these cases, cloud providers do not support updating an existing resource so a new instance will be created and the old one deleted. By default, to minimize downtime, Pulumi creates new instances of resources before deleting old ones.
 
-Setting the `deleteBeforeReplace` option to true means that Pulumi will delete the existing resource before creating its replacement. Be aware that this behavior has a cascading impact on dependencies so more resources may be replaced, which can lead to downtime. However, this option may be necessary for some resources that manage scarce resources behind the scenes, and/or resources that cannot exist side-by-side.
+Setting the `deleteBeforeReplace` option to true means that Pulumi will delete the existing resource before creating its replacement. Be aware that this behavior has a cascading impact on dependents so more resources may be replaced, which can lead to downtime. However, this option may be necessary for some resources that manage scarce resources behind the scenes, and/or resources that cannot exist side-by-side.
 
 This example deletes a database entirely before its replacement is created:
 

--- a/content/docs/iac/concepts/options/deletebeforereplace.md
+++ b/content/docs/iac/concepts/options/deletebeforereplace.md
@@ -16,7 +16,7 @@ aliases:
 
 A resource may need to be replaced if an immutable property changes. In these cases, cloud providers do not support updating an existing resource so a new instance will be created and the old one deleted. By default, to minimize downtime, Pulumi creates new instances of resources before deleting old ones.
 
-Setting the `deleteBeforeReplace` option to true means that Pulumi will delete the existing resource before creating its replacement. Be aware that this behavior has a cascading impact on dependents so more resources may be replaced, which can lead to downtime. However, this option may be necessary for some resources that manage scarce resources behind the scenes, and/or resources that cannot exist side-by-side.
+While Setting the `deleteBeforeReplace` option may be necessary for some resources that manage scarce resources behind the scenes, and/or resources that cannot exist side-by-side, be aware that it introduces some risks. Since this behavior has a cascading impact on dependents so more resources may be replaced, it can lead to downtime. Separately, consider the consistency guarantees offered by your Cloud Providers. For example, AWS's APIs are all eventually consistent. In some scenarios, it is possible to create corrupted dependent resources because the dependency deletion has not propagated before the dependent's creation is executed.
 
 This example deletes a database entirely before its replacement is created:
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

1. Typo fix closes #13934 
1. Additional warning for eventually consistent systems.

For (2), we recently ran into this with AWS. In this scenario, an IAM Role with `deleteBeforeReplace` had an `eks.AccessEntry` dependency. The API calls executed by the aws provider looked like this:

```
2025-01-06T21:01:49Z           DeleteRole
2025-01-06T21:01:50Z           CreateRole
2025-01-06T21:01:51Z    CreateAccessEntry
```

The DeleteRole operation is eventually consistent, and in this instance it took several seconds to propagate through AWS. The CreateAccessEntry call thus succeeded with a reference to the deleted role, and the newly created role was unable to access the cluster. Since the ARN for the role did not change (we had changed the provider), the Pulumi state was wholly unaware of this.

GCP does [not have this problem](https://google.aip.dev/121#strong-consistency). I'm not sure about other cloud providers.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
- Closes #13934 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
