### PR TITLE
fix: Address broken links reported in issue #17506

### DIFF
--- a/content/docs/administration/access-identity/rbac/scopes/org-settings.md
+++ b/content/docs/administration/access-identity/rbac/scopes/org-settings.md
@@ -16,7 +16,7 @@ aliases:
 - /docs/pulumi-cloud/access-management/rbac/scopes/org-settings/
 ---
 
-This document defines all the available scopes in Pulumi Cloud, organized by [entity type](../permission-sets#entity-types) and group.
+This document defines all the available scopes in Pulumi Cloud, organized by [entity type](../../permission-sets#entity-types) and group.
 
 ## Agent Pools
 

--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -400,6 +400,7 @@ function getDefaultExcludedKeywords() {
         "https://github.com/jasonsmithio/pulumi-experiments",
         // Old example repository paths that have been renamed or removed
         "https://github.com/pulumi/examples/tree/master/aws-js-webserver",
+        "https://github.com/pulumi/examples/blob/master/aws-js-webserver/index.js",
         "https://github.com/pulumi/examples/tree/master/aws-js-s3-folder",
         "https://github.com/pulumi/examples/tree/master/aws-js-sqs-slack",
         "https://github.com/pulumi/examples/tree/master/aws-py-oidc-provider-pulumi-cloud",
@@ -446,6 +447,9 @@ function excludeAcceptable(links) {
 
         // Ignore HTTP 503s.
         .filter(b => b.reason !== "HTTP_503")
+
+        // Ignore HTTP 502s (Bad Gateway - transient server errors).
+        .filter(b => b.reason !== "HTTP_502")
 
         // Ignore HTTP 415s (Unsupported Media Type - often bot protection).
         .filter(b => b.reason !== "HTTP_415")


### PR DESCRIPTION
Fixes three categories of broken links identified by the automated link checker:

## Changes
- Fixed relative path for internal link in org-settings.md (changed `../` to `../../` for correct navigation to permission-sets#entity-types anchor)
- Added HTTP_502 filtering to link checker to treat Bad Gateway errors like HTTP_503 (transient server issues)
- Added exception for old GitHub example repository path that no longer exists

Resolves #17506