### PR TITLE
Fix workshop presenter assignments

### DIFF
--- a/content/events/getting-started-with-iac-aws-typescript/index.md
+++ b/content/events/getting-started-with-iac-aws-typescript/index.md
@@ -59,9 +59,9 @@ main:
 
     # The webinar presenters
     presenters:
-        - name: Engin Diri
-          role: Senior Solutions Architect, Pulumi
-          photo: /images/team/engin-diri.jpg
+        - name: Adam Gordon Bell
+          role: Community Engineer, Pulumi
+          photo: /images/team/adam-gordon-bell.jpg
 
     # case-sensitive
     tags:

--- a/content/events/getting-started-with-kubernetes-google-cloud/index.md
+++ b/content/events/getting-started-with-kubernetes-google-cloud/index.md
@@ -59,9 +59,9 @@ main:
         - Understand the lifecycle of Kubernetes infrastructure on Google Cloud
     # The webinar presenters
     presenters:
-        - name: Adam Gordon Bell
-          role: Community Engineer, Pulumi
-          photo: /images/team/adam-gordon-bell.jpg
+        - name: Engin Diri
+          role: Senior Solutions Architect, Pulumi
+          photo: /images/team/engin-diri.jpg
 
     # case-sensitive
     tags:


### PR DESCRIPTION
## Summary
- **Apr 15 AWS TypeScript**: Changed presenter from Engin → Adam to match workshop schedule spreadsheet
- **May 13 K8s on Google Cloud**: Changed presenter from Adam → Engin (rotation swap so we alternate presenters)

## Context
Workshop schedule spreadsheet is the source of truth. These event pages had stale/incorrect presenter assignments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)