### PR TITLE
Add redirect for Pulumi .NET reference documentation

### DIFF
--- a/scripts/redirects/general-broken-links-redirects.txt
+++ b/scripts/redirects/general-broken-links-redirects.txt
@@ -32,4 +32,4 @@ docs/insights/policy/metadata/index.html|/docs/insights/policy/policy-packs/meta
 docs/iac/using-pulumi/crossguard/core-concepts/index.html|/docs/insights/policy/
 blog/pulumi-kubernetes-operator-2-0-ga/index.html|/blog/pko-2-0-ga/
 registry/packages/pinecone/api-docs/pineconeindex/index.html|/registry/packages/pinecone/
-/docs/reference/pkg/dotnet/pulumi/pulumi.html|/docs/reference/pkg/dotnet/Pulumi/Pulumi.html
+docs/reference/pkg/dotnet/pulumi/pulumi.html|/docs/reference/pkg/dotnet/Pulumi/Pulumi.html


### PR DESCRIPTION
Discovered an issue with the .NET SDK links in the left nav--apparently they're case sensitive links, and Hugo is smooshing them to lower case. This handles that.

