### PR TITLE
Handle cypress error coming from 3rd party lib

### DIFF
--- a/cypress/e2e/site.cy.js
+++ b/cypress/e2e/site.cy.js
@@ -1,4 +1,11 @@
-// Handle uncaught exceptions from third-party scripts
+/**
+ * Handle uncaught exceptions from third-party scripts.
+ * 
+ * The vector.co pixel.js script throws an uncaught exception when it detects a cloud provider environment.
+ * This happens in the GitHub Actions runner but not locally, causing tests to fail in CI.
+ * 
+ * We catch and ignore this specific error while still allowing other legitimate errors to fail the tests.
+ */
 Cypress.on('uncaught:exception', (err) => {
     // Return false to prevent the error from failing the test
     if (err.message.includes('Cloud provider detected')) {

--- a/cypress/e2e/site.cy.js
+++ b/cypress/e2e/site.cy.js
@@ -1,3 +1,13 @@
+// Handle uncaught exceptions from third-party scripts
+Cypress.on('uncaught:exception', (err) => {
+    // Return false to prevent the error from failing the test
+    if (err.message.includes('Cloud provider detected')) {
+        return false;
+    }
+    // Return true for other errors to fail the test
+    return true;
+});
+
 describe("www.pulumi.com", () => {
 
     describe("home page", () => {


### PR DESCRIPTION
Ignores "Cloud provider detected" error being thrown by vector.co/pixel.js script. These analytics scripts try to detect and block traffic from cloud hosted environments , which a GH runner technically is, in order to prevent abuse and filter out "non-human" traffic. So this handles that error so we do not fail the tests on that specific error.