### PR TITLE
feat(insights): add rest api docs for insights endpoints

### DIFF
--- a/content/docs/pulumi-cloud/reference/cloud-rest-api/_index.md
+++ b/content/docs/pulumi-cloud/reference/cloud-rest-api/_index.md
@@ -3059,6 +3059,186 @@ curl \
   }
 ]
 ```
+
+<!-- ###################################################################### -->
+## Insight Accounts
+
+### Create Account
+
+Creates a new account for use with Pulumi Insights.
+
+```
+POST /api/preview/insights/pulumi/accounts/{accountName}
+```
+
+#### Parameters
+
+| Parameter        | Type   | In    | Description                                                                                           |
+|------------------|--------|-------|-------------------------------------------------------------------------------------------------------|
+| `provider`       | string | body  | The cloud provider for the account (e.g., `aws`, `azure`, `oci`)                               |
+| `environment`    | string | body  | The environment reference for the account, such as `insights/pulumi-staging@2`                         |
+| `cron`           | string | body  | The cron expression defining when the account scan is scheduled (e.g., `0 0 * * *`)                    |
+| `providerConfig` | object | body  | The configuration specific to the provider, such as regions for `aws` (e.g., `["us-east-1", "us-east-2"]`) |
+
+#### Example
+
+```bash
+curl \
+  -X POST \
+  -H "Accept: application/vnd.pulumi+6" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  -d '{
+    "provider": "aws",
+    "environment": "insights/pulumi-staging@2",
+    "cron": "0 0 * * *",
+    "providerConfig": {
+      "regions": ["us-east-1", "us-east-2", "us-west-2"]
+    }
+  }' \
+  https://api.pulumi.com/api/preview/insights/pulumi/accounts/FizzBuzz%20AWS%20Staging
+```
+
+#### Default response
+
+```
+Status: 200 OK
+```
+
+```
+{
+  "message": "Account FizzBuzz AWS Staging created successfully."
+}
+```
+
+<!-- ###################################################################### -->
+### List Accounts
+
+Lists Insight Accounts available to the authenticated user.
+
+```
+GET /api/preview/insights/pulumi/accounts
+```
+
+#### Parameters
+
+| Parameter             | Type   | In    | Description                                                                                          |
+|-----------------------|--------|-------|------------------------------------------------------------------------------------------------------|
+| `count`               | integer| query | **Optional.** the number of results to return (default is 100)                                        |
+| `continuationToken`   | string | query | **Optional.** the continuation token to use for retrieving the next set of results if results were truncated |
+
+#### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/preview/insights/pulumi/accounts?count=1000
+```
+
+#### Default response
+
+```
+Status: 200 OK
+```
+
+```
+{
+  "accounts": [
+    {
+      "name": "FizzBuzz Aws Prod",
+      "provider": "aws",
+      "providerEnvRef": "fizzbuzz/insights-pulumi-prod@4",
+      "scheduledScanEnabled": false,
+      "scanStatus": {
+        "id": "",
+        "orgId": "",
+        "userId": "",
+        "status": "",
+        "startedAt": "2025-01-01T00:00:00Z",
+        "finishedAt": null,
+        "lastUpdatedAt": "2025-01-01T00:00:00Z",
+        "jobTimeout": "2025-01-01T00:00:00Z"
+      }
+    },
+    {
+      "name": "FizzBuzz Aws Staging",
+      "provider": "aws",
+      "providerEnvRef": "fizzbuzz/insights-pulumi-staging@2",
+      "scheduledScanEnabled": true,
+      "scanStatus": {
+        "id": "",
+        "orgId": "",
+        "userId": "",
+        "status": "succeeded",
+        "startedAt": "2025-02-03T12:01:00.000Z",
+        "finishedAt": "2025-02-03T12:05:00.000Z",
+        "lastUpdatedAt": "2025-02-03T12:05:00.000Z",
+        "resourceCount": 250
+      }
+    }
+  ]
+}
+```
+
+<!-- ###################################################################### -->
+### Get Account
+
+Gets Insight Account details for the specific account.
+
+```
+GET /api/preview/insights/pulumi/accounts/{accountName}
+```
+
+#### Parameters
+
+| Parameter    | Type   | In    | Description                                            |
+|--------------|--------|-------|--------------------------------------------------------|
+| `accountName`| string | path  | The name of the account to retrieve details for.       |
+
+#### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+6" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/preview/insights/pulumi/accounts/FizzBuzz%20AWS%20Staging
+```
+
+#### Default response
+
+```
+Status: 200 OK
+```
+
+```
+{
+  "name": "FizzBuzz AWS Staging",
+  "provider": "aws",
+  "providerEnvRef": "insights/pulumi-staging@2",
+  "scheduledScanEnabled": true,
+  "providerConfig": {
+    "regions": [
+      "us-east-1",
+      "us-east-2",
+      "us-west-2"
+    ]
+  },
+  "scanStatus": {
+    "id": "",
+    "orgId": "",
+    "userId": "",
+    "status": "",
+    "startedAt": "0001-01-01T00:00:00Z",
+    "finishedAt": "0001-01-01T00:00:00Z",
+    "lastUpdatedAt": "0001-01-01T00:00:00Z",
+    "jobTimeout": "0001-01-01T00:00:00Z"
+  }
+}
+```
+
 <!-- ###################################################################### -->
 
 ## Policy Groups
@@ -5839,25 +6019,34 @@ System.out.println(response.toString());
 
 {{< /chooser >}}
 
-`GET /api/orgs/{org}/search/resources`
+`GET /api/orgs/{org}/search/resourcesv2`
 
 Search for resources belonging to the given organization.
 
 ### Parameters
 
-| Name       | In    | Type          | Required | Description                                                                                                                              |
-|------------|-------|---------------|----------|------------------------------------------------------------------------------------------------------------------------------------------|
-| org        | path  | string        | true     | Name of the organization to search.                                                                                                      |
-| query      | query | string        | false    | The search query to execute. If omitted all resources are returned (subject to any pagination limits).                                   |
-| sort       | query | array[string] | false    | The field(s) by which to sort.                                                                                                           |
-| asc        | query | boolean       | false    | Whether to return results in ascending or descending sort order.                                                                         |
-| size       | query | integer       | false    | How many results to return at a time.                                                                                                    |
-| page       | query | number        | false    | The page of results to return.                                                                                                           |
-| cursor     | query | string        | false    | A continuation token for pagination that allows fetching more than 10,000 resources.                                                     |
-| facet      | query | array[string] | false    | If provided, an aggregation will be returned with the top-5 values for the given facet, along with how many resources have those values. |
-| properties | query | boolean       | false    | Whether to include resource properties in results. Not supported for all subscriptions.                                                  |
+| Parameter     | Type   | In    | Description                                                       |
+|---------------|--------|-------|-------------------------------------------------------------------|
+| `organization`| string | query | **Required.** The organization name to search resources for.      |
+| `page`        | integer| query | **Optional.** Page number to retrieve results from. Default is 1.|
+| `size`        | integer| query | **Optional.** Number of results to retrieve per page. Default is 50. |
+| `sort`        | string | query | **Optional.** Sort by a property, such as `modified`. Default is `modified`. |
+| `asc`         | boolean| query | **Optional.** Sort results in ascending order. Default is `false`. |
+| `query`       | string | query | **Optional.** A search query to filter the results. |
+| `properties`  | boolean| query | **Optional.** If `true`, includes the resource properties. Default is `false`. |
+| `source`      | string | query | **Optional.** The source for resource search. |
 
-#### Detailed descriptions
+### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+6" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/orgs/fizzbuzz/search/resourcesv2?page=1&size=50&sort=modified&asc=false&query=&properties=true&source=resource-search
+```
+
+### Detailed descriptions
 
 **org**: Name of the organization to search.
 The organization can belong to a team, enterprise, or an individual user.
