### PR TITLE
Add error mapping for 403 Forbidden to 404 Not Found in CloudFront distribution

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -820,7 +820,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         // Map 403 Forbidden errors to 404 Not Found.
         // S3 returns 403 when it can't determine if an object exists due to bucket policy
         // that denies ListBucket permission. This provides a better user experience by
-        // showing a 404 error page instead of a confusing 403 error.
+        // translating HTTP 403s into proper 404s and showing the 404 error page.
         {
             errorCode: 403,
             responseCode: 404,


### PR DESCRIPTION
Map 403 Forbidden errors to 404 Not Found in the CloudFront distribution 
