### PR TITLE
fix display of `<version>` in install script

### DIFF
--- a/content/docs/iac/download-install/_index.md
+++ b/content/docs/iac/download-install/_index.md
@@ -506,7 +506,7 @@ Most installation methods choose the latest version by default. To install a spe
 <h3 class="no-anchor pt-4">macOS Installation Script</h3>
 
 <div class="highlight">
-   <pre class="chroma"><code class="language-bash" data-lang="bash" data-track="install-pulumi-macos-install-script">$ curl -fsSL https://get.pulumi.com | sh -s -- --version <version></code></pre>
+   <pre class="chroma"><code class="language-bash" data-lang="bash" data-track="install-pulumi-macos-install-script">$ curl -fsSL https://get.pulumi.com | sh -s -- --version &lt;version&gt;</code></pre>
 </div>
 
 {{% /choosable %}}
@@ -518,7 +518,7 @@ Most installation methods choose the latest version by default. To install a spe
 To install, run our installation script:
 
 <div class="highlight">
-   <pre class="chroma"><code class="language-bash" data-lang="bash" data-track="install-pulumi-linux-install-script">$ curl -fsSL https://get.pulumi.com | sh -s -- --version <version></code></pre>
+   <pre class="chroma"><code class="language-bash" data-lang="bash" data-track="install-pulumi-linux-install-script">$ curl -fsSL https://get.pulumi.com | sh -s -- --version &lt;version&gt;</code></pre>
 </div>
 
 {{% /choosable %}}


### PR DESCRIPTION
`<version>` is interpreted as a HTML tag here, which results in it not being shown on the HTML page.  Fix this by using the `&lt;` and `&gt;` HTML escape codes.

Currently:

![image](https://github.com/user-attachments/assets/18a6dd22-0bf7-4375-b0c0-8f09cde6c6c0)

After:

![image](https://github.com/user-attachments/assets/6bbe97bf-0463-47d9-911b-d62f887c956f)

