### PR TITLE
Adding details on path parameter in automation api set config

### DIFF
--- a/content/blog/disable-default-providers/index.md
+++ b/content/blog/disable-default-providers/index.md
@@ -314,7 +314,7 @@ configuration file:
 pulumi:disable-default-providers: ["*"]
 ```
 
-To add the `disable-default-providers` configuration setting to your stack configuration file using the Pulumi CLI or the Automation API SDK, please visit the [Resource providers](/docs/iac/concepts/resources/providers/#disabling-default-providers) page.
+To add the `disable-default-providers` configuration setting to your stack configuration file using the Pulumi CLI or the Automation API SDK, please see the [Resource providers](/docs/iac/concepts/resources/providers/#disabling-default-providers) page.
 
 Now that you can [disable the default provider][dis-def-prov], you don’t have to worry about all of the possible unexpected consequences
 accidentally relying on your system configuration. We can’t wait to find out what you’ll build next! If you want to have

--- a/content/docs/iac/concepts/resources/providers.md
+++ b/content/docs/iac/concepts/resources/providers.md
@@ -631,14 +631,14 @@ stack.set_config("pulumi:disable-default-providers[0]", auto.ConfigValue(value="
 {{% choosable language go %}}
 
 ```go
-stack..SetConfig(ctx, "pulumi:disable-default-providers[0]", auto.ConfigValue{Value: "*"}, true)
+stack.SetConfig(ctx, "pulumi:disable-default-providers[0]", auto.ConfigValue{Value: "*"}, true)
 ```
 
 {{% /choosable %}}
 {{% choosable language java %}}
 
 ```java
-tack.setConfig("pulumi:disable-default-providers[0]", new ConfigValue("*"), true);
+stack.setConfig("pulumi:disable-default-providers[0]", new ConfigValue("*"), true);
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
There have been a couple of questions about the `path` parameter in automation API. Here's the most recent on the subject of disabling default providers

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

* Updated blog post on disabling default providers to point to docs page
* Updated docs page on resource providers to include code for automation API

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
