### PR TITLE
Added details about specifying a seperate yaml file in a YAML project

### DIFF
--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -53,7 +53,7 @@ Some languages also support using `main` to point to a specific file to change w
 
 - For .NET projects, `main` can point to a .NET project file (e.g., `example.csproj`) and the file will be passed to `dotnet run`.
 
-- For YAML projects, `main` can point to another YAML file (it must be named `main.yaml` but it can be in a sub-folder of the project folder) containing the `variables`, `resources`, and `output` properties. The `config` property can exist in either the `Pulumi.yaml` or the referenced file.
+- For YAML projects, `main` can point to another YAML file (it must be named `Main.yaml` but it can be in a sub-folder of the project folder) containing the `variables`, `resources`, and `output` properties. The `config` property can exist in either the `Pulumi.yaml` or the referenced file.
 
 For all other languages, the actual filename is ignored, and the system behaves as though `main` referred to the file's containing directory.
 

--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -53,6 +53,8 @@ Some languages also support using `main` to point to a specific file to change w
 
 - For .NET projects, `main` can point to a .NET project file (e.g., `example.csproj`) and the file will be passed to `dotnet run`.
 
+- For YAML projects, `main` can point to another YAML file (it must be named `main.yaml` but it can be in a sub-folder of the project folder) containing the `variables`, `resources`, and `output` properties. The `config` property can exist in either the `Pulumi.yaml` or the referenced file.
+
 For all other languages, the actual filename is ignored, and the system behaves as though `main` referred to the file's containing directory.
 
 ### `runtime` options


### PR DESCRIPTION
Added details about `main` in the Pulumi.yaml file for a yaml project

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

We specify that .net, nodejs or python projects can use the `main` property, but you can also do this with YAML as well.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
