### PR TITLE
Revert "Improve Infrastructure as Code page for SEO"

### DIFF
--- a/content/what-is/what-is-infrastructure-as-code.md
+++ b/content/what-is/what-is-infrastructure-as-code.md
@@ -1,43 +1,23 @@
 ---
-title: What is Infrastructure as Code (IaC)?
-meta_desc: Infrastructure as Code (IaC) manages cloud infrastructure using code and automation. Learn how IaC works, key benefits, and get started with examples.
+title: What is Infrastructure as Code?
+meta_desc: |
+    Understand what is infrastructure as code, along with the main benefits and importance for modern application development.
 type: what-is
 page_title: "What is Infrastructure as Code?"
 ---
 
-**Infrastructure as Code (IaC) manages and provisions infrastructure using code and automated processes, rather than manual configuration. IaC enables teams to define, version, test, and deploy infrastructure changes reliably through version control systems and CI/CD pipelines.**
-
-Infrastructure as code (IaC) is an approach to automating the provisioning and management of infrastructure. At its heart, infrastructure as code is about bringing software engineering principles, approaches, and tools into the cloud infrastructure space.
+Infrastructure as code (IaC) is an approach to automating the provisioning and management of infrastructure. At its heart, **infrastructure as code is about bringing software engineering principles, approaches, and tools into the cloud infrastructure space.**
 
 Before infrastructure as code, infrastructure was (and in some cases still is!) provisioned in a variety of ways, such as by pointing and clicking in a user interface (UI), by running commands via a command-line interface (CLI), by running batch scripts, or by using configuration management tools that may not have been designed with cloud infrastructure in mind. Each of these methods falls short in some way; interactive methods involving a UI or a CLI often create problems with repeatability and consistency while batch scripts or configuration management tools may be unable to declaratively manage infrastructure. Today, modern approaches use platforms, such as [Pulumi](/), which embrace and support the full software engineering lifecycle.
 
-## How Infrastructure as Code Works
+In this article, we'll touch on four key questions regarding infrastructure as code:
 
-Infrastructure as Code fundamentally changes how we manage cloud resources by treating them as software. This approach involves several key components working together:
+* Why is infrastructure as code important?
+* What are the key elements of infrastructure as code?
+* What benefits does infrastructure as code provide?
+* How do you get started with infrastructure as code?
 
