### PR TITLE
breaking appart resource explorer and search

### DIFF
--- a/content/docs/insights/Resources/_index.md
+++ b/content/docs/insights/Resources/_index.md
@@ -1,0 +1,33 @@
+---
+title: Resources
+meta_desc: Learn how to explore and analyze your cloud infrastructure using Pulumi Resource Explorer and Resource Search.
+title_tag: Explore Your Cloud Resources | Pulumi Insights
+menu:
+  insights:
+    parent: insights-home
+    identifier: insights-resources
+    weight: 3
+---
+
+Pulumi Insights helps you explore, search, and analyze all the cloud infrastructure in your organization, across every stack and cloud provider.
+
+The **Resources** page in the Pulumi Cloud console offers three main ways to explore your infrastructure:
+
+- **Resource Explorer** – A visual interface for filtering, grouping, and navigating your cloud resources interactively.
+- **Resource Search** – A powerful structured query language for advanced filtering, tagging, and property-based searches.
+- **AI Assist**– Built into both experiences, allowing you to ask natural-language questions like "show me all production resources" or "list S3 buckets created last month."
+
+Each method gives you different ways to answer questions about your cloud environment, including:
+
+- What resources are publicly exposed?
+- How many compute instances are running across all providers?
+- Which resources were modified in the last 30 days?
+- What stacks have resources tagged with `costcenter:1234`?
+
+You can explore these resources directly in the UI or programmatically via the [Pulumi Cloud REST API](/docs/pulumi-cloud/cloud-rest-api/#resource-search).
+
+To get started, choose the method that best suits your workflow:
+
+- Use **[Resource Explorer](/docs/insights/resources/explorer/)** to click, filter, and group resources interactively.
+- Use **[Resource Search](/docs/insights/resources/search/)** for fine-grained control over your queries.
+- Use **[AI Assist](/docs/insights/resources/resource-search/#ai-assist)** ask natural-language questions about your infrastructure.

--- a/content/docs/insights/Resources/resource-explorer.md
+++ b/content/docs/insights/Resources/resource-explorer.md
@@ -1,0 +1,36 @@
+---
+title: Resource explorer
+meta_desc: Learn how to visually explore your cloud infrastructure with Pulumi Resource Explorer using filters, grouping, and AI Assist.
+title_tag: Pulumi Resource Explorer | Pulumi Insights
+menu:
+  insights:
+    parent: insights-resources
+    identifier: insights-resource-explorer
+    weight: 1
+---
+
+Pulumi Resource Explorer gives you a real-time view of your infrastructure across every stack, project, and cloud provider. It’s the fastest way to explore your resources visually—no query syntax required. All scanned resources are displayed on the **Resources** page in Pulumi Cloud.  
+
+Use Resource Explorer to:
+
+* Filter and group resources by tag, type, project, stack, or provider
+* Quickly answer common infrastructure questions
+* Collaborate with your team during audits, cost reviews, and troubleshooting
+* Jump directly into a stack or resource for further investigation
+
+### Viewing resources in the grid
+
+* **Grid structure**:  
+  * **Project column**: Displays the ultimate parent account name.  
+  * **Stack/Account column**: Displays the full child account path. For example:  
+    * **Project**: `my-aws-account`  
+    * **Stack/Account**: `us-east-1/my-cluster`
+
+![Resources page](/docs/insights/assets/insights-resource-explorer.png)
+
+* **Resource navigation**: Click on a resource's name to view its resource details. This page includes:  
+  * **Resource history**: Pulumi tracks and displays all versions of a resource, with changes based on property updates.  
+  * **Properties**: View detailed properties for each resource version.  
+  * **References**: See edges (relationships) to other resources in the same account.
+
+![Resource details page](/docs/insights/assets/insights-resources.png)

--- a/content/docs/insights/Resources/resource-search.md
+++ b/content/docs/insights/Resources/resource-search.md
@@ -1,20 +1,19 @@
 ---
 title: Resource search
-title_tag: "Pulumi Insights: Resource search"
+title_tag: Resource search | Pulumi Insights
 h1: Resource search
 meta_desc: Documentation and query syntax for the Pulumi Insights search feature.
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   insights:
-    parent: insights-home
-    weight: 4
-aliases:
-  - /docs/intro/insights/search/
-  - /docs/pulumi
-  - /docs/pulumi-cloud/insights/search/
+    parent: insights-resources
+    identifier: insights-resource-search
+    weight: 2
 ---
 
-Resource Search allows you to explore your resources, stacks and projects in detail.
+Resource Search gives you a powerful way to ask questions about your infrastructure using a structured query language. You can search across all stacks, projects, and cloud providers to find exactly what you're looking for—by tag, type, creation date, team, or even nested resource properties.
+
+Not sure how to write a query? Use [AI Assist](#ai-assist) to describe what you’re looking for in natural language—like *“show me all public S3 buckets”*—and let Pulumi generate the search syntax for you.
 
 ## Query Syntax
 

--- a/content/docs/insights/_index.md
+++ b/content/docs/insights/_index.md
@@ -10,6 +10,7 @@ menu:
 expanded_menu_ids:
     - insights-get-started
     - insights-concepts
+    - insights-resources
 meta_desc: Pulumi Insights is an intelligent infrastructure management service to discover, understand, manage, and improve any cloud infrastructure.
 meta_image: /images/docs/meta-images/insights-meta.png
 h1: Pulumi Insights Documentation

--- a/content/docs/insights/accounts.md
+++ b/content/docs/insights/accounts.md
@@ -70,27 +70,6 @@ Key benefits of child accounts include:
 * **Granular control**: Actions can also target specific child accounts, affecting only them and their children.  
 * **Configuration inheritance**: Child accounts can inherit ESC credentials and other configurations from their parent account.
 
-## Resources
-
-All scanned resources are displayed on the **Resources** page in Pulumi Cloud.  
-
-### Viewing resources in the grid
-
-* **Grid structure**:  
-  * **Project column**: Displays the ultimate parent account name.  
-  * **Stack/Account column**: Displays the full child account path. For example:  
-    * **Project**: `my-aws-account`  
-    * **Stack/Account**: `us-east-1/my-cluster`
-
-![Resources page](/docs/insights/assets/insights-resource-explorer.png)
-
-* **Resource navigation**: Click on a resource's name to view its **Resource Details** page. This page includes:  
-  * **Resource history**: Pulumi tracks and displays all versions of a resource, with changes based on property updates.  
-  * **Properties**: View detailed properties for each resource version.  
-  * **References**: See edges (relationships) to other resources in the same account.
-
-![Resource details page](/docs/insights/assets/insights-resources.png)
-
 ## Configure ESC credentials
 
 ### AWS


### PR DESCRIPTION
Per Craig; We should separate the Resources grid from Resource search in the information architecture. ie. the panel on the left should be called 'Resources' like it does in the app and should Resources Search and Resources Explorer as sub headings with separate pages. 