### PR TITLE
Remove outdated azure-native-v2 redirect

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -134,10 +134,6 @@ function getCloudProvidersRedirect(uri: string): string | undefined {
             .replace("setup", "installation-configuration");
     }
 
-    if (uri.includes("/registry/packages/azure-native-v2")) {
-        return uri.replace("azure-native-v2", "azure-native")
-    }
-
     return undefined;
 }
 


### PR DESCRIPTION
We added this redirect when we removed the beta docs of azure native v2, to make sure people's links still work. But now, we released azure native v3, so now `azure-native` is the current v3 and `azure-native-v2` are the v2 docs, so the redirect is wrong.