### PR TITLE
Fix links Node and Python SDKs

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -239,11 +239,21 @@ iac:
     url: https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/
     weight: 1
     identifier: iac-languages-javascript-sdk
+  - name: Policy SDK docs
+    parent: iac-languages-javascript
+    url: https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/policy
+    weight: 2
+    identifier: iac-languages-javascript-policy-sdk
   - name: SDK docs
     parent: iac-languages-python
     url: https://www.pulumi.com/docs/reference/pkg/python/pulumi/
     weight: 1
     identifier: iac-languages-python-sdk
+  - name: Policy SDK docs
+    parent: iac-languages-python
+    url: https://www.pulumi.com/docs/reference/pkg/python/pulumi_policy/
+    weight: 2
+    identifier: iac-languages-python-policy-sdk
   - name: SDK docs
     parent: iac-languages-go
     url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi

--- a/content/docs/iac/languages-sdks/javascript/_index.md
+++ b/content/docs/iac/languages-sdks/javascript/_index.md
@@ -360,15 +360,8 @@ Pulumi SDKs also publish pre-release versions, that include all the latest chang
 
 ## Package Documentation
 
-In addition to the standard and cloud-agnostic packages the [Pulumi Registry](/registry/) houses 100+ Node.js packages.
+The following reference documentation resources are available:
 
-### Standard Packages
-
-<dl class="tabular">
-    <dt>Pulumi SDK</dt>
-    <dd><a href="/docs/reference/pkg/nodejs/pulumi/pulumi">@pulumi/pulumi</a></dd>
-    <dt>Pulumi Policy</dt>
-    <dd><a href="/docs/reference/pkg/nodejs/pulumi/policy">@pulumi/policy</a></dd>
-    <dt>Pulumi Terraform</dt>
-    <dd><a href="/docs/reference/pkg/nodejs/pulumi/terraform">@pulumi/terraform</a></dd>
-</dl>
+* The [Pulumi SDK `@pulumi/pulumi`](/docs/reference/pkg/nodejs/pulumi/pulumi) allows you to work with with basic Pulumi constructs. You will need to reference it in most Pulumi IaC programs.
+* The [Pulumi Policy SDK `@pulumi/policy`](/docs/reference/pkg/nodejs/pulumi/policy) allows you to author Pulumi Policy as Code policies. You will need to reference it when authoring Pulumi Policy as code.
+* For managing resources in a Pulumi IaC program, you can find the relevant SDK reference docs for a given provider in [the Pulumi Registry](/registry/).

--- a/content/docs/iac/languages-sdks/python/_index.md
+++ b/content/docs/iac/languages-sdks/python/_index.md
@@ -257,15 +257,8 @@ poetry add --allow-prereleases ${PACKAGE_NAME}
 
 ## Package Documentation
 
-In addition to the standard packages the [Pulumi Registry](/registry/) houses 100+ Python packages.
+The following reference documentation resources are available:
 
-### Standard Packages
-
-<dl class="tabular">
-    <dt>Pulumi SDK</dt>
-    <dd><a href="/docs/reference/pkg/python/pulumi">pulumi</a></dd>
-    <dt>Pulumi Policy</dt>
-    <dd><a href="/docs/reference/pkg/python/pulumi_policy">pulumi_policy</a></dd>
-    <dt>Pulumi Terraform</dt>
-    <dd><a href="/docs/reference/pkg/python/pulumi_terraform">pulumi_terraform</a></dd>
-</dl>
+* The [Pulumi SDK `pulumi`](/docs/reference/pkg/python/pulumi) allows you to work with with basic Pulumi constructs. You will need to reference it in most Pulumi IaC programs.
+* The [Pulumi Policy SDK `pulumi_policy`](/docs/reference/pkg/python/pulumi_policy) allows you to author Pulumi Policy as Code policies. You will need to reference it when authoring Pulumi Policy as code.
+* For managing resources in a Pulumi IaC program, you can find the relevant SDK reference docs for a given provider in [the Pulumi Registry](/registry/).

--- a/content/docs/iac/languages-sdks/python/python-blocking-async.md
+++ b/content/docs/iac/languages-sdks/python/python-blocking-async.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Blocking & async
         parent: iac-languages-python
-        weight: 2
+        weight: 3
     languages:
         parent: python
         weight: 5


### PR DESCRIPTION
- Remove the obsolete link to the Terraform SDK from back before the registry existed
- Add the Policy SDK links to the nav

Fixes #14674
Fixes #11513 