### PR TITLE
Emphasize auto-naming and create-before-delete in Terraform comparison

### DIFF
--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -68,8 +68,8 @@ With Pulumi IaC, you can:
 - Advanced automation capabilities
 - Enhanced security with built-in secret encryption
 - Full IDE support with code completion and type checking
-- Automatic resource naming prevents naming conflicts across stacks
-- Zero-downtime replacements with create-before-delete semantics
+- Automatic resource naming to prevent naming conflicts across stacks
+- Zero-downtime replacements using create-before-delete semantics
 
 ## What is Pulumi?
 
@@ -224,9 +224,9 @@ While Terraform requires you to manually ensure unique names across workspaces (
 
 For more details, see [Resource Names](/docs/iac/concepts/resources/names/).
 
-**Create-Before-Delete Replacement Strategy**
+**Create-before-delete replacement strategy**
 
-When a resource must be replaced rather than updated in place, Pulumi creates the new resource first, updates any references to point to the new resource, and only then deletes the old resource. This create-before-delete approach minimizes downtime and reduces the risk of service interruption during infrastructure updates.
+When a resource needs to be replaced rather than updated in place, Pulumi creates the new resource first, updates any references to point to the new resource, and only then deletes the old resource. This create-before-delete approach minimizes downtime and reduces the risk of service interruption during infrastructure updates.
 
 Terraform typically uses a delete-before-create strategy, which can cause downtime during replacements. While Terraform offers a `create_before_destroy` lifecycle setting, it must be explicitly configured on each resource and comes with limitations. Pulumi makes create-before-delete the default behavior, ensuring zero-downtime deployments without additional configuration.
 


### PR DESCRIPTION
Enhances the Terraform comparison page to prominently feature two key Pulumi differentiators: automatic resource naming and create-before-delete replacement semantics.
    
## Changes

### At a Glance Section
Added two new bullets to the "Key Differences" list:
- Automatic resource naming prevents naming conflicts across stacks
- Zero-downtime replacements with create-before-delete semantics

### New Detailed Section
Added a new "Resource Management and Deployment Workflow" section that explains:

**Automatic Resource Naming**
- How Pulumi automatically appends random suffixes to resource names
- Benefits for collision prevention across stacks
- How it enables zero-downtime replacements
- Comparison with Terraform's manual name management approach

**Create-Before-Delete Replacement Strategy**
- How Pulumi creates new resources before deleting old ones
- Contrast with Terraform's delete-before-create default
- Benefits for minimizing downtime
- When and how to opt into delete-before-replace if needed

## Why This Matters

These are significant competitive advantages that help differentiate Pulumi from Terraform:
- **Auto-naming** eliminates a common source of friction and enables better multi-stack workflows
- **Create-before-delete** provides zero-downtime deployments by default, without additional configuration

Fixes #16982
 