### PR TITLE
Add series tags to blog post series for improved navigation

### DIFF
--- a/content/blog/advanced-aws-networking-part-1/index.md
+++ b/content/blog/advanced-aws-networking-part-1/index.md
@@ -31,6 +31,7 @@ tags:
     - networking
     - hub-and-spoke
     - python
+series: aws-networking-advanced
 ---
 
 In this blog series you will learn how to create a hub-and-spoke network architecture in AWS with centralized egress and traffic inspection. In this first installment, we'll talk about the benefits of this architecture and begin to lay out some of its parts in Python with Pulumi, the infrastructure as code tool that enables you to manage infrastructure with real programming languages!

--- a/content/blog/advanced-aws-networking-part-2/index.md
+++ b/content/blog/advanced-aws-networking-part-2/index.md
@@ -37,6 +37,7 @@ tags:
     - networking
     - hub-and-spoke
     - python
+series: aws-networking-advanced
 
 # See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details,

--- a/content/blog/ai-slack-bot-adding-data-to-pinecone-using-s3-embedchain-and-pulumi-on-aws/index.md
+++ b/content/blog/ai-slack-bot-adding-data-to-pinecone-using-s3-embedchain-and-pulumi-on-aws/index.md
@@ -10,6 +10,7 @@ tags:
 - slack
 - chatbot
 - ai
+series: ai-slack-bot
 meta_desc: "Learn how to add data to Pinecone using S3, Embedchain and Pulumi on AWS for an AI Slack bot."
 date: 2024-04-10T17:00:00+01:00
 meta_image: meta.png

--- a/content/blog/ai-slack-bot-to-chat-using-embedchain-and-pulumi-on-aws/index.md
+++ b/content/blog/ai-slack-bot-to-chat-using-embedchain-and-pulumi-on-aws/index.md
@@ -9,6 +9,7 @@ tags:
 - slack
 - chatbot
 - ai
+series: ai-slack-bot
 meta_desc: "Learn how to build an AI-powered Slack bot with Embedchain & Pulumi on AWS."
 date: 2024-03-18T17:21:02+01:00
 updated: 2025-03-20

--- a/content/blog/ai-slackbot-in-real-time-using-s3-sqs-and-pulumi-on-aws-uploading-documents/index.md
+++ b/content/blog/ai-slackbot-in-real-time-using-s3-sqs-and-pulumi-on-aws-uploading-documents/index.md
@@ -12,6 +12,7 @@ tags:
 - sqs
 - s3
 - ai
+series: ai-slack-bot
 meta_desc: "Uploading documents to your AI Slackbot in real-time using S3, SQS and Pulumi on AWS"
 date: 2024-06-03T17:21:02+01:00
 meta_image: meta.png

--- a/content/blog/architecture-as-code-intro/index.md
+++ b/content/blog/architecture-as-code-intro/index.md
@@ -10,6 +10,7 @@ tags:
     - serverless
     - architecture-as-code
     - microservices
+series: architecture-as-code
 ---
 
 Abstraction is key to building resilient systems because it encapsulates behavior and decouples code, letting each component perform its function independently. The same principles apply to infrastructure, where we want to declare behavior or state and not implementation details. As an industry, we've moved away from monolithic applications to distributed systems such as serverless, microservices, Kubernetes, and virtual machine deployments. In this article, we'll take a closer look at the characteristics of these architectures and how Pulumi can abstract the components that comprise these systems.

--- a/content/blog/architecture-as-code-kubernetes/index.md
+++ b/content/blog/architecture-as-code-kubernetes/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - kubernetes
+series: architecture-as-code
 ---
 
 This is the fifth and last installment of the [Architecture as Code](/blog/architecture-as-code-intro/) series. In previous articles, we examined how to create reusable components for the primary architectural patterns for cloud infrastructure. Starting with [virtual machines](/blog/architecture-as-code-vm/), we examined how to create and configure VMs. In the follow-up article, we demonstrated how to create reusable components from resources that comprise a [microservices](/blog/architecture-as-code-microservices/) architecture. After microservices, we looked at [serverless](/blog/architecture-as-code-serverless/) architecture, which despite its name, also requires additional resources to deploy a function or application. In this article, we’ll look at deployment patterns for Kubernetes with a focus on multi-tenancy issues.

