### PR TITLE
Fix duplicate word in import tutorial documentation

### DIFF
--- a/content/tutorials/importing-aws-infrastructure/index.md
+++ b/content/tutorials/importing-aws-infrastructure/index.md
@@ -80,7 +80,7 @@ In Pulumi, there are three paths to take when importing resources:
 
 ### Import using the CLI
 
-The `pulumi import` command looks up the resource using the specified type token and resource identifier, adds the resource to the stack's current state, and emits the code required to manage the resource with Pulumi from that point forward. This option requires the least manual effort, so it is generally recommended and best suited to projects consisting consisting of only one stack.
+The `pulumi import` command looks up the resource using the specified type token and resource identifier, adds the resource to the stack's current state, and emits the code required to manage the resource with Pulumi from that point forward. This option requires the least manual effort, so it is generally recommended and best suited to projects consisting of only one stack.
 
 To import an existing cloud resource with the Pulumi CLI, use the following syntax:
 

--- a/content/tutorials/importing-azure-infrastructure/index.md
+++ b/content/tutorials/importing-azure-infrastructure/index.md
@@ -73,7 +73,7 @@ In Pulumi, there are three paths to take when importing resources:
 
 ### Import using the CLI
 
-The `pulumi import` command looks up the resource using the specified type token and resource identifier, adds the resource to the stack's current state, and emits the code required to manage the resource with Pulumi from that point forward. This option requires the least manual effort, so it is generally recommended and best suited to projects consisting consisting of only one stack.
+The `pulumi import` command looks up the resource using the specified type token and resource identifier, adds the resource to the stack's current state, and emits the code required to manage the resource with Pulumi from that point forward. This option requires the least manual effort, so it is generally recommended and best suited to projects consisting of only one stack.
 
 To import an existing cloud resource with the Pulumi CLI, use the following syntax:
 

--- a/content/tutorials/importing-gcp-infrastructure/index.md
+++ b/content/tutorials/importing-gcp-infrastructure/index.md
@@ -75,7 +75,7 @@ In Pulumi, there are three paths to take when importing resources:
 
 ### Import using the CLI
 
-The `pulumi import` command looks up the resource using the specified type token and resource identifier, adds the resource to the stack's current state, and emits the code required to manage the resource with Pulumi from that point forward. This option requires the least manual effort, so it is generally recommended and best suited to projects consisting consisting of only one stack.
+The `pulumi import` command looks up the resource using the specified type token and resource identifier, adds the resource to the stack's current state, and emits the code required to manage the resource with Pulumi from that point forward. This option requires the least manual effort, so it is generally recommended and best suited to projects consisting of only one stack.
 
 To import an existing cloud resource with the Pulumi CLI, use the following syntax:
 


### PR DESCRIPTION
Fixes #16033 

Remove duplicate "consisting" word from three import tutorial files.

🤖 Generated with [Claude Code](https://claude.ai/code)
