### PR TITLE
fix: broken link in from-terraform page

### DIFF
--- a/content/docs/iac/adopting-pulumi/migrating-to-pulumi/from-terraform.md
+++ b/content/docs/iac/adopting-pulumi/migrating-to-pulumi/from-terraform.md
@@ -23,7 +23,7 @@ If your infrastructure was provisioned with Terraform, there are a number of opt
 * **Coexist** with resources provisioned by Terraform by referencing a `.tfstate` file.
 * **Import** existing resources into Pulumi [in the usual way](/docs/using-pulumi/adopting-pulumi/import/) or using `pulumi convert --from terraform` along with some `pulumi import --from terraform` to adopt all resources from an existing `.tfstate` file.
 * **Convert** any Terraform HCL to Pulumi code using `pulumi convert --from terraform`.
-* **Use Terraform Modules** directly within your Pulumi programs through the [Terraform Module](docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) feature.
+* **Use Terraform Modules** directly within your Pulumi programs through the [Terraform Module](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) feature.
 
 This range of techniques helps to either temporarily or permanently use Pulumi alongside Terraform, in addition to fully migrating existing infrastructure to Pulumi.
 

--- a/content/docs/iac/cli/commands/pulumi_import.md
+++ b/content/docs/iac/cli/commands/pulumi_import.md
@@ -55,7 +55,7 @@ Where import.json is a file that matches the following JSON format:
         ],
     }
 
-The full import file schema references can be found in the [import documentation](https://www.pulumi.com/docs/iac/adopting-pulumi/import/#bulk-import-operations).
+The full import file schema references can be found in the [import documentation](/docs/iac/adopting-pulumi/import/#bulk-import-operations).
 
 The import JSON file can be generated from a Pulumi program by running
 

--- a/content/docs/iac/cli/commands/pulumi_import.md
+++ b/content/docs/iac/cli/commands/pulumi_import.md
@@ -55,8 +55,7 @@ Where import.json is a file that matches the following JSON format:
         ],
     }
 
-The full import file schema references can be found in the [import documentation]
-(https://www.pulumi.com/docs/iac/adopting-pulumi/import/#bulk-import-operations).
+The full import file schema references can be found in the [import documentation](https://www.pulumi.com/docs/iac/adopting-pulumi/import/#bulk-import-operations).
 
 The import JSON file can be generated from a Pulumi program by running
 


### PR DESCRIPTION
### Proposed changes

The Terraform module link is broken on this page https://www.pulumi.com/docs/iac/adopting-pulumi/migrating-to-pulumi/from-terraform/
