### PR TITLE
Update example cf2pulumi program

### DIFF
--- a/content/migrate/cf2pulumi.md
+++ b/content/migrate/cf2pulumi.md
@@ -25,7 +25,7 @@ examples:
           myLogGroup:
             Type: AWS::Logs::LogGroup
             Properties:
-              KmsKeyId: Fn::Sub: ${KmsKeyId}
+              KmsKeyId: !Sub ${KmsKeyId}
               LogGroupName: myLogGroup
               RetentionInDays: 7
 


### PR DESCRIPTION
The `Fn::Sub:` syntax isn't supported on the latest version of cf2pulumi
