### PR TITLE
Restore /b/ PPC landing pages

### DIFF
--- a/content/b/_index.md
+++ b/content/b/_index.md
@@ -1,0 +1,256 @@
+---
+######################################################################################################
+#                    This is a PPC landing page, exclusively for paid ads                            #
+######################################################################################################
+title: Pulumi - Universal Infrastructure as Code
+meta_desc: Pulumi's open source infrastructure as code SDK enables you to create, deploy, and manage infrastructure on any cloud, using your favorite languages.
+
+block_external_search_index: true
+
+type: page
+layout: home-b
+
+hero:
+  title: [ "Automate your infrastructure at any scale", "Your Code, Your Cloud, Your Success" ]
+  description: |
+    Build, manage, and scale your infrastructure, secrets, and configurations in one place.
+  cta_text: Get Started
+  cta_link: /docs/iac/get-started/
+  secondary_cta_text: Talk to a human
+  secondary_cta_link: /contact/?form=sales
+
+code_faster:
+  title: Build and ship faster with infrastructure as code
+  description: |
+    Author infrastructure code using programming languages you know and love. Write statements to define infrastructure using your IDE with autocomplete, type checking, and documentation.
+
+security:
+  title: Drive security and compliance
+  image: /images/solutions/ai/ai_save_cost.svg
+  description: |
+    Enforce compliance and security, understand cloud usage, and discover cost savings to drive better efficiency, security, and reliability across all cloud assets.
+
+ai:
+  title: Code on demand with Pulumi AI
+  image: /images/home/ai-graphic.svg
+  alt: AI prompted to 'Give me an AWS static website behind a CloudFront CDN' and outputting Pulumi code
+  description: |
+    Want help writing infrastructure code? Use Pulumi AI to generate code for your desired infrastructure – all through natural language commands.
+
+    Ask Pulumi AI to iterate on your code to make changes and add new resources.
+
+embed:
+  title: Build productive platforms for both developers and operators
+  image: /blog/developer-portal-platform-teams/platform-teams.png
+  alt: a flowchart with arrows going from Automation API program to Infrasctucture as Code programs to Pulumi Engine deploys stacks
+  description: |
+    Internal developer portals (IDPs) enable your developers to quickly provision security-compliant infrastructure, boost productivity with pre-configured architectures and automate testing and deployments, adhering to organizational standards.
+
+    Pulumi’s infrastructure and policy as code engine fosters collaboration between your developers, security, and operation teams through common, popular programming languages.
+
+secrets:
+  title: Manage configuration and secrets with modular Environments
+  image: /blog/environments-secrets-configurations-management/esc.gif
+  alt: a screenshot of Pulumi ESC
+  description: |
+    Easy-to-use single source of truth for all configurations with guardrails. Seamlessly adopt short-lived dynamic secrets. Never have downtime over changed configurations because you can change once and have it updated everywhere. Enforce least-privileged access through role-based access controls.
+
+customer_logos:
+  title: Trusted by your peers
+  logos:
+    - name: bmw
+      link: /case-studies/
+    - name: snowflake
+      link: /case-studies/
+    - name: nvidia
+      link: /case-studies/
+    - name: moderna
+      link: /case-studies/
+    - name: docker
+      link: /case-studies/
+    - name: unity
+      link: /case-studies/
+    - name: deloitte
+      link: /case-studies/
+    - name: stokespace
+      link: /case-studies/
+    - name: univision
+      link: /case-studies/
+    - name: washington-trust
+      link: /case-studies/
+    - name: kyruus
+      link: /case-studies/
+    - name: modular-ai
+      link: /case-studies/
+    - name: korber
+      link: /case-studies/    
+    - name: lemonade
+      link: /case-studies/
+    - name: pinecone
+      link: /case-studies/
+    - name: ware2go
+      link: /case-studies/
+    - name: nubank
+      link: /case-studies/
+    - name: mindbody
+      link: /case-studies/
+    - name: fenergo
+      link: /case-studies/
+    - name: webflow
+      link: /case-studies/
+    - name: bluenile
+      link: /case-studies/
+    - name: dutchie
+      link: /case-studies/
+    - name: panther-labs
+      link: /case-studies/
+    - name: materialize
+      link: /case-studies/
+    - name: altana
+      link: /case-studies/
+    - name: mercedes-benz
+      link: /case-studies/
+    - name: bt
+      link: /case-studies/
+    - name: portx
+      link: /case-studies/
+    - name: tivityhealth
+      link: /case-studies/
+    - name: starburst
+      link: /case-studies/
+    - name: linktree
+      link: /case-studies/
+
+customer_quotes:
+  panther:
+    text: |
+      “Our developers needed a fast, modular, and testable platform for managing cloud infrastructure. <b>Nothing is better than having standard programming languages for building and managing infrastructure</b>”
+    author: Austin Byers, Principal Platform Engineer
+    logo: panther-labs
+  starburst:
+    text: |
+      “Pulumi let us build and <b>automate cloud infrastructure projects</b> at a scale that simply wasn’t imaginable using prior-generation infrastructure as code technologies”
+    author: Matt Stephenson, Senior Principal Software Engineer
+    logo: starburst
+  snowflake:
+    text: |
+      “Pulumi helped our team to ship a new product faster. We needed <b>one tool to setup and manage multi-cloud, multi-region Kubernetes clusters</b> that infrastructure and applications teams could use collaboratively”
+    author: Justin Fitzhugh, VP of Cloud Platform Engineering
+    logo: snowflake
+
+get_started:
+  tweets:
+    -
+      source: twitter
+      username: "@BryanMigliorisi"
+      avatar: https://pbs.twimg.com/profile_images/752334791782039552/BsVNGBaV_400x400.jpg
+      link: https://twitter.com/BryanMigliorisi/status/1450123026901651460
+      text: |
+        There is no way around the fact that devops is complicated but @PulumiCorp is a game changer for me.  Blows away CloudForamtion, TerraForm, CDK, etc.
+    -
+      source: twitter
+      username: "@krangarajan"
+      avatar: https://pbs.twimg.com/profile_images/837774934805925888/I51_kI-H_400x400.jpg
+      link: https://twitter.com/krangarajan/status/1580618068203479040
+      text: |
+        Continuing on my thread about @PulumiCorp from a while ago: holy shit I am a convert. I needed to setup a staging environment that was mostly identical to prod, and once I trued up our Pulumi stack with AWS, it took *minutes* to do this. How have I lived without this until now?
+    -
+      source: twitter
+      username: "@Vetium"
+      avatar: https://pbs.twimg.com/profile_images/1197754531335016449/etr4hfpJ_400x400.jpg
+      link: https://twitter.com/Vetium/status/1589452885149900800
+      text: |
+        Without a doubt the most approachable tool in the IaaC space is
+        @PulumiCorp.
+
+        Somewhat enjoying provisioning a scheduled run of a Lambda.
+    -
+      source: twitter
+      username: "@justedagain"
+      avatar: https://pbs.twimg.com/profile_images/1576905831626440706/wigR9_hF_400x400.jpg
+      link: https://twitter.com/justedagain/status/1583063827524251649
+      text: |
+        The developer experience of Pulumi is just sublime. As a prior Terraform user, the grass is substantially greener on this side. I'm so glad I made the switch two years back. Using Terraform for my current use case would be a massive downgrade.
+    -
+      source: twitter
+      username: "@hossambarakat_"
+      avatar: https://pbs.twimg.com/profile_images/1578466430739271681/FZnNwxcA_400x400.jpg
+      link: https://twitter.com/hossambarakat_/status/1357640859018162176
+      text: |
+        Give Pulumi a shot and you will never look back @PulumiCorp
+    -
+      source: twitter
+      username: "@matticala"
+      avatar: https://pbs.twimg.com/profile_images/1289826906024693766/LOdbjWdW_400x400.jpg
+      link: https://twitter.com/matticala/status/1369038327341531140
+      text: |
+        With @PulumiCorp I said goodbye to #YAML and JSON supersets.
+        I went back to what I love: #code.
+        Code. End to end. Functional, even.
+        #Kubernetes is pleasant again.
+    -
+      source: twitter
+      username: "@ddoomen"
+      avatar: https://pbs.twimg.com/profile_images/1591057460940480517/d0xy4n3b_400x400.jpg
+      link: https://twitter.com/ddoomen/status/1644343201459740673
+      text: |
+        Deploying cloud resources using @PulumiCorp is just amazing. Why would anybody bother with JSON, YAML or some other DSL?
+    -
+      source: twitter
+      username: "@Meliora245"
+      avatar: https://pbs.twimg.com/profile_images/1536753333972525056/WN2SVAmq_400x400.jpg
+      link: https://twitter.com/Meliora245/status/1633110529420976130
+      text: |
+        Been using Pulumi with Typescript for a IaaC managing k8s and stateful databases. Don't see myself going back to using terraform after this.
+    -
+      source: twitter
+      username: "@rybavery"
+      avatar: https://pbs.twimg.com/profile_images/1146562967317520385/wuPwKFUZ_400x400.jpg
+      link: https://twitter.com/rybavery/status/1576987704189128704
+      text: |
+        our team at @devseed is now gravitating toward using https://pulumi.com/docs/concepts/vs/terraform/ instead of terraform because it's all in python so it is easier to onboard new people to the tool and makes it easier to manage the same infra definition in different test, staging, and deploy envs.
+    -
+      source: twitter
+      username: "@SparkyCodes"
+      avatar: https://pbs.twimg.com/profile_images/1564710917014802433/k0QzTysD_400x400.jpg
+      link: https://twitter.com/SparkyCodes/status/1572999315919978502
+      text: |
+        It wouldn't have been possible to build Sparky without @PulumiCorp. Shout out to the team and community for helping us get up and running!
+    -
+      source: twitter
+      username: "@0xksure"
+      avatar: https://pbs.twimg.com/profile_images/1560526743865360384/QBkajFhq_400x400.jpg
+      link: https://twitter.com/0xksure/status/1570769681434415104
+      text: |
+        ok so pulumi is awesome. almost no clicking, just scripting go and up
+    -
+      source: twitter
+      username: "@krangarajan"
+      avatar: https://pbs.twimg.com/profile_images/837774934805925888/I51_kI-H_400x400.jpg
+      link: https://twitter.com/krangarajan/status/1564712184717881344
+      text: |
+        New gig uses @PulumiCorp to manage AWS infra. Initially I was skeptical and was tempted to go back to Terraform, but after using pulumi imports and discovering the ability to write tests easily, I'm a convert. (1/4)
+    -
+      source: twitter
+      username: "@swarupdonepudi"
+      avatar: https://pbs.twimg.com/profile_images/1581098587034771457/9HrxXWw4_400x400.jpg
+      link: https://twitter.com/swarupdonepudi/status/1644820071167201280
+      text: |
+        I love @PulumiCorp so much because it is like 50% of the reason why we dared to build https://planton.cloud.
+
+        An equivalent of 50K lines of declarative infra code has been put behind APIs to support the features on the platform with https://www.pulumi.com/docs/using-pulumi/automation-api/
+    -
+      source: twitter
+      username: "@iamjmoa"
+      avatar: https://pbs.twimg.com/profile_images/1529025993893195777/Wo8EXvLO_400x400.jpg
+      link: https://twitter.com/iamjmoa/status/1624702662456352768
+      text: |
+        Today is a good day.
+
+        Finished no-code website builder.
+
+        Managed to automate deploying a website created with said builder with @PulumiCorp
+
+  title: Built by engineers for engineers. Open source.
+  description: "[Join us](/community) in the community, and let’s build together."
+---

