### PR TITLE
Move ESC OIDC documentation to Guides section

### DIFF
--- a/content/docs/deployments/deployments/cloud-credentials.md
+++ b/content/docs/deployments/deployments/cloud-credentials.md
@@ -44,7 +44,7 @@ pulumi env run my-esc-project/my-esc-environment -- npm install
 
 Both Pulumi Deployments OIDC and Pulumi ESC require configuring an OIDC Identity Provider in your cloud environment in order to enable the secure exchange of tokens between Pulumi Cloud and your cloud provider in order to obtain temporary credentials. For more information:
 
-- If using Pulumi ESC, see [Configuring OpenID Connect for Pulumi ESC](/docs/esc/environments/configuring-oidc/).
+- If using Pulumi ESC, see [Configuring OpenID Connect for Pulumi ESC](/docs/esc/guides/configuring-oidc/).
 - If using Pulumi Deployments OIDC, see [OIDC Setup for Pulumi Deployments](/docs/deployments/deployments/oidc/).
 
 After an OIDC Identity Provider has been configured:

--- a/content/docs/esc/concepts/how-esc-works.md
+++ b/content/docs/esc/concepts/how-esc-works.md
@@ -37,7 +37,7 @@ Pulumi ESC integrates with many popular cloud login providers and secrets manage
 * [HashiCorp Vault OIDC](/docs/esc/integrations/dynamic-login-credentials/vault-login/) and [Vault Secrets](/docs/esc/integrations/dynamic-secrets/vault-secrets/)
 * [1Password](/docs/esc/integrations/dynamic-secrets/1password-secrets/), [Kubernetes](/docs/esc/integrations/kubernetes/), among others.
 
