### PR TITLE
Consolidate GitHub App installation documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,3 @@ _vendor/
 *.sln
 
 .claude
->>>>>>> 702eed7c40 (Add stuff to gitignore)

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ _vendor/
 *.sln
 
 .claude
+>>>>>>> 702eed7c40 (Add stuff to gitignore)

--- a/.prettierignore
+++ b/.prettierignore
@@ -43,3 +43,4 @@ origin-bucket-metadata.json
 
 # Ignore js scripts added to the static folder
 static/js
+.claude/settings.local.json

--- a/content/docs/esc/integrations/dynamic-login-credentials/gh-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/gh-login.md
@@ -28,6 +28,10 @@ To use the provider, you must register a new GitHub App into your personal GitHu
 Other GitHub accounts then install the application into their account to grant you access with the permissions
 defined by your GitHub App.
 
+{{% notes type="info" %}}
+This is different from installing the Pulumi GitHub App for Deployments and CI/CD integration, which should be installed according to the instructions in the [GitHub App documentation](/docs/iac/using-pulumi/continuous-delivery/github-app/#installation-and-configuration).
+{{% /notes %}}
+
 - To register an app on a personal account, visit: [https://github.com/settings/apps/new](https://github.com/settings/apps/new?contents=read&metadata=read&webhook_active=false&description=Enables%20access%20for%20a%20Pulumi%20ESC%20environment.&url=https://www.pulumi.com/product/esc/).
 
 - To register an app on an organization account, visit: [https://github.com/organizations/ORGANIZATION/settings/apps/new](https://github.com/organizations/ORGANIZATION/settings/apps/new?contents=read&metadata=read&webhook_active=false&description=Enables%20access%20for%20a%20Pulumi%20ESC%20environment.&url=https://www.pulumi.com/product/esc/).

--- a/content/docs/iac/using-pulumi/continuous-delivery/github-app.md
+++ b/content/docs/iac/using-pulumi/continuous-delivery/github-app.md
@@ -38,6 +38,14 @@ This provides even more detail about any resource changes, including the full up
 
 ## Installation and Configuration
 
+{{% notes type="warning" %}}
+While the app can be installed via GitHub, it **must be installed through the Pulumi Cloud** using the steps below to ensure correct setup. Installing through the Pulumi Cloud ensures we have a connection from Pulumi to your GitHub user or organization.
+{{% /notes %}}
+
+{{% notes type="info" %}}
+To install the GitHub App, you must have admin permissions in **both** the target GitHub organization and the Pulumi organization. This is required to establish the correct connection between the two platforms.
+{{% /notes %}}
+
 1. [Sign in to your Pulumi account.](https://app.pulumi.com/signin)
 2. Ensure you have selected the Pulumi organization you wish to use with the GitHub app by choosing it in the Organization drop-down.
 3. Navigate to Settings > Integrations.
@@ -56,7 +64,12 @@ This provides even more detail about any resource changes, including the full up
 If you installed the GitHub app in the past and the steps above aren't showing it as installed for your desired organization, please try the following:
 
 1. Ensure you're a GitHub admin of the GitHub organization where you're installing the app.
-2. Uninstall the app (via github.com) and re-install it following the steps above.
+2. Uninstall the app (via github.com) and re-install it following the steps above. **Note:** Uninstalling the app will delete any push-to-deploy configurations you may have already set up.
+
+### Limitations
+
+- The GitHub app may only be installed by a user who is both a GitHub admin and a Pulumi admin.
+- By default, there is a 1:1 mapping between GitHub organizations and Pulumi organizations. If you need to map a single GitHub organization to multiple Pulumi organizations, please contact [Pulumi support](https://www.pulumi.com/support/) to request this configuration.
 
 ### Configure Git Push-to-Deploy with Pulumi Deployments
 

--- a/content/docs/iac/using-pulumi/continuous-delivery/github-app.md
+++ b/content/docs/iac/using-pulumi/continuous-delivery/github-app.md
@@ -69,7 +69,7 @@ If you installed the GitHub app in the past and the steps above aren't showing i
 ### Limitations
 
 - The GitHub app may only be installed by a user who is both a GitHub admin and a Pulumi admin.
-- By default, there is a 1:1 mapping between GitHub organizations and Pulumi organizations. If you need to map a single GitHub organization to multiple Pulumi organizations, please contact [Pulumi support](https://www.pulumi.com/support/) to request this configuration.
+- By default, there is a 1:1 mapping between GitHub organizations and Pulumi organizations. If you need to map a single GitHub organization to multiple Pulumi organizations, please contact [Pulumi support](https://www.pulumi.com/support/) to request this configuration. This option is only available for Enterprise and Business Critical customers.
 - Multiple GitHub organizations mapping to a single Pulumi organization is not currently supported.
 
 ### Configure Git Push-to-Deploy with Pulumi Deployments

--- a/content/docs/iac/using-pulumi/continuous-delivery/github-app.md
+++ b/content/docs/iac/using-pulumi/continuous-delivery/github-app.md
@@ -70,6 +70,7 @@ If you installed the GitHub app in the past and the steps above aren't showing i
 
 - The GitHub app may only be installed by a user who is both a GitHub admin and a Pulumi admin.
 - By default, there is a 1:1 mapping between GitHub organizations and Pulumi organizations. If you need to map a single GitHub organization to multiple Pulumi organizations, please contact [Pulumi support](https://www.pulumi.com/support/) to request this configuration.
+- Multiple GitHub organizations mapping to a single Pulumi organization is not currently supported.
 
 ### Configure Git Push-to-Deploy with Pulumi Deployments
 

--- a/content/docs/pulumi-cloud/deployments/reference.md
+++ b/content/docs/pulumi-cloud/deployments/reference.md
@@ -165,39 +165,13 @@ The `pulumi preview` on Pull Request capability requires that the Github user cr
 
 ### GitHub App Installation
 
-You'll need to install and configure the [Pulumi GitHub App](/docs/using-pulumi/continuous-delivery/github-app/#installation-and-configuration) to use push-to-deploy functionality. The app requires read access to your repos so it can clone your Pulumi programs and listen to merge commits to automatically trigger deployments on `git push`.
+To use push-to-deploy functionality, you'll need to install and configure the [Pulumi GitHub App](/docs/iac/using-pulumi/continuous-delivery/github-app/#installation-and-configuration). The app requires read access to your repos so it can clone your Pulumi programs and listen to merge commits to automatically trigger deployments on `git push`.
 
-{{% notes type="warning" %}}
-
-While the app can be installed via GitHub, it **must be installed through the Pulumi Cloud** using the steps below to ensure correct setup. Installing through the Pulumi Cloud ensures we have a connection from Pulumi to your GitHub user or organization.
-
-{{% /notes %}}
-
-Follow these steps:
-
-1. Ensure you have selected the Pulumi organization you wish to use with Pulumi Deployments in the Organization drop-down.
-2. Navigate to Settings > Integrations.
-3. Select the "Install the Pulumi GitHub App" button.
-
-   If this page says you already have the app installed, you can stop here. If the page asks you to accept additional permissions for the app, please accept the permissions and stop here.
-
-4. After clicking "Install" you will be directed to GitHub. Select the GitHub organization you wish to use with Pulumi Deployments.
-5. Select which repos (or all repos) Pulumi Deployments can have access to, and then Install.
-6. You will be redirected to the Pulumi Cloud (app.pulumi.com). Return to **Settings** > **Integrations** to confirm the GitHub App is installed.
-
-If you installed the GitHub app in the past and the steps above aren't showing it as installed for your desired organization, please try the following:
-
-- Ensure you're a GitHub admin of the GitHub organization where you're installing the app.
-- Uninstall the app (via GitHub) and re-install it following the steps above. **Note:** Uninstalling the app will delete any push-to-deploy configurations you may have already setup.
+The complete installation instructions are available in the [GitHub App documentation](/docs/iac/using-pulumi/continuous-delivery/github-app/#installation-and-configuration).
 
 ### Configuring settings
 
 Once the GitHub app has been installed, the deployment settings for a stack can be defined using the methods defined in the `Deployment Settings` section.
-
-### Limitations
-
-- The GitHub app may only be installed by a GitHub *and* Pulumi admin.
-- Currently, there is a 1 to 1 mapping between GitHub organizations and Pulumi organizations.
 
 ## Common Scenarios
 

--- a/content/tutorials/pulumi-deployments-click-to-deploy/index.md
+++ b/content/tutorials/pulumi-deployments-click-to-deploy/index.md
@@ -34,7 +34,7 @@ First sign in to Pulumi Cloud via the [Pulumi sign in page](https://app.pulumi.c
 
 ## Install and configure the GitHub App
 
-Next, the [Pulumi GitHub App](/docs/iac/packages-and-automation/continuous-delivery/github-app/) is required to enable Pulumi Deployment's [New Project Wizard](/docs/pulumi-cloud/developer-portals/new-project-wizard/) and push-to-deploy functionality. Follow the GitHub app [installation instructions](/docs/pulumi-cloud/deployments/reference/#github-app-installation) to ensure your Pulumi organization is set up to work seamlessly with Pulumi Deployments.
+Next, the [Pulumi GitHub App](/docs/iac/using-pulumi/continuous-delivery/github-app/) is required to enable Pulumi Deployment's [New Project Wizard](/docs/pulumi-cloud/developer-portals/new-project-wizard/) and push-to-deploy functionality. Follow the GitHub app [installation instructions](/docs/iac/using-pulumi/continuous-delivery/github-app/#installation-and-configuration) to ensure your Pulumi organization is set up to work seamlessly with Pulumi Deployments.
 
 ## Create a New Project with the New Project Wizard
 


### PR DESCRIPTION
Fixes #15033 

- Move all GitHub App installation instructions to a single location
- Add notes about admin requirements in both GitHub and Pulumi orgs
- Add info about mapping GitHub orgs to multiple Pulumi orgs
- Update links in related documentation to point to the main docs

🤖 Generated with [Claude Code](https://claude.ai/code)