--- a/content/blog/architecture-as-code-microservices/index.md
+++ b/content/blog/architecture-as-code-microservices/index.md
@@ -8,6 +8,7 @@ authors:
 tags:
     - architecture-as-code
     - microservices
+series: architecture-as-code
 ---
 
 This article is the third in a series about Architecture as Code. The [first article](/blog/architecture-as-code-intro/) provided an overview of virtual machines, microservices, serverless, and Kubernetes. The [second](/blog/architecture-as-code-vm/) one went in-depth on deploying virtual machines as reusable components. In this third installment, we'll look at microservices and how to implement them as reusable components with Pulumi.

--- a/content/blog/architecture-as-code-serverless/index.md
+++ b/content/blog/architecture-as-code-serverless/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - serverless
+series: architecture-as-code
 ---
 
 In this fourth installment of Architecture as Code series, we’ll take a look at serverless, an architectural pattern that has quickly gained popularity among cloud practitioners. There are two reasons why serverless usage has proliferated: a cost-saving pay as you go model and elasticity that goes from zero to as many as needed to complete the task without managing servers.

--- a/content/blog/architecture-as-code-vm/index.md
+++ b/content/blog/architecture-as-code-vm/index.md
@@ -8,6 +8,7 @@ authors:
 tags:
     - architecture-as-code
     - virtual-machines
+series: architecture-as-code
 ---
 
 In a [previous article](/blog/architecture-as-code-intro/), we presented an overview of four infrastructure patterns for deploying modern applications. The article reviewed virtual machines, serverless, Kubernetes, and microservices. In this post, we'll examine virtual machines in-depth.

--- a/content/blog/cloud-systems-part-one/index.md
+++ b/content/blog/cloud-systems-part-one/index.md
@@ -16,6 +16,7 @@ tags:
     - 101
     - tutorials
     - cloud-engineering
+series: cloud-systems
 ---
 
 Cloud engineering is taking over software development. In a lot of ways, this is great; it allows us to build and deploy more complicated applications with less difficulty, and maintaining those applications becomes less troublesome too. We can release smaller updates more quickly than ever, ensuring that we can stay on top of feature requests and security issues. That said, the rise of cloud engineering has also introduced a lot of complexity in the form of dozens of services even within just one cloud provider. Figuring out where to start can be tough, so let’s take a practical tour! In this series, I’ll walk you through building a personal website and deploying it using modern cloud engineering practices.

--- a/content/blog/cloud-systems-part-three/index.md
+++ b/content/blog/cloud-systems-part-three/index.md
@@ -15,6 +15,7 @@ tags:
     - aws
     - tutorials
     - docker
+series: cloud-systems
 ---
 
 Cloud engineering is taking over software development. In a lot of ways, this is great; it allows us to build and deploy more complicated applications with less difficulty, and maintaining those applications becomes less troublesome too. We can release smaller updates more quickly than ever, ensuring that we can stay on top of feature requests and security issues. That said, the rise of cloud engineering has also introduced a lot of complexity in the form of dozens of services even within just one cloud provider. Figuring out where to start can be tough, so let’s take a practical tour! In this series, I’ll walk you through building a personal website and deploying it using modern cloud engineering practices.

--- a/content/blog/cloud-systems-part-two/index.md
+++ b/content/blog/cloud-systems-part-two/index.md
@@ -16,7 +16,7 @@ tags:
     - cloud-systems
     - tutorials
     - docker
-
+series: cloud-systems
 ---
 
 Cloud engineering is taking over software development. In a lot of ways, this is great; it allows us to build and deploy more complicated applications with less difficulty, and maintaining those applications becomes less troublesome too. We can release smaller updates more quickly than ever, ensuring that we can stay on top of feature requests and security issues. That said, the rise of cloud engineering has also introduced a lot of complexity in the form of dozens of services even within just one cloud provider. Figuring out where to start can be tough, so let’s take a practical tour! In this series, I’ll walk you through building a personal website and deploying it using modern cloud engineering practices.

