### PR TITLE
Fix link to stacks on the concepts overview page

### DIFF
--- a/content/docs/iac/concepts/_index.md
+++ b/content/docs/iac/concepts/_index.md
@@ -96,7 +96,7 @@ The following topics provide more details on the core concepts of Pulumi and how
         <p>Learn how Pulumi projects are organized and configured.</p>
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/iac/concepts/stack"><i class="fas fa-layer-group pr-2"></i>Stacks</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/iac/concepts/stacks"><i class="fas fa-layer-group pr-2"></i>Stacks</a></h3>
         <p>Learn how to create and deploy stacks.</p>
     </div>
 </div>


### PR DESCRIPTION
I think this got missed when the links updated to use the `/docs/iac` prefix.

There's an alias for `/docs/concepts/stack/`, which is probably why the old link worked, but with the update to use `/docs/iac` the alias no longer works.
