### PR TITLE
Event landing-page template follow-ups

### DIFF
--- a/content/kubecon/_index.md
+++ b/content/kubecon/_index.md
@@ -131,7 +131,7 @@ location:
     March 23-26, 2026
   description: |
     Stop by to see Neo in action, grab an exclusive Neo plushie, register for $500 in AWS credits, and talk infrastructure automation with the Pulumi engineering team.
-  map_embed: '<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2437.6116720155323!2d4.886040676670286!3d52.341190572014874!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c60a1f63d57e25%3A0xa08f37a724d09338!2sAmsterdam%20RAI!5e0!3m2!1sen!2sus!4v1769463657049!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>'
+  map_embed: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2437.6116720155323!2d4.886040676670286!3d52.341190572014874!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c60a1f63d57e25%3A0xa08f37a724d09338!2sAmsterdam%20RAI!5e0!3m2!1sen!2sus!4v1769463657049!5m2!1sen!2sus"
   cta_text: Book a technical demo
   cta_link: https://info.pulumi.com/book-demo-kubecon-2026
   anchor: location

--- a/layouts/partials/template-partials/template-card.html
+++ b/layouts/partials/template-partials/template-card.html
@@ -36,13 +36,13 @@
         </div>
 
         {{ if $description }}
-        <div class="card-description mb-4">
+        <div class="card-description mb-6">
             {{ $description | markdownify }}
         </div>
         {{ end }}
 
         {{ if $ctaText }}
-        <a href="{{ $ctaLink }}" class="btn-secondary-template-variant self-start">{{ $ctaText }}</a>
+        <a href="{{ $ctaLink }}" class="btn-secondary-template-variant block text-center xl:text-left self-start w-full xl:w-auto">{{ $ctaText }}</a>
         {{ end }}
     </div>
 </div>

--- a/layouts/partials/template-partials/template-footer-cta.html
+++ b/layouts/partials/template-partials/template-footer-cta.html
@@ -18,16 +18,16 @@
 {{ $anchor := .anchor }}
 
 <section class="template-footer"{{ if $anchor }} id="{{ $anchor }}"{{ end }}>
-    <div class="flex flex-col xxl:flex-row items-start xxl:items-center justify-center lg:justify-between gap-8">
+    <div class="flex flex-col xxl:flex-row items-start xxl:items-center justify-center lg:justify-between gap-6">
         {{ if $title }}
         <h2 class="template-footer-title text-left xxl:text-center">{{ $title }}</h2>
         {{ end }}
-        <div class="flex flex-col sm:flex-row gap-4 justify-start items-start sm:items-center">
+        <div class="flex flex-col lg:flex-row w-full xl:w-auto gap-4 items-center">
             {{ if $ctaPrimaryText }}
-            <a href="{{ $ctaPrimaryLink }}" class="btn-primary">{{ $ctaPrimaryText }}</a>
+            <a href="{{ $ctaPrimaryLink }}" class="btn-primary text-center w-full lg:w-1/2 xl:w-auto">{{ $ctaPrimaryText }}</a>
             {{ end }}
             {{ if $ctaSecondaryText }}
-            <a href="{{ $ctaSecondaryLink }}" class="btn-secondary">{{ $ctaSecondaryText }}</a>
+            <a href="{{ $ctaSecondaryLink }}" class="btn-secondary text-center w-full lg:w-1/2 xl:w-auto">{{ $ctaSecondaryText }}</a>
             {{ end }}
         </div>
     </div>

--- a/layouts/partials/template-partials/template-hero.html
+++ b/layouts/partials/template-partials/template-hero.html
@@ -56,13 +56,13 @@
             {{ end }}
             <p class="description mb-12">{{ $description }}</p>
             {{ if $ctaText }}
-            <div class="flex flex-col sm:flex-row items-start gap-4">
-                <a href="{{ $ctaLink }}" class="btn-primary-template-variant inline-flex items-center gap-2">
+            <div class="flex flex-col lg:flex-row items-start gap-4">
+                <a href="{{ $ctaLink }}" class="btn-primary-template-variant inline-flex items-center gap-2 w-full xl:w-auto justify-center xl:justify-start">
                     <span>{{ $ctaText }}</span>
                     <span>→</span>
                 </a>
                 {{ if $ctaSecondaryText }}
