### PR TITLE
Correct docs in `import` with Diff

### DIFF
--- a/content/docs/iac/concepts/resources/options/import.md
+++ b/content/docs/iac/concepts/resources/options/import.md
@@ -196,9 +196,9 @@ resources:
 
 For this to work, your Pulumi stack must be configured correctly. In this example, it’s important that the AWS region is correct.
 
-If the resource’s arguments differ from the imported state, the import will succeed and then the resource will be modified to reflect the inputs in your Pulumi program.
+If the resource's arguments differ from the imported state, the import will succeed, and the resource will then be modified to reflect the inputs in your Pulumi program.
 
-```console
+```bash
 $ pulumi preview
 Previewing update (dev)
 
@@ -216,6 +216,6 @@ Resources:
     2 changes. 2 unchanged
 ```
 
-Because of auto-naming, it is common to run into this import-update when you import a resource’s name property. Unless you explicitly specify a name, Pulumi will auto-generate one, which is guaranteed not to match, because it will have a random hex suffix. To fix this problem, explicitly specify the resource’s name or disable auto-naming [as described here](/docs/iac/concepts/resources/names/#autonaming-configuration). Note that, in the example for the EC2 security group, the name was specified by passing `web-sg-62a569b` as the resource’s name property.
+Because of auto-naming, it is common to see this update during import when you import a resource's name property. Unless you explicitly specify a name, Pulumi will auto-generate one, which is guaranteed not to match, because it will have a random hex suffix. To fix this problem, explicitly specify the resource's name or disable auto-naming [as described here](/docs/iac/concepts/resources/names/#autonaming-configuration). Note that, in the example for the EC2 security group, the name was specified by passing `web-sg-62a569b` as the resource's name property.
 
 Once a resource is successfully imported, remove the `import` option because Pulumi is now managing the resource.


### PR DESCRIPTION
The behavior of import changed with https://github.com/pulumi/pulumi/pull/19339, and our docs should reflect the current behavior.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
