### PR TITLE
note about supported union types

### DIFF
--- a/content/docs/iac/concepts/components/_index.md
+++ b/content/docs/iac/concepts/components/_index.md
@@ -149,7 +149,7 @@ The following types are supported in component arguments:
 
 The following types are not supported in component arguments:
 
-- **Union types**: TypeScript and Python union types like `string | number` are not supported due to limitations in schema inference. One exception to this are unions consisting of `undefined` (TypeScript) or `None` (Python) and exactly one other type, for example `string | undefined`, or `str | None`. These are supported and signify optional values.
+- **Union types**: TypeScript and Python union types like `string | number` are not supported due to limitations in schema inference. One exception: unions of `undefined` (TypeScript) or `None` (Python) with exactly one other type are supported to represent optional values (e.g., `string | undefined` or `str | None`).
 - **Functions/callbacks**: Functions cannot be used in component arguments as they cannot be represented in the schema.
 - **Platform-specific types**: Types that exist only in one language and cannot be translated.
 


### PR DESCRIPTION
There's an exception to unions not being supported: we can use them for optional types.

Fixes https://github.com/pulumi/pulumi/issues/21637