### PR TITLE
Simplify the Getting Started landing page

### DIFF
--- a/content/docs/get-started/_index.md
+++ b/content/docs/get-started/_index.md
@@ -20,237 +20,50 @@ aliases:
     - /docs/tour/
 ---
 
-Pulumi is a modern [infrastructure as code](/what-is/what-is-infrastructure-as-code/) and [secrets management](/what-is/what-is-secrets-management/) platform that allows you to use familiar programming languages and tools to automate, secure and manage everything you run in the cloud.
+Pulumi is a modern [infrastructure as code](/what-is/what-is-infrastructure-as-code/) (IaC) platform that lets you use familiar programming languages and tools to automate, secure and manage everything you run in the cloud.
 
-Pulumi IaC is free, [open source](https://github.com/pulumi/pulumi), and optionally pairs with the [Pulumi Platform](/docs/deployments/) to make managing infrastructure secure, reliable, and hassle-free.
+Pulumi IaC is free, [open source](https://github.com/pulumi/pulumi), and optionally pairs with [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/) to make managing infrastructure secure, reliable, and hassle-free.
 
-Select one of the following options to get started:
+Choose a cloud provider to get started:
 
-{{% chooser cloud "aws,azure,gcp,kubernetes" / %}}
-
-{{% choosable cloud aws %}}
-
-<div class="tiles flex-wrap justify-center items-stretch mt-4">
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="aws-get-started" href="/docs/iac/get-started/aws/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-folder text-blue-400 pr-2"></i>Infrastructure as Code</h4>
-                <p>Install the CLI, configure AWS, and deploy your first infrastructure.</p>
-            </div>
-        </a>
+<section class="docs-home mt-4 mb-12">
+    <div class="docs-home-section">
+        <div class="cards-logo-label-link clouds">
+            <a data-track="aws-get-started" href="/docs/iac/get-started/aws/">
+                <div class="card-icon">
+                    <div class="icon aws-40"></div>
+                </div>
+                <div class="label">
+                    <span class="text-sm text-gray-800">Get started with Pulumi &amp; AWS &rarr;</span>
+                </div>
+            </a>
+            <a data-track="azure-get-started" href="/docs/iac/get-started/azure/">
+                <div class="card-icon">
+                    <div class="icon azure-40"></div>
+                </div>
+                <div class="label">
+                    <span class="text-sm text-gray-800">Get started with Pulumi &amp; Azure &rarr;</span>
+                </div>
+            </a>
+            <a data-track="google-get-started" href="/docs/iac/get-started/gcp/">
+                <div class="card-icon">
+                    <div class="icon google-cloud-40"></div>
+                </div>
+                <div class="label">
+                    <span class="text-sm text-gray-800">Get started with Pulumi &amp; Google Cloud &rarr;</span>
+                </div>
+            </a>
+            <a data-track="kubernetes-get-started" href="/docs/iac/get-started/kubernetes/">
+                <div class="card-icon">
+                    <div class="icon kubernetes-40"></div>
+                </div>
+                <div class="label">
+                    <span class="text-sm text-gray-800">Get started with Pulumi &amp; Kubernetes &rarr;</span>
+                </div>
+            </a>
+        </div>
     </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="esc-get-started" href="/docs/esc/get-started/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-key text-blue-400 pr-2"></i>Secrets & Configuration</h4>
-                <p>Create your first environment and manage secrets and configuration.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="insights-get-started" href="/docs/insights/get-started/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-search-plus text-blue-400 pr-2"></i>Insights & Governance</h4>
-                <p>Discover and manage cloud infrastructure across all your resources.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="aws-kubernetes" href="/templates/kubernetes/aws/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-cubes text-blue-400 pr-2"></i>Amazon Elastic Kubernetes Service (EKS)</h4>
-                <p>Create an EKS cluster that provides a managed Kubernetes control plane.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="aws-static-website" href="/templates/static-website/aws/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-cloud text-blue-400 pr-2"></i>S3 and Cloudfront Website</h4>
-                <p>Create a static website hosted in S3 with a CloudFront Distribution to serve the website with caching and HTTPs.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="aws-serverless" href="/templates/serverless-application/aws/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-sitemap text-blue-400 pr-2"></i>Serverless with API Gateway</h4>
-                <p>Create an API Gateway REST API and a static website that consumes that API.</p>
-            </div>
-        </a>
-    </div>
- </div>
-
-{{< /choosable >}}
-
-{{% choosable cloud azure %}}
-
-<div class="tiles flex-wrap justify-center items-stretch mt-4">
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="azure-get-started" href="/docs/iac/get-started/azure/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-folder text-blue-400 pr-2"></i>Infrastructure as Code</h4>
-                <p>Install the CLI, configure Azure, and deploy your first infrastructure.</p>
-            </div>
-        </a>
-    </div>
-         <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="esc-get-started" href="/docs/esc/get-started/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-key text-blue-400 pr-2"></i>Secrets & Configuration</h4>
-                <p>Create your first environment and manage secrets and configuration.</p>
-            </div>
-        </a>
-    </div>
-        <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="insights-get-started" href="/docs/insights/get-started/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-search-plus text-blue-400 pr-2"></i>Insights & Governance</h4>
-                <p>Discover and manage cloud infrastructure across all your resources.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="azure-kubernetes" href="/templates/kubernetes/azure/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-cubes text-blue-400 pr-2"></i>Azure Kubernetes Service (AKS)</h4>
-                <p>
-                    Create an Azure Virtual Network with three subnets and deploy an Azure Kubernetes Service (AKS) cluster.
-                </p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="azure-static-website" href="/templates/static-website/azure/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-cloud text-blue-400 pr-2"></i>Static Website with a CDN</h4>
-                <p>Create a static website with a Blob storage and a CDN to serve the website with caching and HTTPs.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="azure-serverless" href="/templates/serverless-application/azure/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-sitemap text-blue-400 pr-2"></i>Full Stack Serverless App</h4>
-                <p>Create a Function App and a static website that consumes that Function.</p>
-            </div>
-        </a>
-    </div>
-</div>
-
-{{< /choosable >}}
-
-{{% choosable cloud gcp %}}
-
-<div class="tiles flex-wrap justify-center items-stretch mt-4">
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="google-get-started" href="/docs/iac/get-started/gcp/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-folder text-blue-400 pr-2"></i>Infrastructure as Code</h4>
-                <p>Install the CLI, configure Google Cloud, and deploy your first infrastructure.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="esc-get-started" href="/docs/esc/get-started/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-key text-blue-400 pr-2"></i>Secrets & Configuration</h4>
-                <p>Create your first environment and manage secrets and configuration.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="insights-get-started" href="/docs/insights/get-started/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-search-plus text-blue-400 pr-2"></i>Insights & Governance</h4>
-                <p>Discover and manage cloud infrastructure across all your resources.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="google-kubernetes" href="/templates/kubernetes/gcp/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-cubes text-blue-400 pr-2"></i>Google Kubernetes Engine (GKE)</h4>
-                <p>
-                    Create a VPC network with a subnet and deploy a Google Kubernetes Engine (GKE) cluster.
-                </p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="google-static-website" href="/templates/static-website/gcp/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-cloud text-blue-400 pr-2"></i>Static Website with a CDN</h4>
-                <p>Create a static website with a Cloud Storage bucket and a CDN to serve the website with caching and HTTPs.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="google-serverless" href="/templates/serverless-application/gcp/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-sitemap text-blue-400 pr-2"></i>Full Stack Serverless App</h4>
-                <p>Create a Cloud Function and a static website that consumes that function.</p>
-            </div>
-        </a>
-    </div>
-</div>
-
-{{< /choosable >}}
-
-{{% choosable cloud kubernetes %}}
-
-<div class="tiles flex-wrap justify-center items-stretch mt-4">
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="kubernetes-get-started" href="/docs/iac/get-started/kubernetes/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-folder text-blue-400 pr-2"></i>Infrastructure as Code</h4>
-                <p>Install the CLI, configure the Kubernetes Provider, and deploy your first infrastructure.</p>
-            </div>
-        </a>
-    </div>
-         <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="esc-get-started" href="/docs/esc/get-started/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-key text-blue-400 pr-2"></i>Secrets & Configuration</h4>
-                <p>Create your first environment and manage secrets and configuration.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="insights-get-started" href="/docs/insights/get-started/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-search-plus text-blue-400 pr-2"></i>Insights & Governance</h4>
-                <p>Discover and manage cloud infrastructure across all your resources.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="kubernetes-helm" href="/templates/kubernetes-application/helm-chart/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-cloud text-blue-400 pr-2"></i>Helm Chart</h4>
-                <p>Deploy a Helm chart to an existing cluster using Pulumi.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="kubernetes-web-app" href="/templates/kubernetes-application/web-application/" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-sitemap text-blue-400 pr-2"></i>Web App</h4>
-                <p>Deploy and example web application into an existing Kubernetes cluster.</p>
-            </div>
-        </a>
-    </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
-        <a data-track="kubernetes-aws" href="/templates/kubernetes/aws" class="tile h-full">
-            <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-                <h4 class="no-anchor"><i class="fas fa-cubes text-blue-400 pr-2"></i>Amazon Elastic Kubernetes Service (EKS)</h4>
-                <p>Create an EKS cluster that provides a managed Kubernetes control plane.</p>
-            </div>
-        </a>
-    </div>
-</div>
-
-{{< /choosable >}}
+</section>
 
 ## Additional resources
 

--- a/content/docs/iac/get-started/kubernetes/_index.md
+++ b/content/docs/iac/get-started/kubernetes/_index.md
@@ -1,8 +1,8 @@
 ---
-title_tag: Get Started with Kubernetes
+title_tag: Get Started Pulumi and Kubernetes
 meta_desc: This page provides an overview and guide on how to get started with Kubernetes.
 title: Kubernetes
-h1: Get Started with Kubernetes
+h1: Get Started with Pulumi and Kubernetes
 menu:
     iac:
         name: Kubernetes


### PR DESCRIPTION
This change simplifies the Getting Started landing page by removing the links to our product-specific guides and templates and focusing the page around getting started with IaC.

Before:

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/6be428ce-5de6-4fb0-a468-aafc01c7a946" />

After:

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/a2130399-3fb4-45d0-8852-f74171b94b6b" />

Part of https://github.com/pulumi/marketing/issues/1570.

Fixes MA-2.

