### PR TITLE
Add no-code deployment settings to Rest API docs

### DIFF
--- a/content/docs/pulumi-cloud/reference/_index.md
+++ b/content/docs/pulumi-cloud/reference/_index.md
@@ -51,6 +51,7 @@ The Pulumi Cloud REST API is organized into the following resource categories:
 - [Resources Under Management](/docs/pulumi-cloud/reference/resources-under-management/) - Query managed resources
 - [Schedules](/docs/pulumi-cloud/reference/schedules/) - Configure scheduled tasks
 - [Services](/docs/pulumi-cloud/reference/services/) - Interact with service information
+- [Stack Config](/docs/pulumi-cloud/reference/stack-config/) - Manage configuration settings for stacks
 - [Stack Policy](/docs/pulumi-cloud/reference/stack-policy/) - Apply and manage policy on stacks
 - [Stack Tags](/docs/pulumi-cloud/reference/stack-tags/) - Manage metadata tags on stacks
 - [Stack Updates](/docs/pulumi-cloud/reference/stack-updates/) - Manage the update lifecycle for stacks

--- a/content/docs/pulumi-cloud/reference/deployments/_index.md
+++ b/content/docs/pulumi-cloud/reference/deployments/_index.md
@@ -937,7 +937,9 @@ or with credentials:
 
 ### SourceContext
 
-The source context contains information about where the source code for your project is located. Currently, only git repos are supported as a source.
+The source context contains information about where the source code for your project is located. Currently, git repos or templates are supported as a source.
+
+#### Git
 
 ```json
 {
@@ -949,8 +951,6 @@ The source context contains information about where the source code for your pro
 }
 ```
 
-#### Properties
-
 | Name          | Type           | Description                                      |
 |---------------|----------------|--------------------------------------------------|
 | `git.repoURL` | string | **Optional.** URL of the git repository. |
@@ -958,6 +958,24 @@ The source context contains information about where the source code for your pro
 | `git.repoDir` | string | **Optional.** Directory where Pulumi.yaml is located. |
 | `git.commit` | string | **Optional.** Hash of the commit to deploy. Mutually exclusive with branch. |
 | `git.gitAuth` | object | **Optional.** Authentication information for the git repo. |
+
+#### Template
+
+Using templates as the source for the deployment enables deploying Pulumi programs without having to manage the underlying IaC code.
+Leverage [Stack Config](/docs/pulumi-cloud/reference/stack-config/) to manage configuration settings for these template based stacks, including environment settings and secrets management configuration.
+
+```json
+{
+  "template": {
+    "sourceUrl": "https://github.com/pulumi/templates/kubernetes-aws-yaml"
+  }
+}
+```
+
+| Name                    | Type   | Description                                                                 |
+|-------------------------|--------|-----------------------------------------------------------------------------|
+| `template.sourceURL`    | string | URL of the template.                                                        |
+| `template.gitAuth`      | object | **Optional.** Authentication information for templates hosted in git repos. |
 
 ### OperationContext
 

--- a/content/docs/pulumi-cloud/reference/stack-config/_index.md
+++ b/content/docs/pulumi-cloud/reference/stack-config/_index.md
@@ -8,7 +8,7 @@ menu:
         weight: 20
 ---
 
-Stack config endpoints allow you to manage configuration settings for your Pulumi stacks, including environment settings and secrets management configuration. If stack configuration is returned by the API, it used in place of the local stack config file (e.g. `Pulumi.[stack].yaml`).
+Stack config endpoints allow you to manage configuration settings for your Pulumi stacks, including environment settings and secrets management configuration. If stack configuration is returned by the API, it is used in place of the local stack config file (e.g. `Pulumi.[stack].yaml`).
 
 ## Stack Config Operations
 


### PR DESCRIPTION
No-Code deployments can now be configured using the Deployment Settings APIs, this adds the necessary docs for that.

Relates to https://github.com/pulumi/pulumi-service/pull/29584 (do not merge before this is released)
Relates to https://github.com/pulumi/pulumi-service/issues/28437