### PR TITLE
Fix Kubernetes guide GitHub links pointing to wrong cloud

### DIFF
--- a/content/docs/iac/clouds/kubernetes/guides/apps.md
+++ b/content/docs/iac/clouds/kubernetes/guides/apps.md
@@ -22,39 +22,23 @@ resources, and typical apps and workloads.
 
 {{% choosable cloud aws %}}
 
-The full code for the AWS apps stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/aws/06-apps
-<!-- markdownlint-enable url -->
+The full code for the AWS apps stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/aws/06-apps).
 
 {{% /choosable %}}
 
 {{% choosable cloud azure %}}
 
-The full code for the Azure apps stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/azure/06-apps
-<!-- markdownlint-enable url -->
+The full code for the Azure apps stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/azure/06-apps).
 
 {{% /choosable %}}
 
 {{% choosable cloud gcp %}}
 
-The full code for the Google Cloud apps stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/06-apps
-<!-- markdownlint-enable url -->
+The full code for the Google Cloud apps stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/06-apps).
 
 {{% /choosable %}}
 
-The full code for the apps is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/apps
-<!-- markdownlint-enable url -->
+The full code for the apps is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/apps).
 
 ## Overview
 

--- a/content/docs/iac/clouds/kubernetes/guides/cluster-services.md
+++ b/content/docs/iac/clouds/kubernetes/guides/cluster-services.md
@@ -24,21 +24,13 @@ policy enforcement and service meshes.
 
 {{% choosable cloud aws %}}
 
-The full code for the AWS cluster services is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/aws/04-cluster-services
-<!-- markdownlint-enable url -->
+The full code for the AWS cluster services is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/aws/04-cluster-services).
 
 {{% /choosable %}}
 
 {{% choosable cloud azure %}}
 
-The full code for the Azure cluster services is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/azure/04-cluster-services
-<!-- markdownlint-enable url -->
+The full code for the Azure cluster services is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/azure/04-cluster-services).
 
 {{% /choosable %}}
 
@@ -46,20 +38,11 @@ The full code for the Azure cluster services is on [GitHub][gh-repo-stack].
 
 GKE logging and monitoring is managed by Google Cloud through StackDriver.
 
-The repo for the Google Cloud cluster services is on [GitHub][gh-repo-stack], but it is empty since no extra steps are required after cluster and Node Pool creation in the [Cluster Configuration][crosswalk-k8s-cluster] stack.
-
-<!-- markdownlint-disable url -->
-[crosswalk-k8s-cluster]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/04-cluster-services
-<!-- markdownlint-enable url -->
+The repo for the Google Cloud cluster services is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/04-cluster-services), but it is empty since no extra steps are required after cluster and Node Pool creation in the [Cluster Configuration](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration) stack.
 
 {{% /choosable %}}
 
-The full code for the general cluster services is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/general-cluster-services
-<!-- markdownlint-enable url -->
+The full code for the general cluster services is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/general-cluster-services).
 
 {{% choosable cloud aws %}}
 

--- a/content/docs/iac/clouds/kubernetes/guides/configure-access-control.md
+++ b/content/docs/iac/clouds/kubernetes/guides/configure-access-control.md
@@ -27,11 +27,7 @@ The `kubeconfig` will be shared across users for access, and each IAM role
 will have a particular binding into the cluster's auth to determine how it works
 with the cluster.
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/aws/03-cluster-configuration
-<!-- markdownlint-enable url -->
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/aws/03-cluster-configuration).
 
 {{% /choosable %}}
 
@@ -44,11 +40,7 @@ The `kubeconfig` will contain user authentication tokens for access, and each AD
 will have a particular binding into the cluster's auth to determine how it works
 with the cluster.
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/azure/03-cluster-configuration
-<!-- markdownlint-enable url -->
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/azure/03-cluster-configuration).
 
 {{% /choosable %}}
 
@@ -61,11 +53,7 @@ The `kubeconfig` will be shared across ServiceAccounts for access, and each
 ServiceAccount will have a particular binding into the cluster's auth to determine how it works
 with the cluster.
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration
-<!-- markdownlint-enable url -->
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration).
 
 {{% /choosable %}}
 