--- a/content/b/iac-platform-engineering-idp.md
+++ b/content/b/iac-platform-engineering-idp.md
@@ -1,0 +1,256 @@
+---
+######################################################################################################
+#                    This is a PPC landing page, exclusively for paid ads                            #
+######################################################################################################
+title: Pulumi - Universal Infrastructure as Code
+meta_desc: Pulumi's open source infrastructure as code SDK enables you to create, deploy, and manage infrastructure on any cloud, using your favorite languages.
+
+block_external_search_index: true
+
+type: page
+layout: home-b
+
+hero:
+  title: [ "Automate your infrastructure at any scale", "Your Code, Your Cloud, Your Success" ]
+  description: |
+    Build, manage, and scale your infrastructure, secrets, and configurations in one place.
+  cta_text: Get Started
+  cta_link: /docs/iac/get-started/
+  secondary_cta_text: Talk to a human
+  secondary_cta_link: /contact/?form=sales
+
+code_faster:
+  title: Build and ship faster with infrastructure as code
+  description: |
+    Author infrastructure code using programming languages you know and love. Write statements to define infrastructure using your IDE with autocomplete, type checking, and documentation.
+
+security:
+  title: Drive security and compliance
+  image: /images/solutions/ai/ai_save_cost.svg
+  description: |
+    Enforce compliance and security, understand cloud usage, and discover cost savings to drive better efficiency, security, and reliability across all cloud assets.
+
+ai:
+  title: Code on demand with Pulumi AI
+  image: /images/home/ai-graphic.svg
+  alt: AI prompted to 'Give me an AWS static website behind a CloudFront CDN' and outputting Pulumi code
+  description: |
+    Want help writing infrastructure code? Use Pulumi AI to generate code for your desired infrastructure – all through natural language commands.
+
+    Ask Pulumi AI to iterate on your code to make changes and add new resources.
+
+embed:
+  title: Build productive platforms for both developers and operators
+  image: /blog/developer-portal-platform-teams/platform-teams.png
+  alt: a flowchart with arrows going from Automation API program to Infrasctucture as Code programs to Pulumi Engine deploys stacks
+  description: |
+    Internal developer portals (IDPs) enable your developers to quickly provision security-compliant infrastructure, boost productivity with pre-configured architectures and automate testing and deployments, adhering to organizational standards.
+
+    Pulumi’s infrastructure and policy as code engine fosters collaboration between your developers, security, and operation teams through common, popular programming languages.
+
+secrets:
+  title: Manage configuration and secrets with modular Environments
+  image: /blog/environments-secrets-configurations-management/esc.gif
+  alt: a screenshot of Pulumi ESC
+  description: |
+    Easy-to-use single source of truth for all configurations with guardrails. Seamlessly adopt short-lived dynamic secrets. Never have downtime over changed configurations because you can change once and have it updated everywhere. Enforce least-privileged access through role-based access controls.
+
+customer_logos:
+  title: Trusted by your peers
+  logos:
+    - name: bmw
+      link: /case-studies/
+    - name: snowflake
+      link: /case-studies/
+    - name: nvidia
+      link: /case-studies/
+    - name: moderna
+      link: /case-studies/
+    - name: docker
+      link: /case-studies/
+    - name: unity
+      link: /case-studies/
+    - name: deloitte
+      link: /case-studies/
+    - name: stokespace
+      link: /case-studies/
+    - name: univision
+      link: /case-studies/
+    - name: washington-trust
+      link: /case-studies/
+    - name: kyruus
+      link: /case-studies/
+    - name: modular-ai
+      link: /case-studies/
+    - name: korber
+      link: /case-studies/    
+    - name: lemonade
+      link: /case-studies/
+    - name: pinecone
+      link: /case-studies/
+    - name: ware2go
+      link: /case-studies/
+    - name: nubank
+      link: /case-studies/
+    - name: mindbody
+      link: /case-studies/
+    - name: fenergo
+      link: /case-studies/
+    - name: webflow
+      link: /case-studies/
+    - name: bluenile
+      link: /case-studies/
+    - name: dutchie
+      link: /case-studies/
+    - name: panther-labs
+      link: /case-studies/
+    - name: materialize
+      link: /case-studies/
+    - name: altana
+      link: /case-studies/
+    - name: mercedes-benz
+      link: /case-studies/
+    - name: bt
+      link: /case-studies/
+    - name: portx
+      link: /case-studies/
+    - name: tivityhealth
+      link: /case-studies/
+    - name: starburst
+      link: /case-studies/
+    - name: linktree
+      link: /case-studies/
+
+customer_quotes:
+  panther:
+    text: |
+      “Our developers needed a fast, modular, and testable platform for managing cloud infrastructure. <b>Nothing is better than having standard programming languages for building and managing infrastructure</b>”
+    author: Austin Byers, Principal Platform Engineer
+    logo: panther-labs
+  starburst:
+    text: |
+      “Pulumi let us build and <b>automate cloud infrastructure projects</b> at a scale that simply wasn’t imaginable using prior-generation infrastructure as code technologies”
+    author: Matt Stephenson, Senior Principal Software Engineer
+    logo: starburst
+  snowflake:
+    text: |
+      “Pulumi helped our team to ship a new product faster. We needed <b>one tool to setup and manage multi-cloud, multi-region Kubernetes clusters</b> that infrastructure and applications teams could use collaboratively”
+    author: Justin Fitzhugh, VP of Cloud Platform Engineering
+    logo: snowflake
+
+get_started:
+  tweets:
+    -
+      source: twitter
+      username: "@BryanMigliorisi"
+      avatar: https://pbs.twimg.com/profile_images/752334791782039552/BsVNGBaV_400x400.jpg
+      link: https://twitter.com/BryanMigliorisi/status/1450123026901651460
+      text: |
+        There is no way around the fact that devops is complicated but @PulumiCorp is a game changer for me.  Blows away CloudForamtion, TerraForm, CDK, etc.
+    -
+      source: twitter
+      username: "@krangarajan"
+      avatar: https://pbs.twimg.com/profile_images/837774934805925888/I51_kI-H_400x400.jpg
+      link: https://twitter.com/krangarajan/status/1580618068203479040
+      text: |
+        Continuing on my thread about @PulumiCorp from a while ago: holy shit I am a convert. I needed to setup a staging environment that was mostly identical to prod, and once I trued up our Pulumi stack with AWS, it took *minutes* to do this. How have I lived without this until now?
+    -
+      source: twitter
+      username: "@Vetium"
+      avatar: https://pbs.twimg.com/profile_images/1197754531335016449/etr4hfpJ_400x400.jpg
+      link: https://twitter.com/Vetium/status/1589452885149900800
+      text: |
+        Without a doubt the most approachable tool in the IaaC space is
+        @PulumiCorp.
+
+        Somewhat enjoying provisioning a scheduled run of a Lambda.
+    -
+      source: twitter
+      username: "@justedagain"
+      avatar: https://pbs.twimg.com/profile_images/1576905831626440706/wigR9_hF_400x400.jpg
+      link: https://twitter.com/justedagain/status/1583063827524251649
+      text: |
+        The developer experience of Pulumi is just sublime. As a prior Terraform user, the grass is substantially greener on this side. I'm so glad I made the switch two years back. Using Terraform for my current use case would be a massive downgrade.
+    -
+      source: twitter
+      username: "@hossambarakat_"
+      avatar: https://pbs.twimg.com/profile_images/1578466430739271681/FZnNwxcA_400x400.jpg
+      link: https://twitter.com/hossambarakat_/status/1357640859018162176
+      text: |
+        Give Pulumi a shot and you will never look back @PulumiCorp
+    -
+      source: twitter
+      username: "@matticala"
+      avatar: https://pbs.twimg.com/profile_images/1289826906024693766/LOdbjWdW_400x400.jpg
+      link: https://twitter.com/matticala/status/1369038327341531140
+      text: |
+        With @PulumiCorp I said goodbye to #YAML and JSON supersets.
+        I went back to what I love: #code.
+        Code. End to end. Functional, even.
+        #Kubernetes is pleasant again.
+    -
+      source: twitter
+      username: "@ddoomen"
+      avatar: https://pbs.twimg.com/profile_images/1591057460940480517/d0xy4n3b_400x400.jpg
+      link: https://twitter.com/ddoomen/status/1644343201459740673
+      text: |
+        Deploying cloud resources using @PulumiCorp is just amazing. Why would anybody bother with JSON, YAML or some other DSL?
+    -
+      source: twitter
+      username: "@Meliora245"
+      avatar: https://pbs.twimg.com/profile_images/1536753333972525056/WN2SVAmq_400x400.jpg
+      link: https://twitter.com/Meliora245/status/1633110529420976130
+      text: |
+        Been using Pulumi with Typescript for a IaaC managing k8s and stateful databases. Don't see myself going back to using terraform after this.
+    -
+      source: twitter
+      username: "@rybavery"
+      avatar: https://pbs.twimg.com/profile_images/1146562967317520385/wuPwKFUZ_400x400.jpg
+      link: https://twitter.com/rybavery/status/1576987704189128704
+      text: |
+        our team at @devseed is now gravitating toward using https://pulumi.com/docs/concepts/vs/terraform/ instead of terraform because it's all in python so it is easier to onboard new people to the tool and makes it easier to manage the same infra definition in different test, staging, and deploy envs.
+    -
+      source: twitter
+      username: "@SparkyCodes"
+      avatar: https://pbs.twimg.com/profile_images/1564710917014802433/k0QzTysD_400x400.jpg
+      link: https://twitter.com/SparkyCodes/status/1572999315919978502
+      text: |
+        It wouldn't have been possible to build Sparky without @PulumiCorp. Shout out to the team and community for helping us get up and running!
+    -
+      source: twitter
+      username: "@0xksure"
+      avatar: https://pbs.twimg.com/profile_images/1560526743865360384/QBkajFhq_400x400.jpg
+      link: https://twitter.com/0xksure/status/1570769681434415104
+      text: |
+        ok so pulumi is awesome. almost no clicking, just scripting go and up
+    -
+      source: twitter
+      username: "@krangarajan"
+      avatar: https://pbs.twimg.com/profile_images/837774934805925888/I51_kI-H_400x400.jpg
+      link: https://twitter.com/krangarajan/status/1564712184717881344
+      text: |
+        New gig uses @PulumiCorp to manage AWS infra. Initially I was skeptical and was tempted to go back to Terraform, but after using pulumi imports and discovering the ability to write tests easily, I'm a convert. (1/4)
+    -
+      source: twitter
+      username: "@swarupdonepudi"
+      avatar: https://pbs.twimg.com/profile_images/1581098587034771457/9HrxXWw4_400x400.jpg
+      link: https://twitter.com/swarupdonepudi/status/1644820071167201280
+      text: |
+        I love @PulumiCorp so much because it is like 50% of the reason why we dared to build https://planton.cloud.
+
+        An equivalent of 50K lines of declarative infra code has been put behind APIs to support the features on the platform with https://www.pulumi.com/docs/using-pulumi/automation-api/
+    -
+      source: twitter
+      username: "@iamjmoa"
+      avatar: https://pbs.twimg.com/profile_images/1529025993893195777/Wo8EXvLO_400x400.jpg
+      link: https://twitter.com/iamjmoa/status/1624702662456352768
+      text: |
+        Today is a good day.
+
+        Finished no-code website builder.
+
+        Managed to automate deploying a website created with said builder with @PulumiCorp
+
+  title: Built by engineers for engineers. Open source.
+  description: "[Join us](/community) in the community, and let’s build together."
+---

