### PR TITLE
Adjust the ordering of the left nav in IaC docs

### DIFF
--- a/content/docs/iac/adopting-pulumi/_index.md
+++ b/content/docs/iac/adopting-pulumi/_index.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Adopting Pulumi
         parent: iac-home
-        weight: 75
+        weight: 25
         identifier: iac-adopting
     usingpulumi:
         identifier: adopting-pulumi

--- a/content/docs/iac/automation-api/_index.md
+++ b/content/docs/iac/automation-api/_index.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Automation API
         parent: iac-home
-        weight: 55
+        weight: 50
         identifier: iac-automation-api
 aliases:
 - /docs/guides/automation-api/

--- a/content/docs/iac/build-with-pulumi/_index.md
+++ b/content/docs/iac/build-with-pulumi/_index.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Build with Pulumi
         parent: iac-home
-        weight: 76
+        weight: 30
         identifier: iac-build-with-pulumi
 aliases:
 - /docs/iac/using-pulumi/extending-pulumi/

--- a/content/docs/iac/cli/_index.md
+++ b/content/docs/iac/cli/_index.md
@@ -8,7 +8,7 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   iac:
     name: Pulumi CLI
-    weight: 80
+    weight: 45
     identifier: iac-cli
     parent: iac-home
 aliases:

--- a/content/docs/iac/clouds/_index.md
+++ b/content/docs/iac/clouds/_index.md
@@ -8,7 +8,7 @@ menu:
   iac:
     parent: iac-home
     name: Clouds
-    weight: 45
+    weight: 40
     identifier: iac-clouds
 aliases:
   - /docs/clouds/

--- a/content/docs/iac/concepts/_index.md
+++ b/content/docs/iac/concepts/_index.md
@@ -7,7 +7,7 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
         name: Concepts
-        weight: 30
+        weight: 15
         parent: iac-home
         identifier: iac-concepts
     concepts:

--- a/content/docs/iac/crossguard/_index.md
+++ b/content/docs/iac/crossguard/_index.md
@@ -9,7 +9,7 @@ menu:
     iac:
         name: Policy as code
         parent: iac-home
-        weight: 60
+        weight: 55
         identifier: iac-policy
 aliases:
 - /docs/guides/crossguard/

--- a/content/docs/iac/download-install/_index.md
+++ b/content/docs/iac/download-install/_index.md
@@ -7,7 +7,7 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
         parent: iac-home
-        weight: 10
+        weight: 5
         identifier: iac-install
     install:
         name: Overview

--- a/content/docs/iac/get-started/_index.md
+++ b/content/docs/iac/get-started/_index.md
@@ -10,7 +10,7 @@ menu:
         name: Get started
         identifier: iac-get-started
         parent: iac-home
-        weight: 20
+        weight: 10
     getstarted:
         name: Overview
         weight: 2

--- a/content/docs/iac/languages-sdks/_index.md
+++ b/content/docs/iac/languages-sdks/_index.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Languages & SDKs
         parent: iac-home
-        weight: 40
+        weight: 35
         identifier: iac-languages
     languages:
         name: Overview

--- a/content/docs/iac/support/_index.md
+++ b/content/docs/iac/support/_index.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Support
         parent: iac-home
-        weight: 90
+        weight: 60
         identifier: iac-support
     support:
         name: Overview

--- a/content/docs/iac/using-pulumi/_index.md
+++ b/content/docs/iac/using-pulumi/_index.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Using Pulumi
         parent: iac-home
-        weight: 65
+        weight: 20
         identifier: iac-using-pulumi
 aliases:
 - /docs/guides/


### PR DESCRIPTION
This change ensures that:
- Using/Adopting/Building sections are moved higher up (under Concepts)
- Pulumi CLI ref docs are between Clouds and Automation API
- all menu items have consistent weight spacing (multiples of 5, since there are more than 10 items)