### PR TITLE
Update verbiage and link to Policies from AWS Overview page

### DIFF
--- a/content/docs/iac/clouds/aws/_index.md
+++ b/content/docs/iac/clouds/aws/_index.md
@@ -117,8 +117,8 @@ guides:
   - display_name: AWS index of services
     url: guides/aws-index-of-services/
 policy:
-  url: awsguard/
-  description: Use AWSGuard to configure and enforce best practices for your Pulumi stacks.
+  url: policy/
+  description: Use Pulumi Policies to configure and enforce best practices for your Pulumi stacks.
 aliases:
   - /docs/clouds/aws/
 ---

--- a/layouts/partials/docs/special-pages/cloud-overview.html
+++ b/layouts/partials/docs/special-pages/cloud-overview.html
@@ -305,7 +305,7 @@
 
     {{ $policy := .Params.policy }}
     {{ if $policy }}
-        <a href="/docs/using-pulumi/crossguard/{{ $policy.url }}">
+        <a href="/docs/insights/{{ $policy.url }}">
             <section class="policies card-outer card-outer-hover">
                 <div class="card-heading card-heading-2">
                     <div class="heading">


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

The AWS Overview page was referring to Policies as AWSGuard and going to a page that redirected to https://github.com/pulumi/pulumi-policy-aws

Opted to use "Pulumi Policies" as the product name and linked to its overview page.