### PR TITLE
fix(theme): prevent code disappearing in Safari chooser tabs (#17951)

### DIFF
--- a/theme/stencil/src/components/choosable/choosable.scss
+++ b/theme/stencil/src/components/choosable/choosable.scss
@@ -1,5 +1,7 @@
-pulumi-choosable {
+pulumi-choosable:defined {
     // Immediate descendents are hidden by default, visible when active.
+    // The :defined pseudo-class ensures content stays visible until the custom element
+    // is registered, preventing a flash of invisible content in Safari (#17951).
     > * {
         display: none;
 

--- a/theme/stencil/src/components/choosable/choosable.tsx
+++ b/theme/stencil/src/components/choosable/choosable.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Listen, Prop, Watch } from "@stencil/core";
+import { Component, Element, h, Listen, Prop, Watch, forceUpdate } from "@stencil/core";
 import { store, Unsubscribe } from "@stencil/redux";
 import { AppState } from "../../store/state";
 import { ChooserType, ChooserKey, ChooserMode } from "../chooser/chooser";
@@ -71,6 +71,14 @@ export class Choosable {
         // This avoids waiting for the "rendered" event when possible.
         if (store.getStore()) {
             this.subscribeToStore();
+        } else {
+            // Fallback: if the "rendered" event was missed (e.g., due to Safari lifecycle
+            // ordering), retry once after a short delay (#17951).
+            setTimeout(() => {
+                if (!this.storeUnsubscribe && this.mode === "global" && store.getStore()) {
+                    this.subscribeToStore();
+                }
+            }, 100);
         }
     }
 
@@ -107,6 +115,10 @@ export class Choosable {
                         return { selection: pythontoolchain };
                 }
             });
+
+            // Force a re-render to ensure the selection from mapStateToProps is applied
+            // immediately, closing the race window where content stays hidden (#17951).
+            forceUpdate(this.el);
         }
     }
 

--- a/theme/stencil/src/components/chooser/chooser.tsx
+++ b/theme/stencil/src/components/chooser/chooser.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, h, Listen, Prop, State } from "@stencil/core";
+import { Component, Element, Host, h, Listen, Prop, State, forceUpdate } from "@stencil/core";
 import { store, Unsubscribe } from "@stencil/redux";
 import { AppState } from "../../store/state";
 import { setLanguage, setK8sLanguage, setOS, setCloud, setPersona, setBackEnd, setPythonToolchain } from "../../store/actions/preferences";
@@ -233,6 +233,10 @@ export class Chooser {
                     return {};
             }
         });
+
+        // Force a re-render to ensure the selection from mapStateToProps is applied
+        // immediately, which triggers componentDidRender → applyChoice (#17951).
+        forceUpdate(this.el);
     }
 
     render() {


### PR DESCRIPTION
Fixes a race condition where code blocks in language chooser tabs disappear in Safari after Stencil web components hydrate.

## Changes
- Gate CSS `display: none` behind `:defined` pseudo-class so content stays visible until the custom element JS is registered
- Add `forceUpdate` after store subscription in both `choosable.tsx` and `chooser.tsx` to guarantee immediate re-render with selection
- Add 100ms timeout fallback in `choosable.tsx` for cases where the `rendered` event is missed due to Safari lifecycle ordering

(Hopefully) Fixes #17951