### PR TITLE
Add camelCase warning note to Python unit testing mocks

### DIFF
--- a/content/docs/iac/guides/testing/unit.md
+++ b/content/docs/iac/guides/testing/unit.md
@@ -335,6 +335,10 @@ pulumi.runtime.set_mocks(
 )
 ```
 
+{{% notes type="warning" %}}
+When returning explicit output properties from `new_resource`, property names must use camelCase (e.g., `"publicIp"`, `"instanceState"`) rather than snake_case. This is because Pulumi uses camelCase for its internal property serialization regardless of the programming language. For example, use `"publicIp"` rather than `"public_ip"`.
+{{% /notes %}}
+
 {{% /choosable %}}
 
 {{% choosable language go %}}


### PR DESCRIPTION
Adds a warning note explaining that mocked resource property names must use camelCase in Python, even though Python normally uses snake_case.

Fixes #11731.
