### PR TITLE
Fix missing /docs/iac/using-pulumi/ aliases causing 404s

### DIFF
--- a/content/docs/iac/crossguard/_index.md
+++ b/content/docs/iac/crossguard/_index.md
@@ -16,6 +16,7 @@ aliases:
 - /policy-as-code/
 - /docs/using-pulumi/crossguard/
 - /docs/iac/packages-and-automation/crossguard/
+- /docs/iac/using-pulumi/crossguard/
 ---
 
 CrossGuard is Pulumi's Policy as Code offering. CrossGuard empowers you to set guardrails to enforce compliance for resources so developers within an organization can provision their own infrastructure while sticking to best practices and security compliance. Using Policy as Code, you can write flexible business or security policies.

--- a/content/docs/iac/crossguard/api-policy-manager.md
+++ b/content/docs/iac/crossguard/api-policy-manager.md
@@ -13,6 +13,7 @@ menu:
 aliases:
     - /docs/using-pulumi/crossguard/api-policy-manager/
     - /docs/iac/packages-and-automation/crossguard/api-policy-manager/
+    - /docs/iac/using-pulumi/crossguard/api-policy-manager/
 ---
 ## Classes
 

--- a/content/docs/iac/crossguard/awsguard.md
+++ b/content/docs/iac/crossguard/awsguard.md
@@ -15,6 +15,7 @@ aliases:
 - /docs/guides/crossguard/awsguard/
 - /docs/using-pulumi/crossguard/awsguard/
 - /docs/iac/packages-and-automation/crossguard/awsguard/
+- /docs/iac/using-pulumi/crossguard/awsguard/
 ---
 <!-- markdownlint-disable ul code -->
 

--- a/content/docs/iac/crossguard/best-practices.md
+++ b/content/docs/iac/crossguard/best-practices.md
@@ -14,6 +14,7 @@ aliases:
 - /docs/guides/crossguard/best-practices/
 - /docs/using-pulumi/crossguard/best-practices/
 - /docs/iac/packages-and-automation/crossguard/best-practices/
+- /docs/iac/using-pulumi/crossguard/best-practices/
 ---
 
 ## Naming Policies

--- a/content/docs/iac/crossguard/compliance-ready-policies-aws.md
+++ b/content/docs/iac/crossguard/compliance-ready-policies-aws.md
@@ -12,6 +12,7 @@ menu:
 aliases:
     - /docs/using-pulumi/crossguard/compliance-ready-policies-aws/
     - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-aws/
+    - /docs/iac/using-pulumi/crossguard/compliance-ready-policies-aws/
 ---
 There's a total of 93 Compliance Ready Policies for the AWS provider.
 

--- a/content/docs/iac/crossguard/compliance-ready-policies-awsnative.md
+++ b/content/docs/iac/crossguard/compliance-ready-policies-awsnative.md
@@ -12,6 +12,7 @@ menu:
 aliases:
     - /docs/using-pulumi/crossguard/compliance-ready-policies-awsnative
     - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-awsnative/
+    - /docs/iac/using-pulumi/crossguard/compliance-ready-policies-awsnative/
 ---
 There's a total of 54 Compliance Ready Policies for the AWS Cloud Control provider.
 

--- a/content/docs/iac/crossguard/compliance-ready-policies-azure.md
+++ b/content/docs/iac/crossguard/compliance-ready-policies-azure.md
@@ -12,6 +12,7 @@ menu:
 aliases:
     - /docs/using-pulumi/crossguard/compliance-ready-policies-azure/
     - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-azure/
+    - /docs/iac/using-pulumi/crossguard/compliance-ready-policies-azure/
 ---
 There's a total of 3 Compliance Ready Policies for the Azure provider.
 

--- a/content/docs/iac/crossguard/compliance-ready-policies-azurenative.md
+++ b/content/docs/iac/crossguard/compliance-ready-policies-azurenative.md
@@ -13,6 +13,7 @@ menu:
 aliases:
     - /docs/using-pulumi/crossguard/compliance-ready-policies-azurenative/
     - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-azurenative/
+    - /docs/iac/using-pulumi/crossguard/compliance-ready-policies-azurenative/
 ---
 There's a total of 1914 Compliance Ready Policies for the Azurenative provider.
 

