### PR TITLE
Fix GHA permissions

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 name: Add issues to project
 on:
   issues:

--- a/.github/workflows/automerge-workflow.yml
+++ b/.github/workflows/automerge-workflow.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 jobs:
   automerge:
     if: (github.event.pull_request.user.login == 'pulumi-bot') && (github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/check-lighthouse.yml
+++ b/.github/workflows/check-lighthouse.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 name: "Scheduled jobs: Lighthouse CI"
 on:
   schedule:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 name: "Scheduled jobs: Check links"
 on:
   schedule:

--- a/.github/workflows/check-search-urls.yml
+++ b/.github/workflows/check-search-urls.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 name: "Scheduled jobs: Check search URLs"
 on:
   schedule:

--- a/.github/workflows/customer-managed-deployment-agent-cli.yml
+++ b/.github/workflows/customer-managed-deployment-agent-cli.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi

--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi

--- a/.github/workflows/generate-provider-docs.yml
+++ b/.github/workflows/generate-provider-docs.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 env:
   PROVIDER_CATEGORY: ${{ github.event.client_payload.category }}
   PROVIDER_DISPLAY_NAME: ${{ github.event.client_payload.display-name }}

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -1,5 +1,5 @@
-permissions:
-  id-token: write
+permissions: write-all # Same as the default permissions + id-token: write
+
 env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 name: "Run Example Code Tests"
 on:
   schedule:

--- a/.github/workflows/scheduled-upgrade-programs.yml
+++ b/.github/workflows/scheduled-upgrade-programs.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 name: "Scheduled Jobs: Upgrade Examples"
 on:
   schedule:

--- a/.github/workflows/scheduled-upstream-sync.yaml
+++ b/.github/workflows/scheduled-upstream-sync.yaml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 name: "Scheduled Jobs: Upstream Sync"
 
 on:

--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -1,5 +1,4 @@
-permissions:
-  id-token: write
+permissions: write-all # Equivalent to default permissions + id-token: write
 name: "Scheduled jobs: Update Search Index"
 on:
   schedule:


### PR DESCRIPTION
The move to ESC secrets incorrectly restricted permissions on the GH
token by enabling only `id-token: write` on workflows that originally
used default token permissions. These changes update these workflows to
use `write-all` permissions, which are equivalent to the default
permisisons plus `id-token: write`.

Fixes #14896
Fixes #14897
