### PR TITLE
Restore missing REST API endpoints for teams and webhooks

### DIFF
--- a/content/docs/reference/cloud-rest-api/webhooks/_index.md
+++ b/content/docs/reference/cloud-rest-api/webhooks/_index.md
@@ -24,6 +24,7 @@ The API provides endpoints for the following operations:
 - Getting webhook details
 - Updating webhook configuration
 - Testing webhooks with ping functionality
+- Viewing webhook delivery history
 - Deleting webhooks
 
 ## Create Webhook
@@ -264,4 +265,66 @@ curl \
   -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
   --request POST \
   https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}/ping
+```
+
+## List Webhook Deliveries
+
+List the delivery history for a webhook, showing details about each webhook invocation including payload, response, and timing information.
+
+```plain
+// List organization webhook deliveries
+GET /api/orgs/{organization}/hooks/{webhookname}/deliveries
+
+// List stack webhook deliveries
+GET /api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}/deliveries
+```
+
+### Parameters
+
+| Parameter      | Type   | In   | Description                                            |
+|----------------|--------|------|--------------------------------------------------------|
+| `organization` | string | path | organization name                                      |
+| `project`      | string | path | project name (only for stack webhooks)                 |
+| `stack`        | string | path | stack name (only for stack webhooks)                   |
+| `webhookname`  | string | path | webhook name                                           |
+
+### Example
+
+```bash
+# List organization webhook deliveries
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/orgs/{organization}/hooks/{webhookname}/deliveries
+
+# List stack webhook deliveries
+curl \
+  -H "Accept: application/vnd.pulumi+8" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+  https://api.pulumi.com/api/stacks/{organization}/{project}/{stack}/hooks/{webhookname}/deliveries
+```
+
+### Default response
+
+```plain
+Status: 200 OK
+```
+
+```plain
+[
+  {
+    "id": "ea01abd2-90b4-4670-acce-15cc019ed6e4",
+    "kind": "ping",
+    "payload": "{\"timestamp\":1632735487,\"message\":\"🍹 Just a friendly ping from Pulumi 🍹\"}",
+    "timestamp": 1632735487,
+    "duration": 196,
+    "requestUrl": "{webhookurl}",
+    "requestHeaders": "Content-Type: application/json\r\nPulumi-Webhook-Id: ea01abd2-90b4-4670-acce-15cc019ed6e4\r\nPulumi-Webhook-Kind: ping\r\n",
+    "responseCode": 200,
+    "responseHeaders": "{headersfromwebhook}",
+    "responseBody": "OK"
+  }
+]
 ```


### PR DESCRIPTION
This restores 5 REST API endpoint sections that were accidentally omitted during the May 2025 documentation reorganization (commit 834368552e):

Organizations API:
- Grant Stack Access to Team
- Remove Stack Access from Team
- List Team Access Tokens
- Create Team Access Token
- Delete Team Access Token

Webhooks API:
- List Webhook Deliveries

These endpoints were originally documented from November 2021 and are still functional, but the documentation was lost when the large REST API page was split into separate topic-specific files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
