### PR TITLE
Add dedicated REST API reference for Pulumi Cloud webhooks

### DIFF
--- a/content/docs/pulumi-cloud/reference/_index.md
+++ b/content/docs/pulumi-cloud/reference/_index.md
@@ -56,3 +56,4 @@ The Pulumi Cloud REST API is organized into the following resource categories:
 - [Stack Tags](/docs/pulumi-cloud/reference/stack-tags/) - Manage metadata tags on stacks
 - [Stack Updates](/docs/pulumi-cloud/reference/stack-updates/) - Manage the update lifecycle for stacks
 - [Stacks](/docs/pulumi-cloud/reference/stacks/) - Create, update, and manage Pulumi stacks
+- [Webhooks](/docs/pulumi-cloud/reference/webhooks/) - Create and manage webhooks for organizations and stacks

--- a/content/docs/pulumi-cloud/reference/organizations/_index.md
+++ b/content/docs/pulumi-cloud/reference/organizations/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Organizations
 title_tag: "Pulumi Cloud REST API: Organizations"
-meta_desc: Learn about the Pulumi Cloud REST API endpoints for managing organizations, teams, members, and organization-level access tokens and webhooks.
+meta_desc: Learn about the Pulumi Cloud REST API endpoints for managing organizations, teams, members, and organization-level access tokens.
 menu:
     cloud:
         parent: pulumi-cloud-reference
@@ -18,7 +18,6 @@ The API provides endpoints for the following categories of operations:
 - Managing organization access tokens
 - Creating and managing teams
 - Managing team access tokens
-- Creating and managing webhooks
 
 ## User Management
 
@@ -396,64 +395,4 @@ curl \
 
 ## Webhooks
 