-**Code-based Definitions:** Infrastructure is defined using configuration files written in code—whether that's TypeScript, Python, Go, C#, Java, or YAML. These files describe the desired state of your cloud environment in a declarative way. Instead of writing step-by-step instructions (imperative), you describe what you want the end result to be, and the IaC tool figures out how to achieve it. This declarative approach means you can focus on the "what" rather than the "how," making infrastructure definitions clearer and more maintainable.
-
-**Automation and Orchestration:** IaC tools like Pulumi automate the entire deployment process. They read your code, understand the dependencies between resources, and create them in the correct order. If a database needs to exist before an application server can connect to it, the tool handles that sequencing automatically. This automation extends to updates as well—when you change your infrastructure code, the tool determines what needs to be modified, replaced, or removed, and executes those changes in the correct sequence. This eliminates manual steps and reduces human error significantly.
-
-**Version Control Integration:** All infrastructure definitions are stored in version control systems like Git, GitHub, or GitLab. This provides complete audit trails of all infrastructure changes, the ability to review changes before they're applied, instant rollback to previous configurations if issues arise, collaboration through pull requests and code reviews, and branch-based development workflows for testing changes.
-
-**Continuous Testing:** Infrastructure code goes through the same rigorous testing as application code. Teams write unit tests to validate individual components, integration tests to verify system interactions, and compliance tests to ensure security and regulatory requirements are met. This testing happens automatically before any changes reach production, catching issues early in the development cycle when they're easier and less expensive to fix.
-
-## Key Benefits of Infrastructure as Code
-
-The adoption of Infrastructure as Code provides transformative benefits for organizations managing cloud infrastructure:
-
-**Speed and Efficiency:** What once took hours or days of manual configuration now happens in minutes. IaC automates the entire provisioning process, from creating networks and compute instances to configuring security rules and deploying applications. Teams can spin up complete environments with a single command, enabling rapid prototyping and reducing time-to-market for new features. This speed extends to disaster recovery scenarios as well—entire infrastructures can be recreated quickly in new regions if needed.
-
-**Consistency and Repeatability:** Every deployment happens exactly the same way, every time. Whether you're creating a development environment or deploying to production, IaC ensures identical configurations. This eliminates the "works on my machine" problem that has plagued software development for decades. Configuration drift—the gradual divergence of environments over time—becomes a thing of the past when infrastructure is defined in code and regularly reconciled.
-
-**Reduced Errors:** Manual configuration is prone to mistakes—a mistyped IP address, a forgotten security rule, or an inconsistent setting across environments. IaC eliminates these human errors by codifying best practices and automating their application. When changes are needed, they're reviewed through pull requests, tested automatically, and applied consistently across all environments.
-
-**Enhanced Scalability:** Scaling infrastructure becomes as simple as changing a number in code. Need to go from 2 servers to 200? Update the configuration and deploy. The same applies to scaling down—resources can be decommissioned just as easily, preventing unnecessary costs. This elasticity enables organizations to respond quickly to changing demands without the operational overhead traditionally associated with scaling.
-
-**Complete Audit Trails:** Every infrastructure change is tracked in version control, providing a complete history of who changed what, when, and why. This audit trail is invaluable for troubleshooting issues, meeting compliance requirements, and understanding how your infrastructure has evolved over time. Unlike manual changes that might go undocumented, every IaC modification is automatically recorded.
-
-**Improved Collaboration:** Infrastructure as code breaks down silos between development and operations teams. When infrastructure is defined in code, developers can understand and contribute to infrastructure decisions, while operations teams gain visibility into application requirements. This shared language and toolset fosters better communication and more effective problem-solving across traditional organizational boundaries.
+Let's start with examing why infrastructure as code is important.
 
 ## Why is infrastructure as code important?
 
@@ -67,35 +47,23 @@ Finally, the rate of change for a company's infrastructure is increasing. Part o
 
 For teams managing tens or hundreds of cloud resources that change once every few months, managing infrastructure using scripts or via interactive means (such as using a UI or a CLI) might still be possible. More commonly, teams finding themselves managing thousands or tens of thousands of resources that change daily or even hourly. Embracing automation via infrastructure as code is the only way to take control of that kind of complexity.
 
-## Core Elements of Modern Infrastructure as Code
+## What are the key elements of infrastructure as code?
 
-The key elements of infrastructure as code mirror those found in mature software engineering practices:
+The key elements of infrastructure as code are the same key elements you'd find in the majority of software engineering environments. These include:
 
