### PR TITLE
[esc] add note on large environment open failures

### DIFF
--- a/content/docs/esc/environments/working-with-environments.md
+++ b/content/docs/esc/environments/working-with-environments.md
@@ -372,6 +372,15 @@ $ esc env open myorg/myproject/test 'aws.secrets.app-secret' | jq -r 'fromjson |
 secretValue
 ```
 
+{{% notes type="warning" %}}
+
+**Why is my environment failing to open**
+
+Extremely large environments (>10mb) may fail to open due to timeouts. It's recommended to keep only values you
+are using within your environment.
+{{% /notes %}}
+
+
 ## Projecting environment variables
 
 Pulumi ESC can automatically project the settings of a given environment as a set of environment variables. This projection does not happen by default, however; instead, you must define which settings to project, as well as how to name and format them.

--- a/content/docs/esc/environments/working-with-environments.md
+++ b/content/docs/esc/environments/working-with-environments.md
@@ -380,7 +380,6 @@ Extremely large environments (>10mb) may fail to open due to timeouts. It's reco
 are using within your environment.
 {{% /notes %}}
 
-
 ## Projecting environment variables
 
 Pulumi ESC can automatically project the settings of a given environment as a set of environment variables. This projection does not happen by default, however; instead, you must define which settings to project, as well as how to name and format them.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Add a note to the ESC docs on keeping environment contents slimmed down to only the values necessary as larger environment definitions (e.g. dumping a JSON blob into one) can result in the environment failing to open.

### Related issues (optional)

https://github.com/pulumi/pulumi-service/issues/22205