### PR TITLE
Restore Dependabot ignore rule for pulumi/action-install-pulumi-cli

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,6 +90,8 @@ updates:
     labels: ["dependencies", "github-actions"]
     commit-message:
       prefix: "ci"
+    ignore:
+      - dependency-name: "pulumi/action-install-pulumi-cli"
 
   # Python dependencies
   - package-ecosystem: "pip"

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -3402,6 +3402,13 @@ On the first Monday of each month, Dependabot generates exactly 5 grouped PRs (o
 - Reason: Breaking changes require manual migration
 - Revisit: During planned design system updates
 
+**pulumi/action-install-pulumi-cli:**
+- Ignored in `dependabot.yml` GitHub Actions section
+- Reason: v2+ has circular dependency on `versions.json` which the CLI release workflow creates
+- Current version: v1.0.1 (downloads directly from GitHub releases)
+- Usage: `.github/workflows/pulumi-cli.yml` only; `pulumi/actions` should be used elsewhere
+- Revisit: When action is fixed to support direct GitHub release downloads without `versions.json`
+
 **Major Versions (Wildcard):**
 - Ignored across all ecosystems via wildcard rule
 - Reason: Breaking changes require manual review and testing


### PR DESCRIPTION
## Summary

Restores the Dependabot ignore rule that was added in PR #17271 but accidentally removed in PR #17323 during configuration restructure. Also adds documentation for this exception.

## Changes

- Add ignore rule to `.github/dependabot.yml` GitHub Actions section
- Document exception in `BUILD-AND-DEPLOY.md` "Known exceptions" section

## Background

- `pulumi/action-install-pulumi-cli@v1.0.1` is used in `.github/workflows/pulumi-cli.yml`
- v2+ has a circular dependency on `versions.json` (the file that the workflow creates)
- v1.0.1 downloads directly from GitHub releases without this dependency
- Without this ignore rule, Dependabot will create PRs to upgrade to v2+, which would break CLI releases

## Test Plan

- [x] Verify ignore rule present in `.github/dependabot.yml`
- [x] Verify documentation present in `BUILD-AND-DEPLOY.md`
- [x] Verify workflow still uses v1.0.1
- [x] Verify site builds successfully