### PR TITLE
Document limitations of inline automation API programs

### DIFF
--- a/content/docs/iac/automation-api/concepts-terminology.md
+++ b/content/docs/iac/automation-api/concepts-terminology.md
@@ -57,4 +57,4 @@ A local program is a traditional Pulumi CLI-driven program with its own director
 
 Unlike traditional Pulumi programs, inline programs don't require a separate package on disk, with its own file and a `Pulumi.yaml`. Inline programs are functions that can be authored in the same file as your Automation API program or be imported from another package.
 
-The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. It is unsafe to perform actions outside the scope of the inline program function. Doing so can lead to unpredictable behavior, so always ensure that all resource operations and side effects occur within the inline program's execution context.
+The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. It's unsafe to perform actions outside the scope of the inline program function. Doing so can lead to unpredictable behavior.

--- a/content/docs/iac/automation-api/concepts-terminology.md
+++ b/content/docs/iac/automation-api/concepts-terminology.md
@@ -56,3 +56,5 @@ A local program is a traditional Pulumi CLI-driven program with its own director
 ## Inline Program
 
 Unlike traditional Pulumi programs, inline programs don't require a separate package on disk, with its own file and a `Pulumi.yaml`. Inline programs are functions that can be authored in the same file as your Automation API program or be imported from another package.
+
+The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. It is unsafe to perform actions outside the scope of the inline program function. Doing so can lead to unpredictable behavior, so always ensure that all resource operations and side effects occur within the inline program's execution context.

--- a/content/docs/iac/automation-api/getting-started-automation-api.md
+++ b/content/docs/iac/automation-api/getting-started-automation-api.md
@@ -124,7 +124,7 @@ const pulumiProgram = async () => {
 };
 ```
 
-> **Note:** The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. It is unsafe to perform actions outside the scope of the inline program function. Doing so can lead to unpredictable behavior, so always ensure that all resource operations and side effects occur within the inline program's execution context.
+> **Note:** The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. It's unsafe to perform actions outside the scope of the inline program function. Doing so can lead to unpredictable behavior.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/automation-api/getting-started-automation-api.md
+++ b/content/docs/iac/automation-api/getting-started-automation-api.md
@@ -124,6 +124,8 @@ const pulumiProgram = async () => {
 };
 ```
 
+> **Note:** The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. It is unsafe to perform actions outside the scope of the inline program function. Doing so can lead to unpredictable behavior, so always ensure that all resource operations and side effects occur within the inline program's execution context.
+
 {{% /choosable %}}
 
 {{% choosable language python %}}

--- a/content/docs/iac/automation-api/getting-started-automation-api.md
+++ b/content/docs/iac/automation-api/getting-started-automation-api.md
@@ -124,8 +124,6 @@ const pulumiProgram = async () => {
 };
 ```
 
-> **Note:** The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. It's unsafe to perform actions outside the scope of the inline program function. Doing so can lead to unpredictable behavior.
-
 {{% /choosable %}}
 
 {{% choosable language python %}}
@@ -392,6 +390,10 @@ private static void pulumiProgram(Context ctx) {
 
 {{% /choosable %}}
 {{< /chooser >}}
+
+{{% notes type="warning" %}}
+The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. It's unsafe to perform actions outside the scope of the inline program function. Doing so can lead to unpredictable behavior.
+{{% /notes %}}
 
 ## Associate with a stack
 


### PR DESCRIPTION
Clarify the restrictions on inline programs using the automation API. Emphasize that the program's lifecycle must be contained within the function or closure, and highlight the risks of performing actions outside this scope, which can lead to unpredictable behavior.

Fixes #15588