### PR TITLE
Update frontmatter with keywords

### DIFF
--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -7,7 +7,7 @@ jobs:
   update:
     name: Update Algolia Search Index
     runs-on: ubuntu-latest
-    environment: production
+    environment: testing
     steps:
       - name: Install Node
         uses: actions/setup-node@v1

--- a/layouts/partials/docs/search.html
+++ b/layouts/partials/docs/search.html
@@ -8,7 +8,7 @@
             data-app-id="{{ getenv "ALGOLIA_APP_ID" }}"
             data-search-key="{{ getenv "ALGOLIA_APP_SEARCH_KEY" }}"
             data-facets="Docs,Registry,Tutorials"
-            data-index="production"
+            data-index="testing"
         ></div>
     </div>
     <div class="content-width-controls">

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -7,7 +7,7 @@ source ./scripts/ci-login.sh
 ./scripts/build-site.sh
 ./scripts/sync-and-test-bucket.sh update
 
-./scripts/generate-search-index.sh
+# ./scripts/generate-search-index.sh
 
 node ./scripts/await-in-progress.js
 

--- a/scripts/ci-push.sh
+++ b/scripts/ci-push.sh
@@ -7,7 +7,7 @@ source ./scripts/ci-login.sh
 ./scripts/build-site.sh
 ./scripts/sync-and-test-bucket.sh update
 
-# ./scripts/generate-search-index.sh
+./scripts/generate-search-index.sh
 
 node ./scripts/await-in-progress.js
 

--- a/scripts/search/keywords/keyword_gen_md.py
+++ b/scripts/search/keywords/keyword_gen_md.py
@@ -8,6 +8,8 @@ from ruamel.yaml import YAML
 from typing import List, Dict, Any
 import concurrent.futures
 import frontmatter
