### PR TITLE
Update Kubernetes YAML ConfigFile/ConfigGroup examples to use v2 API …

### DIFF
--- a/content/docs/iac/clouds/aws/guides/eks.md
+++ b/content/docs/iac/clouds/aws/guides/eks.md
@@ -2235,9 +2235,9 @@ Specifying your Kubernetes object configurations in Pulumi lets you take advanta
 like variables, loops, conditionals, functions, and classes. It is possible, however, to deploy existing Kubernetes
 YAML. The two approaches can be mixed, which is useful when converting an existing project.
 
-The [`ConfigFile` class](/registry/packages/kubernetes/api-docs/yaml/configfile) can be
+The [`ConfigFile` class](/registry/packages/kubernetes/api-docs/yaml/v2/configfile) can be
 used to deploy a single YAML file, whereas the [`ConfigGroup` class](
-/registry/packages/kubernetes/api-docs/yaml/configgroup) can deploy
+/registry/packages/kubernetes/api-docs/yaml/v2/configgroup) can deploy
 a collection of files, either from a set of files or in-memory representations.
 
 For example, imagine we have a directory, `yaml/`, containing the full YAML for the [Kubernetes Guestbook application](
@@ -2255,7 +2255,7 @@ import * as k8s from "@pulumi/kubernetes";
 const cluster = new eks.Cluster("my-cluster");
 
 // Create resources from standard Kubernetes guestbook YAML example.
-const guestbook = new k8s.yaml.ConfigGroup("guestbook",
+const guestbook = new k8s.yaml.v2.ConfigGroup("guestbook",
     { files: "yaml/*.yaml" },
     { provider: cluster.provider },
 );
@@ -2270,20 +2270,20 @@ export const frontendIp = guestbook.getResource("v1/Service", "frontend", "").sp
 ```python
 import pulumi
 import pulumi_eks as eks
-import pulumi_kubernetes as k8s
+from pulumi_kubernetes.yaml.v2 import ConfigGroup
 
 # Create an EKS cluster.
-cluster = eks.Cluster('my-cluster')
+cluster = eks.Cluster("my-cluster")
 
 # Create resources from standard Kubernetes guestbook YAML example.
-guestbook = k8s.yaml.ConfigGroup('guestbook',
-    files = ['yaml/*.yaml'],
-    opts = pulumi.ResourceOptions(provider = cluster.provider)
+guestbook = ConfigGroup("guestbook",
+    files=["yaml/*.yaml"],
+    opts=pulumi.ResourceOptions(provider=cluster.provider)
 )
 
 # Export the (cluster-private) IP address of the Guestbook frontend.
-pulumi.export('frontendIp',
-    guestbook.get_resource('v1/Service', 'frontend', '').spec.cluster_ip)
+pulumi.export("frontendIp",
+    guestbook.get_resource("v1/Service", "frontend", "").spec.cluster_ip)
 ```
 
 {{% /choosable %}}
@@ -2294,12 +2294,11 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/pulumi/pulumi-eks/sdk/go/eks"
-	k8s "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
-	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
-	k8syaml "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/yaml"
+	k8s "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	k8syaml "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/yaml/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -2328,7 +2327,7 @@ func main() {
 
 		// Create resources from standard Kubernetes guestbook YAML example.
 		guestbook, err := k8syaml.NewConfigGroup(ctx, "guestbook", &k8syaml.ConfigGroupArgs{
-			Files: []string{"yaml/*.yaml"},
+			Files: pulumi.StringArray{pulumi.String("yaml/*.yaml")},
 		}, pulumi.Provider(prov))
 
 		// Export the (cluster-private) IP address of the Guestbook frontend.
@@ -2346,7 +2345,7 @@ func main() {
 ```csharp
 using K8s = Pulumi.Kubernetes;
 using K8sCore = Pulumi.Kubernetes.Core.V1;
-using K8sYaml = Pulumi.Kubernetes.Yaml;
+using K8sYaml = Pulumi.Kubernetes.Yaml.V2;
 using Newtonsoft.Json;
 using Pulumi;
 using Pulumi.Eks;
@@ -2358,7 +2357,7 @@ class MyStack : Stack
         // Create an EKS cluster.
         var cluster = new Cluster("my-cluster");
 
-		// Create a Kubernetes provider using the new cluster's Kubeconfig.
+        // Create a Kubernetes provider using the new cluster's Kubeconfig.
         var eksProvider = new K8s.Provider("eksProvider", new K8s.ProviderArgs {
             KubeConfig = cluster.Kubeconfig.Apply(JsonConvert.SerializeObject)
         });
@@ -2371,7 +2370,7 @@ class MyStack : Stack
             new ComponentResourceOptions { Provider = eksProvider }
         );
 
-		// Export the (cluster-private) IP address of the Guestbook frontend.
+        // Export the (cluster-private) IP address of the Guestbook frontend.
         this.FrontendIp = guestbook.GetResource<K8sCore.Service>(
             "frontend").Apply((svc) => svc.Spec.Apply((spec) => spec.ClusterIP));
     }
@@ -2448,16 +2447,10 @@ outputs:
 
 {{% /choosable %}}
 
-The `ConfigFile` and `ConfigGroup` classes both support a [`transformations` property](
-/registry/packages/kubernetes#transformations_nodejs) which can be used to ['monkey patch'](
+The `ConfigFile` and `ConfigGroup` classes support [`transforms`](
+/docs/concepts/options/transforms/) via `ResourceOptions`, which can be used to ['monkey patch'](
 https://en.wikipedia.org/wiki/Monkey_patch) Kubernetes configuration on the fly. This can be used to rewrite
 configuration to include additional services (like Envoy sidecars), inject tags, and so on.
-
-{{% notes type="info" %}}
-Note that the `transformations` property is available only with the "v1" version
-of `ConfigFile` and `ConfigGroup`; for the "v2" version, use the
-`transforms` option.
-{{% /notes %}}
 
 For example, a transformation like the following can make all services private to a cluster, by
 changing `LoadBalancer` specs into `ClusterIPs`, in addition to placing objects into a desired namespace:
@@ -2467,26 +2460,22 @@ changing `LoadBalancer` specs into `ClusterIPs`, in addition to placing objects 
 {{% choosable language typescript %}}
 
 ```typescript
-const guestbook = new k8s.yaml.ConfigGroup("guestbook",
+const guestbook = new k8s.yaml.v2.ConfigGroup("guestbook",
+    { files: "yaml/*.yaml" },
     {
-        files: "yaml/*.yaml",
-        transformations: [
-            (obj: any) => {
+        provider: eksProvider,
+        transforms: [
+            async (args) => {
+                const props = args.props as any;
                 // Make every service private to the cluster.
-                if (obj.kind == "Service" && obj.apiVersion == "v1") {
-                    if (obj.spec && obj.spec.type && obj.spec.type == "LoadBalancer") {
-                        obj.spec.type = "ClusterIP";
-                    }
+                if (args.type === "kubernetes:core/v1:Service" &&
+                        props?.spec?.type === "LoadBalancer") {
+                    props.spec.type = "ClusterIP";
                 }
+                // Put every resource in the created namespace.
+                props.metadata = { ...props.metadata, namespace: namespaceName };
+                return { props, opts: args.opts };
             },
-            // Put every resource in the created namespace.
-            (obj: any) => {
-                if (obj.metadata !== undefined) {
-                    obj.metadata.namespace = namespaceName
-                } else {
-                    obj.metadata = {namespace: namespaceName}
-                }
-            }
         ],
     },
 );
@@ -2496,29 +2485,25 @@ const guestbook = new k8s.yaml.ConfigGroup("guestbook",
 {{% choosable language python %}}
 
 ```python
-def xform_service_private(obj):
-    """Make every service private to the cluster."""
-    if (isinstance(obj, k8s.core.v1.Service) and
-            obj.kind == 'Service' and obj.api_version == 'v1' and
-            obj.spec and obj.spec.type and obj.spec.type == 'LoadBalancer'):
-        obj.spec.type = 'ClusterIP'
+def xform(args):
+    props = dict(args.props)
+    # Make every service private to the cluster.
+    if args.type_ == "kubernetes:core/v1:Service":
+        spec = dict(props.get("spec", {}))
+        if spec.get("type") == "LoadBalancer":
+            spec["type"] = "ClusterIP"
+            props["spec"] = spec
+    # Put every resource in the created namespace.
+    meta = dict(props.get("metadata", {}))
+    meta["namespace"] = namespace_name
+    props["metadata"] = meta
+    return pulumi.ResourceTransformResult(props=props, opts=args.opts)
 
-def xform_resource_ns(obj):
-    """Put every resource in the created namespace."""
-    if (hasattr(obj, 'metadata')):
-        if (obj.metadata is not None):
-            obj.metadata.namespace = namespaceName
-        else:
-            obj.metadata = k8s.meta.v1.ObjectMetaArgs(namespace = namespaceName)
-
-guestbook = k8s.yaml.ConfigGroup('guestbook',
-    files = ['yaml/*.yaml'],
-    opts = pulumi.ResourceOptions(
-        provider = cluster.provider,
-        transformations = [
-            xform_service_private,
-            xform_resource_ns,
-        ]
+guestbook = ConfigGroup("guestbook",
+    files=["yaml/*.yaml"],
+    opts=pulumi.ResourceOptions(
+        provider=cluster.provider,
+        transforms=[xform],
     )
 )
 ```
@@ -2528,28 +2513,30 @@ guestbook = k8s.yaml.ConfigGroup('guestbook',
 
 ```go
 guestbook, err := k8syaml.NewConfigGroup(ctx, "guestbook", &k8syaml.ConfigGroupArgs{
-    Files: []string{"yaml/*.yaml"},
-    Transformations: []k8syaml.Transformation{
+    Files: pulumi.StringArray{pulumi.String("yaml/*.yaml")},
+}, pulumi.Provider(prov), pulumi.Transforms([]pulumi.ResourceTransform{
+    func(ctx context.Context, args *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
+        props := args.Props.ObjectValue()
         // Make every service private to the cluster.
-        func(state map[string]interface{}, opts ...pulumi.ResourceOption) {
-            if state["kind"] == "Service" && state["apiVersion"] == "v1" {
-                spec := state["spec"].(map[string]interface{})
-                spec["type"] = "ClusterIP"
-            }
-        },
-        // Put every resource in the created namespace.
-        func(state map[string]interface{}, opts ...pulumi.ResourceOption) {
-            if state["metadata"] != nil {
-                meta := state["metadata"].(map[string]interface{})
-                meta["namespace"] = namespaceName
-            } else {
-                state["metadata"] = map[string]interface{}{
-                    "namespace": namespaceName,
+        if args.Type == "kubernetes:core/v1:Service" {
+            if spec, ok := props["spec"]; ok {
+                specMap := spec.ObjectValue()
+                if specMap["type"].StringValue() == "LoadBalancer" {
+                    specMap["type"] = resource.NewStringProperty("ClusterIP")
+                    props["spec"] = resource.NewObjectProperty(specMap)
                 }
             }
-        },
+        }
+        // Put every resource in the created namespace.
+        meta := props["metadata"].ObjectValue()
+        meta["namespace"] = resource.NewStringProperty(namespaceName)
+        props["metadata"] = resource.NewObjectProperty(meta)
+        return &pulumi.ResourceTransformResult{
+            Props: resource.NewObjectProperty(props),
+            Opts:  args.Opts,
+        }
     },
-})
+}))
 ```
 
 {{% /choosable %}}
@@ -2559,41 +2546,43 @@ guestbook, err := k8syaml.NewConfigGroup(ctx, "guestbook", &k8syaml.ConfigGroupA
 var guestbook = new K8sYaml.ConfigGroup("guestbook",
     new K8sYaml.ConfigGroupArgs {
         Files = new[] { "yaml/*.yaml" },
-        Transformations = {
-            // Make every service private to the cluster.
-            (state, opts) => {
-                if (state["kind"] != null && state["kind"].Equals("Service") &&
-                        state["apiVersion"] != null && state["apiVersion"].Equals("v1")) {
-                    var spec = (ImmutableDictionary<string, object>)state["spec"];
-                    return state.SetItem("spec", spec.SetItem("type", "ClusterIP"));
-                }
-                return state;
-            },
-            // Put every resource in the created namespace.
-            (state, opts) => {
-                if (state["metadata"] != null) {
-                    var meta = (ImmutableDictionary<string, object>)state["metadata"];
-                    return state.SetItem("metadata", meta.SetItem("namespace", namespaceName));
-                }
-                return state.SetItem("metadata", new Dictionary<string, object> {
-                    { "namespace", namespaceName }
-                }.ToImmutableDictionary());
-            }
-        }
     },
-    new ComponentResourceOptions { Provider = eksProvider }
+    new ComponentResourceOptions {
+        Provider = eksProvider,
+        ResourceTransformations = {
+            (args) => {
+                var props = args.Args as ImmutableDictionary<string, object>
+                    ?? ImmutableDictionary<string, object>.Empty;
+                // Make every service private to the cluster.
+                if (args.Resource.GetResourceType() == "kubernetes:core/v1:Service") {
+                    var spec = props.GetValueOrDefault("spec")
+                        as ImmutableDictionary<string, object>
+                        ?? ImmutableDictionary<string, object>.Empty;
+                    if (spec.TryGetValue("type", out var t) && (string)t == "LoadBalancer") {
+                        props = props.SetItem("spec", spec.SetItem("type", "ClusterIP"));
+                    }
+                }
+                // Put every resource in the created namespace.
+                var meta = props.GetValueOrDefault("metadata")
+                    as ImmutableDictionary<string, object>
+                    ?? ImmutableDictionary<string, object>.Empty;
+                props = props.SetItem("metadata", meta.SetItem("namespace", namespaceName));
+                return new ResourceTransformationResult(props, args.Options);
+            },
+        }
+    }
 );
 ```
 
 {{% /choosable %}}
 {{% choosable language java %}}
 {{% notes type="info" %}}
-This functionality is currently not available in Java.
+Transforms are not yet supported for this resource in Java.
 {{% /notes %}}
 {{% /choosable %}}
 {{% choosable language yaml %}}
 {{% notes type="info" %}}
-This functionality is currently not available in YAML.
+Transforms are not yet supported for this resource in Pulumi YAML.
 {{% /notes %}}
 {{% /choosable %}}
 

--- a/content/docs/iac/guides/migration/migrating-to-pulumi/from-kubernetes.md
+++ b/content/docs/iac/guides/migration/migrating-to-pulumi/from-kubernetes.md
@@ -34,7 +34,7 @@ By defining these resources in code, you can deploy off-the-shelf Kubernetes YAM
 
 ### Deploying a Single Kubernetes YAML File
 
-The `ConfigFile` resource type accepts a `file` parameter that indicates the path or URL to read the YAML configuration from. By default, names are used as-is, however you can specify a `resourcePrefix` to rewrite the names. One or more `transformations` callbacks can be supplied to arbitrarily rewrite resource configurations on-the-fly before deploying them.
+The `ConfigFile` resource type accepts a `file` parameter that indicates the path or URL to read the YAML configuration from. By default, names are used as-is, however you can specify a `resourcePrefix` to rewrite the names. One or more `transforms` callbacks can be supplied via `ResourceOptions` to arbitrarily rewrite resource configurations on-the-fly before deploying them.
 
 To deploy the Kubernetes Guestbook Application using a single YAML file, first download the "all-in-one" configuration:
 
@@ -45,7 +45,7 @@ $ curl -L --remote-name \
 
 This Pulumi program uses `ConfigFile` to read that YAML file, provision the resources inside it, and export the resulting IP addresses:
 
-{{< chooser language "typescript,python,go,csharp" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language typescript %}}
 
@@ -53,7 +53,7 @@ This Pulumi program uses `ConfigFile` to read that YAML file, provision the reso
 import * as k8s from "@pulumi/kubernetes";
 
 // Create resources from standard Kubernetes guestbook YAML example.
-const guestbook = new k8s.yaml.ConfigFile("guestbook", {
+const guestbook = new k8s.yaml.v2.ConfigFile("guestbook", {
     file: "guestbook-all-in-one.yaml",
 });
 
@@ -67,14 +67,14 @@ export const privateIp = frontend.spec.clusterIP;
 
 ```python
 import pulumi
-import pulumi_kubernetes as k8s
+from pulumi_kubernetes.yaml.v2 import ConfigFile
 
 # Create resources from standard Kubernetes guestbook YAML example.
-guestbook = k8s.yaml.ConfigFile('guestbook', 'guestbook-all-in-one.yaml')
+guestbook = ConfigFile("guestbook", file="guestbook-all-in-one.yaml")
 
 # Export the private cluster IP address of the frontend.
-frontend = guestbook.get_resource('v1/Service', 'frontend')
-pulumi.export('private_ip', frontend.spec['cluster_ip'])
+frontend = guestbook.get_resource("v1/Service", "frontend")
+pulumi.export("private_ip", frontend.spec["cluster_ip"])
 ```
 
 {{% /choosable %}}
@@ -84,15 +84,15 @@ pulumi.export('private_ip', frontend.spec['cluster_ip'])
 package main
 
 import (
-    corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
-    "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/yaml"
+    corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+    yamlv2 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/yaml/v2"
     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
     pulumi.Run(func(ctx *pulumi.Context) error {
-        guestbook, err := yaml.NewConfigFile(ctx, "guestbook", &yaml.ConfigFileArgs{
-            File: "guestbook-all-in-one.yaml",
+        guestbook, err := yamlv2.NewConfigFile(ctx, "guestbook", &yamlv2.ConfigFileArgs{
+            File: pulumi.String("guestbook-all-in-one.yaml"),
         })
         if err != nil {
             return err
@@ -113,11 +113,10 @@ func main() {
 ```csharp
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using Pulumi;
-using Pulumi.Kubernetes.Yaml;
+using Pulumi.Kubernetes.Yaml.V2;
 using Pulumi.Kubernetes.Core.V1;
 
 class Program
@@ -141,6 +140,41 @@ class Program
         });
     }
 }
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+```java
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.kubernetes.yaml.v2.ConfigFile;
+import com.pulumi.kubernetes.yaml.v2.ConfigFileArgs;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        // Create resources from standard Kubernetes guestbook YAML example.
+        var guestbook = new ConfigFile("guestbook",
+            ConfigFileArgs.builder()
+                .file("guestbook-all-in-one.yaml")
+                .build());
+    }
+}
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```yaml
+resources:
+  guestbook:
+    type: kubernetes:yaml/v2:ConfigFile
+    properties:
+      file: guestbook-all-in-one.yaml
 ```
 
 {{% /choosable %}}
@@ -173,7 +207,7 @@ Resources:
 
 ### Deploying Multiple Kubernetes YAML Files
 
-The `ConfigGroup` resource type is similar to `ConfigFile`. Instead of a single file, it accepts a `files` parameter that contains a list of file paths, file globs, and/or URLs from which to read the YAML configuration from. By default, names are used as-is, however you can specify a `resourcePrefix` to rewrite the names. One or more `transformations` callbacks can be supplied to arbitrarily rewrite resource configurations on-the-fly before deploying them.
+The `ConfigGroup` resource type is similar to `ConfigFile`. Instead of a single file, it accepts a `files` parameter that contains a list of file paths, file globs, and/or URLs from which to read the YAML configuration from. By default, names are used as-is, however you can specify a `resourcePrefix` to rewrite the names. One or more `transforms` callbacks can be supplied via `ResourceOptions` to arbitrarily rewrite resource configurations on-the-fly before deploying them.
 
 To deploy the Kubernetes Guestbook Application using a collection of YAML files, first create a `yaml` directory and download them into it:
 
@@ -187,7 +221,7 @@ $ popd
 
 This Pulumi program uses `ConfigGroup` to read these YAML files, provision the resources inside of them, and export the resulting IP addresses:
 
-{{< chooser language "typescript,python,go,csharp" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language typescript %}}
 
@@ -196,7 +230,7 @@ import * as k8s from "@pulumi/kubernetes";
 import * as path from "path";
 
 // Create resources from standard Kubernetes guestbook YAML example.
-const guestbook = new k8s.yaml.ConfigGroup("guestbook", {
+const guestbook = new k8s.yaml.v2.ConfigGroup("guestbook", {
     files: [ path.join("yaml", "*.yaml") ],
 });
 
@@ -209,19 +243,15 @@ export const privateIp = frontend.spec.clusterIP;
 {{% choosable language python %}}
 
 ```python
-from pulumi_kubernetes.yaml import ConfigGroup
-from pulumi import export
+import pulumi
+from pulumi_kubernetes.yaml.v2 import ConfigGroup
 
 # Create resources from standard Kubernetes guestbook YAML example.
-guestbook = ConfigGroup(
-  "guestbook",
-  files=["yaml/*.yaml"])
+guestbook = ConfigGroup("guestbook", files=["yaml/*.yaml"])
 
 # Export the private cluster IP address of the frontend.
 frontend = guestbook.get_resource("v1/Service", "frontend")
-export(
-  name="privateIp",
-  value=frontend.spec.cluster_ip)
+pulumi.export("private_ip", frontend.spec["cluster_ip"])
 ```
 
 {{% /choosable %}}
@@ -233,15 +263,15 @@ package main
 import (
     "path/filepath"
 
-    corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
-    "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/yaml"
+    corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+    yamlv2 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/yaml/v2"
     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
     pulumi.Run(func(ctx *pulumi.Context) error {
-        guestbook, err := yaml.NewConfigGroup(ctx, "guestbook", &yaml.ConfigGroupArgs{
-            Files: []string{filepath.Join("yaml", "*.yaml")},
+        guestbook, err := yamlv2.NewConfigGroup(ctx, "guestbook", &yamlv2.ConfigGroupArgs{
+            Files: pulumi.StringArray{pulumi.String(filepath.Join("yaml", "*.yaml"))},
         })
         if err != nil {
             return err
@@ -262,12 +292,11 @@ func main() {
 ```csharp
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 
 using Pulumi;
-using Pulumi.Kubernetes.Yaml;
+using Pulumi.Kubernetes.Yaml.V2;
 using Pulumi.Kubernetes.Core.V1;
 
 class Program
@@ -291,6 +320,42 @@ class Program
         });
     }
 }
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+```java
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.kubernetes.yaml.v2.ConfigGroup;
+import com.pulumi.kubernetes.yaml.v2.ConfigGroupArgs;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        // Create resources from standard Kubernetes guestbook YAML example.
+        var guestbook = new ConfigGroup("guestbook",
+            ConfigGroupArgs.builder()
+                .files("yaml/*.yaml")
+                .build());
+    }
+}
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```yaml
+resources:
+  guestbook:
+    type: kubernetes:yaml/v2:ConfigGroup
+    properties:
+      files:
+      - "yaml/*.yaml"
 ```
 
 {{% /choosable %}}
@@ -965,23 +1030,29 @@ There are two important caveats to note about YAML rendering support:
 
 ## Configuration Transformations
 
-Let's see how to assign our service a public IP address, starting with [the single `ConfigFile` example above](#deploying-a-single-kubernetes-yaml-file), using transformations.
+Let's see how to assign our service a public IP address, starting with [the single `ConfigFile` example above](#deploying-a-single-kubernetes-yaml-file), using transforms.
 
-The Kubernetes Guestbook by default does not assign a load balancer for the frontend service. To fix this, we could edit the YAML file, of course, but let's see `transformations` in action. By supplying the `transformations` callback that rewrites the object configuration on the fly, we can cause a load balancer to get created:
+The Kubernetes Guestbook by default does not assign a load balancer for the frontend service. To fix this, we could edit the YAML file, of course, but let's see `transforms` in action. By supplying a `transforms` callback in the resource options, we can rewrite the object configuration on the fly and cause a load balancer to get created:
 
-{{< chooser language "typescript,python,go,csharp" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language typescript %}}
 
 ```typescript
 ...
-const guestbook = new k8s.yaml.ConfigFile("guestbook", {
+const guestbook = new k8s.yaml.v2.ConfigFile("guestbook", {
     file: "guestbook-all-in-one.yaml",
-    transformations: [(obj: any) => {
-        if (obj.kind === "Service" && obj.metadata.name === "frontend") {
-            obj.spec.type = "LoadBalancer";
-        }
-    }],
+}, {
+    transforms: [
+        async (args) => {
+            if (args.type === "kubernetes:core/v1:Service" &&
+                    (args.props as any)?.metadata?.name === "frontend") {
+                const props = args.props as any;
+                props.spec = { ...props.spec, type: "LoadBalancer" };
+                return { props, opts: args.opts };
+            }
+        },
+    ],
 });
 ...
 export const publicIp = frontend.status.loadBalancer.ingress[0].ip;
@@ -992,13 +1063,20 @@ export const publicIp = frontend.status.loadBalancer.ingress[0].ip;
 
 ```python
 ...
-def make_frontend_public(obj):
-    if obj['kind'] == "Service" and obj['metadata']['name'] == "frontend":
-        obj['spec']['type'] = "LoadBalancer"
-guestbook = k8s.yaml.ConfigFile('guestbook', 'guestbook-all-in-one.yaml',
-    transformations=[make_frontend_public])
+def make_frontend_public(args):
+    if (args.type_ == "kubernetes:core/v1:Service" and
+            args.props.get("metadata", {}).get("name") == "frontend"):
+        props = dict(args.props)
+        spec = dict(props.get("spec", {}))
+        spec["type"] = "LoadBalancer"
+        props["spec"] = spec
+        return pulumi.ResourceTransformResult(props=props, opts=args.opts)
+
+guestbook = ConfigFile("guestbook",
+    file="guestbook-all-in-one.yaml",
+    opts=pulumi.ResourceOptions(transforms=[make_frontend_public]))
 ...
-pulumi.export('public_ip', frontend.status['load_balancer']['ingress'][0]['ip'])
+pulumi.export("public_ip", frontend.status["load_balancer"]["ingress"][0]["ip"])
 ```
 
 {{% /choosable %}}
@@ -1006,14 +1084,26 @@ pulumi.export('public_ip', frontend.status['load_balancer']['ingress'][0]['ip'])
 
 ```go
 ...
-guestbook, err := yaml.NewConfigFile(ctx, "guestbook", &yaml.ConfigFileArgs{
-    File: "guestbook-all-in-one.yaml",
-    Transformations: []yaml.Transformation{func(state map[string]interface{}, opts ...pulumi.ResourceOption) {
-        if kind, ok := state["kind"]; ok && kind == "Service" && state["metadata"].(map[string]interface{})["name"] == "frontend" {
-            state["spec"].(map[string]interface{})["type"] = "LoadBalancer"
+guestbook, err := yamlv2.NewConfigFile(ctx, "guestbook", &yamlv2.ConfigFileArgs{
+    File: pulumi.String("guestbook-all-in-one.yaml"),
+}, pulumi.Transforms([]pulumi.ResourceTransform{
+    func(ctx context.Context, args *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
+        if args.Type == "kubernetes:core/v1:Service" {
+            props := args.Props.ObjectValue()
+            meta := props["metadata"].ObjectValue()
+            if name, ok := meta["name"]; ok && name.StringValue() == "frontend" {
+                spec := props["spec"].ObjectValue()
+                spec["type"] = resource.NewStringProperty("LoadBalancer")
+                props["spec"] = resource.NewObjectProperty(spec)
+                return &pulumi.ResourceTransformResult{
+                    Props: resource.NewObjectProperty(props),
+                    Opts:  args.Opts,
+                }
+            }
         }
-    }},
-})
+        return nil
+    },
+}))
 if err != nil {
     return err
 }
@@ -1030,23 +1120,31 @@ ctx.Export("publicIP", frontend.Status.LoadBalancer().Ingress().Index(pulumi.Int
 
 ```csharp
 ...
-Func<ImmutableDictionary<string, object>,
-    CustomResourceOptions, ImmutableDictionary<string, object>>[] transformations =
-{
-    (obj, opts) => {
-        if ((string)obj["kind"] == "Service" &&
-                (string)((ImmutableDictionary<string, object>)obj["metadata"])["name"] == "frontend")
-        {
-            var spec = ((ImmutableDictionary<string, object>)obj["spec"]);
-            obj = obj.SetItem("spec", spec.SetItem("type", "LoadBalancer"));
-        }
-        return obj;
-    },
-};
 var guestbook = new ConfigFile("guestbook", new ConfigFileArgs
 {
     File = "guestbook-all-in-one.yaml",
-    Transformations = transformations,
+}, new ComponentResourceOptions
+{
+    ResourceTransformations =
+    {
+        (args) => {
+            if (args.Resource.GetResourceType() == "kubernetes:core/v1:Service") {
+                var props = args.Args as ImmutableDictionary<string, object>
+                    ?? ImmutableDictionary<string, object>.Empty;
+                var meta = props.GetValueOrDefault("metadata")
+                    as ImmutableDictionary<string, object>
+                    ?? ImmutableDictionary<string, object>.Empty;
+                if (meta.TryGetValue("name", out var name) && (string)name == "frontend") {
+                    var spec = props.GetValueOrDefault("spec")
+                        as ImmutableDictionary<string, object>
+                        ?? ImmutableDictionary<string, object>.Empty;
+                    props = props.SetItem("spec", spec.SetItem("type", "LoadBalancer"));
+                    return new ResourceTransformationResult(props, args.Options);
+                }
+            }
+            return null;
+        },
+    },
 });
 ...
 return new Dictionary<string, object?>
@@ -1057,6 +1155,16 @@ return new Dictionary<string, object?>
 ...
 ```
 
+{{% /choosable %}}
+{{% choosable language java %}}
+{{% notes type="info" %}}
+Transforms are not yet supported for this resource in Java.
+{{% /notes %}}
+{{% /choosable %}}
+{{% choosable language yaml %}}
+{{% notes type="info" %}}
+Transforms are not yet supported for this resource in Pulumi YAML.
+{{% /notes %}}
 {{% /choosable %}}
 
 {{< /chooser >}}
@@ -1091,7 +1199,7 @@ $ curl http://$(pulumi stack output publicIp)
 </html>
 ```
 
-Although this example shows the YAML `ConfigFile` resource, the same behavior is available with YAML `ConfigGroup` and Helm `Chart` resource types.
+Although this example shows the YAML `ConfigFile` resource, the same transform behavior is available with YAML `ConfigGroup` and Helm `Chart` resource types.
 
 ## Provisioning Mixed Configurations
 


### PR DESCRIPTION
…with full language coverage

Fixes #17724 by replacing all v1 ConfigFile/ConfigGroup usage with the v2 API (kubernetes/yaml/v2) across the Kubernetes migration guide and EKS guide. Adds Java and YAML choosables where missing and updates transforms examples to use the v2 ResourceTransform API.
