### PR TITLE
Add menu entries for cloud documentation sections

### DIFF
--- a/content/docs/iac/get-started/azure/_index.md
+++ b/content/docs/iac/get-started/azure/_index.md
@@ -1,12 +1,13 @@
 ---
 title_tag: Get Started with Azure
 meta_desc: This page provides an overview and guide on how to get started with Azure.
-title: Get started
+title: Azure
 h1: Get started with Pulumi & Azure
 menu:
     iac:
         name: Azure
         parent: iac-get-started
+        identifier: azure-get-started
         weight: 2
     clouds:
         parent: azure

--- a/content/docs/iac/get-started/azure/begin.md
+++ b/content/docs/iac/get-started/azure/begin.md
@@ -4,6 +4,12 @@ meta_desc: This page provides an overview on how to get started with Pulumi when
 title: Before you begin
 h1: "Pulumi & Azure: Before you begin"
 weight: 2
+menu:
+    iac:
+        name: Install Pulumi
+        identifier: azure-get-started.begin
+        parent: azure-get-started
+        weight: 2
 aliases:
     - /docs/quickstart/azure/begin/
     - /docs/quickstart/azure/install-pulumi/

--- a/content/docs/iac/get-started/azure/create-project.md
+++ b/content/docs/iac/get-started/azure/create-project.md
@@ -4,6 +4,12 @@ meta_desc: This page provides an overview of how to create a new Azure + Pulumi 
 title: Create project
 h1: "Pulumi & Azure: Create project"
 weight: 3
+menu:
+    iac:
+        name: Create project
+        identifier: azure-get-started.create-project
+        parent: azure-get-started
+        weight: 3
 aliases:
     - /docs/quickstart/azure/create-project/
     - /docs/get-started/azure/create-project/

--- a/content/docs/iac/get-started/azure/deploy-changes.md
+++ b/content/docs/iac/get-started/azure/deploy-changes.md
@@ -4,6 +4,12 @@ meta_desc: Learn how to deploy changes to an Azure project in this guide.
 title: Deploy changes
 h1: "Pulumi & Azure: Deploy changes"
 weight: 7
+menu:
+    iac:
+        name: Deploy changes
+        identifier: azure-get-started.deploy-changes
+        parent: azure-get-started
+        weight: 7
 aliases:
 - /docs/quickstart/azure/deploy-changes/
 - /docs/get-started/azure/deploy-changes/

--- a/content/docs/iac/get-started/azure/deploy-stack.md
+++ b/content/docs/iac/get-started/azure/deploy-stack.md
@@ -4,6 +4,12 @@ meta_desc: Learn how to deploy your stack to an Azure project in this guide.
 title: Deploy stack
 h1: "Pulumi & Azure: Deploy stack"
 weight: 5
+menu:
+    iac:
+        name: Deploy stack
+        identifier: azure-get-started.deploy-stack
+        parent: azure-get-started
+        weight: 5
 aliases:
 - /docs/quickstart/azure/deploy-stack/
 - /docs/get-started/azure/deploy-stack/

--- a/content/docs/iac/get-started/azure/destroy-stack.md
+++ b/content/docs/iac/get-started/azure/destroy-stack.md
@@ -4,6 +4,12 @@ meta_desc: This page provides an overview of how to destroy a Pulumi stack of an
 title: Destroy stack
 h1: "Pulumi & Azure: Destroy stack"
 weight: 8
+menu:
+    iac:
+        name: Destroy stack
+        identifier: azure-get-started.destroy-stack
+        parent: azure-get-started
+        weight: 8
 aliases:
 - /docs/quickstart/azure/destroy-stack/
 - /docs/get-started/azure/destroy-stack/

--- a/content/docs/iac/get-started/azure/modify-program.md
+++ b/content/docs/iac/get-started/azure/modify-program.md
@@ -4,6 +4,12 @@ meta_desc: This page provides an overview on how to update an Azure project from
 title: Modify program
 h1: "Pulumi & Azure: Modify program"
 weight: 6
+menu:
+    iac:
+        name: Modify program
+        identifier: azure-get-started.modify-program
+        parent: azure-get-started
+        weight: 6
 aliases:
 - /docs/quickstart/azure/modify-program/
 - /docs/get-started/azure/modify-program/

