### PR TITLE
Update AWS Guides intro page

### DIFF
--- a/content/docs/iac/clouds/aws/guides/_index.md
+++ b/content/docs/iac/clouds/aws/guides/_index.md
@@ -28,18 +28,18 @@ This section contains guides for working with AWS services using Pulumi. The gui
 - [EKS (`@pulumi/eks`)](/registry/packages/eks/) — components for creating and managing [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks/) clusters
 - [AWS Cloud Control (`@pulumi/aws-native`)](/registry/packages/aws-native/) — provider with coverage of all resources in the AWS Cloud Control API
 
-### Containers
+## Containers
 
 - [Elastic Container Service (ECS)](ecs)
 - [Elastic Kubernetes Service (EKS)](eks)
 - [Elastic Container Registry (ECR)](ecr)
 
-### Serverless
+## Serverless
 
 - [Lambda](lambda/)
 - [API Gateway](api-gateway/)
 
-### Core infrastructure
+## Core infrastructure
 
 - [Elastic Load Balancing (ELB)](elb)
 - [Identity and Access Management (IAM)](iam)


### PR DESCRIPTION
Removes Crosswalk branding, marketing copy, logo, infographic, code example, video, Getting Started section, Continuous Deployment link, and FAQ. Replaces with a concise docs-style overview listing the relevant AWS packages with registry links.

Fixes #17816 