### PR TITLE
Fix multiple broken links from DocsBot scan

### DIFF
--- a/content/blog/pko-2-0-ga/index.md
+++ b/content/blog/pko-2-0-ga/index.md
@@ -14,6 +14,9 @@ tags:
   - releases
   - features
 
+aliases:
+  - /blog/pulumi-kubernetes-operator-2-0-ga/
+
 social:
     twitter: "The GA release of Pulumi Kubernetes Operator 2.0 is here! Enhanced logging control, improved observability, and smarter workspace management make infrastructure automation easier than ever. Get started today!"
     linkedin: "Announcing Pulumi Kubernetes Operator 2.0 GA: Now with enhanced logging control, richer controller events, and flexible workspace management. Experience enterprise-grade infrastructure automation with improved observability and resource management in your Kubernetes clusters."

--- a/content/docs/esc/environments/dynamic-environment-variables.md
+++ b/content/docs/esc/environments/dynamic-environment-variables.md
@@ -11,7 +11,7 @@ menu:
     weight: 6
 ---
 
-The Pulumi ESC CLI includes a [`run` command](/docs/esc-cli/commands/esc_run/) that allows you to run commands with Pulumi ESC managed environment variables, without exporting them to your shell.
+The Pulumi ESC CLI includes a [`run` command](/docs/esc/cli/commands/esc_run/) that allows you to run commands with Pulumi ESC managed environment variables, without exporting them to your shell.
 
 You can run `esc run` using an environment:
 

--- a/content/docs/support/troubleshooting/ci-cd.md
+++ b/content/docs/support/troubleshooting/ci-cd.md
@@ -75,7 +75,7 @@ beforehand using the `pulumi stack init` command and in the **appropriate organi
 
   For example, for a stack named `production`, the `Pulumi.production.yaml` file must exist alongside the `Pulumi.yaml`.
   If your Pulumi app is in a different folder, you can use the `--cwd` flag with almost every `pulumi` command.
-  Learn more about the [global flags](/docs/cli/commands/#options).
+  Learn more about the [global flags](/docs/iac/cli/commands/pulumi/#options).
 
 ### Installing the Pulumi CLI
 

--- a/data/partners/partners.yaml
+++ b/data/partners/partners.yaml
@@ -23,7 +23,7 @@
   logo: /logos/tech/checkly.svg
 
 - name: Chronosphere
-  link: https://docs.chronosphere.io/administer/infrastructure/pulumi
+  link: https://docs.chronosphere.io/tooling/infrastructure/pulumi
   logo: /logos/tech/chronosphere.svg
 
 - name: Civo


### PR DESCRIPTION
Fixes broken internal links detected by the automated DocsBot scan on 2026-02-26.

## Changes
- Updated ESC CLI link in `dynamic-environment-variables.md` (`/docs/esc-cli/` → `/docs/esc/cli/`)
- Updated global flags link in `ci-cd.md` to correct anchor (`/docs/cli/commands/#options` → `/docs/iac/cli/commands/pulumi/#options`)
- Added alias `pulumi-kubernetes-operator-2-0-ga` to the `pko-2-0-ga` blog post
- Updated Chronosphere partner URL to new location (`/administer/infrastructure/pulumi` → `/tooling/infrastructure/pulumi`)

Closes #17698