### PR TITLE
Remove Crosswalk for Kubernetes branding from guides

### DIFF
--- a/content/docs/iac/clouds/kubernetes/_index.md
+++ b/content/docs/iac/clouds/kubernetes/_index.md
@@ -69,7 +69,7 @@ guides:
   - display_name: Introductory Video
     url: https://www.youtube.com/watch?v=2P8JLgAc5QI
     external_link: true
-  - display_name: Crosswalk playbooks for Kubernetes
+  - display_name: Kubernetes playbooks
     url: guides/playbooks/
   - display_name: Control plane
     url: guides/control-plane/

--- a/content/docs/iac/clouds/kubernetes/guides/_index.md
+++ b/content/docs/iac/clouds/kubernetes/guides/_index.md
@@ -1,7 +1,6 @@
 ---
-title_tag: "Crosswalk for Kubernetes Guides"
-meta_desc: Pulumi Crosswalk for Kubernetes is production-ready Kubernetes for teams. Work together to deliver
-           Kubernetes to AWS, Azure, Google Cloud, or private.
+title_tag: "Kubernetes Guides"
+meta_desc: Production-ready Kubernetes guides for teams. Work together to deliver Kubernetes to AWS, Azure, Google Cloud, or private.
 title: Guides
 h1: Pulumi & Kubernetes guides
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
@@ -18,13 +17,7 @@ aliases:
 - /docs/clouds/kubernetes/guides/
 ---
 
-<a href="./">
-    <img src="/images/docs/reference/crosswalk/kubernetes/crosswalk-for-k8s.svg" align="right" width="280" style="margin: 0 0 32px 16px;">
-</a>
-
-[Pulumi Crosswalk for Kubernetes][cw-index] is production-ready Kubernetes
-for teams. Work together to deliver Kubernetes to any cloud, AWS, Azure, Google
-Cloud, or private.
+These guides cover production-ready Kubernetes for teams. Work together to deliver Kubernetes to any cloud — AWS, Azure, Google Cloud, or private.
 
 If you are just getting started with Pulumi and Kubernetes, the [Get Started][k8s-get-started] guide is a better place to start.
 
@@ -36,25 +29,9 @@ Kubernetes Service (AKS)][aks], or [Google Kubernetes Engine (GKE)][gke].
 
 Discover solutions to the hardest Kubernetes problems to avoid mitigating
 pitfalls around infrastructure, security, governance, reliability, and
-maintainability of the cluster, it's workloads, and underlying resources.
+maintainability of the cluster, its workloads, and underlying resources.
 
-[Get started][cw-playbooks] with the playbooks to manage Kubernetes in production with your team.
-
-## Making Kubernetes Accessible to Everyone
-
-Pulumi exposes 100% of the Kubernetes API in [`pulumi/kubernetes`][pulumi-k8s],
-which means you use modern programming practices to reduce YAML/JSON complexity,
-repetition, and encapsulate workloads effectively.
-
-Through the new Crosswalk library extensions, the authorship experience has
-improved to make the API more accessible and approachable to operators
-and developers.
-
-By reducing the Kubernetes API syntax used, including sane
-defaults where possible, and maintaining idiomatic Kubernetes, it is
-easier to work with the API and deploy resources. Crosswalk revamps the Kubernetes API resource
-composition, but produces the exact semantic API output type. The ability to
-drop into and inject a given API type's raw spec is maintained through out.
+[Get started][k8s-playbooks] with the playbooks to manage Kubernetes in production with your team.
 
 ## Pulumi Kubernetes Operator
 
@@ -77,30 +54,12 @@ out CI/CD and automation systems into your clusters, creating native support to 
 [stack]: /docs/concepts/stack/
 [k8s-operator-cicd]: /docs/using-pulumi/continuous-delivery/pulumi-kubernetes-operator/
 
-## Join the Community
-
-With Pulumi's unique approach to open source [infrastructure as code][gh-pulumi], you'll focus more on
-code and business logic, and less on resource templates, YAML or DSL configuration languages.
-
-Leverage Pulumi's collection of open source [tools][gh-pulumi],
-Kubernetes [frameworks][pulumi-cloud-k8s], [continuous delivery integrations][pulumi-cd],
-and [playbooks][cw-playbooks] to help you deliver production-ready Kubernetes.
-
-Join the Pulumi team and thousands of practitioners in our
-[Community Slack][pulumi-slack] for questions and support, follow us on [Twitter][pulumi-twitter] for our latest news, and subscribe to our [YouTube channel][pulumi-yt] to access educational content.
-
 <!-- markdownlint-disable url -->