--- a/content/docs/iac/get-started/azure/next-steps.md
+++ b/content/docs/iac/get-started/azure/next-steps.md
@@ -5,6 +5,12 @@ meta_desc: This page provides a list of tutorials that take a deeper dive into
 title: Next steps
 h1: "Pulumi & Azure: Next steps"
 weight: 9
+menu:
+    iac:
+        name: Next steps
+        identifier: azure-get-started.next-steps
+        parent: azure-get-started
+        weight: 9
 aliases:
 - /docs/quickstart/azure/next-steps/
 - /docs/get-started/azure/next-steps/

--- a/content/docs/iac/get-started/azure/review-project.md
+++ b/content/docs/iac/get-started/azure/review-project.md
@@ -5,9 +5,14 @@ title: Review project
 h1: "Pulumi & Azure: Review project"
 weight: 4
 menu:
-  clouds:
-    parent: azure-get-started
-    identifier: azure-review-project
+    iac:
+        name: Review project
+        identifier: azure-get-started.review-project
+        parent: azure-get-started
+        weight: 4
+    clouds:
+        parent: azure-get-started
+        identifier: azure-review-project
 
 aliases:
 - /docs/quickstart/azure/review-project/

--- a/content/docs/iac/get-started/gcp/_index.md
+++ b/content/docs/iac/get-started/gcp/_index.md
@@ -1,11 +1,12 @@
 ---
 title_tag: Get Started with Google Cloud
 meta_desc: This page provides an overview and guide on how to get started with Google Cloud.
-title: Get started
+title: Google Cloud
 h1: Get started with Pulumi & Google Cloud
 menu:
     iac:
         name: Google Cloud
+        identifier: gcp-get-started
         parent: iac-get-started
         weight: 3
     clouds:

--- a/content/docs/iac/get-started/gcp/begin.md
+++ b/content/docs/iac/get-started/gcp/begin.md
@@ -4,6 +4,12 @@ meta_desc: This page provides an overview on how to get started with Pulumi and 
 title: Before you begin
 h1: "Pulumi & Google Cloud: Before you begin"
 weight: 2
+menu:
+    iac:
+        name: Install Pulumi
+        identifier: gcp-get-started.begin
+        parent: gcp-get-started
+        weight: 2
 aliases:
 - /docs/quickstart/gcp/begin/
 - /docs/quickstart/gcp/install-pulumi/

--- a/content/docs/iac/get-started/gcp/create-project.md
+++ b/content/docs/iac/get-started/gcp/create-project.md
@@ -4,6 +4,12 @@ meta_desc: This page provides an overview of how to create a new Google Cloud + 
 title: Create project
 h1: "Pulumi & Google Cloud: Create project"
 weight: 3
+menu:
+    iac:
+        name: Create project
+        identifier: gcp-get-started.create-project
+        parent: gcp-get-started
+        weight: 3
 aliases:
 - /docs/quickstart/gcp/create-project/
 - /docs/get-started/gcp/create-project/

--- a/content/docs/iac/get-started/gcp/deploy-changes.md
+++ b/content/docs/iac/get-started/gcp/deploy-changes.md
@@ -5,9 +5,14 @@ title: Deploy changes
 h1: "Pulumi & Google Cloud: Deploy changes"
 weight: 7
 menu:
-  clouds:
-    parent: google-cloud-get-started
-    identifier: gcp-deploy-changes
+    iac:
+        name: Deploy changes
+        identifier: gcp-get-started.deploy-changes
+        parent: gcp-get-started
+        weight: 7
+    clouds:
+        parent: google-cloud-get-started
+        identifier: gcp-deploy-changes
 
 aliases:
 - /docs/quickstart/gcp/deploy-changes/

--- a/content/docs/iac/get-started/gcp/deploy-stack.md
+++ b/content/docs/iac/get-started/gcp/deploy-stack.md
@@ -5,9 +5,14 @@ title: Deploy stack
 h1: "Pulumi & Google Cloud: Deploy stack"
 weight: 5
 menu:
