### PR TITLE
AWS ECS guide: remove outdated Crosswalk branding

### DIFF
--- a/content/docs/iac/clouds/aws/guides/ecs.md
+++ b/content/docs/iac/clouds/aws/guides/ecs.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Using AWS Elastic Container Service (ECS) | Crosswalk"
+title_tag: "Using AWS Elastic Container Service (ECS) | AWS Guides"
 title: ECS
 h1: AWS Elastic Container Service (ECS)
-meta_desc: Pulumi Crosswalk for AWS ECS simplifies deploying containerized applications into ECS and managing all of the
+meta_desc: Pulumi's AWSX library simplifies deploying containerized applications into ECS and managing all of the
             associated resources.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
@@ -18,8 +18,6 @@ aliases:
 - /docs/clouds/aws/guides/ecs/
 ---
 
-{{< crosswalk-header >}}
-
 [Amazon Elastic Container Service (Amazon ECS)](https://aws.amazon.com/ecs) is a scalable, high-performance container
 orchestration service that supports Docker containers and allows you to easily run and scale containerized applications
 on AWS. ECS eliminates the need for you to install and operate your own container orchestration software, manage and
@@ -27,7 +25,7 @@ scale a cluster of virtual machines, or schedule containers on those virtual mac
 
 ## Overview
 
-Pulumi Crosswalk for AWS ECS simplifies deploying containerized applications into ECS and managing all of the
+Pulumi's AWSX library simplifies deploying containerized applications into ECS and managing all of the
 associated resources. This includes simple support for load-balanced container services and one-off tasks, in addition
 to managing the clusters and associated scaling, network, and security policies. This includes ECS Fargate---the
 simplest option, alleviating the need to manage the cluster's servers themselves---in addition to ECS classic---
@@ -37,7 +35,7 @@ providing full control over the underlying EC2 machine resources that power your
 > containerized applications in a cluster. EKS tends to be more complex to provision and manage, but has
 > the added advantage of using the industry standard container orchestrator, Kubernetes, and therefore can help
 > with portability between clouds and self-hosted configurations. See
-> [Pulumi Crosswalk for AWS EKS](/docs/clouds/aws/guides/eks/) for more information about using EKS.
+> [the EKS guide](/docs/clouds/aws/guides/eks/) for more information about using EKS.
 
 ## Creating a Load Balanced ECS Service
 
@@ -65,7 +63,7 @@ Giving the following output:
 
 We have chosen to create an [Elastic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing) so that we
 can access our services over the Internet at a stable address, spread evenly across two instances. Any of the ELB
-options described in the [Pulumi Crosswalk for ELB documentation](/docs/clouds/aws/guides/elb/) can be used with our ECS service.
+options described in [the ELB guide](/docs/clouds/aws/guides/elb/) can be used with our ECS service.
 
 Behind the scenes, our program creates the ECS cluster in the default VPC to run the compute. This is something
 [we can configure](/docs/clouds/aws/guides/eks#configuring-your-eks-clusters-networking) if we want to use a different VPC.
@@ -80,7 +78,7 @@ approach is simple and hides a lot of complexity, it's often desirable to contro
 ## Creating an ECS Cluster in a VPC
 
 To create an ECS service inside of a VPC, we will first create or use an existing VPC using any of the techniques
-described in [Pulumi Crosswalk for AWS VPC](/docs/clouds/aws/guides/vpc/). Then we pass the subnets
+described in [the VPC guide](/docs/clouds/aws/guides/vpc/). Then we pass the subnets
 from that VPC into the network configuration argument for our cluster:
 
 {{< example-program path="awsx-vpc-fargate-service" >}}
@@ -108,7 +106,7 @@ For full details of the available component arguments, please refer to the regis
 
 ## Building and Publishing Docker Images Automatically
 
-Containers with Pulumi Crosswalk for AWS ECS are far more flexible than just accepting a preexisting image URL,
+Containers with the AWSX library are far more flexible than just accepting a preexisting image URL,
 and can even refer to a `Dockerfile` on disk so you do not need to build and publish
 it separately ahead of time. This makes it very easy to use private registrations for your ECS workloads.
 
@@ -117,7 +115,7 @@ the private ECR repository path to the container:
 
 {{< example-program path="awsx-load-balanced-fargate-ecr" >}}
 
-For more information about using ECR, refer to [Pulumi Crosswalk for AWS ECR](/docs/clouds/aws/guides/ecr/).
+For more information about using ECR, refer to [the ECR guide](/docs/clouds/aws/guides/ecr/).
 
 ## Additional ECS Resources
 


### PR DESCRIPTION
Fixes #17857 (part of #17815).
    
    This page was written under the old "Pulumi Crosswalk for AWS" branding, which is no longer in active use. The page has been updated to use neutral, accurate language that reflects the current state of the tooling.
    
    ## Changes
    
    - **`title_tag`**: Updated from `"Using AWS Elastic Container Service (ECS) | Crosswalk"` to `"Using AWS Elastic Container Service (ECS) | AWS Guides"`
    - **`meta_desc`**: Updated from `"Pulumi Crosswalk for AWS ECS simplifies..."` to `"Pulumi's AWSX library simplifies..."`
    - **Removed `{{< crosswalk-header >}}`**: The shortcode that renders the old Crosswalk logo/banner
    - **Overview paragraph**: Updated `"Pulumi Crosswalk for AWS ECS"` to `"Pulumi's AWSX library"`
    - **"Building and Publishing" section**: Updated `"Containers with Pulumi Crosswalk for AWS ECS"` to `"Containers with the AWSX library"`
    - **Cross-page references**: Updated all `"Pulumi Crosswalk for AWS [service]"` link text to use neutral guide link text (`"the EKS guide"`, `"the ELB guide"`, `"the VPC guide"`, `"the ECR guide"`)
    - **URL aliases**: Retained all existing crosswalk URL aliases for backward compatibility
    
    ## Checklist
    
    - [x] Remove "CrossWalk" / "Crosswalk" terminology from `title_tag`, `meta_desc`, and prose
    - [x] Remove the crosswalk-header shortcode
    - [x] Update in-prose references to use `"Pulumi's AWSX library"`
    - [x] Update cross-page references to use neutral language
    - [x] Verified all examples use example-program shortcodes
    - [x] Verified examples use up-to-date major versions (aws v7, awsx v3, pulumi v3)
    
    ---
    🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*