### PR TITLE
Remove redundant sudo from GitLab CI setup script

### DIFF
--- a/content/docs/iac/guides/continuous-delivery/gitlab-ci.md
+++ b/content/docs/iac/guides/continuous-delivery/gitlab-ci.md
@@ -153,8 +153,12 @@ pulumi-preview:
 
 ### `setup.sh`
 
-The `setup.sh` installs the `pulumi` CLI on the GitLab CI Runner, and other tools.
+The `setup.sh` script installs the Pulumi CLI on the GitLab CI Runner, along with other tools.
 It also installs `yarn` and `nodejs` since that's the runtime for this sample project.
+
+{{% notes type="info" %}}
+This script assumes the CI runner executes jobs as root, which is typical for containerized GitLab runners. If your runner doesn't run as root, you may need to prefix commands with `sudo`.
+{{% /notes %}}
 
 ```bash
 #!/bin/bash
@@ -169,12 +173,12 @@ export PATH=$PATH:$HOME/.pulumi/bin
 pulumi login
 # update the GitLab Runner's packages
 apt-get update -y
-apt-get install sudo ca-certificates curl gnupg -y
+apt-get install -y ca-certificates curl gnupg
 # nodejs
 mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 NODE_MAJOR=20
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 apt-get update -y
 apt-get install -y nodejs
 # yarn


### PR DESCRIPTION
The setup script was installing sudo via apt-get and then using sudo for subsequent commands. Since apt-get requires root privileges, if the script can run apt-get, it's already running as root and doesn't need sudo. This removes the circular dependency and adds a note clarifying that the script assumes running as root.

Fixes #11620