### PR TITLE
Claude skill update: Refine quality checks matrix by content type

### DIFF
--- a/.claude/commands/shipit/references/quality-checks.md
+++ b/.claude/commands/shipit/references/quality-checks.md
@@ -11,11 +11,14 @@ Quick reference for quality check procedures in the `/shipit` skill.
 | Content Changed | Mandatory Checks | Optional Suggestions |
 |-------------------|------------------|---------------------|
 | Markdown files - meta content (README.md, AGENTS.md, Claude commands, etc.) | Correctness check | - |
-| Markdown files - docs/blogs/website content | `make lint` (unless already run) | `make build` (unless already run), `/docs-review` (if not in history) |
-| Hugo templates and shortcodes | `make build` (unless already run) | `/docs-review` (if not in history) |
-| Layout and style files (static/css/, static/js/) | `make build` (unless already run) | `/docs-review` (if not in history) |
-| Inline code snippets | Test inline code compilation | `/docs-review` (if not in history) |
+| Markdown files - docs/blogs/website content | `make lint` | `make build`, `/docs-review` |
+| Hugo templates and shortcodes | `make build` | `/docs-review` |
+| Layout and style files (static/css/, static/js/) | `make build` | `/docs-review` |
+| Inline code snippets | Test inline code compilation | `/docs-review` |
 | Program examples (`static/programs/`) | Test changed programs | - |
+| Other changes | Use your best judgment | - |
+
+Any check above may be skipped at your discretion, e.g. if it was run recently or is unnecessary in context.
 
 ## Detecting Already-Run Checks
 


### PR DESCRIPTION
Updates the `/shipit` skill's quality checks detection matrix to provide clearer guidance based on content type rather than file type.

## Changes
- Distinguishes meta content (README, AGENTS.md, Claude commands) from site content (docs/blogs)
- Adds explicit rows for Hugo templates and layout files
- Removes overly generic "Any" row for more precise check selection