### PR TITLE
Fix broken CSS references when running Hugo server

### DIFF
--- a/layouts/partials/assets.html
+++ b/layouts/partials/assets.html
@@ -12,22 +12,24 @@
 {{ $js := resources.Get "js/bundle.js" | fingerprint }}
 <script src="{{ $js.RelPermalink }}" defer></script>
 
+{{/* Inline template for CSS links: uses fingerprinted bundle in dev, post-processed bundle in prod */}}
+{{ define "css-link" }}
+    {{- $css := resources.Get .source | fingerprint -}}
+    {{- $_ := $css.Permalink -}}
+    {{- if hugo.IsServer -}}
+        <link rel="stylesheet" href="{{ $css.RelPermalink }}">
+    {{- else -}}
+        <link rel="stylesheet" href="/css/{{ .name }}.{{ getenv "CSS_BUNDLE_ID" }}.css">
+    {{- end -}}
+{{ end }}
+
 <!--
   Our marketing styles diverge a bit from the other parts of the website so we load
   in a different bundle on our marketing pages.
 -->
 {{ $nonMarketingSections := slice "docs" "registry" "blog" "learn" "tutorials" "providers" "collections" "templates" "ai" "authors" "tags" "legal" }}
-{{ if in $nonMarketingSections .Section }}
-{{ else }}
-    {{/* Force Hugo to publish the resource by fingerprinting it, but don't use the fingerprinted URL */}}
-    {{ $marketingCss := resources.Get "css/marketing.css" | fingerprint }}
-    {{ $_ := $marketingCss.Permalink }}
-    {{ $cssBundleId := getenv "CSS_BUNDLE_ID" }}
-    <link rel="stylesheet" href="/css/marketing.{{ $cssBundleId }}.css">
+{{ if not (in $nonMarketingSections .Section) }}
+    {{ template "css-link" (dict "source" "css/marketing.css" "name" "marketing") }}
 {{ end }}
 
-{{/* Force Hugo to publish the resource by fingerprinting it, but don't use the fingerprinted URL */}}
-{{ $css := resources.Get "css/bundle.css" | fingerprint }}
-{{ $_ := $css.Permalink }}
-{{ $cssBundleId := getenv "CSS_BUNDLE_ID" }}
-<link rel="stylesheet" href="/css/bundle.{{ $cssBundleId }}.css">
+{{ template "css-link" (dict "source" "css/bundle.css" "name" "bundle") }}


### PR DESCRIPTION
The improvements in #16259 made a slight change to the way we build our CSS `link` tags that works with `make build`, but not with `make serve`, because the latter doesn't run postCSS, which wrote out the files those `link` tags expected. 

This PR uses `hugo.IsServer`](https://gohugo.io/functions/hugo/isserver/)) to fall back to the asset paths Hugo generates automatically when running `make serve` (and refactors slightly to remove a little duplication). 