### PR TITLE
add warning about configuring aws credentials for Kubernetes deployments

### DIFF
--- a/content/docs/iac/get-started/kubernetes/deploy-stack.md
+++ b/content/docs/iac/get-started/kubernetes/deploy-stack.md
@@ -66,15 +66,9 @@ The `name` of the deployment that we exported is shown as a [stack output](/docs
 
 {{< console-note >}}
 
-<div class="note note-info">
-    <div class="icon-and-line">
-        <i class="fas fa-info-circle"></i>
-        <div class="line"></div>
-    </div>
-    <div class="content">
-       If you get the error <code>configured Kubernetes cluster is unreachable: unable to load schema information from the API server: the server has asked for the client to provide credentials</code>, you may need to configure valid AWS credentials.
-    </div>
-</div>
+{{% notes type="info" %}}
+If you get the error `configured Kubernetes cluster is unreachable: unable to load schema information from the API server: the server has asked for the client to provide credentials`, you may need to configure valid AWS credentials.
+{{% /notes %}}
 
 Next, we'll make some modifications to the program.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
Add a warning that AWS credentials need to be present to create a Kubernetes Deployment 

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
