### PR TITLE
Fix typo on Typescript installation command

### DIFF
--- a/content/docs/iac/languages-sdks/javascript/_index.md
+++ b/content/docs/iac/languages-sdks/javascript/_index.md
@@ -239,7 +239,7 @@ Your `tsconfig.json` file should also be updated to ensure that TypeScript outpu
 Install a recent version of `typescript` and `ts-node`.
 
 ```bash
-npm isntall typescript@^5
+npm install typescript@^5
 npm install ts-node@^10
 ```
 


### PR DESCRIPTION
### Proposed changes

Fix the typo of `isntall` to `install` for custom typescript version installation.

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
