### PR TITLE
add a non-external field for events that have internal landing pages …

### DIFF
--- a/content/events/pulumiup-apac/index.md
+++ b/content/events/pulumiup-apac/index.md
@@ -21,7 +21,8 @@ type: webinars
 # landing/registration page. If the webinar is external you will need
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
-external: true
+external: false
+internal_landing_page: true
 block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external

--- a/content/events/pulumiup-eu/index.md
+++ b/content/events/pulumiup-eu/index.md
@@ -21,7 +21,8 @@ type: webinars
 # landing/registration page. If the webinar is external you will need
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
-external: true
+external: false
+internal_landing_page: true
 block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -187,7 +187,7 @@
                     {{ if eq $data.Type "webinars" }}
 
                         <!-- Set the url to link to. -->
-                        {{ if $data.Params.external }}
+                        {{ if or $data.Params.external $data.Params.internal_landing_page }}
                             {{ $link = $data.Params.url_slug }}
                             {{ $external = true }}
                         {{ else }}
@@ -243,7 +243,7 @@
                     <!-- Set the values based on the type of the page. -->
                     {{ if eq $data.Type "webinars" }}
                         <!-- Set the url to link to. -->
-                        {{ if $data.Params.external }}
+                        {{ if or $data.Params.external $data.Params.internal_landing_page }}
                             {{ $link = $data.Params.url_slug }}
                             {{ $external = true }}
                         {{ else }}


### PR DESCRIPTION
…separate from workshop registration pages - solves RSS feed issue for full URLs

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Adds the field `internal-landing-page` for events that have non-workshop internal landing pages, allowing them to be treated differently from external pages (for RSS feed URL to generate properly, and also for general clarity on how those events entries actually work in the code)
