### PR TITLE
Store Google Creds on Env Variables to Avoid Token Expiration problem

### DIFF
--- a/content/docs/esc/environments/configuring-oidc/gcp.md
+++ b/content/docs/esc/environments/configuring-oidc/gcp.md
@@ -83,9 +83,8 @@ To configure OIDC for Pulumi ESC, create a new environment in the [Pulumi Consol
               serviceAccount: <your-service-account>
       environmentVariables:
         GOOGLE_PROJECT: ${gcp.login.project}
+        GOOGLE_OAUTH_ACCESS_TOKEN: ${gcp.login.accessToken}
         CLOUDSDK_AUTH_ACCESS_TOKEN: ${gcp.login.accessToken}
-      pulumiConfig:
-        gcp:accessToken: ${gcp.login.accessToken}
     ```
 
 6. Replace `<your-project-id>`, `<your-pool-id>`, `<your-provider-id>`, and `<your-service-account>` with the values from the previous steps.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
Changing how the suggested GCP OIDC works per https://archive.pulumi.com/t/23139759/expected-oauth-2-access-token-login-cookie-or-other-valid-au

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
