### PR TITLE
Add DWH access to cloudfront logs

### DIFF
--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -16,3 +16,4 @@ config:
   www.pulumi.com:websiteLogsBucketName: www-prod.pulumi.com-website-logs
   www.pulumi.com:answersStack: "pulumi/answers/production"
   www.pulumi.com:cdnLogDeliverySourceName: "CreatedByCloudFront-E3PRSXO1BZJEEY"
+  www.pulumi.com:enableDataWarehouseAccess: "true"


### PR DESCRIPTION
I missed adding the configuration so the logs bucket can be accessed by the DWH stack