### PR TITLE
Update pulumi-packages/authoring.md for a separate registry repo

### DIFF
--- a/content/docs/iac/using-pulumi/pulumi-packages/authoring.md
+++ b/content/docs/iac/using-pulumi/pulumi-packages/authoring.md
@@ -170,7 +170,7 @@ From there, a Pulumi employee will work with you to get your Pulumi Package publ
 
 1. Review your pull request and trigger the automation that builds the package listing and the API docs from your schema.
 1. Merge upon approval of your PR
-1. Merge the resulting pull request in `pulumi/docs` that pulls the latest Registry content into pulumi.com and publishes it.
+1. On merging, CI will automatically publish your package listing and API docs to pulumi.com/registry.
 
 ## Congratulations
 


### PR DESCRIPTION
Just a quick update to reflect the seperation of pulumi/docs and pulumi/registry.
