### PR TITLE
Fix MCP server args in VS Code settings

### DIFF
--- a/content/docs/iac/using-pulumi/mcp-server.md
+++ b/content/docs/iac/using-pulumi/mcp-server.md
@@ -121,10 +121,13 @@ Add to your VS Code settings.json:
 
 ```json
 {
-  "mcp.servers": {
+  "servers": {
     "pulumi": {
       "command": "npx",
-      "args": ["@pulumi/mcp-server"],
+      "args": [
+        "@pulumi/mcp-server",
+        "stdio"
+      ],
       "type": "stdio"
     }
   }


### PR DESCRIPTION
This seemed to be necessary in order for the server to start successfully. Before adding this line, I got the following error in in the Output tab:

```
2025-09-02 17:45:27.183 [warning] [server stderr] mcp-server <command>
2025-09-02 17:45:27.183 [warning] [server stderr] 
2025-09-02 17:45:27.183 [warning] [server stderr] Commands:
2025-09-02 17:45:27.183 [warning] [server stderr]   mcp-server stdio  Start Pulumi MCP server using stdio transport.
2025-09-02 17:45:27.183 [warning] [server stderr]   mcp-server sse    Start Pulumi MCP server using SSE transport.
2025-09-02 17:45:27.183 [warning] [server stderr] 
2025-09-02 17:45:27.183 [warning] [server stderr] Options:
2025-09-02 17:45:27.183 [warning] [server stderr]   --help     Show help                                                 [boolean]
2025-09-02 17:45:27.183 [warning] [server stderr]   --version  Show version number                                       [boolean]
2025-09-02 17:45:27.183 [warning] [server stderr] 
2025-09-02 17:45:27.183 [warning] [server stderr] Not enough non-option arguments: got 0, need at least 1
2025-09-02 17:45:27.199 [info] Connection state: Error Process exited with code 1
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->