### PR TITLE
Move property paths to reference section

### DIFF
--- a/content/docs/esc/environments/syntax/interpolations-and-references.md
+++ b/content/docs/esc/environments/syntax/interpolations-and-references.md
@@ -19,7 +19,7 @@ References take the form `${property-path}`. References may appear alone or embe
 
 ## Property paths
 
-Property paths--[used throughout the Pulumi ecosystem](/docs/iac/concepts/miscellaneous/property-paths)--are JavaScript-inspired expressions that refer to properties within JSON-like values.
+Property paths--[used throughout the Pulumi ecosystem](/docs/reference/property-paths/)--are JavaScript-inspired expressions that refer to properties within JSON-like values.
 
 The syntax supports both dot notation and bracket notation.
 For keys that contain special characters (i.e. `[`, `]`, `"`, or `.`) or begin with a digit,

--- a/content/docs/iac/concepts/resources/options/additionalsecretoutputs.md
+++ b/content/docs/iac/concepts/resources/options/additionalsecretoutputs.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: additionalSecretOutputs
     parent: options-concepts
-    weight: 1
+    weight: 10
 aliases:
   - /docs/intro/concepts/resources/options/additionalsecretoutputs/
   - /docs/concepts/options/additionalsecretoutputs/

--- a/content/docs/iac/concepts/resources/options/aliases.md
+++ b/content/docs/iac/concepts/resources/options/aliases.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: aliases
     parent: options-concepts
-    weight: 2
+    weight: 20
 aliases:
   - /docs/iac/concepts/options/aliases/
   - /docs/intro/concepts/resources/#aliases

--- a/content/docs/iac/concepts/resources/options/customtimeouts.md
+++ b/content/docs/iac/concepts/resources/options/customtimeouts.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: customTimeouts
     parent: options-concepts
-    weight: 3
+    weight: 30
 aliases:
   - /docs/iac/concepts/options/customtimeouts/
   - /docs/intro/concepts/resources/options/customtimeouts/

--- a/content/docs/iac/concepts/resources/options/deletebeforereplace.md
+++ b/content/docs/iac/concepts/resources/options/deletebeforereplace.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: deleteBeforeReplace
     parent: options-concepts
-    weight: 4
+    weight: 40
 aliases:
   - /docs/intro/concepts/resources/options/deletebeforereplace/
   - /docs/concepts/options/deletebeforereplace/

--- a/content/docs/iac/concepts/resources/options/deletedwith.md
+++ b/content/docs/iac/concepts/resources/options/deletedwith.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: deletedWith
     parent: options-concepts
-    weight: 5
+    weight: 50
 aliases:
   - /docs/intro/concepts/resources/options/deletedwith/
   - /docs/concepts/options/deletedwith/

--- a/content/docs/iac/concepts/resources/options/dependson.md
+++ b/content/docs/iac/concepts/resources/options/dependson.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: dependsOn
     parent: options-concepts
-    weight: 6
+    weight: 60
 aliases:
   - /docs/iac/concepts/options/dependson/
   - /docs/intro/concepts/resources/options/dependson/

--- a/content/docs/iac/concepts/resources/options/envvarmappings.md
+++ b/content/docs/iac/concepts/resources/options/envvarmappings.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: envVarMappings
     parent: options-concepts
-    weight: 6
+    weight: 70
 aliases:
   - /docs/iac/concepts/options/envvarmappings/
   - /docs/intro/concepts/resources/options/envvarmappings/

--- a/content/docs/iac/concepts/resources/options/hidediffs.md
+++ b/content/docs/iac/concepts/resources/options/hidediffs.md
@@ -8,13 +8,21 @@ menu:
   iac:
     identifier: hideDiffs
     parent: options-concepts
-    weight: 8
+    weight: 80
 aliases:
   - /docs/iac/concepts/options/hidediffs/
   - /docs/concepts/options/hidediffs/
 ---
 
 The `hideDiffs` resource option specifies a list of property paths whose diff details Pulumi will compact in CLI output. Setting `hideDiffs` does not affect what resources are updated, only how those updates are displayed.
+
+{{% notes type="info" %}}
+The `hideDiffs` option only affects CLI display output. It does not change resource update behavior, prevent changes from being detected, or modify what gets stored in state.
+{{% /notes %}}
+
+{{% notes type="info" %}}
+Unlike `ignoreChanges`, `hideDiffs` does not affect which properties trigger updates. If you want to prevent updates based on property changes, use the [`ignoreChanges`](/docs/concepts/options/ignorechanges/) option instead.
+{{% /notes %}}
 
 ## How hideDiffs works
 
