### PR TITLE
Add missing front matter for blog post meta image

### DIFF
--- a/content/blog/excluding-targets-from-stack-operations/index.md
+++ b/content/blog/excluding-targets-from-stack-operations/index.md
@@ -2,6 +2,7 @@
 title: "New in Pulumi IaC: Support for skipping a resource"
 date: 2025-05-14
 meta_desc: "Pulumi now supports excluding specific resources from stack operations, giving you more control and efficiency in managing your infrastructure"
+meta_image: meta.png
 authors:
     - tom-harding
 tags:


### PR DESCRIPTION
Meta image in blog post "support for skipping a resource" isn't showing up. That's due to a missing front matter option in the markdown.

<img width="754" alt="image" src="https://github.com/user-attachments/assets/19f13c6f-37a5-4570-8eed-7820dc868a0c" />
