### PR TITLE
Rename Azure Active Directory references to Microsoft Entra ID

### DIFF
--- a/content/docs/administration/access-identity/scim/entra.md
+++ b/content/docs/administration/access-identity/scim/entra.md
@@ -23,7 +23,7 @@ Please note that some advanced SCIM features aren't supported yet. For more info
 
 ## Prerequisites
 
-* Your organization must already be configured to use [SAML SSO](/docs/administration/access-identity/saml/aad/) with Pulumi.
+* Your organization must already be configured to use [SAML SSO](/docs/administration/access-identity/saml/entra/) with Pulumi.
 * You must be an admin of your Pulumi organization.
 * (Optional, but highly recommended) You should have more than one admin for your Pulumi organization.
 

--- a/content/docs/iac/concepts/pulumi-cloud.md
+++ b/content/docs/iac/concepts/pulumi-cloud.md
@@ -60,7 +60,7 @@ Pulumi Cloud also offers short-lived stacks in the form of [Review Stacks](/docs
 
 ### 2. Automatic security
 
-Pulumi Cloud has [a rich identity model](/docs/pulumi-cloud/access-management/) that integrates with your security identity provider of choice, whether that is Azure Active Directory, Google Workspace, Okta, or any SAML/SSO provider, to regulate all access to your cloud assets.
+Pulumi Cloud has [a rich identity model](/docs/pulumi-cloud/access-management/) that integrates with your security identity provider of choice, whether that is Microsoft Entra ID, Google Workspace, Okta, or any SAML/SSO provider, to regulate all access to your cloud assets.
 
 If you manage your IaC state with a DIY approach, you will need to come up with a scheme that works for your organization. While you can use AWS IAM for the S3 bucket that stores your state, large-scale teams rarely want to grant full access to all engineers. In fact, this may be the difference between passing and failing a compliance audit.
 


### PR DESCRIPTION
Fixes #13220

## What changed

Microsoft renamed Azure Active Directory to Microsoft Entra ID. The main SAML Entra ID page had already been updated (renamed from `aad.md` to `entra.md`, with the title and body content updated accordingly). This PR cleans up two remaining stale references:

**`content/docs/administration/access-identity/scim/entra.md`**
- The prerequisites section linked to `/docs/administration/access-identity/saml/aad/` (the old path). Updated to use the canonical `/docs/administration/access-identity/saml/entra/` URL. The old path still works via its registered alias, but internal links should point to the canonical URL.

**`content/docs/iac/concepts/pulumi-cloud.md`**
- The "Automatic security" section listed "Azure Active Directory" as an example identity provider. Updated to "Microsoft Entra ID" to reflect Microsoft's current naming.

## What was not changed

- URL aliases in `saml/entra.md` and `scim/entra.md` frontmatter (e.g., `/saml/aad/`, `/scim/azuread/`) — these are kept intentionally for backward-compatible redirects.
- Image asset paths like `/images/docs/reference/service/scim/azuread/...` — these are physical file paths to existing image assets, and renaming them would break the images.
- The `components` section in `content/docs/iac/clouds/azure/_index.md` which refers to the `pulumi-azuread` provider package — this reflects the Pulumi registry package name, not Microsoft's product branding.
- Kubernetes guide references to Azure AD in the context of AKS cluster authentication — those are Azure service documentation and are a separate concern from Pulumi Cloud SAML SSO.

---
🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*