### PR TITLE
Add documentation for caching Pulumi plugins and policy packs in GitHub Actions

### DIFF
--- a/content/docs/iac/guides/continuous-delivery/github-actions.md
+++ b/content/docs/iac/guides/continuous-delivery/github-actions.md
@@ -891,11 +891,11 @@ jobs:
 
 {{< /chooser >}}
 
-### Caching Plugins and Policy Packs
+### Caching plugins and policy packs
 
 GitHub Actions downloads plugins and policy packs on each workflow run. To improve CI performance and reduce workflow execution times, you can cache these artifacts using GitHub's [`actions/cache`](https://github.com/actions/cache).
 
-Pulumi stores plugins in `~/.pulumi/plugins` and policy packs in `~/.pulumi/policies`. By caching these directories, subsequent workflow runs can skip downloading plugins and policies that have already been fetched, significantly reducing the time spent in the setup phase.
+Pulumi stores plugins in `~/.pulumi/plugins` and policy packs in `~/.pulumi/policies`. By caching these directories, subsequent workflow runs skip re-downloading plugins and policies, significantly reducing setup time.
 
 Here's an example workflow that caches both plugins and policy packs:
 


### PR DESCRIPTION
This PR adds documentation for caching Pulumi plugins and policy packs in GitHub Actions workflows.
 
## Changes
    
  Added a new section "Caching Plugins and Policy Packs" to the GitHub Actions CI/CD documentation that explains:
  
  - Why caching is beneficial for improving CI performance
  - How to use GitHub's `actions/cache` to cache `~/.pulumi/plugins` and `~/.pulumi/policies`
  - Complete working examples for all supported languages (TypeScript, Python, Go, C#)
  - Smart cache key strategies using dependency file hashes
  - Advanced caching scenarios for complex setups
  
  ## Context
  
  Users running Pulumi in CI/CD environments often experience slow workflow times due to repeated plugin and policy pack downloads. This documentation provides a clear, actionable guide to implementing caching, significantly reducing workflow execution times.
  
  The examples use dependency file hashes (e.g., `package.json`, `requirements.txt`, `go.sum`, `*.csproj`) in cache keys to ensure cache invalidation when dependencies change, while providing fallback cache restoration for maximum benefit.
  
  Fixes #17026