### PR TITLE
Remove code sample from "vs. serverless framework"

### DIFF
--- a/content/docs/iac/concepts/vs/serverless.md
+++ b/content/docs/iac/concepts/vs/serverless.md
@@ -31,6 +31,3 @@ Where Serverless Framework treats each function as a configurable entity, Pulumi
 program. This means in practice that most Serverless Framework solutions also need to involve other solutions -- like
 AWS CloudFormation -- and that you as a user are left orchestrating changes in multiple systems.
 This often leads to the very "pile of bash scripts" problems that you had sought to solve in the first place.
-
-For a good specific comparison of Pulumi and the Serverless Framework, refer to this example: [the before code using the Serverless Framework](https://serverless.com/blog/serverless-application-for-long-running-process-fargate-lambda/) takes about 38 pages
-of explanation, including manual steps and AWS CloudFormation; [the after code using Pulumi](https://github.com/pulumi/examples/tree/5f3eae87bb132595e4c60d2d5f8e8ee1473f6a7b/cloud-js-thumbnailer) is only about 38 lines of code.


### PR DESCRIPTION
This page had a reference to the now-defunct Pulumi Cloud Framework. The referenced code has already been deleted from pulumi/examples. (The reference was to a git SHA before the example was deleted.)
