### PR TITLE
Removed duplicated import environment text in working-with-environmen…

### DIFF
--- a/content/docs/esc/environments/working-with-environments.md
+++ b/content/docs/esc/environments/working-with-environments.md
@@ -450,11 +450,11 @@ For additional options and details, see `esc run --help`.
 
 ## Importing other environments
 
-Environments can also be composed from other environments.
+Pulumi ESC lets you define common configuration values once as reusable environments and then import them into other environments to avoid duplication, delegate ownership, and share settings (including secrets) across applications.
 
-Different applications are often configured in similar ways and with common values --- for example, an e-commerce site and order-management system both configured to use the same cloud account, database-connection string, and third-party API key. Managing the duplication of these values across multiple configuration files, however, can be difficult, especially when one of those values changes --- e.g., when an API key is regenerated.
-
-To address these challenges, Pulumi ESC allows you to identify common or closely related configuration settings and define them only once, as individual environments, and then _import_ those environments into other, more specialized environments as needed. Imports also allow you to expose certain environments without having to distribute any concrete values and to delegate responsibility for particular environments to other teams in your organization. Environments can import both static and dynamic values, including secrets, from any number of other environments.
+{{% notes type="info" %}}
+For a detailed description on how to work with imports, please refer to [Importing other Environments](./imports.md) documentation page.
+{{% /notes %}}
 
 In the following example, two environments, `aws/dev` and `stripe/dev`, are used to compose a third environment, `myapp/dev`:
 


### PR DESCRIPTION
### Proposed changes

This PR replaces the (duplicated) detailed description for environment imports in the "working with environments" page and references to the corresponding docs page.

Fixes: #14130 
