### PR TITLE
Changed runtime of lambda to NodeJS 22

### DIFF
--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -1536,7 +1536,7 @@ Delivery: CloudWatch Logs infrastructure v2
 
 ```typescript
 const edgeRedirects = new aws.lambda.Function("edge-redirects", {
-    runtime: "nodejs18.x",
+    runtime: "nodejs22.x",
     handler: "index.handler",
     role: edgeRole.arn,
     code: new pulumi.asset.AssetArchive({

--- a/infrastructure/lambdaEdge.ts
+++ b/infrastructure/lambdaEdge.ts
@@ -115,7 +115,7 @@ export class LambdaEdge extends pulumi.ComponentResource {
                 memorySize: 128,
                 publish: true,
                 role: this.role,
-                runtime: aws.lambda.Runtime.NodeJS18dX,
+                runtime: aws.lambda.Runtime.NodeJS22dX,
                 // Note that Lambda@Edge functions have a different max timeout of 30 seconds
                 // than the regular Lambda functions.
                 timeout: 5,


### PR DESCRIPTION
(18 isn't supported anymore)

The changes in #17190 caused the lambda function to be redeployed
