### PR TITLE
Add support for Mermaid.js diagrams

### DIFF
--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -84,6 +84,40 @@ This bit of info is serious. If you missed it, bad things could happen.
 
 > This is something a person said.
 
+## Diagrams
+
+Hugo supports two types of diagrams for visualizing concepts and architecture:
+
+* **GoAT (Go ASCII art Tool)**: Creates diagrams from ASCII art. Good for simple flowcharts, boxes, and connections.
+* **Mermaid**: Creates diagrams from a declarative syntax. Supports flowcharts, sequence diagrams, class diagrams, and more.
+
+### GoAT example
+
+```goat
+      .               .                .               .--- 1          .-- 1     / 1
+     / \              |                |           .---+            .-+         +
+    /   \         .---+---.         .--+--.        |   '--- 2      |   '-- 2   / \ 2
+   +     +        |       |        |       |    ---+            ---+          +
+  / \   / \       |       |        |       |       |   .--- 3      |   .-- 3   \ / 3
+ /   \ /   \      '---+---'         '--+--'        '---+            '-+         +
+ 1   2 3   4          |                |               '--- 4          '-- 4     \ 4
+```
+
+For more details, see the [Hugo diagrams documentation](https://gohugo.io/content-management/diagrams/).
+
+### Mermaid example
+
+```mermaid
+graph TD
+    A[Christmas] -->|Get money| B(Go shopping)
+    B --> C{Let me think}
+    C -->|One| D[Laptop]
+    C -->|Two| E[iPhone]
+    C -->|Three| F[fa:fa-car Car]
+```
+
+For more details, see the [Mermaid.js documentation](https://mermaid.js.org/).
+
 ## Lists
 
 * Present instructional steps in lists.

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -86,7 +86,7 @@ This bit of info is serious. If you missed it, bad things could happen.
 
 ## Diagrams
 
-Hugo supports two types of diagrams for visualizing concepts and architecture:
+We support two types of diagrams for visualizing concepts and architecture:
 
 * **GoAT (Go ASCII art Tool)**: Creates diagrams from ASCII art. Good for simple flowcharts, boxes, and connections.
 * **Mermaid**: Creates diagrams from a declarative syntax. Supports flowcharts, sequence diagrams, class diagrams, and more.

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,4 @@
+{{ .Page.Store.Set "hasMermaid" true }}
+<pre class="mermaid">
+  {{ .Inner | htmlEscape | safeHTML }}
+</pre>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -563,6 +563,12 @@
     </script>
     {{ end }}
 
+    {{ if .Store.Get "hasMermaid" }}
+    <script type="module">
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
+        mermaid.initialize({ startOnLoad: true });
+    </script>
+    {{ end }}
 
     {{/* Tests to enforce required frontmatter for certain content types. */}}
     {{ if and (eq .Type "blog") (eq .BundleType "leaf") .IsPage }}

--- a/theme/src/scss/_code.scss
+++ b/theme/src/scss/_code.scss
@@ -61,10 +61,14 @@ pre {
     .code-max-h & {
         @apply border-none my-0;
     }
-
+    
     // For code samples that contain tabs (e.g., Go), limit them to four spaces, to make
     // better use of horizontal space.
     tab-size: 4;
+}
+pre.mermaid {
+    @apply bg-transparent p-0;
+    @apply text-gray-900;
 }
 
 div.highlight.line-numbers {


### PR DESCRIPTION
This PR adds support for Mermaid.js diagrams, as well as docs on how to use them, and a update to the CSS bundle. 