### PR TITLE
Fix misleading getOutputDetails example in stack references docs

### DIFF
--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -833,12 +833,12 @@ BucketObject logFile = new BucketObject("log", new BucketObjectArgs.Builder()
 
 {{< /chooser >}}
 
-`getOutputDetails` is useful when you need direct, synchronous access to an output value.
+`getOutputDetails` is useful when you need direct access to a resolved output value.
 This is most helpful when you want to inspect whether a value is marked as a secret, or when
 you need to use the value in your program logic without calling `Output.apply()`. The method
-returns a `StackReferenceOutputDetails` object whose `value` field holds the raw value for
-non-secret outputs, and whose `secretValue` field holds the raw value for outputs the
-referenced stack has marked as secret.
+returns an `OutputDetails` object whose `value` field holds the raw value for non-secret
+outputs, and whose `secretValue` field holds the raw value for outputs the referenced stack
+has marked as secret.
 
 As an example, suppose your referenced stack exports a database hostname as a plain string:
 


### PR DESCRIPTION
## Description

This PR addresses the misleading `getOutputDetails` example in the [stack references documentation](https://www.pulumi.com/docs/iac/concepts/stacks/#reading-outputs-from-stack-references).

### What was wrong

The previous example described a scenario where the referenced stack exported a list of subnets as a **JSON-serialized string**, then used `JSON.parse` (and language equivalents like `json.Unmarshal` in Go and `JsonConvert.DeserializeObject` in C#) to decode the value back into an object. This was confusing and misleading for two reasons:

1. It is unusual to intentionally JSON-serialize a value before exporting it from a Pulumi stack. Most programs export native values (arrays, objects, strings, numbers) directly.
2. The example implied that `getOutputDetails` always returns a raw JSON string requiring manual parsing. In reality, `getOutputDetails` returns the output's native value — if you export an array, you get an array back, not a JSON string.

The bug report notes that users were misled into assuming they needed to JSON-serialize their stack outputs to use `getOutputDetails`, or that the method returned raw strings from all output types.

### What changed

- **Bullet description**: Updated the `getOutputDetails` entry in the output-reading method list to mention the `value` and `secretValue` fields of the returned `StackReferenceOutputDetails` object, which is the key distinction users need to understand about this method.
- **Example section**: Replaced the JSON-serialized string scenario with a simple, realistic example — retrieving a database hostname (a plain string) from a referenced stack. Each language example now shows direct access to `.value` (or `.Value`/`getValue()`), with a comment explaining that `.secretValue` is used for outputs marked as secret in the referenced stack.

Closes #13855

---

🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*