+from sklearn.feature_extraction.text import TfidfVectorizer
+import numpy as np
 
 def find_markdown_files(directory: str) -> List[str]:
     """
@@ -21,7 +23,249 @@ def find_markdown_files(directory: str) -> List[str]:
                 markdown_files.append(os.path.join(root, file))
     return markdown_files
 
-def process_markdown_file(file_path: str) -> Dict[str, Any]:
+def extract_document_content(file_path: str, title_weight: float = 0.5, meta_desc_weight: float = 0.3, content_weight: float = 0.2) -> Dict[str, Any]:
+    """
+    Extract content and frontmatter from a markdown file and somewhat hacky
+    way to generate weighted text.
+    
+    Params:
+    - file_path: path to the md file
+    - title_weight: relative importance of the title
+    - meta_desc_weight: relative importance of the meta description 
+    - content_weight: relative importance of the main content
+    """
+    with open(file_path, "r") as f:
+        content = f.read()
+    
+    # Parse frontmatter and content
+    page = frontmatter.loads(content)
+    
+    # Extract title and meta description
+    title = page.metadata.get("title", "")
+    meta_desc = page.metadata.get("meta_desc", "")
+    
+    # Check if meta_desc is missing and rebalance weights if needed
+    if not meta_desc:
+        # Redistribute meta_desc weight relative to title and content
+        total_remaining = title_weight + content_weight
+        if total_remaining > 0:  # Avoid division by zero
+            # Distribute meta_desc_weight proportionally
+            title_weight += meta_desc_weight * (title_weight / total_remaining)
+            content_weight += meta_desc_weight * (content_weight / total_remaining)
+        meta_desc_weight = 0
+    
+    # Normalize weights to ensure they sum to 1.0. 
+    # If they do not, then rebalance the weights based on the total sum.
+    total_weight = title_weight + meta_desc_weight + content_weight
+    if total_weight != 1.0:
+        title_weight = title_weight / total_weight
+        meta_desc_weight = meta_desc_weight / total_weight
+        content_weight = content_weight / total_weight
+    
+    # add 1 to avoid divide by zero
+    title_len = len(title.split()) + 1
+    meta_desc_len = len(meta_desc.split()) + 1 if meta_desc else 1
+    content_len = len(page.content.split()) + 1
+    
+    # calculate repetition values as a way to ensure each segment is weighted relative to the sizes of the text.
+    content_repeat = 1
+    title_repeat = int((title_weight * content_len * content_repeat) / (content_weight * title_len)) + 1 if content_weight > 0 else 1
+    
+    # Only calculate meta_desc_repeat if we have a meta_desc and its weight is > 0. Sometimes a meta_desc is not present
+    # in the hugo frontmatter.
+    if meta_desc and meta_desc_weight > 0:
+        meta_desc_repeat = int((meta_desc_weight * content_len * content_repeat) / (content_weight * meta_desc_len)) + 1 if content_weight > 0 else 1
+        weighted_text = f"{' '.join([title] * title_repeat)} {' '.join([meta_desc] * meta_desc_repeat)} {page.content}"
+    else:
+        # Skip meta_desc in the weighted text if it's missing
+        weighted_text = f"{' '.join([title] * title_repeat)} {page.content}"
+    
+    return {
+        "file_path": file_path,
+        "weighted_text": weighted_text,
+        "title": title,
+        "content": content,
+        "page": page
+    }
+
+def keybert_tfidf_keyword_extraction(documents: List[Dict[str, Any]], num_keywords=5, disallow=None) -> Dict[str, List[str]]:
+    """
+    Extract keywords using both corpus-level TF-IDF and KeyBERT.
+    Opting for a combined approach here which leverages distinctiveness
+    from TF-IDF and while also deriving semantic meaning from KeyBERT.
+
+    TF-IDF is a way to find the most important words in a page by comparing how often
+    they appear in a specific page relative to all the other pages. This helps us identify
+    the unique keywords that make each page more distinct, helping to reject noise and common
+    words that are of less meaning.
+    
+    Term Frequency: how often a word appears in the page
+    Inverse Document Frequency: how rare a word is across all the pages
+    
+    KeyBERT is a way to find the most important words in a document by looking at the semantic
+    meaning of the words. This helps us identify the keywords that are most important to the
+    meaning of the page.
+    
+    Parameters:
+    - documents: List of document dictionaries
+    - num_keywords: Number of keywords to extract per document
+    - disallow: List of terms to exclude from keywords
+    """
+    print(f"Performing hybrid keyword extraction on {len(documents)} documents")
+    
+    # Initialize disallow list if not provided
+    if disallow is None:
+        disallow = []
+    else:
+        print(f"Using disallow list with {len(disallow)} terms")
+    
+    # Create corpus from all documents
+    corpus = [doc["weighted_text"] for doc in documents]
+    file_paths = [doc["file_path"] for doc in documents]
+    
+    # Vectorizer that will be used to convert the enitre corpus into a TF-IDF matrix.
+    print("Building corpus-level TF-IDF vectorizer...")
+    vectorizer = TfidfVectorizer(
+        ngram_range=(1, 1),
+        stop_words='english',
+        lowercase=True,
+        max_features=10000,
+        min_df=1,
+        max_df=1.0
+    )
+    
+    # fit_transform combines fit and transform.
+    # fit calculates the IDF values for each term
+    # transform performs dot product between the term frequency
+    # vectors and the inverse document frequency values.
+    tfidf_matrix = vectorizer.fit_transform(corpus)
+    feature_names = vectorizer.get_feature_names_out()
+    print(f"terms: {len(feature_names)} terms")
+    
+    # Extract 10 TF-IDF keywords
+    tfidf_keywords = extract_tfidf_keywords(tfidf_matrix, feature_names, file_paths, 10, disallow)
+    
+    # Extract 10 KeyBERT keywords
+    keybert_keywords = extract_keybert_keywords(documents, vectorizer, 10, disallow)
+    
+    # Combine the results with a preference for keywords that appear in both methods
+    combined_keywords = {}
+    
+    # Iterate over each file and combine the keywords from both methods
+    for file_path in tfidf_keywords:
+        # Get keywords from both methods
+        tfidf_kw = tfidf_keywords[file_path]
+        keybert_kw = keybert_keywords[file_path]
+
+        print(f"TF-IDF keywords for {file_path}:\n\t {tfidf_kw}")
+        print(f"KeyBERT keywords for {file_path}:\n\t {keybert_kw}")
+        
+        # First prioritize common keywords that appear in both methods
+        common_kw = []
+        for kw in tfidf_kw:
+            if any(kw.lower() == kb.lower() for kb in keybert_kw):
+                common_kw.append(kw)
+        
+        print(f"Common keywords for {file_path}:\n\t {common_kw}")
+
+        # Then add unique keywords from each method until we reach the desired count
+        unique_kw = []
+        # First add remaining TF-IDF keywords that aren't in common_kw
+        for kw in tfidf_kw:
+            if kw not in common_kw and not any(kw.lower() == unique.lower() for unique in unique_kw):
+                unique_kw.append(kw)
+                
+        # Then add KeyBERT keywords that aren't in common_kw or already in unique_kw
+        for kw in keybert_kw:
+            if not any(kw.lower() == common.lower() for common in common_kw) and \
+               not any(kw.lower() == unique.lower() for unique in unique_kw):
+                unique_kw.append(kw)
+
+        print(f"Unique keywords for {file_path}:\n\t {unique_kw}")
+        
+        # Combine results and prioritize common keywords
+        result = common_kw + unique_kw
+        combined_keywords[file_path] = result[:num_keywords]
+
+        print(f"Combined keywords for {file_path}:\n\t {combined_keywords[file_path]}")
+    
+    return combined_keywords
+
+def extract_tfidf_keywords(tfidf_matrix, feature_names, file_paths, num_keywords=5, disallow=None) -> Dict[str, List[str]]:
+    """
+    Extract keywords from a pre-computed TF-IDF matrix.
+    """
+    print("Extracting corpus-level TF-IDF keywords...")
+    
+    # Initialize disallow list if not provided
+    if disallow is None:
+        disallow = []
+    
+    # Extract top keywords for each document
+    document_keywords = {}
+    
+    for i, file_path in enumerate(file_paths):
+        # Get document's TF-IDF scores
+        tfidf_scores = tfidf_matrix[i].toarray()[0]
+        
+        # Get indices of highest TF-IDF scores
+        sorted_indices = tfidf_scores.argsort()[::-1]
+        
+        # Get top keywords filtering out low scores and disallowed terms
+        top_keywords = []
+        for idx in sorted_indices:
+            term = feature_names[idx]
+            if tfidf_scores[idx] > 0.01 and len(top_keywords) < num_keywords:
+                # Check if the term is in the disallow list
+                if not any(disallowed_term.lower() in term.lower() for disallowed_term in disallow):
+                    top_keywords.append(term)
+        
+        document_keywords[file_path] = top_keywords
+    
+    return document_keywords
+
+def extract_keybert_keywords(documents: List[Dict[str, Any]], vectorizer, num_keywords=5, disallow=None) -> Dict[str, List[str]]:
+    """
+    Extract keywords using KeyBERT
+    """
+    print("Extracting KeyBERT keywords...")
+    
+    # Initialize disallow list if not provided
+    if disallow is None:
+        disallow = []
+    
+    # Initialize KeyBERT model
+    kw_model = KeyBERT()
+    
+    # Extract keywords for each document
+    document_keywords = {}
+    
+    for doc in documents:
+        file_path = doc["file_path"]
+        weighted_text = doc["weighted_text"]
+        
+        # Extract keywords using KeyBERT with the provided vectorizer
+        keywords = kw_model.extract_keywords(
+            weighted_text,
+            keyphrase_ngram_range=(1, 1),
+            stop_words='english',
+            use_mmr=True,
+            diversity=0.7,
+            top_n=num_keywords
+        )
+        
+        # Filter out disallowed terms
+        filtered_keywords = []
+        for kw, score in keywords:
+            if not any(disallowed_term.lower() in kw.lower() for disallowed_term in disallow):
+                filtered_keywords.append((kw, score))
+        
+        # Store just the keywords without scores (limited to requested number)
+        document_keywords[file_path] = [kw for kw, _ in filtered_keywords[:num_keywords]]
+    
+    return document_keywords
+
+def process_markdown_file(file_path: str, keywords: List[str]) -> Dict[str, Any]:
     """
     Process markdown file and generate keywords for it.
     """
@@ -38,112 +282,110 @@ def process_markdown_file(file_path: str) -> Dict[str, Any]:
     # Use ruamel.yaml for this so that we can preserve the comments that are in
     # the frontmatter. This also allows us to preserve the ordering of the keys
     # that were originally on the page to cut down on file diffs.
-    yaml = YAML()
-    yaml.preserve_quotes = True
     # best guess at indentation for most of our files to retain original integrity as 
     # much as possible :shrug:
+    yaml = YAML()
+    yaml.preserve_quotes = True
     yaml.indent(mapping=2, sequence=4, offset=2)
     ordered_frontmatter = yaml.load(frontmatter_content)
-
-    # Extract title and meta description properties so we can use them
-    # as part of the keyword generation process.
+    
+    # Get existing title for logging
     title = ordered_frontmatter.get("title", "")
-    meta_desc = ordered_frontmatter.get("meta_desc", "")
     
-    # Combine title, meta_desc, and content for keyword generation. We may want to weight these
-    # differently in the future, but can make optimizations later.
-    combined_text = f"{title} {meta_desc} {page.content}"
-    
-    # Generate keywords. Up to 5 keywords and 1-gram (single word) range.
-    new_keywords = generate_keywords(combined_text, 5, (1, 1))
-    
-    # Update the frontmatter with new keywords under search and initialize search key if
-    # it doesn't exist.
+    # Initialize search in frontmatter if it doesn't exist
     if "search" not in ordered_frontmatter:
         ordered_frontmatter["search"] = {}
-
-    # Handle existing search.keywords if there happen to be any.
-    if "keywords" in ordered_frontmatter["search"]:
-        # Get existing keywords
-        existing_keywords = ordered_frontmatter["search"]["keywords"]
         
-        # Combine existing and new keywords and also dedupe.
+    # Combine existing and new keywords and also dedupe.
+    if "keywords" in ordered_frontmatter["search"]:
+        existing_keywords = ordered_frontmatter["search"]["keywords"]
         combined_keywords = list(existing_keywords)
-        for keyword in new_keywords:
+        for keyword in keywords:
             if keyword not in combined_keywords:
                 combined_keywords.append(keyword)
-        
-        # Update keywords
         ordered_frontmatter["search"]["keywords"] = combined_keywords
     else:
-        # if no existing keywords, just set them with the new ones.
-        ordered_frontmatter["search"]["keywords"] = new_keywords
+        ordered_frontmatter["search"]["keywords"] = keywords
     
-    # Write the updated frontmatter back to the file
+    # Write updated frontmatter back to file
     with open(file_path, "w") as f:
         f.write("---\n")
         yaml.dump(ordered_frontmatter, f)
         f.write("---\n\n")
-        f.write(page.content)
-    
-    # return back the list of keywords for logging purposes.
-    final_keywords = ordered_frontmatter["search"]["keywords"]
-    
+        f.write(page.content + "\n")
+
+    # Return info for logging
     return {
         "file": file_path,
         "title": title,
-        "keywords": final_keywords
+        "keywords": ordered_frontmatter["search"]["keywords"]
     }
 
-def process_batch(files: List[str], batch_size) -> List[Dict[str, Any]]:
+def write_keywords_to_files(files: List[str], file_keyword_map: Dict[str, List[str]]) -> List[Dict[str, Any]]:
     """
