### PR TITLE
Add CLI exit code docs

### DIFF
--- a/content/docs/iac/cli/_index.md
+++ b/content/docs/iac/cli/_index.md
@@ -58,6 +58,6 @@ Below is the complete documentation for all available commands:
 
 For a list of environment variables that you can use to work with the Pulumi CLI, see [Environment variables](/docs/cli/environment-variables/).
 
-## Error and Exit Codes
+## Error and exit codes
 
 To learn how Pulumi maps internal errors to stable CLI exit codes you can use in automation, see [Pulumi CLI exit codes](/docs/iac/cli/exit-codes/).

--- a/content/docs/iac/cli/exit-codes.md
+++ b/content/docs/iac/cli/exit-codes.md
@@ -14,7 +14,9 @@ meta_image: /images/docs/meta-images/docs-meta.png
 
 The Pulumi CLI returns numeric exit codes that indicate the result of a command. Scripts, CI/CD systems, and tools can use these codes to distinguish between different kinds of failures.
 
-> The global CLI exit code mapping described here was introduced in Pulumi CLI **v3.226.1**. Earlier versions may behave differently and do not guarantee the same mapping.
+{{% notes type="info" %}}
+The global CLI exit code mapping described here was introduced in Pulumi CLI **v3.226.1**. Earlier versions may behave differently and do not guarantee the same mapping.
+{{% /notes %}}
 
 This page explains how Pulumi exit codes work and how to consume them safely in automation. A zero exit code means the operation was **successful**, and any other code means **failure**.
 


### PR DESCRIPTION
Part of the work to make the CLI more LLM-friendly, this documents the reason work to add explicit exit codes.