### PR TITLE
Fix broken /crosswalk/ redirect

### DIFF
--- a/content/crosswalk/_index.md
+++ b/content/crosswalk/_index.md
@@ -2,6 +2,6 @@
 title: Pulumi Crosswalk
 meta_desc: Pulumi Crosswalk is a collection of libraries that use well-architected best practices to make common infrastructure-as-code tasks easier and more secure.
 layout: aws
-redirect_to: /crosswalk/aws
+redirect_to: /docs/iac/clouds/aws/guides/
 redirect_temporarily: true
 ---


### PR DESCRIPTION
## Summary
- Fixes the broken redirect from `/crosswalk/` that was causing a 404 error
- Updates redirect to point to the correct AWS Crosswalk documentation location

## Problem
The `/crosswalk/` page was redirecting to `/crosswalk/aws` which doesn't exist, causing visitors to land on a 404 page.

## Root Cause
The redirect was never updated after the content reorganization in May 2023 when AWS Crosswalk docs were moved from `/docs/guides/crosswalk/aws/` to `/docs/clouds/aws/guides/` (now at `/docs/iac/clouds/aws/guides/`).

## Solution
Update the redirect in `/content/crosswalk/_index.md` to point to `/docs/iac/clouds/aws/guides/` where the AWS Crosswalk documentation actually resides.