### PR TITLE
List ESC Python SDK proxy environment variable support

### DIFF
--- a/content/docs/esc/development/languages-sdks/python.md
+++ b/content/docs/esc/development/languages-sdks/python.md
@@ -48,7 +48,7 @@ configuration = esc.Configuration(access_token=myAccessToken)
 client = esc.EscClient(configuration)
 ```
 
-Standard proxy environment variables are honored: `https_proxy`, `http_proxy`, and `no_proxy` (upper case accepted as well).
+The Python SDK honors standard proxy environment variables: `https_proxy`, `http_proxy`, and `no_proxy`. Both lowercase and uppercase variants are supported.
 
 ## Examples
 

--- a/content/docs/esc/development/languages-sdks/python.md
+++ b/content/docs/esc/development/languages-sdks/python.md
@@ -48,6 +48,8 @@ configuration = esc.Configuration(access_token=myAccessToken)
 client = esc.EscClient(configuration)
 ```
 
+Standard proxy environment variables are honored: `https_proxy`, `http_proxy`, and `no_proxy` (upper case accepted as well).
+
 ## Examples
 
 All of these examples expect a `PULUMI_ACCESS_TOKEN` and `PULUMI_ORG` environment variable to be set.


### PR DESCRIPTION
### Proposed changes

List ESC Python SDK proxy environment variable support.

There isn't a great place to include these in the generated Python API docs. We direct users to this doc for high level documentation of the Python SDK.

Support for these was added in https://github.com/pulumi/esc-sdk/pull/108


### Related issues (optional)

Closes https://github.com/pulumi/esc-sdk/issues/112
