### PR TITLE
Ensure consistency on pricing page

### DIFF
--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -71,7 +71,7 @@ tiers:
                   Everything in **Team**, plus:
                   - Unlimited members & teams
                   - Role-based access control (RBAC)
-                  - Organization Access Tokens
+                  - Organization access tokens
                   - SAML/SSO
                   - Secrets versioning
                   - Audit logs

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -3,10 +3,10 @@
     <section class="container mx-auto text-center mb-16 mt-4">
         <div class="flex flex-row justify-center space-x-0 sm:space-x-4 my-4 border-b-1 border-gray-200">
             <div id="iac-pricing-select" class="text-md sm:text-2xl cursor-pointer p-2 px-4 rounded-t-lg border-b-4 border-blue-600 bg-violet-100">
-                <div id="iac-pricing-select-text" class="rainbow-text">Infrastructure as Code</div>
+                <div id="iac-pricing-select-text" class="rainbow-text">Pulumi IaC</div>
             </div>
             <div id="esc-pricing-select" class="text-md sm:text-2xl cursor-pointer p-2 px-4 rounded-t-lg border-b-4 border-gray-300">
-                <div id="esc-pricing-select-text">Secrets Management</div>
+                <div id="esc-pricing-select-text">Pulumi ESC</div>
             </div>
             <div id="insights-pricing-select" class="text-md sm:text-2xl cursor-pointer p-2 px-4 rounded-t-lg border-b-4 border-gray-300">
                 <div id="insights-pricing-select-text">Pulumi Insights</div>


### PR DESCRIPTION
There were two inconsistencies

- Casing of the feature for org access tokens.

- Mixing product category ("Infrastructure as Code") with product name ("Pulumi Insights") in the header.

This change addresses both of these, making them consistent.