@@ -98,7 +106,7 @@ resources:
 
 ## Property Paths
 
-In addition to passing simple property names, nested properties can also be supplied to hide diffs for a more targeted nested part of the resource's properties. See [property paths](/docs/iac/concepts/inputs-outputs/property-paths/) for examples of legal paths that can be passed to specify nested properties of objects and arrays.
+In addition to passing simple property names, nested properties can also be supplied to hide diffs for a more targeted nested part of the resource's properties. See [property paths](/docs/reference/property-paths/) for examples of legal paths that can be passed to specify nested properties of objects and arrays.
 
 For example, to hide diffs for all weights in an AWS load balancer listener's target groups:
 
@@ -254,11 +262,3 @@ resources:
 {{% /choosable %}}
 
 {{< /chooser >}}
-
-{{% notes type="info" %}}
-The `hideDiffs` option only affects CLI display output. It does not change resource update behavior, prevent changes from being detected, or modify what gets stored in state.
-{{% /notes %}}
-
-{{% notes type="info" %}}
-Unlike `ignoreChanges`, `hideDiffs` does not affect which properties trigger updates. If you want to prevent updates based on property changes, use the [`ignoreChanges`](/docs/concepts/options/ignorechanges/) option instead.
-{{% /notes %}}

--- a/content/docs/iac/concepts/resources/options/hooks.md
+++ b/content/docs/iac/concepts/resources/options/hooks.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: hooks
     parent: options-concepts
-    weight: 7
+    weight: 90
 aliases:
   - /docs/iac/concepts/options/hooks/
   - /docs/intro/concepts/resources/options/hooks/

--- a/content/docs/iac/concepts/resources/options/ignorechanges.md
+++ b/content/docs/iac/concepts/resources/options/ignorechanges.md
@@ -8,14 +8,30 @@ menu:
   iac:
     identifier: ignoreChanges
     parent: options-concepts
-    weight: 8
+    weight: 100
 aliases:
   - /docs/intro/concepts/resources/options/ignorechanges/
   - /docs/concepts/options/ignorechanges/
   - /docs/iac/concepts/options/ignorechanges/
 ---
 
-The `ignoreChanges` resource option specifies a list of properties that Pulumi will ignore when it updates existing resources. Pulumi ignores a property by using the old value from the state instead of the value provided by the Pulumi program when determining whether an update or replace is needed. Ignored properties will still be used from the program when there is no previous value in the state, most importantly when creating the resource.
+The `ignoreChanges` resource option specifies a list of properties that Pulumi will ignore when it updates existing resources. Pulumi ignores a property by using the old value from the state instead of the value provided by the Pulumi program when determining whether an update or replace is needed. Ignored properties will still be used from the program when there is no previous value in the state (most commonly when creating the resource).
+
+{{% notes type="info" %}}
+The `ignoreChanges` option only applies to resource inputs, not outputs.
+{{% /notes %}}
+
+{{% notes type="warning" %}}
+The `ignoreChanges` resource option does not automatically apply to inputs to component resources.  If `ignoreChanges` is passed to a component resource, it is up to that component's implementation to decide what if anything it will do.
+{{% /notes %}}
+
+In addition to passing simple property names, nested properties can also be supplied to ignore changes to a more targeted nested part of the resource's inputs. See [property paths](/docs/reference/property-paths/) for examples of legal paths that can be passed to specify nested properties of objects and arrays.
+
+{{% notes type="info" %}}
+For arrays with different lengths, only changes for elements that are in both arrays are ignored. If the new input array is longer, additional elements will be taken from the new array. If the new array is shorter, we only take that number of elements from the original array.
+
+For example `ignoreChanges` on an old array `[1, 2]` and a new array `[a, b, c]` results in `[1, 2, c]`, and an old array `[1, 2, 3]` and a new array `[a, b]` results in `[1, 2]`.
+{{% /notes %}}
 
 ## How ignoreChanges works
 
@@ -405,19 +421,3 @@ resources:
 {{< /chooser >}}
 
 After the initial deployment, an external process could change the weights (for example, to a 50/50 split). Before you next run `pulumi up` to add a third target group, run `pulumi refresh` so that the stack captures the live weights. Without the refresh, Pulumi retains the original `100` and `0` values in state and will resend them to the AWS API on the next update, resetting the weights you meant to preserve.
