### PR TITLE
Add links to content/docs/iac/get-started/aws/deploy-changes.md

### DIFF
--- a/content/docs/iac/get-started/aws/deploy-changes.md
+++ b/content/docs/iac/get-started/aws/deploy-changes.md
@@ -16,7 +16,7 @@ Now let's deploy your changes.
 $ pulumi up
 ```
 
-Pulumi will run the `preview` step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
+Pulumi will run the [`preview`](/docs/iac/cli/commands/pulumi_preview/) step of the update, which computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
 Previewing update (dev):
@@ -124,7 +124,7 @@ Now that `index.html` is in the bucket, update the program to turn the bucket in
 
 ## Update the program
 
-Add a new `BucketWebsiteConfiguration` resource to make `index.html` the home page of the website:
+Add a new [`BucketWebsiteConfiguration`](/registry/packages/aws/api-docs/s3/bucketwebsiteconfigurationv2/) resource to make `index.html` the home page of the website:
 
 {{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
 
@@ -216,9 +216,9 @@ website:
 
 Lastly, you'll make a few adjustments to make these resources accessible on the Internet.
 
-For the bucket itself, you'll need two new resources: a `BucketOwnershipControls` resource, to define the bucket's file-ownership settings, and a `BucketPublicAccessBlock` resource to allow the bucket to be accessed publicly.
+For the bucket itself, you'll need two new resources: a [`BucketOwnershipControls`](/registry/packages/aws/api-docs/s3/bucketownershipcontrols/) resource, to define the bucket's file-ownership settings, and a [`BucketPublicAccessBlock`](/registry/packages/aws/api-docs/s3/bucketpublicaccessblock/) resource to allow the bucket to be accessed publicly.
 
-For the `BucketObject`, you'll need an access-control (ACL) setting of `public-read` to allow the page to be accessed anonymously (e.g., in a browser) and a content type of `text/html` to tell AWS to serve the file as a web page. Add the following lines to your program, updating the `BucketObject` in place:
+For the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobjectv2/), you'll need an access-control (ACL) setting of `public-read` to allow the page to be accessed anonymously (e.g., in a browser) and a content type of `text/html` to tell AWS to serve the file as a web page. Add the following lines to your program, updating the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobjectv2/) in place:
 
 {{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
 
@@ -430,7 +430,7 @@ resources:
 
 {{% /choosable %}}
 
-Note that the `BucketObject` also includes the Pulumi resource option [`dependsOn`](/docs/concepts/options/dependson/). This setting tells Pulumi that the `BucketObject` relies indirectly on the `BucketPublicAccessBlock`, which is responsible for enabling public access to its contents. If you omitted this setting, the attempt to grant `public-read` access to `index.html` would fail, as all S3 buckets and their objects are blocked from public access by default.
+Note that the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobjectv2/) also includes the Pulumi resource option [`dependsOn`](/docs/concepts/options/dependson/). This setting tells Pulumi that the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobjectv2/) relies indirectly on the [`BucketPublicAccessBlock`](/registry/packages/aws/api-docs/s3/bucketpublicaccessblock/), which is responsible for enabling public access to its contents. If you omitted this setting, the attempt to grant `public-read` access to `index.html` would fail, as all S3 buckets and their objects are blocked from public access by default.
 
 Finally, at the end of the program, export the resulting bucket’s endpoint URL so you can browse to it easily:
 
@@ -564,7 +564,7 @@ Resources:
 Duration: 8s
 ```
 
-When the deployment completes, you can check out your new website at the URL in the `Outputs` section of your update or make a `curl` request and see the contents of `index.html` in your terminal:
+When the deployment completes, you can check out your new website at the URL in the [`Outputs`](/docs/iac/concepts/inputs-outputs/#outputs) section of your update or make a `curl` request and see the contents of `index.html` in your terminal:
 
 {{% choosable language javascript %}}
 

--- a/content/docs/iac/get-started/aws/modify-program.md
+++ b/content/docs/iac/get-started/aws/modify-program.md
@@ -52,7 +52,7 @@ echo '<html>
 
 {{% /choosable %}}
 
-Now, open the program and add this file to the S3 bucket. To do this, you'll use Pulumi's `FileAsset` resource to assign the content of the file to a new  `BucketObject`:
+Now, open the program and add this file to the S3 bucket. To do this, you'll use Pulumi's [`FileAsset`](/docs/iac/concepts/assets-archives/#assets) to assign the content of the file to a new  [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobject/):
 
 {{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
 
@@ -72,7 +72,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 
 {{% choosable language typescript %}}
 
-In `index.ts`, create the `BucketObject` right after creating the bucket itself:
+In `index.ts`, create the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobject/) right after creating the bucket itself:
 
 ```typescript
 // Create an S3 Bucket object
@@ -101,7 +101,7 @@ bucketObject = s3.BucketObject(
 
 {{% choosable language go %}}
 
-In `main.go`, create the `BucketObject` right after creating the bucket itself:
+In `main.go`, create the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobject/) right after creating the bucket itself:
 
 ```go
 // Create an S3 Bucket object
@@ -118,7 +118,7 @@ if err != nil {
 
 {{% choosable language csharp %}}
 
-In `Program.cs`, create a new `BucketObject` right after creating the bucket itself.
+In `Program.cs`, create a new [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobject/) right after creating the bucket itself.
 
 ```csharp
 // Create an S3 Bucket object
@@ -133,7 +133,7 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 
 {{% choosable language java %}}
 
-In {{< langfile >}}, import the `FileAsset`, `BucketObject`, and `BucketObjectArgs` classes, then create the `BucketObject` right after creating the bucket itself.
+In {{< langfile >}}, import the [`FileAsset`](/docs/iac/concepts/assets-archives/#assets), [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobject/), and `BucketObjectArgs` classes, then create the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobject/) right after creating the bucket itself.
 
 ```java
 package myproject;
@@ -170,7 +170,7 @@ public class App {
 
 {{% choosable language "yaml" %}}
 
-In {{< langfile >}}, create the `BucketObject` right below the bucket itself.
+In {{< langfile >}}, create the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobject/) right below the bucket itself.
 
 ```yaml
 name: quickstart
@@ -197,9 +197,9 @@ outputs:
 
 {{% /choosable %}}
 
-This bucket object is part of the `Bucket` that we deployed earlier because we _reference_ the bucket name in the properties of the bucket object.
+This bucket object is part of the [`Bucket`](/registry/packages/aws/api-docs/s3/bucket/) that we deployed earlier because we _reference_ the bucket name in the properties of the bucket object.
 
-We refer to this relationship as the `BucketObject` being a _child_ resource of the S3 `Bucket` that is the _parent_ resource. This is how Pulumi knows what S3 bucket the object should live in.
+We refer to this relationship as the [`BucketObject`](/registry/packages/aws/api-docs/s3/bucketobject/) being a _child_ resource of the S3 `Bucket` that is the _parent_ resource. This is how Pulumi knows what S3 bucket the object should live in.
 
 Next, you'll deploy your changes.
 


### PR DESCRIPTION
Apply links to appropriate objects in `content/docs/iac/get-started/aws/deploy-changes.md`.

Motivated by https://docs.google.com/document/d/1BvAaF34TSf8b34jG8-lI-dz7l4mPFZJKqfTbFgQooR0/edit?tab=t.0#heading=h.raiot1mmfahj. (internal doc)
