### PR TITLE
Add note on availability of pre-built policy packs based on Pulumi Cloud plan

### DIFF
--- a/content/docs/insights/policy/policy-packs/pre-built-packs.md
+++ b/content/docs/insights/policy/policy-packs/pre-built-packs.md
@@ -26,7 +26,7 @@ Pulumi Cloud comes with pre-built policy packs that codify best practices for co
 
 ### Available policy packs
 
-The following pre-built policy packs are available today out of the box in Pulumi Cloud. For details on which packs are included with each Pulumi Cloud plan, see [Pricing](/pricing/).
+The following pre-built policy packs are available out of the box in Pulumi Cloud. Availability varies by plan—see [Pricing](/pricing/) for details.
 
 | Framework | Supported Cloud Providers | Description |
 | ----- | ----- | ----- |


### PR DESCRIPTION
Include a note indicating that the availability of specific pre-built policy packs varies depending on the Pulumi Cloud plan.