--- a/content/docs/iac/crossguard/compliance-ready-policies-gcp.md
+++ b/content/docs/iac/crossguard/compliance-ready-policies-gcp.md
@@ -12,6 +12,7 @@ menu:
 aliases:
     - /docs/using-pulumi/crossguard/compliance-ready-policies-gcp/
     - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-gcp/
+    - /docs/iac/using-pulumi/crossguard/compliance-ready-policies-gcp/
 ---
 There's a total of 1 Compliance Ready Policies for the Gcp provider.
 

--- a/content/docs/iac/crossguard/compliance-ready-policies-googlenative.md
+++ b/content/docs/iac/crossguard/compliance-ready-policies-googlenative.md
@@ -12,6 +12,7 @@ menu:
 aliases:
     - /docs/using-pulumi/crossguard/compliance-ready-policies-googlenative/
     - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-googlenative/
+    - /docs/iac/using-pulumi/crossguard/compliance-ready-policies-googlenative/
 ---
 There's a total of 926 Compliance Ready Policies for the Googlenative provider.
 

--- a/content/docs/iac/crossguard/compliance-ready-policies-kubernetes.md
+++ b/content/docs/iac/crossguard/compliance-ready-policies-kubernetes.md
@@ -11,7 +11,8 @@ menu:
         weight: 8
 aliases:
     - /docs/using-pulumi/crossguard/compliance-ready-policies-kubernetes/
-    - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-kubernetes/    
+    - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-kubernetes/
+    - /docs/iac/using-pulumi/crossguard/compliance-ready-policies-kubernetes/    
 ---
 There's a total of 237 Compliance Ready Policies for the Kubernetes provider.
 

--- a/content/docs/iac/crossguard/configuration.md
+++ b/content/docs/iac/crossguard/configuration.md
@@ -14,6 +14,7 @@ aliases:
 - /docs/guides/crossguard/configuration/
 - /docs/using-pulumi/crossguard/configuration/
 - /docs/iac/packages-and-automation/crossguard/configuration/
+- /docs/iac/using-pulumi/crossguard/configuration/
 ---
 
 <!-- markdownlint-disable ul code -->

--- a/content/docs/iac/crossguard/core-concepts.md
+++ b/content/docs/iac/crossguard/core-concepts.md
@@ -16,6 +16,7 @@ aliases:
 - /docs/guides/crossguard/core-concepts/
 - /docs/using-pulumi/crossguard/core-concepts/
 - /docs/iac/packages-and-automation/crossguard/core-concepts/
+- /docs/iac/using-pulumi/crossguard/core-concepts/
 ---
 
 Pulumi CrossGuard provides policy as code capabilities that can be used in two key ways:

--- a/content/docs/iac/crossguard/faq.md
+++ b/content/docs/iac/crossguard/faq.md
@@ -16,6 +16,7 @@ aliases:
 - /docs/using-pulumi/crossguard/faq/
 - /docs/iac/packages-and-automation/crossguard/
 - /docs/iac/packages-and-automation/crossguard/faq/
+- /docs/iac/using-pulumi/crossguard/faq/
 ---
 
 ## Is CrossGuard open source?

--- a/content/docs/iac/crossguard/get-started.md
+++ b/content/docs/iac/crossguard/get-started.md
@@ -19,6 +19,8 @@ aliases:
 - /docs/guides/crossguard/get-started/
 - /docs/using-pulumi/crossguard/get-started/
 - /docs/iac/packages-and-automation/crossguard/get-started/
+- /docs/iac/using-pulumi/crossguard/get-started/
+- /docs/iac/packages-and-automation/crossguard/get-started/
 ---
 
 Pulumi CrossGuard is a product that provides gated deployments via Policy as Code.

--- a/content/docs/iac/crossguard/policy-violations.md
+++ b/content/docs/iac/crossguard/policy-violations.md
@@ -13,6 +13,7 @@ menu:
 aliases:
     - /docs/using-pulumi/crossguard/policy-violations/
     - /docs/iac/packages-and-automation/crossguard/policy-violations/
+    - /docs/iac/using-pulumi/crossguard/policy-violations/
 ---
 
 ## Overview

--- a/content/docs/iac/crossguard/snyk-policy.md
+++ b/content/docs/iac/crossguard/snyk-policy.md
@@ -15,6 +15,7 @@ aliases:
 - /docs/using-pulumi/crossguard/snyk-container-scanning/
 - /docs/using-pulumi/crossguard/snyk-policy/
 - /docs/iac/packages-and-automation/crossguard/snyk-policy/
