### PR TITLE
Clarify that auto-generated physical names vary by provider

### DIFF
--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -115,7 +115,7 @@ This random suffix serves two purposes:
 
 {{% notes type="info" %}}
 
-The exact format of auto-generated physical names varies by provider. While the general pattern is the logical name followed by a random suffix, individual providers may transform the logical name—for example, by removing hyphens or truncating it—to satisfy the naming constraints of the underlying cloud platform. Consult the [Registry](/registry/) for provider-specific documentation on naming behavior.
+The exact format of auto-generated physical names varies by provider. While the general pattern is a logical name followed by a random suffix, individual providers may transform the logical name—for example, by removing hyphens or truncating it—to satisfy platform naming constraints. Consult the [Registry](/registry/) for provider-specific documentation.
 
 {{% /notes %}}
 


### PR DESCRIPTION
## What does this PR do?

Adds an informational note to the "Physical Names and Auto-Naming" section of the resource names documentation clarifying that the exact format of auto-generated physical names depends on the cloud provider's implementation.

The existing text says names "typically look something like `my-role-d7c2fa0`", which implies the format is uniform across all providers. In practice, individual providers may transform the logical name portion of the generated name—for example, by removing hyphens or truncating it—to satisfy the naming constraints of the underlying cloud platform. This behavior has caused user confusion, as reported in #12199.

## Related issues

Fixes #12199

## Checklist

- [x] Added/updated documentation
- [x] No new code examples (docs-only change)

---
🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*