### PR TITLE
Update review-project.md

### DIFF
--- a/content/docs/iac/get-started/aws/review-project.md
+++ b/content/docs/iac/get-started/aws/review-project.md
@@ -44,7 +44,7 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-{{% choosable language "javascript,typescript,go,csharp,java" %}}
+{{% choosable language "javascript,typescript,go,java" %}}
 
 <!-- The wrapping spans are infortunately necessary here; without them, the renderer gets confused and generates invalid markup. -->
 - <span>{{< langfile >}}</span> is the Pulumi program that defines your stack resources.


### PR DESCRIPTION
Remove duplicate Program.cs filename from the list of generated project files

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

The current documentation displays the same filename for `C#` stack twice:

<img width="680" alt="image" src="https://github.com/user-attachments/assets/83be2feb-d3d0-4a4a-9d06-662f05002e62" />

This PR intends to fix it
