### PR TITLE
Force CSS fingerprint regeneration to bust CloudFront cache

### DIFF
--- a/theme/tailwind.config.js
+++ b/theme/tailwind.config.js
@@ -160,6 +160,10 @@ const green = {
 };
 
 module.exports = {
+    // ⚠️ CACHE BUST: October 2025 - Force new CSS fingerprint to invalidate CloudFront cache
+    // This is a temporary fix for the reinvent page missing CSS classes.
+    // See GitHub issue #16274 for long-term architectural fix.
+    // TODO: Remove this unused color after proper fingerprinting is implemented.
     purge: false,
     theme: {
         extend: {
@@ -170,6 +174,10 @@ module.exports = {
             },
             boxShadow: {
                 "3xl": "0 35px 70px -20px rgba(0, 0, 0, 0.5)",
+            },
+            // Unused color added solely to bust CloudFront CSS cache - See #16274
+            colors: {
+                'cache-bust-2025-10': '#000001',
             },
         },
         rgbColors: {


### PR DESCRIPTION
## Summary

Adds a comment to `theme/tailwind.config.js` to force CSS regeneration, which busts the CloudFront cache that was serving stale CSS for the reinvent page.

## Problem

The reinvent page (https://www.pulumi.com/reinvent) was not displaying correctly in production because the CSS class `-translate-y-1/2` was missing from the served CSS file. 

**Root cause**: The build process fingerprints CSS **before** PurgeCSS runs, causing CloudFront to cache CSS with a filename that doesn't match the actual content. When the reinvent template was added, PurgeCSS output changed (to include the new class), but the filename hash stayed the same because the source CSS didn't change.

CloudFront was serving a 20+ hour old cached version of `bundle.34a92c....css` that was generated before the reinvent template existed.

## Solution

This PR adds a comment and unused class to `tailwind.config.js` to force Webpack to regenerate the CSS with new content. This causes Hugo to compute a **new fingerprint hash**, resulting in a new filename that CloudFront has never cached.

When this deploys:
- New filename: `bundle.<NEW_HASH>.css` 
- CloudFront cache miss → fetches fresh CSS
- Reinvent page displays correctly ✓

## Long-Term Fix

This is a **temporary workaround**. The proper architectural fix is tracked in #16274, which proposes:
- Computing CSS fingerprints **after** PurgeCSS runs, or
- Adding CloudFront cache invalidation to the deployment process

## Testing

- [x] Local build generates new CSS filename
- [x] Local reinvent page displays correctly
- [ ] Production deployment will generate new CSS hash
- [ ] CloudFront will serve fresh CSS (within 5 minutes of deployment)

## Files Changed

- `theme/tailwind.config.js` - Added cache-bust comment with reference to #16274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>