### PR TITLE
mention minimum pulumi version for journaling

### DIFF
--- a/content/blog/journaling/index.md
+++ b/content/blog/journaling/index.md
@@ -91,7 +91,7 @@ The second example is setting up an instance of the Pulumi app and API. Here we'
 ![Comparison chart of the bytes sent shown in the tables above](size.png)
 
 {{% notes type="tip" %}}
-This feature is still behind a feature flag, but we are ready for testers. To get enrolled in the feature flag, please reach out to us, either on the [Community Slack](https://slack.pulumi.com/), or through our [Support channels](https://support.pulumi.com/hc/en-us). Once that's done, all you need to do is to set the `PULUMI_ENABLE_JOURNALING` environment variable to `true`, and your operations will start finishing faster.
+This feature is still behind a feature flag, but we are ready for testers. To get enrolled in the feature flag, please reach out to us, either on the [Community Slack](https://slack.pulumi.com/), or through our [Support channels](https://support.pulumi.com/hc/en-us). Once that's done, all you need to do is get a `pulumi` version newer than v3.211.0, set the `PULUMI_ENABLE_JOURNALING` environment variable to `true`, and your operations will start finishing faster.
 {{% /notes %}}
 
 If you are interested in the more technical details read on!


### PR DESCRIPTION
This version includes https://github.com/pulumi/pulumi/pull/21183 and https://github.com/pulumi/pulumi/pull/21185, which were the last performance optimizations we did for journaling.
