### PR TITLE
Add meta images to rss feed

### DIFF
--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -13,7 +13,12 @@
                 <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
                 <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
                 <guid>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</guid>
-                <description>{{ .Content | html }}</description>
+                <description>
+                    {{ if .Params.meta_image }}
+                        &lt;img src=&quot;{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}{{ .Params.meta_image }}&quot; /&gt;
+                    {{ end }}
+                    {{ .Content | html }}
+                </description>
                 {{ range $id := .Params.authors }}
                     {{ $author := index $.Site.Data.team.team $id }}
                     {{ if $author }}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Add meta images to blog rss feed. I initially wanted to use <media:content> but somehow my rss feed reader didn't really like it so I think adding the image to the top of the description is simpler
Without adding the meta images, my feed reader was showing a random image from the article as the main image, which isn't as nice

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
