### PR TITLE
Fix YAML Component docs

### DIFF
--- a/content/docs/iac/languages-sdks/yaml/yaml-component-reference.md
+++ b/content/docs/iac/languages-sdks/yaml/yaml-component-reference.md
@@ -17,7 +17,7 @@ aliases:
 
 Pulumi components can be defined in many languages, and the Pulumi YAML dialect offers an additional language for authoring Pulumi components.
 
-The Pulumi YAML provider supports components written in YAML or JSON. Each YAML component plugin consists of a top level `components` section, which consists of a map of component names to a component definition.
+Pulumi supports components written with YAML or JSON syntax. Each YAML component plugin consists of a top level `components` section, which consists of a map of component names to a component definition.
 
 ```yaml
 components:

--- a/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
+++ b/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
@@ -19,7 +19,7 @@ aliases:
 
 Pulumi programs can be defined in many languages, and the Pulumi YAML dialect offers an additional language for authoring Pulumi programs.
 
-The Pulumi YAML provider supports programs written in YAML or JSON.  In both cases, the programs (`.yaml` or `.json` files) follow a simple schema, including four top level sections:
+Pulumi supports programs written in YAML or JSON.  In both cases, the programs (`.yaml` or `.json` files) follow a simple schema, including four top level sections:
 
 | Property | Type | Required | Expression | Description |
 | - | - | - | - | - |


### PR DESCRIPTION
There is no such thing as a Pulumi YAML provider. The component syntax is a property of the language.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
