### PR TITLE
Fix example code test output

### DIFF
--- a/scripts/programs/test.sh
+++ b/scripts/programs/test.sh
@@ -206,11 +206,11 @@ fi
 
 # Report passing and failing projects.
 if [ ${#failed_projects[@]} -ne 0 ]; then
-    echo "The following projects failed:"
+    echo -e "\n\nThe following projects failed:"
     for project in "${failed_projects[@]}"; do
         echo "- $project"
     done
-    echo "\nThe following projects passed:"
+    echo -e "\n\nThe following projects passed:"
     for project in "${passing_projects[@]}"; do
         echo "- $project"
     done

--- a/scripts/programs/test.sh
+++ b/scripts/programs/test.sh
@@ -206,12 +206,12 @@ fi
 
 # Report passing and failing projects.
 if [ ${#failed_projects[@]} -ne 0 ]; then
-    echo -e "\n\nThe following projects failed:"
-    for project in "${failed_projects[@]}"; do
-        echo "- $project"
-    done
     echo -e "\n\nThe following projects passed:"
     for project in "${passing_projects[@]}"; do
+        echo "- $project"
+    done
+    echo -e "\n\nThe following projects failed:"
+    for project in "${failed_projects[@]}"; do
         echo "- $project"
     done
     exit 1


### PR DESCRIPTION
Fixes: https://github.com/pulumi/docs/issues/14384
Fixes the example code test output to make it more readable. 

It is hard to parse through the passing and failing sections without a new line separator and switched it to `echo -e` so the shell interprets the escape sequences rather than printing them. I added this to improve readability. I also swapped around the order so it prints the passing programs first. This is because when opening the log output in github actions it automatically scrolls to the end of the output and then we need to scroll up through all the passed ones to get to the failures.