### PR TITLE
Add fast-track CI for version file updates

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,9 +8,82 @@ permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      version-files-only: ${{ steps.check.outputs.version-files-only }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            version-files:
+              - 'static/latest-dev-version'
+              - 'static/latest-version'
+              - 'static/esc/latest-version'
+              - 'static/customer-managed-workflow-agent/latest-version'
+            other-files:
+              - '**/*'
+              - '!static/latest-dev-version'
+              - '!static/latest-version'
+              - '!static/esc/latest-version'
+              - '!static/customer-managed-workflow-agent/latest-version'
+
+      - name: Check if version files only
+        id: check
+        run: |
+          if [[ "${{ steps.filter.outputs.version-files }}" == "true" && "${{ steps.filter.outputs.other-files }}" == "false" ]]; then
+            echo "version-files-only=true" >> $GITHUB_OUTPUT
+          else
+            echo "version-files-only=false" >> $GITHUB_OUTPUT
+          fi
+
+  fast-track-version-update:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.version-files-only == 'true'
+    name: Fast-track version file validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.154.5'
+          extended: true
+
+      - name: Install dependencies
+        run: make ensure
+
+      - name: Validate version files
+        run: |
+          # Check for whitespace in version files
+          for file in static/latest-dev-version static/latest-version static/esc/latest-version static/customer-managed-workflow-agent/latest-version; do
+            if [[ -f "$file" ]]; then
+              if grep -q '[[:space:]]' "$file"; then
+                echo "ERROR: $file contains whitespace"
+                exit 1
+              fi
+              echo "✓ $file is valid"
+            fi
+          done
+
+      - name: Quick Hugo build test
+        run: hugo --minify --quiet
+        env:
+          HUGO_ENVIRONMENT: production
+
   buildSite:
     # Only run this job for events that originate on this repository.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: detect-changes
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.detect-changes.outputs.version-files-only == 'false'
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Install deps and build site
@@ -70,10 +143,13 @@ jobs:
           name: origin-bucket-metadata
           path: origin-bucket-metadata.json
   notify:
-    if: (startsWith(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'pulumi-bot')) && failure()
+    if: |
+      always() &&
+      (startsWith(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'pulumi-bot')) &&
+      (needs.buildSite.result == 'failure' || needs.fast-track-version-update.result == 'failure')
     name: Send slack notification
     runs-on: ubuntu-latest
-    needs: [buildSite]
+    needs: [detect-changes, fast-track-version-update, buildSite]
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets


### PR DESCRIPTION
## Problem

Version files (`static/latest-dev-version`, `static/latest-version`, etc.) are updated multiple times daily via automated PRs. These PRs often get delayed or blocked by:

- Transient CI/CD failures  
- Long-running test suites (~10-15 minutes)
- Full site builds and deployments for a 22-byte text file change

Current workflow runs expensive checks that aren't necessary for version files:
- Full Hugo site build and deployment to test environment
- Cypress browser tests
- Example code tests
- All this for a simple text file update

## Proposed Solution

This PR adds a fast-track validation path for PRs that **only** change version files:

- `static/latest-dev-version`
- `static/latest-version`
- `static/esc/latest-version`
- `static/customer-managed-workflow-agent/latest-version`

### How It Works

**New `detect-changes` job:**
- Uses `dorny/paths-filter` to analyze changed files
- Outputs `version-files-only` flag (true/false)

**New `fast-track-version-update` job (runs when version-files-only=true):**
- Installs dependencies (`make ensure`)
- Validates no whitespace in version files (critical requirement)
- Runs quick Hugo build test (`hugo --minify --quiet`)
- **Duration:** ~2-3 minutes

**Updated `buildSite` job:**
- Now conditional: only runs when `version-files-only=false`
- Preserves all existing functionality for regular PRs

### What's Validated

✅ No whitespace in version files (enforced by Hugo template)  
✅ Hugo can build successfully  
✅ Dependencies install correctly

### What's Skipped (for version files only)

❌ Full site deployment to S3  
❌ Cypress browser tests  
❌ Search index generation

These are unnecessary because version files are plain text served directly and don't affect site rendering.

## Benefits

1. **5-7x faster merges:** Version updates merge in 2-3 minutes instead of 10-15+ minutes
2. **Fewer failures:** Reduced test surface area = fewer transient failure points
3. **Same safety:** Hugo validation still runs, catches whitespace errors
4. **Audit trail preserved:** PRs still created, just merge faster
5. **Automatic:** Works for all four version files with no changes to existing automation

## Questions for Review

@justinvp @cnunciato - I'd like your feedback on this approach:

1. **Is this optimization worthwhile?** Does the complexity of conditional CI paths justify the time savings?
2. **Are we skipping anything critical?** The fast-track validation includes whitespace checking and Hugo build, but skips deployment/tests.
3. **Alternative approach?** Would you prefer a different strategy (e.g., direct S3 updates, separate workflow)?

If this seems unnecessary or overly complex, I'm happy to abandon the approach. The current workflow does eventually succeed, it just takes longer and occasionally hits transient failures.

## Testing Plan

If approved:
1. Merge this PR
2. Create a test PR that only changes `static/latest-dev-version`
3. Verify fast-track job runs (~2-3 min) and buildSite is skipped
4. Monitor next automated version update PR to confirm it merges quickly