### PR TITLE
Update pulumi-cli.yml

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -137,7 +137,7 @@ jobs:
         pythonversion:
           - "3.13"
         nodeversion:
-          - "18.x"
+          - "20.x"
   notify:
     if: failure()
     name: Send slack notification


### PR DESCRIPTION
Bumps version to Node 20 from 18, because pulumi CLI now requires that and it's causing this job to fail.

Fixes #15229 