### PR TITLE
Fix typos in blog posts

### DIFF
--- a/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
+++ b/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
@@ -429,5 +429,5 @@ Check out the video clip below for a demo.
 
 Full CLI Documentation is [available](https://www.pulumi.com/docs/cli/commands/pulumi_import/), showing all of the different
 import command flags. The flags include writing directly to a file and the ability to ensure
-a resource is not protected on import. Examples of importing resources can be found on their specifc resource documentation
+a resource is not protected on import. Examples of importing resources can be found on their specific resource documentation
 pages. Such an example for importing a VPC can be found in the [VPC import documentation](https://www.pulumi.com/registry/packages/aws/api-docs/ec2/vpc/#import).

--- a/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
+++ b/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
@@ -3,7 +3,7 @@ title: "ECS vs Fargate vs EKS: The Lowdown on Containers in AWS"
 authors: ["joe-duffy"]
 tags: ["AWS","containers","Kubernetes","ecs", "eks", "fargate"]
 date: "2019-06-20"
-meta_desc: "Use Pulumi's infrastucture-as-code approach to simplify working with ECS Fargate, ECS with EC2 instances, and EKS."
+meta_desc: "Use Pulumi's infrastructure-as-code approach to simplify working with ECS Fargate, ECS with EC2 instances, and EKS."
 meta_image: "pulumi-crosswalk-for-aws.png"
 ---
 


### PR DESCRIPTION
## Summary
- Fix "infrastucture" → "infrastructure" in ECS vs Fargate vs EKS blog post meta description
- Fix "specifc" → "specific" in pulumi import blog post

## Test plan
- [ ] Verify the site builds without errors
- [ ] Confirm the corrected text renders properly on both blog pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)