### PR TITLE
Expand Pulumi IDP to define the acronym

### DIFF
--- a/content/blog/announcing-pulumi-idp/index.md
+++ b/content/blog/announcing-pulumi-idp/index.md
@@ -20,7 +20,7 @@ social:
     linkedin: "TODO"
 ---
 
-Today, we’re excited to introduce Pulumi Internal Developer Platform (Pulumi IDP), the latest evolution of the Pulumi Cloud Platform, designed to help organizations automate, secure, and manage everything they run in the cloud.
+Today, we’re excited to introduce Pulumi IDP (Internal Developer Platform), the latest evolution of the Pulumi Cloud Platform, designed to help organizations automate, secure, and manage everything they run in the cloud.
 
 <!--more-->
 {{< blog/cta-button "Get Started with Pulumi IDP" "/docs/idp/get-started/" >}}

--- a/content/docs/idp/_index.md
+++ b/content/docs/idp/_index.md
@@ -7,8 +7,7 @@ menu:
   idp:
     identifier: idp-home
     weight: 1
-# if you have submenus, that you want to be expanded by default add their menu ids here.
-#
+
 expanded_menu_ids:
     - idp-get-started
 
@@ -29,7 +28,7 @@ sections:
 - type: flat
   heading: Overview
   description_md: |
-    Pulumi IDP gives platform teams the ability to build secure, compliant, and customizable golden paths for provisioning infrastructure. It uses a bottom-up approach, ensuring best practices are codified from the start. 
+    Pulumi IDP (Internal Developer Platform) gives platform teams the ability to build secure, compliant, and customizable golden paths for provisioning infrastructure. It uses a bottom-up approach, ensuring best practices are codified from the start. 
     
     Platform teams define building blocks using components and templates, enabling developers to provision infrastructure in the way that best suits them. Developers can leverage components when writing Pulumi programs in their preferred programming language, scaffold components using low-code YAML templates, or deploy no-code programs from the Pulumi console.
 
@@ -51,9 +50,6 @@ sections:
   - heading: Services
     link: /docs/idp/get-started/services/
     description: Bring organizational context to Pulumi through Services, the logical grouping of Pulumi entities.
-
-
-
 
 - type: flat
   heading: Have questions?


### PR DESCRIPTION
This adds an expansion of the term Pulumi IDP to the product homepage on first usage, and updates prior usage for consistent formatting. Fixes #15027

Note: After some discussion, we choose to standardize on the format of "LFA (Long Form of Acronym)" for product names that include acronyms, rather than the grammatical standard of "Long Form of Acronym (LFA)". This PR applies that standard to previous uses. Will update the style guide to reflect.