### PR TITLE
skill(pr-review): fix misleading file name and enforce AskUserQuestion

### DIFF
--- a/.claude/commands/pr-review/SKILL.md
+++ b/.claude/commands/pr-review/SKILL.md
@@ -151,9 +151,9 @@ Continue to Step 7.
 
 ### Step 7: Present Action Menu
 
-Present action menu based on contributor type (bot vs non-bot) and review findings.
+**Use AskUserQuestion** (max 4 options) to present the appropriate action menu based on contributor type (bot vs non-bot) and review findings.
 
-See `pr-review:references:bot-action-menus` for complete menu structures and logic.
+See `pr-review:references:action-menus` for complete menu structures and logic.
 
 Continue to Step 8 with selected action.
 

--- a/.claude/commands/pr-review/references/action-menus.md
+++ b/.claude/commands/pr-review/references/action-menus.md
@@ -3,9 +3,9 @@ user-invocable: false
 description: Action menu options for bot and non-bot PRs
 ---
 
-# Bot Action Menus
+# Action Menus
 
-**Decision Point**: If contributor type is bot, use bot-specific action menu. Otherwise, use standard action menu.
+**Decision Point**: Select the appropriate section based on contributor type.
 
 ## Dependabot PRs
 

--- a/.claude/commands/pr-review/references/action-preview-templates.md
+++ b/.claude/commands/pr-review/references/action-preview-templates.md
@@ -21,7 +21,7 @@ description: Preview formats and confirmation flows for PR actions
 
 **Note**: Not available for bot PRs (excluded from bot menus)
 
-**Flow**: Ask user for changes, then display preview:
+**Flow**: Use AskUserQuestion to ask user what changes to make, then display preview:
 
 ```
 ## Preview: Changes and Approval
@@ -60,7 +60,7 @@ Use AskUserQuestion with these options:
 
 ### Edit comment
 
-1. Ask user for revised comment text
+1. Use AskUserQuestion to ask user for revised comment text (open-ended)
 2. Show updated preview with new text
 3. Ask for confirmation again (repeat confirmation question)
 4. Loop until user chooses "Yes, proceed" or "Cancel"


### PR DESCRIPTION
Renames `bot-action-menus.md` → `action-menus.md` since the file covers all contributor types (Dependabot, other bots, and non-bot contributors), not just bots. Also adds explicit AskUserQuestion requirements at missing touch points.

## Changes
- Renamed `bot-action-menus.md` → `action-menus.md`, updated H1 and decision-point text
- Updated SKILL.md Step 7 to explicitly require AskUserQuestion (max 4 options)
- Updated `action-preview-templates.md` "Make changes and approve" and "Edit comment" flows to specify AskUserQuestion