### PR TITLE
fix: update pulumi-aws sdk to v7

### DIFF
--- a/content/docs/iac/get-started/aws/create-component.md
+++ b/content/docs/iac/get-started/aws/create-component.md
@@ -146,7 +146,7 @@ class AwsS3Website(pulumi.ComponentResource):
 package main
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -402,7 +402,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Update the import to `github.com/pulumi/pulumi-aws/sdk/v7/go/aws/s3` to match the original aws-go template.
