### PR TITLE
feat: Add Kiro configuration instructions to index.md

### DIFF
--- a/content/docs/iac/using-pulumi/mcp-server/index.md
+++ b/content/docs/iac/using-pulumi/mcp-server/index.md
@@ -132,8 +132,7 @@ After adding the configuration, authenticate via browser when prompted.
 ```
 
 > [!INFO]
-> Kiro currently supports local stdio MCP servers, however you can add remote MCP servers by leveraging the [mcp-remote npm package](https://www.npmjs.com/package/mcp-remote) to make requests to the remote MCP endpoint. 
->
+> Kiro currently supports local stdio MCP servers, however you can add remote MCP servers by leveraging the [mcp-remote npm package](https://www.npmjs.com/package/mcp-remote) to make requests to the remote MCP endpoint.
 > For more information, see [Remote MCP Servers](https://kiro.dev/docs/mcp/servers/#remote-mcp-servers) in the Kiro documentation.
 
 The `mcp.json` configuration file can be placed in several locations. See [Configuration Locations](https://kiro.dev/docs/mcp/configuration/#configuration-locations) in the Kiro documentation for details on where to place this file.


### PR DESCRIPTION
This pull request adds documentation for configuring the Pulumi MCP server with the Kiro AI coding assistant. The new section provides step-by-step instructions and helpful links for users integrating MCP servers with Kiro.

Integration with Kiro:

* Added a new section describing how to configure the Pulumi MCP server in Kiro, including a sample `mcp.json` configuration snippet.
* Included notes about support for remote MCP servers via the `mcp-remote` npm package and provided links to relevant Kiro documentation for remote server setup and configuration file locations.
* Clarified the authentication process for Kiro users, mentioning the browser popup prompt.