### PR TITLE
Add alias for installation documentation page

### DIFF
--- a/content/docs/get-started/download-install/_index.md
+++ b/content/docs/get-started/download-install/_index.md
@@ -19,6 +19,7 @@ aliases:
   - /docs/reference/install/
   - /install/
   - /docs/install
+  - /docs/get-started/install/
 
 search:
    boost: true


### PR DESCRIPTION
Introduce a new alias for the installation Fixes #16494