### PR TITLE
Suggested improvements to the PulumiUP page

### DIFF
--- a/content/pulumi-up/_index.md
+++ b/content/pulumi-up/_index.md
@@ -122,7 +122,7 @@ schedule:
       time: "Europe & Americas"
       time2: "Asia Pacific"
 
-    - title: A Lap Around Pulumi
+    - title: Product News and Announcements
       description:
       time: "9:00 AM ET"
       time2: "4:00 PM PT"

--- a/layouts/page/pulumi-up-2023-confirmation.html
+++ b/layouts/page/pulumi-up-2023-confirmation.html
@@ -10,6 +10,8 @@
         </div>
     </div>
 
+    {{ partial "event-schedule.html" (dict "schedule" .Params.schedule "bg_color" "gray-100" ) }}
+
     {{ range .Params.panels }}
     <section id="panel" class="py-8">
         <div class="container mx-auto text-center">
@@ -39,8 +41,6 @@
         </div>
     </section>
     {{ end }}
-
-    {{ partial "event-schedule.html" (dict "schedule" .Params.schedule "bg_color" "gray-100" ) }}
 
     {{ partial "pulumi-up/speakers.html" (dict "speakers" .Params.speakers ) }}
 

--- a/layouts/page/pulumi-up-2023.html
+++ b/layouts/page/pulumi-up-2023.html
@@ -9,8 +9,9 @@
             <div class="banner-description mx-auto mb-12 w-2/3 2xl:w-1/3">
                 <h4>May 6 - 9 am ET / 2 pm GMT</h4>
                 <h4 class="mt-0">May 6 - 4 pm PT / May 7 - 9 am AEST</h4>
-                <p class="px-12">
-                    Join us for a virtual event featuring real-world enterprise platform engineering success stories, technical demos, and expert discussions. Hear from Pulumi leaders, engineers, and industry experts on how they’ve built platforms that automate infrastructure with Pulumi.
+                <p class="px-32">
+                    Join our virtual event for exciting product announcements, demos, and stories about how
+                    real-world enterprise platform engineering experts are building infrastructure platforms with Pulumi.
                 </p>
             </div>
             <div class="my-8 flex flex-col flex-wrap sm:flex-row justify-center">
@@ -23,9 +24,12 @@
         <h4>Session 1 |  May 6, 9 am ET / 2 pm GMT</h4>
         <h4 class="mt-0">Session 2 | May 6, 4 pm PT / May 7, 9 am AEST</h4>
         <p>
-             Join us for a virtual event featuring real-world enterprise platform engineering success stories, technical demos, and expert discussions. Hear from Pulumi leaders, engineers, and industry experts on how they’ve built platforms that automate infrastructure with Pulumi.
+            Join our virtual event for exciting product announcements, demos, and stories about how
+            real-world enterprise platform engineering experts are building infrastructure platforms with Pulumi.
         </p>
     </div>
+
+    {{ partial "event-schedule.html" (dict "schedule" .Params.schedule "bg_color" "gray-100" ) }}
 
     <section class="container mx-auto my-20 lg:mt-16 lg:mb-8 p-4">
         <div class="lg:flex">
@@ -117,8 +121,6 @@
         </div>
     </section>
     {{ end }}
-
-    {{ partial "event-schedule.html" (dict "schedule" .Params.schedule "bg_color" "gray-100" ) }}
 
     {{ partial "pulumi-up/speakers.html" (dict "speakers" .Params.speakers ) }}
 


### PR DESCRIPTION
* We are launching new products! This is exciting! But you wouldn't know it from the current page. Instead, "Lap Around Pulumi" sounds like a rehash of last year's product demos. Let's spruce this up.

* Similarly, we can tighten up the overview message, with a highlight on *excitement*.

* Finally, I don't know about you, but the first thing I like to see when considering an event is the agenda. Right now it's buried at the bottom. This change pulls it up closer to the fold.
