### PR TITLE
Update node package manager requirements

### DIFF
--- a/content/docs/pulumi-cloud/deployments/using/settings.md
+++ b/content/docs/pulumi-cloud/deployments/using/settings.md
@@ -155,7 +155,7 @@ Dependency caching is supported for the following runtimes:
 - `.NET` - no special configuration required
 - `Python` - ensure that you have `requirements.txt` in the root of your source code.
 - `Go` - ensure that you have `go.mod` and `go.sum` in the root of your source code.
-- `NodeJS` - ensure that you have `packageManager` field specified in `package.json`. For now, only `npm` and `yarn` are supported.
+- `NodeJS` - only `npm` and `yarn` are currently supported.
   - For `npm`, ensure that you have `package-lock.json` in the root of your source code.
   - For `yarn`, ensure that you have `yarn.lock` in the root of your source code.
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Remove the now-obsolete requirement to specify `packageManger` in the `package.json`. This is done automatically when using yarn v2 or greater but is no longer required for other package managers & versions.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