-
-{{% notes type="info" %}}
-The `ignoreChanges` option only applies to resource inputs, not outputs.
-{{% /notes %}}
-
-{{% notes type="info" %}}
-The `ignoreChanges` resource option does not apply to inputs to component resources.  If `ignoreChanges` is passed to a component resource, it is up to that component's implementation to decide what if anything it will do.
-{{% /notes %}}
-
-In addition to passing simple property names, nested properties can also be supplied to ignore changes to a more targeted nested part of the resource's inputs. See [property paths](/docs/iac/concepts/inputs-outputs/property-paths/) for examples of legal paths that can be passed to specify nested properties of objects and arrays.
-
-{{% notes type="info" %}}
-For arrays with different lengths, only changes for elements that are in both arrays are ignored. If the new input array is longer, additional elements will be taken from the new array. If the new array is shorter, we only take that number of elements from the original array.
-
-For example `ignoreChanges` on an old array `[1, 2]` and a new array `[a, b, c]` results in `[1, 2, c]`, and an old array `[1, 2, 3]` and a new array `[a, b]` results in `[1, 2]`.
-{{% /notes %}}

--- a/content/docs/iac/concepts/resources/options/import.md
+++ b/content/docs/iac/concepts/resources/options/import.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: resource-option-import
     parent: options-concepts
-    weight: 9
+    weight: 110
 aliases:
   - /docs/iac/concepts/options/import/
   - /docs/intro/concepts/resources/options/import/

--- a/content/docs/iac/concepts/resources/options/parent.md
+++ b/content/docs/iac/concepts/resources/options/parent.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: parent
     parent: options-concepts
-    weight: 10
+    weight: 120
 aliases:
   - /docs/intro/concepts/resources/options/parent/
   - /docs/concepts/options/parent/

--- a/content/docs/iac/concepts/resources/options/protect.md
+++ b/content/docs/iac/concepts/resources/options/protect.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: protect
     parent: options-concepts
-    weight: 11
+    weight: 130
 aliases:
   - /docs/iac/concepts/options/protect/
   - /docs/intro/concepts/resources/options/protect/

--- a/content/docs/iac/concepts/resources/options/provider.md
+++ b/content/docs/iac/concepts/resources/options/provider.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: provider
     parent: options-concepts
-    weight: 12
+    weight: 140
 aliases:
   - /docs/concepts/resources/options/provider/
   - /docs/concepts/options/provider/

--- a/content/docs/iac/concepts/resources/options/providers.md
+++ b/content/docs/iac/concepts/resources/options/providers.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: providers
     parent: options-concepts
-    weight: 13
+    weight: 150
 aliases:
   - /docs/iac/concepts/options/providers/
   - /docs/concepts/resources/options/providers/

--- a/content/docs/iac/concepts/resources/options/replacementtrigger.md
+++ b/content/docs/iac/concepts/resources/options/replacementtrigger.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: replacementTrigger
     parent: options-concepts
-    weight: 5
+    weight: 160
 aliases:
   - /docs/intro/concepts/resources/options/replacementtrigger/
   - /docs/concepts/options/replacementtrigger/

--- a/content/docs/iac/concepts/resources/options/replaceonchanges.md
+++ b/content/docs/iac/concepts/resources/options/replaceonchanges.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: replaceOnChanges
     parent: options-concepts
-    weight: 14
+    weight: 170
 aliases:
   - /docs/intro/concepts/resources/options/replaceonchanges/
   - /docs/concepts/options/replaceonchanges/
