### PR TITLE
Update docs to indicate increase to 40 policies per OIDC issuer

### DIFF
--- a/content/docs/pulumi-cloud/access-management/oidc-client/_index.md
+++ b/content/docs/pulumi-cloud/access-management/oidc-client/_index.md
@@ -66,7 +66,7 @@ To prevent a range of security attacks, Pulumi stores the provider's TLS certifi
 ### Configure the authorization policies
 
 {{< notes type="info" >}}
-The max amount of policies is limited to 20 policies per OIDC Issuer.
+The max amount of policies is limited to 40 policies per OIDC Issuer.
 {{< /notes >}}
 
 When a new OIDC issuer is registered, a default authorization policy is provisioned denying any token exchange. Explicitly configuring **allow** policies is required.


### PR DESCRIPTION
Update public docs to indicate the increase of maximum number of policies per OIDC issuer from 20 to 40.