### PR TITLE
Add Customer Managed Keys to pricing and comparison table

### DIFF
--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -54,6 +54,7 @@ tiers:
                   - Audit logs
                   - Drift detection and remediation
                   - Time-to-live stacks
+                  - Customer Managed Keys
                   - Priority feature requests
                   - 12x5 Enterprise Support available
             - title: Business Critical
@@ -391,6 +392,13 @@ comparison_table:
                   - content: _check
               - title: Database Secrets Rotation in private networks
                 link: /blog/esc-db-secrets-rotation-launch/
+                items:
+                  - content: _blank
+                  - content: _blank
+                  - content: _check
+                  - content: _check
+              - title: Customer Managed Keys
+                link: /docs/esc/administration/customer-managed-keys/
                 items:
                   - content: _blank
                   - content: _blank


### PR DESCRIPTION
We noticed we missed adding CMK to the pricing page.

Added "Customer Managed Keys" feature to the pricing page:
- Added to the Enterprise tier feature list
- Added to the comparison table with availability across tiers (available in Business Critical and Enterprise tiers only)
- Included link to the Customer Managed Keys documentation

This change reflects the availability of customer-managed key functionality in higher-tier plans.

