### PR TITLE
Update /gads/terraform/ with HCP free tier urgency messaging

### DIFF
--- a/content/gads/terraform/index.md
+++ b/content/gads/terraform/index.md
@@ -7,7 +7,7 @@ utm_source: gads-terraform
 aliases:
     - /gads/gads-template
 
-heading: "Terraform Free Tier Ending March 31"
+heading: "Terraform Free Tier Ends Mar 31"
 subheading: |
     HCP Terraform's legacy Free plan ends March 31, 2026. Pulumi is free, open source,
     and has no resource caps. Switch to real programming languages for your infrastructure.

--- a/layouts/gads/gads-template.html
+++ b/layouts/gads/gads-template.html
@@ -18,7 +18,7 @@
             </div>
         </div>
         <div class="container mx-auto">
-            <p id="dynamic-description" class="mx-auto text-center text-gray-600 w-6/12">
+            <p id="dynamic-description" class="mx-auto text-center text-gray-600 w-full px-4 lg:w-6/12">
                 {{ .Params.overview.description | markdownify }}
             </p>
         </div>


### PR DESCRIPTION
## Summary

- Updates the `/gads/terraform/` landing page with time-sensitive messaging about HCP Terraform's legacy Free plan ending March 31, 2026
- Adds a "Migrate from Terraform in minutes" feature section highlighting tf2pulumi, state import, and no resource caps
- Updates case studies to emphasize migration stories (Starburst, Snowflake)

## Context

HashiCorp is ending the legacy HCP Terraform Free plan on March 31, 2026. The new Free tier caps users at 500 managed resources. This creates a forced evaluation moment for Terraform users. We're running Google Ads campaigns targeting this audience and this landing page update provides message match for the urgency-based ad copy.

## Revert plan

After April 1, 2026, revert the heading/subheading/overview back to evergreen "Terraform Alternative" messaging. The migration tools section can stay permanently.

## Test plan

- [x] Verify page renders correctly at `/gads/terraform/`
- [x] Confirm CTA button points to `https://app.pulumi.com/signup`
- [x] Check mobile responsiveness of new migration section