### PR TITLE
AWS v7: Update Language-specific Documentation for BucketV2 to Bucket (#15790)

### DIFF
--- a/content/docs/iac/automation-api/getting-started-automation-api.md
+++ b/content/docs/iac/automation-api/getting-started-automation-api.md
@@ -75,7 +75,7 @@ This tutorial is based on the [`inlineProgram-ts` example](https://github.com/pu
 ```typescript
 const pulumiProgram = async () => {
     // Create a bucket and expose a website index document.
-    const siteBucket = new s3.BucketV2("s3-website-bucket", {});
+    const siteBucket = new s3.Bucket("s3-website-bucket", {});
 
     const indexContent = `<html><head>
 <title>Hello S3</title><meta charset="UTF-8">
@@ -135,7 +135,7 @@ This tutorial is based on the [`inline_program` example](https://github.com/pulu
 ```python
 def pulumi_program():
     # Create a bucket and expose a website index document.
-    site_bucket = s3.BucketV2("s3-website-bucket")
+    site_bucket = s3.Bucket("s3-website-bucket")
 
     index_content = """
     <html>
@@ -192,7 +192,7 @@ This tutorial is based on the [`inline_program` example](https://github.com/pulu
 deployFunc := func(ctx *pulumi.Context) error {
     // Similar go git_repo_program, our program defines a s3 website.
     // Here we create the bucket.
-    siteBucket, err := s3.NewBucketV2(ctx, "s3-website-bucket", nil)
+    siteBucket, err := s3.NewBucket(ctx, "s3-website-bucket", nil)
     if err != nil {
         return err
     }
@@ -338,7 +338,7 @@ This tutorial is based on the [`InlineProgram` example](https://github.com/pulum
 private static void pulumiProgram(Context ctx) {
 
     // Create an AWS resource (S3 Bucket)
-    var siteBucket = new BucketV2("s3-website-bucket");
+    var siteBucket = new Bucket("s3-website-bucket");
 
     var website = new BucketWebsiteConfigurationV2("website", BucketWebsiteConfigurationV2Args.builder()
             .bucket(siteBucket.id())

--- a/content/docs/iac/languages-sdks/python/python-blocking-async.md
+++ b/content/docs/iac/languages-sdks/python/python-blocking-async.md
@@ -48,7 +48,7 @@ import os
 from pulumi import export, FileAsset
 from pulumi_aws import s3
 
-bucket = s3.BucketV2('s3-bucket')
+bucket = s3.Bucket('s3-bucket')
 
 content_dir = "www"
 for file in os.listdir(content_dir):

--- a/content/docs/iac/languages-sdks/yaml/_index.md
+++ b/content/docs/iac/languages-sdks/yaml/_index.md
@@ -41,7 +41,7 @@ config:
     type: string
 resources:
   my-bucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
   my-bucket-website:
     type: aws:s3:BucketWebsiteConfigurationV2
     properties:

--- a/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
+++ b/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
@@ -139,7 +139,7 @@ resources:
     options:
       version: 6.45.0
   my-bucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
 ```
 
 In this example the `my-bucket` resource, and any other AWS resources, uses the default AWS provider version 6.45.0.
@@ -183,7 +183,7 @@ To declare a resource with a specific provider version use the `version` option 
 ```yaml
 resources:
   something:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
     properties:
       ...
     options:
@@ -207,7 +207,7 @@ resources:
       version: 6.45.0
       pluginDownloadURL: github://api.github.com/pulumi
   my-bucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
 ```
 
 ### Outputs and Stack References


### PR DESCRIPTION
## Summary
Updates documentation for AWS provider v7 compatibility by replacing deprecated `BucketV2` with unified `Bucket` resource across all language examples and core documentation files.

Fixes #15790 

## Changes Made
- Updated 4 core documentation files specified in issue #15790:
  - `content/docs/iac/languages-sdks/python/python-blocking-async.md`
  - `content/docs/iac/languages-sdks/yaml/_index.md` 
  - `content/docs/iac/languages-sdks/yaml/yaml-language-reference.md`
  - `content/docs/iac/automation-api/getting-started-automation-api.md`

- Updated 46 static program examples across all supported languages:
  - TypeScript, JavaScript, Python, Go, Java, C#, YAML
  - Custom policy pack examples
  - S3 website bucket examples
  - S3 bucket policy examples 
  - S3 bucket object examples
  - Lambda EventBridge examples

## Technical Details
- Replaced `s3.BucketV2` → `s3.Bucket`
- Replaced `aws:s3:BucketV2` → `aws:s3:Bucket`
- Replaced `NewBucketV2` → `NewBucket` (Go)
- Updated import statements and type references
- Maintained all existing functionality and syntax

## Validation
- ✅ Build successful (`make build`)
- ✅ Linting passed (`make lint`)
- ✅ No breaking changes required for `loggings`/`routingRules` in scope files

## Test plan
- [x] Verify all core documentation files render correctly
- [x] Confirm static program examples maintain proper syntax
- [x] Validate build and lint processes pass
- [x] Ensure consistency across all language variants

🤖 Generated with [Claude Code](https://claude.ai/code)