### PR TITLE
Document .gitignore usage for Python policy packs

### DIFF
--- a/content/docs/insights/policy/policy-packs/authoring.md
+++ b/content/docs/insights/policy/policy-packs/authoring.md
@@ -131,6 +131,17 @@ Create your first policy pack:
     >     virtualenv: .venv
     > ```
 
+    > **Using .gitignore to manage policy pack size**: Create a `.gitignore` file alongside `PulumiPolicy.yaml` to exclude unnecessary files from the published policy pack archive (`.tgz`). Add patterns to ignore Python bytecode files, virtual environments, and other development artifacts:
+    >
+    > ```
+    > *.pyc
+    > __pycache__/
+    > venv/
+    > .venv/
+    > ```
+    >
+    > This keeps your published policy pack size small and ensures only the necessary policy code is distributed.
+
 3. Replace the generated policy in `__main__.py` with this example, which demonstrates a clearer pattern for organizational policy enforcement:
 
     Each policy must have:


### PR DESCRIPTION
Adds documentation about using `.gitignore` to exclude unnecessary files (`*.pyc`, `__pycache__/`, `venv/`, `.venv/`) from published policy pack archives. This helps keep the `.tgz` package size small.

Fixes #17027