### PR TITLE
Remove 6sense script

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -292,11 +292,6 @@
 
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 
-    {{- if eq hugo.Environment "production" }}
-        <!-- 6sense -->
-        <script async defer id="6senseWebTag" src="https://j.6sc.co/j/a4dca4b3-351c-4764-bda9-03c5caf5fedf.js"></script>
-    {{- end }}
-
     <!--Segment tracking-->
     <script>
         // Do not load Segment for these user agents.


### PR DESCRIPTION
Removing the 6sense script to unblock our pipeline. This script is giving our tests timeout errors due to issues fetching the script. This is possibly due to issues with our account not being on a paid version. We checked in with @calon-pulumi and confirmed it was ok to temporarily (maybe permanently) remove this. 