### PR TITLE
Fix broken anchor link for #verbose-logging

### DIFF
--- a/content/docs/support/troubleshooting/_index.md
+++ b/content/docs/support/troubleshooting/_index.md
@@ -63,4 +63,10 @@ sections:
 if (window.location.hash === "#conflict") {
   window.location = "/docs/support/troubleshooting/common-issues/update-conflicts/"
 }
+
+// Redirect old verbose-logging anchor to new logging page
+// https://github.com/pulumi/docs/issues/16985
+if (window.location.hash === "#verbose-logging") {
+  window.location = "/docs/support/debugging/logging/#cli-verbose-logging"
+}
 </script>


### PR DESCRIPTION
## Summary

Adds a JavaScript redirect for the old `/docs/support/troubleshooting/#verbose-logging` anchor to redirect to the new location at `/docs/support/debugging/logging/#cli-verbose-logging`.

## Details

Older versions of Pulumi Azure Native (and potentially other providers) contain hardcoded links to the `#verbose-logging` anchor on the troubleshooting page. When the troubleshooting documentation was reorganized, the verbose logging content was moved to a dedicated logging page, breaking these links.

This fix follows the same pattern as the existing `#conflict` redirect already in place, ensuring users following old documentation links are automatically redirected to the correct location.

## Testing

- Manual verification of the redirect code syntax
- Follows the exact pattern of the existing `#conflict` redirect
- CI will validate the change

Fixes #16985