-  clouds:
-    parent: google-cloud-get-started
-    identifier: gcp-deploy-stack
+    iac:
+        name: Deploy stack
+        identifier: gcp-get-started.deploy-stack
+        parent: gcp-get-started
+        weight: 5
+    clouds:
+        parent: google-cloud-get-started
+        identifier: gcp-deploy-stack
 
 aliases:
 - /docs/quickstart/gcp/deploy-stack/

--- a/content/docs/iac/get-started/gcp/destroy-stack.md
+++ b/content/docs/iac/get-started/gcp/destroy-stack.md
@@ -5,6 +5,11 @@ title: Destroy stack
 h1: "Pulumi & Google Cloud: Destroy stack"
 weight: 8
 menu:
+  iac:
+    name: Destroy stack
+    identifier: gcp-get-started.destroy-stack
+    parent: gcp-get-started
+    weight: 8
   clouds:
     parent: google-cloud-get-started
     identifier: gcp-destroy-stack

--- a/content/docs/iac/get-started/gcp/modify-program.md
+++ b/content/docs/iac/get-started/gcp/modify-program.md
@@ -5,9 +5,14 @@ title: Modify program
 h1: "Pulumi & Google Cloud: Modify program"
 weight: 6
 menu:
-  clouds:
-    parent: google-cloud-get-started
-    identifier: gcp-modify-program
+    iac:
+        name: Modify program
+        identifier: gcp-get-started.modify-program
+        parent: gcp-get-started
+        weight: 6
+    clouds:
+        parent: google-cloud-get-started
+        identifier: gcp-modify-program
 
 aliases:
 - /docs/quickstart/gcp/modify-program/

--- a/content/docs/iac/get-started/gcp/next-steps.md
+++ b/content/docs/iac/get-started/gcp/next-steps.md
@@ -6,6 +6,11 @@ title: Next steps
 h1: "Pulumi & Google Cloud: Next steps"
 weight: 9
 menu:
+  iac:
+    name: Next steps
+    identifier: gcp-get-started.next-steps
+    parent: gcp-get-started
+    weight: 9
   clouds:
     parent: google-cloud-get-started
     identifier: gcp-next-steps

--- a/content/docs/iac/get-started/gcp/review-project.md
+++ b/content/docs/iac/get-started/gcp/review-project.md
@@ -5,9 +5,14 @@ title: Review project
 h1: "Pulumi & Google Cloud: Review project"
 weight: 4
 menu:
-  clouds:
-    parent: google-cloud-get-started
-    identifier: gcp-review-project
+    iac:
+        name: Review project
+        identifier: gcp-get-started.review-project
+        parent: gcp-get-started
+        weight: 4
+    clouds:
+        parent: google-cloud-get-started
+        identifier: gcp-review-project
 
 aliases:
 - /docs/quickstart/gcp/review-project/

--- a/content/docs/iac/get-started/kubernetes/_index.md
+++ b/content/docs/iac/get-started/kubernetes/_index.md
@@ -1,11 +1,12 @@
 ---
 title_tag: Get Started with Kubernetes
 meta_desc: This page provides an overview and guide on how to get started with Kubernetes.
-title: Get started
+title: Kubernetes
 h1: Get Started with Kubernetes
 menu:
     iac:
         name: Kubernetes
+        identifier: kubernetes-get-started
         parent: iac-get-started
         weight: 4
     clouds:

--- a/content/docs/iac/get-started/kubernetes/begin.md
+++ b/content/docs/iac/get-started/kubernetes/begin.md
@@ -5,6 +5,11 @@ title: Before you begin
 h1: "Pulumi & Kubernetes: Before you begin"
 weight: 2
 menu:
+  iac:
+    name: Install Pulumi
+    identifier: kubernetes-get-started.begin
+    parent: kubernetes-get-started
+    weight: 2
   clouds:
     parent: kubernetes-get-started
     identifier: kubernetes-begin

--- a/content/docs/iac/get-started/kubernetes/create-project.md
+++ b/content/docs/iac/get-started/kubernetes/create-project.md
@@ -5,6 +5,11 @@ title: Create project
 h1: "Pulumi & Kubernetes: Create project"
 weight: 3
 menu:
