### PR TITLE
Add guides sitemap to sitemap-index.xml

### DIFF
--- a/static/sitemap-index.xml
+++ b/static/sitemap-index.xml
@@ -6,4 +6,7 @@
   <sitemap>
     <loc>https://www.pulumi.com/registry/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://www.pulumi.com/guides/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Summary
- Adds the guides sitemap (`https://www.pulumi.com/guides/sitemap.xml`) to the master sitemap index
- Enables search engines to discover guides content for improved crawlability and SEO

## Test plan
- [ ] Verify the sitemap-index.xml is valid XML
- [ ] After deployment, confirm https://www.pulumi.com/sitemap-index.xml includes the guides entry