-**Version Control:** When infrastructure is described as code, it gains all the benefits of modern version control systems. Teams can track changes, understand history, and collaborate effectively. Version control systems like [GitHub](https://github.com/), [GitLab](https://about.gitlab.com/), or [BitBucket](https://bitbucket.org/) enable you to see what changes were made, when they were made, and who made them. This visibility is crucial for maintaining large-scale infrastructure. Teams can use branching strategies to test changes in isolation, merge requests to review infrastructure modifications, and tags to mark specific versions for deployment.
+1. **An infrastructure as code mechanism:** For all practical purposes, in order to do infrastructure as code you need a tool or engine that is responsible for translating the IaC instructions into something the cloud provider APIs understand and can use. Infrastructure as code tools may be provided by and limited to a single cloud provider (AWS Cloudformation is one example), or may support multiple cloud providers. Tools may be limited to supporting YAML or JSON; may require the use of a specialized and proprietary domain-specific language (DSL); or may support the use of general purpose programming languages such as TypeScript/JavaScript, C#, Go, Python, and Java.
+1. **Version control:** When infrastructure is described as code, it can be checked into source control, versioned and code-reviewed using existing software engineering practices. Version control systems, like [GitHub](https://github.com/), [GitLab](https://about.gitlab.com/), or [BitBucket](https://bitbucket.org/), enable you to see _what_ changes were made, _when_ the changes were made, and _who_ made the changes.
+1. **Tests:** As any critical system grows in complexity, people can start to feel nervous about making changes. With infrastructure as code, teams can write tests for their infrastructure to ensure its correctness. They can encode policies so that all provisioned infrastructure and its configurations [are compliant](/docs/iac/concepts/testing/property-testing/). Once they're tested, infrastructure components can be reusable pieces of code that capture best practices and that can be shared across teams. No more reinventing the wheel.
+1. **CI/CD pipelines:** Assuming the infrastructure as code tool supports the functionality (most do), changes to infrastructure---found in changes to the code that defines the infrastructure---can be deployed using existing CI/CD tools, much in the same way CI/CD pipelines automatically build and deploy other forms of software.
 
-**Testing:** Infrastructure testing has evolved to match the sophistication of application testing. Teams write unit tests to validate individual resource configurations, integration tests to verify components work together correctly, [policy tests to ensure compliance](/docs/iac/concepts/testing/property-testing/) with security and regulatory requirements, performance tests to validate scalability assumptions, and smoke tests to verify basic functionality after deployment. These tests run automatically in CI/CD pipelines, catching issues before they reach production. The result is infrastructure that's not just functional, but proven to be correct.
+## What benefits does infrastructure as code provide?
 
-**CI/CD Pipelines:** Infrastructure deployments flow through the same continuous integration and continuous deployment pipelines as application code. This integration enables automated testing on every change, preview environments to see changes before applying them, approval workflows for production deployments, gradual rollouts to minimize risk, automatic rollback capabilities if issues are detected, and integration with monitoring and alerting systems.
+Infrastructure as code tames the complexity of cloud infrastructure because it uses the same software engineering principles, approaches, and tools that have enabled other software-based systems to scale up. Here are some of the benefits infrastructure as code provides.
 
-**Infrastructure as Code Tools:** The IaC ecosystem offers various tools to meet different organizational needs. Cloud-specific tools like AWS CloudFormation excel at deep integration with a single provider, offering native support for all services. Multi-cloud tools like Pulumi enable management across multiple providers, avoiding vendor lock-in. Language support varies from simple YAML/JSON configurations to full programming languages like TypeScript, Python, Go, C#, and Java. State management approaches differ, with some tools managing state automatically while others require manual configuration.
-
-## Infrastructure as Code in Practice
-
-Here's a real-world example demonstrating how Infrastructure as Code works with Pulumi. This example creates an EC2 instance with a security group, showing how multiple cloud resources work together:
-
-{{< example-program path="aws-ec2-instance-with-sg" >}}
-
-This example demonstrates several important IaC concepts:
-
-**Resource Creation:** Both a security group and an EC2 instance are defined in code, showing how infrastructure components are declared as objects in your programming language.
-
-**Dependencies:** The EC2 instance automatically depends on the security group through the vpcSecurityGroupIds reference. Pulumi understands these relationships and creates resources in the correct order.
-
-**Configuration as Code:** Security rules, instance type, and AMI are all specified declaratively. Changes to these values in code will be reflected in your infrastructure when deployed.
-
-**Output Values:** Important information like the instance's public IP and DNS are exported, making them available for other systems or team members to use.
-
-To learn more about creating cloud infrastructure with Pulumi, check out our [getting started guide](/docs/iac/get-started/aws/).
+* **Repeatability and consistency**: Infrastructure that is defined via IaC can be deployed in a highly repeatable fashion. Do you need a development environment that is a high fidelity copy of the production environment? Or do you need to ensure that infrastructure is deployed the same across multiple regions? This is easily accomplished with infrastructure as code.
+* **Accountability**: Changes to the infrastructure can be easily tracked via the use of version control with your infrastructure as code files.
+* **Improved productivity**: Most developers have an integrated development environment (IDE) that they use all the time. When infrastructure is code, you can take advantage of all the features that an IDE offers, such as autocompletion and the ability to look up methods and their parameters.
+* **Better alignment among teams**: Infrastructure as code enables infrastructure teams and software development teams to adopt DevOps principles and work together more closely. When infrastructure is code and is integrated into your company's software lifecycle, there's a common language and a common set of practices that stakeholders already understand. That common understanding fosters cross-team collaboration, which is fundamental to DevOps.
 
 ## How do I get started with infrastructure as code?
 
@@ -136,24 +104,6 @@ It's important to plan policies and security because one of the goals of infrast
 ### Start small
 
 Any time you make a significant change in technology, you want to do it incrementally. You might start with a new service so you don't disrupt existing ones. Once you've figured out what successful patterns look like, go back and figure out how to transform some existing infrastructure. Pick a project where you'll start seeing value early and then iterate.
-
-## Frequently Asked Questions
-
-### What is Infrastructure as Code?
-
-Infrastructure as Code (IaC) is the practice of managing and provisioning cloud infrastructure through machine-readable code files rather than manual configuration, enabling consistent, repeatable, and automated infrastructure deployment.
-
-### How does IaC differ from configuration management?
-
-While configuration management tools (Chef, Puppet) focus on configuring existing servers, Infrastructure as Code provisions and manages the infrastructure itself - creating servers, networks, databases, and other cloud resources from scratch.
-
-### What programming languages does Pulumi support for IaC?
-
-Pulumi supports TypeScript, JavaScript, Python, Go, C#, Java, and YAML, allowing teams to use languages they already know rather than learning proprietary DSLs.
-
-### Why is Infrastructure as Code important for DevOps?
-
-IaC enables DevOps practices by treating infrastructure the same as application code - with version control, testing, code reviews, and CI/CD pipelines, breaking down silos between development and operations teams.
 
 ## Another look at infrastructure as code
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -83,49 +83,6 @@
         </script>
     {{ end }}
 
-    <!-- FAQ schema for Infrastructure as Code page -->
-    {{ if eq .Params.page_title "What is Infrastructure as Code?" }}
-        <script type="application/ld+json">
-            {
-                "@context": "https://schema.org",
-                "@type": "FAQPage",
-                "mainEntity": [
-                    {
-                        "@type": "Question",
-                        "name": "What is Infrastructure as Code?",
-                        "acceptedAnswer": {
-                            "@type": "Answer",
-                            "text": "Infrastructure as Code (IaC) is the practice of managing and provisioning cloud infrastructure through machine-readable code files rather than manual configuration, enabling consistent, repeatable, and automated infrastructure deployment."
-                        }
-                    },
-                    {
-                        "@type": "Question",
-                        "name": "How does IaC differ from configuration management?",
-                        "acceptedAnswer": {
-                            "@type": "Answer",
-                            "text": "While configuration management tools (Chef, Puppet) focus on configuring existing servers, Infrastructure as Code provisions and manages the infrastructure itself - creating servers, networks, databases, and other cloud resources from scratch."
-                        }
-                    },
-                    {
-                        "@type": "Question",
-                        "name": "What programming languages does Pulumi support for IaC?",
-                        "acceptedAnswer": {
-                            "@type": "Answer",
-                            "text": "Pulumi supports TypeScript, JavaScript, Python, Go, C#, Java, and YAML, allowing teams to use languages they already know rather than learning proprietary DSLs."
-                        }
-                    },
-                    {
-                        "@type": "Question",
-                        "name": "Why is Infrastructure as Code important for DevOps?",
-                        "acceptedAnswer": {
-                            "@type": "Answer",
-                            "text": "IaC enables DevOps practices by treating infrastructure the same as application code - with version control, testing, code reviews, and CI/CD pipelines, breaking down silos between development and operations teams."
-                        }
-                    }
-                ]
-            }
-        </script>
-    {{ end }}
 
     <!-- Workshop info for Google events. -->
     {{ if .Params.event_data }}


### PR DESCRIPTION
Reverts pulumi/docs#15941 because the change to [What is Iac? page](https://www.pulumi.com/what-is/what-is-infrastructure-as-code/) had a negative effect on "infrastructure as code" searches:

- Google SERP Impressions dropped: 4.54K Sep 9 to Sep 23 (2 weeks) vs 7.53K Aug 25 to Sep 8 (2 weeks before that)
- Google AIO "right rail" dropped from ~5th place to ~8th position