### PR TITLE
Don't imply the CLI isn't required for Auto API

### DIFF
--- a/content/docs/iac/automation-api/_index.md
+++ b/content/docs/iac/automation-api/_index.md
@@ -17,7 +17,7 @@ aliases:
 - /docs/iac/using-pulumi/automation-api/
 ---
 
-The Pulumi Automation API is a programmatic interface for running Pulumi programs without the Pulumi CLI. Conceptually, this can be thought of as encapsulating the functionality of the CLI (`pulumi up`, `pulumi preview`, `pulumi destroy`, `pulumi stack init`, etc.) but with more flexibility. It is a strongly typed and safe way to use Pulumi in embedded contexts such as web servers, without requiring invoking the CLI from a shell process.
+The Pulumi Automation API is a programmatic interface for running Pulumi programs without the Pulumi CLI. Conceptually, this can be thought of as encapsulating the functionality of the CLI (`pulumi up`, `pulumi preview`, `pulumi destroy`, `pulumi stack init`, etc.) but with more flexibility. It is a strongly typed and a safe way to use Pulumi in embedded contexts such as web servers, without requiring the user to run the `pulumi` CLI from a shell process manually.
 
 ![automation-api](automation-api.png)
 


### PR DESCRIPTION
The intent behind "without requiring invoking the CLI from a shell process" is to highlight that you don't need to run the `pulumi` binary "by hand", but it might lead people to think that you don't need the `pulumi` binary. This change rewords the sentence so it doesn't imply the `pulumi` binary isn't required.

Fixes #15895