### PR TITLE
docs: fix no new variables left side error in build a provider example

### DIFF
--- a/content/docs/iac/using-pulumi/extending-pulumi/build-a-provider.md
+++ b/content/docs/iac/using-pulumi/extending-pulumi/build-a-provider.md
@@ -163,7 +163,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err := provider.Run(context.Background(), "file", "0.1.0")
+	err = provider.Run(context.Background(), "file", "0.1.0")
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())


### PR DESCRIPTION
### Proposed changes

- Avoid error `./main.go:26:6: no new variables on left side of :=` in provider creation guide.

