### PR TITLE
Change `types` to `resources`

### DIFF
--- a/content/blog/pulumi-convert-terraform-improvements/index.md
+++ b/content/blog/pulumi-convert-terraform-improvements/index.md
@@ -434,7 +434,7 @@ With the release of [Pulumi 3.153.0](https://github.com/pulumi/pulumi/releases/t
     pulumi package get-schema terraform-provider backblaze/b2
     ```
 
-    Inside the JSON response we can find the `types` section and from here extract the type corresponding to the resource we want to import. In this case, the type we're after is `b2:index/bucket:Bucket`.
+    Inside the JSON response we can find the `resources` section and from here extract the type corresponding to the resource we want to import. In this case, the type we're after is `b2:index/bucket:Bucket`.
 
     For the internal provider ID, we can exploit the fact that this is part of
     the Terraform state and use the `terraform show` command to find it.


### PR DESCRIPTION
Resource "types" can be found in the `resources` section of the Pulumi schema. Object "types" can be found in the `types` section of the Pulumi schema.