### PR TITLE
removing references to this pulumi-cloud in our sdk docs

### DIFF
--- a/content/docs/iac/languages-sdks/javascript/_index.md
+++ b/content/docs/iac/languages-sdks/javascript/_index.md
@@ -364,14 +364,3 @@ In addition to the standard and cloud-agnostic packages the [Pulumi Registry](/r
     <dt>Pulumi Terraform</dt>
     <dd><a href="/docs/reference/pkg/nodejs/pulumi/terraform">@pulumi/terraform</a></dd>
 </dl>
-
-### Cloud-Agnostic Packages
-
-<dl class="tabular">
-    <dt>Pulumi Cloud Framework</dt>
-    <dd>
-        <a href="/docs/reference/pkg/nodejs/pulumi/cloud">@pulumi/cloud</a>
-        <span class="ml-2 badge badge-preview">PREVIEW</span>
-        <p>A highly productive, cloud-agnostic package for container and serverless programming.</p>
-    </dd>
-</dl>


### PR DESCRIPTION
Removing this link as this repository has been archived; you can learn a bit more about the history of this project and why it was archived in https://github.com/pulumi/pulumi-cloud/issues/844 For alternative cloud specific abstractions consider Pulumi's [Crosswalk for AWS](https://www.pulumi.com/docs/clouds/aws/guides/). There are also other multi-cloud abstractions that have been built on Pulumi such as [SST](https://sst.dev/)

fixes https://github.com/pulumi/docs/issues/13767