### PR TITLE
Fix exception type in blocking python docs

### DIFF
--- a/content/docs/iac/languages-sdks/python/python-blocking-async.md
+++ b/content/docs/iac/languages-sdks/python/python-blocking-async.md
@@ -117,7 +117,7 @@ def blocking_operation(foo: str) -> str:
   """
   res = subprocess.run(['my-cli', foo], encoding='utf-8', capture_output=True)
   if res.returncode is not 0:
-    raise Error(f'my-cli returned {res.returncode}: {res.stderr}')
+    raise Exception(f'my-cli returned {res.returncode}: {res.stderr}')
   return res.stdout
 
 # Use asyncio to call the blocking_operation function on another thread
@@ -154,7 +154,7 @@ async def async_operation(foo: str) -> str:
   stdout, stderr = await proc.communicate()
 
   if proc.returncode is not 0:
-    raise Error(f'my-cli returned {proc.returncode}: {stderr.decode()}')
+    raise Exception(f'my-cli returned {proc.returncode}: {stderr.decode()}')
   return stdout.decode
 
 # Calling an async function directly (without the await keyword) returns a


### PR DESCRIPTION
This should use `Exception` to raise the exception, `Error` does not exist in Python.
