### PR TITLE
Add API docs for stack config

### DIFF
--- a/content/docs/pulumi-cloud/reference/stack-config/_index.md
+++ b/content/docs/pulumi-cloud/reference/stack-config/_index.md
@@ -1,0 +1,152 @@
+---
+title: Stack Config
+title_tag: "Pulumi Cloud REST API: Stack Config"
+meta_desc: Learn about the Pulumi Cloud REST API endpoints for managing stack config.
+menu:
+    cloud:
+        parent: pulumi-cloud-reference
+        weight: 20
+---
+
+Stack config endpoints allow you to manage configuration settings for your Pulumi stacks, including environment settings and secrets management configuration. If stack configuration is returned by the API, it used in place of the local stack config file (e.g. `Pulumi.[stack].yaml`).
+
+## Stack Config Operations
+
+The API provides endpoints for the following operations:
+
+- Getting a stack's configuration
+- Updating a stack's configuration
+- Deleting a stack's configuration
+
+## Get Stack Config
+
+Retrieves the configuration settings for a specific stack.
+
+```plain
+GET /api/stacks/{organization}/{project}/{stack}/config
+```
+
+### Parameters
+
+| Parameter      | Type   | In   | Description       |
+|----------------|--------|------|-------------------|
+| `organization` | string | path | organization name |
+| `project`      | string | path | project name      |
+| `stack`        | string | path | stack name        |
+
+### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/config
+```
+
+### Default response
+
+```plain
+Status: 200 OK
+```
+
+```json
+{
+  "environment": "string",
+  "secretsProvider": "string",
+  "encryptedKey": "string",
+  "encryptionSalt": "string"
+}
+```
+
+## Update Stack Config
+
+Updates the configuration settings for a specific stack.
+
+```plain
+PUT /api/stacks/{organization}/{project}/{stack}/config
+```
+
+### Parameters
+
+| Parameter      | Type   | In   | Description       |
+|----------------|--------|------|-------------------|
+| `organization` | string | path | organization name |
+| `project`      | string | path | project name      |
+| `stack`        | string | path | stack name        |
+
+### Request Body
+
+The request body should be a `StackConfig` object with the following fields:
+
+| Field             | Type   | Description                                    |
+|-------------------|--------|------------------------------------------------|
+| `environment`     | string | **Optional.** The reference to the ESC environment to use as stack configuration |
+| `secretsProvider` | string | **Optional.** The secrets provider configuration             |
+| `encryptedKey`    | string | **Optional.** The encrypted key for secrets management       |
+| `encryptionSalt`  | string | **Optional.** The encryption salt used for secrets           |
+
+### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request PUT \
+  --data '{
+    "environment": "default/prod",
+    "secretsProvider": "default",
+    "encryptedKey": "key",
+    "encryptionSalt": "salt"
+  }' \
+  https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/config
+```
+
+### Default response
+
+```plain
+Status: 200 OK
+```
+
+```json
+{
+  "environment": "default/prod",
+  "secretsProvider": "default",
+  "encryptedKey": "key",
+  "encryptionSalt": "salt"
+}
+```
+
+## Delete Stack Config
+
+Deletes the configuration settings for a specific stack.
+
+```plain
+DELETE /api/stacks/{organization}/{project}/{stack}/config
+```
+
+### Parameters
+
+| Parameter      | Type   | In   | Description       |
+|----------------|--------|------|-------------------|
+| `organization` | string | path | organization name |
+| `project`      | string | path | project name      |
+| `stack`        | string | path | stack name        |
+
+### Example
+
+```bash
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request DELETE \
+  https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/config
+```
+
+### Default response
+
+```plain
+Status: 204 No Content
+```

--- a/content/docs/pulumi-cloud/reference/stack-policy/_index.md
+++ b/content/docs/pulumi-cloud/reference/stack-policy/_index.md
@@ -5,7 +5,7 @@ meta_desc: Learn about the Pulumi Cloud REST API endpoints for managing policy e
 menu:
     cloud:
         parent: pulumi-cloud-reference
-        weight: 20
+        weight: 21
 ---
 
 Stack policy APIs allow you to retrieve information about policy groups and policy packs associated with a Pulumi stack. Policies define governance rules that are enforced during stack updates.

--- a/content/docs/pulumi-cloud/reference/stack-tags/_index.md
+++ b/content/docs/pulumi-cloud/reference/stack-tags/_index.md
@@ -5,7 +5,7 @@ meta_desc: Learn about the Pulumi Cloud REST API endpoints for managing stack ta
 menu:
     cloud:
         parent: pulumi-cloud-reference
-        weight: 21
+        weight: 22
 ---
 
 Stack tags are key-value metadata attached to Pulumi stacks. They can be used for organization, filtering, and to store additional information about your stacks.

--- a/content/docs/pulumi-cloud/reference/stack-updates/_index.md
+++ b/content/docs/pulumi-cloud/reference/stack-updates/_index.md
@@ -5,7 +5,7 @@ meta_desc: Learn about the Pulumi Cloud REST API endpoints for managing and moni
 menu:
     cloud:
         parent: pulumi-cloud-reference
-        weight: 22
+        weight: 23
 ---
 
 Stack updates are operations that create, update, or delete resources in a Pulumi stack. The Stack Updates API allows you to list updates, check status, and view detailed events for each operation.

--- a/content/docs/pulumi-cloud/reference/stacks/_index.md
+++ b/content/docs/pulumi-cloud/reference/stacks/_index.md
@@ -5,7 +5,7 @@ meta_desc: Learn about the Pulumi Cloud REST API endpoints for creating, reading
 menu:
     cloud:
         parent: pulumi-cloud-reference
-        weight: 23
+        weight: 24
 ---
 
 The Stacks API allows you to create and manage Pulumi stacks, which are isolated, independently configurable instances of your Pulumi program.
@@ -36,6 +36,11 @@ POST /api/stacks/{organization}/{project}
 | `organization` | string | path | Organization name                                                                                |
 | `project`      | string | path | Name of the project to create the stack under. If the project doesn't exist, it will be created. |
 | `stackName`    | string | body | Name of the stack being created.                                                                 |
+| `config`       | object | body | Configuration of the stack being created - see following parameters                              |
+| `config.environment` | string | body | **Optional.** The reference to the ESC environment to create for storing stack configuration. Must not exist yet. |
+| `config.secretsProvider` | string | body | **Optional.** The stack's secrets provider.                                            |
+| `config.encryptedKey` | string | body | **Optional.** The KMS-encrypted ciphertext for the data key used for secrets encryption. Only used for cloud-based secrets providers. |
+| `config.encryptionSalt` | string | body | **Optional.** The stack's base64 encoded encryption salt. Only used for passphrase-based secrets providers. |
 
 ### Example
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This adds docs for the stack config APIs. In detail, this will allow users to associate ESC environments with their stacks - enabling cloud-backed configuration.