--- a/content/docs/iac/clouds/kubernetes/guides/configure-defaults.md
+++ b/content/docs/iac/clouds/kubernetes/guides/configure-defaults.md
@@ -23,31 +23,19 @@ segment the cluster as needed.
 
 {{% choosable cloud aws %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/aws/03-cluster-configuration
-<!-- markdownlint-enable url -->
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/aws/03-cluster-configuration).
 
 {{% /choosable %}}
 
 {{% choosable cloud azure %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/azure/03-cluster-configuration
-<!-- markdownlint-enable url -->
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/azure/03-cluster-configuration).
 
 {{% /choosable %}}
 
 {{% choosable cloud gcp %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration
-<!-- markdownlint-enable url -->
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration).
 
 {{% /choosable %}}
 

--- a/content/docs/iac/clouds/kubernetes/guides/identity.md
+++ b/content/docs/iac/clouds/kubernetes/guides/identity.md
@@ -33,9 +33,8 @@ In [Crosswalk for AWS][crosswalk-aws] we showcase how to define IAM:
 - [Roles][iam-roles]
 - [Policies][iam-policies]
 
-The full code for this stack is on [GitHub][gh-repo-stack].
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/aws/01-identity).
 
-<!-- markdownlint-disable url -->
 [iam]: https://aws.amazon.com/iam/
 [users]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html
 [groups]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html
@@ -46,8 +45,6 @@ The full code for this stack is on [GitHub][gh-repo-stack].
 [iam-groups]: /docs/clouds/aws/guides/iam/#iam-groups
 [iam-roles]: /docs/clouds/aws/guides/iam/#iam-roles
 [iam-policies]: /docs/clouds/aws/guides/iam/#using-the-policydocument-interface
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/aws/01-identity
-<!-- markdownlint-enable url -->
 
 {{% /choosable %}}
 
@@ -60,17 +57,14 @@ allocated baseline permissions using [IAM Permissions][azure-permissions].
 
 Azure services can also be granted permissions temporarily, without the need for usernames and passwords, using [Applications and ServicePrincipals][azure-sp].
 
-The full code for this stack is on [GitHub][gh-repo-stack].
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/azure/01-identity).
 
-<!-- markdownlint-disable url -->
 [azure-iam]: https://azure.microsoft.com/en-us/services/active-directory/
 [azure-users]: https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/directory-overview-user-model
 [azure-groups]: https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/directory-overview-user-model
 [azure-roles]: https://docs.microsoft.com/en-us/azure/role-based-access-control/rbac-and-directory-admin-roles?context=azure/active-directory/users-groups-roles/context/ugr-context
 [azure-permissions]: https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/users-default-permissions?context=azure/active-directory/users-groups-roles/context/ugr-context
 [azure-sp]: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/azure/01-identity
-<!-- markdownlint-enable url -->
 
 {{% /choosable %}}
 
@@ -83,16 +77,13 @@ and GSuite accounts, and can then be allocated [IAM Roles][gcp-roles] with basel
 
 Google Cloud services can also be granted permissions temporarily, without the need for usernames and passwords, using [ServiceAccounts][gcp-sa].
 
-The full code for this stack is on [GitHub][gh-repo-stack].
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/01-identity).
 
-<!-- markdownlint-disable url -->
 [gcp-iam]: https://cloud.google.com/iam/docs/overview
 [gcp-policies]: https://cloud.google.com/iam/docs/reference/rest/v1/Policy
 [gcp-roles]: https://cloud.google.com/iam/docs/understanding-roles
 [gcp-members]: https://cloud.google.com/iam/docs/overview
 [gcp-sa]: https://cloud.google.com/iam/docs/service-accounts
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/01-identity
-<!-- markdownlint-enable url -->
 
 {{% /choosable %}}
 

--- a/content/docs/iac/clouds/kubernetes/guides/managed-infra.md
+++ b/content/docs/iac/clouds/kubernetes/guides/managed-infra.md
@@ -29,10 +29,8 @@ resources into a virtual network. With the VPC you can define the region's [Avai
 Zones][aws-azs] to use, along with [Route Tables][aws-rts], [Subnets][aws-subnets], [Internet Gateways][aws-igw],
 [NAT Gateways][aws-ngw] and [Security Groups][aws-sgs].
 
-The full code for this stack is on [GitHub][gh-repo-stack].
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/aws/02-managed-infra).
 
-<!-- markdownlint-disable url -->
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/aws/02-managed-infra
 [crosswalk-aws]: /docs/clouds/aws/guides/
 [aws-managed-svcs]: https://aws.amazon.com/products/
 [aws-vpc]: https://aws.amazon.com/vpc/
