### PR TITLE
fix(ci): grant Claude Code action write permissions to push commits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
## Summary

- Changes `contents` permission from `read` to `write` so the `GITHUB_TOKEN` can push commits
- Changes `pull-requests` permission from `read` to `write` so Claude can post comments back to PRs

Without `contents: write`, Claude can make commits locally in the Actions runner but cannot push them, requiring manual cherry-picks.