### PR TITLE
AWS v7: Update remaining BucketV2 references in documentation content

### DIFF
--- a/content/docs/iac/clouds/aws/guides/cdk.md
+++ b/content/docs/iac/clouds/aws/guides/cdk.md
@@ -778,7 +778,7 @@ create the following staging resources.
   2a. `AES256`
 3. [aws.s3.BucketVersioningV2](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketversioningv2/)
   3a. `Enabled`
-4. [aws.s3.BucketLifecycleConfigurationV2](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketlifecycleconfigurationv2/)
+4. [aws.s3.BucketLifecycleConfiguration](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketlifecycleconfiguration/)
   4a. Expire old versions > 365 days
   5b. Expire deploy-time assets > 30 days
 5. [aws.s3.BucketPolicy](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketpolicy/)

--- a/content/events/how-to-deploy-a-django-application-on-aws/index.md
+++ b/content/events/how-to-deploy-a-django-application-on-aws/index.md
@@ -32,7 +32,7 @@ application = elasticbeanstalk.Application('django_application',
     description="A Django application")
 
 # Create a S3 bucket for the static files
-static_bucket = s3.BucketV2('my-static-bucket')
+static_bucket = s3.Bucket('my-static-bucket')
 
 # Create a database instance
 db_instance = rds.Instance('my-database-instance',
@@ -76,7 +76,7 @@ Next, we create an S3 bucket to store our static files. Static files are assets 
 
 ```python
 # Create a S3 bucket for the static files
-static_bucket = s3.BucketV2('my-static-bucket')
+static_bucket = s3.Bucket('my-static-bucket')
 ```
 
 #### RDS Database Instance

--- a/content/migrate/terraform.md
+++ b/content/migrate/terraform.md
@@ -111,7 +111,7 @@ examples:
             import * as aws from "@pulumi/aws";
 
             // Create an S3 Bucket.
-            const bucket = new aws.s3.BucketV2("mybucket");
+            const bucket = new aws.s3.Bucket("mybucket");
 
             // Register a Lambda to handle the Bucket notification.
             bucket.onObjectCreated("newObj", async (ev, ctx) => {

--- a/content/tutorials/abstraction-encapsulation/component-resources/index.md
+++ b/content/tutorials/abstraction-encapsulation/component-resources/index.md
@@ -50,7 +50,7 @@ type PolicyType = "default" | "locked" | "permissive";
 // Create a class that encapsulates the functionality by subclassing
 // pulumi.ComponentResource.
 class OurBucketComponent extends pulumi.ComponentResource {
-    public bucket: aws.s3.BucketV2;
+    public bucket: aws.s3.Bucket;
     private bucketPolicy: aws.s3.BucketPolicy;
 
     private policies: { [K in PolicyType]: aws.iam.PolicyStatement } = {
@@ -90,7 +90,7 @@ class OurBucketComponent extends pulumi.ComponentResource {
         // declare all the same things all over again.
         super("pkg:index:OurBucketComponent", name, args, opts);
 
-        this.bucket = new aws.s3.BucketV2(name, {}, { parent: this });
+    this.bucket = new aws.s3.Bucket(name, {}, { parent: this });
 
         this.bucketPolicy = new aws.s3.BucketPolicy(`${name}-policy`, {
             bucket: this.bucket.id,
@@ -182,7 +182,7 @@ pulumi.export("bucket_name", bucket1.bucket.id)
 
 {{% /choosable %}}
 
-With the call to `super()`, we pass in a name for the resource, which [we recommend](/docs/concepts/resources/components#authoring-a-new-component-resource) being of the form `<package>:<module>:<type>` to avoid type conflicts since it's being registered alongside other resources like the Bucket resource we're calling (`aws:s3:BucketV2`).
+With the call to `super()`, we pass in a name for the resource, which [we recommend](/docs/concepts/resources/components#authoring-a-new-component-resource) being of the form `<package>:<module>:<type>` to avoid type conflicts since it's being registered alongside other resources like the Bucket resource we're calling (`aws:s3:Bucket`).
 
 {{% choosable language python %}}
 

--- a/content/tutorials/abstraction-encapsulation/encapsulation/index.md
+++ b/content/tutorials/abstraction-encapsulation/encapsulation/index.md
@@ -27,7 +27,7 @@ Let's take a fairly uncomplicated piece of Pulumi code: the definition of an S3 
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
-const bucket = new aws.s3.BucketV2("my-bucket");
+const bucket = new aws.s3.Bucket("my-bucket");
 
 export const bucketName = bucket.id;
 ```
@@ -40,7 +40,7 @@ export const bucketName = bucket.id;
 import pulumi
 import pulumi_aws_native as aws_native
 
-bucket = aws_native.s3.BucketV2("my-bucket")
+bucket = aws_native.s3.Bucket("my-bucket")
 
 pulumi.export("bucket", bucket.bucket_name)
 ```
@@ -57,7 +57,7 @@ Here, we're creating one resource and exporting the output from that resource. I
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
-const bucket = new aws.s3.BucketV2("my-bucket");
+const bucket = new aws.s3.Bucket("my-bucket");
 const bucketPolicy = new aws.s3.BucketPolicy("my-bucket-policy", {
     bucket: bucket.id,
     policy: {
@@ -131,11 +131,11 @@ import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
 class OurBucketClass {
-    private bucket: aws.s3.BucketV2;
+    private bucket: aws.s3.Bucket;
     private bucketPolicy: aws.s3.BucketPolicy;
 
     constructor(name: string, policyName: string) {
-        this.bucket = new aws.s3.BucketV2(name);
+    this.bucket = new aws.s3.Bucket(name);
 
         this.bucketPolicy = new aws.s3.BucketPolicy(policyName, {
             bucket: this.bucket.id,
@@ -211,7 +211,7 @@ import * as aws from "@pulumi/aws";
 type PolicyType = "default" | "locked" | "permissive";
 
 class OurBucketClass {
-    private bucket: aws.s3.BucketV2;
+    private bucket: aws.s3.Bucket;
     private bucketPolicy: aws.s3.BucketPolicy;
 
     private policies: { [K in PolicyType]: aws.iam.PolicyStatement } = {
@@ -245,7 +245,7 @@ class OurBucketClass {
     };
 
     constructor(name: string, policy: PolicyType) {
-        this.bucket = new aws.s3.BucketV2(name);
+    this.bucket = new aws.s3.Bucket(name);
         this.bucketPolicy = new aws.s3.BucketPolicy(`${name}-policy`, {
             bucket: this.bucket.id,
             policy: this.getBucketPolicy(policy),

--- a/content/tutorials/custom-policy-pack/create-policy-pack/index.md
+++ b/content/tutorials/custom-policy-pack/create-policy-pack/index.md
@@ -162,7 +162,7 @@ Replace the contents of `index.ts` with the following:
 
 Here we define three different policies:
 
-- **s3-product-prefix**: Ensures S3 buckets are prefixed with the product name by checking the `bucketPrefix` property on all `aws:s3/bucket:BucketV2` resources.
+- **s3-product-prefix**: Ensures S3 buckets are prefixed with the product name by checking the `bucketPrefix` property on all `aws:s3:Bucket` resources.
 - **ec2-instance-type-restricted**: Restricts EC2 instance types to only use the affordable `t2.micro` type, by checking the `instanceType` property on all `aws:ec2/instance:Instance` resources.
 - **all-aws-resources-must-have-tags**: Ensures all AWS resources have at least one tag by checking the `tags` property on all resources who's type starts with `aws`.
 
@@ -185,7 +185,7 @@ $ pulumi stack
 Current stack resources (5):
     TYPE                                    NAME
     pulumi:pulumi:Stack                     custom-policy-pack-integration-test-dev
-    ├─ aws:s3/bucketV2:BucketV2             my-bucket
+    ├─ aws:s3:Bucket                        my-bucket
     ├─ aws:ec2/securityGroup:SecurityGroup  ssh-security-group
     ├─ aws:ec2/instance:Instance            web-server
     └─ pulumi:providers:aws                 default_6_65_0
@@ -212,7 +212,7 @@ Replace the contents of `__main__.py` with the following:
 
 Here we define three different policies:
 
-- **s3-product-prefix**: Ensures S3 buckets are prefixed with the product name by checking the `bucketPrefix` property on all `aws:s3/bucket:BucketV2` resources.
+- **s3-product-prefix**: Ensures S3 buckets are prefixed with the product name by checking the `bucketPrefix` property on all `aws:s3:Bucket` resources.
 - **ec2-instance-type-restricted**: Restricts EC2 instance types to only use the affordable `t2.micro` type, by checking the `instanceType` property on all `aws:ec2/instance:Instance` resources.
 - **all-aws-resources-must-have-tags**: Ensures all AWS resources have at least one tag by checking the `tags` property on all resources who's type starts with `aws`.
 
@@ -234,7 +234,7 @@ $ pulumi stack
 Current stack resources (5):
     TYPE                                    NAME
     pulumi:pulumi:Stack                     custom-policy-pack-integration-test-dev
-    ├─ aws:s3/bucketV2:BucketV2             my-bucket
+    ├─ aws:s3:Bucket                        my-bucket
     ├─ aws:ec2/securityGroup:SecurityGroup  ssh-security-group
     ├─ aws:ec2/instance:Instance            web-server
     └─ pulumi:providers:aws                 default_6_65_0

--- a/content/tutorials/custom-policy-pack/validate-policy-pack/index.md
+++ b/content/tutorials/custom-policy-pack/validate-policy-pack/index.md
@@ -76,7 +76,7 @@ Loading policy packs...
 
      Type                      Name                                                Plan
  +   pulumi:pulumi:Stack       custom-policy-pack-integration-test-typescript-dev  create
- +   ├─ aws:s3:BucketV2        my-bucket                                           create
+ +   ├─ aws:s3:Bucket           my-bucket                                           create
  +   ├─ aws:ec2:Instance       web-server                                          create
  +   └─ aws:ec2:SecurityGroup  ssh-security-group                                  create
 
@@ -85,13 +85,13 @@ Policies:
         - [mandatory]  all-aws-resources-must-have-tags  (aws:ec2/securityGroup:SecurityGroup: ssh-security-group)
           Ensures all AWS resources have at least one tag.
           All AWS resources must have at least one tag.
-        - [mandatory]  all-aws-resources-must-have-tags  (aws:s3/bucketV2:BucketV2: my-bucket)
+  - [mandatory]  all-aws-resources-must-have-tags  (aws:s3:Bucket: my-bucket)
           Ensures all AWS resources have at least one tag.
           All AWS resources must have at least one tag.
         - [mandatory]  ec2-instance-type-restricted  (aws:ec2/instance:Instance: web-server)
           Ensures EC2 instances use approved instance type.
           Invalid instance type: 't3.micro'. EC2 instances must use 't2.micro' instance type.
-        - [mandatory]  s3-product-prefix  (aws:s3/bucketV2:BucketV2: my-bucket)
+  - [mandatory]  s3-product-prefix  (aws:s3:Bucket: my-bucket)
           Ensures S3 buckets have the correct product prefix.
           Invalid prefix: 'something-unexpected-'. S3 buckets must use 'myproduct-' prefix.
 ```
@@ -107,7 +107,7 @@ Loading policy packs...
 
      Type                      Name                                            Plan
  +   pulumi:pulumi:Stack       custom-policy-pack-integration-test-python-dev  create
- +   ├─ aws:s3:BucketV2        my-bucket                                       create
+ +   ├─ aws:s3:Bucket           my-bucket                                       create
  +   ├─ aws:ec2:Instance       web-server                                      create
  +   └─ aws:ec2:SecurityGroup  ssh-security-group                              create
 
@@ -116,13 +116,13 @@ Policies:
         - [mandatory]  all-aws-resources-must-have-tags  (aws:ec2/securityGroup:SecurityGroup: ssh-security-group)
           Ensures all AWS resources have at least one tag.
           All AWS resources must have at least one tag.
-        - [mandatory]  all-aws-resources-must-have-tags  (aws:s3/bucketV2:BucketV2: my-bucket)
+  - [mandatory]  all-aws-resources-must-have-tags  (aws:s3:Bucket: my-bucket)
           Ensures all AWS resources have at least one tag.
           All AWS resources must have at least one tag.
         - [mandatory]  ec2-instance-type-restricted  (aws:ec2/instance:Instance: web-server)
           Ensures EC2 instances use approved instance type.
           Invalid instance type: 't3.micro'. EC2 instances must use 't2.micro' instance type.
-        - [mandatory]  s3-product-prefix  (aws:s3/bucketV2:BucketV2: my-bucket)
+  - [mandatory]  s3-product-prefix  (aws:s3:Bucket: my-bucket)
           Ensures S3 buckets have the correct product prefix.
           Invalid prefix: 'something-unexpected-'. S3 buckets must use 'myproduct-' prefix.
 ```
@@ -177,7 +177,7 @@ Loading policy packs...
 
      Type                      Name                                                Plan
  +   pulumi:pulumi:Stack       custom-policy-pack-integration-test-typescript-dev  create
- +   ├─ aws:s3:BucketV2        my-bucket                                           create
+ +   ├─ aws:s3:Bucket           my-bucket                                           create
  +   ├─ aws:ec2:Instance       web-server                                          create
  +   └─ aws:ec2:SecurityGroup  ssh-security-group                                  create
 
@@ -196,7 +196,7 @@ Loading policy packs...
 
      Type                      Name                                            Plan
  +   pulumi:pulumi:Stack       custom-policy-pack-integration-test-python-dev  create
- +   ├─ aws:s3:BucketV2        my-bucket                                       create
+ +   ├─ aws:s3:Bucket          my-bucket                                       create
  +   ├─ aws:ec2:Instance       web-server                                      create
  +   └─ aws:ec2:SecurityGroup  ssh-security-group                              create
 

--- a/content/tutorials/stack-outputs-refs-aws/index.md
+++ b/content/tutorials/stack-outputs-refs-aws/index.md
@@ -380,7 +380,7 @@ Previewing update (dev):
      Type                      Name                     Plan
  +   pulumi:pulumi:Stack     my-first-app-dev           create
  +   ├─ aws:iam:Role         s3-writer-role             create
- +   ├─ aws:s3:BucketV2      my-bucket                  create
+ +   ├─ aws:s3:Bucket        my-bucket                  create
  +   └─ aws:lambda:Function  s3-writer-lambda-function  create
 
 Outputs:
@@ -396,7 +396,7 @@ Updating (dev):
      Type                      Name                     Status
  +   pulumi:pulumi:Stack     my-first-app-dev           created (18s)
  +   ├─ aws:iam:Role         s3-writer-role             created (1s)
- +   ├─ aws:s3:BucketV2      my-bucket                  created (1s)
+ +   ├─ aws:s3:Bucket        my-bucket                  created (1s)
  +   └─ aws:lambda:Function  s3-writer-lambda-function  created (13s)
 
 Outputs:

--- a/content/what-is/guide-to-automating-file-expiration-in-aws-s3.md
+++ b/content/what-is/guide-to-automating-file-expiration-in-aws-s3.md
@@ -11,7 +11,7 @@ page_title: Automate AWS S3 File Expiration with Pulumi
 
 In this guide, we'll walk through the process of automating AWS S3 file expiration using Pulumi. Lifecycle rules in AWS S3 allow you to specify actions on objects that meet certain criteria over time, such as transitioning objects to a different storage class or automatically deleting them after a specified period. By following these simple steps in this guide, you'll be able to efficiently manage the lifecycle policies for objects stored in S3 buckets, ensuring that outdated files are automatically expired and removed.
 
-With Pulumi, we can automate S3 file expiration by creating a Pulumi program that sets up these lifecycle rules. We'll use the `aws.s3.BucketLifecycleConfigurationV2` resource, which allows us to define these rules programmatically.
+With Pulumi, we can automate S3 file expiration by creating a Pulumi program that sets up these lifecycle rules. We'll use the `aws.s3.BucketLifecycleConfiguration` resource, which allows us to define these rules programmatically.
 
 Here's a step-by-step explanation of what we'll do:
 
@@ -26,12 +26,12 @@ import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
 // Create an S3 bucket
-const bucket = new aws.s3.BucketV2("my-automated-bucket", {
+const bucket = new aws.s3.Bucket("my-automated-bucket", {
     // Bucket settings can be added here
 });
 
 // Define a lifecycle rule to transition objects to Glacier after 90 days
-const bucketLifecyclePolicy = new aws.s3.BucketLifecycleConfigurationV2("my-bucket-lifecycle", {
+const bucketLifecyclePolicy = new aws.s3.BucketLifecycleConfiguration("my-bucket-lifecycle", {
     bucket: bucket.id,
     rules: [
         {

--- a/content/what-is/what-is-yaml.md
+++ b/content/what-is/what-is-yaml.md
@@ -110,7 +110,7 @@ name: simple-yaml
 runtime: yaml
 resources:
   my-bucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
   my-bucket-ownership-controls:
     type: aws:s3:BucketOwnershipControls
     properties:
@@ -160,7 +160,7 @@ To begin with, we're naming our program `simple-yaml`, and defining the runtime 
 ```yaml
 resources:
   my-bucket:
-    type: aws:s3:BucketV2
+    type: aws:s3:Bucket
   my-bucket-website:
     type: aws:s3:BucketWebsiteConfigurationV2
     properties:


### PR DESCRIPTION
Update remaining non-`content/docs` documentation to replace all instances of `BucketV2` with `Bucket` for AWS provider v7 compatibility. This change ensures that code examples reflect the current API and maintains the accuracy and functionality of the documentation.

All examples were tested.

Fixes #15870.