### PR TITLE
Add SCaLE 23x and DevOpsDays LA 2026 talks to Engin Diri

### DIFF
--- a/content/community/community-engineering/engin-diri.md
+++ b/content/community/community-engineering/engin-diri.md
@@ -8,6 +8,14 @@ layout: community-engineering/single
 aliases:
   - /engin
 talks:
+- event: "SCaLE 23x"
+  title: "Building AI Platforms Without Losing Your Engineering Principles"
+  url: "https://www.socallinuxexpo.org/scale/23x/presentations/building-ai-platforms-without-losing-your-engineering-principles"
+  date: 2026-03-08T11:45:00.000-07:00
+- event: "DevOpsDays LA 2026"
+  title: "The Ralph Wiggum Loop: How Autonomous AI Loops Built My Serverless SaaS While I Slept"
+  url: "https://devopsdays.org/events/2026-los-angeles/program/engin-diri"
+  date: 2026-03-06T13:45:00.000-07:00
 - event: "CfgMgmtCamp 2026 Ghent"
   title: "Building AI-Assisted Operations: Agentic AI Workshop"
   url: "https://cfp.cfgmgmtcamp.org/ghent2026/talk/DCRWVC/"


### PR DESCRIPTION
## Summary
- Add SCaLE 23x talk "Building AI Platforms Without Losing Your Engineering Principles" (March 8, 2026)
- Add DevOpsDays LA 2026 talk "The Ralph Wiggum Loop: How Autonomous AI Loops Built My Serverless SaaS While I Slept" (March 6, 2026)

## Test plan
- [ ] Verify the talks render correctly on the Engin Diri community engineering page
- [ ] Confirm date sorting is correct (newest first)