### PR TITLE
add http_server_port config option to customer managed agents

### DIFF
--- a/content/docs/deployments/deployments/customer-managed-agents.md
+++ b/content/docs/deployments/deployments/customer-managed-agents.md
@@ -155,6 +155,10 @@ env_forward_allowlist: []
 # Deployment target for the agent: docker (default) or kubernetes
 # Environment variable override: PULUMI_AGENT_DEPLOY_TARGET
 deploy_target: "docker"
+
+# Port of health check endpoint
+# Environment variable override: PULUMI_AGENT_HTTP_SERVER_PORT
+http_server_port: 8080
 ```
 
 ### Kubernetes-Managed Agents


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

add http_server_port config option to customer managed agents

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
