### PR TITLE
Update GitHub Actions action versions in CI/CD examples

### DIFF
--- a/content/docs/iac/guides/continuous-delivery/github-actions.md
+++ b/content/docs/iac/guides/continuous-delivery/github-actions.md
@@ -22,7 +22,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-The content and examples in this guide refer to Pulumi's GitHub Action v3. Pulumi's GitHub Action v1 has been deprecated
+The content and examples in this guide refer to Pulumi's GitHub Action v6. Pulumi's GitHub Action v1 has been deprecated
 and reached its End of Life (EOL) on August 31st, 2021.
 {{% /notes %}}
 
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
       - name: Configure AWS Credentials
@@ -182,9 +182,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.0.x
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
       - name: Configure AWS Credentials
@@ -324,9 +324,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 10.0.x
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -505,7 +505,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
       - name: Configure AWS Credentials
@@ -538,9 +538,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 10.0.x
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -664,7 +664,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
       - name: Configure AWS Credentials
@@ -701,9 +701,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 10.0.x
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -828,7 +828,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
       - name: Configure AWS Credentials
@@ -866,9 +866,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 10.0.x
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -1003,7 +1003,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
       - name: Configure AWS Credentials
@@ -1048,9 +1048,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.0.x
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
Fixes #11527.

The GitHub Actions continuous delivery guide contained workflow examples using several significantly outdated action versions. This PR brings them up to date with current stable releases.

## Changes

**`actions/setup-go`**: Updated from `@v3` and `@v5` → `@v6` (latest stable release: v6.3.0, published February 2026). Applied to all 6 occurrences across the language tab examples.

**`actions/setup-dotnet`**: Updated from `@v1` and `@v3` → `@v5` (latest stable release: v5.1.0, published January 2026). Applied to all 6 occurrences across the language tab examples.

**`.NET SDK version (`dotnet-version`)**: Updated from `3.1.x` and `6.0.x` → `10.0.x`. .NET 3.1 reached End of Life in December 2022; .NET 6.0 reached End of Life in November 2024. .NET 10.0 is the current Long Term Support (LTS) release (released November 2025, supported until November 2028).

**Header note**: Updated the introductory note to correctly reference Pulumi's GitHub Action `v6` rather than `v3`, matching the version used in all examples throughout the page.

Actions and versions that were already current and required no changes:
- `actions/checkout@v4` ✓
- `actions/setup-node@v4` ✓
- `actions/setup-python@v5` ✓
- `aws-actions/configure-aws-credentials@v4` ✓
- `pulumi/actions@v6` ✓

---
🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*