### PR TITLE
Replace Airflow with Astro role for CloudFront logs bucket access

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -79,7 +79,7 @@ const cloudAiAppDomain = aiAppStack.requireOutput('cloudAiAppDistributionDomain'
 // Reference to the Astro stack for data warehouse access (only if enabled)
 let astroAwsRoleArn: pulumi.Output<any> | undefined;
 if (config.enableDataWarehouseAccess) {
-    const astroStack = new pulumi.StackReference('pulumi/dwh-workflows-orchestrate-astro/production');
+    const astroStack = new pulumi.StackReference('pulumi/dwh-workflows-astro/production');
     astroAwsRoleArn = astroStack.getOutput('astroAwsRoleArn');
 }
 


### PR DESCRIPTION
The data warehouse is migrating from Airflow to Astro. Update the bucket policy to reference the Astro role instead of the Airflow task role for cross-account S3 access to CloudFront logs.

