### PR TITLE
esc: bump node version in GHA

### DIFF
--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         nodeversion:
-          - "18.x"
+          - "20.x"
   notify:
     if: failure()
     name: Send slack notification


### PR DESCRIPTION
The Pulumi SDK now requires node 20+. This change was already made for
other workflows.
