### PR TITLE
Upgrade test programs from .NET 6.0 to .NET 8.0

### DIFF
--- a/static/programs/aws-ec2-instance-with-sg-csharp/aws-ec2-instance-with-sg-csharp.csproj
+++ b/static/programs/aws-ec2-instance-with-sg-csharp/aws-ec2-instance-with-sg-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-ec2-sg-nginx-server-csharp/aws-ec2-sg-nginx-server-csharp.csproj
+++ b/static/programs/aws-ec2-sg-nginx-server-csharp/aws-ec2-sg-nginx-server-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-ec2-vpc-resources-csharp/aws-ec2-vpc-resources-csharp.csproj
+++ b/static/programs/aws-ec2-vpc-resources-csharp/aws-ec2-vpc-resources-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-eks-cluster-csharp/aws-eks-cluster-csharp.csproj
+++ b/static/programs/aws-eks-cluster-csharp/aws-eks-cluster-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-iam-role-instanceprofile-csharp/aws-iam-role-instanceprofile-csharp.csproj
+++ b/static/programs/aws-iam-role-instanceprofile-csharp/aws-iam-role-instanceprofile-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-iam-role-policyattachment-managedpolicy-csharp/aws-iam-role-policyattachment-managedpolicy-csharp.csproj
+++ b/static/programs/aws-iam-role-policyattachment-managedpolicy-csharp/aws-iam-role-policyattachment-managedpolicy-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-iam-user-group-grouppolicy-csharp/aws-iam-user-group-grouppolicy-csharp.csproj
+++ b/static/programs/aws-iam-user-group-grouppolicy-csharp/aws-iam-user-group-grouppolicy-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-iam-user-userpolicy-csharp/aws-iam-user-userpolicy-csharp.csproj
+++ b/static/programs/aws-iam-user-userpolicy-csharp/aws-iam-user-userpolicy-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-import-export-pulumi-config-csharp/aws-import-export-pulumi-config-csharp.csproj
+++ b/static/programs/aws-import-export-pulumi-config-csharp/aws-import-export-pulumi-config-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-import-iac-iam-role-csharp/aws-import-iac-iam-role-csharp.csproj
+++ b/static/programs/aws-import-iac-iam-role-csharp/aws-import-iac-iam-role-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-lambda-stepfunctions-jsonhelper-csharp/aws-lambda-stepfunctions-jsonhelper-csharp.csproj
+++ b/static/programs/aws-lambda-stepfunctions-jsonhelper-csharp/aws-lambda-stepfunctions-jsonhelper-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-s3-bucket-resources-csharp/aws-s3-bucket-resources-csharp.csproj
+++ b/static/programs/aws-s3-bucket-resources-csharp/aws-s3-bucket-resources-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-s3-bucketpolicy-jsonstringify-csharp/aws-s3-bucketpolicy-jsonstringify-csharp.csproj
+++ b/static/programs/aws-s3-bucketpolicy-jsonstringify-csharp/aws-s3-bucketpolicy-jsonstringify-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/aws-s3bucket-s3objects-random-csharp/aws-s3bucket-s3objects-random-csharp.csproj
+++ b/static/programs/aws-s3bucket-s3objects-random-csharp/aws-s3bucket-s3objects-random-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-api-keys-csharp/awsx-apigateway-api-keys-csharp.csproj
+++ b/static/programs/awsx-apigateway-api-keys-csharp/awsx-apigateway-api-keys-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-auth-cognito-csharp/awsx-apigateway-auth-cognito-csharp.csproj
+++ b/static/programs/awsx-apigateway-auth-cognito-csharp/awsx-apigateway-auth-cognito-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-auth-lambda-csharp/awsx-apigateway-auth-lambda-csharp.csproj
+++ b/static/programs/awsx-apigateway-auth-lambda-csharp/awsx-apigateway-auth-lambda-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-custom-domain-csharp/awsx-apigateway-custom-domain-csharp.csproj
+++ b/static/programs/awsx-apigateway-custom-domain-csharp/awsx-apigateway-custom-domain-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-http-proxy-csharp/awsx-apigateway-http-proxy-csharp.csproj
+++ b/static/programs/awsx-apigateway-http-proxy-csharp/awsx-apigateway-http-proxy-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-lambda-csharp/awsx-apigateway-lambda-csharp.csproj
+++ b/static/programs/awsx-apigateway-lambda-csharp/awsx-apigateway-lambda-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-openapi-full-csharp/awsx-apigateway-openapi-full-csharp.csproj
+++ b/static/programs/awsx-apigateway-openapi-full-csharp/awsx-apigateway-openapi-full-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-openapi-route-csharp/awsx-apigateway-openapi-route-csharp.csproj
+++ b/static/programs/awsx-apigateway-openapi-route-csharp/awsx-apigateway-openapi-route-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-s3-csharp/awsx-apigateway-s3-csharp.csproj
+++ b/static/programs/awsx-apigateway-s3-csharp/awsx-apigateway-s3-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-apigateway-validation-types-csharp/awsx-apigateway-validation-types-csharp.csproj
+++ b/static/programs/awsx-apigateway-validation-types-csharp/awsx-apigateway-validation-types-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-ecr-eks-deployment-service-csharp/awsx-ecr-eks-deployment-service-csharp.csproj
+++ b/static/programs/awsx-ecr-eks-deployment-service-csharp/awsx-ecr-eks-deployment-service-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-ecr-image-csharp/awsx-ecr-image-csharp.csproj
+++ b/static/programs/awsx-ecr-image-csharp/awsx-ecr-image-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-ecr-repository-csharp/awsx-ecr-repository-csharp.csproj
+++ b/static/programs/awsx-ecr-repository-csharp/awsx-ecr-repository-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-elb-multi-listener-redirect-csharp/awsx-elb-multi-listener-redirect-csharp.csproj
+++ b/static/programs/awsx-elb-multi-listener-redirect-csharp/awsx-elb-multi-listener-redirect-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-elb-private-subnet-csharp/awsx-elb-private-subnet-csharp.csproj
+++ b/static/programs/awsx-elb-private-subnet-csharp/awsx-elb-private-subnet-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-elb-vpc-csharp/awsx-elb-vpc-csharp.csproj
+++ b/static/programs/awsx-elb-vpc-csharp/awsx-elb-vpc-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-elb-web-listener-csharp/awsx-elb-web-listener-csharp.csproj
+++ b/static/programs/awsx-elb-web-listener-csharp/awsx-elb-web-listener-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-load-balanced-ec2-instances-csharp/awsx-load-balanced-ec2-instances-csharp.csproj
+++ b/static/programs/awsx-load-balanced-ec2-instances-csharp/awsx-load-balanced-ec2-instances-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-load-balanced-fargate-ecr-csharp/awsx-load-balanced-fargate-ecr-csharp.csproj
+++ b/static/programs/awsx-load-balanced-fargate-ecr-csharp/awsx-load-balanced-fargate-ecr-csharp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/static/programs/awsx-load-balanced-fargate-nginx-csharp/awsx-load-balanced-fargate-nginx-csharp.csproj
+++ b/static/programs/awsx-load-balanced-fargate-nginx-csharp/awsx-load-balanced-fargate-nginx-csharp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/static/programs/awsx-vpc-azs-csharp/awsx-vpc-azs-csharp.csproj
+++ b/static/programs/awsx-vpc-azs-csharp/awsx-vpc-azs-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-vpc-cidr-csharp/awsx-vpc-cidr-csharp.csproj
+++ b/static/programs/awsx-vpc-cidr-csharp/awsx-vpc-cidr-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-vpc-csharp/awsx-vpc-csharp.csproj
+++ b/static/programs/awsx-vpc-csharp/awsx-vpc-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-vpc-default-csharp/awsx-vpc-default-csharp.csproj
+++ b/static/programs/awsx-vpc-default-csharp/awsx-vpc-default-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-vpc-fargate-service-csharp/awsx-vpc-fargate-service-csharp.csproj
+++ b/static/programs/awsx-vpc-fargate-service-csharp/awsx-vpc-fargate-service-csharp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/static/programs/awsx-vpc-nat-gateways-csharp/awsx-vpc-nat-gateways-csharp.csproj
+++ b/static/programs/awsx-vpc-nat-gateways-csharp/awsx-vpc-nat-gateways-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-vpc-security-groups-csharp/awsx-vpc-security-groups-csharp.csproj
+++ b/static/programs/awsx-vpc-security-groups-csharp/awsx-vpc-security-groups-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-vpc-sg-ec2-csharp/awsx-vpc-sg-ec2-csharp.csproj
+++ b/static/programs/awsx-vpc-sg-ec2-csharp/awsx-vpc-sg-ec2-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/awsx-vpc-subnets-csharp/awsx-vpc-subnets-csharp.csproj
+++ b/static/programs/awsx-vpc-subnets-csharp/awsx-vpc-subnets-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/azure-native-static-website-csharp/azure-native-static-website-csharp.csproj
+++ b/static/programs/azure-native-static-website-csharp/azure-native-static-website-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/azure-native-storage-account-blob-csharp/azure-native-storage-account-blob-csharp.csproj
+++ b/static/programs/azure-native-storage-account-blob-csharp/azure-native-storage-account-blob-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/gcp-simple-webserver-csharp/gcp-simple-webserver-csharp.csproj
+++ b/static/programs/gcp-simple-webserver-csharp/gcp-simple-webserver-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/static/programs/gcp-storage-bucket-object-csharp/gcp-storage-bucket-object-csharp.csproj
+++ b/static/programs/gcp-storage-bucket-object-csharp/gcp-storage-bucket-object-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
This change upgrades the 47 C# programs that are failing tests due to targeting the .NET 6.0 framework instead of .NET 8.0.

Fixes #15817 and #13885

