### PR TITLE
Add YAML examples to stack reference outputs section

### DIFF
--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -978,7 +978,7 @@ infra.outputDetailsAsync("dbHost").thenAccept(dbHostDetails -> {
 {{% choosable language yaml %}}
 
 {{% notes "info" %}}
-`getOutputDetails` is not currently supported in Pulumi YAML. To read a stack reference
+`getOutputDetails` is not supported in Pulumi YAML. To read a stack reference
 output in YAML, use the `outputs` property of a `StackReference` resource, as shown in the
 `requireOutput` example above.
 {{% /notes %}}


### PR DESCRIPTION
Fixes #13176

## Summary

This PR adds Pulumi YAML language examples to the three code chooser blocks in the "Reading outputs from stack references" subsection of the [Stacks concept page](https://www.pulumi.com/docs/iac/concepts/stacks/#stackreferences).

Previously, all three chooser blocks listed only `typescript,python,go,csharp,java` — YAML was present in every other chooser block on the page but missing from this subsection.

## Changes

**`requireOutput` block:** Adds a YAML example showing a `StackReference` resource declaration with a `variables` block that accesses the output via interpolation. This is the direct equivalent of `requireOutput` — Pulumi's YAML runtime fails at deployment time if the named output does not exist in the referenced stack.

**`getOutput` block:** Adds a YAML example demonstrating the same interpolation pattern used for resource inputs, plus a note explaining that Pulumi YAML does not distinguish between `requireOutput` and `getOutput` semantics — output access always fails if the key is missing.

**`getOutputDetails` block:** Adds a note explaining that `getOutputDetails` is not currently supported in Pulumi YAML, and points readers back to the `requireOutput` example for the standard approach.

---
🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*