### PR TITLE
Remove obsolete link in Pulumi Cloud Stacks page.

### DIFF
--- a/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
+++ b/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
@@ -5,6 +5,7 @@ meta_desc: "This blog shows how to build Pulumi projects and stacks from templat
 meta_image: "meta.png"
 authors: ["marc-holmes"]
 tags: ["features"]
+canonical_url: "https://www.pulumi.com/docs/pulumi-cloud/developer-platforms/new-project-wizard/"
 ---
 
 When you're able to build an app for any cloud using familiar languages,

--- a/content/docs/pulumi-cloud/projects-and-stacks.md
+++ b/content/docs/pulumi-cloud/projects-and-stacks.md
@@ -333,6 +333,6 @@ To restore a stack:
 3. Choose **Restore deleted stacks** from the dropdown.
 4. Use the three dot menu on the stack you want to restore and select **Restore stack**.
 
-## Related Blogs
+## Related Docs
 
-* [Building New Pulumi Projects and Stacks From Templates](/blog/building-new-pulumi-projects-and-stacks-from-templates/)
+* [New Project Wizard](/docs/pulumi-cloud/developer-platforms/new-project-wizard/)


### PR DESCRIPTION
Updates the Pulumi Cloud Stacks page to remove a link to a way-old blog post and replaces it with a link to the formal NPW docs.

Also adds a canonical link to the old blog post we linked to.

Authored via Claude code.