### PR TITLE
Adding arm64 support to the script which generates the versions file

### DIFF
--- a/scripts/get-versions.js
+++ b/scripts/get-versions.js
@@ -54,6 +54,7 @@ const createDownloadLinks = (version) => ({
   "darwin-x64": `${baseUrl}/pulumi-${version}-darwin-x64.tar.gz`,
   "darwin-arm64": `${baseUrl}/pulumi-${version}-darwin-arm64.tar.gz`,
   "windows-x64": `${baseUrl}/pulumi-${version}-windows-x64.zip`,
+  "windows-arm64": `${baseUrl}/pulumi-${version}-windows-arm64.zip`,
 });
 
 const main = async () => {


### PR DESCRIPTION
Hello, to support ARM64 builds for windows we need to add the correct download links [to this file](https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json) which is generated by the file modified in this PR. 

You can see the ARM build artifacts are already being generated in the pulumi/pulumi releases [as seen here ](https://github.com/pulumi/pulumi/releases/tag/v3.165.0)