@@ -106,7 +106,7 @@ var widget = new com.pulumi.kubernetes.apiextensions.CustomResource("widget",
 
 {{< /chooser >}}
 
-The [property paths](/docs/iac/concepts/inputs-outputs/property-paths/) provided as input to `replaceOnChanges` can each describe a subset of the properties of the resource which should trigger a replacement on changes.  The `*` wildcard can be used in any part of a path.  A few examples of what changes will trigger replacement for a given property path string are:
+The [property paths](/docs/reference/property-paths/) provided as input to `replaceOnChanges` can each describe a subset of the properties of the resource which should trigger a replacement on changes.  The `*` wildcard can be used in any part of a path.  A few examples of what changes will trigger replacement for a given property path string are:
 
 - `*`: any property change
 - `spec`: any change to the `spec` property or any of its children

--- a/content/docs/iac/concepts/resources/options/replacewith.md
+++ b/content/docs/iac/concepts/resources/options/replacewith.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: replaceWith
     parent: options-concepts
-    weight: 5
+    weight: 180
 aliases:
   - /docs/intro/concepts/resources/options/replacewith/
   - /docs/concepts/options/replacewith/

--- a/content/docs/iac/concepts/resources/options/retainOnDelete.md
+++ b/content/docs/iac/concepts/resources/options/retainOnDelete.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: retainOnDelete
     parent: options-concepts
-    weight: 15
+    weight: 190
 aliases:
   - /docs/intro/concepts/resources/options/retainondelete/
   - /docs/concepts/options/retainondelete/

--- a/content/docs/iac/concepts/resources/options/transformations.md
+++ b/content/docs/iac/concepts/resources/options/transformations.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: transformations
     parent: options-concepts
-    weight: 16
+    weight: 200
 aliases:
   - /docs/iac/concepts/options/transformations/
   - /docs/intro/concepts/resources/options/transformations/

--- a/content/docs/iac/concepts/resources/options/transforms.md
+++ b/content/docs/iac/concepts/resources/options/transforms.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: transforms
     parent: options-concepts
-    weight: 16
+    weight: 210
 aliases:
   - /docs/intro/concepts/resources/options/transforms/
   - /docs/concepts/options/transforms/

--- a/content/docs/iac/concepts/resources/options/version.md
+++ b/content/docs/iac/concepts/resources/options/version.md
@@ -8,7 +8,7 @@ menu:
   iac:
     identifier: resource-option-version
     parent: options-concepts
-    weight: 17
+    weight: 220
 aliases:
   - /docs/iac/concepts/options/version/
   - /docs/intro/concepts/resources/options/version/

--- a/content/docs/insights/discovery/search.md
+++ b/content/docs/insights/discovery/search.md
@@ -282,7 +282,7 @@ If you would like to use it, [contact us](/contact?form=sales) to upgrade.
 Property search allows you to query resources by their inputs and outputs.
 
 A property query is similar to a field query but it is triggered by a leading `.` followed by a
-[property path](/docs/iac/concepts/inputs-outputs/property-paths/):
+[property path](/docs/reference/property-paths/):
 
 > .\<property path>:<value?>
 

--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -87,6 +87,11 @@ sections:
     description: Reference for ESC environment definitions, interpolations, functions, and providers.
     link: /docs/esc/environments/syntax/
 
+  - emoji: 🔗
+    heading: Property Paths
+    description: Reference for property path syntax used in resource options, ESC, and Insights.
+    link: /docs/reference/property-paths/
+
 - type: button-cards
   heading: Packages & Providers
   cards:

--- a/content/docs/reference/property-paths.md
+++ b/content/docs/reference/property-paths.md
@@ -5,11 +5,12 @@ title: Property Paths
 h1: Property Paths
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-    iac:
+    reference:
         name: Property Paths
-        parent: iac-concepts-inputs-outputs
-        weight: 4
+        parent: reference-home
+        weight: 10
 aliases:
+- /docs/iac/concepts/inputs-outputs/property-paths/
 - /docs/iac/concepts/resources/options/property-paths/
 - /docs/iac/concepts/miscellaneous/property-paths/
 ---
@@ -38,3 +39,14 @@ Below are some example property paths:
 - `["root key with a ."][100]`
 - `root.array[*].field`
 - `root.array["*"].field`
+
+## Used in
+
+Property paths are used in the following Pulumi features (this list is not exhaustive):
+
+- [`ignoreChanges`](/docs/iac/concepts/resources/options/ignorechanges/) resource option
+- [`replaceOnChanges`](/docs/iac/concepts/resources/options/replaceonchanges/) resource option
+- [`hideDiffs`](/docs/iac/concepts/resources/options/hidediffs/) resource option
+- [`pulumi config set --path`](/docs/iac/cli/commands/pulumi_config_set/) flag
+- [ESC interpolations and references](/docs/esc/environments/syntax/interpolations-and-references/)
+- [Insights resource search](/docs/insights/discovery/search/)


### PR DESCRIPTION
Move property-paths.md to content/docs/reference/, add bidirectional links to feature pages, and sort resource option nav weights alphabetically.

Fixes #16708
