### PR TITLE
Fix broken Neo documentation link

### DIFF
--- a/content/product/neo.md
+++ b/content/product/neo.md
@@ -98,7 +98,7 @@ learn:
             - link: https://www.youtube.com/watch?v=9GB9M2l1OgY
               type: primary
               action: See Neo in Action
-            - link: /docs/pulumi-cloud/neo/
+            - link: /docs/iac/neo/
               type: secondary
               action: Read the Docs
 ---


### PR DESCRIPTION
Updates CTA link from /docs/pulumi-cloud/neo/ to /docs/iac/neo/