### PR TITLE
Show latest version of `pulumi/actions` in docs

### DIFF
--- a/content/docs/esc/integrations/dev-tools/github.md
+++ b/content/docs/esc/integrations/dev-tools/github.md
@@ -125,7 +125,7 @@ $ pulumi config env add ${ESC_ENV} --stack dev --yes
 
 ### Define a workflow that uses the Pulumi CLI Action
 
-Below is a simple example of a workflow using the [Pulumi CLI Action](https://github.com/marketplace/actions/pulumi-cli-action#pulumi-github-actions). This workflow will be triggered upon a push to the `main` branch. It uses `pulumi/actions@v5` to perform a `pulumi up` command against the `dev` stack.
+Below is a simple example of a workflow using the [Pulumi CLI Action](https://github.com/marketplace/actions/pulumi-cli-action#pulumi-github-actions). This workflow will be triggered upon a push to the `main` branch. It uses `pulumi/actions@v6` to perform a `pulumi up` command against the `dev` stack.
 
 You will need to [create a new Pulumi Access Token](https://app.pulumi.com/account/tokens) for this example.
 
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pulumi/actions@v5
+      - uses: pulumi/actions@v6
         with:
           command: up
           # Provide the fully qualified stack name

--- a/content/docs/pulumi-cloud/access-management/oidc/client/github.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/client/github.md
@@ -81,7 +81,7 @@ jobs:
           organization: org-name
           requested-token-type: urn:pulumi:token-type:access_token:organization
 
-      - uses: pulumi/actions@v5
+      - uses: pulumi/actions@v6
         with:
           command: preview
           stack-name: org-name/stack-name


### PR DESCRIPTION
Most doc pages have already been updated, but there were a few places where we were still mentioning an older version of `pulumi/actions`. This change updates to the latest version (v6).

Fixes https://github.com/pulumi/actions/issues/1297