### PR TITLE
Update AWS S3 documentation from BucketV2 to Bucket

### DIFF
--- a/content/docs/iac/concepts/how-pulumi-works.md
+++ b/content/docs/iac/concepts/how-pulumi-works.md
@@ -66,8 +66,8 @@ Let's walk through a simple example. Suppose we have the following Pulumi progra
 "use strict";
 const aws = require("@pulumi/aws");
 
-const mediaBucket = new aws.s3.BucketV2("media-bucket");
-const contentBucket = new aws.s3.BucketV2("content-bucket");
+const mediaBucket = new aws.s3.Bucket("media-bucket");
+const contentBucket = new aws.s3.Bucket("content-bucket");
 ```
 
 {{% /choosable %}}
@@ -76,8 +76,8 @@ const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```typescript
 import * as aws from "@pulumi/aws";
 
-const mediaBucket = new aws.s3.BucketV2("media-bucket");
-const contentBucket = new aws.s3.BucketV2("content-bucket");
+const mediaBucket = new aws.s3.Bucket("media-bucket");
+const contentBucket = new aws.s3.Bucket("content-bucket");
 ```
 
 {{% /choosable %}}
@@ -86,8 +86,8 @@ const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```python
 from pulumi_aws import s3
 
-media_bucket = s3.BucketV2('media-bucket')
-content_bucket = s3.BucketV2('content-bucket')
+media_bucket = s3.Bucket('media-bucket')
+content_bucket = s3.Bucket('content-bucket')
 ```
 
 {{% /choosable %}}
@@ -103,11 +103,11 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		mediaBucket, err := s3.NewBucketV2(ctx, "media-bucket", nil)
+		mediaBucket, err := s3.NewBucket(ctx, "media-bucket", nil)
 		if err != nil {
 			return err
 		}
-		contentBucket, err := s3.NewBucketV2(ctx, "content-bucket", nil)
+		contentBucket, err := s3.NewBucket(ctx, "content-bucket", nil)
 		if err != nil {
 			return err
 		}
@@ -127,8 +127,8 @@ using Aws = Pulumi.Aws;
 
 return await Deployment.RunAsync(() =>
 {
-    var mediaBucket = new Aws.S3.BucketV2("media-bucket");
-    var contentBucket = new Aws.S3.BucketV2("content-bucket");
+    var mediaBucket = new Aws.S3.Bucket("media-bucket");
+    var contentBucket = new Aws.S3.Bucket("content-bucket");
 });
 ```
 
@@ -139,13 +139,13 @@ return await Deployment.RunAsync(() =>
 package myproject;
 
 import com.pulumi.Pulumi;
-import com.pulumi.aws.s3.BucketV2;
+import com.pulumi.aws.s3.Bucket;
 
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            var mediaBucket = new BucketV2("media-bucket");
-            var contentBucket = new BucketV2("content-bucket");
+            var mediaBucket = new Bucket("media-bucket");
+            var contentBucket = new Bucket("content-bucket");
         });
     }
 }
@@ -159,9 +159,9 @@ name: my-yaml-project
 runtime: yaml
 resources:
     mediaBucket:
-        type: aws:s3:BucketV2
+        type: aws:s3:Bucket
     contentBucket:
-        type: aws:s3:BucketV2
+        type: aws:s3:Bucket
 ```
 
 {{% /choosable %}}
@@ -180,8 +180,8 @@ After both operations have completed, the language host exits as the program has
 
 ```
 stack mystack
-   - aws.s3.BucketV2 "media-bucket653a4"
-   - aws.s3.BucketV2 "content-bucket125ce"
+   - aws.s3.Bucket "media-bucket653a4"
+   - aws.s3.Bucket "content-bucket125ce"
 ```
 
 Note the extra suffixes on the end of these bucket names. This is due to a process called [auto-naming](/docs/concepts/resources/names/#autonaming), which Pulumi uses by default in order to allow you to deploy multiple copies of your infrastructure without creating name collisions for resources. This behavior can be disabled if desired.
@@ -196,10 +196,10 @@ Now, let's make a change to one of resources and run `pulumi up` again.  Since P
 "use strict";
 const aws = require("@pulumi/aws");
 
-const mediaBucket = new aws.s3.BucketV2("media-bucket", {
+const mediaBucket = new aws.s3.Bucket("media-bucket", {
     tags: {"owner": "media-team"},
 });
-const contentBucket = new aws.s3.BucketV2("content-bucket");
+const contentBucket = new aws.s3.Bucket("content-bucket");
 ```
 
 {{% /choosable %}}
