### PR TITLE
Remove refs to S3 folder component

### DIFF
--- a/content/blog/how-to-deploy-jenkins-to-kubernetes-with-pulumi/index.md
+++ b/content/blog/how-to-deploy-jenkins-to-kubernetes-with-pulumi/index.md
@@ -166,4 +166,4 @@ Find out more:
 
 - Get the [example code on GitHub](https://github.com/pulumi/examples/tree/master/kubernetes-ts-jenkins)
 - Read the docs on [Kubernetes](/registry/packages/kubernetes/api-docs/)
-- See the tutorial on [building components](/registry/packages/aws/how-to-guides/s3-folder-component/)
+- See the tutorial on [building components](/docs/iac/using-pulumi/build-a-component/)

--- a/content/docs/iac/concepts/components/_index.md
+++ b/content/docs/iac/concepts/components/_index.md
@@ -126,8 +126,6 @@ A component resource must register a unique type name with the base constructor.
 For a complete end-to-end walkthrough of building a component from scratch, including setup, implementation, and publishing, see the [Build a Component](/docs/iac/using-pulumi/build-a-component/) guide.
 {{< /notes >}}
 
-For more information about component resources, see the [S3 Folder Pulumi Component](/registry/packages/aws/how-to-guides/s3-folder-component/) guide.
-
 ## Creating Child Resources
 
 Component resources often contain child resources. The names of child resources are often derived from the component resources's name to ensure uniqueness. For example, you might use the component resource's name as a prefix. Also, when constructing a resource, children must be registered as such. To do this, pass the component resource itself as the `parent` option.


### PR DESCRIPTION
The S3 folder component guide in the registry is out of date and incomplete, so we should reference the Build a Component guide in the docs, which is a more production-ready example and uses our most up to date packaging feature.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
