### PR TITLE
Add related content links to CDKTF comparison page

### DIFF
--- a/content/docs/iac/comparisons/cloud-template-transpilers/cdktf/_index.md
+++ b/content/docs/iac/comparisons/cloud-template-transpilers/cdktf/_index.md
@@ -108,4 +108,9 @@ Pulumi has built-in support for [secrets management](/docs/iac/concepts/secrets/
 
 For teams interested in migrating from CDKTF, Pulumi has several options, including automated tooling that can convert your CDKTF code to Pulumi and import your existing Terraform state. To learn more, see [Migrating from CDKTF to Pulumi](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/).
 
+## Related content
+
+- [CDKTF is deprecated: What's next for your team?](/blog/cdktf-is-deprecated-whats-next-for-your-team/) - A detailed guide on migration options
+- [Pulumi for All Your IaC — Including Terraform and HCL](/blog/all-iac-including-terraform-and-hcl/) - How Pulumi supports Terraform, OpenTofu, and HCL alongside general-purpose languages
+
 {{< get-started >}}


### PR DESCRIPTION
Add a Related content section with links to:
- The CDKTF deprecation blog post (migration guidance)
- The all-IaC announcement blog post (broader Terraform/HCL support)

This improves discoverability of related content for teams evaluating their options after CDKTF's deprecation.

Fixes #11651