### PR TITLE
Fix apigateway.RestAPI eventHandler reference

### DIFF
--- a/content/docs/iac/clouds/aws/guides/lambda.md
+++ b/content/docs/iac/clouds/aws/guides/lambda.md
@@ -354,7 +354,7 @@ const api = new apigateway.RestAPI("api", {
                         body: JSON.stringify({
                             eventPath: event.path,
                             functionName: context.functionName,
-                        })
+                        }),
                     };
                 },
             }),


### PR DESCRIPTION
The API for the `RestAPI` resource seems to have changed. This fixes it up.

Fixes #16824.