@@ -5871,7 +6060,7 @@ If omitted, results are sorted according to their search relevance. If there is 
 
 If specified more than once, the first parameter is the primary sort order and subsequent parameters control additional sorting criteria.
 
-Allowed values: created, custom, delete, id, modified, module, name, package, parent.urn, pending, project, protected, provider.urn, stack, type, urn.
+Allowed values: created, custom, delete, dependencies, id, modified, module, name, package, parentUrn, project, protected, providerUrn, stack, type, urn, managed, category
 
 **asc**: Whether to return results in ascending or descending sort order.
 Results are returned in descending order by default.
@@ -5886,58 +6075,111 @@ Paginating with the `page` parameter is not transactional. The order of results 
 Only available on Enterprise plans.
 Paginating with the `cursor` parameter is not transactional. The order of results can be impacted if a stack update completes while paginating.
 
-**facet**: If provided, an aggregation will be returned with the top-5 values for the given facet, along with how many resources have those values.
-
-This parameter can be provided multiple times to return aggregations for up to 5 dimensions.
-
-Allowed values: created, custom, delete, id, modified, module, name, package, parent.urn, pending, project, protected, provider.urn, stack, type, urn.
-
 **properties**: Whether to include resource properties in results. Not supported for all subscriptions.
 
 Attempting to set this on an unsupported subscription results in a 402 status code. [Contact us](/contact?form=sales) to upgrade your subscription.
 
