### PR TITLE
Add output property declarations to Python component examples

### DIFF
--- a/content/docs/iac/concepts/components/_index.md
+++ b/content/docs/iac/concepts/components/_index.md
@@ -448,6 +448,9 @@ class MyComponent extends pulumi.ComponentResource {
 
 ```python
 class MyComponent(pulumi.ComponentResource):
+    bucket_dns_name: pulumi.Output[str]
+    """bucket_dns_name: The DNS name of the bucket"""
+
     def __init__(self, name, my_component_args, opts = None):
         super().__init__('pkg:index:MyComponent', name, None, opts)
 


### PR DESCRIPTION
## Description
    
Adds missing output property type annotations to Python component examples in the components documentation.

## Changes

Updated the Python component example that uses `register_outputs` to include the output property declaration with type annotation and docstring:

```python
class MyComponent(pulumi.ComponentResource):
bucket_dns_name: pulumi.Output[str]
"""bucket_dns_name: The DNS name of the bucket"""

def __init__(self, name, my_component_args, opts = None):
    # ... rest of implementation
```

This ensures correct schema generation during package build/publish, as missing output declarations can result in incorrect schema generation.

## Related Issue

Fixes #16614

## Testing

- Manual review of Python syntax
- CI will validate with make lint
 