### PR TITLE
Improve functions docs

### DIFF
--- a/content/docs/iac/concepts/resources/functions.md
+++ b/content/docs/iac/concepts/resources/functions.md
@@ -235,7 +235,7 @@ Bridged providers, which take a Terraform provider as an underlying dependency, 
 
 Provider functions are exposed in each language as regular functions, in two variations:
 
- 1. The **direct form** accepts plain arguments (e.g. `string`, as opposed to `pulumi.Input<string>`) and returns an asynchronous value or blocks until the result is available.These functions are typically named, e.g., `getX()`.
+ 1. The **direct form** accepts plain arguments (e.g., `string`, as opposed to `pulumi.Input<string>`) and returns an asynchronous value (e.g., a `Promise` in Node.js, a `Task` in Python, etc.) or blocks until the result is available. These functions are typically named, e.g., `getX()`.
  1. The **output form** accepts Pulumi Inputs (or plain values) as arguments and returns a Pulumi Output as a result. For more information on these types, see [Inputs and Outputs](/docs/concepts/inputs-outputs/). These functions are typically named, e.g., `getXOutput()`.
 
 The [Pulumi Registry](/registry) contains authoritative documentation for all provider functions.


### PR DESCRIPTION
Fixes #15368

- Indicate which version should be preferred (output form)
- Explain how bridged providers expose data sources as functions
- Explain when each form executes
- Add scenarios where one form or the other _must_ be used
- Explain why resource methods return outputs
