### PR TITLE
fix stack-outputs-refs-azure tutorial code

### DIFF
--- a/static/programs/azure-native-storage-account-blob-python/__main__.py
+++ b/static/programs/azure-native-storage-account-blob-python/__main__.py
@@ -31,5 +31,5 @@ blob_resource = azure_native.storage.Blob("blobresource",
 )
 
 pulumi.export("resourceGroupName", resource_group.name)
-pulumi.export("storageName", storage_account.name)
-pulumi.export("containerName", blob_container.name)
+pulumi.export("storageAccountName", storage_account.name)
+pulumi.export("blobContainerName", blob_container.name)


### PR DESCRIPTION
In the python code for this tutorial, the name for the export doesn't match the name we try to use in the second program to get the output from the stack ref. Fix that up.