### PR TITLE
add enterprise tech leadership summit to /events

### DIFF
--- a/content/events/enterprise-tech-leadership-summit/index.md
+++ b/content/events/enterprise-tech-leadership-summit/index.md
@@ -1,0 +1,68 @@
+---
+# Name of the event, <= 60 characters
+title: Enterprise Tech Leadership Summit
+meta_desc: Join Pulumi at the Enterprise Tech Leadership Summit to help redefine how complex enterprises deliver software for speed and market success.
+meta_image: 
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: https://itrevolution.com/product/enterprise-tech-leadership-summit-las-vegas/
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: Enterprise Tech Leadership Summit
+
+    event_type: event # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2025-09-23T09:00:00-04:00
+
+    # Duration of the webinar.
+    duration:
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: Las Vegas, NV
+
+    # Description of the webinar.
+    description:
+
+    # The webinar presenters
+    presenters:
+
+    # case-sensitive
+    tags:
+        level: # Beginner, Intermediate, Advanced
+        topics: []
+        languages: []
+        clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Added https://github.com/pulumi/marketing/issues/1485 to `/events`

I had to trim the meta description to fit, let me know if we'd like to adjust wording (under 160chars)