@@ -42,7 +40,6 @@ The full code for this stack is on [GitHub][gh-repo-stack].
 [aws-igw]: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html
 [aws-ngw]: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html
 [aws-sgs]: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html
-<!-- markdownlint-enable url -->
 
 {{% /choosable %}}
 
@@ -58,7 +55,7 @@ resources into a virtual network. With the VPC you can define
 use, along with [Route Tables][azure-rts], [Subnets][azure-subnets],
 [Security Groups][azure-sgs] and [VPN Gateways][azure-vpn-gw].
 
-The full code for this stack is on [GitHub][gh-repo-stack].
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/azure/02-managed-infra).
 
 [azure-managed-svcs]: https://azure.microsoft.com/en-us/services/
 [azure-vpc]: https://azure.microsoft.com/en-us/services/
@@ -66,7 +63,6 @@ The full code for this stack is on [GitHub][gh-repo-stack].
 [azure-rts]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview#user-defined
 [azure-sgs]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#security
 [azure-vpn-gw]: https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-vnet-vnet-rm-ps
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/azure/02-managed-infra
 
 {{% /choosable %}}
 
@@ -82,17 +78,14 @@ resources into a virtual network. With the VPC you can define the region to use,
 along with [Routes][gcp-rts], [Subnets][gcp-subnets], [Forwarding Rules][gcp-fwd-rules],
 and [Firewall Rules][gcp-fw-rules].
 
-The full code for this stack is on [GitHub][gh-repo-stack].
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/02-managed-infra).
 
-<!-- markdownlint-disable url -->
 [gcp-managed-svcs]: https://cloud.google.com/products/
 [gcp-subnets]: https://cloud.google.com/vpc/docs/vpc#vpc_networks_and_subnets
 [gcp-fwd-rules]: https://cloud.google.com/compute/docs/protocol-forwarding
 [gcp-vpc]: https://cloud.google.com/vpc/docs/overview
 [gcp-rts]: https://cloud.google.com/vpc/docs/routes
 [gcp-fw-rules]: https://cloud.google.com/vpc/docs/firewalls
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/02-managed-infra
-<!-- markdownlint-enable url -->
 
 {{% /choosable %}}
 

--- a/content/docs/iac/clouds/kubernetes/guides/try-out-the-cluster.md
+++ b/content/docs/iac/clouds/kubernetes/guides/try-out-the-cluster.md
@@ -23,25 +23,19 @@ contents, and its cluster name for reference.
 
 {{% choosable cloud aws %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/aws/03-cluster-configuration
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/aws/03-cluster-configuration).
 
 {{% /choosable %}}
 
 {{% choosable cloud azure %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/azure/03-cluster-configuration
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/azure/03-cluster-configuration).
 
 {{% /choosable %}}
 
 {{% choosable cloud gcp %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration).
 
 {{% /choosable %}}
 

--- a/content/docs/iac/clouds/kubernetes/guides/worker-nodes.md
+++ b/content/docs/iac/clouds/kubernetes/guides/worker-nodes.md
@@ -27,25 +27,19 @@ See the [official Kubernetes docs][k8s-docs] for more details.
 
 {{% choosable cloud aws %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/aws/03-cluster-configuration
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/aws/03-cluster-configuration).
 
 {{% /choosable %}}
 
 {{% choosable cloud azure %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/azure/03-cluster-configuration
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/azure/03-cluster-configuration).
 
 {{% /choosable %}}
 
 {{% choosable cloud gcp %}}
 
-The full code for this stack is on [GitHub][gh-repo-stack].
-
-[gh-repo-stack]: https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration
+The full code for this stack is on [GitHub](https://github.com/pulumi/kubernetes-guides/tree/master/gcp/03-cluster-configuration).
 
 {{% /choosable %}}
 


### PR DESCRIPTION
The Kubernetes playbook pages used markdown reference-style links with the same name [gh-repo-stack] in different cloud sections (AWS, Azure, GCP). Since markdown only uses the first definition, all links resolved to the AWS URLs regardless of which cloud section was being viewed.

Fixed by converting to inline links so each cloud section correctly points to its own repository path.

Files fixed:
- apps.md
- cluster-services.md
- configure-access-control.md
- configure-defaults.md
- identity.md
- managed-infra.md
- try-out-the-cluster.md
- worker-nodes.md

Fixes #11530