### PR TITLE
Add subprocessors page to legal section

### DIFF
--- a/content/legal/subprocessors.md
+++ b/content/legal/subprocessors.md
@@ -1,0 +1,74 @@
+---
+title: Subprocessors
+url: /subprocessors
+meta_desc: The current list of data subprocessors used by Pulumi Corporation.
+menu:
+    legal:
+        weight: 6
+---
+
+<p>Pulumi Corporation ("Pulumi," "we," "us," or "our") uses third-party service providers ("subprocessors") to help deliver our products and services. This page lists the subprocessors that may process personal data on our behalf.</p>
+
+<p>We regularly review and update this list as our use of subprocessors changes. If you have questions about our subprocessors, please contact us at <a href="mailto:privacy@pulumi.com">privacy@pulumi.com</a>.</p>
+
+<br />
+
+<h2>Current subprocessors</h2>
+
+<br />
+
+<table>
+    <thead>
+        <tr>
+            <th>Company</th>
+            <th>Department</th>
+            <th>Country</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr><td>Amazon Web Services</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Anthropic</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Astronomer</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Avalara</td><td>Finance</td><td>United States</td></tr>
+        <tr><td>BigMarker</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>Bill.com</td><td>Finance</td><td>United States</td></tr>
+        <tr><td>Calendly</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>Census</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>Clari</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>ClearFeed</td><td>Support</td><td>United States</td></tr>
+        <tr><td>Cloudflare</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Common Room</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>Credly (Pearson)</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>DocuSign</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>Floqer</td><td>Marketing</td><td>Canada</td></tr>
+        <tr><td>GitHub</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Google Ads</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>Google Workspace</td><td>Collaboration</td><td>United States</td></tr>
+        <tr><td>Growthbook</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>Honeycomb</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>HubSpot</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>LaunchDarkly</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>LeadIQ</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>LeanData</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>LinkedIn</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>Mailchimp</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Maxio</td><td>Finance</td><td>United States</td></tr>
+        <tr><td>Microsoft</td><td>Collaboration</td><td>United States</td></tr>
+        <tr><td>Netsuite (Oracle)</td><td>Finance</td><td>United States</td></tr>
+        <tr><td>Notion</td><td>Collaboration</td><td>United States</td></tr>
+        <tr><td>Outreach</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>PandaDoc</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>Salesforce</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>Segment (Twilio)</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Sentry</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Slack</td><td>Collaboration</td><td>United States</td></tr>
+        <tr><td>Snowflake</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Stripe</td><td>Engineering</td><td>United States</td></tr>
+        <tr><td>Suger</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>Validity</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>Verifone</td><td>Sales</td><td>United States</td></tr>
+        <tr><td>Zapier</td><td>Marketing</td><td>United States</td></tr>
+        <tr><td>Zendesk</td><td>Support</td><td>United States</td></tr>
+        <tr><td>Zoom</td><td>Collaboration</td><td>United States</td></tr>
+    </tbody>
+</table>

--- a/content/legal/subprocessors.md
+++ b/content/legal/subprocessors.md
@@ -13,6 +13,11 @@ menu:
 
 <br />
 
+<script src="https://js.hsforms.net/forms/embed/4429525.js" defer></script>
+<div class="hs-form-frame" data-region="na1" data-form-id="95c3440e-96b2-42c3-933f-bc5085921fcc" data-portal-id="4429525"></div>
+
+<br />
+
 <h2>Current subprocessors</h2>
 
 <br />


### PR DESCRIPTION
## Summary

- Adds `content/legal/subprocessors.md` with a description and full table of Pulumi's current data subprocessors
- Follows the existing legal page format (frontmatter, HTML content, menu weight)
- Lists 44 subprocessors with company name, department, and country

## Test plan

- [ ] Page renders at `/subprocessors`
- [ ] Table displays correctly with all 44 entries
- [ ] Page appears in the legal section navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)