### PR TITLE
Use pulumi/action-install-pulumi-cli@v1.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,3 +94,5 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    ignore:
+      - dependency-name: "pulumi/action-install-pulumi-cli"

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2.0.0
+        uses: pulumi/action-install-pulumi-cli@v1.0.1
         with:
           pulumi-version: ${{ env.PULUMI_VERSION }}
       - name: Install go

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -3086,7 +3086,7 @@ Dependabot automatically updates GitHub Actions versions. Review and merge Depen
 | `peaceiris/actions-hugo` | v2 | Hugo installation |
 | `pulumi/actions` | v4 | Pulumi CLI installation |
 | `pulumi/esc-action` | v1 | Pulumi ESC integration |
-| `pulumi/action-install-pulumi-cli` | v2.0.0 | Pulumi CLI installation (specific version) |
+| `pulumi/action-install-pulumi-cli` | v1.0.1 | Legacy action used in the CLI release workflow; `pulumi/actions` should be used everywhere else |
 | `jaxxstorm/action-install-gh-release` | v2.1.0 | Install tools from GitHub releases |
 | `treosh/lighthouse-ci-action` | v12 | Lighthouse CI integration |
 | `hmarr/auto-approve-action` | v4 | Automated PR approval |
@@ -3098,7 +3098,6 @@ Dependabot automatically updates GitHub Actions versions. Review and merge Depen
 - **setup-node v4 → v6**: Updated Node.js setup action with improved caching and performance
 - **jaxxstorm/action-install-gh-release v1 → v2**: Enhanced GitHub release installation with better error handling
 - **create-github-app-token v1 → v2**: Updated GitHub App token generation with security improvements
-- **pulumi/action-install-pulumi-cli v1 → v2**: Major version update for Pulumi CLI installation
 
 **Example Update:**
 


### PR DESCRIPTION
This change unblocks Pulumi CLI releases.

`pulumi/action-install-pulumi-cli` is used in one workflow: the workflow that is used to update `latest-version` and `data/versions.json` for a new CLI release and regenerate docs.

Prior to https://github.com/pulumi/docs/pull/17190, the workflow was using `pulumi/action-install-pulumi-cli@v1.0.1` to install the just-released CLI. It would download this directly from the release on GitHub.

With https://github.com/pulumi/docs/pull/17190, the action was updated to use `pulumi/action-install-pulumi-cli@v2.0.0`, but this no longer works for just-released CLIs. This version of the action looks for the release at https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json, but it won't be present there because the running workflow is the workflow that updates that file.

Ideally, we'd move to `pulumi/actions`, which is our non-legacy and maintained action for installing the CLI. However, it also consults with the versions.json file. We should consider fixing the action to support downloading the CLI from the GitHub release without having to consult with versions.json.

In the meantime, to unblock CLI releases, this change reverts back to using `pulumi/action-install-pulumi-cli@v1.0.1` and includes a dependabot config to avoid upgrading this action.

Fixes #17265