### PR TITLE
Add canonical URL and info note to any Terraform provider blog post

### DIFF
--- a/content/blog/any-terraform-provider/index.md
+++ b/content/blog/any-terraform-provider/index.md
@@ -4,7 +4,6 @@ date: 2024-08-29T10:00:00-06:00
 allow_long_title: true
 meta_desc: "Pulumi now supports using any Terraform or OpenTofu provider with Pulumi, in just a few seconds"
 meta_image: meta.png # TODO
-canonical_url: "/docs/iac/concepts/providers/any-terraform-provider/"
 authors:
   - luke-hoban
   - ian-wahbe


### PR DESCRIPTION
This directs readers to the documentation page for the most up-to-date information about using any Terraform provider with Pulumi.
