### PR TITLE
adding integrations and development as expanded menu items for ESC

### DIFF
--- a/content/docs/esc/_index.md
+++ b/content/docs/esc/_index.md
@@ -9,6 +9,8 @@ menu:
     weight: 1
 expanded_menu_ids:
     - esc-environments
+    - esc-integrations
+    - esc-development
 aliases:
   - /docs/pulumi-cloud/esc/
 


### PR DESCRIPTION
fixes this request: https://github.com/pulumi/docs/issues/13968

 Now by default keep ‘Environments’, ‘Integrations’, and ‘Development’ expanded