### PR TITLE
Update docs for native ESM in TypeScript

### DIFF
--- a/content/docs/iac/languages-sdks/javascript/_index.md
+++ b/content/docs/iac/languages-sdks/javascript/_index.md
@@ -254,6 +254,8 @@ runtime:
     nodeargs: "--loader ts-node/esm --no-warnings"
 ```
 
+Note that if you provide any of the `--loader`, `--import` or `--require` arguments in `nodeargs`, Pulumi will not automatically configure an ESM loader, and you have to specify one yourself, for example `--loader ts-node/esm` as above, or `--import tsx` when using [tsx](https://tsx.is).
+
 {{< /notes >}}
 
 ## Using ESM only modules with CommonJS Pulumi templates


### PR DESCRIPTION
The recommended setup for Node.js projects is to set both `module` and `moduleResolution` to `nodendext`.

With https://github.com/pulumi/pulumi/pull/19980 we no longe rneed to manually set the `—loader` argument.