### PR TITLE
Add redirect for broken GCP OIDC how-to guide

### DIFF
--- a/scripts/redirects/general-broken-links-redirects.txt
+++ b/scripts/redirects/general-broken-links-redirects.txt
@@ -1,4 +1,5 @@
 registry/packages/azure/api-docs/mobile/index.html|/registry/packages/azure/
+registry/packages/gcp/how-to-guides/gcp-py-oidc-provider-pulumi-cloud/index.html|/docs/esc/guides/configuring-oidc/gcp/
 containers/index.html|/docs/iac/clouds/kubernetes/
 docs/guides/index.html|/docs/iac/guides/
 docs/iac/guides/index.html|/docs/iac/


### PR DESCRIPTION
Redirect the broken registry page to the ESC OIDC documentation: /registry/packages/gcp/how-to-guides/gcp-py-oidc-provider-pulumi-cloud/ → /docs/esc/guides/configuring-oidc/gcp/

The original how-to guide references an example that no longer exists in the pulumi/examples repository (gcp-py-oidc-provider-pulumi-cloud). The ESC documentation provides the same functionality.

Slack thread: https://pulumi.slack.com/archives/C85BS3LJZ/p1771010871963879

https://claude.ai/code/session_01SUoxQD8M7Nnuo69kP5BWgm

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
