### PR TITLE
Drop old ciphers vulnerable to Lucky13

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -712,7 +712,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     viewerCertificate: {
         acmCertificateArn: config.certificateArn,
         sslSupportMethod: "sni-only",
-        minimumProtocolVersion: "TLSv1.2_2018",
+        minimumProtocolVersion: "TLSv1.2_2021",
     },
 
     loggingConfig: {


### PR DESCRIPTION
This is the version we've been running on app.pulumi.com without complaint for many months now without issue.

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html

### Related issues (optional)

https://github.com/pulumi/pulumi-service/issues/26208