### PR TITLE
fix: correct incorrect link to autonaming doc

### DIFF
--- a/content/blog/autonaming-configuration/index.md
+++ b/content/blog/autonaming-configuration/index.md
@@ -88,7 +88,7 @@ pulumi:autonaming:
   pattern: ${project}-${stack}-${name}${alphanum(6)}
 ```
 
-See the [auto-naming configuration documentation](/docs/concepts/resources/names/#auto-naming-configuration) to see the full list of available expressions.
+See the [auto-naming configuration documentation](/docs/concepts/resources/names/#autonaming-configuration) to see the full list of available expressions.
 
 ## See It In Action
 


### PR DESCRIPTION
### Proposed changes

Correct an incorrect link to the auto-naming section of the doc.