### PR TITLE
website: eliminate CDN drift

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -777,7 +777,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             cachePolicyId: cachingDisabledId,
             lambdaFunctionAssociations: [],
             forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
-            // unset defaultTtl and maxTtl: the caching disabled policy will reset these to zero.
+            // Set defaultTtl and maxTtl to 0 to match what the caching-disabled policy enforces.
             defaultTtl: 0,
             maxTtl: 0,
         },
@@ -794,7 +794,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             cachePolicyId: cachingDisabledId,
             lambdaFunctionAssociations: config.doAIAnswersRewrites ? [getAIAnswersRewriteAssociation()] : [],
             forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
-            // unset defaultTtl and maxTtl: the caching disabled policy will reset these to zero.
+            // Set defaultTtl and maxTtl to 0 to match what the caching-disabled policy enforces.
             defaultTtl: 0,
             maxTtl: 0,
         },
@@ -814,7 +814,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             lambdaFunctionAssociations: [],
             forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
             responseHeadersPolicyId: CopilotSecurityHeadersPolicy.id,
-            // unset defaultTtl and maxTtl: the caching disabled policy will reset these to zero.
+            // Set defaultTtl and maxTtl to 0 to match what the caching-disabled policy enforces.
             defaultTtl: 0,
             maxTtl: 0,
         },
@@ -832,7 +832,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             lambdaFunctionAssociations: [],
             forwardedValues: undefined, // forwardedValues conflicts with cachePolicyId, so we unset it.
             responseHeadersPolicyId: CopilotSecurityHeadersPolicy.id,
-            // unset defaultTtl and maxTtl: the caching disabled policy will reset these to zero.
+            // Set defaultTtl and maxTtl to 0 to match what the caching-disabled policy enforces.
             defaultTtl: 0,
             maxTtl: 0,
         }


### PR DESCRIPTION
These changes fix some drift between the docs website's Pulumi program
and the infra as it is actually deployed.

The CDN's ordered cache rules for `ai` routes inherit the base caching
behavior, but then override the cache policy ID so that these rules
disable caching. The managed policy that disables caching causes AWS to
set the default TTL and max TTL for these rules to 0. This conflicts
with the values for these properties that are inherited from the base
cache behavior. Fix this by explicitly setting `defaultTTL` and
`maxTTL` to 0 in these rules.
