### PR TITLE
Add default social card image for documentation pages

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -13,6 +13,8 @@ norightnav: true
 nobreadcrumb: true
 h1: Pulumi Docs
 description: <p>Pulumi is an <a href="https://github.com/pulumi/pulumi" target="_blank">open source</a> platform for <a href="/docs/iac">automating</a>, <a href="/docs/esc">securing</a>, and <a href="/docs/pulumi-cloud">managing</a> cloud resources, configuration, and secrets, using your favorite <a href="/docs/iac/languages-sdks/">programming languages.</a></p>
+cascade:
+  meta_image: /images/docs/meta-images/docs-meta.png
 link_buttons:
   primary:
     label: Get Started


### PR DESCRIPTION
## Summary
- Implements Hugo's cascade feature to provide a default social card image for all documentation pages
- Adds `cascade: meta_image` configuration to `/content/docs/_index.md`
- Ensures proper social media previews for 371+ docs pages currently missing custom meta images

## Problem
Many documentation pages were missing social card images, causing them to fall back to the generic Pulumi logo when shared on social media platforms like Twitter/X. This resulted in less professional and less informative social previews for documentation content.

## Solution
Using Hugo's native cascade feature, all documentation pages now automatically inherit the docs-branded social card image (`/images/docs/meta-images/docs-meta.png`) unless they have a custom `meta_image` explicitly set in their frontmatter.

## Benefits
- **Immediate coverage**: All 371+ docs pages without explicit meta_image now have proper social cards
- **Future-proof**: New documentation pages automatically get appropriate social cards
- **Maintains flexibility**: Pages with custom meta_image values retain their specific images
- **Clean implementation**: Uses Hugo's intended feature for section defaults, no template hacks needed

## Testing
Verified locally that:
- ✅ Docs pages without meta_image now correctly show the docs-branded social card
- ✅ Pages with existing meta_image continue to use their custom images
- ✅ Non-docs sections (blog, homepage) are unaffected

## Technical Details
The cascade feature works by setting default frontmatter values that are inherited by all descendant pages in the `/docs/` section. This is the Hugo-idiomatic way to handle section-level defaults.

Example of the improved social preview: Instead of showing the generic Pulumi logo, docs pages will now display the dedicated docs meta image when shared on social media.