### PR TITLE
Fix a few 404s to tutorials

### DIFF
--- a/content/docs/iac/cli/environment-variables.md
+++ b/content/docs/iac/cli/environment-variables.md
@@ -82,7 +82,7 @@ aliases:
     </dt>
     <dd>
         <p>
-            Sets <a href="/docs/concepts/config">configuration</a> for <a href="/docs/using-pulumi/testing/unit">unit testing</a>. Must be in JSON format.
+            Sets <a href="/docs/concepts/config">configuration</a> for <a href="/docs/iac/guides/testing/unit/">unit testing</a>. Must be in JSON format.
         </p>
         <p>
             <strong>This environment variable is ignored during normal Pulumi operations -- e.g., <code>up</code>, <code>preview</code>, etc. -- but must be valid JSON if present.</strong>

--- a/content/docs/iac/get-started/aws/next-steps.md
+++ b/content/docs/iac/get-started/aws/next-steps.md
@@ -43,7 +43,7 @@ With Pulumi ESC you can:
 
 Let our AWS tutorials guide you through key Pulumi concepts.
 
-{{< get-started-next-step path="/docs/using-pulumi/" label="Browse tutorials" ref="gs-aws-tutorials" >}}
+{{< get-started-next-step path="/tutorials/" label="Browse tutorials" ref="gs-aws-tutorials" >}}
 
 ## Launch a new project with a template
 

--- a/content/docs/iac/get-started/gcp/next-steps.md
+++ b/content/docs/iac/get-started/gcp/next-steps.md
@@ -44,7 +44,7 @@ With Pulumi ESC you can:
 
 Let our Google Cloud tutorials guide you through key Pulumi concepts.
 
-{{< get-started-next-step path="/docs/using-pulumi/" label="Browse tutorials" ref="gs-gcp-tutorials" >}}
+{{< get-started-next-step path="/tutorials/" label="Browse tutorials" ref="gs-gcp-tutorials" >}}
 
 ## Launch a new project with a template
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Fix a few 404s to tutorial page.

@pierskarsenbarg noted these could go to https://www.pulumi.com/docs/iac/clouds/aws/ - I erred towards directing the viewer to the tutorials to match the button text. If we want it to go elsewhere I am happy to change the button text & URL.
