### PR TITLE
Add output property declarations to Python component examples (#17137)

### DIFF
--- a/content/docs/iac/concepts/components/_index.md
+++ b/content/docs/iac/concepts/components/_index.md
@@ -449,7 +449,7 @@ class MyComponent extends pulumi.ComponentResource {
 ```python
 class MyComponent(pulumi.ComponentResource):
     bucket_dns_name: pulumi.Output[str]
-    """bucket_dns_name: The DNS name of the bucket"""
+    """The DNS name of the bucket"""
 
     def __init__(self, name, my_component_args, opts = None):
         super().__init__('pkg:index:MyComponent', name, None, opts)


### PR DESCRIPTION
Fixes #16614

Python component examples should include output property type annotations to ensure correct schema generation during package build/publish.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
