### PR TITLE
Add CfgMgmtCamp 2026 Ghent workshop to Engin's profile

### DIFF
--- a/content/community/community-engineering/engin-diri.md
+++ b/content/community/community-engineering/engin-diri.md
@@ -8,6 +8,10 @@ layout: community-engineering/single
 aliases:
   - /engin
 talks:
+- event: "CfgMgmtCamp 2026 Ghent"
+  title: "Building AI-Assisted Operations: Agentic AI Workshop"
+  url: "https://cfp.cfgmgmtcamp.org/ghent2026/talk/DCRWVC/"
+  date: 2026-02-04T09:00:00.000+01:00
 - event: "AWS / Honeycomb / Pulumi Workshop"
   title: "AI Agents That Reason Over Your Infrastructure"
   url: "https://www.pulumi.com/events/ai-agents-that-reason/"


### PR DESCRIPTION
## Summary
- Adds the "Building AI-Assisted Operations: Agentic AI Workshop" to Engin Diri's community engineering profile
- Workshop taking place at CfgMgmtCamp 2026 Ghent on February 4, 2026

## Test plan
- [x] Verify the workshop appears correctly on Engin's profile page