### PR TITLE
Remove unimplemented status options from Policy Findings docs

### DIFF
--- a/content/docs/insights/policy/policy-findings.md
+++ b/content/docs/insights/policy/policy-findings.md
@@ -86,7 +86,7 @@ For organizations with access to Pulumi Neo, you can select multiple issues and 
 
 For each issue, you can set:
 
-- **Status:** Open, In Progress, By Design, Fixed, or Ignored (By Design and Ignored require justification)
+- **Status:** Open, In Progress, Fixed, or Ignored
 - **Priority:** P0 (critical) through P4 (low)
 - **Assignment:** Assign to specific team members in your organization
 


### PR DESCRIPTION
Remove "By Design" status option and associated justification text since these features are not yet implemented.

Slack thread: https://pulumi.slack.com/archives/CJUCSNNNS/p1770769705238459?thread_ts=1770739110.783089&cid=CJUCSNNNS

https://claude.ai/code/session_014DxEYCdTKJ6G6ezRdcLjXy

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
