### PR TITLE
Add AI Agents workshop to Engin's talks page

### DIFF
--- a/content/community/community-engineering/engin-diri.md
+++ b/content/community/community-engineering/engin-diri.md
@@ -8,6 +8,10 @@ layout: community-engineering/single
 aliases:
   - /engin
 talks:
+- event: "AWS / Honeycomb / Pulumi Workshop"
+  title: "AI Agents That Reason Over Your Infrastructure"
+  url: "https://www.pulumi.com/events/ai-agents-that-reason/"
+  date: 2026-01-14T15:00:00.000-07:00
 - event: "AiDevTLV 2025"
   title: "What is AI Platform Engineering and Why Should You Care?"
   url: "https://aidevtlv.com/agenda/"


### PR DESCRIPTION
## Summary
Add the "AI Agents That Reason Over Your Infrastructure" workshop (January 14, 2026) to Engin Diri's talks page.

## Changes
Added the AWS/Honeycomb/Pulumi workshop entry to `engin-diri.md`

## Test plan
- [x] `make lint` passes
- [x] `make build` succeeds
- [ ] Verify workshop appears on https://www.pulumi.com/engin page after deploy