-    Process markdown files in parallel.
+    Write generated keywords to markdown files.
     """
-    print(f"Starting batch processing with {len(files)} files using {batch_size} workers")
-    start_time = time.time()
+    print(f"Starting to write keywords to {len(files)} files")
     
-    with concurrent.futures.ThreadPoolExecutor(max_workers=batch_size) as executor:
-        results = list(executor.map(process_markdown_file, files))
+    start_time = time.time()
+    results = []
+    
+    for file_path in files:
+        keywords = file_keyword_map[file_path]
+        result = process_markdown_file(file_path, keywords)
+        results.append(result)
     
     end_time = time.time()
-    print(f"Batch processing completed in {end_time - start_time:.2f} seconds")
+    print(f"Finished writing keywords")
     return results
-
-def generate_keywords(text, num_keywords, ngram_range=(1, 1)):
-    """
-    Generate keywords for input text using KeyBERT. Using very generic settings for now.
-    We can fine tune this later after we prove concept.
-    """
-    # Initialize KeyBERT model
-    kw_model = KeyBERT()
-    
-    # Extract keywords
-    keywords = kw_model.extract_keywords(
-        text,
-        keyphrase_ngram_range=ngram_range,
-        stop_words="english",
-        top_n=num_keywords
-    )
-    
-    # Return just the keywords without the scoring
-    return [kw for kw, _ in keywords]
-
 
 def main():
     # Root directory to start processing markdown files. Will recurse through subdirs.
-    docs_dir = "content/docs/esc/"
+    docs_dir = "content/docs/"
+    
+    # list of terms to exclude from generated keywords
+    disallow = [
+        "example",
+        "click",
+        "documentation",
+        "note",
+        "pulumi",
+        "href", 
+        "src", 
+        "div", 
+        "shortcode", 
+        "notes",
+        "chooser", 
+        "choosable"
+    ]
+    
+    # Configure normalized weights - must sum to 1.0
+    title_weight = 0.5     # title 50%
+    meta_desc_weight = 0.3  # meta_desc 30% 
+    content_weight = 0.2    # content 20%
+    
+    # Number of keywords to extract per document
+    num_keywords = 7
     
     # Find all markdown files
     markdown_files = find_markdown_files(docs_dir)
     print(f"Found {len(markdown_files)} markdown files total")
     
     # TODO: Remove this... only processing a subset of files for testing purposes.
-    markdown_files = markdown_files[:32]
+    # markdown_files = markdown_files[:32]
     print(f"Processing {len(markdown_files)} files")
     
-    # Process files in batches
-    batch_size = 8
-    results = process_batch(markdown_files, batch_size)
+    # Extract document content for corpus building with normalized weights
+    print("Extracting document content...")
+    documents = []
+    for file_path in markdown_files:
+        documents.append(extract_document_content(file_path, title_weight, meta_desc_weight, content_weight))
+    
+    # Extract keywords using hybrid approach with TF-IDF and KeyBERT
+    file_keyword_map = keybert_tfidf_keyword_extraction(documents, num_keywords=num_keywords, disallow=disallow)
+    
+    # Update documents with new keywords
+    results = write_keywords_to_files(markdown_files, file_keyword_map)
     
     # Print summary
     print("\nProcessing complete!")

--- a/scripts/search/keywords/keyword_gen_md.py
+++ b/scripts/search/keywords/keyword_gen_md.py
@@ -1,0 +1,157 @@
+import os
+import time
+import threading
+from collections import OrderedDict
+from functools import partial
+from keybert import KeyBERT
+from ruamel.yaml import YAML
+from typing import List, Dict, Any
+import concurrent.futures
+import frontmatter
+
+def find_markdown_files(directory: str) -> List[str]:
+    """
+    Find all markdown files in the given directory and their subdirectories.
+    """
+    # get all markdown files in the given directory and their subdirectories.
+    markdown_files = []
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".md"):
+                markdown_files.append(os.path.join(root, file))
+    return markdown_files
+
+def process_markdown_file(file_path: str) -> Dict[str, Any]:
+    """
+    Process markdown file and generate keywords for it.
+    """
+    print(f"Processing file: {file_path}")
+    
+    # Read the markdown file.
+    with open(file_path, "r") as f:
+        content = f.read()
+
+    # break apart the frontmatter and the content
+    page = frontmatter.loads(content)
+    frontmatter_content = content.split("---", 2)[1]
+
+    # Use ruamel.yaml for this so that we can preserve the comments that are in
+    # the frontmatter. This also allows us to preserve the ordering of the keys
+    # that were originally on the page to cut down on file diffs.
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    # best guess at indentation for most of our files to retain original integrity as 
+    # much as possible :shrug:
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    ordered_frontmatter = yaml.load(frontmatter_content)
+
+    # Extract title and meta description properties so we can use them
+    # as part of the keyword generation process.
+    title = ordered_frontmatter.get("title", "")
+    meta_desc = ordered_frontmatter.get("meta_desc", "")
+    
+    # Combine title, meta_desc, and content for keyword generation. We may want to weight these
+    # differently in the future, but can make optimizations later.
+    combined_text = f"{title} {meta_desc} {page.content}"
+    
+    # Generate keywords. Up to 5 keywords and 1-gram (single word) range.
+    new_keywords = generate_keywords(combined_text, 5, (1, 1))
+    
+    # Update the frontmatter with new keywords under search and initialize search key if
+    # it doesn't exist.
+    if "search" not in ordered_frontmatter:
+        ordered_frontmatter["search"] = {}
+
+    # Handle existing search.keywords if there happen to be any.
+    if "keywords" in ordered_frontmatter["search"]:
+        # Get existing keywords
+        existing_keywords = ordered_frontmatter["search"]["keywords"]
+        
+        # Combine existing and new keywords and also dedupe.
+        combined_keywords = list(existing_keywords)
+        for keyword in new_keywords:
+            if keyword not in combined_keywords:
+                combined_keywords.append(keyword)
+        
+        # Update keywords
+        ordered_frontmatter["search"]["keywords"] = combined_keywords
+    else:
+        # if no existing keywords, just set them with the new ones.
+        ordered_frontmatter["search"]["keywords"] = new_keywords
+    
+    # Write the updated frontmatter back to the file
+    with open(file_path, "w") as f:
+        f.write("---\n")
+        yaml.dump(ordered_frontmatter, f)
+        f.write("---\n\n")
+        f.write(page.content)
+    
+    # return back the list of keywords for logging purposes.
+    final_keywords = ordered_frontmatter["search"]["keywords"]
+    
+    return {
+        "file": file_path,
+        "title": title,
+        "keywords": final_keywords
+    }
+
+def process_batch(files: List[str], batch_size) -> List[Dict[str, Any]]:
+    """
+    Process markdown files in parallel.
+    """
+    print(f"Starting batch processing with {len(files)} files using {batch_size} workers")
+    start_time = time.time()
+    
+    with concurrent.futures.ThreadPoolExecutor(max_workers=batch_size) as executor:
+        results = list(executor.map(process_markdown_file, files))
+    
+    end_time = time.time()
+    print(f"Batch processing completed in {end_time - start_time:.2f} seconds")
+    return results
+
+def generate_keywords(text, num_keywords, ngram_range=(1, 1)):
+    """
+    Generate keywords for input text using KeyBERT. Using very generic settings for now.
+    We can fine tune this later after we prove concept.
+    """
+    # Initialize KeyBERT model
+    kw_model = KeyBERT()
+    
+    # Extract keywords
+    keywords = kw_model.extract_keywords(
+        text,
+        keyphrase_ngram_range=ngram_range,
+        stop_words="english",
+        top_n=num_keywords
+    )
+    
+    # Return just the keywords without the scoring
+    return [kw for kw, _ in keywords]
+
+
+def main():
+    # Root directory to start processing markdown files. Will recurse through subdirs.
+    docs_dir = "content/docs/esc/"
+    
+    # Find all markdown files
+    markdown_files = find_markdown_files(docs_dir)
+    print(f"Found {len(markdown_files)} markdown files total")
+    
+    # TODO: Remove this... only processing a subset of files for testing purposes.
+    markdown_files = markdown_files[:32]
+    print(f"Processing {len(markdown_files)} files")
+    
+    # Process files in batches
+    batch_size = 8
+    results = process_batch(markdown_files, batch_size)
+    
+    # Print summary
+    print("\nProcessing complete!")
+    print(f"Processed {len(results)} files")
+    for result in results:
+        print(f"\nFile: {result['file']}")
+        print(f"Title: {result['title']}")
+        print(f"Generated keywords: {', '.join(result['keywords'])}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/search/keywords/keyword_gen_md.py
+++ b/scripts/search/keywords/keyword_gen_md.py
@@ -215,7 +215,7 @@ def extract_tfidf_keywords(tfidf_matrix, feature_names, file_paths, num_keywords
         top_keywords = []
         for idx in sorted_indices:
             term = feature_names[idx]
-            if tfidf_scores[idx] > 0.01 and len(top_keywords) < num_keywords:
+            if tfidf_scores[idx] > 0.02 and len(top_keywords) < num_keywords:
                 # Check if the term is in the disallow list
                 if not any(disallowed_term.lower() in term.lower() for disallowed_term in disallow):
                     top_keywords.append(term)
@@ -229,10 +229,6 @@ def extract_keybert_keywords(documents: List[Dict[str, Any]], vectorizer, num_ke
     Extract keywords using KeyBERT
     """
     print("Extracting KeyBERT keywords...")