@@ -208,10 +208,10 @@ const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```typescript
 import * as aws from "@pulumi/aws";
 
-const mediaBucket = new aws.s3.BucketV2("media-bucket", {
+const mediaBucket = new aws.s3.Bucket("media-bucket", {
     tags: {"owner": "media-team"},
 });
-const contentBucket = new aws.s3.BucketV2("content-bucket");
+const contentBucket = new aws.s3.Bucket("content-bucket");
 ```
 
 {{% /choosable %}}
@@ -220,8 +220,8 @@ const contentBucket = new aws.s3.BucketV2("content-bucket");
 ```python
 from pulumi_aws import s3
 
-media_bucket = s3.BucketV2('media-bucket', tags={'owner': 'media-team'})
-content_bucket = s3.BucketV2('content-bucket')
+media_bucket = s3.Bucket('media-bucket', tags={'owner': 'media-team'})
+content_bucket = s3.Bucket('content-bucket')
 ```
 
 {{% /choosable %}}
@@ -237,7 +237,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		mediaBucket, err := s3.NewBucketV2(ctx, "mediaBucket", &s3.BucketV2Args{
+		mediaBucket, err := s3.NewBucket(ctx, "mediaBucket", &s3.BucketArgs{
 			Tags: pulumi.StringMap{
 				"owner": pulumi.String("media-team"),
 			},
@@ -245,7 +245,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		contentBucket, err := s3.NewBucketV2(ctx, "contentBucket", nil)
+		contentBucket, err := s3.NewBucket(ctx, "contentBucket", nil)
 		if err != nil {
 			return err
 		}
@@ -265,14 +265,14 @@ using Aws = Pulumi.Aws;
 
 return await Deployment.RunAsync(() =>
 {
-    var mediaBucket = new Aws.S3.BucketV2("media-bucket", new()
+    var mediaBucket = new Aws.S3.Bucket("media-bucket", new()
     {
         Tags =
         {
             { "owner", "media-team" },
         },
     }););
-    var contentBucket = new Aws.S3.BucketV2("content-bucket");
+    var contentBucket = new Aws.S3.Bucket("content-bucket");
 });
 ```
 
@@ -284,16 +284,16 @@ package myproject;
 
 import java.util.Map;
 import com.pulumi.Pulumi;
-import com.pulumi.aws.s3.BucketV2;
-import com.pulumi.aws.s3.BucketV2Args;
+import com.pulumi.aws.s3.Bucket;
+import com.pulumi.aws.s3.BucketArgs;
 
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            var mediaBucket = new BucketV2("mediaBucket", BucketV2Args.builder()
+            var mediaBucket = new Bucket("mediaBucket", BucketArgs.builder()
                 .tags(Map.of("owner", "media-team"))
                 .build());
-            var contentBucket = new BucketV2("content-bucket");
+            var contentBucket = new Bucket("content-bucket");
         });
     }
 }
@@ -307,19 +307,19 @@ name: my-yaml-project
 runtime: yaml
 resources:
   mediaBucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
     properties:
       tags:
         owner: media-team
   contentBucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
 ```
 
 {{% /choosable %}}
 
 {{< /chooser >}}
 
-When you run `pulumi preview` or `pulumi up`, the entire process starts over.  The language host starts running your program and the call to aws.s3.BucketV2 causes a new resource registration request to be sent to the engine. This time, however, our state already contains a resource named `media-bucket`, so engine asks the resource provider to compare the existing state from our previous run of `pulumi up` with the desired state expressed by the program. The process detects that the `tags` property has changed from empty to a map assigning the `owner` tag. By again consulting the resource provider the engine determines that it is able to update this property without creating a new bucket, and so it tells the provider to update the `tags` property to set the `owner` tag. When this operation completes, the current state is updated to reflect the change that had been made.
+When you run `pulumi preview` or `pulumi up`, the entire process starts over.  The language host starts running your program and the call to aws.s3.Bucket causes a new resource registration request to be sent to the engine. This time, however, our state already contains a resource named `media-bucket`, so engine asks the resource provider to compare the existing state from our previous run of `pulumi up` with the desired state expressed by the program. The process detects that the `tags` property has changed from empty to a map assigning the `owner` tag. By again consulting the resource provider the engine determines that it is able to update this property without creating a new bucket, and so it tells the provider to update the `tags` property to set the `owner` tag. When this operation completes, the current state is updated to reflect the change that had been made.
 
 The engine also receives a resource registration request for "content-bucket".  However, since there are no changes between the current state and the desired state, the engine does not need to make any changes to the resource.
 
@@ -332,10 +332,10 @@ Now, suppose we rename `content-bucket` to `app-bucket`.
 ```javascript
 "use strict";
 const aws = require("@pulumi/aws");
-const mediaBucket = new aws.s3.BucketV2("media-bucket", {
+const mediaBucket = new aws.s3.Bucket("media-bucket", {
     tags: {"owner": "media-team"},
 });
-const appBucket = new aws.s3.BucketV2("app-bucket");
+const appBucket = new aws.s3.Bucket("app-bucket");
 ```
 
 {{% /choosable %}}
@@ -344,10 +344,10 @@ const appBucket = new aws.s3.BucketV2("app-bucket");
 ```typescript
 import * as aws from "@pulumi/aws";
 
-const mediaBucket = new aws.s3.BucketV2("media-bucket", {
+const mediaBucket = new aws.s3.Bucket("media-bucket", {
     tags: {"owner": "media-team"},
 });
-const appBucket = new aws.s3.BucketV2("app-bucket");
+const appBucket = new aws.s3.Bucket("app-bucket");
 ```
 
 {{% /choosable %}}
@@ -356,8 +356,8 @@ const appBucket = new aws.s3.BucketV2("app-bucket");
 ```python
 from pulumi_aws import s3
 
-media_bucket = s3.BucketV2('media-bucket', tags={'owner': 'media-team'})
-app_bucket = s3.BucketV2('app-bucket')
+media_bucket = s3.Bucket('media-bucket', tags={'owner': 'media-team'})
+app_bucket = s3.Bucket('app-bucket')
 ```
 
 {{% /choosable %}}
@@ -373,7 +373,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		mediaBucket, err := s3.NewBucketV2(ctx, "mediaBucket", &s3.BucketV2Args{
+		mediaBucket, err := s3.NewBucket(ctx, "mediaBucket", &s3.BucketArgs{
 			Tags: pulumi.StringMap{
 				"owner": pulumi.String("media-team"),
 			},
@@ -381,7 +381,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		appBucket, err := s3.NewBucketV2(ctx, "appBucket", nil)
+		appBucket, err := s3.NewBucket(ctx, "appBucket", nil)
 		if err != nil {
 			return err
 		}
@@ -401,14 +401,14 @@ using Aws = Pulumi.Aws;
 
 return await Deployment.RunAsync(() =>
 {
-    var mediaBucket = new Aws.S3.BucketV2("media-bucket", new()
+    var mediaBucket = new Aws.S3.Bucket("media-bucket", new()
     {
         Tags =
         {
             { "owner", "media-team" },
         },
     }););
-    var appBucket = new Aws.S3.BucketV2("app-bucket");
+    var appBucket = new Aws.S3.Bucket("app-bucket");
 });
 ```
 
@@ -420,16 +420,16 @@ package myproject;
 
 import java.util.Map;
 import com.pulumi.Pulumi;
-import com.pulumi.aws.s3.BucketV2;
-import com.pulumi.aws.s3.BucketV2Args;
+import com.pulumi.aws.s3.Bucket;
+import com.pulumi.aws.s3.BucketArgs;
 
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            var mediaBucket = new BucketV2("mediaBucket", BucketV2Args.builder()
+            var mediaBucket = new Bucket("mediaBucket", BucketArgs.builder()
                 .tags(Map.of("owner", "media-team"))
                 .build());
-            var appBucket = new BucketV2("appBucket");
+            var appBucket = new Bucket("appBucket");
         });
     }
 }
@@ -443,12 +443,12 @@ name: my-yaml-project
 runtime: yaml
 resources:
   mediaBucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
     properties:
       tags:
         owner: media-team
   appBucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/projects/_index.md
+++ b/content/docs/iac/concepts/projects/_index.md
@@ -93,7 +93,7 @@ The following are other examples of `Pulumi.yaml` files that define project conf
     runtime: yaml
     resources:
       bucket:
-        type: aws:s3:BucketV2
+        type: aws:s3:Bucket
     ```
 
 For more information on valid Pulumi project metadata, see the [Pulumi.yaml reference](/docs/reference/pulumi-yaml/).

--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -192,7 +192,7 @@ resources:
 
 {{< /chooser >}}
 
-If the `name` property is not available on a resource, consult the [Registry](/registry/) for the specific resource you are creating. Some resources use a different property to override auto-naming. For instance, the `aws.s3.BucketV2` type uses the property `bucket` instead of name. Other resources, such as `aws.kms.Key`, do not have physical names and use other auto-generated IDs to uniquely identify them.
+If the `name` property is not available on a resource, consult the [Registry](/registry/) for the specific resource you are creating. Some resources use a different property to override auto-naming. For instance, the `aws.s3.Bucket` type uses the property `bucket` instead of name. Other resources, such as `aws.kms.Key`, do not have physical names and use other auto-generated IDs to uniquely identify them.
 
 Overriding auto-naming makes your project susceptible to naming collisions. As a result, for resources that may need to be replaced, you should specify `deleteBeforeReplace: true` in the resource’s options. This option ensures that old resources are deleted before new ones are created, which will prevent those collisions.
 
@@ -413,21 +413,21 @@ Changing the autonaming setting on an existing stack doesn't cause any immediate
 
 Each resource is an instance of a specific Pulumi resource type.  This type is specified by a type token in the format `<package>:<module>:<typename>`.  Concrete examples of this format are:
 
-- `aws:s3/bucketv2:BucketV2`
+- `aws:s3/bucket:Bucket`
 - `azure-native:compute:VirtualMachine`
 - `kubernetes:apps/v1:Deployment`
 - `random:index:RandomPassword`
 
 The `<package>` component of the type (e.g. `aws`, `azure-native`, `kubernetes`, `random`) specifies which [Pulumi Package](/docs/using-pulumi/pulumi-packages/) defines the resource.  This is mapped to the package in the [Pulumi Registry](/registry/) and to the underlying [Resource Provider](/docs/concepts/resources/providers/).
 
-The `<module>` component of the type (e.g. `s3/bucket`, `compute`, `apps/v1`, `index`) is the module path where the resource lives within the package.  It is `/` delimited by component of the path.  Per-language Pulumi SDKs use the module path to emit nested namespaces/modules in a language-specific way to organize all the types defined in a package.  For example, the `Deployment` resource above is available at `kubernetes.apps.v1.Deployment` in TypeScript and in the `github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/apps/v1` module in Go.  For historical reasons only, some packages include the type name itself as a final component of the module (e.g. `s3/bucketv2` for the type name `BucketV2`) - in this case, this component is not included in the SDK namespace.  The name `index` indicates that the resource is not nested, and is instead available at the top level of the package.  For example, the `RandomPassword` resource above is available at `random.RandomPassword` in TypeScript.
+The `<module>` component of the type (e.g. `s3/bucket`, `compute`, `apps/v1`, `index`) is the module path where the resource lives within the package.  It is `/` delimited by component of the path.  Per-language Pulumi SDKs use the module path to emit nested namespaces/modules in a language-specific way to organize all the types defined in a package.  For example, the `Deployment` resource above is available at `kubernetes.apps.v1.Deployment` in TypeScript and in the `github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/apps/v1` module in Go.  For historical reasons only, some packages include the type name itself as a final component of the module (e.g. `s3/bucket` for the type name `Bucket`) - in this case, this component is not included in the SDK namespace.  The name `index` indicates that the resource is not nested, and is instead available at the top level of the package.  For example, the `RandomPassword` resource above is available at `random.RandomPassword` in TypeScript.
 
-The `<typename>` component of the type (e.g. `BucketV2`, `VirtualMachine`, `Deployment`, `RandomPassword`) is the identifier used to refer to the resource itself.  It is mapped to the class or constructor name in the per-language Pulumi SDK.
+The `<typename>` component of the type (e.g. `Bucket`, `VirtualMachine`, `Deployment`, `RandomPassword`) is the identifier used to refer to the resource itself.  It is mapped to the class or constructor name in the per-language Pulumi SDK.
 
 Note that because of some of the historical details of how `<module>` is defined, a "simplified" resource type name is accepted or presented in certain places, and mapped into the "full" resource type name specified above.  The simplified resource type name applies the following rules:
 
 1. If the type token is two components instead of three, that is `<package>:<typename>`, it is interpreted as if it was `<package>:index:<typename>`.
-2. The repetition of the `<typename>` as part of the module definition is not required, and will be inferred if necessary - that is `aws:s3:BucketV2` will be interpreted as referring to `aws:s3/bucketv2:BucketV2`.
+2. The repetition of the `<typename>` as part of the module definition is not required, and will be inferred if necessary - that is `aws:s3:Bucket` will be interpreted as referring to `aws:s3/bucket:Bucket`.
 
 This "simplified" type name format is currently used in the following places:
 
@@ -435,7 +435,7 @@ This "simplified" type name format is currently used in the following places:
 
 The examples above can be written in simplified form as:
 
-- `aws:s3:BucketV2`
+- `aws:s3:Bucket`
 - `azure-native:compute:VirtualMachine`
 - `kubernetes:apps/v1:Deployment`
 - `random:RandomPassword`
@@ -449,7 +449,7 @@ The URN is automatically constructed from the project name, stack name, resource
 The following is an example of a URN:
 
 ```text
-urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket
+urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucket:Bucket::my-bucket
            ^^^^^^^^^^  ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^
            <stack-name> <project-name>   <parent-type>             <resource-type>       <resource-name>
 ```
@@ -459,7 +459,7 @@ The type components of the URN are [resource types](#types) as defined above, an
 The URN must be globally unique. This means all of the components that go into a URN must be unique within your program. If you create two resources with the same name, type, and parent path, for instance, you will see an error:
 
 ```bash
-error: Duplicate resource URN 'urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket'; try giving it a unique name
+error: Duplicate resource URN 'urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucket:Bucket::my-bucket'; try giving it a unique name
 ```
 
 Any change to the URN of a resource causes the old and new resources to be treated as unrelated—the new one will be created (since it was not in the prior state) and the old one will be deleted (since it is not in the new desired state). This behavior happens when you change the `name` used to construct the resource or the structure of a resource’s parent hierarchy.

--- a/content/docs/iac/concepts/testing/integration.md
+++ b/content/docs/iac/concepts/testing/integration.md
@@ -100,7 +100,7 @@ integration.ProgramTest(t, &integration.ProgramTestOptions{
     ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
         var foundBuckets int
         for _, res := range stack.Deployment.Resources {
-            if res.Type == "aws:s3/bucketv2:BucketV2" {
+            if res.Type == "aws:s3/bucket:Bucket" {
                 foundBuckets++
             }
         }

--- a/content/docs/iac/concepts/update-plans.md
+++ b/content/docs/iac/concepts/update-plans.md
@@ -89,9 +89,9 @@ template](https://github.com/pulumi/templates/tree/master/aws-typescript).
         "aws:region": "us-east-1"
     },
     "resourcePlans": {
-        "urn:pulumi:dev::examplets::aws:s3/bucketv2:BucketV2::my-bucket": {
+        "urn:pulumi:dev::examplets::aws:s3/bucket:Bucket::my-bucket": {
             "goal": {
-                "type": "aws:s3/bucketv2:BucketV2",
+                "type": "aws:s3/bucket:Bucket",
                 "name": "my-bucket",
                 "custom": true,
                 "inputDiff": {
@@ -176,7 +176,7 @@ template](https://github.com/pulumi/templates/tree/master/aws-typescript).
 This is a textual representation of the goals, and operation steps that the program planned to take.
 
 For the most part this should be readable without much internal knowledge of Pulumi, for example you can see
-this plans on creating an `s3:BucketV2` object called "my-bucket-6209a55". A lot of the other options correspond
+this plans on creating an `s3:Bucket` object called "my-bucket-6209a55". A lot of the other options correspond
 directly to things you should be familiar with from Pulumi programs (such as parents, providers, custom or
  component resources).
 


### PR DESCRIPTION
## Summary
• Updated documentation to reflect AWS S3 resource changes from BucketV2 to Bucket
• Updated code examples across multiple documentation files to use the current Bucket resource type
• Ensured consistency across all language examples (JavaScript, TypeScript, Python, Go, C#, Java, YAML)

## Files Changed
- `content/docs/iac/concepts/how-pulumi-works.md` - Updated S3 examples in How Pulumi Works guide
- `content/docs/iac/concepts/projects/_index.md` - Updated project configuration examples
- `content/docs/iac/concepts/resources/names.md` - Updated resource naming examples and type references
- `content/docs/iac/concepts/testing/integration.md` - Updated integration testing examples
- `content/docs/iac/concepts/update-plans.md` - Updated update plan examples

## Test Plan
- [x] Verified all S3 references changed from BucketV2 to Bucket
- [x] Ensured consistency across all programming language examples
- [x] Maintained proper code formatting and syntax

🤖 Generated with [Claude Code](https://claude.ai/code)