### PR TITLE
Update IaC Testing page links

### DIFF
--- a/content/docs/iac/concepts/testing/_index.md
+++ b/content/docs/iac/concepts/testing/_index.md
@@ -30,7 +30,7 @@ Similarly, Pulumi provides multiple testing styles for cloud programs:
 
 The following table summarizes the differences between the three approaches:
 
-|                                | [**Unit Tests**](/docs/using-pulumi/testing/unit)    | [**Property Tests**](/docs/using-pulumi/testing/property-testing)  | [**Integration Tests**](/docs/using-pulumi/testing/integration)  |
+|                                | [**Unit Tests**](/docs/iac/concepts/testing/unit)    | [**Property Tests**](/docs/iac/concepts/testing/property-testing)  | [**Integration Tests**](/docs/iac/concepts/testing/integration)  |
 |--------------------------------|---------------|---------|----------|
 | Provision real infrastructure  | No            | Yes     | Yes      |
 | Require the Pulumi CLI         | No            | Yes     | Yes      |


### PR DESCRIPTION
* Fix the link to Property Testing (went to Unit Testing page, presumably via internal redirects)
* Change all 3 links to their new paths
