### PR TITLE
Fix broken link in IaC Best Practices Blog

### DIFF
--- a/content/blog/iac-best-practices-understanding-code-organization-stacks/index.md
+++ b/content/blog/iac-best-practices-understanding-code-organization-stacks/index.md
@@ -27,7 +27,7 @@ Here are links to all the blog posts in the series:
 * [IaC Best Practices: Enabling Developer Stacks and Git Branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/)
 * [IaC Best Practices: Structuring Pulumi Projects](/blog/iac-best-practices-structuring-pulumi-projects/)
 * [IaC Best Practices: Applying Stack References](/blog/iac-best-practices-applying-stack-references/)
-* [IaC Best Practices: Implementing RBAC and Security](/blog/iac-best-practices-rbac-and-security/)
+* [IaC Best Practices: Implementing RBAC and Security](/blog/iac-best-practices-implementing-rbac-and-security/)
 * [IaC Best Practices: Using Automation API](/blog/iac-best-practices-using-automation-api/)
 * [IaC Best Practices: Summarizing Key Learnings](/blog/iac-best-practices-summarizing-key-learnings)
 


### PR DESCRIPTION
### Proposed changes

Currently, the page https://www.pulumi.com/blog/iac-best-practices-understanding-code-organization-stacks/ has a link to [IaC Best Practices: Implementing RBAC and Security](https://www.pulumi.com/blog/iac-best-practices-rbac-and-security/), but this link leads to a 404.

This PR updates the link to the correct one: https://www.pulumi.com/blog/iac-best-practices-implementing-rbac-and-security/
