### PR TITLE
Fix typo in Go code in component blog

### DIFF
--- a/content/blog/pulumi-components/index.md
+++ b/content/blog/pulumi-components/index.md
@@ -656,7 +656,7 @@ func main() {
     prov, err := infer.NewProviderBuilder().
             WithNamespace("your-org-name").
             WithComponents(
-                infer.ComponentF(MyComponent),
+                infer.ComponentF(NewSecureBucket),
             ).
             Build()
     if err != nil {


### PR DESCRIPTION
The Go snippet above "Define an entry point" created a `NewSecureBucket` function, not `MyComponent`.