-#### Example responses
+### Example responses
 
 > 200 Response
 
 ```json
 {
-  "total": 10000,
+  "total": 3,
   "resources": [
     {
-      "created": "string",
-      "custom": true,
-      "delete": true,
-      "dependencies": ["string"],
-      "id": "string",
-      "modified": "string",
-      "module": "string",
-      "name": "string",
-      "package": "string",
-      "parent.urn": "string",
-      "pending": "creating",
-      "project": "string",
-      "properties": {},
-      "protected": true,
-      "provider.urn": "string",
-      "stack": "string",
-      "type": "string",
-      "urn": "string"
+      "created": "2025-02-10T19:33:09.6611691Z",
+      "custom": false,
+      "delete": false,
+      "dependencies": [],
+      "id": "i-12345abcde67890fg",
+      "modified": "2025-02-10T19:33:09.6611691Z",
+      "module": "aws",
+      "name": "fizzbuzz-ec2-instance",
+      "package": "aws",
+      "parent.urn": "urn:fizzbuzz::example-stack::pulumi:pulumi:Stack::example-stack-fizzbuzz",
+      "project": "example-stack",
+      "protected": false,
+      "provider.urn": "urn:fizzbuzz::example-stack::pulumi:providers:aws::default_4_16_7::ec2-1234abcde-5f6g-7h8i-9jklmno9876",
+      "stack": "fizzbuzz",
+      "type": "aws:ec2/instance:Instance",
+      "urn": "urn:fizzbuzz::example-stack::aws:ec2/instance:Instance::fizzbuzz-ec2-instance",
+      "properties": {
+        "ami": "ami-0123456789abcdef0",
+        "instanceType": "t2.micro",
+        "keyName": "fizzbuzz-keypair",
+        "securityGroups": ["fizzbuzz-sg"],
+        "tags": {
+          "Name": "fizzbuzz-ec2-instance"
+        }
+      },
+      "metadata": {},
+      "category": "compute",
+      "managed": "Pulumi (discovered)"
+    },
+    {
+      "created": "2025-02-10T19:33:09.406814916Z",
+      "custom": false,
+      "delete": false,
+      "dependencies": [],
+      "id": "db-12345xyz67890pq",
+      "modified": "2025-02-10T19:33:09.406814916Z",
+      "module": "aws",
+      "name": "fizzbuzz-rds-instance",
+      "package": "aws",
+      "parent.urn": "urn:fizzbuzz::example-stack::pulumi:pulumi:Stack::example-stack-fizzbuzz",
+      "project": "example-stack",
+      "protected": false,
+      "provider.urn": "urn:fizzbuzz::example-stack::pulumi:providers:aws::default_4_16_7::rds-xyzabc-1d2e-3f4g-5h6i7jklm8n9",
+      "stack": "fizzbuzz",
+      "type": "aws:rds/instance:Instance",
+      "urn": "urn:fizzbuzz::example-stack::aws:rds/instance:Instance::fizzbuzz-rds-instance",
+      "properties": {
+        "allocatedStorage": 20,
+        "engine": "mysql",
+        "engineVersion": "8.0",
+        "instanceClass": "db.t2.micro",
+        "name": "fizzbuzz-db",
+        "username": "[secret]",
+        "password": "[secret]",
+        "skipFinalSnapshot": true
+      },
+      "metadata": {},
+      "category": "data",
+      "managed": "Pulumi"
+    },
+    {
+      "created": "2025-02-10T19:34:09.406814916Z",
+      "custom": false,
+      "delete": false,
+      "dependencies": [],
+      "id": "s3-12345xyz67890pq",
+      "modified": "2025-02-10T19:34:09.406814916Z",
+      "module": "aws",
+      "name": "fizzbuzz-s3-bucket",
+      "package": "aws",
+      "parent.urn": "urn:fizzbuzz::example-stack::pulumi:pulumi:Stack::example-stack-fizzbuzz",
+      "project": "example-stack",
+      "protected": false,
+      "provider.urn": "urn:fizzbuzz::example-stack::pulumi:providers:aws::default_4_16_7::s3-xyzabc-1d2e-3f4g-5h6i7jklm8n9",
+      "stack": "fizzbuzz",
+      "type": "aws:s3/bucket:Bucket",
+      "urn": "urn:fizzbuzz::example-stack::aws:s3/bucket:Bucket::fizzbuzz-s3-bucket",
+      "properties": {
+        "bucket": "fizzbuzz-s3-bucket",
+        "acl": "private",
+        "tags": {
+          "Name": "fizzbuzz-s3-bucket"
+        }
+      },
+      "metadata": {},
+      "category": "storage",
+      "managed": "None"
     }
   ],
-  "aggregations": {
-    "others": 0,
-    "results": [
-      {
-        "name": "string",
-        "count": 0
-      }
-    ]
-  },
   "pagination": {
-    "previous": "string",
-    "next": "string",
-    "cursor": "string"
+    "next": "https://api.pulumi.com/api/orgs/fizzbuzz/search/resources?page=2\u0026size=50\u0026sort=modified",
+    "cursor": "https://api.pulumi.com/api/orgs/fizzbuzz/search/resources?cursor=H4sIAAAAAAAA_wTAwQ2AMAgF0Ltj9CwJX_gIsxgPpLX7j-B7cFtdoDtU9RzJqC9okhtTfLKkkZTIpbGb1svGe_wBAAD__3DHC1U3AAAA\u0026size=50\u0026sort=modified"
   }
 }
 ```


### PR DESCRIPTION

### Proposed changes

This adds rest api docs for insights endpoints to enable copilot to consume them.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

closes https://github.com/pulumi/pulumi-service/issues/25856

