### PR TITLE
Fix tutorial collection page sidebar styling

### DIFF
--- a/data/tutorials/collections.yaml
+++ b/data/tutorials/collections.yaml
@@ -1,28 +1,28 @@
 - id: aws
   type: provider
   name: AWS
-  description: Here is a description of the collection.
+  description: Learn how to use Pulumi to deploy and manage infrastructure on AWS.
   logo: /logos/pkg/aws.svg
   featured: true
 
 - id: azure
   type: provider
   name: Microsoft Azure
-  description: Here is a description of the collection.
+  description: Learn how to use Pulumi to deploy and manage infrastructure on Microsoft Azure.
   logo: /logos/pkg/azure.svg
   featured: true
 
 - id: gcp
   type: provider
   name: Google Cloud
-  description: Here is a description of the collection.
+  description: Learn how to use Pulumi to deploy and manage infrastructure on Google Cloud.
   logo: /logos/pkg/gcp.svg
   featured: true
 
 - id: kubernetes
   type: provider
   name: Kubernetes
-  description: Here is a description of the collection.
+  description: Learn how to use Pulumi to deploy and manage infrastructure on Kubernetes.
   logo: /logos/pkg/kubernetes.svg
   featured: true
 

--- a/layouts/taxonomy/collection.html
+++ b/layouts/taxonomy/collection.html
@@ -2,13 +2,23 @@
     {{ $id := .Path | path.Base }}
     {{ $collection := index (where .Site.Data.tutorials.collections "id" $id) 0 }}
     {{ .Store.Set "collectionTitle" $collection.name }}
-    <div class="flex mb-8">
-        <div class="sticky top-12 max-h-75">
-            {{ partial "tutorials/nav.html" . }}
+    <div class="docs-list-main">
+        <div class="docs-main-nav-toggle-wrapper">
+            <div class="docs-main-nav-wrapper">
+                <div id="docs-main-nav" class="docs-main-nav">
+                    <nav class="main-nav">
+                        {{ partial "tutorials/nav.html" . }}
+                    </nav>
+                </div>
+            </div>
+            <div class="docs-nav-toggle">
+                <div class="docs-nav-toggle-icon icon icon-24-24"></div>
+            </div>
         </div>
-        <div class="mt-8 mr-6 ml-4 flex justify-center w-full">
-            <div class="max-w-5xl">
-                <div>
+
+        <div class="docs-main-content-wrapper">
+            <div class="docs-main-content">
+                <div class="max-w-5xl">
                     <header class="mb-6">
                         {{ partial "tutorials/breadcrumb.html" . $collection }}
                     </header>


### PR DESCRIPTION
The `/tutorials/aws/`, `/tutorials/azure/`, `/tutorials/gcp/`, and `/tutorials/kubernetes/` pages had broken sidebar formatting — plain unstyled lists instead of the styled nav with chevrons and collapsible sections shown on the main `/tutorials/` page.

## Changes
- `layouts/taxonomy/collection.html`: replaced the bare `flex mb-8` + `sticky` div with the full `docs-main-nav-toggle-wrapper` / `docs-main-nav` / `nav.main-nav` hierarchy that the existing `.section-collections nav.main-nav` CSS rules target
- `data/tutorials/collections.yaml`: replaced placeholder descriptions for AWS, Azure, GCP, and Kubernetes collections