### PR TITLE
Add missing alias for old GCP getting started URL

### DIFF
--- a/content/docs/iac/get-started/gcp/_index.md
+++ b/content/docs/iac/get-started/gcp/_index.md
@@ -12,6 +12,7 @@ menu:
 
 aliases:
     - /docs/quickstart/gcp/
+    - /docs/get-started/gcp/
     - /docs/clouds/gcp/get-started/
     - /docs/iac/get-started/gcp/deploy-changes/
     - /docs/iac/get-started/gcp/review-project/


### PR DESCRIPTION
## Summary

- Adds `/docs/get-started/gcp/` alias to the GCP getting started page, fixing a 404 when users click "Get started" from the [GCP registry page](https://www.pulumi.com/registry/packages/gcp/)
- AWS and Azure already had this alias; GCP was missed during the move to `/docs/iac/get-started/gcp/`

Fixes #17869