### PR TITLE
Add cross-links to resource options for component authors

### DIFF
--- a/content/docs/iac/concepts/components/_index.md
+++ b/content/docs/iac/concepts/components/_index.md
@@ -115,6 +115,10 @@ A component resource must register a unique type name with the base constructor.
 For a complete end-to-end walkthrough of building a component from scratch, including setup, implementation, and publishing, see the [Build a Component](/docs/iac/using-pulumi/build-a-component/) guide.
 {{< /notes >}}
 
+{{< notes type="info" >}}
+Not all [resource options](/docs/iac/concepts/resources/options/) apply to component resources. For a complete list of which options work with components and how to apply options to child resources, see [Resource options and component resources](/docs/iac/concepts/resources/options/#resource-options-and-component-resources).
+{{< /notes >}}
+
 ## Component arguments and type requirements
 
 When authoring components that will be consumed across different languages (multi-language components), the arguments class has specific requirements and limitations due to the need for serialization. These constraints ensure that component arguments can be transmitted to the Pulumi engine and reconstructed across language boundaries.

--- a/content/docs/iac/guides/building-extending/components/build-a-component.md
+++ b/content/docs/iac/guides/building-extending/components/build-a-component.md
@@ -50,8 +50,12 @@ If your component uses a local package (such as any Terraform provider via `terr
 A Pulumi Component consists of three main parts:
 
 - The **component resource** encapsulates multiple Pulumi resources, grouping them into a logical unit.
-- The **component resource arguments** define configurable input properties, allowing users to specify parameters that tailor the component’s behavior to specific needs.
+- The **component resource arguments** define configurable input properties, allowing users to specify parameters that tailor the component's behavior to specific needs.
 - The **provider host** registers and runs your component resources, acting as the foundational layer for component creation.
+
+{{< notes type="info" >}}
+Not all [resource options](/docs/iac/concepts/resources/options/) apply to component resources. For example, `ignoreChanges` and `customTimeouts` have no effect on components themselves. To see which options work with components and how to apply options to child resources using `transforms`, see [Resource options and component resources](/docs/iac/concepts/resources/options/#resource-options-and-component-resources).
+{{< /notes >}}
 
 ## Example: Static Web Page Component
 


### PR DESCRIPTION
Add info notes in the component documentation pages linking to the
new "Resource options and component resources" section, making it
discoverable for anyone authoring a component.