### PR TITLE
Bust CSS cache

### DIFF
--- a/theme/tailwind.config.js
+++ b/theme/tailwind.config.js
@@ -160,7 +160,7 @@ const green = {
 };
 
 module.exports = {
-    // ⚠️ CACHE BUST: October 2025 - Force new CSS fingerprint to invalidate CloudFront cache
+    // ⚠️ CACHE BUST: October/December 2025 - Force new CSS fingerprint to invalidate CloudFront cache
     // This is a temporary fix for the reinvent page missing CSS classes.
     // See GitHub issue #16274 for long-term architectural fix.
     // TODO: Remove this unused color after proper fingerprinting is implemented.
@@ -177,7 +177,7 @@ module.exports = {
             },
             // Unused color added solely to bust CloudFront CSS cache - See #16274
             colors: {
-                'cache-bust-2025-10': '#000001',
+                'cache-bust-2025-12': '#000001',
             },
         },
         rgbColors: {


### PR DESCRIPTION
Same as https://github.com/pulumi/docs/pull/16275, we need to manually change the tailwind css to force a new hash for the filename.

See also: https://github.com/pulumi/docs/issues/16274