### PR TITLE
CONV-004: Neo as Default Hero Experience A/B Test

### DIFF
--- a/layouts/page/home-b.html
+++ b/layouts/page/home-b.html
@@ -1,24 +1,27 @@
+{{/* CONV-004: Neo as Default Hero Experience
+     This treatment variant makes Neo the default hero experience instead of hiding it behind a toggle.
+     The hypothesis is that leading with AI-powered IaC capabilities will improve conversion. */}}
 {{ define "hero" }}
-    <header class="home-page-hero shadow">
+    <header class="home-page-hero shadow conv-004-neo-hero">
         <div class="home-page-hero-background">
-            <div class="flex">
-                <div class="w-full p-6 home-page-hero-text">
-                    <h1 class="flex flex-col items-center">
-                        <span class="inline-block mb-3 text-center" data-text="{{ index (.Params.hero.title) 0 }}">{{ index (.Params.hero.title) 0 }}</span>
-                        <span class="rainbow-text inline-block text-center" data-text="{{ index (.Params.hero.title) 1 }}">{{ index (.Params.hero.title) 1 }}</span>
+            <div class="flex flex-col lg:flex-row">
+                <div class="w-full lg:w-1/2 p-6 home-page-hero-text">
+                    <h1 class="flex flex-col items-center lg:items-start">
+                        <span class="inline-block mb-3 text-center lg:text-left" data-text="Meet Neo,">Meet Neo,</span>
+                        <span class="rainbow-text inline-block text-center lg:text-left" data-text="Your AI Platform Engineer.">Your AI Platform Engineer.</span>
                     </h1>
 
-                    <p class="mt-6 text-center leading-7">{{ .Params.hero.description | markdownify }}</p>
+                    <p class="mt-6 text-center lg:text-left leading-7">{{ .Params.neo.description | markdownify }}</p>
 
-                    <div class="relative z-10 overlay-middle mt-8 flex text-center justify-center items-center flex-col mx-auto lg:mx-0 md:flex-row">
-                        <a class="home-hero-btn-primary mr-0 md:mr-4 mb-3 md:mb-0" href="{{ .Params.hero.cta_link }}">{{ .Params.hero.cta_text }}</a>
-                        <a class="btn-secondary home-hero-btn-secondary rounded-full cursor-pointer" href="{{ .Params.hero.secondary_cta_link }}">{{ .Params.hero.secondary_cta_text }}</a>
+                    <div class="relative z-10 overlay-middle mt-8 flex text-center justify-center lg:justify-start items-center flex-col mx-auto lg:mx-0 md:flex-row">
+                        <a class="home-hero-btn-primary mr-0 md:mr-4 mb-3 md:mb-0" href="https://app.pulumi.com/signup?utm_source=neo-hero">Try Neo for Free</a>
+                        <a class="btn-secondary home-hero-btn-secondary rounded-full cursor-pointer" href="/product/neo/">Learn More</a>
                     </div>
                 </div>
 
-                <!--<div class="hidden lg:block lg:w-1/2 p-6 flex justify-center align-center">
-                    <img src="/images/home/dancing-music.svg" />
-                </div>-->
+                <div class="hidden lg:flex lg:w-1/2 p-6 justify-center items-center">
+                    <img src="{{ .Params.neo.image }}" alt="{{ .Params.neo.alt }}" class="rounded-xl shadow-xl max-w-full" />
+                </div>
             </div>
         </div>
     </header>

--- a/theme/src/scss/_hero.scss
+++ b/theme/src/scss/_hero.scss
@@ -200,3 +200,25 @@
         @apply top-0;
     }
 }
+
+/* CONV-004: Neo as Default Hero Experience
+   This styling supports the Neo hero variant with side-by-side text and image layout */
+.conv-004-neo-hero {
+    min-height: 28rem;
+
+    @screen lg {
+        min-height: 32rem;
+        height: auto;
+    }
+
+    .home-page-hero-text {
+        @screen lg {
+            @apply flex flex-col justify-center;
+
+            p {
+                @apply mx-0;
+                max-width: 36rem !important;
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Note:** This PR should not be merged directly. The changes will be controlled via GrowthBook feature flags and run as an A/B experiment. Merge only after experiment concludes and a winner is declared.

---

This experiment tests making Neo the default homepage hero experience instead of hiding it behind a toggle. Early data suggests users who engage with Neo during their trial convert to paid customers at over 2x the rate. While causation vs correlation is unclear, this signal warrants testing.

The treatment variant replaces the current homepage hero with the Neo-focused experience, putting AI-powered infrastructure-as-code capabilities front and center.

**Hypothesis:** If we make Neo the default hero experience (instead of hiding it behind a toggle), then we will increase both signup conversion and downstream trial-to-paid conversion by exposing more users to our AI-powered IaC capabilities early.

**Success metrics:**
- Primary: Visitor-to-signup conversion rate (target: >1.5%)
- Secondary: Neo adoption during trial (target: >50% of signups)
- Secondary: Trial-to-paid conversion rate (validate 2x correlation hypothesis)

GrowthBook feature flag: `conv-004-neo-default-hero` (boolean)
Traffic split: 50/50