+- /docs/iac/using-pulumi/crossguard/snyk-policy/
 ---
 <!-- markdownlint-disable ul code -->
 

--- a/content/docs/iac/extending-pulumi/debugging-providers.md
+++ b/content/docs/iac/extending-pulumi/debugging-providers.md
@@ -15,6 +15,7 @@ aliases:
     - /docs/iac/packages-and-automation/pulumi-packages/debugging-provider-packages/
     - /docs/using-pulumi/pulumi-packages/debugging-provider-packages/
     - /docs/iac/using-pulumi/pulumi-packages/debugging-provider-packages/
+    - /docs/iac/using-pulumi/extending-pulumi/debugging-providers/
 ---
 
 When developing or troubleshooting Pulumi providers, you may need to debug the provider code locally. This guide walks you through starting your provider in debug mode, setting breakpoints, and running tests.

--- a/content/docs/iac/extending-pulumi/publishing-packages.md
+++ b/content/docs/iac/extending-pulumi/publishing-packages.md
@@ -16,6 +16,7 @@ aliases:
 - /docs/using-pulumi/pulumi-packages/authoring/
 - /docs/iac/packages-and-automation/pulumi-packages/authoring/
 - /docs/iac/using-pulumi/pulumi-packages/authoring/
+- /docs/iac/using-pulumi/extending-pulumi/publishing-packages/
 ---
 
 This guide will take you step-by-step through creating and publishing a Pulumi Package. You can use this guide to create any [type of Pulumi Package](/docs/guides/pulumi-packages#types-of-pulumi-packages): a component, custom provider, or an existing Terraform provider packaged for use within Pulumi. This guide assumes you're using GitHub to host your package's source code and GitHub Actions to publish various parts of your package.

--- a/content/docs/iac/extending-pulumi/schema.md
+++ b/content/docs/iac/extending-pulumi/schema.md
@@ -15,6 +15,7 @@ aliases:
 - /docs/using-pulumi/pulumi-packages/schema/
 - /docs/iac/packages-and-automation/pulumi-packages/schema/
 - /docs/iac/using-pulumi/pulumi-packages/schema/
+- /docs/iac/using-pulumi/extending-pulumi/schema/
 ---
 
 Pulumi Packages are described by a package schema, which is used to drive code generation for SDKs in each supported Pulumi language, as well as generation of language-agnostic package documentation.  This schema can be manually authored (for component packages) or generated from some other source (such as a cloud provider's API specifications for a native Pulumi resource provider).  Packages can expose resources and functions, define types used by these resources and functions, and provide packaging metadata for language-specific SDKs.


### PR DESCRIPTION
## Summary

Fix 404 errors by adding missing URL aliases for 21 files that were affected during recent docs reorganization. This addresses the root cause where content was moved from `/docs/iac/using-pulumi/` to top-level sections but aliases for the intermediate URLs were not added.

## Problem

URLs like `https://www.pulumi.com/docs/iac/using-pulumi/crossguard/configuration/` were returning 404 errors because the content was moved to `https://www.pulumi.com/docs/iac/crossguard/configuration/` without proper redirects.

## Root Cause

This stems from three docs reorganizations:
1. **Sept 2024**: `/docs/` → `/docs/iac/` (✅ aliases added)
2. **Dec 2024**: `packages-and-automation` → `using-pulumi` (✅ aliases added) 
3. **Recent**: `/docs/iac/using-pulumi/[section]/` → `/docs/iac/[section]/` (❌ missing aliases)

The gap was in the final reorganization where intermediate `/docs/iac/using-pulumi/` URLs didn't get aliases.

## Changes

**Crossguard (18 files):**
- Added `/docs/iac/using-pulumi/crossguard/[page-name]/` alias to all crossguard pages

**Extending Pulumi (3 files):**
- Added `/docs/iac/using-pulumi/extending-pulumi/[page-name]/` alias to:
  - `debugging-providers.md`
  - `publishing-packages.md` 
  - `schema.md`

## Test Plan

- [x] All files pass linting and formatting checks
- [ ] Manually verify redirects work (can be tested after merge)
- [ ] Monitor for any remaining 404s in analytics