### PR TITLE
Convert Deployments FAQ to Security and Operations guide

### DIFF
--- a/content/docs/esc/faq.md
+++ b/content/docs/esc/faq.md
@@ -43,7 +43,6 @@ Yes. [Contact sales](/contact/?form=sales) for a demo or trial of self-hosted Pu
 
 - [Pulumi IaC FAQ](/docs/iac/support/faq/)
 - [Pulumi Cloud FAQ](/docs/pulumi-cloud/faq/)
-- [Pulumi Cloud Deployments FAQ](/docs/pulumi-cloud/deployments/faq/)
 - [Pulumi Cloud SCIM FAQ](/docs/pulumi-cloud/access-management/scim/faq/)
 - [Kubernetes guides FAQ](/docs/clouds/kubernetes/guides/faq/)
 - [Pulumi CrossGuard FAQ](/docs/using-pulumi/crossguard/faq/)

--- a/content/docs/iac/clouds/kubernetes/guides/faq.md
+++ b/content/docs/iac/clouds/kubernetes/guides/faq.md
@@ -63,7 +63,6 @@ aliases:
 * [Pulumi IaC FAQ](/docs/iac/support/faq/)
 * [Pulumi ESC FAQ](/docs/esc/faq/)
 * [Pulumi Cloud FAQ](/docs/pulumi-cloud/faq/)
-* [Pulumi Cloud Deployments FAQ](/docs/pulumi-cloud/deployments/faq/)
 * [Pulumi Cloud SCIM FAQ](/docs/pulumi-cloud/access-management/scim/faq/)
 * [Kubernetes guides FAQ](/docs/clouds/kubernetes/guides/faq/)
 * [Pulumi CrossGuard FAQ](/docs/using-pulumi/crossguard/faq/)

--- a/content/docs/iac/support/faq.md
+++ b/content/docs/iac/support/faq.md
@@ -83,7 +83,6 @@ Pulumi uses strongly typed languages with programming languages that support [I
 
 - [Pulumi ESC FAQ](/docs/esc/faq/)
 - [Pulumi Cloud FAQ](/docs/pulumi-cloud/faq/)
-- [Pulumi Cloud Deployments FAQ](/docs/pulumi-cloud/deployments/faq/)
 - [Pulumi Cloud SCIM FAQ](/docs/pulumi-cloud/access-management/scim/faq/)
 - [Kubernetes guides FAQ](/docs/clouds/kubernetes/guides/faq/)
 - [Pulumi CrossGuard FAQ](/docs/using-pulumi/crossguard/faq/)

--- a/content/docs/iac/using-pulumi/crossguard/faq.md
+++ b/content/docs/iac/using-pulumi/crossguard/faq.md
@@ -176,6 +176,5 @@ venv/bin/pip install -r requirements.txt
 - [Pulumi IaC FAQ](/docs/iac/support/faq/)
 - [Pulumi ESC FAQ](/docs/esc/faq/)
 - [Pulumi Cloud FAQ](/docs/pulumi-cloud/faq/)
-- [Pulumi Cloud Deployments FAQ](/docs/pulumi-cloud/deployments/faq/)
 - [Pulumi Cloud SCIM FAQ](/docs/pulumi-cloud/access-management/scim/faq/)
 - [Kubernetes guides FAQ](/docs/clouds/kubernetes/guides/faq/)

--- a/content/docs/pulumi-cloud/access-management/scim/faq.md
+++ b/content/docs/pulumi-cloud/access-management/scim/faq.md
@@ -126,6 +126,5 @@ Yes. In addition to the SCIM-managed teams, one can also configure and manage Pu
 - [Pulumi IaC FAQ](/docs/iac/support/faq/)
 - [Pulumi ESC FAQ](/docs/esc/faq/)
 - [Pulumi Cloud FAQ](/docs/pulumi-cloud/faq/)
-- [Pulumi Cloud Deployments FAQ](/docs/pulumi-cloud/deployments/faq/)
 - [Pulumi CrossGuard FAQ](/docs/using-pulumi/crossguard/faq/)
 - [Kubernetes guides FAQ](/docs/clouds/kubernetes/guides/faq/)

--- a/content/docs/pulumi-cloud/deployments/security-and-operations.md
+++ b/content/docs/pulumi-cloud/deployments/security-and-operations.md
@@ -1,17 +1,18 @@
 ---
-title_tag: "Pulumi Deployments: FAQ & Pricing"
-meta_desc: Frequently asked questions including pricing, general availability, and roadmap.
-title: FAQ
-h1: Pulumi Deployments FAQ
+title_tag: "Pulumi Deployments: Security and Operations"
+meta_desc: Security and operational considerations for Pulumi Deployments including isolation, deployment queues, dependency caching, and operational details.
+title: Security and operations
+h1: Pulumi Deployments Security and Operations
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   cloud:
-    name: FAQ
+    name: Security and operations
     parent: pulumi-cloud-deployments
     weight: 100
-    identifier: pulumi-cloud-deployments-faq
+    identifier: pulumi-cloud-deployments-security-operations
 aliases:
   - /docs/intro/deployments/faq/
+  - /docs/pulumi-cloud/deployments/faq/
 ---
 
 ## Security and Isolation

--- a/content/docs/pulumi-cloud/faq.md
+++ b/content/docs/pulumi-cloud/faq.md
@@ -218,7 +218,6 @@ used.
 
 - [Pulumi IaC FAQ](/docs/iac/support/faq/)
 - [Pulumi ESC FAQ](/docs/esc/faq/)
-- [Pulumi Cloud Deployments FAQ](/docs/pulumi-cloud/deployments/faq/)
 - [Pulumi Cloud SCIM FAQ](/docs/pulumi-cloud/access-management/scim/faq/)
 - [Pulumi CrossGuard FAQ](/docs/using-pulumi/crossguard/faq/)
 - [Kubernetes guides FAQ](/docs/clouds/kubernetes/guides/faq/)


### PR DESCRIPTION
Fixes #15203

Rename and restructure the Deployments FAQ page to better reflect its content:
- Rename faq.md to security-and-operations.md with updated titles
- Remove FAQ cross-references since new page is not FAQ format
- Add aliases to maintain backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)