-Teams can setup [OpenID Connect integration](/docs/esc/environments/configuring-oidc/) in their cloud providers to allow ESC environments to pull short-lived credentials via **OIDC** for secure, time-limited access to secrets. These credentials can then be used in both [Pulumi IaC](/docs/pulumi-cloud/esc/environments/#using-with-pulumi-iac) workflows and [external CLIs](/docs/pulumi-cloud/esc/environments/#running-third-party-commands-using-pulumi-esc-secrets-and-config) like `aws`, `kubectl`, etc.
+Teams can setup [OpenID Connect integration](/docs/esc/guides/configuring-oidc/) in their cloud providers to allow ESC environments to pull short-lived credentials via **OIDC** for secure, time-limited access to secrets. These credentials can then be used in both [Pulumi IaC](/docs/pulumi-cloud/esc/environments/#using-with-pulumi-iac) workflows and [external CLIs](/docs/pulumi-cloud/esc/environments/#running-third-party-commands-using-pulumi-esc-secrets-and-config) like `aws`, `kubectl`, etc.
 
 ## The ESC data model
 

--- a/content/docs/esc/get-started/_index.md
+++ b/content/docs/esc/get-started/_index.md
@@ -143,7 +143,7 @@ New to Pulumi IaC? Start with the [Pulumi IaC Get Started guide](/docs/get-start
 Extend ESC with external secret providers and advanced OIDC configuration:
 
 - **[Dynamic secrets](/docs/esc/integrations/dynamic-secrets/)** - Pull secrets from external providers like AWS Secrets Manager, Azure Key Vault, and 1Password
-- **[Configuring OIDC](/docs/esc/environments/configuring-oidc/)** - Deep dive into OpenID Connect configuration and trust relationships
+- **[Configuring OIDC](/docs/esc/guides/configuring-oidc/)** - Deep dive into OpenID Connect configuration and trust relationships
 
 ### Learn the fundamentals
 

--- a/content/docs/esc/guides/_index.md
+++ b/content/docs/esc/guides/_index.md
@@ -15,6 +15,7 @@ These guides walk you through common Pulumi ESC tasks. Each guide is self-contai
 ## Getting started guides
 
 - **[Integrate with Pulumi IaC](/docs/esc/guides/integrate-with-pulumi-iac/)** - Use ESC environments in your Pulumi infrastructure code
+- **[Configuring OIDC](/docs/esc/guides/configuring-oidc/)** - Set up OpenID Connect for secure, credential-free authentication
 - **[Managing secrets](/docs/esc/guides/managing-secrets/)** - Store, retrieve, and organize secrets in ESC environments
 - **[Running commands with esc run](/docs/esc/guides/running-commands-with-esc/)** - Inject secrets into any command or script
 

--- a/content/docs/esc/guides/configuring-oidc/_index.md
+++ b/content/docs/esc/guides/configuring-oidc/_index.md
@@ -7,9 +7,11 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   esc:
     name: Configuring OIDC
-    identifier: esc-configuring-oidc
-    parent: esc-environments
-    weight: 7
+    identifier: esc-guides-configuring-oidc
+    parent: esc-guides
+    weight: 20
+aliases:
+  - /docs/esc/environments/configuring-oidc/
 ---
 
 Pulumi ESC can be configured to act as an OpenID Connect (OIDC) provider, issuing signed, short-lived tokens. These tokens can then be exchanged by external systems for temporary cloud provider credentials, eliminating the need for hard-coded credentials.
@@ -35,12 +37,12 @@ In this example we have an environment definition and ARN that identifies us to 
 
 To configure OIDC for your cloud provider, refer to one of our guides:
 
-* [Configuring OIDC for AWS](/docs/esc/environments/configuring-oidc/aws/)
-* [Configuring OIDC for Azure](/docs/esc/environments/configuring-oidc/azure/)
-* [Configuring OIDC for Doppler](/docs/esc/environments/configuring-oidc/doppler/)
-* [Configuring OIDC for Google Cloud](/docs/esc/environments/configuring-oidc/gcp/)
-* [Configuring OIDC for Infisical](/docs/esc/environments/configuring-oidc/infisical/)
-* [Configuring OIDC for Vault](/docs/esc/environments/configuring-oidc/vault/)
+* [Configuring OIDC for AWS](/docs/esc/guides/configuring-oidc/aws/)
+* [Configuring OIDC for Azure](/docs/esc/guides/configuring-oidc/azure/)
+* [Configuring OIDC for Doppler](/docs/esc/guides/configuring-oidc/doppler/)
+* [Configuring OIDC for Google Cloud](/docs/esc/guides/configuring-oidc/gcp/)
+* [Configuring OIDC for Infisical](/docs/esc/guides/configuring-oidc/infisical/)
+* [Configuring OIDC for Vault](/docs/esc/guides/configuring-oidc/vault/)
 
 ## Customizing OIDC claims
 

--- a/content/docs/esc/guides/configuring-oidc/aws.md
+++ b/content/docs/esc/guides/configuring-oidc/aws.md
@@ -7,8 +7,10 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   esc:
     name: AWS
-    parent: esc-configuring-oidc
+    parent: esc-guides-configuring-oidc
     weight: 1
+aliases:
+  - /docs/esc/environments/configuring-oidc/aws/
 ---
 
 This document outlines the steps required to configure Pulumi to use OpenID Connect to authenticate with AWS. OIDC in AWS uses a web identity provider to assume an IAM role. Access to the IAM role is authorized using a trust policy that validates the contents of the OIDC token issued by the Pulumi Cloud.

--- a/content/docs/esc/guides/configuring-oidc/azure.md
+++ b/content/docs/esc/guides/configuring-oidc/azure.md
@@ -7,8 +7,10 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   esc:
     name: Azure
-    parent: esc-configuring-oidc
+    parent: esc-guides-configuring-oidc
     weight: 2
+aliases:
+  - /docs/esc/environments/configuring-oidc/azure/
 ---
 
 This document outlines the steps required to configure Pulumi to use OpenID Connect to authenticate with Azure. OIDC in Azure uses [workload identity federation](https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation) to access Azure resources via a Microsoft Entra App. Access to the temporary credentials is authorized using federated credentials that validate the contents of the OIDC token issued by the Pulumi Cloud.

--- a/content/docs/esc/guides/configuring-oidc/doppler.md
+++ b/content/docs/esc/guides/configuring-oidc/doppler.md
@@ -1,59 +1,60 @@
 ---
-title_tag: Configure OpenID Connect for Infisical | Pulumi ESC
-meta_desc: This page describes how to configure OIDC token exchange in Infisical for use with Pulumi
-title: Infisical
-h1: Configuring OpenID Connect for Infisical
+title_tag: Configure OpenID Connect for Doppler | Pulumi ESC
+meta_desc: This page describes how to configure OIDC token exchange in Doppler for use with Pulumi
+title: Doppler
+h1: Configuring OpenID Connect for Doppler
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   esc:
-    name: Infisical
-    parent: esc-configuring-oidc
-    weight: 6
+    name: Doppler
+    parent: esc-guides-configuring-oidc
+    weight: 4
+aliases:
+  - /docs/esc/environments/configuring-oidc/doppler/
 ---
 
-This document outlines the steps required to configure Pulumi to use OpenID Connect to authenticate with Infisical. OIDC
-in Infisical uses [identities](https://infisical.com/docs/documentation/platform/identities/oidc-auth/general) to access
-Infisical resources. Access to the temporary credentials is authorized using identities that validate the contents of
+This document outlines the steps required to configure Pulumi to use OpenID Connect to authenticate with Doppler. OIDC
+in Doppler uses [service account identities](https://docs.doppler.com/docs/service-account-identities) to access
+Doppler resources. Access to the temporary credentials is authorized using identities that validate the contents of
 the OIDC token issued by the Pulumi Cloud.
 
 ## Prerequisites
 
-* You must be an admin of your Infisical organization to create and configure identities.
+* Your Doppler workplace must be on the Team or Enterprise plan in order to use service account identities.
+* You must be an admin of your Doppler workplace to create and configure service account identities.
 
 {{< notes type="warning" >}}
 Please note that this guide provides step-by-step instructions based on the official provider documentation which is
 subject to change. For the most current and precise information, always refer to
-the [official Infisical documentation](https://infisical.com/docs/documentation/platform/identities/oidc-auth/general).
+the [official Doppler documentation](https://docs.doppler.com/docs/service-account-identities).
 {{< /notes >}}
 
-## Creating an Identity
+## Creating a Service Account
 
-In the navigation pane of the [Infisical app](https://app.infisical.com):
+To create a new service account, in the navigation pane of the [Doppler dashboard](https://dashboard.doppler.com):
 
-1. Select **Admin**, **Access Control**, **Identities** and then click **Create Identity**.
-2. Provide a name for your application (ex: `pulumi-esc-oidc-app`).
-3. Select a **Role** for the identity.
-4. Click **Create**.
+1. Select **Team**, **Service Accounts** and then click **New Service Account**.
+2. Provide a name for your service account (ex: `pulumi-esc-oidc-app`).
+3. Click **Create**.
+4. Select a **Role** for the service account or manually grant project access.
 
-After the Identity has been created, take note of the Identity ID. This value will be necessary when enabling OIDC for your service.
+## Add an Identity (OIDC Authentication)
 
-## Add OIDC Authentication
+To add an identity to a service account:
 
-Once you have created your new identity, you will be redirected to the identity's **Overview** page. In the
-Authentication section:
-
-1. Remove the existing Universal Auth configuration.
-2. Click on the **Add Auth Method** button. This will start an "Add Auth Method" wizard.
-3. In the wizard, select **OIDC Auth** as the **Auth Method**.
-4. Fill in the remaining form fields as follows:
-    * **OIDC Discovery URL:** `https://api.pulumi.com/oidc`
-    * **Issuer:** `https://api.pulumi.com/oidc`
-    * **Subject:** This can be left empty. If it's empty, all ESC Environments of your organization would be able to assume this identity. We recommend configuring the subject claim for finer permission. (see examples at the end of this section).
-    * **Audiences:** This is different between Pulumi deployments and ESC. For Deployments this is only the name of your Pulumi organization. For ESC this is the name of your Pulumi organization prefixed with `infisical:` (e.g. `infisical:{org}`).
+1. Navigate to the service account from **Team**, **Service Accounts**
+2. Click **New Identity**.
+3. Fill in the form fields as follows:
+    * **Discovery URL:** `https://api.pulumi.com/oidc`.
+    * **Audience:** This is different between Pulumi deployments and ESC. For Deployments this is only the name of your Pulumi organization. For ESC this is the name of your Pulumi organization prefixed with `doppler:` (e.g. `doppler:{org}`).
+    * **Subject:** `pulumi:environments:org:<your-pulumi-org>:env:<your-project>/<your-environment>` (see more examples at the end of this section).
+4. Click **Create Identity**.
 {{< notes type="info" >}}
 For environments in the `default` project the audience will use just the Pulumi organization name. This is to
 prevent regressions for legacy environments.
 {{< /notes >}}
+
+After the Identity has been created, take note of the Identity ID. This value will be necessary when enabling OIDC for your service.
 
 ## Configure ESC for OIDC
 
@@ -70,13 +71,13 @@ that you have the correct organization selected in the left-hand navigation menu
 
     ```yaml
     values:
-      infisical:
+      doppler:
         login:
-          fn::open::infisical-login:
+          fn::open::doppler-login:
             oidc:
               identityId: <your-identity-id>
       environmentVariables:
-        INFISICAL_TOKEN: ${infisical.login.accessToken}
+        DOPPLER_TOKEN: ${doppler.login.accessToken}
     ```
 
 6. Replace `<your-identity-id>` with the value from the previous steps.
@@ -92,13 +93,13 @@ organization, project, and environment file respectively. You should see output 
 
 ```json
 {
-  "infisical": {
+  "doppler": {
     "login": {
-      "accessToken": "eyJh...."
+      "accessToken": "dp.said.XXX..."
     }
   },
   "environmentVariables": {
-    "INFISICAL_TOKEN": "eyJh...."
+    "DOPPLER_TOKEN": "dp.said.XXX..."
   }
 }
 ```
@@ -126,9 +127,9 @@ every key configured will be appended to this prefix. For example, consider the 
 
 ```yaml
 values:
-  infisical:
+  doppler:
     login:
-      fn::open::infisical-login:
+      fn::open::doppler-login:
         oidc:
           identityId: <your-identity-id>
           subjectAttributes:
@@ -170,7 +171,7 @@ organization:
 
 If you are integrating Pulumi ESC with Pulumi IaC, the default subject identifier of the ESC environment will not work
 at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the subject identifier's
-value sent to Infisical from Pulumi.
+value sent to Doppler from Pulumi.
 
 Use 'subjectAttributes' to customize the subject identifier to work with Pulumi IaC. Alternatively, you can use this
 syntax: `pulumi:environments:org:contoso:env:<yaml>` when configuring the subject claim in your cloud provider account.

--- a/content/docs/esc/guides/configuring-oidc/gcp.md
+++ b/content/docs/esc/guides/configuring-oidc/gcp.md
@@ -7,8 +7,10 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   esc:
     name: Google Cloud
-    parent: esc-configuring-oidc
+    parent: esc-guides-configuring-oidc
     weight: 5
+aliases:
+  - /docs/esc/environments/configuring-oidc/gcp/
 ---
 
 This document outlines the steps required to configure Pulumi to use OpenID Connect to authenticate with Google Cloud. OIDC in Google Cloud uses [workload identity federation](https://cloud.google.com/iam/docs/workload-identity-federation) to allow access to resources. Access to the resources is authorized using attribute conditions that validate the contents of the OIDC token issued by the Pulumi Cloud.

--- a/content/docs/esc/guides/configuring-oidc/infisical.md
+++ b/content/docs/esc/guides/configuring-oidc/infisical.md
@@ -1,58 +1,61 @@
 ---
-title_tag: Configure OpenID Connect for Doppler | Pulumi ESC
-meta_desc: This page describes how to configure OIDC token exchange in Doppler for use with Pulumi
-title: Doppler
-h1: Configuring OpenID Connect for Doppler
+title_tag: Configure OpenID Connect for Infisical | Pulumi ESC
+meta_desc: This page describes how to configure OIDC token exchange in Infisical for use with Pulumi
+title: Infisical
+h1: Configuring OpenID Connect for Infisical
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   esc:
-    name: Doppler
-    parent: esc-configuring-oidc
-    weight: 4
+    name: Infisical
+    parent: esc-guides-configuring-oidc
+    weight: 6
+aliases:
+  - /docs/esc/environments/configuring-oidc/infisical/
 ---
 
-This document outlines the steps required to configure Pulumi to use OpenID Connect to authenticate with Doppler. OIDC
-in Doppler uses [service account identities](https://docs.doppler.com/docs/service-account-identities) to access
-Doppler resources. Access to the temporary credentials is authorized using identities that validate the contents of
+This document outlines the steps required to configure Pulumi to use OpenID Connect to authenticate with Infisical. OIDC
+in Infisical uses [identities](https://infisical.com/docs/documentation/platform/identities/oidc-auth/general) to access
+Infisical resources. Access to the temporary credentials is authorized using identities that validate the contents of
 the OIDC token issued by the Pulumi Cloud.
 
 ## Prerequisites
 
-* Your Doppler workplace must be on the Team or Enterprise plan in order to use service account identities.
-* You must be an admin of your Doppler workplace to create and configure service account identities.
+* You must be an admin of your Infisical organization to create and configure identities.
 
 {{< notes type="warning" >}}
 Please note that this guide provides step-by-step instructions based on the official provider documentation which is
 subject to change. For the most current and precise information, always refer to
-the [official Doppler documentation](https://docs.doppler.com/docs/service-account-identities).
+the [official Infisical documentation](https://infisical.com/docs/documentation/platform/identities/oidc-auth/general).
 {{< /notes >}}
 
-## Creating a Service Account
+## Creating an Identity
 
-To create a new service account, in the navigation pane of the [Doppler dashboard](https://dashboard.doppler.com):
+In the navigation pane of the [Infisical app](https://app.infisical.com):
 
-1. Select **Team**, **Service Accounts** and then click **New Service Account**.
-2. Provide a name for your service account (ex: `pulumi-esc-oidc-app`).
-3. Click **Create**.
-4. Select a **Role** for the service account or manually grant project access.
+1. Select **Admin**, **Access Control**, **Identities** and then click **Create Identity**.
+2. Provide a name for your application (ex: `pulumi-esc-oidc-app`).
+3. Select a **Role** for the identity.
+4. Click **Create**.
 
-## Add an Identity (OIDC Authentication)
+After the Identity has been created, take note of the Identity ID. This value will be necessary when enabling OIDC for your service.
 
-To add an identity to a service account:
+## Add OIDC Authentication
 
-1. Navigate to the service account from **Team**, **Service Accounts**
-2. Click **New Identity**.
-3. Fill in the form fields as follows:
-    * **Discovery URL:** `https://api.pulumi.com/oidc`.
-    * **Audience:** This is different between Pulumi deployments and ESC. For Deployments this is only the name of your Pulumi organization. For ESC this is the name of your Pulumi organization prefixed with `doppler:` (e.g. `doppler:{org}`).
-    * **Subject:** `pulumi:environments:org:<your-pulumi-org>:env:<your-project>/<your-environment>` (see more examples at the end of this section).
-4. Click **Create Identity**.
+Once you have created your new identity, you will be redirected to the identity's **Overview** page. In the
+Authentication section:
+
+1. Remove the existing Universal Auth configuration.
+2. Click on the **Add Auth Method** button. This will start an "Add Auth Method" wizard.
+3. In the wizard, select **OIDC Auth** as the **Auth Method**.
+4. Fill in the remaining form fields as follows:
+    * **OIDC Discovery URL:** `https://api.pulumi.com/oidc`
+    * **Issuer:** `https://api.pulumi.com/oidc`
+    * **Subject:** This can be left empty. If it's empty, all ESC Environments of your organization would be able to assume this identity. We recommend configuring the subject claim for finer permission. (see examples at the end of this section).
+    * **Audiences:** This is different between Pulumi deployments and ESC. For Deployments this is only the name of your Pulumi organization. For ESC this is the name of your Pulumi organization prefixed with `infisical:` (e.g. `infisical:{org}`).
 {{< notes type="info" >}}
 For environments in the `default` project the audience will use just the Pulumi organization name. This is to
 prevent regressions for legacy environments.
 {{< /notes >}}
-
-After the Identity has been created, take note of the Identity ID. This value will be necessary when enabling OIDC for your service.
 
 ## Configure ESC for OIDC
 
@@ -69,13 +72,13 @@ that you have the correct organization selected in the left-hand navigation menu
 
     ```yaml
     values:
-      doppler:
+      infisical:
         login:
-          fn::open::doppler-login:
+          fn::open::infisical-login:
             oidc:
               identityId: <your-identity-id>
       environmentVariables:
-        DOPPLER_TOKEN: ${doppler.login.accessToken}
+        INFISICAL_TOKEN: ${infisical.login.accessToken}
     ```
 
 6. Replace `<your-identity-id>` with the value from the previous steps.
@@ -91,13 +94,13 @@ organization, project, and environment file respectively. You should see output 
 
 ```json
 {
-  "doppler": {
+  "infisical": {
     "login": {
-      "accessToken": "dp.said.XXX..."
+      "accessToken": "eyJh...."
     }
   },
   "environmentVariables": {
-    "DOPPLER_TOKEN": "dp.said.XXX..."
+    "INFISICAL_TOKEN": "eyJh...."
   }
 }
 ```
@@ -125,9 +128,9 @@ every key configured will be appended to this prefix. For example, consider the 
 
 ```yaml
 values:
-  doppler:
+  infisical:
     login:
-      fn::open::doppler-login:
+      fn::open::infisical-login:
         oidc:
           identityId: <your-identity-id>
           subjectAttributes:
@@ -169,7 +172,7 @@ organization:
 
 If you are integrating Pulumi ESC with Pulumi IaC, the default subject identifier of the ESC environment will not work
 at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the subject identifier's
-value sent to Doppler from Pulumi.
+value sent to Infisical from Pulumi.
 
 Use 'subjectAttributes' to customize the subject identifier to work with Pulumi IaC. Alternatively, you can use this
 syntax: `pulumi:environments:org:contoso:env:<yaml>` when configuring the subject claim in your cloud provider account.

--- a/content/docs/esc/guides/configuring-oidc/vault.md
+++ b/content/docs/esc/guides/configuring-oidc/vault.md
@@ -7,9 +7,10 @@ meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   esc:
     name: Vault
-    parent: esc-configuring-oidc
+    parent: esc-guides-configuring-oidc
     weight: 7
 aliases:
+  - /docs/esc/environments/configuring-oidc/vault/
   - /docs/pulumi-cloud/oidc/provider/vault
   - /docs/pulumi-cloud/oidc/provider/vault/
   - /docs/administration/access-identity/oidc/provider/vault

--- a/content/docs/esc/guides/importing-environments.md
+++ b/content/docs/esc/guides/importing-environments.md
@@ -7,7 +7,7 @@ menu:
   esc:
     parent: esc-guides
     identifier: esc-guides-importing-environments
-    weight: 5
+    weight: 50
 aliases:
   - /docs/esc/get-started/import-environments/
   - /docs/pulumi-cloud/esc/get-started/import-environments/

--- a/content/docs/esc/guides/integrate-with-pulumi-iac.md
+++ b/content/docs/esc/guides/integrate-with-pulumi-iac.md
@@ -7,7 +7,7 @@ menu:
   esc:
     parent: esc-guides
     identifier: esc-guides-integrate-pulumi-iac
-    weight: 1
+    weight: 10
 aliases:
   - /docs/esc/get-started/integrate-with-pulumi-iac/
   - /docs/pulumi-cloud/esc/get-started/integrate-with-pulumi-iac/
@@ -112,7 +112,7 @@ values:
 
 This pattern works everywhere Pulumi runs: locally, in CI/CD, Pulumi Deployments, and GitHub Actions. Similar patterns are available for Azure (`fn::open::azure-login`) and GCP (`fn::open::gcp-login`).
 
-Learn more in [Dynamic login credentials](/docs/esc/integrations/dynamic-login-credentials/) and [Configuring OIDC](/docs/esc/environments/configuring-oidc/).
+Learn more in [Dynamic login credentials](/docs/esc/integrations/dynamic-login-credentials/) and [Configuring OIDC](/docs/esc/guides/configuring-oidc/).
 
 ### Managing API keys and secrets
 

--- a/content/docs/esc/guides/managing-secrets.md
+++ b/content/docs/esc/guides/managing-secrets.md
@@ -7,7 +7,7 @@ menu:
   esc:
     parent: esc-guides
     identifier: esc-guides-managing-secrets
-    weight: 2
+    weight: 30
 aliases:
   - /docs/esc/get-started/store-and-retrieve-secrets/
   - /docs/pulumi-cloud/esc/get-started/store-and-retrieve-secrets/

--- a/content/docs/esc/guides/running-commands-with-esc.md
+++ b/content/docs/esc/guides/running-commands-with-esc.md
@@ -7,7 +7,7 @@ menu:
   esc:
     parent: esc-guides
     identifier: esc-guides-running-commands
-    weight: 3
+    weight: 40
 ---
 
 This guide shows you how to use `esc run` to inject secrets and configuration from ESC environments into any command or script as environment variables.

--- a/content/docs/esc/integrations/dynamic-login-credentials/_index.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/_index.md
@@ -17,7 +17,7 @@ aliases:
 
 Pulumi ESC integrates with the following dynamic login providers to enables you to log in to your account using OpenID Connect (OIDC) or by providing static credentials. The provider will return a set of credentials that can be used to access resources or fetch secrets.
 
-To learn how to set up and use each provider, follow the links below. To learn how to configure OpenID Connect (OIDC) for the providers that support it, see [OpenID Connect integration](/docs/esc/environments/configuring-oidc/).
+To learn how to set up and use each provider, follow the links below. To learn how to configure OpenID Connect (OIDC) for the providers that support it, see [OpenID Connect integration](/docs/esc/guides/configuring-oidc/).
 
 | Provider                                                                             | Description                                                                                                   |
 |--------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|

--- a/content/docs/esc/integrations/dynamic-login-credentials/aws-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/aws-login.md
@@ -35,7 +35,7 @@ values:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/aws/) documentation.
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/aws/) documentation.
 
 ## Inputs
 
@@ -52,7 +52,7 @@ To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, se
 | `sessionName` | string   | The name of the role session.                                                                                                                                                                                                                     |
 | `duration`    | string   | [Optional] - The duration of the role session. Defaults to 2 hours. Unless explicitly specified, AWS sets MaxDuration to 1 hour by default. You may need to configure your AWS role with a higher MaxDuration or set the duration here to 1 hour. |
 | `policyArns`  | string[] | [Optional] - ARNs for additional policies to apply to the role session.                                                                                                                                                                           |
-| `subjectAttributes`  | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/environments/configuring-oidc/#custom-token-claim) documentation |
+| `subjectAttributes`  | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/guides/configuring-oidc/#custom-token-claim) documentation |
 
 ### AWSLoginStatic
 

--- a/content/docs/esc/integrations/dynamic-login-credentials/azure-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/azure-login.md
@@ -31,7 +31,7 @@ values:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Azure, see the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/azure/) documentation.
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Azure, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/azure/) documentation.
 
 ## Inputs
 
@@ -42,7 +42,7 @@ To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Azure, 
 | `subscriptionId` | string | The subscription ID to use                                        |
 | `clientSecret`   | string | [Optional] - The client secret to use for authentication, if any. |
 | `oidc`           | bool   | [Optional] - Whether to use OIDC to log in. Defaults to `false`.  |
-| `subjectAttributes`  | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/environments/configuring-oidc/#custom-token-claim) documentation |
+| `subjectAttributes`  | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/guides/configuring-oidc/#custom-token-claim) documentation |
 
 ## Outputs
 

--- a/content/docs/esc/integrations/dynamic-login-credentials/doppler-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/doppler-login.md
@@ -33,7 +33,7 @@ values:
 ## Configuring OIDC
 
 To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Doppler, see
-the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/doppler/) documentation.
+the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/doppler/) documentation.
 
 ## Inputs
 
@@ -46,7 +46,7 @@ the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/doppler
 | Property            | Type     | Description                                                                                                                                                                                              |
 |---------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `identityId`        | string   | The identityId of the Doppler service account identity to assume.                                                                                                                                                                |
-| `subjectAttributes` | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/environments/configuring-oidc/#custom-token-claim) documentation |
+| `subjectAttributes` | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/guides/configuring-oidc/#custom-token-claim) documentation |
 
 ## Outputs
 

--- a/content/docs/esc/integrations/dynamic-login-credentials/gcp-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/gcp-login.md
@@ -67,7 +67,7 @@ This configuration enables:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Google Cloud, see the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/gcp/) documentation.
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Google Cloud, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/gcp/) documentation.
 
 ## Inputs
 
@@ -94,7 +94,7 @@ To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Google 
 | `serviceAccount` | string | The email address of the service account to use.                           |
 | `region`         | string | [Optional] - The region of the GCP project.                                |
 | `tokenLifetime`  | string | [Optional] - The lifetime of the temporary credentials.                    |
-| `subjectAttributes`  | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/environments/configuring-oidc/#custom-token-claim) documentation |
+| `subjectAttributes`  | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/guides/configuring-oidc/#custom-token-claim) documentation |
 
 ## Outputs
 

--- a/content/docs/esc/integrations/dynamic-login-credentials/infisical-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/infisical-login.md
@@ -33,7 +33,7 @@ values:
 ## Configuring OIDC
 
 To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Infisical, see
-the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/infisical/) documentation.
+the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/infisical/) documentation.
 
 ## Inputs
 
@@ -48,7 +48,7 @@ the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/infisic
 | Property            | Type     | Description                                                                                                                                                                                              |
 |---------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `identityId`        | string   | The identityId of the Identity to assume.                                                                                                                                                                |
-| `subjectAttributes` | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/environments/configuring-oidc/#custom-token-claim) documentation |
+| `subjectAttributes` | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/guides/configuring-oidc/#custom-token-claim) documentation |
 
 ### InfisicalLoginStatic
 

--- a/content/docs/esc/integrations/dynamic-login-credentials/vault-login.md
+++ b/content/docs/esc/integrations/dynamic-login-credentials/vault-login.md
@@ -44,7 +44,7 @@ values:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Vault, see the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/vault/) documentation.
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Vault, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/vault/) documentation.
 
 ## Inputs
 
@@ -61,7 +61,7 @@ To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Vault, 
 |----------|--------|-----------------------------------------------------------|
 | `role`   | string | The name of the role to use for login.                    |
 | `mount`  | string | [Optional] - The name of the authentication engine mount. Defaults to `jwt`. |
-| `subjectAttributes`  | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/environments/configuring-oidc/#custom-token-claim) documentation |
+| `subjectAttributes`  | string[] | [Optional] - Subject attributes to be included in the OIDC token. For more information see the [OpenID subject customization](/docs/esc/guides/configuring-oidc/#custom-token-claim) documentation |
 
 ### VaultLoginToken
 

--- a/content/docs/esc/integrations/dynamic-secrets/aws-parameter-store.md
+++ b/content/docs/esc/integrations/dynamic-secrets/aws-parameter-store.md
@@ -45,7 +45,7 @@ values:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/aws/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/aws/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
 
 * `esc open <org>/<project>/<environment>` command of the [Pulumi ESC CLI](/docs/esc-cli/)
 * `pulumi env open <org>/<project>/<environment>` command of the [Pulumi CLI](/docs/install/)

--- a/content/docs/esc/integrations/dynamic-secrets/aws-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/aws-secrets.md
@@ -68,7 +68,7 @@ values:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see [Configuring OpenID Connect for AWS](/docs/esc/environments/configuring-oidc/aws/). Once you have completed these steps, you can validate that your configuration is working by running either of the following:
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see [Configuring OpenID Connect for AWS](/docs/esc/guides/configuring-oidc/aws/). Once you have completed these steps, you can validate that your configuration is working by running either of the following:
 
 * `esc open <org>/<project>/<environment>` command of the [Pulumi ESC CLI](/docs/esc-cli/)
 * `pulumi env open <org>/<project>/<environment>` command of the [Pulumi CLI](/docs/install/)

--- a/content/docs/esc/integrations/dynamic-secrets/azure-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/azure-secrets.md
@@ -39,7 +39,7 @@ values:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Azure, see the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/azure/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Azure, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/azure/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
 
 * `esc open <org>/<project>/<environment>` command of the [Pulumi ESC CLI](/docs/esc-cli/)
 * `pulumi env open <org>/<project>/<environment>` command of the [Pulumi CLI](/docs/install/)

--- a/content/docs/esc/integrations/dynamic-secrets/doppler-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/doppler-secrets.md
@@ -40,7 +40,7 @@ values:
 ## Configuring OIDC
 
 To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Doppler, see
-the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/doppler/) documentation. Once you have completed
+the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/doppler/) documentation. Once you have completed
 these steps, you can validate that your configuration is working by running either of the following:
 
 * `esc open <org>/<project>/<environment>` command of the [Pulumi ESC CLI](/docs/esc-cli/)

--- a/content/docs/esc/integrations/dynamic-secrets/gcp-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/gcp-secrets.md
@@ -40,7 +40,7 @@ values:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Google Cloud, see the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/gcp/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Google Cloud, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/gcp/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
 
 * `esc open <org>/<project>/<environment>` command of the [Pulumi ESC CLI](/docs/esc-cli/)
 * `pulumi env open <org>/<project>/<environment>` command of the [Pulumi CLI](/docs/install/)

--- a/content/docs/esc/integrations/dynamic-secrets/infisical-secrets.md
+++ b/content/docs/esc/integrations/dynamic-secrets/infisical-secrets.md
@@ -42,7 +42,7 @@ values:
 ## Configuring OIDC
 
 To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Infisical, see
-the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/infisical/) documentation. Once you have completed
+the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/infisical/) documentation. Once you have completed
 these steps, you can validate that your configuration is working by running either of the following:
 
 * `esc open <org>/<project>/<environment>` command of the [Pulumi ESC CLI](/docs/esc-cli/)

--- a/content/docs/esc/integrations/rotated-secrets/aws-iam.md
+++ b/content/docs/esc/integrations/rotated-secrets/aws-iam.md
@@ -63,7 +63,7 @@ values:
 
 ## Configuring OIDC
 
-To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see the [OpenID Connect integration](/docs/esc/environments/configuring-oidc/aws/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
+To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/aws/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
 
 * `esc open <org>/<project>/<environment>` command of the [Pulumi ESC CLI](/docs/esc-cli/)
 * `pulumi env open <org>/<project>/<environment>` command of the [Pulumi CLI](/docs/install/)

--- a/content/docs/insights/discovery/accounts.md
+++ b/content/docs/insights/discovery/accounts.md
@@ -125,7 +125,7 @@ The AWS scanner for Pulumi Cloud requires access to the AWS account you want to 
   Learn more about the [AWS ReadOnlyAccess policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ReadOnlyAccess.html).  
 {{< /notes >}}
 
-3. **Create an ESC environment**: Configure it to assume the role via OIDC. See [ESC AWS provider documentation](/docs/esc/environments/configuring-oidc/aws/).
+3. **Create an ESC environment**: Configure it to assume the role via OIDC. See [ESC AWS provider documentation](/docs/esc/guides/configuring-oidc/aws/).
 
 4. **Assign the ESC environment**: Link the ESC environment to your Insights account during account creation.
 
@@ -140,7 +140,7 @@ The Azure scanner for Pulumi Cloud requires access to your Azure subscription. T
 #### Option 1: OIDC authentication (recommended)
 
 1. Create a Microsoft Entra application and configure federated credentials:
-   * Follow the steps in [Configuring OpenID Connect for Azure](/docs/esc/environments/configuring-oidc/azure/)
+   * Follow the steps in [Configuring OpenID Connect for Azure](/docs/esc/guides/configuring-oidc/azure/)
    * When configuring the federated credential:
      * **Audience**: `azure:<your-pulumi-org-name>`
      * **Subject identifier**: `pulumi:environments:org:<your-pulumi-org-name>:env:<esc-project-name>/<esc-environment-name>`
@@ -387,7 +387,7 @@ echo "Kubeconfig written to $KUBECONFIG_PATH"
 The Google Cloud scanner for Pulumi Cloud requires read access to your project. Configure ESC to generate Service Account credentials dynamically through OpenID Connect (OIDC).
 
 1. Configure OpenID Connect for Google Cloud:
-   * Follow the steps in [Configuring OpenID Connect For Google Cloud](/docs/esc/environments/configuring-oidc/gcp/)
+   * Follow the steps in [Configuring OpenID Connect For Google Cloud](/docs/esc/guides/configuring-oidc/gcp/)
    * The service account must be granted the **Viewer** role
 
 2. Use the following ESC configuration:

--- a/content/docs/insights/discovery/get-started/begin.md
+++ b/content/docs/insights/discovery/get-started/begin.md
@@ -77,7 +77,7 @@ This will set up a trust relationship to allow Pulumi Cloud to assume the role u
 }
 ```
 
-For a more detailed step-by-step guide, including screenshots see the [Configuring OpenID Connect for AWS](/docs/esc/environments/configuring-oidc/aws/) Pulumi documentation.
+For a more detailed step-by-step guide, including screenshots see the [Configuring OpenID Connect for AWS](/docs/esc/guides/configuring-oidc/aws/) Pulumi documentation.
 
 Next, go back to Pulumi ESC and configure your cloud credentials using the role ARN and trust relationship you just created:
 


### PR DESCRIPTION
Reorganizes OIDC configuration documentation from /docs/esc/environments/configuring-oidc/ to /docs/esc/guides/configuring-oidc/ to better reflect its nature as step-by-step setup guides. Positions OIDC guides after "Integrate with Pulumi IaC" and before "Managing Secrets" as it's typically one of the first things customers set up.

Changes:
- Moved 7 OIDC documentation files to guides section
- Added aliases to preserve SEO and external links
- Updated navigation weights to multiples of 10 to reduce future churn
- Updated all internal links in docs and product pages

Fixes #17315
