### PR TITLE
Remove delisted scopes

### DIFF
--- a/content/docs/administration/access-identity/rbac/scopes/environments.md
+++ b/content/docs/administration/access-identity/rbac/scopes/environments.md
@@ -25,7 +25,6 @@ Note that creating, listing, or restoring environments are organization-level op
 | Value | Description |
 |-------|-------------|
 | `environment:clone` | Create a copy of an existing environment with all its configurations. This is useful for creating staging or testing environments.<br><br>**Granted by default permission**: `Environment Open` |
-| `environment:read_decrypt` | Access and decrypt sensitive environment data. This allows viewing encrypted configuration values and secrets.<br><br>**Granted by default permission**: `Environment Open` |
 | `environment:delete` | Remove an environment and its associated resources. This permanently deletes the environment and its configurations.<br><br>**Granted by default permission**: `Environment Admin` |
 | `environment:open` | Access and interact with an environment's resources. This includes the ability to view and modify environment configurations.<br><br>**Granted by default permission**: `Environment Open` |
 | `environment:read` | View environment configurations and settings. This provides read-only access to environment details and parameters.<br><br>**Granted by default permission**: `Environment Read` |
@@ -63,7 +62,6 @@ Note that creating, listing, or restoring environments are organization-level op
 | Value | Description |
 |-------|-------------|
 | `environment_version:create` | Create a new version of an environment. This allows tracking changes and maintaining environment history.<br><br>**Granted by default permission**: `Environment Write` |
-| `environment_version:read_decrypt` | Access and decrypt sensitive data in an environment version. This allows viewing encrypted configuration values.<br><br>**Granted by default permission**: `Environment Open` |
 | `environment_version:delete` | Remove a specific version of an environment. This permanently deletes the version and its configurations.<br><br>**Granted by default permission**: `Environment Write` |
 | `environment_version:open` | Access and interact with a specific environment version. This includes viewing and using version-specific configurations.<br><br>**Granted by default permission**: `Environment Open` |
 | `environment_version:read` | View details of a specific environment version. This provides access to version-specific configurations and metadata.<br><br>**Granted by default permission**: `Environment Open` |

--- a/content/docs/administration/access-identity/rbac/scopes/org-settings.md
+++ b/content/docs/administration/access-identity/rbac/scopes/org-settings.md
@@ -93,9 +93,7 @@ This document defines all the available scopes in Pulumi Cloud, organized by [en
 | `org_member:read` | View details about organization members. This includes access to user profiles and roles.<br><br>**Granted by default roles**: `Member`, `Admin`, `Billing Manager` |
 | `org_member:set_admin` | Grant or revoke admin privileges for an organization member. This controls elevated access.<br><br>**Granted by default roles**: `Admin` |
 | `org_member:update` | Update organization member information and roles. This allows changing user details and permissions.<br><br>**Granted by default roles**: `Admin` |
-| `org_requests:create` | Submit a new request to join or interact with the organization. This is used for onboarding or special access. |
 | `org_requests:read` | View all organization requests. This provides visibility into pending and processed requests.<br><br>**Granted by default roles**: `Admin` |
-| `org_requests:status` | Check the status of an organization request. This helps track onboarding or access progress. |
 | `org_requests:update` | Update or process organization requests. This allows approving or denying requests.<br><br>**Granted by default roles**: `Admin` |
 | `invites:create` | Send invitations to new users to join the organization. This enables onboarding of new team members.<br><br>**Granted by default roles**: `Admin` |
 | `invites:read` | View pending and sent invitations for organization membership. This provides visibility into user onboarding status.<br><br>**Granted by default roles**: `Admin` |
@@ -119,8 +117,6 @@ This document defines all the available scopes in Pulumi Cloud, organized by [en
 | `organization:billing` | Manage billing settings and payment methods for the organization. This includes access to invoices and payment history.<br><br>**Granted by default roles**: `Admin`, `Billing Manager` |
 | `organization:change_backend` | Change the backend infrastructure for the organization. This is used for advanced configuration and migration.<br><br>**Granted by default roles**: `Admin` |
 | `organization:delete` | Delete the organization and all its resources. This is a permanent and irreversible action.<br><br>**Granted by default roles**: `Admin` |
-| `organization:read` | View organization details and settings. This includes access to organizational metadata and configuration.<br><br>**Granted by default roles**: `Member`, `Admin`, `Billing Manager` |
-| `organization:read_activity` | View recent activity and audit logs for the organization. This provides insight into changes and events.<br><br>**Granted by default roles**: `Member`, `Admin`, `Billing Manager` |
 | `organization:read_usage` | View usage statistics and metrics for the organization. This includes resource consumption and cost data.<br><br>**Granted by default roles**: `Member`, `Admin`, `Billing Manager` |
 | `organization:rename` | Change the name of the organization. This updates the organization's display name across the platform.<br><br>**Granted by default roles**: `Admin` |
 | `organization:transfer_stacks` | Transfer ownership of stacks between organizations. This is used for organizational restructuring or migration.<br><br>**Granted by default roles**: `Admin` |


### PR DESCRIPTION
In the interest of making fine-grained scopes easier for customers to manage, we consolidated some of our scopes. These scopes have already been removed from the service; this removes the delisted scopes from our docs.

Relevant PRs removing the scopes:
- https://github.com/pulumi/pulumi-service/pull/31039
- https://github.com/pulumi/pulumi-service/pull/32317
- https://github.com/pulumi/pulumi-service/pull/32402
- https://github.com/pulumi/pulumi-service/pull/32422
- https://github.com/pulumi/pulumi-service/pull/34020

