### PR TITLE
Fix innacurate example

### DIFF
--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -366,7 +366,8 @@ config:
       azure-native:
         mode: verbatim  # Azure resources use exact names
         resources:
-          "azure-native:storage:Account": ${name}${string(6)}  # Storage accounts need unique names
+          azure-native:storage:Account:
+            pattern: ${name}${string(6)}  # Storage accounts need unique names
 ```
 
 ### Strict Name Pattern Enforcement


### PR DESCRIPTION
When specifying autonaming configuration for a particular resource, we need to have a `pattern` field, otherwise Pulumi complains with the error message:

```
error: getting autonaming config: failed to parse autonaming config: invalid autonaming config structure: json: cannot unmarshal string into Go struct field providerConfigJSON.providers.resources of type autonaming.namingConfigJSON
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
