### PR TITLE
update spec.env to spec.environment

### DIFF
--- a/content/docs/iac/guides/continuous-delivery/pulumi-kubernetes-operator.md
+++ b/content/docs/iac/guides/continuous-delivery/pulumi-kubernetes-operator.md
@@ -165,7 +165,7 @@ See ["States & Backends"][states-backends] for more information.
 
 [Pulumi ESC (Environments, Secrets, and Configuration)][pulumi-esc] provides centralized management of secrets and configuration. You can attach ESC environments to Stack objects to access shared configuration and secrets across multiple stacks.
 
-Use the `spec.envs` field to specify one or more ESC environment names:
+Use the `spec.environment` field to specify one or more ESC environment names:
 
 ```yaml
 apiVersion: pulumi.com/v1
@@ -177,7 +177,7 @@ spec:
   stack: my-org/my-app/prod
   projectRepo: https://github.com/example/app
   branch: main
-  envs:
+  environment:
     - prod-shared-config
     - aws-credentials
   envRefs:


### PR DESCRIPTION
### Proposed changes

Updated spec.env to spec.environment as env is deprecated according to [PKO Repo docs](https://github.com/pulumi/pulumi-kubernetes-operator/blob/master/docs/stacks.md#stackspec).

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

Fixes https://github.com/pulumi/docs/issues/17893