### PR TITLE
Add cross-references between packages and plugins documentation

### DIFF
--- a/content/docs/iac/concepts/plugins.md
+++ b/content/docs/iac/concepts/plugins.md
@@ -27,7 +27,9 @@ Pulumi supports five categories of plugins:
 
 ### Resource plugins
 
-Resource plugins (also known as [providers](/docs/iac/concepts/resources/providers/)) expose standardized interfaces for managing cloud resources. A listing of providers is available in the [Pulumi Registry](/registry/).
+Resource plugins (also known as [providers](/docs/iac/concepts/resources/providers/)) expose standardized interfaces for managing cloud resources. Resource plugins are distributed as [Pulumi packages](/docs/iac/concepts/packages/). A listing of providers is available in the [Pulumi Registry](/registry/).
+
+In addition to the packages in the Pulumi Registry, you can write your own [components](/docs/iac/concepts/resources/components/) and distribute them as resource plugins, enabling consumption in any Pulumi language. Components can be published to [Pulumi IDP](/docs/idp/) for discoverability within your organization or shared directly via Git references.
 
 When you first run `pulumi preview` or `pulumi up`, the Pulumi CLI will install any required providers that are not already in your plugin cache.
 

--- a/content/docs/iac/guides/building-extending/packages/packages.md
+++ b/content/docs/iac/guides/building-extending/packages/packages.md
@@ -25,7 +25,7 @@ Pulumi Packages are the core technology that enables Pulumi [resources](/docs/ia
 
 Pulumi packages consist of two parts that allow them to be consumed in any Pulumi language:
 
-1. **The provider plugin** which contains Pulumi code and can be written in any language Pulumi supports. The provider plugin contains custom resources, functions, and components. Custom resources define CRUD operations for infrastructure resources. Functions query cloud providers for resource data. Components encapsulate custom resources or other components into reusable abstractions.
+1. **The [provider plugin](/docs/iac/concepts/plugins/#resource-plugins)** which contains Pulumi code and can be written in any language Pulumi supports. The provider plugin contains custom resources, functions, and components. Custom resources define CRUD operations for infrastructure resources. Functions query cloud providers for resource data. Components encapsulate custom resources or other components into reusable abstractions.
 1. **An SDK** in the language of the consuming program, which is generated from the provider's schema file. SDKs may be published and hosted on package feeds (npm, PyPI, etc.) or they may be generated locally by the Pulumi CLI (in combination with the package schema) when the package is added to your Pulumi program.
 
 ## Consuming packages


### PR DESCRIPTION
This change strengthens the connection between the packages and plugins concepts by adding bidirectional links and clarifying their relationship. The packages page now links to the plugins page at the first mention of provider plugin. The plugins page explains that resource plugins are distributed as Pulumi packages and that custom components can be distributed as resource plugins via Pulumi IDP or Git references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
