### PR TITLE
Add missing alias for Cloud REST API reference

### DIFF
--- a/content/docs/reference/cloud-rest-api/_index.md
+++ b/content/docs/reference/cloud-rest-api/_index.md
@@ -13,7 +13,6 @@ aliases:
   - /docs/intro/insights/api/
   - /docs/reference/cloud-rest-api/
   - /docs/pulumi-cloud/cloud-rest-api/
-  - /docs/reference/cloud-rest-api/
   - /docs/pulumi-cloud/reference/
 ---
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Adds an alias for the top link when googling "pulumi rest api" which is currently 404ing.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
