### PR TITLE
Revert commit "adding warning around scim team name limit"

### DIFF
--- a/content/docs/pulumi-cloud/access-management/scim/entra.md
+++ b/content/docs/pulumi-cloud/access-management/scim/entra.md
@@ -27,10 +27,6 @@ Please note that some advanced SCIM features aren't supported yet. For more info
 
 ## Enabling Automatic Provisioning
 
-    {{% notes type="warning" %}}
-**Team name character limit**: Pulumi team names created via SCIM must not exceed 40 characters. If your Entra group name is longer than this limit, you’ll need to rename the group before pushing it to Pulumi. Otherwise, the provisioning will fail.
-    {{% /notes %}}
-
 1. Navigate to the Microsoft Entra ID application where you have configured Single Sign On using SAML with Pulumi.
 2. Select **Enterprise Applications** and select the app in which you configured Single Sign On with Pulumi earlier.
 3. Select the **Provisioning** feature, and change the value of **Provisioning Mode** to **Automatic**.

--- a/content/docs/pulumi-cloud/access-management/scim/okta.md
+++ b/content/docs/pulumi-cloud/access-management/scim/okta.md
@@ -135,11 +135,7 @@ To set this up, you need to enable Push Groups as a supported provisioning actio
 ## Setting up Group Provisioning {#setupgroupprovisioning}
 
     {{% notes type="warning" %}}
- **Important:** If there are members in a group that are not yet assigned to the Pulumi Cloud application in Okta, they will not be added to the team in the Pulumi Cloud. Ensure that all members in the group have been assigned to the application before pushing the group.
-    {{% /notes %}}
-
-    {{% notes type="warning" %}}
-**Team name character limit**: Pulumi team names created via SCIM must not exceed 40 characters. If your Okta group name is longer than this limit, you’ll need to rename the group before pushing it to Pulumi. Otherwise, the provisioning will fail.
+ >**Important:** If there are members in a group that are not yet assigned to the Pulumi Cloud application in Okta, they will not be added to the team in the Pulumi Cloud. Ensure that all members in the group have been assigned to the application before pushing the group.
     {{% /notes %}}
 
 To specify which groups you would like to push with group provisioning, select the **Push Groups** tab in your Pulumi Cloud application in Okta and complete the following steps.

--- a/content/docs/pulumi-cloud/access-management/scim/onelogin.md
+++ b/content/docs/pulumi-cloud/access-management/scim/onelogin.md
@@ -114,10 +114,6 @@ At this point, SCIM provisioning of users into the Pulumi organization will work
 
 Beyond managing users, Pulumi's SCIM support enables you to manage Pulumi Teams and team membership. To set this up, Pulumi supports using OneLogin's Role-Group mapping to manage Pulumi teams membership.
 
-    {{% notes type="warning" %}}
-**Team name character limit**: Pulumi team names created via SCIM must not exceed 40 characters. If your OneLogin group name is longer than this limit, you’ll need to rename the group before pushing it to Pulumi. Otherwise, the provisioning will fail.
-    {{% /notes %}}
-
 ### Set up OneLogin Application to Manage Groups in Pulumi
 
 Navigate to the SCIM application in OneLogin.

--- a/content/docs/pulumi-cloud/reference/cloud-rest-api/_index.md
+++ b/content/docs/pulumi-cloud/reference/cloud-rest-api/_index.md
@@ -2304,10 +2304,6 @@ Status: 200 OK
 For GitHub-backed organizations the `teamType` path parameter must be `github`. For all other organization types the `teamType` path parameter must be `pulumi`.
 {{% /notes %}}
 
-    {{% notes type="warning" %}}
-**Team name character limit**: Pulumi team names created via SCIM must not exceed 40 characters. If your group name is longer than this limit, you’ll need to rename the group before pushing it to Pulumi. Otherwise, the provisioning will fail.
-    {{% /notes %}}
-
 ```
 POST /api/orgs/{org}/teams/{teamType}
 ```


### PR DESCRIPTION
This reverts commit 678c252aa456637a13c3ede62957ddc0d7770944