### PR TITLE
Add registry REST API docs

### DIFF
--- a/content/docs/pulumi-cloud/reference/cloud-rest-api/_index.md
+++ b/content/docs/pulumi-cloud/reference/cloud-rest-api/_index.md
@@ -6556,6 +6556,315 @@ created,custom,delete,id,modified,module,name,package,parent_urn,pending,project
 | 422    | [Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)   | Unprocessable query. Not safe to retry.                                                         | None                                       |
 | 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | Server error. Safe to retry.                                                                    | None                                       |
 
+## Registry
+
+<!-- ###################################################################### -->
+
+Resources in the Registry are identified by a three-part identifier: `{source}/{publisher}/{name}`.
+
+- **Source**: Indicates the package's origin. For example:
+  - `pulumi`: Packages published directly to the public Pulumi registry
+  - `opentofu`: OpenTofu packages bridged to Pulumi
+  - `private`: Organization-specific private registry packages
+- **Publisher**: The organization that owns the package
+  - For private packages: Matches the organization's canonical name
+  - For public packages: Managed by Registry Administrators
+- **Name**: The unique identifier for the package within its source and publisher
+
+### List Registry Packages
+
+```
+GET /api/preview/registry/packages
+```
+
+List all registry packages visible to the user.
+
+#### Parameters
+
+| Parameter           | Type    | In    | Description                                                                                                  |
+|---------------------|---------|-------|--------------------------------------------------------------------------------------------------------------|
+| `name`              | string  | query | **Optional.** Filter results to packages with this specific name                                             |
+| `orgLogin`          | string  | query | **Optional.** Filter results to packages owned by this organization                                          |
+| `limit`             | integer | query | **Optional.** Number of results to retrieve per page. Default is 100                                         |
+| `continuationToken` | string  | query | **Optional.** The continuation token to use for retrieving the next set of results if results were truncated |
+
+#### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/preview/registry/packages
+```
+
+#### Default response
+
+```
+Status: 200 OK
+```
+
+```json
+{
+  "packages": [
+    {
+      "name": "aws",
+      "publisher": "pulumi",
+      "source": "pulumi",
+      "version": "6.80.0",
+      "title": "AWS",
+      "description": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
+      "repoUrl": "https://github.com/pulumi/pulumi-aws",
+      "category": "cloud",
+      "isFeatured": false,
+      "packageTypes": [
+        "bridged"
+      ],
+      "packageStatus": "ga",
+      "readmeURL": "https://artifacts.pulumi.com/providers/f5de3f9d-cde1-4be0-a6c4-12fb7aa20cb8/docs/index.md",
+      "schemaURL": "https://artifacts.pulumi.com/providers/f5de3f9d-cde1-4be0-a6c4-12fb7aa20cb8/schema.json",
+      "createdAt": "2025-05-07T04:25:34.582Z",
+      "visibility": "public"
+    }
+  ]
+}
+```
+
+---
+
+### Get Registry Package Version
+
+```
+GET /api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}
+```
+
+Retrieve metadata for a specific package version.
+
+#### Parameters
+
+| Parameter   | Type   | In   | Description                |
+|-------------|--------|------|----------------------------|
+| `source`    | string | path | Registry source            |
+| `publisher` | string | path | Publisher name             |
+| `name`      | string | path | Package name               |
+| `version`   | string | path | Package version number (SemVer) or 'latest'  |
+
+#### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}
+```
+
+#### Default response
+
+```
+Status: 200 OK
+```
+
+```json
+{
+  "name": "aws",
+  "publisher": "pulumi",
+  "source": "pulumi",
+  "version": "6.80.0",
+  "title": "AWS",
+  "description": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
+  "repoUrl": "https://github.com/pulumi/pulumi-aws",
+  "category": "cloud",
+  "isFeatured": false,
+  "packageTypes": [
+    "bridged"
+  ],
+  "packageStatus": "ga",
+  "readmeURL": "https://artifacts.pulumi.com/providers/f5de3f9d-cde1-4be0-a6c4-12fb7aa20cb8/docs/index.md",
+  "schemaURL": "https://artifacts.pulumi.com/providers/f5de3f9d-cde1-4be0-a6c4-12fb7aa20cb8/schema.json",
+  "createdAt": "2025-05-07T04:25:34.582Z",
+  "visibility": "public"
+}
+```
+
+---
+
+### Publish Registry Package Version
+
+```
+POST /api/preview/registry/packages/{source}/{publisher}/{name}/versions
+```
+
+Initiates the process of publishing a new version of a package to the registry. This API is the first step in the package publishing workflow; it initiates the package publishing process. After uploading the required package files to the provided URLs, you must call the [Complete Registry Package Publish](#complete-registry-package-publish) API to finalize the publishing process.
+
+#### Parameters
+
+| Parameter   | Type   | In   | Description      |
+|-------------|--------|------|------------------|
+| `source`    | string | path | Registry source  |
+| `publisher` | string | path | Publisher name   |
+| `name`      | string | path | Package name     |
+
+#### Body
+
+| Key                       | Type   | In   | Description                            |
+|---------------------------|--------|------|----------------------------------------|
+| `version`                 | string | body | Version number (SemVer) of the package to publish |
+
+#### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  --request POST \
+  --data '{"version":"6.0.0"}' \
+  https://api.pulumi.com/api/preview/registry/packages/{source}/{publisher}/{name}/versions
+```
+
+#### Default response
+
+```
+Status: 202 Accepted
+```
+
+```json
+{
+  "operationID": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "uploadURLs": {
+    "schema": "https://s3.aws.amazon.com/...",
+    "index": "https://s3.aws.amazon.com/...",
+    "installationConfiguration": "https://s3.aws.amazon.com/..."
+  }
+}
+```
+
+---
+
+### Complete Registry Package Publish
+
+```
+POST /api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete
+```
+
+Complete the package publishing process after uploading all required files.
+
+This endpoint should be called after successfully uploading all files to the URLs provided by the [Publish Registry Package Version](#publish-registry-package-version). It finalizes the publishing process and makes the package version available in the registry.
+
+#### Parameters
+
+| Parameter   | Type   | In   | Description                |
+|-------------|--------|------|----------------------------|
+| `source`    | string | path | Registry source            |
+| `publisher` | string | path | Publisher name             |
+| `name`      | string | path | Package name               |
+| `version`   | string | path | Package version identifier |
+
+#### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request POST \
+  --data '{"operationID":"f47ac10b-58cc-4372-a567-0e02b2c3d479"}' \
+  https://api.pulumi.com/api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete
+```
+
+#### Default response
+
+```
+Status: 201 Created
+```
+
+```json
+{}
+```
+
+---
+
+### Delete Registry Package Version
+
+```
+DELETE /api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}
+```
+
+Delete a specific version of a package from the registry.
+
+#### Parameters
+
+| Parameter   | Type   | In   | Description                |
+|-------------|--------|------|----------------------------|
+| `source`    | string | path | Registry source            |
+| `publisher` | string | path | Publisher name             |
+| `name`      | string | path | Package name               |
+| `version`   | string | path | Package version identifier |
+
+#### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request DELETE \
+  https://api.pulumi.com/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}
+```
+
+#### Default response
+
+```
+Status: 204 No Content
+```
+
+---
+
+### Get Registry Template
+
+```
+GET /api/preview/registry/templates/{source}/{publisher}/{name}/versions/{version}
+```
+
+#### Parameters
+
+| Parameter   | Type   | In   | Description      |
+|-------------|--------|------|------------------|
+| `source`    | string | path | Registry source  |
+| `publisher` | string | path | Publisher name   |
+| `name`      | string | path | Template name    |
+| `version`   | string | path | Template version (SemVer) or 'latest' |
+
+#### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/preview/registry/templates/{source}/{publisher}/{name}/versions/{version}
+```
+
+#### Default response
+
+```
+Status: 200 OK
+```
+
+```json
+{
+    "name": "pulumi/templates/static-website-aws-yaml",
+    "publisher": "pulumi",
+    "source": "github",
+    "displayName": "static-website-aws-yaml",
+    "description": "A Pulumi YAML program to deploy a static website on AWS",
+    "language": "yaml",
+    "templateURL": "https://github.com/pulumi/templates/static-website-aws-yaml",
+    "readmeURL": "https://api.pulumi.com/api/orgs/pulumi/template/readme?url=https%3A%2F%2Fgithub.com%2Fpulumi%2Ftemplates%2Fstatic-website-aws-yaml",
+    "repoSlug": "pulumi/templates",
+    "visibility": "public",
+    "updatedAt": "2025-05-12T20:53:05.016991943Z"
+}
+```
+
+---
+
 ## Schemas
 
 ### ResourceSearchResult


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This change adds the API docs for the Registry APIs in the Pulumi Cloud service. In detail, the covered APIs are:
* POST /preview/registry/packages/{source}/{publisher}/{name}/versions
* POST /preview/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete
* GET /preview/registry/packages/{source}/{publisher}/{name}/versions/{version}
* DELETE /preview/registry/packages/{source}/{publisher}/{name}/versions/{version}
* GET /preview/registry/packages
* GET /preview/registry/templates/{source}/{publisher}/{name}/versions/{version}

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Closes https://github.com/pulumi/pulumi-service/issues/28259
