### PR TITLE
Fix Typescript optionality of opts for consistency

### DIFF
--- a/content/docs/iac/get-started/aws/create-component.md
+++ b/content/docs/iac/get-started/aws/create-component.md
@@ -145,7 +145,7 @@ export interface AwsS3WebsiteArgs {
 export class AwsS3Website extends pulumi.ComponentResource {
     public readonly url: pulumi.Output<string>; // the S3 website url.
 
-    constructor(name: string, args: AwsS3WebsiteArgs, opts: pulumi.ComponentResourceOptions) {
+    constructor(name: string, args: AwsS3WebsiteArgs, opts?: pulumi.ComponentResourceOptions) {
         super("quickstart:index:AwsS3Website", name, args, opts);
 
         // Component initialization will go here next...


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Fixes the initial TypeScript code example on line 148 to match the complete code snippet on line 381.
This comes up if following the TypeScript tutorial along under [Define a new component](https://www.pulumi.com/docs/iac/get-started/aws/create-component/#define-a-new-component), where if you start with the initial code snippet, and refactor the code manually rather than just copy-pasting the finished file example, you'll end up with a TypeScript error.
