### PR TITLE
Add video placeholders with adjusted positioning to multiple product …

### DIFF
--- a/layouts/product/copilot.html
+++ b/layouts/product/copilot.html
@@ -14,6 +14,7 @@
             </div>
         </div>
         <div class="w-full lg:w-1/2 content-center mb-8 lg:mb-0 px-8">
+            <div id="video" style="position: relative; top: -100px;"></div>
             <div class="rounded-xl shadow-2xl relative h-0 overflow-hidden" style="padding-bottom: 50.25%;">
                 <iframe
                     src="https://www.youtube.com/embed/m4kb2k_chyM?si=fHDUOJ-ozZ-2b4_E?rel=0"

--- a/layouts/product/github-actions.html
+++ b/layouts/product/github-actions.html
@@ -17,6 +17,7 @@
                 </div>
             </div>
             <div class="lg:w-1/2">
+                <div id="video" style="position: relative; top: -100px;"></div>
                 <iframe
                     class="rounded shadow-md max-w-full"
                     width="560"
@@ -46,6 +47,7 @@
             </div>
 
             <div class="mb-12">
+                <div id="video2" style="position: relative; top: -100px;"></div>
                 <iframe
                     class="mx-auto rounded shadow-md max-w-full"
                     width="840"
@@ -106,6 +108,7 @@
             </div>
 
             <div class="mb-12">
+                <div id="video3" style="position: relative; top: -100px;"></div>
                 <iframe
                     class="mx-auto rounded shadow-md max-w-full"
                     width="840"

--- a/layouts/product/internal-developer-platforms.html
+++ b/layouts/product/internal-developer-platforms.html
@@ -15,6 +15,7 @@
                 </div>
             </div>
             <div class="w-full lg:w-1/2 mb-8 lg:mb-0">
+                <div id="video" style="position: relative; top: -100px;"></div>
                 <div class="responsive-video-container video-16-9 rounded-xl shadow-2xl relative h-0 overflow-hidden">
                     {{ $videoID := index (split .Params.demo_video.image "?v=") 1 }}
                     <iframe

--- a/layouts/product/pulumi-insights.html
+++ b/layouts/product/pulumi-insights.html
@@ -16,6 +16,7 @@
                 </div>
             </div>
             <div class="w-full lg:w-1/2 mb-8 lg:mb-0">
+                <div id="video" style="position: relative; top: -100px;"></div>
                 <div class="responsive-video-container rounded-xl shadow-2xl relative h-0 overflow-hidden">
                     <iframe
                         src="https://www.youtube.com/embed/fa7s5_oYnaM?rel=0"

--- a/layouts/product/secrets-management.html
+++ b/layouts/product/secrets-management.html
@@ -24,6 +24,7 @@
                 <p>{{ .Params.overview.body | markdownify }}</p>
             </div>
             <div class="w-full lg:w-1/2 mb-8 lg:mb-0">
+                <div id="video" style="position: relative; top: -100px;"></div>
                 <div class="rounded-xl shadow-2xl relative h-0 overflow-hidden" style="padding-bottom: 50.25%;">
                     <iframe
                         src="https://www.youtube.com/embed/JY3Cm1UUIYE?rel=0"


### PR DESCRIPTION
…layouts


Adds #video anchor to touched pages, that is offset anchor for video on page.



<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