-    
-    # Initialize disallow list if not provided
-    if disallow is None:
-        disallow = []
     
     # Initialize KeyBERT model
     kw_model = KeyBERT()
@@ -341,7 +337,7 @@ def write_keywords_to_files(files: List[str], file_keyword_map: Dict[str, List[s
 
 def main():
     # Root directory to start processing markdown files. Will recurse through subdirs.
-    docs_dir = "content/docs/"
+    docs_dir = "content/docs/esc/"
     
     # list of terms to exclude from generated keywords
     disallow = [

--- a/scripts/search/keywords/keyword_gen_md.py
+++ b/scripts/search/keywords/keyword_gen_md.py
@@ -356,9 +356,9 @@ def main():
     ]
     
     # Configure normalized weights - must sum to 1.0
-    title_weight = 0.25     # title 25%
-    meta_desc_weight = 0.25 # meta_desc 25% 
-    content_weight = 0.5    # content 50%
+    title_weight = 0.05     # title 5%
+    meta_desc_weight = 0.05 # meta_desc 5% 
+    content_weight = 0.9    # content 90%
     
     # Number of keywords to extract per document
     num_keywords = 7

--- a/scripts/search/keywords/keyword_gen_md.py
+++ b/scripts/search/keywords/keyword_gen_md.py
@@ -356,9 +356,9 @@ def main():
     ]
     
     # Configure normalized weights - must sum to 1.0
-    title_weight = 0.5     # title 50%
-    meta_desc_weight = 0.3  # meta_desc 30% 
-    content_weight = 0.2    # content 20%
+    title_weight = 0.25     # title 25%
+    meta_desc_weight = 0.25 # meta_desc 25% 
+    content_weight = 0.5    # content 50%
     
     # Number of keywords to extract per document
     num_keywords = 7

--- a/scripts/search/keywords/requirements.txt
+++ b/scripts/search/keywords/requirements.txt
@@ -1,0 +1,3 @@
+keybert>=0.9.0
+ruamel.yaml>=0.18.10
+frontmatter>=3.0.8

--- a/scripts/search/update-search-index.js
+++ b/scripts/search/update-search-index.js
@@ -4,7 +4,7 @@ const algoliasearch = require("algoliasearch");
 
 // URL of the JSON file
 const registrySearchIndexUrl = "https://www.pulumi.com/registry/search-index.json";
-const docsSearchIndexUrl = "https://www.pulumi.com/search-index.json";
+const docsSearchIndexUrl = "https://www.pulumi-test.io/search-index.json";
 
 // Configuration values required for updating the Algolia index.
 const config = {

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -31,7 +31,7 @@ fi
 
 # For previews, name the destination bucket with the PR number, to reduce the number of
 # buckets we create and to facilitate shorter sync times.
-destination_bucket="$(origin_bucket_prefix)-$(build_identifier)"
+destination_bucket=$(echo "$(origin_bucket_prefix)-$(build_identifier)" | tr '_' '-')
 destination_bucket_uri="s3://${destination_bucket}"
 
 # Translate Hugo redirects into a file we'll use for making 301 redirects later. Note that


### PR DESCRIPTION
Generate keywords and add them to frontmatter.

This PR reads in the markdown files and uses the content to generate keywords. It then writes back the frontmatter to the file with keywords list under search.keywords.

I am taking a hybrid approach here that combines tf-idf and keybert. TF-IDF is used to find the keywords in a page by comparing how often they appear in a specific page relative to all the other pages. This helps us identify the unique keywords that make each page more distinct, helping to reject noise and common words that are of less meaning. Keybert is used to extract the keywords by looking at the semantic relevance of the words. We then take the keywords that are extracted that are common to both methods, with the intended result including keywords that are both semantically relevant and distinct across the corpus of pages. There are up to 7 keywords total that are added and we prioritize the keywords that are common to both methods when producing the list.

Outputs using this method to see what this produces:

https://github.com/pulumi/docs/pull/14559
