### PR TITLE
removing admin required prereq, as this is no longer the case

### DIFF
--- a/content/docs/pulumi-cloud/access-management/oidc/provider/aws.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/provider/aws.md
@@ -20,14 +20,6 @@ aliases:
 
 This document outlines the steps required to configure Pulumi to use OpenID Connect to authenticate with AWS. OIDC in AWS uses a web identity provider to assume an IAM role. Access to the IAM role is authorized using a trust policy that validates the contents of the OIDC token issued by the Pulumi Cloud.
 
-## Prerequisites
-
-* You must be an admin of your Pulumi organization.
-
-{{< notes type="warning" >}}
-Please note that this guide provides step-by-step instructions based on the official provider documentation which is subject to change. For the most current and precise information, always refer to the [official AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html).
-{{< /notes >}}
-
 ## Create the identity provider
 
 1. In the navigation pane of the [IAM console](https://console.aws.amazon.com/iam/), choose **Identity providers**, and then choose **Add provider**.

--- a/content/docs/pulumi-cloud/access-management/oidc/provider/azure.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/provider/azure.md
@@ -22,7 +22,6 @@ This document outlines the steps required to configure Pulumi to use OpenID Conn
 
 ## Prerequisites
 
-* You must be an admin of your Pulumi organization.
 * You must have access in the Azure Portal to create and configure Microsoft Entra App registrations.
 
 {{< notes type="warning" >}}

--- a/content/docs/pulumi-cloud/access-management/oidc/provider/gcp.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/provider/gcp.md
@@ -22,7 +22,6 @@ This document outlines the steps required to configure Pulumi to use OpenID Conn
 
 ## Prerequisites
 
-* You must be an admin of your Pulumi organization.
 * You must create a [Google Cloud project with the required APIs enabled](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#configure)
 
 {{< notes type="warning" >}}

--- a/content/docs/pulumi-cloud/access-management/oidc/provider/vault/_index.md
+++ b/content/docs/pulumi-cloud/access-management/oidc/provider/vault/_index.md
@@ -22,7 +22,6 @@ Please note that this guide provides step-by-step instructions based on the offi
 
 ## Prerequisites
 
-* You must be an admin of your Pulumi organization.
 * You must have admin access to Vault.
 * Pulumi Cloud must be able to access Vault.
 


### PR DESCRIPTION
Removing the prereq that Org Admin is required for setting up OIDC for Pulumi Deployments and ESC.