### PR TITLE
Fix broken links reported by DocsBot (#17870)

### DIFF
--- a/content/blog/ai-slack-bot-adding-data-to-pinecone-using-s3-embedchain-and-pulumi-on-aws/index.md
+++ b/content/blog/ai-slack-bot-adding-data-to-pinecone-using-s3-embedchain-and-pulumi-on-aws/index.md
@@ -136,7 +136,7 @@ Now that we have a dynamic approach to loading configuration from YAML, lets mov
 
 The current application architecture uses a single process with the expectation that a response is generated **within 29 seconds**, before the [API Gateway timeout](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#api-gateway-execution-service-limits-table).
 
-[Slack also has an expectation](https://slack.dev/bolt-python/concepts#acknowledge), that we must acknowledge (or ack) a request **within 3 seconds**.
+[Slack also has an expectation](https://docs.slack.dev/tools/bolt-python/concepts/acknowledge/), that we must acknowledge (or ack) a request **within 3 seconds**.
 
 Currently, when the application receives a request, the API Gateway Lambda integration starts the application.  The lifecycle of this single process approach is diagrammed below.
 

--- a/content/blog/ai-slack-bot-to-chat-using-embedchain-and-pulumi-on-aws/index.md
+++ b/content/blog/ai-slack-bot-to-chat-using-embedchain-and-pulumi-on-aws/index.md
@@ -98,7 +98,7 @@ The `app_config` reference is the [Embedchain configuration schema](https://docs
 
 ### The Slack application
 
-Now that our brain is built, we need a way for our users to interact with it. [Slack Bolt](https://slack.dev/bolt-python/tutorial/getting-started) is an official library for building Slack bots.
+Now that our brain is built, we need a way for our users to interact with it. [Slack Bolt](https://docs.slack.dev/tools/bolt-python/getting-started/) is an official library for building Slack bots.
 
 Follow their instructions to [create a new Slack app](https://api.slack.com/start/quickstart).
 

--- a/content/blog/ai-slackbot-in-real-time-using-s3-sqs-and-pulumi-on-aws-uploading-documents/index.md
+++ b/content/blog/ai-slackbot-in-real-time-using-s3-sqs-and-pulumi-on-aws-uploading-documents/index.md
@@ -232,7 +232,7 @@ Of course, this same methodology can be used on any of the events exposed by Sla
 
 ![arti-react.png](./arti-react.png)
 
-To learn more about extending this bot, see [Slack Bolt's documentation](https://slack.dev/bolt-python/concepts#basic).
+To learn more about extending this bot, see [Slack Bolt's documentation](https://docs.slack.dev/tools/bolt-python/concepts/).
 
 ## Conclusion
 

--- a/content/blog/mlops-the-ai-challenge-is-cloud-not-code/index.md
+++ b/content/blog/mlops-the-ai-challenge-is-cloud-not-code/index.md
@@ -67,7 +67,7 @@ Choose one of the following deployment platforms. (You can actually choose more 
 - [Azure](https://azure.microsoft.com/en-us)
   - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [Runpod.io](https://runpod.io)
-  - [Runpod api key](https://docs.runpod.io/docs/graphql-api)
+  - [Runpod api key](https://docs.runpod.io/graphql-api)
 
 Now, for the real fun, let's start the timer and deploy our own chatbot! Note that the instructions below are for Runpod; instructions for the other two deployment platforms are found in [the GitHub repository](https://github.com/pulumiverse/katwalk).
 

--- a/content/docs/iac/_index.md
+++ b/content/docs/iac/_index.md
@@ -93,7 +93,7 @@ sections:
   - emoji: 🤖
     heading: AI Integration
     description: Integrate AI assistants with Pulumi infrastructure.
-    link: /docs/iac/guides/ai-integration/
+    link: /docs/ai/
 - type: flat
   heading: Have questions?
   description: <p>For questions or feedback, reach out on <a href="https://slack.pulumi.com" target="_blank">community Slack</a>, <a href="https://github.com/pulumi" target="_blank">GitHub</a>, or <a href="/support/">contact support</a>.</p>

--- a/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
+++ b/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
@@ -412,7 +412,7 @@ variables:
       return: id
 ```
 
-The expression `${AmazonLinuxAmi}` will return the AMI ID returned from the [`aws:getAmi`](/registry/packages/aws/api-docs/getami/) function.
+The expression `${AmazonLinuxAmi}` will return the AMI ID returned from the [`aws:getAmi`](/registry/packages/aws/api-docs/ec2/getami/) function.
 
 Example calling the `sum` function in the `pulumi-std` provider package to subtract 255 from `${route53Weight}`:
 

--- a/content/docs/reference/cloud-rest-api/deployments/_index.md
+++ b/content/docs/reference/cloud-rest-api/deployments/_index.md
@@ -17,6 +17,8 @@ aliases:
   - /docs/reference/cloud-rest-api/deployments/
   - /docs/reference/deployments-rest-api
   - /docs/reference/deployments-rest-api/
+  - /docs/deployments/api
+  - /docs/deployments/api/
 ---
 
 The Deployments API allows you to configure and manage Pulumi Deployments, which enable you to execute Pulumi updates and other operations through the Pulumi Cloud. With this API, you can configure deployment settings for your stacks, trigger deployments, view deployment status and logs, and manage deployment execution.

--- a/content/docs/version-control/gitlab.md
+++ b/content/docs/version-control/gitlab.md
@@ -131,4 +131,4 @@ Use GitLab repositories as template sources for [Pulumi IDP](/docs/idp/concepts/
 
 ## Pulumi Deployments
 
-Trigger [Pulumi Deployments](/docs/deployments/deployments/) from GitLab CI by calling the [Deployments REST API](https://www.pulumi.com/docs/deployments/api/) from your GitLab CI job. Native push-to-deploy from GitLab repositories is not currently supported; that feature requires the [Pulumi GitHub App](/docs/version-control/github-app/).
+Trigger [Pulumi Deployments](/docs/deployments/deployments/) from GitLab CI by calling the [Deployments REST API](/docs/reference/cloud-rest-api/deployments/) from your GitLab CI job. Native push-to-deploy from GitLab repositories is not currently supported; that feature requires the [Pulumi GitHub App](/docs/version-control/github-app/).


### PR DESCRIPTION
Fixes broken internal and external links detected by DocsBot on March 6–7.

## Changes
- Fixed AI Integration link on IaC landing page to point to `/docs/ai/`
- Fixed `aws:getAmi` link in YAML language reference (added missing `ec2/` path segment)
- Fixed Deployments REST API link in GitLab integration page and added alias for `/docs/deployments/api/`
- Updated 3 blog posts with current Slack Bolt Python documentation URLs (`docs.slack.dev`)
- Updated RunPod API documentation URL in MLOps blog post

Fixes #17870