### PR TITLE
Fix no-op CMWA build failure

### DIFF
--- a/.github/workflows/customer-managed-workflow-agent-cli.yml
+++ b/.github/workflows/customer-managed-workflow-agent-cli.yml
@@ -15,6 +15,7 @@ jobs:
   pull-request:
     runs-on: ubuntu-latest
     needs: build-customer-managed-workflow-agent-cli-docs
+    if: needs.build-customer-managed-workflow-agent-cli-docs.outputs.has_changes == 'true'
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -35,6 +36,8 @@ jobs:
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
   build-customer-managed-workflow-agent-cli-docs:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -55,14 +58,21 @@ jobs:
         run: git status && git diff
         working-directory: docs
       - name: commit changes
+        id: commit
         run: |
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b customer-managed-workflow-agent/${{ github.run_id }}-${{ github.run_number }}
           git add static/
           git add content/
-          git commit -m "Regenerating docs for customer-managed-workflow-agent@${{ env.CMWA_VERSION }}"
-          git push origin customer-managed-workflow-agent/${{ github.run_id }}-${{ github.run_number }}
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "Regenerating docs for customer-managed-workflow-agent@${{ env.CMWA_VERSION }}"
+            git push origin customer-managed-workflow-agent/${{ github.run_id }}-${{ github.run_number }}
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
         working-directory: docs
     strategy:
       matrix:


### PR DESCRIPTION
The workflow failed when the docs for a given version were already up to date, because `git commit` exits 1 when there's nothing to commit. This was surfaced by a failure notification in #docs-ops.

Guards the commit and push with `if git diff --cached --quiet`, and gates the `pull-request` job on a `has_changes` output so it is skipped (not failed) when no changes were made.