### PR TITLE
Improve parent resource option documentation

### DIFF
--- a/content/docs/iac/concepts/options/parent.md
+++ b/content/docs/iac/concepts/options/parent.md
@@ -104,7 +104,7 @@ Previewing update (dev):
 
 ## Inherited resource options
 
-Child resources always inherit the following resource options from their `parent`:
+Child resources inherit the following values from their `parent`:
 
 * [`provider`](/docs/iac/concepts/options/provider): Child resources inherit their parent's provider in order to ensure that child resources are created in the same cloud context (account, region, etc.) as their parent.
 

--- a/content/docs/iac/concepts/options/parent.md
+++ b/content/docs/iac/concepts/options/parent.md
@@ -19,7 +19,7 @@ The `parent` resource option specifies a parent for a resource, which has the fo
 * The child inherits additional resource options from its parent.
 * The Pulumi CLI shows the parent/child hierarchy in CLI output.
 
-By default, resources are parented to the implicitly created `pulumi:pulumi:Stack` resource which is at the root of all Pulumi stacks. The most common use of explicitly setting the `parent` property is when authoring a [Component Resource](/docs/iac/concepts/components/). Resources that are part of a component should be explicitly parented to the component itself. This ensures that all resources within a component share desirable lifecycle behavior. (It is also possible to have multiple levels of nesting within a component for improved visual display in the CLI if desired.)
+By default, resources are parented to the implicitly created `pulumi:pulumi:Stack` resource which is at the root of all Pulumi stacks. The most common use of explicitly setting the `parent` property is when authoring a [Component Resource](/docs/iac/concepts/components/). Resources that are part of a component should be explicitly parented to the component itself. This ensures that all resources within a component share desirable lifecycle behavior. You can also create multiple levels of nesting within a component to improve the visual display in the CLI.
 
 ## Setting a resource's parent
 
@@ -106,12 +106,12 @@ Previewing update (dev):
 
 Child resources inherit the following values from their `parent`:
 
-* [`provider`](/docs/concepts/options/provider): Child resources inherit their parent's provider in order to ensure that child resources are created in the same cloud context (account, region, etc.) as their parent.
+* [`provider`](/docs/iac/concepts/options/provider): Child resources inherit their parent's provider in order to ensure that child resources are created in the same cloud context (account, region, etc.) as their parent.
 
-* [`aliases`](/docs/concepts/options/aliases): Aliases are inherited so that changing the type of a parent resource correctly changes the qualified type of a child resource, and changing the name of a parent resource correctly changes the name prefix of child resources.
+* [`aliases`](/docs/iac/concepts/options/aliases): Aliases are inherited so that changing the type of a parent resource correctly changes the qualified type of a child resource, and changing the name of a parent resource correctly changes the name prefix of child resources.
 
-* [`protect`](/docs/concepts/options/protect): Child resources inherit their parent's protection bit in order to ensure that deletions execute correctly. Children are deleted before their parent, so inheriting protection ensures that if a parent is marked as protected, none of its children will be deleted (because deleting the protected parent would fail).
+* [`protect`](/docs/iac/concepts/options/protect): Child resources inherit their parent's protection bit in order to ensure that deletions execute correctly. Children are deleted before their parent, so inheriting protection ensures that if a parent is marked as protected, none of its children will be deleted (because deleting the protected parent would fail).
 
-* [`transforms`](/docs/concepts/options/transforms):  Transforms applied to a parent will run on the parent and on all child resources. This allows a transform to be applied to a component to intercept and modify any resources created by its children. As a special case, [Stack transforms](/docs/concepts/options/transforms#stack-transforms) will be applied to *all* resources (since all resources ultimately are parented directly or indirectly by the root stack resource).
+* [`transforms`](/docs/iac/concepts/options/transforms):  Transforms applied to a parent will run on the parent and on all child resources. This allows a transform to be applied to a component to intercept and modify any resources created by its children. As a special case, [Stack transforms](/docs/iac/concepts/options/transforms#stack-transforms) will be applied to *all* resources (since all resources ultimately are parented directly or indirectly by the root stack resource).
 
-* [`transformations`](/docs/concepts/options/transformations):  Transformations applied to a parent will run on the parent and on all child resources. This allows a transformation to be applied to a component to intercept and modify any resources created by its children. As a special case, [Stack transformations](/docs/concepts/options/transformations#stack-transformations) will be applied to *all* resources (since all resources ultimately are parented directly or indirectly by the root stack resource). Prefer `transforms` over `transformations` as the latter is deprecated.
+* [`transformations`](/docs/iac/concepts/options/transformations):  Transformations applied to a parent will run on the parent and on all child resources. This allows a transformation to be applied to a component to intercept and modify any resources created by its children. As a special case, [Stack transformations](/docs/iac/concepts/options/transformations#stack-transformations) will be applied to *all* resources (since all resources ultimately are parented directly or indirectly by the root stack resource). Prefer `transforms` over `transformations` as the latter is deprecated.

--- a/content/docs/iac/concepts/options/parent.md
+++ b/content/docs/iac/concepts/options/parent.md
@@ -104,7 +104,7 @@ Previewing update (dev):
 
 ## Inherited resource options
 
-Child resources inherit the following values from their `parent`:
+Child resources always inherit the following resource options from their `parent`:
 
 * [`provider`](/docs/iac/concepts/options/provider): Child resources inherit their parent's provider in order to ensure that child resources are created in the same cloud context (account, region, etc.) as their parent.
 


### PR DESCRIPTION
Fixes #15933 
Fixes #11236

Remove warning about parenting to custom resources and restructure content for better clarity and organization. Changes include:

- Remove warning against parenting to custom resources
- Add clear introduction explaining effects and when to use parent option
- Organize content with section headers for better navigation
- Improve code examples and CLI output examples
- Enhance explanations of inherited resource options with rationale
- Update language chooser to remove JavaScript

🤖 Generated with [Claude Code](https://claude.ai/code)
