### PR TITLE
Tidy up product headers

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -90,8 +90,8 @@
                                         <div class="list-title">
                                             <a href="/product/infrastructure-as-code/">
                                                 <i class="fas fa-code fa-fw"></i>
-                                                Pulumi IaC
-                                                <div class="list-sub-title">Infrastructure as code for engineers in
+                                                Infrastructure as Code
+                                                <div class="list-sub-title">IaC for any cloud, in any language —
                                                     Node.js, Python, Go, .NET, Java, and YAML</div>
                                             </a>
                                         </div>
@@ -108,9 +108,9 @@
                                                 <span>
                                                     <img src="/icons/pdi-neo.svg" class="inline" />
                                                 </span>
-                                                Infrastructure AI
-                                                <div class="list-sub-title">Generative AI-powered intelligent cloud
-                                                    management
+                                                Agentic Infrastructure
+                                                <div class="list-sub-title">Meet Neo, our AI-powered infrastructure
+                                                    engineering agent
                                                 </div>
                                             </a>
                                         </div>


### PR DESCRIPTION
We apparently "missed one" when we went from Pulumi ESC -> Secrets & Configuration, Pulumi Insights -> Insights & Governance, etc. -- and perhaps the most important one too, Pulumi IaC -> Infrastructure as Code. I'll admit, I am not loving the Infrastructure AI part, as it omits the word agentic which is all the rage these days and more accurately reflects what Neo is. So updated that too (the page says Pulumi Neo when you land there, so I also spiffed up the sub-head).
