### PR TITLE
Remove reference to inline environment

### DIFF
--- a/content/docs/iac/concepts/projects/stack-settings-file.md
+++ b/content/docs/iac/concepts/projects/stack-settings-file.md
@@ -73,8 +73,7 @@ Configuration values can be:
 The `environment` section enables Pulumi ESC (Environments, Secrets, and Configuration) integration. This can be:
 
 - A **string**: Single environment name to import
-- **Array of strings**: Multiple environment names to import  
-- **Inline definition**: Complete environment definition with imports and values
+- **Array of strings**: Multiple environment names to import
 
 ## Configuration file location
 


### PR DESCRIPTION
Remove documentation from stack settings for inline ESC environments. This feature is implemented but not officially supported.