### PR TITLE
Remove Crosswalk branding from ELB guide

### DIFF
--- a/content/docs/iac/clouds/aws/guides/elb.md
+++ b/content/docs/iac/clouds/aws/guides/elb.md
@@ -1,9 +1,9 @@
 ---
-title_tag: "Using AWS Elastic Load Balancing (ELB) | Crosswalk"
+title_tag: "Using AWS Elastic Load Balancing (ELB) | AWS Guides"
 title: ELB
 h1: AWS Elastic Load Balancing (ELB)
-meta_desc: Pulumi Crosswalk for AWS ELB provides easy provisioning Application and Network Load Balancers, and easily
-           integrates with functionality of AWS other services.
+meta_desc: Pulumi's AWSX library provides easy provisioning of Application and Network Load Balancers, and easily
+           integrates with other AWS services.
 meta_image: /images/docs/meta-images/docs-clouds-aws-meta-image.png
 menu:
   iac:
@@ -18,8 +18,6 @@ aliases:
 - /docs/clouds/aws/guides/elb/
 ---
 
-{{< crosswalk-header >}}
-
 [Elastic Load Balancing](https://aws.amazon.com/elasticloadbalancing/) (ELB) automatically distributes incoming
 application traffic across multiple targets, such as Amazon EC2 instances, containers, IP addresses, and Lambda
 Functions. It can handle the varying load of your application traffic in a single Availability Zone or across multiple
@@ -27,8 +25,8 @@ Availability Zones.
 
 ## Overview
 
-Pulumi Crosswalk for AWS ELB provides easy APIs for provisioning Application and Network Load Balancers, and
-integrates with functionality for other services, including [API Gateway](/docs/clouds/aws/guides/api-gateway/),
+Pulumi's [AWSX library](https://www.pulumi.com/registry/packages/awsx/) provides easy APIs for provisioning Application and Network Load Balancers, and
+integrates with other services, including [API Gateway](/docs/clouds/aws/guides/api-gateway/),
 [Elastic Container Service (ECS)](/docs/clouds/aws/guides/ecs), [Lambda](/docs/clouds/aws/guides/lambda/), and [VPC](/docs/clouds/aws/guides/vpc/), to provide
 configurable network accessibility to the different kinds of compute you will run inside of AWS.
 
@@ -131,7 +129,7 @@ with your load balancer, pass the listener in your task definition's `portMappin
 
 {{< example-program path="awsx-load-balanced-fargate-nginx" >}}
 
-> [Pulumi Crosswalk for AWS ECS](/docs/clouds/aws/guides/ecs/) -- those classes in the `awsx.ecs` package -- will automatically create the
+> The [AWSX ECS package](/docs/clouds/aws/guides/ecs/) -- those classes in the `awsx.ecs` package -- will automatically create the
 > right ingress and egress rules. If you are using raw `aws.ecs`, you will need to manually manage the security group
 > ingress and egress rules, much like the [EC2 Instance](#load-balancing-ec2-instances) example earlier.
 
@@ -182,7 +180,7 @@ property of the load balancer to associate it with the VPC's public or private s
 
 {{< example-program path="awsx-elb-vpc" >}}
 
-For more information on creating and configuring VPCs, refer to [Pulumi Crosswalk for AWS VPC](/docs/clouds/aws/guides/vpc/).
+For more information on creating and configuring VPCs, refer to the [AWS VPC guide](/docs/clouds/aws/guides/vpc/).
 
 ## Advanced Load Balancer Listener and Target Group Configuration
 
@@ -302,8 +300,3 @@ You can also create a target group manually, either by defining a `defaultTarget
 
 For more extensive information on ELB target groups, [refer to the AWS documentation](
 https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html).
-
-## Additional ELB Resources
-
-For detailed reference documentation, visit the [API docs](
-/docs/reference/pkg/nodejs/pulumi/awsx/lb).


### PR DESCRIPTION
Fixes #17914

## Changes

This PR removes outdated "Crosswalk" branding from the AWS ELB guide, consistent with the broader cleanup effort tracked in #17815.

- Updates `title_tag` from `| Crosswalk` to `| AWS Guides`
- Rewrites `meta_desc` to remove Crosswalk terminology
- Removes the `{{< crosswalk-header >}}` shortcode
- Replaces "Pulumi Crosswalk for AWS ELB" with "Pulumi's AWSX library" in the Overview section
- Updates the ECS section blockquote to reference "The AWSX ECS package" instead of "Pulumi Crosswalk for AWS ECS"
- Updates the VPC cross-reference to "the AWS VPC guide" instead of "Pulumi Crosswalk for AWS VPC"
- Removes the outdated API reference link (`/docs/reference/pkg/nodejs/pulumi/awsx/lb`)
- Retains all URL aliases for backward compatibility

All examples are already sourced via `{{< example-program >}}` shortcodes (no changes needed).

---
🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*