-                <a href="{{ $ctaSecondaryLink }}" class="btn-secondary-template-variant inline-flex items-center gap-2">
+                <a href="{{ $ctaSecondaryLink }}" class="btn-secondary-template-variant inline-flex items-center gap-2 w-full xl:w-auto justify-center xl:justify-start">
                     <span>{{ $ctaSecondaryText }}</span>
                     <span>→</span>
                 </a>

--- a/layouts/partials/template-partials/template-location.html
+++ b/layouts/partials/template-partials/template-location.html
@@ -26,8 +26,8 @@
 {{ $anchor := .anchor }}
 
 <section class="template-location"{{ if $anchor }} id="{{ $anchor }}"{{ end }}>
-    <div class="flex flex-col xl:flex-row justify-between items-start xl:items-center gap-8">
-        <div>
+    <div class="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-8">
+        <div class="w-full lg:w-1/2">
             {{ if $tagLine }}
             <div class="mb-4">
                 <span class="location-tag-line">{{ $tagLine }}</span>
@@ -53,13 +53,19 @@
             <a href="{{ $ctaLink }}" target="_blank" class="btn-primary-template-variant">{{ $ctaText }}</a>
             {{ end }}
         </div>
-        <div class="hidden md:block">
+        <div class="w-full lg:w-1/2">
             {{ if $mapEmbed }}
-            <div class="w-full md:max-w-2xl">
-                {{ $mapEmbed | safeHTML }}
+            <div class="relative w-full overflow-hidden mt-4 lg:mt-0" style="padding-top: 75%;">
+                <iframe
+                    src="{{ $mapEmbed }}"
+                    class="absolute top-0 left-0 w-full h-full border-0"
+                    loading="lazy"
+                    referrerpolicy="no-referrer-when-downgrade"
+                    allowfullscreen
+                ></iframe>
             </div>
             {{ else if $mapImage }}
-            <div class="w-full rounded-lg overflow-hidden shadow-lg">
+            <div class="w-full rounded-lg overflow-hidden mt-4 lg:mt-0">
                 <img src="{{ $mapImage }}" alt="Event location map" class="w-full h-auto" />
             </div>
             {{ end }}

--- a/layouts/partials/template-partials/template-three-column.html
+++ b/layouts/partials/template-partials/template-three-column.html
@@ -47,7 +47,7 @@
             <p class="three-column-item-description mb-6">{{ .description | markdownify }}</p>
             {{ end }}
             {{ if .cta_text }}
-            <a href="{{ .cta_link }}" class="btn-secondary-template-variant">{{ .cta_text }}</a>
+            <a href="{{ .cta_link }}" class="btn-secondary-template-variant block xl:inline-block text-center xl:text-left self-start w-full xl:w-auto">{{ .cta_text }}</a>
             {{ end }}
         </div>
         {{ end }}

--- a/theme/src/scss/_templates.scss
+++ b/theme/src/scss/_templates.scss
@@ -185,12 +185,6 @@ $violet-primary: #673EAC;
     .card-description {
         @include section-body-medium();
     }
-
-    .btn-secondary-template-variant {
-        display: inline-block;
-        width: auto;
-        align-self: flex-start;
-    }
 }
 
 .template-promo-banner {
@@ -230,12 +224,6 @@ $violet-primary: #673EAC;
 
     .three-column-item-description {
         @include section-body-medium();
-    }
-
-    .btn-secondary-template-variant {
-        display: inline-block;
-        width: auto;
-        align-self: flex-start;
     }
 }
 


### PR DESCRIPTION
Makes a few final adjustments to the event landing-page template:

* Use full-width buttons on mobile
* Stack buttons when grouped (e.g., in the hero, footer)
* Show the map on mobile and tablet

https://github.com/user-attachments/assets/0cdcad7f-99ac-4518-bc5b-620f516fe542

Fixes pulumi/marketing#1604.
