### PR TITLE
add o11y and infrastructure ai marathon events to /events page

### DIFF
--- a/content/events/o11y-and-infrastructure-ai-marathon-atlanta/index.md
+++ b/content/events/o11y-and-infrastructure-ai-marathon-atlanta/index.md
@@ -1,0 +1,68 @@
+---
+# Name of the event, <= 60 characters
+title: O11y & Infrastructure AI Marathon - Atlanta '25
+meta_desc: "Accelerating AI-Powered Applications to Production: Building IDPs to Amplify Developer Velocity"
+meta_image: 
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: https://lu.ma/gicotw9t
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: O11y & Infrastructure AI Marathon - Atlanta '25
+
+    event_type: event # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2025-09-02T17:00:00-04:00
+
+    # Duration of the webinar.
+    duration:
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: Atlanta, GA
+
+    # Description of the webinar.
+    description:
+
+    # The webinar presenters
+    presenters:
+
+    # case-sensitive
+    tags:
+        level: # Beginner, Intermediate, Advanced
+        topics: []
+        languages: []
+        clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/o11y-and-infrastructure-ai-marathon-nyc/index.md
+++ b/content/events/o11y-and-infrastructure-ai-marathon-nyc/index.md
@@ -1,0 +1,68 @@
+---
+# Name of the event, <= 60 characters
+title: O11y & Infrastructure AI Marathon - NYC '25
+meta_desc: "Accelerating AI-Powered Applications to Production: Building IDPs to Amplify Developer Velocity"
+meta_image: 
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: https://lu.ma/romecux3
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: O11y & Infrastructure AI Marathon - NYC '25
+
+    event_type: event # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2025-09-04T17:00:00-07:00
+
+    # Duration of the webinar.
+    duration:
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: New York, NY
+
+    # Description of the webinar.
+    description:
+
+    # The webinar presenters
+    presenters:
+
+    # case-sensitive
+    tags:
+        level: # Beginner, Intermediate, Advanced
+        topics: []
+        languages: []
+        clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/o11y-and-infrastructure-ai-marathon-portland/index.md
+++ b/content/events/o11y-and-infrastructure-ai-marathon-portland/index.md
@@ -1,0 +1,68 @@
+---
+# Name of the event, <= 60 characters
+title: O11y & Infrastructure AI Marathon - Portland '25
+meta_desc: "Writing Durable AI Agents for Business Process Automation"
+meta_image: 
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: https://lu.ma/hqd8qs4x
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: O11y & Infrastructure AI Marathon - Portland '25
+
+    event_type: event # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2025-09-11T17:00:00-04:00
+
+    # Duration of the webinar.
+    duration:
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: Portland, OR
+
+    # Description of the webinar.
+    description:
+
+    # The webinar presenters
+    presenters:
+
+    # case-sensitive
+    tags:
+        level: # Beginner, Intermediate, Advanced
+        topics: []
+        languages: []
+        clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/o11y-and-infrastructure-ai-marathon-san-francisco/index.md
+++ b/content/events/o11y-and-infrastructure-ai-marathon-san-francisco/index.md
@@ -1,0 +1,68 @@
+---
+# Name of the event, <= 60 characters
+title: O11y & Infrastructure AI Marathon - San Francisco '25
+meta_desc: "Accelerating AI-Powered Applications to Production: Building IDPs to Amplify Developer Velocity"
+meta_image: 
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: https://lu.ma/67cu6vwr
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: O11y & Infrastructure AI Marathon - San Francisco '25
+
+    event_type: event # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2025-09-16T17:00:00-04:00
+
+    # Duration of the webinar.
+    duration:
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: San Francisco, CA
+
+    # Description of the webinar.
+    description:
+
+    # The webinar presenters
+    presenters:
+
+    # case-sensitive
+    tags:
+        level: # Beginner, Intermediate, Advanced
+        topics: []
+        languages: []
+        clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
`/events` page updates for https://github.com/pulumi/marketing/issues/1486

I used the talk titles for the meta descriptions, let me know if there's different copy we'd like to use instead (under 160 chars)

