### PR TITLE
Add converters concepts page

### DIFF
--- a/content/docs/iac/concepts/_index.md
+++ b/content/docs/iac/concepts/_index.md
@@ -97,3 +97,4 @@ Finally, the server's resulting IP address and DNS name are exported as stack ou
 
 - [Glossary](/docs/iac/concepts/glossary) — Look up definitions for commonly used terms.
 - [Comparisons](/docs/iac/comparisons/) — Learn about how Pulumi compares to other infrastructure tools.
+- [Converters](/docs/iac/concepts/converters) — Learn how to translate IaC from other tools into Pulumi programs.

--- a/content/docs/iac/concepts/converters.md
+++ b/content/docs/iac/concepts/converters.md
@@ -1,0 +1,52 @@
+---
+title_tag: Converters
+meta_desc: Learn about Pulumi converters, which translate IaC written in other tools into Pulumi programs in any supported language.
+title: Converters
+h1: Converters
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Converters
+        parent: iac-concepts
+        weight: 150
+---
+
+Converters are [plugins](/docs/iac/concepts/plugins/) that deterministically translate infrastructure as code written in other tools into Pulumi programs in any [supported Pulumi language](/docs/languages-sdks/).
+
+{{% notes type="info" %}}
+For most conversions, using an LLM is the recommended first option. [Pulumi Neo](/docs/ai/), part of Pulumi Cloud, can convert your infrastructure code using AI. For Terraform specifically, Neo has a [specialized migration skill](/docs/ai/skills/).
+{{% /notes %}}
+
+## Supported converters
+
+| Converter | `--from` value | Description |
+|-----------|---------------|-------------|
+| Terraform | `terraform` | Converts Terraform HCL to Pulumi |
+| Azure Resource Manager (ARM) | `arm` | Converts ARM JSON templates to Pulumi |
+| Azure Bicep | `bicep` | Converts Bicep templates to Pulumi |
+| Kubernetes | `kubernetes` | Converts Kubernetes YAML manifests to Pulumi |
+
+## Using a converter
+
+Run `pulumi convert` with the `--from` flag to specify the converter and `--language` to specify the target Pulumi language:
+
+```bash
+pulumi convert --from terraform --language typescript
+```
+
+Converters are installed automatically when you run `pulumi convert`. For detailed usage and options, see the [`pulumi convert` CLI reference](/docs/iac/cli/commands/pulumi_convert/).
+
+For step-by-step migration guides for each source tool, see [Migrating to Pulumi](/docs/iac/guides/migration/).
+
+## Manual installation
+
+Converter plugins are installed automatically, but you can also install them manually using `pulumi plugin install`:
+
+```bash
+pulumi plugin install converter terraform
+pulumi plugin install converter arm
+pulumi plugin install converter bicep
+pulumi plugin install converter kubernetes
+```
+
+Manual installation is useful for pre-loading plugins in CI/CD pipelines or air-gapped environments. See [plugin installation](/docs/iac/concepts/plugins/#manual-installation) for more details.

--- a/content/docs/iac/concepts/plugins.md
+++ b/content/docs/iac/concepts/plugins.md
@@ -50,7 +50,7 @@ Policy plugins are installed automatically with the Pulumi CLI.
 
 ### Converter plugins
 
-Converter plugins transform existing infrastructure-as-code from other tools (like Terraform, Kubernetes YAML, or CloudFormation) into Pulumi programs. Learn more about [conversion tools](/docs/iac/guides/migration/converters/).
+Converter plugins transform existing infrastructure-as-code from other tools (like Terraform, Kubernetes YAML, or CloudFormation) into Pulumi programs. Learn more about [converters](/docs/iac/concepts/converters/).
 
 Converter plugins are installed automatically with the Pulumi CLI when you run the [`pulumi convert`](/docs/iac/cli/commands/pulumi_convert) command.
 


### PR DESCRIPTION
Adds a new concepts page for Pulumi converters covering supported converters, basic usage, and manual installation. Updates plugins.md and concepts index to link to the new page.

Fixes #17860
