### PR TITLE
Resolve style guide conflicts

### DIFF
--- a/BLOGGING.md
+++ b/BLOGGING.md
@@ -111,7 +111,7 @@ including all the required frontmatter parameters.
 
 Posts are written in [Markdown](https://daringfireball.net/projects/markdown/) and rendered with [BlackFriday](https://github.com/russross/blackfriday), Hugo's default Markdown processor. GitHub's [Mastering Markdown](https://guides.github.com/features/mastering-markdown/) guide is a helpful syntax reference if you need it. You can also include HTML in your posts, if you need greater control over the output than Markdown can provide.
 
-For formatting guidelines, see the Style Guide in [CONTRIBUTING.md](CONTRIBUTING.md#style-guide).
+For formatting guidelines, see [the Style Guide](./STYLE-GUIDE.md).
 
 ### Code Blocks
 
@@ -125,22 +125,6 @@ let bucket = new aws.s3.BucketV2("stuff");
 </pre>
 
 [Additional languages are available](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages) as well.
-
-### Notes
-
-Shortcode for a warning note:
-
-```
-> [!WARNING]
-> **DANGER** Will Robinson!
-```
-
-Shortcode for an info note:
-
-```
-> [!INFO]
-> Using Bastion hosts is a best practice.
-```
 
 ### Media
 
@@ -173,16 +157,16 @@ To use Pulumi's primary brand font Gilroy in your `meta_image`, first [download 
 
 A few things to keep in mind when designing a `meta image`:
 
-   - Avoid placing important text or graphic elements too close to the edges of the frame — elements at the edges may get cropped at some display ratios
-   - Try to include at least one Pulumi identifier (word mark, Pulumipus) so viewers can tell at a glance that the image belongs to the Pulumi blog
-   - Use dark text on light backgrounds, and light text on dark backgrounds to ensure readability
-   - Remember to zoom out from your image and confirm it looks as you intend at a thumbnail size
+- Avoid placing important text or graphic elements too close to the edges of the frame — elements at the edges may get cropped at some display ratios
+- Try to include at least one Pulumi identifier (word mark, Pulumipus) so viewers can tell at a glance that the image belongs to the Pulumi blog
+- Use dark text on light backgrounds, and light text on dark backgrounds to ensure readability
+- Remember to zoom out from your image and confirm it looks as you intend at a thumbnail size
 
 #### Video
 
 To embed a YouTube video, you can use Hugo's built-in [`youtube` shortcode](https://gohugo.io/content-management/shortcodes/#youtube), which takes the video's YouTube ID, obtainable from its public URL on youtube.com:
 
-```
+```plain
 {{< youtube "kDB-YRKFfYE?rel=0" >}}
 ```
 
@@ -209,10 +193,9 @@ After your Pull Request is approved, but before merge/publication date, reach ou
 
 Because the website is deployed in response to a commit to pulumi/docs `master`, it isn't possible to schedule a post to be released automatically at a precise date and time. (The `date` frontmatter property is used only for sorting and display purposes; it has no effect on whether or when a post gets published.) You can, however, influence the timing of the publishing process manually. See the [Merging and Releasing section of the README](README.md#merging-and-releasing) for details.
 
-## Publishing Check List
+## Publishing Checklist
 
 - [ ] As mentioned, use the Hugo blog-post generator instead of copying another post: `make new-blog-post` (or alternatively, the more verbose but equivalent `hugo new --kind blog-post "content/blog/[your-slug]"`)
-- [ ] Spell and grammar check. Consider using a service such as [Grammarly](http://grammarly.com).
 - [ ] Check for a break `<!--more-->` after the first paragraph, and ensure that your post's introduction looks right on the blog home page.
 - [ ] Check that your meta_image appears properly on the blog home page. Do not use animated GIFs for preview images.
 - [ ] Check that your meta_image is using the current logos for Pulumi and others.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,86 +1,43 @@
 # Contributing Pulumi Documentation
 
-## Pulumi terminology
-
-- Use `pulumi` or "the Pulumi CLI" to refer to the CLI.
-- Use `pulumi.com` to refer to the service.
-
 ## Documentation structure
 
-- There is a folder for each heading in the top navigation, such as `Install`, `getting-started`, etc.
+The mapping from documentation page to section and table-of-contents (TOC) is stored largely in each page's front matter, leveraging [Hugo Menus](https://gohugo.io/content-management/menus/). Menus for the CLI commands and API reference are specified in `./config.toml`.
 
-- The mapping from documentation page to section and table-of-contents (TOC) is stored largely in each page's front matter, leveraging [Hugo Menus](https://gohugo.io/content-management/menus/). Menus for the CLI commands and API reference are specified in `./config.toml`.
+## Hugo tips
 
-### Links to other files
+### Short codes
 
-We generally use Hugo's [`relref` shortcode](https://gohugo.io/content-management/shortcodes/#ref-and-relref) when linking to other pages. Examples:
+To share common content across articles, use [Hugo Shortcodes](https://gohugo.io/content-management/shortcodes/). Place a .html file in the [layouts/shortcodes] folder. To include it in a page, use syntax `{{< my-shortcode >}}`
 
-```markdown
-[Install]({{< relref "/docs/get-started/install" >}})
-[Outputs]({{< relref "/docs/intro/concepts/stack#outputs" >}})
+For example, our custom [`cleanup`](layouts/shortcodes/cleanup.html) shortcode can be included in .md files, to include common text about cleaning up stack resources:
+
+```plain
+{{< cleanup >}}
 ```
 
-Which, on a page inside the `./content/reference` directory, will generate:
+HTML layouts can include other layouts inside the [layouts/partials](layouts/partials) directory, e.g.:
 
-```html
-<a href="/docs/install/">Install</a>
-<a href="/docs/intro/concepts/stack/#stack-outputs">Outputs</a>
+```plain
+{{ partial "head.html" . }}
 ```
 
-### Hugo tips
+### Front matter
 
-- **Redirects.** If you rename a file or directory, add a 301 redirect in the front-matter via an [alias](https://gohugo.io/content-management/urls/#aliases) `aliases: [/previous-dir/previousfile.html]`.
+Front matter is defined as a YAML block at the top of a Markdown document that defines metadata about the page. Pulumi docs pages often include the following front matter variables:
 
-- **Includes.**
+- `aliases`: A list of relative URLs that should point to the content in this page. When moving or renaming a page, you must add an `alias` entry for the old path of the page relative to the `content/` folder.
+- `allow_long_title`: Set to `true` in order disable length validation on the `title` attribute.
+- `block_external_search_index`: Set to `true` to prevent crawlers from indexing the page.
+- `h1`: If specified, the `<h1>` at the top of the page will use this value instead of the value in the `title` attribute.
+- `menu`: Specifies where a page appears in the document navigation tree.
+- `meta_desc`: Required (unless `redirect_to` is set), at least 50 characters, no longer than 160 characters. This displays as the description of the page in web search results.
+- `meta_image`: Blog posts only. Relative path to an image to display on the blog post list page and for social media previews. The image must be a PNG file for compatibility.
+- `meta_title`: If specified, the meta title (for OpenGraph) will use this value instead of the value in the `title` attribute.
+- `redirect_to`: The relative or absolute URL of a permanent redirect.
+- `title`: Required (unless `redirect_to` is set), 60 characters or less. This controls the default value for the `<title>` tag as well at the top level `<h1>` in the document.
+- `title_tag`: If specified, the `<title>` tag on the rendered call will use this value instead of the `title` attribute.
 
-  - **.md files.** To share common content across articles, use [Hugo Shortcodes](https://gohugo.io/content-management/shortcodes/). Place a .html file in the [layouts/shortcodes] folder. To include it in a page, use syntax `{{< my-shortcode >}}`
+You can also define arbitrary front-matter variable in the YAML section at the top of a file and refer to that same value in the page content. For instance, the you could add the following front matter `foo: "bar"`, and then reference the variable in markdown with the syntax `{{< param foo >}}`.
 
-    For example, our custom [`cleanup`](layouts/shortcodes/cleanup.html) shortcode can be included in .md files, to include common text about cleaning up stack resources:
-
-    ```md
-    {{< cleanup >}}
-    ```
-
-  - **.html layout files.** HTML layouts can include other layouts inside the [layouts/partials](layouts/partials) directory, e.g.:
-
-    ```html
-    {{ partial "head.html" . }}
-    ```
-
-- **Front-matter variables.** You can define a front-matter variable in the YAML section at the top of a file. For instance, the you could add the following front matter `foo: "bar"`, and then reference the variable in markdown with the syntax `{{< param foo >}}`.
-
-  - **no_on_this_page** Specify this variable to prevent displaying an "On This Page" TOC on the right nav for the page.
-  - **block_external_search_index** Specify this variable to prevent crawlers from indexing the page.
-## Style guide
-
-### Language and terminology styles
-
-- Top level headings use **Title Case**, where each word starts with a capital letter.
-- All other headings use **Sentence case**, where only the first word and any proper nouns have a capital letter.
-- Use capitalization only for a proper noun, and use throughout. For example, "stack" should almost always be lowercase in text.
-
-### Referring to "things"
-
-- References to the Pulumi CLI or CLI commands should be enclosed in backticks (e.g., `pulumi up`).
-- References to UI elements within a webpage should be **bold**. (e.g., "Go to the **Account** page in the Pulumi Console and select **sync profile with GitHub**").
-- Use arrows to indicate a navigation. (e.g., "Go to **FooPage** &gt; **BarItem**").
-
-### Formatting
-
-- Use hash marks for headings (`#`, `##`, etc)
-- Use double-asterisks for bold `**`
-- Use underscore for italic `_`
-- Use `--` for en dashes and `---` for em dashes
-  - Do not put spaces before or after the dashes
-- Use code fences (triple-backticks) and a [language identifier](https://gohugo.io/content-management/syntax-highlighting/) for code formatting and syntax highlighting:
-  <pre><code>```typescript
-  const foo = "bar";
-  ```</code></pre>
-
-### Sections
-
-If a tutorial has more following tutorials, use a **Next steps** section at the end. If you're linking to other reference material, use **Learn more**.
-
-## Blog Post Authoring
-
-For instructions on contributing to the [Pulumi blog](https://www.pulumi.com/blog/), [see BLOGGING.md](BLOGGING.md).
+For more information, see [Front Matter](https://gohugo.io/content-management/front-matter/) in the Hugo docs.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 
 ## Table of contents
 
-- :blue_book: [View Pulumi Docs](https://pulumi.com/docs/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-toc)
-- :clap: [Contributing](#Contributing)
-- :toolbox:	[Setup and Development](#setup-and-development)
-  - [Generating SDK and CLI documentation](#generating-sdk-and-cli-documentation)
-- :busts_in_silhouette: [Pulumi Community](#community)
-- :blue_book: [Pulumi Developer Resources](#pulumi-resources)
-- :compass:	[Pulumi Roadmap](#pulumi-roadmap)
+* :blue_book: [View Pulumi Docs](https://pulumi.com/docs/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-toc)
+* :clap: [Contributing](#Contributing)
+* :toolbox:	[Setup and Development](#setup-and-development)
+  * [Generating SDK and CLI documentation](#generating-sdk-and-cli-documentation)
+* :busts_in_silhouette: [Pulumi Community](#community)
+* :blue_book: [Pulumi Developer Resources](#pulumi-resources)
+* :compass:	[Pulumi Roadmap](#pulumi-roadmap)
 
 ## About this repository
 
@@ -75,7 +75,7 @@ The `Makefile` exposes a number of useful helpers for authoring:
 * `make ensure` resolves and installs all dependencies
 * `make lint` checks all Markdown files for correctness
 * `make format` formats all applicable files to ensure they conform to style guidelines
-* `make serve` runs the Hugo server locally at http://localhost:1313 and watches for changes. You can set `BUILD_FUTURE=false` to simulate production behavior by excluding future-dated content (e.g., `BUILD_FUTURE=false make serve`)
+* `make serve` runs the Hugo server locally at <http://localhost:1313> and watches for changes. You can set `BUILD_FUTURE=false` to simulate production behavior by excluding future-dated content (e.g., `BUILD_FUTURE=false make serve`)
 * `make serve-all` does the same as `make serve`, but also watches for changes to CSS and JS source files
 * `make build` generates the website and writes it to `./public`
 * `make build-assets` builds only the CSS and JavaScript asset bundles
@@ -219,24 +219,25 @@ title: My page
 ...
 block_external_search_index: true
 ```
+
 ## Community
 
 Engage with our community to elevate your developer experience:
 
-- **Join our online [Pulumi Community on Slack](https://slack.pulumi.com/?utm_campaign=pulumi-docs-repo&utm_source=github.com&utm_medium=welcome-slack)** - Interact with thousands of Pulumi developers for collaborative problem-solving and knowledge-sharing!
-- **Join a [Local Pulumi User Groups (PUGs)](https://www.meetup.com/pro/pugs/)**-  Attend tech-packed meetups and hands-on virtual or in-person workshops.
-- **Follow [@PulumiCorp](https://twitter.com/PulumiCorp) on X (Twitter)** - Get real-time updates, technical insights, and sneak peeks into the latest features.
-- **Subscribe to our YouTube Channel, [PulumiTV](https://www.youtube.com/@PulumiTV)** - Learn about AI / ML essentials, launches, workshops, demos and more.
-- **Follow our [LinkedIn](https://www.linkedin.com/company/pulumi/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-community)** - Uncover company news, achievements, and behind-the-scenes glimpses.
+* **Join our online [Pulumi Community on Slack](https://slack.pulumi.com/?utm_campaign=pulumi-docs-repo&utm_source=github.com&utm_medium=welcome-slack)** - Interact with thousands of Pulumi developers for collaborative problem-solving and knowledge-sharing!
+* **Join a [Local Pulumi User Groups (PUGs)](https://www.meetup.com/pro/pugs/)**-  Attend tech-packed meetups and hands-on virtual or in-person workshops.
+* **Follow [@PulumiCorp](https://twitter.com/PulumiCorp) on X (Twitter)** - Get real-time updates, technical insights, and sneak peeks into the latest features.
+* **Subscribe to our YouTube Channel, [PulumiTV](https://www.youtube.com/@PulumiTV)** - Learn about AI / ML essentials, launches, workshops, demos and more.
+* **Follow our [LinkedIn](https://www.linkedin.com/company/pulumi/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-community)** - Uncover company news, achievements, and behind-the-scenes glimpses.
 
 ## Pulumi developer resources
 
 Delve deeper into Pulumi with additional resources:
 
-- [Get Started with Pulumi](https://www.pulumi.com/docs/get-started/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources): Deploy a simple application in AWS, Azure, Google Cloud, or Kubernetes using Pulumi.
-- [Registry](https://www.pulumi.com/registry/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources): Search for packages and learn about the supported resources you need. Install the package directly into your project, browse the API documentation, and start building.
-- [Pulumi Blog](https://www.pulumi.com/blog/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Stay in the loop with our latest tech announcements, insightful articles, and updates.
-- [Try Pulumi AI](https://www.pulumi.com/ai/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Use natural-language prompts to generate Pulumi infrastructure-as-code programs in any language.
+* [Get Started with Pulumi](https://www.pulumi.com/docs/get-started/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources): Deploy a simple application in AWS, Azure, Google Cloud, or Kubernetes using Pulumi.
+* [Registry](https://www.pulumi.com/registry/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources): Search for packages and learn about the supported resources you need. Install the package directly into your project, browse the API documentation, and start building.
+* [Pulumi Blog](https://www.pulumi.com/blog/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Stay in the loop with our latest tech announcements, insightful articles, and updates.
+* [Try Pulumi AI](https://www.pulumi.com/ai/?utm_campaign=pulumi-docs-github-repo&utm_source=github.com&utm_medium=docs-resources) - Use natural-language prompts to generate Pulumi infrastructure-as-code programs in any language.
 
 ## Pulumi roadmap
 

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,8 +1,8 @@
-# Style Guide
+# Style guide
 
 This document defines some general styles we adhere to in the docs.
 
-## Language
+## Using inclusive language
 
 Words are important. Pulumi strives to use language that is clear, harmonious, and friendly to all readers.  With these goals in mind, we use the following guidelines:
 
@@ -19,25 +19,41 @@ Words are important. Pulumi strives to use language that is clear, harmonious, a
 
 ## Headings
 
+* Top level headings use **Title Case**, where each word starts with a capital letter.
+* All other headings use **Sentence case**, where only the first word and any proper nouns have a capital letter.
+* Use capitalization only for a proper noun, and use throughout the heading. For example, "stack" should almost always be lowercase in text.
 * Ensure that readers are able to scan the headings of a page and get an effective overview of the page's content.
-* Every page should have exactly one `h1`.
-* Headings levels should only increment one level at a time.  E.g., if your previous heading level was an `h2`, the next heading must be an `h2` or an `h3`, but not, e.g., an `h4` or `h5`.
+* Every page should have exactly one `h1`. This is typically defined in the `title` attribute of the front matter on a Markdown page.
+* Headings levels must only increment one level at a time.  E.g., if your previous heading level was an `h2`, the next heading must be an `h2` or an `h3`, but not, e.g., an `h4` or `h5`.
 * Docs and registry headings should use sentence case (i.e., first letter of the first word is capitalized).
 
 ## Links
 
+* Use Markdown links to link between pages on the site:
+
+    ```markdown
+    [Link text](/path/to/file)
+    ```
+
+  Or to external sites:
+
+    ```markdown
+    [Link text](https://example.com)
+    ```
+
 * Link text should be descriptive and have meaning outside of the surrounding context: Avoid link text like _here_, _click here_, _see here_ and instead link to the title of the linked page, e.g. "see [Pulumi Pricing](https://www.pulumi.com/pricing/)". (While this practice benefits all readers, it is of particular importance for visually impaired users who use screen readers and often jump through the links of a document.)
-* When changing the URL for an already existing page, add a redirect by using a [Hugo alias](https://gohugo.io/content-management/urls/#yaml-front-matter).
+* When changing the URL for an already existing page (which includes moves and renames within the filesystem), add a redirect by using a [Hugo alias](https://gohugo.io/content-management/urls/#yaml-front-matter).
 
-## Notes and Warnings
+## Notes
 
-Our docs currently support two kinds of note: `info`-level and `warning`-level.
+Our docs support "callouts" with the `{{ notes }}` shortcode:
 
 * Use notes in general to communicate important information.
 * Try to limit the number of notes within a single page.
-* Use `info`-level notes to convey general information.
-* Use `tip`-level notes to convey helpful ideas.
-* Use `warning`-level notes for information that, if missed, could lead to negative or unexpected consequences.
+* The following note levels are supported:
+  * Use `info`-level notes to convey general information.
+  * Use `tip`-level notes to convey helpful ideas.
+  * Use `warning`-level notes for information that, if missed, could lead to negative or unexpected consequences.
 
 ### Examples
 
@@ -58,58 +74,7 @@ This bit of info is serious. If you missed it, bad things could happen.
 ## Paragraphs and Line Breaks
 
 * Keep paragraphs short, rarely use 4 or more sentences in a single paragraph.
-
-* When writing paragraphs and long sentences, use one of the following:
-
-    * Keep the entire paragraph on a single line
-      and use "soft wrapping" in your IDE/editor.
-    * Use [semantic line breaks](https://sembr.org/)
-      to break the paragraph across multiple lines.
-
-    **Do not** "reflow" paragraphs. This causes too much diff noise.
-
-    <details>
-    <summary>Rationale</summary>
-
-    There are two aspects to think about with this choice:
-
-    - editable: how easy is it to suggest changes to the text
-    - reviewable: how easy is it to tell what changed
-
-    And we have three high-level options:
-
-    - all on one line
-
-        ```plain
-        This is a paragraph all on one line. This paragraph is easy to edit because you can suggest changes to the whole paragraph in one go. When anything in this paragraph changes, GitHub will highlight which words changed.
-        ```
-
-    - semantic line breaks
-
-        ```plain
-        This paragraph uses semantic line breaks.
-        Line breaks are introduced between sentences,
-        and where appropriate, even within sentences.
-        This makes it easy to review and edit individual sentences or clauses.
-        When something in a sentence changes,
-        the lines that follow it don't get touched.
-        ```
-
-    - reflowed to a fixed maximum line length
-
-        ```plain
-        This paragraph is split across multiple lines, but it has been run
-        through the editor's reflow function to a maximum line length. This
-        makes it difficult to review because most changes to any sentence will
-        also show the following sentences as changed, and GitHub's word-diff
-        will be less useful there. This is also difficult to edit because
-        suggested changes won't be able to account for reflowing: GitHub's
-        comment box doesn't have reflow support.
-        ```
-
-    In short, only *all on one line* and *semantic line breaks* leave the text
-    adequately editable and reviewable.
-    </details>
+* When writing paragraphs and long sentences keep the entire paragraph on a single line and use "soft wrapping" in your IDE/editor.
 
 ## Blockquotes
 
@@ -123,7 +88,7 @@ This bit of info is serious. If you missed it, bad things could happen.
 
 * Present instructional steps in lists.
 
-## Content Design
+## Content design
 
 * Lead with content that excites and engages, end with exactly one call-to-action.
 * Try and save links for the last 75% of the content.
@@ -132,9 +97,10 @@ This bit of info is serious. If you missed it, bad things could happen.
 * Highlight important points.
 * Avoid emojis unless for notes or absolutely necessary.
 
-## Product Names and Acronyms
+## Product names and acronyms
 
 Pulumi's product names are:
+
 * Pulumi IaC
 * Pulumi ESC
 * Pulumi IDP
@@ -157,7 +123,7 @@ After the first reference, use just the product name:
 
 Always capitalize product names correctly. Do not use variations like "Pulumi IAC", "Pulumi iac", "pulumi IaC", etc.
 
-### Acronym Usage
+### Acronym usage
 
 For acronyms that are not part of Pulumi product names, follow standard grammatical practices:
 
@@ -174,9 +140,23 @@ For subsequent mentions, use just the acronym:
 
 If an acronym is widely known and more commonly used than its spelled-out form (like API, HTTP, REST), you can use the acronym without spelling it out.
 
-This approach follows standard documentation practices like those in the [Google Developer Documentation Style Guide](https://developers.google.com/style/abbreviations). Feel free to reference the Google style guide for a longer, more nuanced explanation of correct usage for acronyms that are *not* part of product names.
+This approach follows standard documentation practices like those in the [Google Developer Documentation Style Guide](https://developers.google.com/style/abbreviations). Feel free to reference the Google style guide for a longer, more nuanced explanation of correct usage for acronyms that are _not_ part of product names.
 
-## Additional Resources
+### Referring to Pulumi commands or UI elements
+
+* References to the Pulumi CLI or CLI commands should be enclosed in backticks (e.g., `pulumi up`).
+* References to UI elements within a webpage should be **bold**. (e.g., "Go to the **Account** page in the Pulumi Console and select **sync profile with GitHub**").
+* Use arrows to indicate a navigation. (e.g., "Go to **FooPage** &gt; **BarItem**").
+
+### Sections in tutorials
+
+If a tutorial has more following tutorials, use a **Next steps** section at the end. If you're linking to other reference material, use **Learn more**.
+
+## Blog post authoring
+
+For instructions on contributing to the [Pulumi blog](https://www.pulumi.com/blog/), [see BLOGGING.md](BLOGGING.md).
+
+## Additional resources
 
 * Markdownlint will help enforce syntactically valid Markdown and is available as a [CLI tool](https://github.com/igorshubovych/markdownlint-cli#installation) or as a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).
 * [Writing inclusive documentation](https://developers.google.com/style/inclusive-documentation) (Google).


### PR DESCRIPTION
Fixes #15472 

- Ensure the style guide only exists in a single doc
- Remove any conflicting guidance (e.g. relrefs are actually linted and will cause a commit to fail)

Note: This PR doesn't make these existing docs as polished and clear in purpose as I would like, but it does resolve most of the duplicated, outdated, and conflicting information and keeps the style guide (mostly?) in a single doc.