--- a/content/blog/embrace-kubernetes-part1/index.md
+++ b/content/blog/embrace-kubernetes-part1/index.md
@@ -7,7 +7,7 @@ authors:
     - lee-briggs
 tags:
     - kubernetes
-
+series: embrace-kubernetes
 ---
 
 When you’re considering whether or not to implement Kubernetes, perhaps the first question to ask yourself is do you need it at all?

--- a/content/blog/embrace-kubernetes-part2/index.md
+++ b/content/blog/embrace-kubernetes-part2/index.md
@@ -7,7 +7,7 @@ authors:
     - lee-briggs
 tags:
     - kubernetes
-
+series: embrace-kubernetes
 ---
 
 In the [first article](/blog/embrace-kubernetes-part1/) in this series,  we gave you some questions to help you and others at your company decide if Kubernetes is right for you. In this post, we’ll give you an example of where Kubernetes can be a good fit.

--- a/content/blog/getting-started-with-k8s-part1/index.md
+++ b/content/blog/getting-started-with-k8s-part1/index.md
@@ -7,7 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - Kubernetes
-
+series: kubernetes-getting-started
 ---
 
 Containers solved the problem of moving software from one environment to another because they encapsulate all the software dependencies. However, an orchestration platform is needed to manage containers at scale. [Kubernetes](https://kubernetes.io/) is a popular open-source solution that uses declarative configuration to specify the desired state of the application. Configuring and deploying an application on Kubernetes is often accomplished with YAML files to define the state and command line tools to manage and control the Kubernetes API. This article demonstrates how to use infrastructure as code to create [basic Kubernetes objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#kubernetes-objects) and higher-level abstractions that build upon the basic objects.

--- a/content/blog/getting-started-with-k8s-part2/index.md
+++ b/content/blog/getting-started-with-k8s-part2/index.md
@@ -7,7 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - Kubernetes
-
+series: kubernetes-getting-started
 ---
 
 Welcome to the second article in a series using infrastructure as code to deploy applications with Kubernetes. The series walks you through building a Kubernetes cluster on cloud providers, deploying applications, and “Day 2” activities such as migrating Node groups. In the [previous article](/blog/getting-started-with-k8s-part1/), we showed how to create a Kubernetes cluster for AWS, Azure, and GCP. In this installment, we’ll learn how to deploy an application using Kubernetes objects.

--- a/content/blog/getting-started-with-k8s-part3/index.md
+++ b/content/blog/getting-started-with-k8s-part3/index.md
@@ -7,7 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - Kubernetes
-
+series: kubernetes-getting-started
 ---
 
 Welcome to the third article in a series using infrastructure as code to deploy applications with Kubernetes. In the previous post, we reviewed basic Kubernetes objects and abstractions used when deploying an application. We examined code examples across the cloud providers to show how to use infrastructure as code to deploy an application using Kubernetes objects. In this installment, we’ll progress from a simple deployment with just a single application container to a complex application with multiple containers and Pods.

--- a/content/blog/getting-started-with-k8s-part4/index.md
+++ b/content/blog/getting-started-with-k8s-part4/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - Kubernetes
+series: kubernetes-getting-started
 ---
 
 This article is the fourth in a series using infrastructure as code to deploy applications with Kubernetes. This series walks you through:

--- a/content/blog/getting-started-with-k8s-part5/index.md
+++ b/content/blog/getting-started-with-k8s-part5/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - Kubernetes
+series: kubernetes-getting-started
 ---
 
 In previous installments, we examined how to deploy applications. However, we only touched on how applications talk to each other inside and outside the cluster. Whether you are building a modern application or modernizing a legacy application, understanding how resources and components talk to each other is essential. In this installment, we’ll examine networking in Kubernetes.

--- a/content/blog/getting-started-with-k8s-part6/index.md
+++ b/content/blog/getting-started-with-k8s-part6/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - kubernetes
+series: kubernetes-getting-started
 ---
 
 Your application made it out of the dev stage, passed the testing stage, and arrived in production. As a developer, you might think that it's an ops problem now. However, DevOps is a collaborative effort between developers and operators to build and maintain applications using shared techniques and processes, often called "Day 2" activities.

--- a/content/blog/iac-best-practices-applying-stack-references/index.md
+++ b/content/blog/iac-best-practices-applying-stack-references/index.md
@@ -11,6 +11,7 @@ tags:
     - best-practices
     - cloud-engineering
     - kubernetes
+series: iac-best-practices
 aliases:
     - /blog/iac-recommended-practices-using-stack-references/
 ---

--- a/content/blog/iac-best-practices-enabling-developer-stacks-git-branches/index.md
+++ b/content/blog/iac-best-practices-enabling-developer-stacks-git-branches/index.md
@@ -13,6 +13,7 @@ tags:
     - cloud-engineering
     - aws
     - eks
+series: iac-best-practices
 aliases:
     - /blog/iac-recommended-practices-developer-stacks-git-branches/
 ---

--- a/content/blog/iac-best-practices-implementing-rbac-and-security/index.md
+++ b/content/blog/iac-best-practices-implementing-rbac-and-security/index.md
@@ -11,6 +11,7 @@ tags:
     - best-practices
     - rbac
     - security
+series: iac-best-practices
 aliases:
     - /blog/iac-recommended-practices-rbac-and-security/
 ---

--- a/content/blog/iac-best-practices-structuring-pulumi-projects/index.md
+++ b/content/blog/iac-best-practices-structuring-pulumi-projects/index.md
@@ -11,6 +11,7 @@ authors:
 tags:
     - best-practices
     - cloud-engineering
+series: iac-best-practices
 aliases:
     - /blog/iac-recommended-practices-structuring-pulumi-projects/
 ---

--- a/content/blog/iac-best-practices-summarizing-key-learnings/index.md
+++ b/content/blog/iac-best-practices-summarizing-key-learnings/index.md
@@ -10,6 +10,7 @@ authors:
     - scott-lowe
 tags:
     - best-practices
+series: iac-best-practices
 aliases:
     - /blog/iac-recommended-practices-wrapping-up/
 ---

--- a/content/blog/iac-best-practices-understanding-code-organization-stacks/index.md
+++ b/content/blog/iac-best-practices-understanding-code-organization-stacks/index.md
@@ -13,6 +13,7 @@ tags:
     - cloud-engineering
     - aws
     - eks
+series: iac-best-practices
 aliases:
     - /blog/iac-recommended-practices-code-organization-and-stacks/
 ---

--- a/content/blog/iac-best-practices-using-automation-api/index.md
+++ b/content/blog/iac-best-practices-using-automation-api/index.md
@@ -11,6 +11,7 @@ tags:
     - best-practices
     - automation-api
     - go
+series: iac-best-practices
 aliases:
     - /blog/iac-recommended-practices-using-automation-api/
 ---

--- a/content/blog/kubernetes-fundamentals-part-one/index.md
+++ b/content/blog/kubernetes-fundamentals-part-one/index.md
@@ -8,6 +8,7 @@ authors:
     - kat-cosgrove
 tags:
     - kubernetes
+series: kubernetes-fundamentals
 ---
 Kubernetes is everywhere now, but it’s primarily been the domain of people working on the Ops side of infrastructure. What about devs, though? You benefit from knowing what Kubernetes is and how to use it, too -- otherwise, we’re still putting teams in silos. In this tutorial, we’re going to define Kubernetes at a high level, talk about the anatomy of a cluster, and learn not just why you should care but how to try it for yourself. We’ll start with local deployments using YAML before getting a little help from infrastructure as code with Pulumi to stand up everything right inside our sample application in a programming language you’re already writing!
 

--- a/content/blog/kubernetes-fundamentals-part-two/index.md
+++ b/content/blog/kubernetes-fundamentals-part-two/index.md
@@ -9,6 +9,7 @@ authors:
 tags:
     - kubernetes
     - google-cloud
+series: kubernetes-fundamentals
 ---
 Kubernetes is everywhere now, but it’s primarily been the domain of people working on the ops side of infrastructure. What about devs, though? You benefit from knowing what Kubernetes is and how to use it, too&mdash;otherwise, we’re still putting teams in silos. In this blog, we're going to build off part one by learning about managed Kubernetes services: what they are, when they're useful, and how you can try deploying to one yourself, starting with Google's Kubernetes Engine (GKE).
 <!--more-->

--- a/content/blog/managing-aws-credentials-on-cicd-part-1/index.md
+++ b/content/blog/managing-aws-credentials-on-cicd-part-1/index.md
@@ -8,6 +8,7 @@ authors:
     - sophia-parafina
 tags:
     - continuous-delivery
+series: aws-credentials-cicd
 ---
 
 Continuous delivery requires providing highly sensitive credentials to your

--- a/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
+++ b/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
@@ -10,6 +10,7 @@ tags:
     - continuous-delivery
     - security
     - secrets
+series: aws-credentials-cicd
 ---
 
 This article is the second part of a series on best practices for securely managing AWS credentials on CI/CD. In this article, we go in-depth on providing AWS credentials securely to a 3rd party and introduce a Pulumi program to automate rotating access keys.

--- a/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
+++ b/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
@@ -10,6 +10,7 @@ tags:
     - continuous-delivery
     - security
     - secrets
+series: aws-credentials-cicd
 ---
 
 This article is the third part of a series on best practices for securely managing AWS credentials on CI/CD. In this article, we cover the

--- a/content/blog/organizational-patterns-automation-team/index.md
+++ b/content/blog/organizational-patterns-automation-team/index.md
@@ -30,6 +30,7 @@ authors:
 # At least one tag is required. Lowercase, hyphen-delimited is recommended.
 tags:
     - development-environment
+series: organizational-patterns
 
 # See the blogging docs at https://github.com/pulumi/docs/blob/master/BLOGGING.md.
 # for additional details, and please remove these comments before submitting for review.

--- a/content/blog/organizational-patterns-developer-portal/index.md
+++ b/content/blog/organizational-patterns-developer-portal/index.md
@@ -14,7 +14,7 @@ authors:
 tags:
     - development-environment
     - automation-api
-
+series: organizational-patterns
 ---
 
 Using Pulumi is more than just writing code and components. In addition to common software development practices, there are also a number of success patterns related to how your company or team builds and deploys Pulumi programs to successfully build, deploy, and manage your infrastructure and applications. In this continuation of a series, I will explore one of these patterns - using the Pulumi [Automation API](https://www.pulumi.com/docs/using-pulumi/automation-api/) to create a developer portal.

--- a/content/blog/organizational-patterns-infra-repo/index.md
+++ b/content/blog/organizational-patterns-infra-repo/index.md
@@ -24,7 +24,7 @@ authors:
 
 tags:
     - development-environment
-
+series: organizational-patterns
 ---
 
 Using Pulumi is more than just writing code and components. In addition to common software development practices, there are also a number of success patterns related to how your company or team builds and deploys Pulumi programs to successfully build, deploy, and manage your infrastructure and applications. In this first post of a series, I will explore one of these patterns - the centralized platform infrastructure repository.

--- a/content/blog/top-5-things-for-azure-devs-devops/index.md
+++ b/content/blog/top-5-things-for-azure-devs-devops/index.md
@@ -10,6 +10,7 @@ tags:
     - azure
     - pipelines
     - devops
+series: azure-top-5
 ---
 
 What comes to mind when you hear DevOps? Frequently, DevOps is described as a cultural practice that enables an organization to deliver high-quality applications quickly. The DevOps model emphasizes the "breaking down of silos" and combining development and operations into a single team. Developing, deploying, and maintaining an application is the responsibility of both developers and operators across the application lifecycle.

--- a/content/blog/top-5-things-for-azure-devs-intro/index.md
+++ b/content/blog/top-5-things-for-azure-devs-intro/index.md
@@ -11,6 +11,7 @@ tags:
     - serverless
     - AKS
     - devops
+series: azure-top-5
 ---
 
 The Azure cloud platform includes over 200 products and cloud services. Wherever you are in your Microsoft cloud engineering journey, you should be familiar with these top 5 cloud tasks that are essential building blocks commonly used to deploy applications and infrastructure to the Azure cloud.

--- a/content/blog/top-5-things-for-azure-devs-kubernetes-apps/index.md
+++ b/content/blog/top-5-things-for-azure-devs-kubernetes-apps/index.md
@@ -10,7 +10,7 @@ tags:
     - kubernetes
     - Azure
     - helm
-
+series: azure-top-5
 ---
 
 All modern software is cloud software, and it's more than likely that it runs on Kubernetes. Developers are faced with the challenge of deploy applications composed of many microservices. And each microservice adds to the complexity of the deployment.

--- a/content/blog/top-5-things-for-azure-devs-kubernetes-infrastructure/index.md
+++ b/content/blog/top-5-things-for-azure-devs-kubernetes-infrastructure/index.md
@@ -10,6 +10,7 @@ tags:
     - Kubernetes
     - AKS
     - Azure
+series: azure-top-5
 ---
 
 History lesson time! In 2011, microservices debuted as an architectural style suited for the cloud. In 2013, Docker simplified building containers. Combining containers and microservices sparked a change in how applications were built and distributed in the cloud. As performance, scaling, and reliability became an increasing concern, container orchestration platforms became widely available. Kubernetes became the dominant container orchestration through community and corporate support, and some have suggested it was [inevitable](https://elastisys.com/why-kubernetes-was-inevitable/). Every major cloud service provider, including Azure, offers a version of Kubernetes.

--- a/content/blog/top-5-things-for-azure-devs-serverless/index.md
+++ b/content/blog/top-5-things-for-azure-devs-serverless/index.md
@@ -10,7 +10,7 @@ tags:
     - azure
     - serverless
     - cloud engineering
-
+series: azure-top-5
 ---
 
 The [previous article](/blog/top-5-things-for-azure-devs-vm/) was a deep dive into virtual machines. First, we used the Azure Portal to create and deploy a virtual machine; then, we repeated the process using infrastructure as code. We further demonstrated how to automate provisioning as part of cloud engineering's build and deploy processes.

--- a/content/blog/top-5-things-for-azure-devs-static-websites/index.md
+++ b/content/blog/top-5-things-for-azure-devs-static-websites/index.md
@@ -9,6 +9,7 @@ authors:
 tags:
     - azure
     - static websites
+series: azure-top-5
 ---
 
 Static web applications are a popular way to publish websites. There are many reasons for adopting static web applications, including speed, security, version control, scalability, and reduced cost.

--- a/content/blog/top-5-things-for-azure-devs-vm/index.md
+++ b/content/blog/top-5-things-for-azure-devs-vm/index.md
@@ -8,6 +8,7 @@ authors:
 tags:
     - azure
     - virtual machines
+series: azure-top-5
 ---
 
 So you want to be an Azure dev and all-around infrastructure wizard? Let's start with the basics, virtual machines! In the [previous article](/blog/top-5-things-for-azure-devs-intro/), the common use case for virtual machines is migrating applications from dedicated hardware. You want full control of the machine to install required software for the application or configure storage and networking.


### PR DESCRIPTION
## Summary
Added `series:` frontmatter tags to 47 blog posts across 12 identified series to enable chronological series navigation similar to the platform-engineering-pillars series.

## Series Tagged
- **iac-best-practices** (7 posts) - Infrastructure as Code best practices
- **kubernetes-getting-started** (6 posts) - Comprehensive Kubernetes guide
- **azure-top-5** (7 posts) - Essential Azure services for developers
- **architecture-as-code** (5 posts) - Different architectural patterns
- **aws-networking-advanced** (2 posts) - Hub-and-spoke architecture
- **aws-credentials-cicd** (3 posts) - Security best practices for CI/CD
- **cloud-systems** (3 posts) - Modern cloud engineering practices
- **ai-slack-bot** (3 posts) - Building AI bots with Pulumi on AWS
- **organizational-patterns** (3 posts) - Platform team organization patterns
- **kubernetes-fundamentals** (2 posts) - Basic Kubernetes concepts
- **embrace-kubernetes** (2 posts) - Evaluating and adopting Kubernetes

## Impact
- Improves content discoverability
- Provides chronological navigation within series
- Enhances user experience for learning paths
- Maintains consistency with existing platform-engineering-pillars series

## Test plan
- [x] All markdown files pass linting
- [x] Prettier formatting checks pass
- [ ] Verify series navigation appears correctly on blog posts