### PR TITLE
Update Plans - remove expiramental/preview warning

### DIFF
--- a/content/docs/iac/concepts/update-plans.md
+++ b/content/docs/iac/concepts/update-plans.md
@@ -20,10 +20,6 @@ aliases:
 - /docs/concepts/update-plans/
 ---
 
-{{% notes type="warning" %}}
-Update plans are currently in experimental preview and will only show up in `--help` if the environment variable `PULUMI_EXPERIMENTAL` is set to `true`.
-{{% /notes %}}
-
 The result of previews can be saved to an _update plan_, this can then be used during a later update to
 constrain the update only to the operations that were planned.
 


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Update update-plans.md to remove warning about preview, as the feature is GA

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
