### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -1,17 +1,26 @@
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Export secrets to ESC
-on: [ workflow_dispatch ]
+on: [workflow_dispatch]
 jobs:
   export-to-esc:
     runs-on: ubuntu-latest
     name: export GitHub secrets to ESC
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Generate a GitHub token
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: 1256780 # Export Secrets GitHub App
-          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+          private-key: ${{ steps.esc-secrets.outputs.EXPORT_SECRETS_PRIVATE_KEY }}
       - name: Export secrets to ESC
         uses: pulumi/esc-export-secrets-action@v1
         with:


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
