### PR TITLE
Fix workflow script for new CLI version

### DIFF
--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Update version lists
         run: |
           NL=$'\n'
-          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/iac/download-install/versions.md
+          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/get-started/download-install/versions.md
         working-directory: docs
       - name: git status
         run: git status && git diff


### PR DESCRIPTION
This fixes the workflow that updates `versions.md` when a new version of the CLI is released. We need to update the file at its new location after the recent restructuring.

After this is merged, I'll re-dispatch the workflow for v3.203.0.

Fixes #16280