### PR TITLE
Add multi-repo structure example to organizing projects & stacks guide

### DIFF
--- a/content/docs/iac/guides/basics/organizing-projects-stacks/_index.md
+++ b/content/docs/iac/guides/basics/organizing-projects-stacks/_index.md
@@ -485,10 +485,10 @@ A second variant of the multi-repo pattern arises when a platform team authors a
 
 There are several tradeoffs to weigh when adopting a multi-repo structure:
 
-- **Team ownership.** Each repository has its own access controls, CI/CD pipeline, and release process. The platform team can evolve shared infrastructure on its own schedule without modifying service team code.
-- **Security.** Pulumi Cloud's [stack permissions](/docs/pulumi-cloud/access-management/stack-permissions/) let you grant service teams read-only access to platform stack outputs without granting write access to the underlying infrastructure.
-- **Stack reference coupling.** Stack references resolve at deployment time, so they always return the current outputs of the referenced stack. If the platform team renames or removes an exported output, service stacks that depend on it will fail until updated. Treat exported output names as a stable interface and coordinate breaking changes carefully.
-- **Discoverability.** In a monorepo, all projects are visible at a glance. In a multi-repo setup, teams need to agree on and document naming conventions for organizations, projects, and stacks.
+* **Team ownership.** Each repository has its own access controls, CI/CD pipeline, and release process. The platform team can evolve shared infrastructure on its own schedule without modifying service team code.
+* **Security.** Pulumi Cloud's [stack permissions](/docs/pulumi-cloud/access-management/stack-permissions/) let you grant service teams read-only access to platform stack outputs without granting write access to the underlying infrastructure.
+* **Stack reference coupling.** Stack references resolve at deployment time, so they always return the current outputs of the referenced stack. If the platform team renames or removes an exported output, service stacks that depend on it will fail until updated. Treat exported output names as a stable interface and coordinate breaking changes carefully.
+* **Discoverability.** In a monorepo, all projects are visible at a glance. In a multi-repo setup, teams need to agree on and document naming conventions for organizations, projects, and stacks.
 
 For most teams starting out, a monorepo requires less coordination. Multi-repo structures become the right choice when team boundaries, access control requirements, or independent deployment lifecycles justify the additional overhead.
 


### PR DESCRIPTION
Closes #13350

## What changed

The organizing-projects-stacks guide already has a detailed monorepo example but only briefly mentions that multi-repo setups exist. This PR adds a concrete **multi-repo structure** example to fill that gap.

### Changes

**`content/docs/iac/guides/basics/organizing-projects-stacks/_index.md`**

- Added a `### Multi-repo structure` section in the Examples area, directly after the monorepo example.
- The new section covers the common platform-team/service-team pattern:
  - Shows directory trees for both a `platform-infra` repo and a `my-service` repo (TypeScript and Go language variants using the existing language chooser shortcode).
  - Includes code examples showing how the platform project exports VPC outputs and how the service project consumes them via `StackReference`, with a dynamically-scoped stack name (`${org}/platform-infra/${pulumi.getStack()}`).
  - Briefly describes the component-package variant (authoring a component in a dedicated repo and publishing to npm/PyPI/NuGet), with a link to the building-extending docs.
  - Lists key tradeoffs: team ownership, security via Pulumi Cloud stack permissions, stack reference coupling risks, and discoverability.
- Updated the `## Aligning to Git Repos` section to add a forward reference to the new example.

---

🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*