### PR TITLE
Account Scan Configuration for Google Cloud

### DIFF
--- a/content/docs/insights/accounts.md
+++ b/content/docs/insights/accounts.md
@@ -400,7 +400,7 @@ The GCP scanner for Pulumi Cloud requires access to your Google Cloud project. C
           oidc:
             workloadPoolId: <workload pool id>
             providerId: <provider id>
-            serviceAccount: <serivce account>
+            serviceAccount: <service account>
     environmentVariables:
       GOOGLE_PROJECT: ${gcp.login.project}
       GOOGLE_OAUTH_ACCESS_TOKEN: ${gcp.login.accessToken}

--- a/content/docs/insights/accounts.md
+++ b/content/docs/insights/accounts.md
@@ -383,7 +383,7 @@ echo "Kubeconfig written to $KUBECONFIG_PATH"
 
 ### Google Cloud
 
-The GCP scanner for Pulumi Cloud requires access to your Google Cloud project. Configure ESC to generate Service Account credentials dynamically through OpenID Connect (OIDC).
+The Google Cloud scanner for Pulumi Cloud requires read access to your project. Configure ESC to generate Service Account credentials dynamically through OpenID Connect (OIDC).
 
 1. Configure OpenID Connect for Google Cloud:
    * Follow the steps in [Configuring OpenID Connect For Google Cloud](/docs/esc/environments/configuring-oidc/gcp/)

--- a/content/docs/insights/accounts.md
+++ b/content/docs/insights/accounts.md
@@ -380,3 +380,28 @@ EOF
 
 echo "Kubeconfig written to $KUBECONFIG_PATH"
 ```
+
+### Google Cloud
+
+The GCP scanner for Pulumi Cloud requires access to your Google Cloud project. Configure ESC to generate Service Account credentials dynamically through OpenID Connect (OIDC).
+
+1. Configure OpenID Connect for Google Cloud:
+   * Follow the steps in [Configuring OpenID Connect For Google Cloud](/docs/esc/environments/configuring-oidc/gcp/)
+   * The service account must be granted the **Viewer** role
+
+2. Use the following ESC configuration:
+
+```yaml
+  values:
+    gcp:
+      login:
+        fn::open::gcp-login:
+          project: <numeric project id>
+          oidc:
+            workloadPoolId: <workload pool id>
+            providerId: <provider id>
+            serviceAccount: <serivce account>
+    environmentVariables:
+      GOOGLE_PROJECT: ${gcp.login.project}
+      GOOGLE_OAUTH_ACCESS_TOKEN: ${gcp.login.accessToken}
+```


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Adding instructions for configuring Account Scans for GCP.

This won't be merged until the GCP Scan feature flag is enabled for all customers