### PR TITLE
Fix release date of ESC protection deletion blog post

### DIFF
--- a/content/blog/esc-deletion-protection/index.md
+++ b/content/blog/esc-deletion-protection/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Deletion Protection for Pulumi ESC Environments"
-date: 2025-10-21T14:00:00-07:00
+date: 2025-11-03T14:00:00-07:00
 draft: false
 meta_desc: "Prevent accidental deletion of critical environments with the new deletion protection feature for Pulumi ESC."
 meta_image: meta.png


### PR DESCRIPTION
I kept the original date of Oct 21 but it should be today.