### PR TITLE
Add org access tokens to pricing overview comparison

### DIFF
--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -62,6 +62,7 @@ tiers:
                   Everything in **Team**, plus:
                   - Unlimited members & teams
                   - Role-based access control (RBAC)
+                  - Organization Access Tokens
                   - SAML/SSO
                   - Secrets versioning
                   - Audit logs


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Organization Access Tokens added to Enterprise list above the fold on `/pricing` per https://github.com/pulumi/docs/issues/14095