-### Create Webhook
-
-Create a new webhook for an organization or stack.
-
-```plain
-// To create an organization webhook
-POST /api/orgs/{organization}/hooks
-
-// To create a stack webhook
-POST /api/stacks/{organization}/{project}/{stack}/hooks
-```
-
-#### Parameters
-
-| Parameter          | Type          | In   | Description                                                                                                                                                                     |
-|--------------------|---------------|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `active`           | boolean       | body | enable webhook                                                                                                                                                                  |
-| `displayName`      | string        | body | name of webhook                                                                                                                                                                 |
-| `organizationName` | string        | body | organization name                                                                                                                                                               |
-| `payloadUrl`       | string        | body | URL to send request to                                                                                                                                                          |
-| `projectName`      | string        | body | **Optional.** project name (required for stack webhooks)                                                                                                                        |
-| `stackName`        | string        | body | **Optional.** stack name (required for stack webhooks)                                                                                                                          |
-| `format`           | string        | body | **Optional.** format of the payload. Possible values are `raw`, `slack`, `ms_teams` or `pulumi_deployments`. Default is `raw`.                                                  |
-| `filters`          | array[string] | body | **Optional.** list of filters for events the webhook should receive. See [webhook docs](/docs/pulumi-cloud/webhooks#filters) for more information on what filters are available |
-| `secret`           | string        | body | **Optional.** secret used as the HMAC key. See [webhook docs](/docs/pulumi-cloud/webhooks#headers) for more information                                                         |
-
-### List Webhooks
-
-List all webhooks for an organization or stack.
-
-```plain
-// List organization webhooks
-GET /api/orgs/{organization}/hooks
-
-// List stack webhooks
-GET /api/stacks/{organization}/{project}/{stack}/hooks
-```
-
-### Get Webhook
-
-Get details about a specific webhook.
-
-```plain
-// Get organization webhook
-GET /api/orgs/{organization}/hooks/{webhookname}
-
-// Get stack webhook
-GET /api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}
-```
-
-### Ping Webhook
-
-Send a test ping to a webhook to validate it's working.
-
-```plain
-// Ping organization webhook
-POST /api/orgs/{organization}/hooks/{webhookname}/ping
-
-// Ping stack webhook
-POST /api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}/ping
-```
+For comprehensive information about webhooks including setup, configuration, event filtering, and complete API reference, see the [Webhooks documentation](/docs/pulumi-cloud/webhooks/) and [Webhooks REST API reference](/docs/pulumi-cloud/reference/webhooks/).

--- a/content/docs/pulumi-cloud/reference/webhooks/_index.md
+++ b/content/docs/pulumi-cloud/reference/webhooks/_index.md
@@ -1,0 +1,264 @@
+---
+title: Webhooks
+title_tag: "Pulumi Cloud REST API: Webhooks"
+meta_desc: Learn about the Pulumi Cloud REST API endpoints for creating and managing webhooks for organizations and stacks.
+menu:
+    cloud:
+        parent: pulumi-cloud-reference
+        weight: 30
+---
+
+The Webhooks API allows you to create and manage webhooks for organizations and stacks. Webhooks notify external services of events happening within your Pulumi organization, such as stack updates, deployments, or policy violations.
+
+For comprehensive information about webhooks including event filtering, payload formats, and UI setup, see the [Webhooks documentation](/docs/pulumi-cloud/webhooks/).
+
+## Webhook Operations
+
+The API provides endpoints for the following operations:
+
+- Creating new webhooks for organizations or stacks
+- Listing webhooks with filtering options
+- Getting webhook details
+- Updating webhook configuration
+- Testing webhooks with ping functionality
+- Deleting webhooks
+
+## Create Webhook
+
+Create a new webhook for an organization or stack.
+
+```plain
+// To create an organization webhook
+POST /api/orgs/{organization}/hooks
+
+// To create a stack webhook
+POST /api/stacks/{organization}/{project}/{stack}/hooks
+```
+
+### Parameters
+
+| Parameter          | Type          | In   | Description                                                                                                                                                                     |
+|--------------------|---------------|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `organization`     | string        | path | Organization name                                                                                                                                                               |
+| `project`          | string        | path | **Optional.** Project name (required for stack webhooks)                                                                                                                        |
+| `stack`            | string        | path | **Optional.** Stack name (required for stack webhooks)                                                                                                                          |
+| `active`           | boolean       | body | Enable webhook                                                                                                                                                                  |
+| `displayName`      | string        | body | Name of webhook                                                                                                                                                                 |
+| `organizationName` | string        | body | Organization name                                                                                                                                                               |
+| `payloadUrl`       | string        | body | URL to send request to                                                                                                                                                          |
+| `projectName`      | string        | body | **Optional.** Project name (required for stack webhooks)                                                                                                                        |
+| `stackName`        | string        | body | **Optional.** Stack name (required for stack webhooks)                                                                                                                          |
+| `format`           | string        | body | **Optional.** Format of the payload. Possible values are `raw`, `slack`, `ms_teams` or `pulumi_deployments`. Default is `raw`.                                                  |
+| `filters`          | array[string] | body | **Optional.** List of filters for events the webhook should receive. See [webhook docs](/docs/pulumi-cloud/webhooks#event-filtering) for more information on what filters are available |
+| `secret`           | string        | body | **Optional.** Secret used as the HMAC key. See [webhook docs](/docs/pulumi-cloud/webhooks#headers) for more information                                                         |
+
+### Example
+
+```bash
+# Create organization webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request POST \
+  --data '{"active": true, "displayName": "My Webhook", "organizationName": "myorg", "payloadUrl": "https://example.com/webhook"}' \
+  https://api.pulumi.com/api/orgs/{organization}/hooks
+
+# Create stack webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request POST \
+  --data '{"active": true, "displayName": "Stack Webhook", "organizationName": "myorg", "projectName": "myproject", "stackName": "production", "payloadUrl": "https://example.com/webhook"}' \
+  https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/hooks
+```
+
+## List Webhooks
+
+List all webhooks for an organization or stack.
+
+```plain
+// List organization webhooks
+GET /api/orgs/{organization}/hooks
+
+// List stack webhooks
+GET /api/stacks/{organization}/{project}/{stack}/hooks
+```
+
+### Parameters
+
+| Parameter           | Type   | In    | Description                                                                                                  |
+|---------------------|--------|-------|--------------------------------------------------------------------------------------------------------------|
+| `organization`      | string | path  | Organization name                                                                                            |
+| `project`           | string | path  | **Optional.** Project name (required for stack webhooks)                                                     |
+| `stack`             | string | path  | **Optional.** Stack name (required for stack webhooks)                                                       |
+| `continuationToken` | string | query | **Optional.** The continuation token to use for retrieving the next set of results if results were truncated |
+
+### Example
+
+```bash
+# List organization webhooks
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/orgs/{organization}/hooks
+
+# List stack webhooks
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/hooks
+```
+
+## Get Webhook
+
+Get details about a specific webhook.
+
+```plain
+// Get organization webhook
+GET /api/orgs/{organization}/hooks/{webhookname}
+
+// Get stack webhook
+GET /api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}
+```
+
+### Parameters
+
+| Parameter      | Type   | In   | Description                                               |
+|----------------|--------|------|-----------------------------------------------------------|
+| `organization` | string | path | Organization name                                         |
+| `project`      | string | path | **Optional.** Project name (required for stack webhooks) |
+| `stack`        | string | path | **Optional.** Stack name (required for stack webhooks)   |
+| `webhookname`  | string | path | Name of the webhook                                       |
+
+### Example
+
+```bash
+# Get organization webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/orgs/{organization}/hooks/{webhookname}
+
+# Get stack webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}
+```
+
+## Update Webhook
+
+Update an existing webhook.
+
+```plain
+// Update organization webhook
+PATCH /api/orgs/{organization}/hooks/{webhookname}
+
+// Update stack webhook
+PATCH /api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}
+```
+
+### Parameters
+
+The update endpoint accepts the same body parameters as the create endpoint. Only include the fields you want to update.
+
+### Example
+
+```bash
+# Update organization webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request PATCH \
+  --data '{"active": false, "displayName": "Updated Webhook Name"}' \
+  https://api.pulumi.com/api/orgs/{organization}/hooks/{webhookname}
+```
+
+## Delete Webhook
+
+Delete a webhook.
+
+```plain
+// Delete organization webhook
+DELETE /api/orgs/{organization}/hooks/{webhookname}
+
+// Delete stack webhook
+DELETE /api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}
+```
+
+### Parameters
+
+| Parameter      | Type   | In   | Description                                               |
+|----------------|--------|------|-----------------------------------------------------------|
+| `organization` | string | path | Organization name                                         |
+| `project`      | string | path | **Optional.** Project name (required for stack webhooks) |
+| `stack`        | string | path | **Optional.** Stack name (required for stack webhooks)   |
+| `webhookname`  | string | path | Name of the webhook                                       |
+
+### Example
+
+```bash
+# Delete organization webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request DELETE \
+  https://api.pulumi.com/api/orgs/{organization}/hooks/{webhookname}
+
+# Delete stack webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request DELETE \
+  https://api.stacks/{organization}/{project}/{stack}/hooks/{webhookname}
+```
+
+## Ping Webhook
+
+Send a test ping to a webhook to validate it's working.
+
+```plain
+// Ping organization webhook
+POST /api/orgs/{organization}/hooks/{webhookname}/ping
+
+// Ping stack webhook
+POST /api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}/ping
+```
+
+### Parameters
+
+| Parameter      | Type   | In   | Description                                               |
+|----------------|--------|------|-----------------------------------------------------------|
+| `organization` | string | path | Organization name                                         |
+| `project`      | string | path | **Optional.** Project name (required for stack webhooks) |
+| `stack`        | string | path | **Optional.** Stack name (required for stack webhooks)   |
+| `webhookname`  | string | path | Name of the webhook                                       |
+
+### Example
+
+```bash
+# Ping organization webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request POST \
+  https://api.pulumi.com/api/orgs/{organization}/hooks/{webhookname}/ping
+
+# Ping stack webhook
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  --request POST \
+  https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}/ping
+```


### PR DESCRIPTION
Fixes #16144 

Extracts webhook REST API documentation from the organizations page into its own dedicated reference page for better organization and discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
