### PR TITLE
Add inline code span support to blog meta image composer

### DIFF
--- a/.claude/commands/blog-meta-image/scripts/compose_meta_image.py
+++ b/.claude/commands/blog-meta-image/scripts/compose_meta_image.py
@@ -149,9 +149,15 @@ def draw_text(
             if is_code:
                 # Pill starts at current x so the full inter-word space is preserved;
                 # text is inset pad_x inside the pill on each side.
+                # Use the actual glyph bounding box for vertical placement so the
+                # visual margin is equal on top and bottom regardless of ascender/
+                # descender space in the font's line box.
                 pad_x, pad_y = 14, 6
+                glyph_bbox = active_font.getbbox(word)  # (l, top, r, bottom) rel. to y
+                glyph_top = y + glyph_bbox[1]
+                glyph_bottom = y + glyph_bbox[3]
                 pill_end = x + 2 * pad_x + word_w - letter_spacing_px
-                rect = [x, y - pad_y, pill_end, y + font_size + pad_y]
+                rect = [x, glyph_top - pad_y, pill_end, glyph_bottom + pad_y]
                 draw.rounded_rectangle(
                     rect,
                     radius=24,


### PR DESCRIPTION
## Summary

- Backtick-delimited tokens in blog post titles (e.g. `` `onError` ``) are now rendered with Iosevka Bold and a rounded-rectangle pill background instead of showing literal backtick characters
- Titles without backticks are completely unaffected
- Falls back to the regular Inter font if Iosevka is unavailable

Example output:

<img width="1200" height="628" alt="image" src="https://github.com/user-attachments/assets/2124a7d6-1cc3-4e89-952c-1c50ac58c3da" />