--- a/layouts/page/home-b.html
+++ b/layouts/page/home-b.html
@@ -1,0 +1,382 @@
+{{ define "hero" }}
+    <header class="home-page-hero shadow">
+        <div class="home-page-hero-background">
+            <div class="flex">
+                <div class="w-full p-6 home-page-hero-text">
+                    <h1 class="flex flex-col items-center">
+                        <span class="inline-block mb-3 text-center" data-text="{{ index (.Params.hero.title) 0 }}">{{ index (.Params.hero.title) 0 }}</span>
+                        <span class="rainbow-text inline-block text-center" data-text="{{ index (.Params.hero.title) 1 }}">{{ index (.Params.hero.title) 1 }}</span>
+                    </h1>
+
+                    <p class="mt-6 text-center leading-7">{{ .Params.hero.description | markdownify }}</p>
+
+                    <div class="relative z-10 overlay-middle mt-8 flex text-center justify-center items-center flex-col mx-auto lg:mx-0 md:flex-row">
+                        <a class="home-hero-btn-primary mr-0 md:mr-4 mb-3 md:mb-0" href="{{ .Params.hero.cta_link }}">{{ .Params.hero.cta_text }}</a>
+                        <a class="btn-secondary home-hero-btn-secondary rounded-full cursor-pointer" href="{{ .Params.hero.secondary_cta_link }}">{{ .Params.hero.secondary_cta_text }}</a>
+                    </div>
+                </div>
+
+                <!--<div class="hidden lg:block lg:w-1/2 p-6 flex justify-center align-center">
+                    <img src="/images/home/dancing-music.svg" />
+                </div>-->
+            </div>
+        </div>
+    </header>
+{{ end }}
+
+{{ define "main" }}
+    {{ $pageContext := . }}
+
+    <!-- Logos carousel -->
+    <section class="container mx-auto text-center overflow-hidden px-3 mt-6">
+        <h3 class="text-center mb-4">{{ .Params.customer_logos.title }}</h3>
+
+        <div class="w-full order-first pb-16 items-center justify-center hidden lg:block">
+            <pulumi-swiper slides="6" centered-slides="true" loop="true" autoplay="true" autoplay-delay="500" speed="2000">
+                {{ range $logo := .Params.customer_logos.logos }}
+                    <pulumi-swipeable>
+                        <div class="p-6 flex flex-col flex-grow items-end h-24 justify-center">
+                            {{ if $logo.link }}
+                                <a class="w-full h-full" href="{{ $logo.link }}" target="_blank">
+                                    {{ partial "customer-logo.html" (dict "logo" $logo.name) }}
+                                </a>
+                            {{ else }}
+                                {{ partial "customer-logo.html" (dict "logo" $logo.name) }}
+                            {{ end }}
+                        </div>
+                    </pulumi-swipeable>
+                {{ end }}
+            </pulumi-swiper>
+        </div>
+
+        <div class="w-full order-first pb-16 items-center justify-center block lg:hidden">
+            <pulumi-swiper slides="3" centered-slides="true" loop="true" autoplay="true" autoplay-delay="500" speed="2000">
+                {{ range $logo := .Params.customer_logos.logos }}
+                    <pulumi-swipeable>
+                        <div class="p-6 flex flex-col flex-grow items-end h-24 justify-center">
+                            {{ if $logo.link }}
+                                <a class="w-full h-full" href="{{ $logo.link }}" target="_blank">
+                                    {{ partial "customer-logo.html" (dict "logo" $logo.name) }}
+                                </a>
+                            {{ else }}
+                                {{ partial "customer-logo.html" (dict "logo" $logo.name) }}
+                            {{ end }}
+                        </div>
+                    </pulumi-swipeable>
+                {{ end }}
+            </pulumi-swiper>
+        </div>
+    </section>
+
+    <!-- Code and ship faster -->
+    <section class="mb-8 p-6 lg:px-0 relative home-page-section">
+        <div class="home-page-build-section-background">
+            <div class="home-page-build-section-image"></div>
+        </div>
+
+        <div class="container mx-auto z-10 relative">
+            <div class="w-full lg:w-2/3 mx-auto">
+                <div class="text-center">
+                    <h3>{{ .Params.code_faster.title }}</h3>
+                    <p class="text-lg">{{ .Params.code_faster.description | markdownify }}</p>
+                    {{ range $item := .Params.code_faster.items }}
+                        <h6>{{ $item.title }}</h6>
+                        <p>{{ $item.description | markdownify }}</p>
+                    {{ end }}
+                </div>
+                <div class="card bg-white shadow-xl p-6 block">
+                    <div>
+                        <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml">
+                            <pulumi-choosable type="language" class="highlight" value="typescript">
+                                <img
+                                    class="mx-auto w-full"
+                                    src="/images/home/typescript.svg"
+                                    alt="Pulumi code being written in TypeScript showing autocomplete for creating a new S3 bucket"
+                                />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="python">
+                                <img class="mx-auto w-full" src="/images/home/python.svg" alt="Pulumi code being written in Python showing autocomplete for creating a new S3 bucket" />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="go">
+                                <img class="mx-auto w-full" src="/images/home/go.svg" alt="Pulumi code being written in GO showing autocomplete for creating a new S3 bucket" />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="csharp">
+                                <img class="mx-auto w-full" src="/images/home/c-sharp.svg" alt="Pulumi code being written in C# showing autocomplete for creating a new S3 bucket" />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="java">
+                                <img class="mx-auto w-full" src="/images/home/java.svg" alt="Pulumi code being written in Java showing autocomplete for creating a new S3 bucket" />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="yaml">
+                                <img class="mx-auto w-full" src="/images/home/yaml.svg" alt="Pulumi code being written in YAML showing autocomplete for creating a new S3 bucket" />
+                            </pulumi-choosable>
+                        </pulumi-chooser>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Panther quote -->
+    <section class="w-full md:w-2/3 lg:w-1/2 mx-auto mt-16 px-6">
+        {{ partial "home/quote.html" (dict "quote" .Params.customer_quotes.panther) }}
+    </section>
+
+    <!-- Tame configuration and secrets sprawl -->
+    <section class="py-12 lg:my-12 px-6 lg:px-0 relative home-page-section">
+        <div class="home-page-manage-section-background">
+            <div class="home-page-manage-section-image"></div>
+        </div>
+
+        <div class="container mx-auto z-10 relative">
+            <div class="w-full lg:w-2/3 mx-auto">
+                <div class="z-10 px-8">
+                    <h3>{{ .Params.secrets.title }}</h3>
+                    <p class="text-lg">{{ .Params.secrets.description | markdownify }}</p>
+                    <div class="mt-8">
+                        <span class="text-lg">Learn more: </span>
+                        <a href="/product/esc" class="underline text-lg">Pulumi ESC<i class="fa fa-arrow-right ml-2"></i></a>
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-center mt-8">
+                    <img src="{{ .Params.secrets.image }}" alt="{{ .Params.secrets.alt }}" class="card shadow-xl" />
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Starburst quote -->
+    <section class="w-full md:w-2/3 lg:w-1/2 mx-auto mt-16 px-6">
+        {{ partial "home/quote.html" (dict "quote" .Params.customer_quotes.starburst) }}
+    </section>
+
+    <!-- Embed IaC Anywhere -->
+    <section class="py-12 lg:my-12 px-6 lg:px-0 relative home-page-section">
+        <div class="home-page-cloud-section-background">
+            <div class="home-page-cloud-section-image"></div>
+        </div>
+
+        <div class="container mx-auto z-10 relative">
+            <div class="w-full lg:w-2/3 mx-auto">
+                <div class="z-10 px-8">
+                    <h3>{{ .Params.embed.title }}</h3>
+                    <div class="text-lg text-black">{{ .Params.embed.description | markdownify }}</div>
+                    <div class="mt-8">
+                        <span class="text-lg">Learn more: </span>
+                        <a href="/blog/developer-portal-platform-teams/" class="underline text-lg">Pulumi For Platform Teams<i class="fa fa-arrow-right ml-2"></i></a>
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-center mt-8 px-8">
+                    <div class="card bg-white shadow-xl p-6">
+                        <img src="{{ .Params.embed.image }}" alt="{{ .Params.embed.alt }}" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Snowflake quote -->
+    <section class="w-full md:w-2/3 lg:w-1/2 mx-auto mt-16 px-6">
+        {{ partial "home/quote.html" (dict "quote" .Params.customer_quotes.snowflake) }}
+    </section>
+
+    <section class="my-4 lg:my-12 px-6 lg:px-0 relative home-page-section">
+        <div class="container mx-auto z-10 relative">
+            <div class="w-full lg:w-2/3 mx-auto">
+                <div class="z-10 px-8">
+                    <h3>{{ .Params.security.title }}</h3>
+                    <p class="text-lg">{{ .Params.security.description | markdownify }}</p>
+                    <div class="mt-8">
+                        <span class="text-lg">Learn more: </span>
+                        <a href="/product/pulumi-insights" class="underline text-lg">Pulumi Insights<i class="fa fa-arrow-right ml-2"></i></a>
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-center mt-8">
+                    <img src="{{ .Params.security.image }}" class="card shadow-xl" />
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Boost productivity with AI -->
+    <section class="py-12 lg:my-12 px-6 lg:px-0 relative home-page-section">
+        <div class="home-page-science-section-background">
+            <div class="home-page-science-section-image"></div>
+        </div>
+
+        <div class="container mx-auto z-10 relative">
+            <div class="card bg-white shadow-xl p-6 w-full lg:w-2/3 mx-auto">
+                <div class="z-10 px-8">
+                    <h3>{{ .Params.ai.title }}</h3>
+                    <p class="text-lg">{{ .Params.ai.description | markdownify }}</p>
+                    <div class="mt-8">
+                        <span class="text-lg">Try it out: </span>
+                        <a href="/ai/" class="underline text-lg">Pulumi AI<i class="fa fa-arrow-right ml-2"></i></a>
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-center mt-8 w-full">
+                    <div class="w-full">
+                        <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml">
+                            <pulumi-choosable type="language" class="highlight" value="typescript">
+                                <img
+                                    class="mx-auto w-full"
+                                    src="/images/home/ai-ts.svg"
+                                    alt="AI prompted to 'Give me an AWS static website behind a CloudFront CDN' and outputting Pulumi code in TypeScript"
+                                />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="python">
+                                <img
+                                    class="mx-auto w-full"
+                                    src="/images/home/ai-python.svg"
+                                    alt="AI prompted to 'Give me an AWS static website behind a CloudFront CDN' and outputting Pulumi code in Python"
+                                />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="go">
+                                <img
+                                    class="mx-auto w-full"
+                                    src="/images/home/ai-go.svg"
+                                    alt="AI prompted to 'Give me an AWS static website behind a CloudFront CDN' and outputting Pulumi code in GO"
+                                />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="csharp">
+                                <img
+                                    class="mx-auto w-full"
+                                    src="/images/home/ai-csharp.svg"
+                                    alt="AI prompted to 'Give me an AWS static website behind a CloudFront CDN' and outputting Pulumi code in C#"
+                                />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="java">
+                                <img
+                                    class="mx-auto w-full"
+                                    src="/images/home/ai-java.svg"
+                                    alt="AI prompted to 'Give me an AWS static website behind a CloudFront CDN' and outputting Pulumi code in Java"
+                                />
+                            </pulumi-choosable>
+
+                            <pulumi-choosable type="language" class="highlight" value="yaml">
+                                <img
+                                    class="mx-auto w-full"
+                                    src="/images/home/ai-yaml.svg"
+                                    alt="AI prompted to 'Give me an AWS static website behind a CloudFront CDN' and outputting Pulumi code in YAML"
+                                />
+                            </pulumi-choosable>
+                        </pulumi-chooser>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Built by engineers + tweets -->
+    <section class="mt-16 mb-36 relative flex flex-col">
+        <div class="container mx-auto px-3 overflow-hidden lg:overflow-visible">
+            <div class="w-full bg-violet-600 rounded-xl shadow p-16 lg:pb-56 align-top">
+                <h2 class="text-white text-center">Built by engineers for engineers. Open source.</h2>
+                <div class="flex flex-col lg:flex-row items-center justify-center mb-4">
+                    <a class="text-white text-lg bold underline flex self-start lg:self-auto mt-4 lg:mt-0 mx-auto lg:mx-0 lg:pr-1" href="https://slack.pulumi.com/"
+                        >Join our community,
+                    </a>
+                    <p class="text-white text-lg mx-auto my-0 lg:mx-0 lg:my-auto">and let’s build together.</p>
+                </div>
+            </div>
+
+            <div class="w-full order-first lg:hidden">
+                <pulumi-swiper slides="1" centered-slides="true" initial-slide="3" loop="true" autoplay="true" autoplay-delay="5000" speed="1000">
+                    {{ range $tweet := .Params.get_started.tweets }}
+                        <pulumi-swipeable>
+                            <div class="w-full px-4">
+                                <div class="flex flex-col card p-6 bg-white">
+                                    <p class="text-left mt-0 overflow-hidden">{{ $tweet.text }}</p>
+                                    <div class="flex flex-grow items-end">
+                                        <div>
+                                            <img class="rounded-full w-12 h-12" src="{{ $tweet.avatar }}" />
+                                        </div>
+                                        <p class="ml-4 text-gray-600">{{ $tweet.username }}</p>
+                                        <div class="flex-grow flex justify-end my-4">
+                                            <img src="/logos/tech/twitter.svg" alt="Twitter" />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </pulumi-swipeable>
+                    {{ end }}
+                </pulumi-swiper>
+            </div>
+            <div class="large-container mx-auto absolute -bottom-12 left-0 pt-12 hidden lg:block">
+                <pulumi-swiper slides="3" centered-slides="true" initial-slide="3" loop="true" autoplay="true" autoplay-delay="4000" speed="1000">
+                    {{ range $tweet := .Params.get_started.tweets }}
+                        <pulumi-swipeable>
+                            <div class="w-full px-4 text-left">
+                                <div class="flex flex-col card p-6 bg-white h-60">
+                                    <p class="flex-grow mt-0">{{ $tweet.text }}</p>
+                                    <div class="flex items-center w-full pb-1">
+                                        <a href="{{ $tweet.link }}" target="_blank" rel="noopener noreferrer">
+                                            <!-- If the browser fails to load the Twitter avatar, just hide it. -->
+                                            <div class="rounded-full border-none w-12 h-12 mr-4 overflow-hidden">
+                                                <img src="{{ $tweet.avatar }}" onerror="$(this).hide();" />
+                                            </div>
+                                        </a>
+                                        <a href="{{ $tweet.link }}" class="flex-grow text-gray-600 hover:text-gray-600 hover:underline" target="_blank" rel="noopener noreferrer">
+                                            {{ $tweet.username }}
+                                        </a>
+
+                                        {{ if eq $tweet.source "twitter" }}
+                                            <img class="w-8 h-8" src="/logos/tech/twitter.svg" alt="Twitter" />
+                                        {{ end }}
+
+                                        {{ if eq $tweet.source "reddit" }}
+                                            <img class="w-8 h-8" src="/logos/tech/reddit.svg" alt="Reddit" />
+                                        {{ end }}
+
+                                        {{ if eq $tweet.source "linkedin" }}
+                                            <img class="w-8 h-8" src="/logos/tech/linkedin.svg" alt="LinkedIn" />
+                                        {{ end }}
+
+                                        {{ if eq $tweet.source "blog" }}
+                                            <i class="fas fa-blog text-gray-500 text-2xl"></i>
+                                        {{ end }}
+                                    </div>
+                                </div>
+                            </div>
+                        </pulumi-swipeable>
+                    {{ end }}
+                </pulumi-swiper>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTAs -->
+    <section class="container mx-auto my-24 px-6">
+        <div class="flex justify-center">
+            <div class="card ready-cta w-full rounded-xl p-0.5 gradient">
+                <div class="flex justify-center rounded-xl bg-purple-100">
+                    <div class="p-8 md:p-16 lg:pt-28 lg:pb-28 inline-flex flex-col items-center">
+                        <h2 class="mb-12 text-center">Ready to try Pulumi?</h2>
+                        <div class="flex flex-col lg:flex-row self-stretch items-center lg:justify-between">
+                            <div class="flex flex-col justify-center align-center text-center lg:ml-14 lg:mr-4 mb-14 lg:mb-0 z-0">
+                                <a href="/docs/get-started/" class="btn-primary py-3">Get Started</a>
+                                <p class="text-xs pt-1 my-0">Follow the step-by-step guide</p>
+                            </div>
+                            <div class="flex flex-col justify-center align-center text-center lg:mr-14 lg:ml-4">
+                                <a href="docs/install/" class="btn-secondary py-3 px-6 whitespace-nowrap">Download Open Source</a>
+                                <p class="text-xs pt-1 my-0">Download our open source SDK</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{{ end }}


### PR DESCRIPTION
## Summary
Restore the `/b/` directory that was accidentally removed in PR #15238.

This includes the mobile-friendly ad pages for paid advertising campaigns and their associated layout template.

## Changes
- `content/b/_index.md`: Main PPC landing page  
- `content/b/iac-platform-engineering-idp.md`: IaC platform engineering variant
- `layouts/page/home-b.html`: Layout template for the pages

## Test plan
- [ ] Verify the `/b/` pages render correctly
- [ ] Confirm mobile-friendly layout is working as expected
- [ ] Test both ad page variants

Fixes the accidental removal from PR #15238.