### PR TITLE
Fix up AWS Overview page

### DIFF
--- a/content/docs/iac/clouds/aws/_index.md
+++ b/content/docs/iac/clouds/aws/_index.md
@@ -1,6 +1,6 @@
 ---
 title_tag: "AWS & Pulumi"
-meta_desc: Pulumi offers full support for AWS, with two providers, 10+ components, multiple templates, and numerous guides.
+meta_desc: Provision and manage AWS infrastructure using TypeScript, Python, Go, C#, Java, or YAML with Pulumi's AWS providers, components, and guides.
 title: "AWS"
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 h1: AWS & Pulumi
@@ -11,14 +11,17 @@ menu:
     parent: iac-clouds
     weight: 1
 cloud_overview: true
-description: Build infrastructure on AWS using TypeScript, Python, Go, C#, Java or YAML. Pulumi supports all AWS services and stays up-to-date with all AWS features.
+description: Build infrastructure on AWS using TypeScript, Python, Go, C#, Java, or YAML. Pulumi supports all AWS services and stays up-to-date with all AWS features.
 get_started_guide:
   link: /docs/iac/get-started/aws/
   icon: aws
 providers:
-  description: Provision hundreds of AWS cloud resources with the AWS provider.
+  description: |
+    The Amazon Web Services (AWS) provider for Pulumi can provision cloud resources in AWS. It uses the AWS SDK to manage resources and should be your default choice for managing AWS resources. The AWS Cloud Control provider provides coverage of all resources in the AWS Cloud Control API, but not all resources are available yet.
+
   provider_list:
   - display_name: AWS
+    recommended: true
     content_links:
     - display_name: Overview
       icon: page-small-black
@@ -32,6 +35,17 @@ providers:
     - display_name: How-to guides
       icon: question-small-black
       url: aws/how-to-guides/
+  - display_name: AWS Cloud Control
+    content_links:
+    - display_name: Overview
+      icon: page-small-black
+      url: aws-native/
+    - display_name: Install & config
+      icon: gear-small-black
+      url: aws-native/installation-configuration/
+    - display_name: API docs
+      icon: book-small-black
+      url: aws-native/api-docs/
 
 components:
 - display_name: AWSx
@@ -40,46 +54,7 @@ components:
 - display_name: AWS API Gateway
   url: aws-apigateway/
   description:
-- display_name: AWS IAM
-  url: aws-iam/
-  description:
-- display_name: AWS static website
-  url: aws-static-website/
-  description:
-- display_name: AWS QuickStart Aurora Postgres
-  url: aws-quickstart-aurora-postgres/
-  description:
-- display_name: AWS QuickStart Redshift
-  url: aws-quickstart-redshift/
-  description:
-- display_name: AWS QuickStart VPC
-  url: aws-quickstart-vpc/
-  description:
-- display_name: AWS S3 Replicated Bucket
-  url: aws-s3-replicated-bucket/
-  description:
-- display_name: Metabase (AWS)
-  url: metabase/
-  description:
 
-aws-native:
-  heading: AWS Cloud Control
-  public_preview: true
-  description: Manage and provision resources defined in the AWS CloudFormation Registry.
-  content_links:
-  - display_name: Overview
-    icon: page-small-black
-    url: aws-native/
-  - display_name: Install & config
-    icon: gear-small-black
-    url: aws-native/installation-configuration/
-  - display_name: API docs
-    icon: book-small-black
-    url: aws-native/api-docs/
-convert:
-- heading: Convert CloudFormation to Pulumi
-  url: /cf2pulumi/
-  description: Convert CloudFormation templates to your language of choice with Pulumi's conversion tool.
 templates:
 - display_name: Container service on AWS
   url: container-service/aws/
@@ -91,6 +66,7 @@ templates:
   url: virtual-machine/aws/
 - display_name: Kubernetes cluster on AWS
   url: kubernetes/aws/
+
 guides:
   description: Learn how to use AWS & Pulumi together.
   guides_list:


### PR DESCRIPTION
- Remove links to Registry packages that are not maintained
- Restore AWS CC link in providers
- Remove link to /cf2pulumi as this tool is not maintained
