### PR TITLE
Fix false-positive broken links for get.pulumi.com

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -8,15 +8,15 @@ const fs = require("fs");
 
 // Internal domain for separating internal vs external broken links
 const INTERNAL_DOMAIN = "pulumi.com";
+// CDN subdomains serve binary downloads, not documentation, and the link checker
+// cannot reliably handle CDN redirects for binary files.
+const CDN_SUBDOMAINS = ["get.pulumi.com"];
 
 // Helper function to check if a URL is an internal Pulumi link
 function isInternalLink(url) {
     try {
         const urlObj = new URL(url);
-        // Exclude CDN subdomains — these serve binary downloads, not documentation,
-        // and the link checker cannot reliably handle CDN redirects for binary files.
-        const cdnSubdomains = ["get.pulumi.com"];
-        if (cdnSubdomains.includes(urlObj.hostname)) return false;
+        if (CDN_SUBDOMAINS.includes(urlObj.hostname)) return false;
         return urlObj.hostname === INTERNAL_DOMAIN || urlObj.hostname.endsWith(`.${INTERNAL_DOMAIN}`);
     } catch {
         return false;


### PR DESCRIPTION
The link checker reports 5 broken links with `HTTP_undefined` for Windows `.zip` binary downloads on `get.pulumi.com`. These are false positives — the URLs return HTTP 200.

Reclassifies `get.pulumi.com` as non-internal in `isInternalLink()`, so the existing `HTTP_undefined` suppression for external links applies without any new suppression logic.

Fixes #17648 