### PR TITLE
Document snake_case to camelCase conversion for Python components

### DIFF
--- a/content/docs/iac/using-pulumi/extending-pulumi/build-a-component.md
+++ b/content/docs/iac/using-pulumi/extending-pulumi/build-a-component.md
@@ -558,6 +558,8 @@ class StaticPageArgs(TypedDict):
 
 Note that argument classes must be *serializable* and use `pulumi.Input` types, rather than the language's default types.
 
+Python class properties are typically written in lowercase with words separated by underscores, known as [`snake_case`](https://en.wikipedia.org/wiki/Snake_case), however properties in the [Pulumi package schema](https://www.pulumi.com/docs/iac/using-pulumi/extending-pulumi/schema/) are usually written in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case), where capital letters are used to separate words. To follow these conventions, the inferred schema for a component will have translated property names. In our example `index_content` will become `indexContent` in the schema. When using a component, the property names will follow the conventions of that language, for example if we use our component from TypeScript, we would refer to `indexContent`, but if we use it from Python, we would use `index_content`.
+
 {{% /choosable %}}
 
 {{% choosable language go %}}


### PR DESCRIPTION
### Proposed changes

When authoring a component in Python, its properties will be converted from `snake_case` to `camelCase` in the schema.

### Related issues (optional)

Fixes https://github.com/pulumi/docs/issues/14881
