### PR TITLE
Add OIDC token type availability by Pulumi edition

### DIFF
--- a/content/docs/pulumi-cloud/access-management/oidc-client/_index.md
+++ b/content/docs/pulumi-cloud/access-management/oidc-client/_index.md
@@ -24,6 +24,16 @@ Pulumi supports establishing trust relationships with third party OIDC providers
 
 For third party services that have capabilities to issue OIDC id_tokens, it is possible to register them as a trusted OIDC Issuer to leverage these tokens to be exchanged by a short-lived Pulumi access token automatically to avoid having to store hardcoded credentials.
 
+## Token types by edition
+
+The available OIDC token types vary depending on your Pulumi edition:
+
+- **Individual**: `personal` tokens only
+- **Team**: `personal` and `organization` tokens
+- **Enterprise and Business Critical**: `personal`, `organization`, and `team` tokens
+
+When configuring authorization policies and requesting tokens, ensure you select a token type that is available for your edition.
+
 ## Configuring trust relationships
 
 ### Register the OIDC issuer

--- a/content/docs/pulumi-cloud/access-management/oidc-client/github.md
+++ b/content/docs/pulumi-cloud/access-management/oidc-client/github.md
@@ -16,6 +16,10 @@ aliases:
 
 This document outlines the steps required to configure Pulumi to accept Github id_tokens to be exchanged by Organization access tokens.
 
+{{< notes type="info" >}}
+This guide demonstrates using `organization` tokens. Depending on your [Pulumi edition](/docs/pulumi-cloud/access-management/oidc-client/#token-types-by-edition), you may also use `personal` or `team` tokens by adjusting the token type in the authorization policies and the `requested-token-type` parameter.
+{{< /notes >}}
+
 ## Prerequisites
 
 * You must be an admin of your Pulumi organization.

--- a/content/docs/pulumi-cloud/access-management/oidc-client/kubernetes-eks.md
+++ b/content/docs/pulumi-cloud/access-management/oidc-client/kubernetes-eks.md
@@ -19,6 +19,10 @@ aliases:
 
 This document outlines the steps required to configure Pulumi to accept Elastic Kubernetes Service (EKS) id_tokens to be exchanged for a personal access token. With this configuration, Kubernetes pods authenticate to Pulumi Cloud using OIDC tokens issued by EKS.
 
+{{< notes type="info" >}}
+This guide demonstrates using `personal` tokens. Depending on your [Pulumi edition](/docs/pulumi-cloud/access-management/oidc-client/#token-types-by-edition), you may also use `organization` or `team` tokens by adjusting the token type in the authorization policies and the `requested_token_type` parameter.
+{{< /notes >}}
+
 ## Prerequisites
 
 * You must be an admin of your Pulumi organization.

--- a/content/docs/pulumi-cloud/access-management/oidc-client/kubernetes-gke.md
+++ b/content/docs/pulumi-cloud/access-management/oidc-client/kubernetes-gke.md
@@ -18,6 +18,10 @@ This document outlines the steps required to configure Pulumi to accept Google K
 
 See ["Bound Tokens"](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-bound-service-account-tokens) for more background.
 
+{{< notes type="info" >}}
+This guide demonstrates using `organization` tokens. Depending on your [Pulumi edition](/docs/pulumi-cloud/access-management/oidc-client/#token-types-by-edition), you may also use `personal` or `team` tokens by adjusting the token type in the authorization policies and the `requested_token_type` parameter.
+{{< /notes >}}
+
 ## Prerequisites
 
 * You must be an admin of your Pulumi organization.


### PR DESCRIPTION
This PR clarifies which OIDC token types (personal, organization, team) are available for each Pulumi edition.

### Changes:
- Added "Token types by edition" section to main OIDC client page
- Updated GitHub, GKE, and EKS OIDC guides with info notes linking to token types
- Clarified that examples show specific token types but others may be available

Fixes #16019

Generated with [Claude Code](https://claude.ai/code)