### PR TITLE
Fix truncated Windows dev release installation script

### DIFF
--- a/content/docs/get-started/download-install/_index.md
+++ b/content/docs/get-started/download-install/_index.md
@@ -585,7 +585,7 @@ To install, run our installation script:
 1. Run our installation script:
 
 <div class="highlight">
-   <pre class="chroma"><code class="language-bash" data-lang="powershell" data-track="install-pulumi-windows-install-script">&gt; @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((New-Object System.Net.WebClient).DownloadString</code></pre>
+   <pre class="chroma"><code class="language-bash" data-lang="powershell" data-track="install-pulumi-windows-install-script">&gt; @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &amp; ([ScriptBlock]::Create((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))) -Version dev" &amp;&amp; SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"</code></pre>
 </div>
 
 {{% /choosable %}}


### PR DESCRIPTION
The PowerShell command for installing dev releases on Windows was truncated in the documentation, cutting off after `DownloadString`. This caused Windows users following the instructions to encounter a syntax error.
    
This PR completes the command to properly download and execute the install.ps1 script with the `-Version dev` parameter.
    
**Changes:**
- Completed the truncated PowerShell one-liner for Windows dev release installation
- Used `[ScriptBlock]::Create()` to properly invoke the downloaded script with parameters, following PowerShell best practices
- Properly HTML-encoded the ampersands for correct rendering
    
**Testing:**
The command structure follows PowerShell best practices for downloading and executing scripts with parameters. The HTML encoding matches the existing pattern used elsewhere in the same file.
    
Fixes #17210