### PR TITLE
Skip failing docs examples

### DIFF
--- a/scripts/programs/ignore.txt
+++ b/scripts/programs/ignore.txt
@@ -33,3 +33,24 @@ awsx-apigateway-custom-domain-.*
 kubernetes-.*
 k8s-.*
 helm-.*
+
+# Skip broken programs to get back to green
+# https://github.com/pulumi/docs/issues/14505
+gcp-import-service-account-yaml
+gcp-import-service-account-csharp
+azure-native-import-resource-group-yaml
+gcp-import-service-account-python
+aws-iampolicy-jsonparse-csharp
+azure-native-import-resource-group-python
+aws-acm-certificate-csharp
+aws-simulated-dbserver-database-csharp
+aws-s3bucket-bucketobject-interpolate-csharp
+gcp-import-service-account-go
+aws-s3websitebucket-oai-bucketpolicy-csharp
+azure-native-import-resource-group-go
+gcp-import-service-account-typescript
+aws-s3bucket-bucketpolicy-csharp
+deepseek-ollama-csharp
+gcp-import-service-account-javascript
+gcp-simple-webserver-yaml
+azure-native-import-resource-group-csharp


### PR DESCRIPTION
There are about 20 failing example programs in master; this results in an alert in the #docs-ops channel everyday and makes it hard for us to notice and fix any new failures in the 300+ programs that are currently working!

This PR disables those failing test so we can catch and fix new failures in the future. I've also filed https://github.com/pulumi/docs/issues/14505 to track fixing these so we can ratchet this up to covering all of these programs. 