### PR TITLE
Fix link in blog post to point to a new URL

### DIFF
--- a/content/blog/code-deploy-and-manage-a-serverless-rest-api-on-aws-with-pulumi/index.md
+++ b/content/blog/code-deploy-and-manage-a-serverless-rest-api-on-aws-with-pulumi/index.md
@@ -189,7 +189,7 @@ To clean up the resources, run `pulumi destroy`.
 ## Next steps
 
 The
-[sample code for this application](https://github.com/pulumi/examples/tree/master/cloud-js-httpserver)
+[sample code for this application](https://github.com/pulumi/examples/)
 is available in the Pulumi examples repo on GitHub. For an end-to-end
 TypeScript application with a frontend, see the
 [URL shortener sample](https://github.com/pulumi/examples/tree/master/cloud-ts-url-shortener).


### PR DESCRIPTION
sending people to the root of examples for this 404

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pulumi/docs/pull/14316?shareId=5e62191a-1f54-4be5-a96f-713c6786844a).