### PR TITLE
Move Providers to top-level concept

### DIFF
--- a/content/docs/deployments/get-started/onboarding-guide/ways-of-working.md
+++ b/content/docs/deployments/get-started/onboarding-guide/ways-of-working.md
@@ -168,7 +168,7 @@ Create providers for new or internal systems where neither Terraform nor Pulumi 
 **[Terraform provider bridging](https://www.pulumi.com/blog/any-terraform-provider/)**
 Bridge any Terraform provider at development time to use it from Pulumi IaC programs.
 
-**[Dynamic providers](https://www.pulumi.com/docs/iac/concepts/resources/dynamic-providers/)**
+**[Dynamic providers](https://www.pulumi.com/docs/iac/concepts/providers/dynamic-providers/)**
 Write CRUD logic inline in your Pulumi IaC program without building a separate provider.
 
 ### Contributing to open source

--- a/content/docs/iac/comparisons/cloud-template-transpilers/cdktf/_index.md
+++ b/content/docs/iac/comparisons/cloud-template-transpilers/cdktf/_index.md
@@ -32,7 +32,7 @@ CDK for Terraform (CDKTF) is a tool that allows you to define infrastructure usi
 
 ## Pulumi vs. CDKTF: Similarities
 
-In addition to supporting general-purpose languages, both CDKTF and Pulumi organize cloud resources into [_stacks_](/docs/iac/concepts/stacks/), encourage the use of higher-level abstractions (called _constructs_ in CDKTF, [_components_](/docs/iac/concepts/resources/components/) in Pulumi), and track [resource state](/docs/iac/concepts/state-and-backends/) similarly, with local, remote, and cloud-hosted options available. Both tools also support deploying to multiple clouds through open-source [resource providers](/docs/iac/concepts/resources/providers/).
+In addition to supporting general-purpose languages, both CDKTF and Pulumi organize cloud resources into [_stacks_](/docs/iac/concepts/stacks/), encourage the use of higher-level abstractions (called _constructs_ in CDKTF, [_components_](/docs/iac/concepts/resources/components/) in Pulumi), and track [resource state](/docs/iac/concepts/state-and-backends/) similarly, with local, remote, and cloud-hosted options available. Both tools also support deploying to multiple clouds through open-source [resource providers](/docs/iac/concepts/providers/).
 
 Also, because many of Pulumi's most popular providers are derived from open-source Terraform provider schemas, their resource models are typically identical to CDKTF's. Compare, for example, the following declaration of an Amazon S3 bucket in CDKTF:
 
@@ -86,7 +86,7 @@ Both CDKTF and Pulumi support the full Terraform provider ecosystem, though in s
 
 ### Dynamic provider support {#dynamic-providers}
 
-In addition to standard pre-built providers, Pulumi also supports [dynamic resource providers](/docs/iac/concepts/resources/dynamic-providers/), which allow you to extend the Pulumi resource model by building and distributing lightweight, custom providers of your own. CDKTF does not support this capability.
+In addition to standard pre-built providers, Pulumi also supports [dynamic resource providers](/docs/iac/concepts/providers/dynamic-providers/), which allow you to extend the Pulumi resource model by building and distributing lightweight, custom providers of your own. CDKTF does not support this capability.
 
 ### Terraform module integration {#terraform-modules}
 

--- a/content/docs/iac/concepts/plugins.md
+++ b/content/docs/iac/concepts/plugins.md
@@ -27,7 +27,7 @@ Pulumi supports five categories of plugins:
 
 ### Resource plugins
 
-Resource plugins (also known as [providers](/docs/iac/concepts/resources/providers/)) expose standardized interfaces for managing cloud resources. Resource plugins are distributed as [Pulumi packages](/docs/iac/concepts/packages/). A listing of providers is available in the [Pulumi Registry](/registry/).
+Resource plugins (also known as [providers](/docs/iac/concepts/providers/)) expose standardized interfaces for managing cloud resources. Resource plugins are distributed as [Pulumi packages](/docs/iac/concepts/packages/). A listing of providers is available in the [Pulumi Registry](/registry/).
 
 In addition to the packages in the Pulumi Registry, you can write your own [components](/docs/iac/concepts/resources/components/) and distribute them as resource plugins, enabling consumption in any Pulumi language. Components can be published to [Pulumi IDP](/docs/idp/) for discoverability within your organization or shared directly via Git references.
 
@@ -104,7 +104,7 @@ For more details about Pulumi plugin architecture and how to contribute to plugi
 
 ## Related topics
 
-- [Providers](/docs/iac/concepts/resources/providers/) - Learn more about resource plugins (providers)
+- [Providers](/docs/iac/concepts/providers/) - Learn more about resource plugins (providers)
 - [How Pulumi works](/docs/iac/concepts/how-pulumi-works/) - Understand how plugins fit into Pulumi's architecture
 - [Policy as Code](/docs/insights/policy/) - Learn about analyzer plugins for policy enforcement
 - [Conversion tools](/docs/iac/guides/migration/converters/) - Use converter plugins to migrate from other IaC tools

--- a/content/docs/iac/concepts/providers/_index.md
+++ b/content/docs/iac/concepts/providers/_index.md
@@ -7,14 +7,16 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
         name: Providers
-        parent: iac-concepts-resources
-        weight: 4
+        parent: iac-concepts
+        weight: 55
+        identifier: iac-concepts-providers
     concepts:
-        parent: resources
+        identifier: providers
         weight: 4
 aliases:
 - /docs/intro/concepts/resources/providers/
 - /docs/concepts/resources/providers/
+- /docs/iac/concepts/resources/providers/
 ---
 
 A resource provider handles communications with a cloud or SaaS service to create, read, update, and delete the resources you define in your Pulumi programs.
@@ -36,7 +38,7 @@ There are two methods for installing a provider and using it in your Pulumi prog
 
 The most common method of installing a provider is to use your language's package management tool: npm in Node.js, PyPI in Python, etc. For example, the [AWS provider](/registry/packages/aws/installation-configuration) has the following SDKs available:
 
-- JavaScript/TypeScript: `@pulumi/aws`
+- TypeScript: `@pulumi/aws`
 - Python: `pulumi-aws`
 - Go: `github.com/pulumi/pulumi-aws/sdk/go/aws`
 - .NET: `Pulumi.Aws`
@@ -541,14 +543,7 @@ pulumi config set --path 'pulumi:disable-default-providers[0]' '*'
 
 To set the value correctly using Automation API, you must use the `path` parameter:
 
-{{< chooser language "javascript,typescript,python,go,csharp,java" >}}
-{{% choosable language javascript %}}
-
-```typescript
-await stack.setConfig("pulumi:disable-default-providers[0]", { value: "*" }, true);
-```
-
-{{% /choosable %}}
+{{< chooser language "typescript,python,go,csharp,java" >}}
 {{% choosable language typescript %}}
 
 ```typescript

--- a/content/docs/iac/concepts/providers/dynamic-providers.md
+++ b/content/docs/iac/concepts/providers/dynamic-providers.md
@@ -7,14 +7,15 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
         name: Dynamic providers
-        parent: iac-concepts-resources
+        parent: iac-concepts-providers
         weight: 6
     concepts:
-        parent: resources
+        parent: providers
         weight: 6
 aliases:
 - /docs/intro/concepts/resources/dynamic-providers/
 - /docs/concepts/resources/dynamic-providers/
+- /docs/iac/concepts/resources/dynamic-providers/
 ---
 
 The dynamic resource provider construct can be used to build a local provider for simple APIs and use-cases. Dynamic resource providers are only able to be used in Pulumi programs written in the same language as the dynamic resource provider. But, they are lighter weight than custom providers and for many use-cases are sufficient to leverage the Pulumi state model. For more sophisticated APIs, one can create a [bridged or native provider](/docs/iac/packages-and-automation/pulumi-packages/).

--- a/content/docs/iac/concepts/resources/_index.md
+++ b/content/docs/iac/concepts/resources/_index.md
@@ -42,10 +42,10 @@ aliases:
         "#creating-child-resources": "/docs/concepts/resources/components/#creating-child-resources",
         "#registering-component-outputs": "/docs/concepts/resources/components/#registering-component-outputs",
         "#inheriting-resource-providers": "/docs/concepts/resources/components/#inheriting-resource-providers",
-        "#providers": "/docs/concepts/resources/providers",
-        "#default-provider-configuration": "/docs/concepts/resources/providers/#default-provider-configuration",
-        "#explicit-provider-configuration": "/docs/concepts/resources/providers/#explicit-provider-configuration",
-        "#dynamicproviders": "/docs/concepts/resources/dynamic-providers",
+        "#providers": "/docs/iac/concepts/providers",
+        "#default-provider-configuration": "/docs/iac/concepts/providers/#default-provider-configuration",
+        "#explicit-provider-configuration": "/docs/iac/concepts/providers/#explicit-provider-configuration",
+        "#dynamicproviders": "/docs/iac/concepts/providers/dynamic-providers",
         "#names": "/docs/concepts/resources/names",
         "#autonaming": "/docs/concepts/resources/names/#autonaming",
         "#urns": "/docs/concepts/resources/names/#urns",
@@ -144,13 +144,13 @@ The following topics provide more details on the core concepts for working with 
         <p>Learn what a component resource is, how to author a new component resource, how to create child resources, and more.</p>
     </div>
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/resources/providers/"><i class="fas fa-server pr-2"></i>Providers</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/iac/concepts/providers/"><i class="fas fa-server pr-2"></i>Providers</a></h3>
         <p>Learn how a resource provider handles communications with a cloud service to create, read, update, and delete the resources you define in your Pulumi programs.</p>
     </div>
 </div>
 <div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/resources/dynamic-providers/"><i class="fas fa-file-alt pr-2"></i>Dynamic Providers</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/iac/concepts/providers/dynamic-providers/"><i class="fas fa-file-alt pr-2"></i>Dynamic Providers</a></h3>
         <p>Learn how to use dynamic providers and use cases for them.</p>
     </div>
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">

--- a/content/docs/iac/guides/building-extending/packages/publishing-packages.md
+++ b/content/docs/iac/guides/building-extending/packages/publishing-packages.md
@@ -72,7 +72,7 @@ Your repository name should start with `pulumi-` followed by the name of your pr
 
 ## Author your resources or components
 
-See the instructions in your new repository's `README.md` file for specific instructions on how to author your package. We also have guides you can follow for building [components](/docs/iac/concepts/resources/components/) and [providers](/docs/iac/concepts/resources/providers/) without the template repos.
+See the instructions in your new repository's `README.md` file for specific instructions on how to author your package. We also have guides you can follow for building [components](/docs/iac/concepts/resources/components/) and [providers](/docs/iac/concepts/providers/) without the template repos.
 
 ## Write documentation
 

--- a/content/docs/iac/guides/building-extending/providers/build-a-provider.md
+++ b/content/docs/iac/guides/building-extending/providers/build-a-provider.md
@@ -21,7 +21,7 @@ This guide uses the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending
 
 ## When to use a provider
 
-A Pulumi Provider allows you to define new resource types, enabling integration with virtually any service or tool. Pulumi providers are ideal when you need to manage resources that are not yet supported by existing Pulumi providers or when you require custom behavior for managing external systems or APIs. Providers are a powerful extension point, but before building a full provider consider if your use case can be covered by [building a component](/docs/iac/using-pulumi/extending-pulumi/build-a-component/) or using [dynamic provider functions](/docs/iac/concepts/resources/dynamic-providers/).
+A Pulumi Provider allows you to define new resource types, enabling integration with virtually any service or tool. Pulumi providers are ideal when you need to manage resources that are not yet supported by existing Pulumi providers or when you require custom behavior for managing external systems or APIs. Providers are a powerful extension point, but before building a full provider consider if your use case can be covered by [building a component](/docs/iac/using-pulumi/extending-pulumi/build-a-component/) or using [dynamic provider functions](/docs/iac/concepts/providers/dynamic-providers/).
 
 ## What’s needed to implement a provider?
 

--- a/content/docs/iac/guides/building-extending/providers/implementers/python.md
+++ b/content/docs/iac/guides/building-extending/providers/implementers/python.md
@@ -14,7 +14,7 @@ menu:
 This guide shows how to implement a Pulumi provider in Python using the gRPC bindings directly. This approach gives you full control over provider behavior and works with any Python version that supports gRPC.
 
 {{% notes type="warning" %}}
-This is an advanced guide for power users. You'll be working directly with the provider protocol, which requires understanding gRPC, Protocol Buffers, and Pulumi's provider semantics. If you're open to writing Go, the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/providers/sdks/pulumi-go-provider-sdk/) offers a more ergonomic experience with less boilerplate. [Dynamic providers](/docs/iac/concepts/resources/dynamic-providers/) can be useful for quick prototyping, but aren't suitable for production providers.
+This is an advanced guide for power users. You'll be working directly with the provider protocol, which requires understanding gRPC, Protocol Buffers, and Pulumi's provider semantics. If you're open to writing Go, the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/providers/sdks/pulumi-go-provider-sdk/) offers a more ergonomic experience with less boilerplate. [Dynamic providers](/docs/iac/concepts/providers/dynamic-providers/) can be useful for quick prototyping, but aren't suitable for production providers.
 {{% /notes %}}
 
 ## Prerequisites

--- a/content/docs/iac/guides/building-extending/providers/provider-architecture.md
+++ b/content/docs/iac/guides/building-extending/providers/provider-architecture.md
@@ -14,7 +14,7 @@ menu:
 A Pulumi provider allows you to define new resource types, enabling integration with virtually any service or tool. Providers are how Pulumi communicates with cloud platforms, SaaS APIs, and other external systems to create, read, update, and delete resources.
 
 {{% notes type="info" %}}
-Pulumi also supports [dynamic providers](/docs/iac/concepts/resources/dynamic-providers/), which are lightweight providers defined inline within a Pulumi program. This page focuses on standalone providers that are built and distributed as separate packages.
+Pulumi also supports [dynamic providers](/docs/iac/concepts/providers/dynamic-providers/), which are lightweight providers defined inline within a Pulumi program. This page focuses on standalone providers that are built and distributed as separate packages.
 {{% /notes %}}
 
 Pulumi providers are built on a layered architecture. Understanding these layers helps you choose the right approach for your needs—from high-level SDKs that handle complexity for you, to low-level protocol access for maximum control.

--- a/content/docs/iac/guides/building-extending/providers/sdks/pulumi-go-provider-sdk.md
+++ b/content/docs/iac/guides/building-extending/providers/sdks/pulumi-go-provider-sdk.md
@@ -16,7 +16,7 @@ aliases:
 - /docs/iac/guides/building-extending/providers/pulumi-provider-sdk/
 ---
 
-The [Pulumi Provider SDK](https://github.com/pulumi/pulumi-go-provider/) is a high-level library that simplifies the process of writing a Pulumi [provider](https://www.pulumi.com/docs/iac/concepts/resources/providers/) in Go. It abstracts much of the complexity involved in defining custom infrastructure resources, allowing developers to focus on business logic rather than boilerplate code.
+The [Pulumi Provider SDK](https://github.com/pulumi/pulumi-go-provider/) is a high-level library that simplifies the process of writing a Pulumi [provider](https://www.pulumi.com/docs/iac/concepts/providers/) in Go. It abstracts much of the complexity involved in defining custom infrastructure resources, allowing developers to focus on business logic rather than boilerplate code.
 
 Some key advantages of the SDK are:
 

--- a/content/docs/insights/policy/policy-packs/authoring.md
+++ b/content/docs/insights/policy/policy-packs/authoring.md
@@ -250,7 +250,7 @@ Most policies are resource validation policies. Stack validation policies are us
 
 ## Writing policies for dynamic providers
 
-[Dynamic providers](/docs/iac/concepts/resources/dynamic-providers/) allow you to create custom resource types directly in your Pulumi programs. When writing policies for dynamic providers, you need to account for a key constraint: **all dynamic resources share the same resource type** (`pulumi-nodejs:dynamic:Resource` for TypeScript/JavaScript or `pulumi-python:dynamic:Resource` for Python).
+[Dynamic providers](/docs/iac/concepts/providers/dynamic-providers/) allow you to create custom resource types directly in your Pulumi programs. When writing policies for dynamic providers, you need to account for a key constraint: **all dynamic resources share the same resource type** (`pulumi-nodejs:dynamic:Resource` for TypeScript/JavaScript or `pulumi-python:dynamic:Resource` for Python).
 
 Since you cannot rely on the resource type alone to identify which dynamic provider a resource uses, you must inspect the resource's properties to differentiate between different dynamic provider implementations.
 


### PR DESCRIPTION
Move the Providers documentation from under Resources to be a top-level concept in the Concepts navigation, positioned between Resources and Inputs & Outputs. Dynamic Providers becomes a sub-page under Providers.

This change improves discoverability of provider documentation by making it more prominent in the navigation hierarchy.

Changes:
- Move providers.md to providers/_index.md as overview page
- Move dynamic-providers.md under new providers directory
- Update navigation menu weights and parent relationships
- Add aliases to preserve SEO and external links
- Update all internal links across docs and product content

Fixes #16707

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
