### PR TITLE
Improve search findability for providers and environment variables

### DIFF
--- a/content/docs/iac/cli/environment-variables.md
+++ b/content/docs/iac/cli/environment-variables.md
@@ -11,6 +11,22 @@ menu:
 aliases:
     - /docs/reference/cli/environment-variables/
     - /docs/cli/environment-variables/
+search:
+  keywords:
+    - PULUMI_CONFIG_PASSPHRASE
+    - PULUMI_CONFIG_PASSPHRASE_FILE
+    - PULUMI_BACKEND_URL
+    - PULUMI_ACCESS_TOKEN
+    - PULUMI_HOME
+    - PULUMI_SKIP_UPDATE_CHECK
+    - PULUMI_PARALLEL
+    - PULUMI_STACK
+    - PULUMI_DEBUG_COMMANDS
+    - PULUMI_ENABLE_LEGACY_DIFF
+    - environment variables
+    - env vars
+    - pulumi env
+  boost: true
 ---
 
 <dl class="tabular tabular-5-col break-words">

--- a/scripts/search/settings.js
+++ b/scripts/search/settings.js
@@ -21,6 +21,7 @@ module.exports = {
             [".NET", "dotnet"],
             ["aws", "aws classic"],
             ["azure", "azure native"],
+            ["aliyun", "alicloud"],
             ["azuread", "azure ad", "azure active directory"],
             ["c#", "csharp"],
             ["cfn", "cloudformation"],
@@ -123,6 +124,30 @@ module.exports = {
                             position: 0,
                             objectIDs: [
                                 page.getObjectID({ href: "/docs/pulumi-cloud/" }),
+                            ],
+                        },
+                    ],
+                },
+            },
+
+            // Promote environment variables page for queries containing "PULUMI_"
+            {
+                objectID: "contains-pulumi-env",
+                enabled: true,
+                conditions: [
+                    {
+                        anchoring: "contains",
+                        pattern: "PULUMI_",
+                        alternatives: false,
+                    }
+                ],
+                consequence: {
+                    filterPromotes: true,
+                    promote: [
+                        {
+                            position: 0,
+                            objectIDs: [
+                                page.getObjectID({ href: "/docs/iac/cli/environment-variables/" }),
                             ],
                         },
                     ],


### PR DESCRIPTION
Improves search discoverability for Alibaba Cloud provider and environment variables based on production testing.

## Changes
- Added synonym: `aliyun` ↔ `alicloud` (only new synonym needed after testing)
- Added search keywords to environment variables documentation page with boost
- Added promotion rule for searches containing `PULUMI_` (uppercase)

## Testing Results
Production testing showed:
- ✅ `aliyun` → `alicloud` synonym missing (this PR fixes it)
- ✅ Environment variable searches (`PULUMI_CONFIG_PASSPHRASE`, etc.) not finding env vars page (this PR fixes it)
- ❌ `proxmox` and `hetzner` synonyms already work in production (removed from PR)
- ❌ Provider promotion rules not needed (package filtering works well, removed from PR)

## Why Testing Environment Cannot Validate Search

Search cannot be validated in the testing environment (`www.pulumi-test.io`) because:

1. **Hardcoded index name**: Hugo templates hardcode `data-index="production"` in:
   - `layouts/partials/docs/menu.html`
   - `layouts/partials/blog/search.html`  
   - `layouts/partials/tutorials/nav.html`

2. **Shared Algolia index**: Both production and testing use the same "production" Algolia index

3. **Testing workflow**: Generates `search-index.json` and uploads to testing S3, but never pushes to Algolia

4. **Production-only updates**: The hourly "Update Search Index" cron only fetches from production URLs (`pulumi.com/search-index.json`) and updates the production index

**Validation approach**: Merge to master, wait for next hourly Algolia update (or manually trigger), then test on production.

## Impact
Fixes searches for Alibaba Cloud provider and ~40 environment variable searches per month.