### PR TITLE
Redirect /neo to /product/neo

### DIFF
--- a/content/neo/_index.md
+++ b/content/neo/_index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /product/neo
+---


### PR DESCRIPTION
## Summary
- Created a redirect from `/neo` to `/product/neo` for a shorter, cleaner URL
- Neo content remains at its original location `/content/product/neo.md`
- Added `/content/neo/_index.md` with redirect to `/product/neo`

## Test plan (in staging)
- [x] Verify that visiting `/neo` redirects to `/product/neo`
- [x] Confirm that the Neo page displays correctly at `/product/neo`
- [x] Check that all content and functionality remains intact