### PR TITLE
Add warning about special characters in secret values

### DIFF
--- a/content/docs/iac/concepts/secrets.md
+++ b/content/docs/iac/concepts/secrets.md
@@ -223,6 +223,10 @@ For example, this command sets a configuration variable named `dbPassword` to th
 $ pulumi config set --secret dbPassword S3cr37
 ```
 
+{{% notes "warning" %}}
+When storing secret values containing special characters (such as `$`, `!`, `@`, `#`, etc.), be aware that shell interpretation may modify the value before it reaches Pulumi. Consider using quotes around the value or escaping special characters according to your shell's requirements. For complex values, you may want to use input redirection or pipe the value from a file to avoid shell interpretation entirely.
+{{% /notes %}}
+
 If we list the configuration for our stack, the plain-text value for `dbPassword` will not be printed:
 
 ```bash

--- a/content/tutorials/managing-config-and-secrets/index.md
+++ b/content/tutorials/managing-config-and-secrets/index.md
@@ -123,6 +123,10 @@ To encrypt a configuration value before runtime, you will need to run the `pulum
 pulumi config set myPassword demo-password-123 --secret
 ```
 
+{{% notes "warning" %}}
+When storing secret values containing special characters (such as `$`, `!`, `@`, `#`, etc.), be aware that shell interpretation may modify the value before it reaches Pulumi. Consider using quotes around the value or escaping special characters according to your shell's requirements. For complex values, you may want to use input redirection or pipe the value from a file to avoid shell interpretation entirely.
+{{% /notes %}}
+
 Now run the `pulumi config` command again, and you will see that, unlike the value for `myEnvironment`, the value for `myPassword` is hidden:
 
 ```bash


### PR DESCRIPTION
Add warning notes to secrets documentation about shell interpretation of special characters when using 'pulumi config set --secret'. This addresses issues where passwords containing characters like $, !, @, # may be modified by the shell before reaching Pulumi.

Fixes https://github.com/pulumi/docs/issues/13564

🤖 Generated with [Claude Code](https://claude.ai/code)