+  iac:
+    name: Create project
+    identifier: kubernetes-get-started.create-project
+    parent: kubernetes-get-started
+    weight: 3
   clouds:
     parent: kubernetes-get-started
     identifier: kubernetes-get-started-create-project

--- a/content/docs/iac/get-started/kubernetes/deploy-changes.md
+++ b/content/docs/iac/get-started/kubernetes/deploy-changes.md
@@ -5,6 +5,11 @@ title: Deploy changes
 h1: "Pulumi & Kubernetes: Deploy changes"
 weight: 7
 menu:
+  iac:
+    name: Deploy changes
+    identifier: kubernetes-get-started.deploy-changes
+    parent: kubernetes-get-started
+    weight: 7
   clouds:
     parent: kubernetes-get-started
     identifier: kubernetes-deploy-changes

--- a/content/docs/iac/get-started/kubernetes/deploy-stack.md
+++ b/content/docs/iac/get-started/kubernetes/deploy-stack.md
@@ -5,9 +5,14 @@ title: Deploy stack
 h1: "Pulumi & Kubernetes: Deploy stack"
 weight: 5
 menu:
-  clouds:
-    parent: kubernetes-get-started
-    identifier: kubernetes-deploy-stack
+    iac:
+        name: Deploy stack
+        identifier: kubernetes-get-started.deploy-stack
+        parent: kubernetes-get-started
+        weight: 5
+    clouds:
+        parent: kubernetes-get-started
+        identifier: kubernetes-deploy-stack
 
 aliases:
 - /docs/quickstart/kubernetes/deploy-stack/

--- a/content/docs/iac/get-started/kubernetes/destroy-stack.md
+++ b/content/docs/iac/get-started/kubernetes/destroy-stack.md
@@ -5,6 +5,11 @@ title: Destroy stack
 h1: "Pulumi & Kubernetes: Destroy stack"
 weight: 8
 menu:
+  iac:
+    name: Destroy stack
+    identifier: kubernetes-get-started.destroy-stack
+    parent: kubernetes-get-started
+    weight: 8
   clouds:
     parent: kubernetes-get-started
     identifier: kubernetes-destroy-stack

--- a/content/docs/iac/get-started/kubernetes/modify-program.md
+++ b/content/docs/iac/get-started/kubernetes/modify-program.md
@@ -5,9 +5,14 @@ title: Modify program
 h1: "Pulumi & Kubernetes: Modify program"
 weight: 6
 menu:
-  clouds:
-    parent: kubernetes-get-started
-    identifier: kubernetes-modify-program
+    iac:
+        name: Modify program
+        identifier: kubernetes-get-started.modify-program
+        parent: kubernetes-get-started
+        weight: 6
+    clouds:
+        parent: kubernetes-get-started
+        identifier: kubernetes-modify-program
 
 aliases:
 - /docs/quickstart/kubernetes/modify-program/

--- a/content/docs/iac/get-started/kubernetes/next-steps.md
+++ b/content/docs/iac/get-started/kubernetes/next-steps.md
@@ -6,6 +6,11 @@ title: Next steps
 h1: "Pulumi & Kubernetes: Next steps"
 weight: 9
 menu:
+  iac:
+    name: Next steps
+    identifier: kubernetes-get-started.next-steps
+    parent: kubernetes-get-started
+    weight: 9
   clouds:
     parent: kubernetes-get-started
     identifier: kubernetes-next-steps

--- a/content/docs/iac/get-started/kubernetes/review-project.md
+++ b/content/docs/iac/get-started/kubernetes/review-project.md
@@ -5,9 +5,14 @@ title: Review project
 h1: "Pulumi & Kubernetes: Review project"
 weight: 4
 menu:
-  clouds:
-    parent: kubernetes-get-started
-    identifier: kubernetes-review-project-get-started
+    iac:
+        name: Review project
+        identifier: kubernetes-get-started.review-project
+        parent: kubernetes-get-started
+        weight: 4
+    clouds:
+        parent: kubernetes-get-started
+        identifier: kubernetes-review-project-get-started
 
 aliases:
 - /docs/quickstart/kubernetes/review-project/


### PR DESCRIPTION
Add menu entries for Azure, Google Cloud, and Kubernetes documentation sections to match AWS experience.

Fixes #15701