### PR TITLE
Update tf2pulumi url

### DIFF
--- a/content/docs/pulumi-cloud/access-management/oidc/provider/aws.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/provider/aws.md
@@ -61,7 +61,7 @@ Once you have created the identity provider, you will see a notification at the 
 
 Make a note of the IAM role's ARN; it will be necessary to enable OIDC for your service.
 
-For more granular access control, edit the trust policy of your IAM role with [Token claims](/docs/pulumi-cloud/oidc/#token-claims) for each service. The `sub` claim can be customized as shown below.
+For more granular access control, edit the trust policy of your IAM role with [Token claims](/docs/pulumi-cloud/access-management/oidc/provider/#custom-claims) for each service. The `sub` claim can be customized as shown below.
 
 ### Pulumi Deployments
 

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -5,7 +5,7 @@ set -o errexit -o pipefail
 source ./scripts/common.sh
 
 # URLs to Pulumi utility services.
-export PULUMI_CONVERT_URL="${PULUMI_CONVERT_URL:-$(pulumi stack output --stack pulumi/tf2pulumi-service/production url)}"
+export PULUMI_CONVERT_URL="${PULUMI_CONVERT_URL:-$(pulumi stack output --stack pulumi/tf2pulumi-service/production-www url)}"
 export PULUMI_AI_WS_URL=${PULUMI_AI_WS_URL:-$(pulumi stack output --stack pulumi/pulumigpt-api/corp websocketUri)}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -17,7 +17,7 @@ export REL_CSS_BUNDLE="/css/styles.${ASSET_BUNDLE_ID}.css"
 export REL_JS_BUNDLE="/js/bundle.min.${ASSET_BUNDLE_ID}.js"
 
 # URL to the Pulumi conversion service.
-export PULUMI_CONVERT_URL="${PULUMI_CONVERT_URL:-$(pulumi stack output --stack pulumi/tf2pulumi-service/production url)}"
+export PULUMI_CONVERT_URL="${PULUMI_CONVERT_URL:-$(pulumi stack output --stack pulumi/tf2pulumi-service/production-www url)}"
 
 # Default to building future content unless explicitly disabled
 BUILD_FUTURE_FLAG="--buildFuture"


### PR DESCRIPTION
Moves to using a newer tf2pulumi stack setup in the `production-www` account.

Also fixes a broken docs link