### PR TITLE
Upgrade example code test runner

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - ubuntu-22.04
+          - pulumi-service-ubuntu-24.04-4core
         go-version:
           - 1.21.x
         node-version:


### PR DESCRIPTION

Upgrades the runner we use for our example code tests. We had reverted this to using one of the free tier runners and has since been failing due to disk space errors. 

We DO need to solve the underlying issue of the disk space consumption, but for now this will address the issue.