### PR TITLE
Remove Pulumi Answers menu item from Learn dropdown

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -340,15 +340,6 @@
                                         </li>
                                         <li>
                                             <div class="list-title">
-                                                <a href="/answers/">
-                                                    <i class="fas fa-robot mr-0.5"></i>
-                                                    Pulumi Answers
-                                                    <div class="list-sub-title">Collection of Q&A about how to set up different cloud infrastructures</div>
-                                                </a>
-                                            </div>
-                                        </li>
-                                        <li>
-                                            <div class="list-title">
                                                 <a href="/community/">
                                                     <i class="fas fa-comments fa-fw"></i>
                                                     Community
@@ -533,9 +524,6 @@
                                     </li>
                                     <li>
                                         <a href="/events#upcoming"> <i class="fas fa-calendar fa-fw"></i> Events and Workshops </a>
-                                    </li>
-                                    <li>
-                                        <a href="/answers/"> <i class="fas fa-robot mr-0.5"></i> Pulumi Answers </a>
                                     </li>
                                     <li>
                                         <a href="/community/"> <i class="fas fa-comments fa-fw"></i> Community </a>


### PR DESCRIPTION
## Summary
- Remove the "Pulumi Answers" menu item from the Learn dropdown in the main navigation
- Affects both desktop and mobile versions of the menu
- Clean removal with no remaining references

## Test plan
- [ ] Verify the Learn dropdown no longer contains "Pulumi Answers" on desktop
- [ ] Verify the Learn dropdown no longer contains "Pulumi Answers" on mobile
- [ ] Confirm all other Learn menu items remain intact and functional