### PR TITLE
Improve SAML SSO docs structure and cross-linking

### DIFF
--- a/content/docs/administration/access-identity/saml/_index.md
+++ b/content/docs/administration/access-identity/saml/_index.md
@@ -2,7 +2,7 @@
 title_tag: SAML Single Sign-On (SSO) Guides
 meta_desc:
   This page provides an overview of how to configure any SAML 2.0 identity provider
-  with the Pulumi Cloud.
+  with Pulumi Cloud.
 title: SAML(SSO)
 h1: Pulumi Cloud SAML(SSO)
 meta_image: /images/docs/meta-images/docs-meta.png
@@ -20,7 +20,9 @@ aliases:
 
 The [Pulumi Cloud](https://app.pulumi.com) can be configured to work with any SAML 2.0 identity provider. SAML support requires Pulumi Enterprise or Pulumi Business Critical. To learn more about the capabilities of Pulumi Enterprise or Pulumi Business Critical, refer to the [pricing page](/pricing/).
 
-> Looking for information on how to enable SAML SSO for self-hosted Pulumi? Learn more [here](/docs/administration/self-hosting/saml-sso/).
+{{% notes type="info" %}}
+Running self-hosted Pulumi Cloud? You'll first need to [configure your self-hosted infrastructure for SAML SSO](/docs/administration/self-hosting/saml-sso/) (API service keys and environment variables), then return here to complete IdP configuration.
+{{% /notes %}}
 
 ## Single Sign-On (SSO)
 

--- a/content/docs/administration/access-identity/saml/auth0.md
+++ b/content/docs/administration/access-identity/saml/auth0.md
@@ -8,7 +8,7 @@ menu:
   administration:
     name: Auth0
     parent: administration-access-identity-saml
-    weight: 2
+    weight: 20
     identifier: pulumi-cloud-access-management-saml-auth0
 aliases:
 - /docs/reference/service/saml-auth0/
@@ -17,16 +17,10 @@ aliases:
 - /docs/pulumi-cloud/access-management/saml/auth0/
 ---
 
-This guide walks you through configuring your Auth0 Authentication Platform as a SAML SSO identity provider
-(IDP) for the Pulumi Cloud.
+This guide walks you through configuring your Auth0 Authentication Platform as a [SAML SSO](/docs/administration/access-identity/saml/) identity provider
+(IDP) for Pulumi Cloud.
 
-## Prerequisites
-
-* Your organization must already be configured to use [SAML](/docs/administration/access-identity/saml/sso/) with Pulumi.
-* You must be an admin of your Pulumi organization.
-* (Optional, but highly recommended) You should have more than one admin for your Pulumi organization.
-
-## Enabling SAML For Your Auth0 Authentication Platform
+## Enabling SAML for your Auth0 authentication platform
 
 To enable SAML for your Auth0 Authentication Platform, navigate to the **Applications** section of your Auth0 dashboard. You may
 need to create a new application or select an existing application. Next, we need to get the SAML metadata XML to
@@ -41,21 +35,8 @@ the browser or a command line tool like `curl`.
 
 ![Auth0 Application Endpoints](/images/docs/reference/service/saml-auth0/auth0-app-endpoints.png)
 
-To configure Pulumi with the SAML metadata:
-
-1. Sign into the Pulumi Cloud and navigate to your organization.
-1. Select **Settings**, then **Access Management**.
-1. Select the **Other** tab.
-1. In the **Membership Requirements** section, select **Change requirements**.
-1. Select **SAML SSO** and then **Next**.
-1. Paste the contents of the downloaded XML file into the text area.
-
-    ![Pulumi SAML SSO Configuration](/images/docs/reference/service/saml-auth0/auth0-saml-sso-config.png)
-
-1. Select **Apply changes**.
-
 Finally, in the **Settings** tab of your application, navigate to the **Application URIs** section. In the **Application
-Login URI** field, enter the URL of your Pulumi organization in following format:
+Login URI** field, enter the URL of your Pulumi organization in the following format:
 
 ```
 https://api.pulumi.com/login/{orgName}/sso/saml/acs
@@ -64,8 +45,20 @@ https://api.pulumi.com/login/{orgName}/sso/saml/acs
 where `{orgName}` is the name of your Pulumi organization. Additionally, in the **Allowed Callback URLs** field, enter
 the same URL.
 
+## Configuring your Pulumi organization
+
+To configure Pulumi with the SAML metadata:
+
+1. Sign in to Pulumi Cloud and navigate to your organization.
+1. Select **Settings** > **Access Management**.
+1. Select the **Other** tab.
+1. In the **Membership Requirements** section, select **Change requirements**.
+1. Select **SAML SSO** and then **Next**.
+1. Paste the contents of the downloaded XML file into the text area.
+1. Select **Apply changes**.
+
 ## Troubleshooting
 
-Auth0 Troubleshoot SAML Configurations: [SAML app error messages](https://auth0.com/docs/troubleshoot/authentication-issues/troubleshoot-saml-configurations)
+Auth0 troubleshooting: [SAML app error messages](https://auth0.com/docs/troubleshoot/authentication-issues/troubleshoot-saml-configurations)
 
-If you need additional assistance, [contact us](/about#contact-us).
+For additional help, see the [SAML SSO troubleshooting guide](/docs/administration/access-identity/saml/troubleshooting/) or [contact support](https://support.pulumi.com/).

--- a/content/docs/administration/access-identity/saml/entra.md
+++ b/content/docs/administration/access-identity/saml/entra.md
@@ -1,6 +1,6 @@
 ---
 title_tag: Configuring Microsoft Entra ID | SAML SSO
-meta_desc: This page provides a walkthrough important aspects of configuring 
+meta_desc: This page provides a walkthrough important aspects of configuring
            Entra ID as a SAML SSO identity provider (IDP).
 title: Microsoft Entra ID
 h1: "SAML: Configuring Microsoft Entra ID"
@@ -9,7 +9,7 @@ menu:
   administration:
     name: Entra ID
     parent: administration-access-identity-saml
-    weight: 3
+    weight: 30
     identifier: pulumi-cloud-access-management-saml-entra
 aliases:
 - /docs/reference/service/saml-aad/
@@ -20,12 +20,8 @@ aliases:
 - /docs/pulumi-cloud/access-management/saml/aad/
 ---
 
-This guide walks you through configuring Microsoft Entra ID as a SAML SSO identity provider
-(IDP) for the Pulumi Cloud.
-
-## Prerequisites
-
-- [Single Sign-On](/docs/administration/access-identity/saml/sso/)
+This guide walks you through configuring Microsoft Entra ID as a [SAML SSO](/docs/administration/access-identity/saml/) identity provider
+(IDP) for Pulumi Cloud.
 
 ## Configuring Microsoft Entra ID
 
@@ -87,10 +83,10 @@ This guide walks you through configuring Microsoft Entra ID as a SAML SSO identi
 > for more information.
 
 Now that the Entra ID side of the SAML SSO configuration is complete, you will need
-to configure the Pulumi Cloud to receive SAML SSO requests from your
+to configure Pulumi Cloud to receive SAML SSO requests from your
 Entra ID application.
 
-## Configuring Your Pulumi Organization
+## Configuring your Pulumi organization
 
 To configure your Pulumi organization to accept SAML SSO requests from Entra ID, you will need to
 download the SAML application's configuration data and then pass that to Pulumi.
@@ -100,33 +96,22 @@ download the SAML application's configuration data and then pass that to Pulumi.
 
     ![Download XML](/images/docs/reference/service/saml-aad/download-xml.png)
 
-1. Sign into the Pulumi Cloud and navigate to your SAML organization. Navigate to the
-  **Settings** tab and then select **Access Management**.
-
+1. Sign in to Pulumi Cloud and navigate to your organization.
+1. Select **Settings** > **Access Management**.
 1. Select the **Other** tab.
-
-1. In the **Membership Requirements** section, select the **Change requirements** button.
-
+1. In the **Membership Requirements** section, select **Change requirements**.
 1. Select **SAML SSO** and then **Next**.
-
-1. Open up the XML document you downloaded from the Entra ID portal, and paste its full contents into the text area.
-
-    ![Provide the XML IDP descriptor](/images/docs/reference/service/saml-aad/pulumi-saml-settings-page.png)
-
+1. Open the XML document you downloaded from the Entra ID portal and paste its full contents into the text area.
 1. Select **Apply changes**.
 
-## Signing into Pulumi using Entra ID
+## Signing in to Pulumi using Entra ID
 
-Once your Entra ID application is created, and its configuration data passed to Pulumi, you can now
-sign in to the Pulumi Cloud using your SAML SSO credentials.
-
-Navigate to [https://app.pulumi.com/signin/sso/](https://app.pulumi.com/signin/sso/) and enter the
+Once your Entra ID application is created and its configuration data passed to Pulumi, you can sign in to
+Pulumi Cloud using your SAML SSO credentials. Navigate to
+[https://app.pulumi.com/signin/sso/](https://app.pulumi.com/signin/sso/) and enter the
 name of your Pulumi organization. If everything is configured correctly, you should be prompted to
-sign in to your Entra ID instance, and then immediately be redirected back to the Pulumi Cloud.
-
-![Pulumi Cloud](/images/docs/reference/service/saml-aad/pulumi-console-signin.png)
+sign in to your Entra ID instance, and then immediately be redirected back to Pulumi Cloud.
 
 ## Troubleshooting
 
-If you have any trouble configuring Entra ID, signing into Pulumi, or need additional assistance, please
-[contact support](https://support.pulumi.com/).
+For help resolving SAML SSO configuration issues, see the [SAML SSO troubleshooting guide](/docs/administration/access-identity/saml/troubleshooting/) or [contact support](https://support.pulumi.com/).

--- a/content/docs/administration/access-identity/saml/gsuite.md
+++ b/content/docs/administration/access-identity/saml/gsuite.md
@@ -9,7 +9,7 @@ menu:
   administration:
     name: Google Workspace
     parent: administration-access-identity-saml
-    weight: 4
+    weight: 40
     identifier: pulumi-cloud-access-management-saml-gsuite
 aliases:
 - /docs/reference/service/saml-gsuite/
@@ -18,14 +18,10 @@ aliases:
 - /docs/pulumi-cloud/access-management/saml/gsuite/
 ---
 
-This guide walks you through configuring your Google Workspace (formerly known as G Suite) service as a SAML SSO identity provider
-(IDP) for the Pulumi Cloud.
+This guide walks you through configuring your Google Workspace (formerly known as G Suite) service as a [SAML SSO](/docs/administration/access-identity/saml/) identity provider
+(IDP) for Pulumi Cloud.
 
-## Prerequisites
-
-- [Single Sign-On](/docs/administration/access-identity/saml/sso/)
-
-## Creating the SAML Application
+## Creating the SAML application
 
 1. In the [administrator console](https://admin.google.com/) for your Google Workspace domain, open the flyout menu
 in the upper-left corner and choose **Apps &gt; Web and mobile apps**.
@@ -81,42 +77,28 @@ domain users by selecting the down arrow in the **User access** panel:
     ![Enable the SAML application part 2](/images/docs/reference/service/saml-gsuite/gsuite-app-enable-2.png)
 
    At this point, you're done configuring Google Workspace, and can move on to completing SAML SSO setup in
-   the Pulumi Cloud.
+   Pulumi Cloud.
 
-## Configuring Your Pulumi Organization
+## Configuring your Pulumi organization
 
-The final step in the process consists of associating your Pulumi organization with your SSO identity
-provider.
-
-1. Sign in to the Pulumi Cloud where your SAML organization resides, then navigate to the **Settings** tab for that
-organization.
-
-1. Select **Access Management**, then select the **Other** tab.
-
+1. Sign in to Pulumi Cloud and navigate to your organization.
+1. Select **Settings** > **Access Management**.
+1. Select the **Other** tab.
 1. In the **Membership Requirements** section, select **Change requirements**.
+1. Select **SAML SSO** and then **Next**.
+1. Paste the full contents of the XML IDP document you downloaded into the text area.
+1. Select **Apply changes**.
 
-1. Select **SAML SSO** and **Next**.
+Your Pulumi organization is now configured to use Google Workspace as a SAML SSO identity provider.
 
-     ![Pulumi SAML SSO](/images/docs/reference/service/saml-gsuite/pulumi-enable-saml-sso.png)
+## Signing in to Pulumi with Google Workspace
 
-1. Paste the full contents of the XML IDP document you have previously downloaded into the text area.
-
-    ![Provide the XML IDP descriptor](/images/docs/reference/service/saml-gsuite/pulumi-load-sso-xml.png)
-
-1. Select **Apply changes** and refresh your browser page to see the SAML SSO settings.
-
-Your Pulumi organization is now configured to use Google as a SAML SSO identity provider.
-
-## Signing in to Pulumi with Google
-
-Members of your Google Workspace can now sign into Pulumi. Navigate to
+Members of your Google Workspace can now sign in to Pulumi. Navigate to
 [https://app.pulumi.com/signin/sso/](https://app.pulumi.com/signin/sso/) and enter the
 name of your Pulumi organization.
 
-![Pulumi Cloud](/images/docs/reference/service/saml-gsuite/pulumi-console-signin.png)
-
 ## Troubleshooting
 
-Google Workspace SAML troubleshooting page: [SAML app error messages](https://support.google.com/a/answer/6301076)
+Google Workspace SAML troubleshooting: [SAML app error messages](https://support.google.com/a/answer/6301076)
 
-If you need additional assistance, [contact us](/about#contact-us).
+For additional help, see the [SAML SSO troubleshooting guide](/docs/administration/access-identity/saml/troubleshooting/) or [contact support](https://support.pulumi.com/).

--- a/content/docs/administration/access-identity/saml/okta.md
+++ b/content/docs/administration/access-identity/saml/okta.md
@@ -2,14 +2,14 @@
 title_tag: Configuring Okta | SAML SSO
 meta_desc: This page provides a walkthrough important aspects of configuring
            Okta as a SAML SSO identity provider (IdP).
+meta_image: /images/docs/meta-images/docs-meta.png
 title: Okta
 h1: "SAML: Configuring Okta"
-meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   administration:
     name: Okta
     parent: administration-access-identity-saml
-    weight: 5
+    weight: 50
     identifier: pulumi-cloud-access-management-saml-okta
 aliases:
 - /docs/reference/service/saml-okta/
@@ -18,20 +18,16 @@ aliases:
 - /docs/pulumi-cloud/access-management/saml/okta/
 ---
 
-This guide walks you through configuring Okta as a SAML SSO identity provider (IdP) for the Pulumi Cloud.
+This guide walks you through configuring Okta as a [SAML SSO](/docs/administration/access-identity/saml/) identity provider (IdP) for Pulumi Cloud.
 
-## Prerequisites
-
-- [Single Sign-On](/docs/administration/access-identity/saml/sso/)
-
-## Creating the Okta Application
+## Creating the Okta application
 
 The first step is to create a new Okta Application Integration. Of the various "sign-in methods"
 available, choose **SAML 2.0**.
 
 ![Creating an Okta Application](/images/docs/reference/service/saml-okta/create-okta-application.png)
 
-### Configuring the Application
+### Configuring the application
 
 Next you will be guided through a wizard to configure the Okta application. The first step is to
 give it a name---Pulumi Cloud for example---and an [icon](https://www.pulumi.com/brand/).
@@ -72,7 +68,7 @@ If you plan on using [SCIM](/docs/administration/access-identity/scim/okta/), yo
 
 ![Configuration Settings](/images/docs/reference/service/saml-okta/configure-saml-settings.png)
 
-### User Assignments
+### User assignments
 
 After the Pulumi SAML application has been created in Okta, the next step is to assign users to it.
 This will grant specific users or groups access to sign into Pulumi with their Okta-provided
@@ -83,11 +79,10 @@ page.
 
 ![User Assignments](/images/docs/reference/service/saml-okta/user-assignments.png)
 
-## Configuring Your Pulumi Organization
+## Configuring your Pulumi organization
 
-The final step is to configure the Pulumi Cloud with details on your new Okta-based
-SAML application. To do this, you need to obtain the IDP metadata document from Okta and then provide
-it to Pulumi.
+To configure Pulumi Cloud with details on your new Okta-based SAML application, you need to
+obtain the IdP metadata document from Okta and then provide it to Pulumi.
 
 First, navigate to the **Sign On** tab on the application page and click the
 **"View SAML setup instructions"** link in the right column.
@@ -101,20 +96,17 @@ a user's identity.
 
 ![SAML Application Metadata](/images/docs/reference/service/saml-okta/okta-xml-descriptor.png)
 
-With the block of XML text in your clipboard, open the Pulumi Cloud and navigate to your SAML
-organization. Select the **Settings** tab, and then select **Access Management**.
+With the block of XML text in your clipboard:
 
-Select the **Other** tab, then in the **Membership Requirements** section, select the **Change requirements** button.
+1. Sign in to Pulumi Cloud and navigate to your organization.
+1. Select **Settings** > **Access Management**.
+1. Select the **Other** tab.
+1. In the **Membership Requirements** section, select **Change requirements**.
+1. Select **SAML SSO** and then **Next**.
+1. Paste the IdP metadata descriptor into the text area.
+1. Select **Apply changes**.
 
-Select **SAML SSO** for the IDP and then **Next**.
-
-Paste the IDP metadata descriptor into the text area and select **Apply changes**.
-
-![Pulumi Organization Settings](/images/docs/reference/service/saml-okta/pulumi-org-settings.png)
-
-Once the IDP metadata descriptor has been saved, you are all set to log into Pulumi.
-
-## Configuring Session Lifetime
+## Configuring session lifetime
 
 The Pulumi Cloud uses the `SessionNotOnOrAfter` attribute in the `AuthnStatement` element to configure the session lifetime. To configure this in Okta, you must use a [SAML assertion inline hook](https://developer.okta.com/docs/guides/saml-inline-hook/main/).
 
@@ -129,23 +121,20 @@ The JSON payload the inline hook sends to Okta should contain the following:
         {
           "op": "add",
           "path": "/authentication/sessionLifetime",
-          "value": 21600 // lifetime in seconds
+          "value": 21600 // Lifetime in seconds
         }
       ]
     }
   ]
 }
-
 ```
 
-### Signing into Pulumi using Okta
+## Signing in to Pulumi using Okta
 
-Members of your Okta application can now sign into Pulumi. Navigate to
+Members of your Okta application can now sign in to Pulumi. Navigate to
 [https://app.pulumi.com/signin/sso/](https://app.pulumi.com/signin/sso/) and enter the
 name of your Pulumi organization.
 
-![Pulumi Cloud](/images/docs/reference/service/saml-okta/pulumi-console-signin.png)
-
 ## Troubleshooting
 
-If you run into any troubles configuring Okta, signing into Pulumi, or need some assistance, [contact us](/about#contact-us).
+For help resolving SAML SSO configuration issues, see the [SAML SSO troubleshooting guide](/docs/administration/access-identity/saml/troubleshooting/) or [contact support](https://support.pulumi.com/).

--- a/content/docs/administration/access-identity/saml/onelogin.md
+++ b/content/docs/administration/access-identity/saml/onelogin.md
@@ -9,7 +9,7 @@ menu:
   administration:
     name: OneLogin
     parent: administration-access-identity-saml
-    weight: 3
+    weight: 60
     identifier: pulumi-cloud-access-management-saml-onelogin
 aliases:
 - /docs/reference/service/saml-onelogin/
@@ -18,13 +18,9 @@ aliases:
 - /docs/pulumi-cloud/access-management/saml/onelogin/
 ---
 
-This guide walks you through configuring OneLogin as a SAML SSO identity provider (IdP) for the Pulumi Cloud.
+This guide walks you through configuring OneLogin as a [SAML SSO](/docs/administration/access-identity/saml/) identity provider (IdP) for Pulumi Cloud.
 
-## Prerequisites
-
-- [Single Sign-On](/docs/administration/access-identity/saml/sso/)
-
-## Creating the OneLogin Application
+## Creating the OneLogin application
 
 The first step is to create a new OneLogin Application for Pulumi SSO:
 
@@ -38,7 +34,7 @@ The first step is to create a new OneLogin Application for Pulumi SSO:
 
     ![Creating a OneLogin Application example](/images/docs/reference/service/saml-onelogin/onelogin-create-saml-app.png)
 
-### Configuring the OneLogin Application
+### Configuring the OneLogin application
 
 Now configure the OneLogin Application with the SAML settings for Pulumi SSO.
 
@@ -67,7 +63,7 @@ Do not change the value of SAML nameID format once your users have started using
 
 ![Configuration settings example ](/images/docs/reference/service/saml-onelogin/onelogin-configure-app.png)
 
-#### Configure SSO Settings
+#### Configure SSO settings
 
 Select the **SSO** view for the application and set/confirm the following:
 
@@ -77,7 +73,7 @@ Select the **SSO** view for the application and set/confirm the following:
 
 ![SSO Settings](/images/docs/reference/service/saml-onelogin/onelogin-sso-sig-setting.png)
 
-### User Assignments
+### User assignments
 
 After the Pulumi SAML application has been created in OneLogin, the next step is to assign users to it.
 This will grant specific users or groups access to sign into Pulumi with their OneLogin-provided
@@ -87,38 +83,30 @@ To assign users or groups to the application, navigate to the **Users** tab in t
 
 ![User Assignments](/images/docs/reference/service/saml-onelogin/onelogin-add-user-sso.png)
 
-## Configuring Your Pulumi Organization
+## Configuring your Pulumi organization
 
-The final step is to configure the Pulumi Cloud with details on your new OneLogin-based
-SAML application. To do this, you need to obtain the IDP metadata document from OneLogin and then provide
-it to Pulumi.
+To configure Pulumi Cloud with details on your new OneLogin-based SAML application, you need to obtain
+the IdP metadata document from OneLogin and then provide it to Pulumi.
 
-First, navigate to the OneLogin Application you created above and select the **More Actions** drop down menu button and select _SAML Metadata_ to download the metadata XML file.
+Navigate to the OneLogin Application you created above and select the **More Actions** drop down menu button and select _SAML Metadata_ to download the metadata XML file.
 
 ![Get Metadata](/images/docs/reference/service/saml-onelogin/onelogin-get-metadata.png)
 
-1. Open the file and copy the entire block of XML text in your clipboard.
-1. Open the Pulumi Cloud and navigate to your SAML organization.
-1. Select the **Settings** tab, and then select **Access Management**.
+1. Open the file and copy the entire block of XML text to your clipboard.
+1. Sign in to Pulumi Cloud and navigate to your organization.
+1. Select **Settings** > **Access Management**.
 1. Select the **Other** tab.
-1. In the **Membership Requirements** section, select the **Change requirements** button.
-1. Select **SAML SSO** and then select **Next**.
-1. Paste the IDP metadata XML into the text area.
-
-    ![Pulumi Organization Settings](/images/docs/reference/service/saml-onelogin/onelogin-pulumi-saml-metadata.png)
-
+1. In the **Membership Requirements** section, select **Change requirements**.
+1. Select **SAML SSO** and then **Next**.
+1. Paste the IdP metadata XML into the text area.
 1. Select **Apply changes**.
 
-Once the IDP metadata descriptor has been saved, you are all set to log into Pulumi.
+## Signing in to Pulumi using OneLogin
 
-### Signing into Pulumi using OneLogin
-
-Members of your OneLogin application can now sign into Pulumi. Navigate to
+Members of your OneLogin application can now sign in to Pulumi. Navigate to
 [https://app.pulumi.com/signin/sso/](https://app.pulumi.com/signin/sso/) and enter the
 name of your Pulumi organization.
 
-![Pulumi Cloud](/images/docs/reference/service/saml-okta/pulumi-console-signin.png)
-
 ## Troubleshooting
 
-If you run into any troubles configuring OneLogin, signing into Pulumi, or need some assistance, [contact us](/about#contact-us).
+For help resolving SAML SSO configuration issues, see the [SAML SSO troubleshooting guide](/docs/administration/access-identity/saml/troubleshooting/) or [contact support](https://support.pulumi.com/).

--- a/content/docs/administration/access-identity/saml/saml-admin.md
+++ b/content/docs/administration/access-identity/saml/saml-admin.md
@@ -1,0 +1,32 @@
+---
+title_tag: SAML Admin | SAML SSO
+meta_desc: Learn about the SAML admin role and how to configure it in Pulumi Cloud.
+title: SAML admin
+h1: SAML admin
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+  administration:
+    name: SAML admin
+    parent: administration-access-identity-saml
+    weight: 70
+    identifier: pulumi-cloud-access-management-saml-admin
+---
+
+A SAML admin can log in to your Pulumi organization using an alternative login method. This ensures someone can always log in to your organization to help resolve errors with the SAML configuration.
+
+Whoever configures SAML for your organization is automatically made the SAML admin. To change the SAML admin:
+
+1. Navigate to **Settings** > **Access Management**.
+1. Select the **SAML & SCIM** tab.
+1. In the **SAML SSO** section, select the **SAML Admin** dropdown.
+1. Select a new SAML admin from the list.
+
+{{% notes type="info" %}}
+Only organization admins can be SAML admins. If you want to designate a member or billing manager as the SAML admin, you will first need to change their role to admin, then make them a SAML admin.
+{{% /notes %}}
+
+{{% notes type="warning" %}}
+When a user stops being a SAML admin, they will automatically lose all other login methods.
+{{% /notes %}}
+
+Only one SAML admin per organization is supported at this time.

--- a/content/docs/administration/access-identity/saml/sso.md
+++ b/content/docs/administration/access-identity/saml/sso.md
@@ -10,7 +10,7 @@ menu:
   administration:
     name: Using SAML
     parent: administration-access-identity-saml
-    weight: 1
+    weight: 10
     identifier: pulumi-cloud-access-management-saml-sso
 aliases:
 - /docs/intro/pulumi-cloud/accounts/saml/
@@ -19,15 +19,11 @@ aliases:
 ---
 
 This document walks through the important aspects of configuring any SAML (Security Assertion Markup Language) 2.0 identity provider to work
-with the [Pulumi Cloud](/docs/pulumi-cloud/).
+with [Pulumi Cloud](/docs/pulumi-cloud/).
 
-> For a specific example, refer to one of our integration guides:
->
-> - [Microsoft Entra ID](/docs/administration/access-identity/saml/entra/)
-> - [Google Workspace](/docs/administration/access-identity/saml/gsuite/)
-> - [Okta](/docs/administration/access-identity/saml/okta/)
-> - [Auth0](/docs/administration/access-identity/saml/auth0/)
-> - [OneLogin](/docs/administration/access-identity/saml/onelogin/)
+{{% notes type="info" %}}
+For examples of setting up SAML SSO with popular identity providers, refer to our [integration guides](/docs/administration/access-identity/saml#integration-guides).
+{{% /notes %}}
 
 ## Terminology
 
@@ -63,7 +59,7 @@ This is the URL where the IdP can `POST` SAML assertions. The URL format is alwa
 
 The (SP) entity ID is a URL where a service provider publishes public information about its SAML configuration. The metadata document published by the service provider shows its public certificate that can be used to verify the signature of authentication requests initiated from the service itself.
 
-**Note**: The IdP also has an entity ID. However, the IdP's entity ID is used to uniquely identify the specific tenant/organization within that IdP. When you are configuring the SAML SSO, you are almost always asked to enter the SP entity ID, which will be specific to your organization in Pulumi.
+The IdP also has an entity ID. However, the IdP's entity ID is used to uniquely identify the specific tenant/organization within that IdP. When you are configuring SAML SSO, you are almost always asked to enter the SP entity ID, which will be specific to your organization in Pulumi.
 
 ### (Default) Relay State
 
@@ -75,8 +71,11 @@ The relay state is a URL, which itself is passed as a query parameter in SSO req
 
 The name ID format is one of the most important aspects of your SAML SSO configuration. It defines how an identity provider identifies a user on the downstream service. The value of the format defines what value would be used for the user's `Subject`.
 
-> **Note:** Pulumi only accepts stable and persistent identifiers for users. Identity providers must be able to set either a persistent randomly unique identifier (`urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`) or the user's email address (`urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`) as the user's `Subject` value.
-> <br /> > **Important:** Once your name ID format is configured and your users have started to use SSO, **DO NOT** change the name identifier. That will prevent your users from being able to sign in.
+{{% notes type="info" %}}
+Pulumi only accepts stable and persistent identifiers for users. Identity providers must be able to set either a persistent randomly unique identifier (`urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`) or the user's email address (`urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`) as the user's `Subject` value.
+
+**Important:** Once your name ID format is configured and your users have started to use SSO, **DO NOT** change the name identifier. That will prevent your users from being able to sign in.
+{{% /notes %}}
 
 ## Session Lifetime
 
@@ -88,90 +87,12 @@ Example of the `AuthnStatement` element with session lifetime configured:
 <saml:AuthnStatement AuthnInstant="2023-05-23T00:49:39Z" SessionNotOnOrAfter="2023-05-23T10:49:39Z" SessionIndex="...">
 ```
 
-If `SessionNotOnAfter` isn't specified, then the Pulumi Cloud will use the default session lifetime of 12 hours.
+If `SessionNotOnAfter` isn't specified, then Pulumi Cloud will use the default session lifetime of 12 hours.
 
-## SAML Admin
+## SAML admin
 
-A SAML admin can log in to your Pulumi organization using an alternative login method. This ensures someone can always log in to your organization to help resolve errors with the SAML configuration.
-
-Whoever configures SAML for your organization is automatically made the SAML admin. To change the SAML admin:
-
-1. Navigate to **Settings** > **Access Management**.
-1. Select the **SAML & SCIM** tab.
-1. In the **SAML SSO** section, select the **SAML Admin** dropdown.
-1. Select a new SAML admin from the list.
-
-{{% notes type="info" %}}
-Only organization admins can be SAML admins. If you want to designate a member or billing manager as the SAML admin, you will first need to change their role to admin, then make them a SAML admin.
-{{% /notes %}}
-
-{{% notes type="warning" %}}
-When a user stops being a SAML admin, they will automatically lose all other login methods.
-{{% /notes %}}
-
-Only one SAML admin per organization is supported at this time.
+For information on the SAML admin role and how to configure it, see [SAML admin](/docs/administration/access-identity/saml/saml-admin/).
 
 ## Troubleshooting
 
-### Validation error while trying to save an IdP-provided metadata XML in the Pulumi Cloud
-
-The Pulumi Cloud typically shows you the reason for the failure. The IdP-provided metadata XML
-contains several XML elements, of which the `<IDPSSODescriptor>` is the element of concern to Pulumi. In the `IDPSSODescriptor`, we expect to see a valid `KeyDescriptor` public key certificate, a `NameIDFormat`, an entity ID identifying your organization in the IdP, and an SSO binding.
-
-The failure is typically due to one of the following reasons:
-
-- Malformed XML
-- KeyDescriptor public key certificate in the IDPSSODescriptor has expired
-- KeyDescriptor public key certificate is missing n the IDPSSODescriptor
-- NameIDFormat does not have the expected value or is completely missing. See the next troubleshooting topic for help on this.
-
-> **Tip:** OneLogin has a suite of free [SAML-related tools](https://www.samltool.com/prettyprint.php).
-
-### Name ID Format is invalid
-
-As mentioned in the `Name ID Format` section, Pulumi expects specific values in your IdP metadata XML.
-Use [One Login's XML Pretty Print](https://www.samltool.com/prettyprint.php) to pretty print your XML and look for `<NameIDFormat>` under the `<IDPSSODescriptor>` XML element.
-
-If you cannot find an element called `NameIDFormat`, add the following line immediately after the closing tag for `KeyDescriptor`:
-
-`<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>`
-
-Here's a sample metadata XML. Note that some values were removed for brevity.
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="...">
-  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-    <md:KeyDescriptor use="signing">
-      ....
-    </md:KeyDescriptor>
-    <!--
-        In this example, all elements have a namespace of `md`. This is why the NameIDFormat has a prefix of `md:`.
-        If the elements in your XML don't have the prefix, then you may skip that.
-    -->
-    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="..."/>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="..."/>
-  </md:IDPSSODescriptor>
-</md:EntityDescriptor>
-```
-
-If your IdP does not support an emailAddress Name ID Format identifier but supports the `persistent` format identifier, then you may use the following:
-
-`<NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>`
-
-### The IdP signing certificate expired and I can't login to Pulumi anymore
-
-[Contact us](/about#contact-us) for assistance with getting the IdP metadata XML updated.
-
-### An SSO binding was not found in the XML. Contact your SSO provider.
-
-This error occurs when the metadata XML you are trying to save does not have any `<SingleSignOnService>` elements under the `<IDPSSODescriptor>`. The `<SingleSignOnService>` is used by the Pulumi Cloud to determine the authentication mechanism supported by the IDP. Learn more about [SAML 2.0 Bindings from Wikipedia](https://en.wikipedia.org/wiki/SAML_2.0#SAML_2.0_Bindings). You must contact your IdP support or your system admin to fix the metadata XML.
-
-Here's an example of an SSO binding for `HTTP-POST`:
-
-```xml
-<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="..."/>
-```
-
-> **Note:** The `Location` attribute is unique to each tenant in your IDP.
+For help resolving SAML SSO configuration issues, see [SAML SSO troubleshooting](/docs/administration/access-identity/saml/troubleshooting/).

--- a/content/docs/administration/access-identity/saml/troubleshooting.md
+++ b/content/docs/administration/access-identity/saml/troubleshooting.md
@@ -1,0 +1,80 @@
+---
+title_tag: Troubleshooting SAML SSO | SAML SSO
+meta_desc: Troubleshooting guide for SAML SSO configuration issues in Pulumi Cloud.
+title: Troubleshooting
+h1: SAML SSO troubleshooting
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+  administration:
+    name: Troubleshooting
+    parent: administration-access-identity-saml
+    weight: 80
+    identifier: pulumi-cloud-access-management-saml-troubleshooting
+---
+
+## Locked out of your organization
+
+If you are locked out of your Pulumi organization due to a SAML configuration error or an expired certificate, a [SAML admin](/docs/administration/access-identity/saml/saml-admin/) can log in using an alternative login method to resolve the issue. If your organization does not have a SAML admin configured, [contact support](https://support.pulumi.com/).
+
+## Validation error while trying to save an IdP-provided metadata XML in Pulumi Cloud
+
+Pulumi Cloud typically shows you the reason for the failure. The IdP-provided metadata XML
+contains several XML elements, of which the `<IDPSSODescriptor>` is the element of concern to Pulumi. In the `IDPSSODescriptor`, we expect to see a valid `KeyDescriptor` public key certificate, a `NameIDFormat`, an entity ID identifying your organization in the IdP, and an SSO binding.
+
+The failure is typically due to one of the following reasons:
+
+- Malformed XML
+- KeyDescriptor public key certificate in the IDPSSODescriptor has expired
+- KeyDescriptor public key certificate is missing in the IDPSSODescriptor
+- NameIDFormat does not have the expected value or is completely missing. See the next troubleshooting topic for help on this.
+
+{{% notes type="info" %}}
+OneLogin has a suite of free [SAML-related tools](https://www.samltool.com/prettyprint.php).
+{{% /notes %}}
+
+## Name ID format is invalid
+
+As mentioned in the [Name ID Format](/docs/administration/access-identity/saml/sso/#name-id-format) section, Pulumi expects specific values in your IdP metadata XML.
+Use [OneLogin's XML Pretty Print](https://www.samltool.com/prettyprint.php) to pretty print your XML and look for `<NameIDFormat>` under the `<IDPSSODescriptor>` XML element.
+
+If you cannot find an element called `NameIDFormat`, add the following line immediately after the closing tag for `KeyDescriptor`:
+
+`<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>`
+
+Here's a sample metadata XML. Note that some values were removed for brevity.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="...">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      ....
+    </md:KeyDescriptor>
+    <!--
+        In this example, all elements have a namespace of `md`. This is why the NameIDFormat has a prefix of `md:`.
+        If the elements in your XML don't have the prefix, then you may skip that.
+    -->
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="..."/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="..."/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>
+```
+
+If your IdP does not support an emailAddress name ID format identifier but supports the `persistent` format identifier, then you may use the following:
+
+`<NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>`
+
+## SSO binding not found in XML
+
+This error occurs when the metadata XML you are trying to save does not have any `<SingleSignOnService>` elements under the `<IDPSSODescriptor>`. The `<SingleSignOnService>` is used by Pulumi Cloud to determine the authentication mechanism supported by the IdP. Learn more about [SAML 2.0 bindings from Wikipedia](https://en.wikipedia.org/wiki/SAML_2.0#SAML_2.0_Bindings). You must contact your IdP support or your system admin to fix the metadata XML.
+
+Here's an example of an SSO binding for `HTTP-POST`:
+
+```xml
+<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="..."/>
+```
+
+{{% notes type="info" %}}
+The `Location` attribute is unique to each tenant in your IdP.
+{{% /notes %}}

--- a/content/docs/administration/self-hosting/saml-sso.md
+++ b/content/docs/administration/self-hosting/saml-sso.md
@@ -17,9 +17,9 @@ aliases:
   - /docs/pulumi-cloud/admin/self-hosted/saml-sso/
 ---
 
-The self-hosted option allows you to control various aspects of the Pulumi Cloud including how users will sign in to the [Pulumi Cloud](/docs/administration/self-hosting/components/console/).
+The self-hosted option allows you to control various aspects of Pulumi Cloud including how users will sign in to the [Pulumi Cloud console](/docs/administration/self-hosting/components/console/).
 
-## Creating The Keys
+## Creating the keys
 
 Before you can use SAML SSO to logon to the Console, you will need to ensure that the [API service](/docs/administration/self-hosting/components/api/) has a pair of keys that will be used to sign
 and validate requests/responses, regardless of the IdP you choose to use.
@@ -29,9 +29,11 @@ In the following snippets, we show you how you can generate a key pair by using 
 The snippet shows the command for a self-hosted API service that is accessible via `api.company.com`.
 Be sure to adjust the value accordingly.
 
-> OpenSSL's official [wiki](https://wiki.openssl.org/index.php/Binaries) site contains links to pre-built binaries.
+{{% notes type="info" %}}
+OpenSSL's official [wiki](https://wiki.openssl.org/index.php/Binaries) site contains links to pre-built binaries.
+{{% /notes %}}
 
-```
+```bash
 # Generate a new 2048-bit RSA key with a validity of 365 days.
 openssl \
   req -x509 -newkey rsa:2048 \
@@ -42,10 +44,11 @@ openssl \
 
 If you also want to additionally specify an SAN (Subject Alternative Name) for your public cert, you can do so by passing the `-addext` flag as shown below.
 
-> For this to work, though, you'll need to install _at least_ version 1.1. Once installed ensure that the 1.1 version is on your path when you run the command.
-> Otherwise `-addext` will not be recognized as a valid flag.
+{{% notes type="info" %}}
+For this to work, you'll need to install _at least_ version 1.1. Once installed, ensure that the 1.1 version is on your path when you run the command. Otherwise `-addext` will not be recognized as a valid flag.
+{{% /notes %}}
 
-```
+```bash
 openssl \
   req -x509 -newkey rsa:2048 \
   -days 365 -nodes -subj "/CN=api.company.com" \
@@ -54,7 +57,7 @@ openssl \
   -out cert.cert
 ```
 
-## Configure The API Service
+## Configure the API service
 
 Once the key pair has been generated, set the value of the following environment variables for the API service:
 
@@ -63,10 +66,16 @@ Once the key pair has been generated, set the value of the following environment
 
 For these values to take effect, you will need to restart the API Service.
 
-> Restart the service only during a planned maintenance window.
+{{% notes type="info" %}}
+Restart the service only during a planned maintenance window.
+{{% /notes %}}
 
 ## Enabling SAML SSO as an identity option
 
 By default, the SAML SSO signin/signup option is not displayed to end users of the Console service.
 To enable this, set the `SAML_SSO_ENABLED` environment variable for the [console](/docs/administration/self-hosting/components/console/) container to `true`
 and restart the service.
+
+## Next steps
+
+Once your self-hosted infrastructure is configured, complete the SAML SSO setup by configuring your identity provider and Pulumi organization using the [Pulumi Cloud SAML SSO guides](/docs/administration/access-identity/saml/).


### PR DESCRIPTION
Splits saml-admin and troubleshooting into separate pages, adds self-hosted <> cloud cross-links, removes prerequisites sections, and converts blockquotes to notes shortcodes.

Fixes #17773 