### PR TITLE
Re-enable testing of kubernetes examples

### DIFF
--- a/scripts/programs/ignore.txt
+++ b/scripts/programs/ignore.txt
@@ -27,9 +27,3 @@ aws-import-iac-iam-role-.*
 # Custom-domain examples won't work because of the hosted-zone lookup (which will fail unless
 # the credentials can access the specified Route 53 zone).
 awsx-apigateway-custom-domain-.*
-
-# Skipping all kubernetes examples for now as they are expected to fail until we provision
-# a Kubernetes cluster in CI.
-kubernetes-.*
-k8s-.*
-helm-.*


### PR DESCRIPTION
Removes kubernetes examples from the ignore list, now that there is a cluster configured in ci for them to run against.