### PR TITLE
Correct IDP documentation aliases

### DIFF
--- a/content/docs/idp/concepts/organization-templates.md
+++ b/content/docs/idp/concepts/organization-templates.md
@@ -13,6 +13,7 @@ aliases:
   - /docs/idp/developer-portals/templates/
   - /docs/pulumi-cloud/developer-platforms/templates/
   - /docs/pulumi-cloud/developer-portals/templates/
+  - /docs/idp/concepts/templates
 ---
 
 {{% notes "info" %}}

--- a/content/docs/idp/concepts/services.md
+++ b/content/docs/idp/concepts/services.md
@@ -4,7 +4,7 @@ title: Services
 h1: "Services"
 meta_desc: Learn about Pulumi Services for organizing and managing infrastructure entities.
 aliases:
-  - /docs/idp/concepts/services/
+  - /docs/idp/get-started/services/
 menu:
   idp:
     parent: idp-concepts

--- a/content/docs/idp/guides/best-practices/patterns/_index.md
+++ b/content/docs/idp/guides/best-practices/patterns/_index.md
@@ -10,7 +10,7 @@ meta_desc: Best practices patterns for building secure, scalable, and flexible d
 h1: IDP Patterns
 description: <p>Common architectural patterns and design approaches for organizing your infrastructure code and workflows with Pulumi IDP.</p>
 aliases:
-  - /docs/idp/guides/best-practices/patterns/
+  - /docs/idp/best-practices/patterns/
 ---
 
 This section provides proven patterns that help you implement best practices solutions with Pulumi IDP. Each pattern includes a description, use cases, anti-patterns, and related patterns to help you choose the right approach for your specific needs.

--- a/content/docs/idp/guides/best-practices/patterns/components-using-other-components.md
+++ b/content/docs/idp/guides/best-practices/patterns/components-using-other-components.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 70
 aliases:
-  - /docs/idp/guides/best-practices/patterns/components-using-other-components/
+  - /docs/idp/best-practices/patterns/components-using-other-components/
 meta_desc: Build complex infrastructure patterns by composing Pulumi components that use other components
 h1: "IDP Pattern: Components using other Components"
 description: <p>Build complex infrastructure patterns by composing Pulumi components that use other components.</p>

--- a/content/docs/idp/guides/best-practices/patterns/composable-environments.md
+++ b/content/docs/idp/guides/best-practices/patterns/composable-environments.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 40
 aliases:
-  - /docs/idp/guides/best-practices/patterns/composable-environments/
+  - /docs/idp/best-practices/patterns/composable-environments/
 meta_desc: Use composable Pulumi ESC environments to share configuration across services, teams, and lifecycle stages
 h1: "IDP Pattern: Composable environments"
 description: Use composable Pulumi ESC environments to share configuration across services, teams, and lifecycle stages.

--- a/content/docs/idp/guides/best-practices/patterns/cost-control-using-components-policies-constrained-inputs.md
+++ b/content/docs/idp/guides/best-practices/patterns/cost-control-using-components-policies-constrained-inputs.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 90
 aliases:
-  - /docs/idp/guides/best-practices/patterns/cost-control-using-components-policies-constrained-inputs/
+  - /docs/idp/best-practices/patterns/cost-control-using-components-policies-constrained-inputs/
 meta_desc: Implement cost control through constrained component inputs, policies, and predefined options
 allow_long_title: true
 h1: "IDP Pattern: Cost control using Components, Policies, and constrained inputs"

--- a/content/docs/idp/guides/best-practices/patterns/one-esc-environment-per-lifecycle-stage.md
+++ b/content/docs/idp/guides/best-practices/patterns/one-esc-environment-per-lifecycle-stage.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 30
 aliases:
-  - /docs/idp/guides/best-practices/patterns/one-esc-environment-per-lifecycle-stage/
+  - /docs/idp/best-practices/patterns/one-esc-environment-per-lifecycle-stage/
 meta_desc: Use one Pulumi ESC environment per lifecycle stage to manage configuration across development, staging, and production environments
 h1: "IDP Pattern: One ESC environment per lifecycle stage"
 description: <p>Use one Pulumi ESC environment per lifecycle stage to manage configuration across development, staging, and production environments.</p>

--- a/content/docs/idp/guides/best-practices/patterns/one-esc-environment-per-service.md
+++ b/content/docs/idp/guides/best-practices/patterns/one-esc-environment-per-service.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 10
 aliases:
-  - /docs/idp/guides/best-practices/patterns/one-esc-environment-per-service/
+  - /docs/idp/best-practices/patterns/one-esc-environment-per-service/
 meta_desc: Use one Pulumi ESC environment per service to maintain clear boundaries and improve security isolation in your Pulumi IDP implementation
 h1: "IDP Pattern: One ESC environment per service"
 description: <p>Use one Pulumi ESC environment per service to maintain clear boundaries and improve security isolation in your Pulumi IDP implementation.</p>

--- a/content/docs/idp/guides/best-practices/patterns/one-esc-environment-per-team.md
+++ b/content/docs/idp/guides/best-practices/patterns/one-esc-environment-per-team.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 20
 aliases:
-  - /docs/idp/guides/best-practices/patterns/one-esc-environment-per-team/
+  - /docs/idp/best-practices/patterns/one-esc-environment-per-team/
 meta_desc: Use one Pulumi ESC environment per team to align configuration management with organizational structure in your Pulumi IDP implementation
 h1: "IDP Pattern: One ESC environment per team"
 description: <p>Use one Pulumi ESC environment per team to align configuration management with organizational structure in your Pulumi IDP implementation.</p>

--- a/content/docs/idp/guides/best-practices/patterns/policies-as-tests.md
+++ b/content/docs/idp/guides/best-practices/patterns/policies-as-tests.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 60
 aliases:
-  - /docs/idp/guides/best-practices/patterns/policies-as-tests/
+  - /docs/idp/best-practices/patterns/policies-as-tests/
 meta_desc: Implement governance and compliance requirements using Pulumi policies that run as automated tests
 h1: "IDP Pattern: Policies as tests"
 description: <p>Implement governance and compliance requirements using Pulumi policies that run as automated tests.</p>

--- a/content/docs/idp/guides/best-practices/patterns/security-updates-using-components.md
+++ b/content/docs/idp/guides/best-practices/patterns/security-updates-using-components.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 100
 aliases:
-  - /docs/idp/guides/best-practices/patterns/security-updates-using-components/
+  - /docs/idp/best-practices/patterns/security-updates-using-components/
 meta_desc: Implement security updates and patches through centralized component management
 h1: "IDP Pattern: Security Updates using Components"
 description: <p>Implement security updates and patches through centralized component management.</p>

--- a/content/docs/idp/guides/best-practices/patterns/validating-component-inputs-using-policy-functions.md
+++ b/content/docs/idp/guides/best-practices/patterns/validating-component-inputs-using-policy-functions.md
@@ -6,7 +6,7 @@ menu:
     parent: idp-patterns
     weight: 80
 aliases:
-  - /docs/idp/guides/best-practices/patterns/validating-component-inputs-using-policy-functions/
+  - /docs/idp/best-practices/patterns/validating-component-inputs-using-policy-functions/
 meta_desc: Use Pulumi policy functions to validate component inputs and enforce constraints at the component level
 allow_long_title: true
 h1: "IDP Pattern: Validating Component Inputs using Policy functions"


### PR DESCRIPTION
Fixes 12 alias entries to point to OLD paths (pre-reorganization) instead of NEW paths, resolving broken links from issue #17537.

Fixes #17537