### PR TITLE
Remove note about camel casing in ignoreChanges

### DIFF
--- a/content/docs/iac/concepts/options/ignorechanges.md
+++ b/content/docs/iac/concepts/options/ignorechanges.md
@@ -106,11 +106,6 @@ The `ignoreChanges` resource option does not apply to inputs to component resour
 In addition to passing simple property names, nested properties can also be supplied to ignore changes to a more targeted nested part of the resource's inputs. See [property paths](/docs/iac/concepts/miscellaneous/property-paths/) for examples of legal paths that can be passed to specify nested properties of objects and arrays.
 
 {{% notes "info" %}}
-The property names passed to `ignoreChanges` should always be the "camelCase" version of the property name, as used in the core Pulumi resource model.
-For example, a property named `nested_resource` would turn into `nestedResource`.
-{{% /notes %}}
-
-{{% notes "info" %}}
 For arrays with different lengths, only changes for elements that are in both arrays are ignored. If the new input array is longer, additional elements will be taken from the new array. If the new array is shorter, we only take that number of elements from the original array.
 
 For example `ignoreChanges` on an old array `[1, 2]` and a new array `[a, b, c]` results in `[1, 2, c]`, and an old array `[1, 2, 3]` and a new array `[a, b]` results in `[1, 2]`.


### PR DESCRIPTION
I think this note has been obsolete for a long time. The names in `ignoreChanges` are translated automatically from the python snake_case name to the schema name  in https://github.com/pulumi/pulumi/blob/cb6c33b51efa04940b645cb0d3d4c18d2a112e3f/sdk/python/lib/pulumi/runtime/resource.py#L609