### PR TITLE
Fix warnings during python doc generation

### DIFF
--- a/tools/pydocgen/source/pulumi.rst
+++ b/tools/pydocgen/source/pulumi.rst
@@ -21,7 +21,7 @@ pulumi.dynamic
     :imported-members:
 
 pulumi.provider
-==============
+===============
 
 .. automodule:: pulumi.provider
     :members:

--- a/tools/pydocgen/source/pulumi_esc_sdk.rst
+++ b/tools/pydocgen/source/pulumi_esc_sdk.rst
@@ -1,6 +1,6 @@
-*************
+**************
 pulumi_esc_sdk
-*************
+**************
 
 .. automodule:: pulumi_esc_sdk
     :ignore-module-all:

--- a/tools/pydocgen/source/pulumi_terraform.rst
+++ b/tools/pydocgen/source/pulumi_terraform.rst
@@ -1,6 +1,6 @@
-*************
+****************
 pulumi_terraform
-*************
+****************
 
 .. automodule:: pulumi_terraform
     :members:


### PR DESCRIPTION
Fix some warnings related to title lines being too short

```
pulumi_esc_sdk.rst:1: WARNING: Title overline too short
```

& similar
