### PR TITLE
adding note about admin scope requirement

### DIFF
--- a/content/docs/pulumi-cloud/access-management/access-tokens.md
+++ b/content/docs/pulumi-cloud/access-management/access-tokens.md
@@ -216,3 +216,17 @@ To delete a team access token:
 1. Choose **Delete token**. You will be prompted in a dialog to confirm your choice.
 
 If you choose to delete a token, its access will immediately be revoked and all further operations using it will fail as unauthorized. The token name will remain reserved for your organization after deletion.
+
+## OIDC issued tokens
+
+OIDC-issued access tokens generated in CI/CD workflows (such as GitHub Actions) do not receive admin privileges by default. To perform operations that require elevated access—such as creating or deleting stacks—you must explicitly request the admin scope when exchanging the OIDC token.
+
+For example:
+
+```json
+{
+  "provider": "github",
+  "audience": "pulumi",
+  "scope": "admin"
+}
+```

--- a/content/docs/pulumi-cloud/access-management/oidc/client/_index.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/client/_index.md
@@ -120,6 +120,11 @@ Parameters:
     - Team token (scope is required): `urn:pulumi:token-type:access_token:team`
     - Personal token (scope is required): `urn:pulumi:token-type:access_token:personal`
 - `scope`: a single scope will be supported initially and used to define when asking for a team or personal token, what team/user it should be assigned to. Format: `team:{TEAM_NAME}` (for example: `team:OPS_AUTOMATIONS`) or `user:{USER_LOGIN}` (for example: `user:djohn`). It is also supported, only for organization tokens, the `admin` scope to request organization tokens with admin privileges (the authorization policy has to explicitly allow admin privileges for it to be accepted).
+
+{{< notes type="info" >}}
+Organization-level access tokens generated via OIDC do not default to admin privileges unless the `scope: admin` field is explicitly set.
+{{< /notes >}}
+
 - `expiration`: (int, time in seconds) used to customize the token expiration required by the operation. The default token expiration (2 hours) will be used.
 - `subject_token`: token issued by the IdP
 


### PR DESCRIPTION
Document missing scope: admin requirement for OIDC-issued Pulumi tokens

Fixes https://github.com/pulumi/docs/issues/14436