### PR TITLE
Fix incorrect VS Code extension links

### DIFF
--- a/content/blog/copilot-in-vscode/index.md
+++ b/content/blog/copilot-in-vscode/index.md
@@ -49,7 +49,7 @@ social:
 ---
 Programming languages offer dozens of advantages for writing Infrastructure as Code (IaC). One of them is that Large Language Models are  effective at using general-purpose programming languages, thanks to the vast amount of high-quality training data available. Building on this advantage, we introduced Pulumi AI and Pulumi Copilot last year to enhance Infrastructure-as-Code development with generative AI capabilities. These tools have significantly streamlined infrastructure deployment for tens of thousands of developers.
 
-Today, we are thrilled to announce that Pulumi Copilot is now available directly within [Visual Studio Code Copilot](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot). By simply typing @pulumi in Copilot Chat, developers can now access the power of Pulumi Copilot right within their IDE, saving them time on writing IaC and getting infrastructure deployed.
+Today, we are thrilled to announce that Pulumi Copilot is now available directly within [Pulumi Copilot Chat Extension](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot). By simply typing @pulumi in Copilot Chat, developers can now access the power of Pulumi Copilot right within their IDE, saving them time on writing IaC and getting infrastructure deployed.
 
 <!--more-->
 ## Video Walk Through

--- a/content/blog/pulumi-vscode-extension/index.md
+++ b/content/blog/pulumi-vscode-extension/index.md
@@ -15,7 +15,7 @@ tags:
 
 At the heart of Pulumi's approach to cloud infrastructure and secrets management is a belief in empowering engineers to use the best software engineering tools to manage complexity at scale and to be maximally productive building cloud infrastructure and applications for their businesses.  
 
-Today, we're excited to announce a next big step in delivering great software engineering tools for Pulumi users, with the launch of a new **Pulumi Visual Studio Code (VS Code) Extension**.  The [Pulumi VS Code Extension](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot) brings Pulumi key features for Pulumi IaC and Pulumi ESC directly into the IDE environment that many Pulumi users work in every day.  Pulumi IaC users can now debug their applications and get Pulumi YAML language support directly in VS Code. And Pulumi ESC users can now create and manage environments, secrets and configuration directly within the IDE with rich IDE features.
+Today, we're excited to announce a next big step in delivering great software engineering tools for Pulumi users, with the launch of a new **Pulumi Visual Studio Code (VS Code) Extension**.  The [Pulumi VS Code Extension](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-tools) brings Pulumi key features for Pulumi IaC and Pulumi ESC directly into the IDE environment that many Pulumi users work in every day.  Pulumi IaC users can now debug their applications and get Pulumi YAML language support directly in VS Code. And Pulumi ESC users can now create and manage environments, secrets and configuration directly within the IDE with rich IDE features.
 
 <!--more-->
 
@@ -33,7 +33,7 @@ The following are a few examples of new capabilities available for Pulumi users 
 ### Install the Software
 
 1. Install Pulumi 3.132.0 (or greater) using [these instructions](/docs/install/).
-2. Install the [Pulumi VS Code extension](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot) from the Visual Studio Marketplace.
+2. Install the [Pulumi VS Code extension](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-tools) from the Visual Studio Marketplace.
 
 ## Debugging Pulumi IaC Programs
 

--- a/content/docs/esc/development/vs-code-extension.md
+++ b/content/docs/esc/development/vs-code-extension.md
@@ -9,13 +9,13 @@ menu:
     weight: 2
 ---
 
-The [Pulumi Tools extension for VS Code](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot) allows you to manage your Pulumi ESC environments directly from your editor. This enables you to create and manage environments, secrets and configuration directly within the IDE with rich IDE features.
+The [Pulumi Tools extension for VS Code](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-tools) allows you to manage your Pulumi ESC environments directly from your editor. This enables you to create and manage environments, secrets and configuration directly within the IDE with rich IDE features.
 
 ## Prerequisites
 
 Before you begin, ensure you have the following installed:
 
-- [Pulumi Tools extension for VS Code](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot)
+- [Pulumi Tools extension for VS Code](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-tools)
 - A [Pulumi Cloud account](https://app.pulumi.com)
 
 ## Getting Started with Pulumi ESC in VS Code

--- a/content/docs/iac/concepts/debugging/_index.md
+++ b/content/docs/iac/concepts/debugging/_index.md
@@ -26,7 +26,7 @@ Pulumi provides an extension that allows you to launch and debug Pulumi programs
 
 ### Install the extension
 
-Install the [Pulumi extension](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot) using Visual Studio Marketplace.
+Install the [Pulumi extension](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-tools) using Visual Studio Marketplace.
 
 ### Open a project
 


### PR DESCRIPTION
Update extension references to use correct extension IDs:
- Change pulumi.pulumi-vscode-copilot to pulumi.pulumi-vscode-tools for general Pulumi VS Code Tools extension
- Keep pulumi.pulumi-vscode-copilot for Copilot-specific functionality
- Fix link text in copilot blog post to reference correct extension name

Fixes https://github.com/pulumi/docs/issues/16001
