### PR TITLE
Flip the testing workflow back to master

### DIFF
--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: null
   push:
     branches:
-      - CamSoper/403-to-404-mapping
+      - master
 permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout


### PR DESCRIPTION
https://github.com/pulumi/docs/pull/17048 passed, so restoring `master` as the target branch for this workflow.