### PR TITLE
docs: update webinar presenters for event

### DIFF
--- a/content/events/designing-reusable-infrastructure-as-code/index.md
+++ b/content/events/designing-reusable-infrastructure-as-code/index.md
@@ -60,12 +60,9 @@ main:
 
     # The webinar presenters
     presenters:
-        - name: Rob Smith
-          role: Solutions Architect, Pulumi
-          photo: /images/team/Rob-Smith.png
-        - name: Mark Huber
-          role: Senior Product Manager, Pulumi
-          photo: /images/team/mark-huber.jpg
+        - name: Engin Diri
+          role: Snr Solutions Architect, Pulumi
+          photo: /images/team/engin-diri.jpg
 
     # case-sensitive
     tags:

--- a/content/events/designing-reusable-infrastructure-as-code/index.md
+++ b/content/events/designing-reusable-infrastructure-as-code/index.md
@@ -61,7 +61,7 @@ main:
     # The webinar presenters
     presenters:
         - name: Engin Diri
-          role: Snr Solutions Architect, Pulumi
+          role: Senior Solutions Architect, Pulumi
           photo: /images/team/engin-diri.jpg
 
     # case-sensitive


### PR DESCRIPTION
Replaced Rob Smith and Mark Huber with Engin Diri as the listed presenter for the event. Adjusted name, role, and photo accordingly to reflect the change.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
