### PR TITLE
give permission to comment on PR

### DIFF
--- a/content/docs/iac/using-pulumi/continuous-delivery/github-actions.md
+++ b/content/docs/iac/using-pulumi/continuous-delivery/github-actions.md
@@ -436,6 +436,8 @@ jobs:
   preview:
     name: Preview
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -469,6 +471,8 @@ jobs:
   preview:
     name: Preview
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -502,6 +506,8 @@ jobs:
   preview:
     name: Preview
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
@@ -535,6 +541,8 @@ jobs:
   preview:
     name: Preview
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v1


### PR DESCRIPTION
On new repositories, the github token has read permissions by default, so with this change we explicitly give permission to write PR comments.

Tested in https://github.com/marcoieni/pulumi-test/pull/3/commits/d355e4b502017b932b57796ae2335a93494ed9c6 after I merged https://github.com/marcoieni/pulumi-test/commit/18f7e6571e78752373f411a993052aa2feb12896