### PR TITLE
Fix SDK docs by correcting url-pattern import

### DIFF
--- a/infrastructure/cloudfrontLambdaAssociations.ts
+++ b/infrastructure/cloudfrontLambdaAssociations.ts
@@ -8,7 +8,7 @@ import {
     CloudFrontResponse,
     CloudFrontResponseEvent,
 } from "aws-lambda";
-import * as URLPattern from "url-pattern";
+const URLPattern = require("url-pattern");
 import { LambdaEdge } from "./lambdaEdge";
 import { getResources } from "@pulumi/aws/resourcegroupstaggingapi/getResources";
 


### PR DESCRIPTION
Fixes SDK documentation 503 errors for Node.js, Python, and .NET.

## Problem
After PR #17190 merged (upgrading Webpack 5.76→5.104), all SDK documentation started returning 503 errors. PR #17257 upgraded the Lambda runtime to Node 22, but the issue persisted.

## Root Cause
CloudWatch logs showed: `ReferenceError: URLPattern is not defined`

The `url-pattern` npm package wasn't being bundled correctly by Webpack 5.104 when using `import * as URLPattern`. The bundled Lambda code referenced `URLPattern` as a global variable instead of including the package code.

## Solution
Changed line 11 in `infrastructure/cloudfrontLambdaAssociations.ts` from:
```typescript
import * as URLPattern from "url-pattern";
```
To:
```typescript
const URLPattern = require("url-pattern");
```

This ensures Webpack properly bundles the package, fixing all three SDK redirect functions:
- `nodeSDKRedirect` (line 216)
- `pythonSDKRedirect` (line 239)
- `dotnetSDKRedirect` (line 259)

## Testing
After infrastructure deployment (via CI or manual `pulumi up`):
- https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/ (should return 200)
- https://www.pulumi.com/docs/reference/pkg/python/pulumi/ (should return 200)
- https://www.pulumi.com/docs/reference/pkg/dotnet/Pulumi/Pulumi.html (should return 200)