### PR TITLE
Minor revision to /shipit skill

### DIFF
--- a/.claude/commands/shipit/SKILL.md
+++ b/.claude/commands/shipit/SKILL.md
@@ -233,6 +233,7 @@ Commands that will run:
    - Brief summary (1-2 sentences from commit message)
    - Changes included (from `git diff --stat master...HEAD`)
    - Keep concise (aim for < 500 characters)
+   - Include issue references if applicable (e.g., "Fixes #123")
    - No "Generated with Claude Code" footer
 
    Example:


### PR DESCRIPTION
Update `/shipit` skill to specify the inclusion of issue references in commit summaries when applicable. 

