### PR TITLE
Adds instructions on how to handle ESM-only packages

### DIFF
--- a/content/docs/iac/languages-sdks/javascript/_index.md
+++ b/content/docs/iac/languages-sdks/javascript/_index.md
@@ -251,6 +251,14 @@ runtime:
     nodeargs: "--loader ts-node/esm --no-warnings"
 ```
 
+## Using ESM only modules with CommonJS Pulumi templates
+
+Older versions of Node.js do not support loading ESM modules using the `require` function (`require` is part of CommonJS, the default runtime targetted by TypeScript in the Pulumi templates). You may encounter an error like the following:
+
+`Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/alice/pulumi/projects/esm-test-project/node_modules/@kubernetes/client-node/dist/index.js from /Users/alice/pulumi/projects/esm-test-project/index.ts not supported.`
+
+To resolve this issue, you can either follow the instructions above to convert your project to ESM, or upgrade to a recent version of Node.js that supports `require`ing ESM modules. At time of writing this is at least [v20.19.0](https://github.com/nodejs/node/releases/tag/v20.19.0) (2025-03) or [v22.12.0](https://github.com/nodejs/node/releases/tag/v22.12.0) (2024-12).
+
 ## Package Management
 
 Pulumi has official support for NPM and Yarn Classic. Pulumi does


### PR DESCRIPTION
### Proposed changes

Adds some explicit instructions on how to handle a particular nodejs error around `require`ing ESM-only modules from commonJS.

Certain large npm packages are starting to go ESM-only, e.g. https://github.com/kubernetes-client/javascript/releases/tag/1.0.0 so it may become more common to bump into this.

NodeJS is only just starting to support loading ESM modules from CommonJS.

Notes:
- This Gist helping people handle these issues has been around since 2021 https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c 