-[cw-index]: /docs/clouds/kubernetes/guides/
-[cw-playbooks]: /docs/clouds/kubernetes/guides/playbooks/
+[k8s-playbooks]: /docs/clouds/kubernetes/guides/playbooks/
 [k8s-get-started]: /docs/iac/get-started/kubernetes/
 [eks]: https://aws.amazon.com/eks/
 [aks]: https://azure.microsoft.com/en-us/services/kubernetes-service/
 [gke]: https://cloud.google.com/kubernetes-engine/
 [pulumi-k8s]: https://github.com/pulumi/pulumi-kubernetes
-[gh-pulumi]: https://github.com/pulumi
-[pulumi-cloud-k8s]: /registry/packages/kubernetes
 [pulumi-cd]: /docs/using-pulumi/continuous-delivery/
-[pulumi-slack]: https://slack.pulumi.com/
-[pulumi-twitter]: https://twitter.com/pulumicorp
-[pulumi-yt]: https://www.youtube.com/channel/UC2Dhyn4Ev52YSbcpfnfP0Mw
 <!-- markdownlint-enable url -->

--- a/content/docs/iac/clouds/kubernetes/guides/playbooks.md
+++ b/content/docs/iac/clouds/kubernetes/guides/playbooks.md
@@ -1,7 +1,6 @@
 ---
-title_tag: "Crosswalk Playbooks for Kubernetes"
-meta_desc: The Pulumi Crosswalk Playbooks for Kubernetes is a collection of
-           industry standard best-practices for managing Kubernetes in production.
+title_tag: "Kubernetes Playbooks"
+meta_desc: The Kubernetes playbooks are a collection of industry standard best-practices for managing Kubernetes in production.
 title: Playbooks
 h1: Kubernetes playbooks
 meta_image: /images/docs/meta-images/docs-clouds-kubernetes-meta-image.png
@@ -16,12 +15,8 @@ aliases:
   - /docs/clouds/kubernetes/guides/playbooks/
 ---
 
-<a href="./">
-    <img src="/images/docs/reference/crosswalk/kubernetes/crosswalk-for-k8s.svg" align="right" width="280" style="margin: 0 0 32px 16px;">
-</a>
-
-The [Pulumi Crosswalk Playbooks for Kubernetes][cw-guides] is a collection of
-industry standard best-practices for managing Kubernetes,
+The Kubernetes playbooks are a collection of
+industry standard best-practices for managing Kubernetes
 and its infrastructure in production.
 
 These guides are for provisioning and configuring production-grade Kubernetes
@@ -159,5 +154,4 @@ Deploy applications and workloads into the cluster.
 [crosswalk-apps]: /docs/clouds/kubernetes/guides/apps/
 [crosswalk-update-worker-nodes]: /docs/clouds/kubernetes/guides/update-worker-nodes/
 [least-privileged]: https://en.wikipedia.org/wiki/Principle_of_least_privilege
-[cw-guides]: /docs/clouds/kubernetes/guides/playbooks/
 <!-- markdownlint-enable url -->

--- a/content/docs/iac/guides/basics/organizing-projects-stacks/_index.md
+++ b/content/docs/iac/guides/basics/organizing-projects-stacks/_index.md
@@ -291,7 +291,7 @@ To be clear, each of the applications/services inside our monorepo (including th
 
 ### Other examples
 
-See also the use of multiple projects and stacks in [Crosswalk for Kubernetes](/docs/clouds/kubernetes/guides/), which contains a tutorial, reference architecture, and collection of prod-first code examples that demonstrate industry best-practices for using Kubernetes in contexts where an organization of people must ship production applications.
+See also the use of multiple projects and stacks in the [Kubernetes guides](/docs/clouds/kubernetes/guides/), which contains a reference architecture and collection of examples demonstrating best-practices for managing Kubernetes with a team.
 
 ## Organizing your project code
 

--- a/content/topics/kubernetes.md
+++ b/content/topics/kubernetes.md
@@ -329,10 +329,4 @@ contact_us_form:
     section_id: contact
     hubspot_form_id: 30017141-1093-4b94-b0eb-20aabc08447b
     headline: Want a demo?
-    quote:
-        title: See why the world’s best engineering teams use Pulumi + Kubernetes to enable true collaboration between developers and operators.
-        name: Fernando Carletti
-        name_title: Head of DevOps, Credijusto
-        content: |
-            Pulumi enables our teams to deploy, scale and manage Kubernetes clusters in a fraction of the time that it took them previously, by giving them the ability to work with the languages they already know, bypassing YAML and unwieldy DSLs. It helps bring together application and infrastructure developers by eliminating silos and reducing friction in their workflows and interactions. We're excited that Pulumi Crosswalk for Kubernetes will simplify our infrastructure provisioning even further, advancing application lifecycle management throughout our organization.
 ---


### PR DESCRIPTION
Removes deprecated 'Crosswalk for Kubernetes' brand name, the Crosswalk SVG image, obsolete community CTAs, and a customer quote referencing the retired brand. Part of #15846.
