### PR TITLE
Add redirects for automation-api URLs

### DIFF
--- a/content/docs/iac/using-pulumi/automation-api/_index.md
+++ b/content/docs/iac/using-pulumi/automation-api/_index.md
@@ -14,6 +14,7 @@ aliases:
 - /docs/guides/automation-api/
 - /docs/using-pulumi/automation-api/
 - /docs/iac/packages-and-automation/automation-api/
+- /docs/iac/using-pulumi/automation-api/
 ---
 
 The Pulumi Automation API is a programmatic interface for running Pulumi programs without the Pulumi CLI. Conceptually, this can be thought of as encapsulating the functionality of the CLI (`pulumi up`, `pulumi preview`, `pulumi destroy`, `pulumi stack init`, etc.) but with more flexibility. It is a strongly typed and safe way to use Pulumi in embedded contexts such as web servers, without requiring invoking the CLI from a shell process.

--- a/content/docs/iac/using-pulumi/automation-api/concepts-terminology.md
+++ b/content/docs/iac/using-pulumi/automation-api/concepts-terminology.md
@@ -14,6 +14,7 @@ aliases:
 - /docs/guides/automation-api/concepts-terminology/
 - /docs/using-pulumi/automation-api/concepts-terminology/
 - /docs/iac/packages-and-automation/automation-api/concepts-terminology/
+- /docs/iac/using-pulumi/automation-api/concepts-terminology/
 ---
 
 Automation API lets you use functionality available in the Pulumi CLI via an SDK, as opposed to a Pulumi program which contains resource declarations and is invoked externally by the `pulumi` CLI. Automation API enables you to define a Pulumi program, its resources, stacks, and configuration for those stacks entirely in code, and then distribute that code as an executable invoked like any other executable in your supported language of choice (e.g., `python3 main.py` as opposed to `pulumi up`). Automation API is distributed as a namespace within the Pulumi SDK, and is part of Pulumi IaC's open source offering.

--- a/content/docs/iac/using-pulumi/automation-api/getting-started-automation-api.md
+++ b/content/docs/iac/using-pulumi/automation-api/getting-started-automation-api.md
@@ -14,6 +14,7 @@ aliases:
 - /docs/guides/automation-api/getting-started-automation-api/
 - /docs/using-pulumi/automation-api/getting-started-automation-api/
 - /docs/iac/packages-and-automation/automation-api/getting-started-automation-api/
+- /docs/iac/using-pulumi/automation-api/getting-started-automation-api/
 ---
 
 Pulumi’s Automation API enables you to provision your infrastructure programmatically using the Pulumi engine by exposing Pulumi programs and stacks as strongly-typed and composable building blocks.


### PR DESCRIPTION
## Summary
- Fix 404s for legacy automation-api URLs by adding Hugo aliases
- Redirects `/docs/iac/using-pulumi/automation-api/*` paths to `/docs/iac/automation-api/*`

## URLs Fixed
- `/docs/iac/using-pulumi/automation-api/` → `/docs/iac/automation-api/`
- `/docs/iac/using-pulumi/automation-api/getting-started-automation-api/` → `/docs/iac/automation-api/getting-started-automation-api/`
- `/docs/iac/using-pulumi/automation-api/concepts-terminology/` → `/docs/iac/automation-api/concepts-terminology/`

## Test plan
- [ ] Verify redirects work locally with `make serve`
- [ ] Test that old URLs redirect to new URLs after deployment