### PR TITLE
Restore correct product page headers/subheaders

### DIFF
--- a/content/product/internal-developer-platforms.md
+++ b/content/product/internal-developer-platforms.md
@@ -7,7 +7,7 @@ meta_image: /images/product/idp-meta.png
 
 heading: Internal Developer Platform
 subheading: |
-    Accelerate cloud delivery with secure developer self-service
+    Everything platform engineers need to build an IDP
 
 aliases:
     - /solutions/platforms/

--- a/content/product/pulumi-insights.md
+++ b/content/product/pulumi-insights.md
@@ -2,7 +2,7 @@
 title: Cloud Asset and Compliance Management – Pulumi Insights
 layout: pulumi-insights
 
-heading: Pulumi Insights
+heading: Insights & Governance
 subheading: |
     Complete visibility and control for your cloud
 


### PR DESCRIPTION
https://github.com/pulumi/docs/pull/16185 did not correctly restore our product page headings and subheadings.