### PR TITLE
Document requireOutput() for stack references and recommend it over getOutput()

### DIFF
--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -672,8 +672,8 @@ you access the outputs of that stack.
 
 In the above example, you construct a stack reference to a specific stack in this project which has the same name
 as your current stack (i.e. when deploying the "staging" stack of the above program, you reference the "staging" stack)
-from the infra project. Once you have that resource, you can fetch the `kubeConfig` output variable with the `getOutput`
-function. From that point onwards, Pulumi understands the inter-stack dependency for scenarios like cascading updates.
+from the infra project. Once you have that resource, you can read output variables from it.
+From that point onwards, Pulumi understands the inter-stack dependency for scenarios like cascading updates.
 
 ### Reading outputs from stack references
 
@@ -687,8 +687,8 @@ Stack references support the following methods for reading outputs from the refe
   `undefined` (or `None` in Python) if the output does not exist. Use this only when the
   absence of an output is an expected and explicitly handled condition in your program.
 * `getOutputDetails` returns an `OutputDetails` object that provides direct access to the output
-  value. This is useful when you want to process the output directly in your program's logic
-  rather than threading it through as an `Output` to another resource.
+  value. This is useful when you need the raw value in your program's logic rather than an
+  `Output` wrapper.
 
 The following example uses `requireOutput`, the recommended method for reading stack reference
 outputs. It reads a `vpcId` export and fails immediately at deployment time if that output is
@@ -745,7 +745,7 @@ var vpcId = infra.RequireOutput("vpcId");
 StackReference infra = new StackReference("acmecorp/infra/prod");
 
 // Fails at deployment time if "vpcId" is not in the referenced stack's exports.
-Output<Object> vpcId = infra.requireOutput(Output.of("vpcId"));
+Output<Object> vpcId = infra.requireOutput("vpcId");
 ```
 
 {{% /choosable %}}
@@ -754,7 +754,8 @@ Output<Object> vpcId = infra.requireOutput(Output.of("vpcId"));
 
 Use `getOutput` when the absence of an output is an expected, handled condition in your program.
 The following example reads a `privateIp` output and transforms it with `Output.apply` to build
-a derived value, where a missing output would result in an undefined key rather than an error:
+a derived value. If the output is missing, the undefined value propagates silently rather than
+surfacing as an error:
 
 {{< chooser language "typescript,python,go,csharp,java" >}}
 


### PR DESCRIPTION
## Summary

The "Reading outputs from stack references" section on the stacks page documented `getOutput` and `getOutputDetails`, but made no mention of `requireOutput` — leaving the safer and generally preferred method invisible to most readers.

As noted in the issue, this page is where most people land when learning about stack references, so the omission meant that `requireOutput` was effectively undiscovered unless a developer already knew to look for it in the SDK API reference.

This PR makes three improvements to the section:

**1. Updates the method list to lead with `requireOutput`**

The bullet list now presents `requireOutput` first and explicitly calls it out as the recommended method for most use cases. The description explains *why*: it surfaces a missing or misspelled output name as a clear, immediate deployment error rather than silently wrapping `undefined` in an `Output` that propagates problems downstream.

**2. Adds a `requireOutput` example in all five supported languages**

A new code chooser (TypeScript, Python, Go, C#, Java) demonstrates `requireOutput` usage. It is placed before the existing `getOutput` example to match the recommended ordering in the method list. Each example uses a realistic `vpcId` output and includes a comment explaining what happens when the output is missing.

**3. Reframes the `getOutput` example**

The transition text before the existing `getOutput` example now clarifies when `getOutput` is appropriate — only when the absence of an output is an expected, explicitly handled condition — so readers understand it as the exception rather than the default.

Fixes #11763

---
🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*