### PR TITLE
docs(logging): document PULUMI_OPTION_* environment variables for pipeline logging

### DIFF
--- a/content/docs/support/debugging/logging.md
+++ b/content/docs/support/debugging/logging.md
@@ -38,7 +38,7 @@ Enabling verbose logging may reveal sensitive information (tokens, credentials..
 $ pulumi up --logtostderr --logflow -v=9 2> out.txt
 ```
 
-### Logging in a pipeline
+### Enabling logs in a pipeline
 
 If you are running your `pulumi up` command in a pipeline and are not able to alter the command to add the arguments mentioned above, you can use some of the `PULUMI_OPTION_*` environment variables instead. The following is the equivalent of the command above:
 


### PR DESCRIPTION
## Summary

- Adds a new \"Logging in a pipeline\" section to the logging docs explaining how to use `PULUMI_OPTION_*` environment variables as an alternative to CLI flags
- Adds the `PULUMI_OPTION_LOGFLOW`, `PULUMI_OPTION_LOGTOSTDERR`, and `PULUMI_OPTION_VERBOSE` equivalents to the `--logtostderr --logflow -v=9` flags
- Cross-references the CLI environment variables documentation for further reading
- Adds a proper heading for the existing \"Provider Diagnostic Logging\" section

## Test plan

- [ ] Preview renders correctly at `/docs/support/debugging/logging/`
- [ ] Environment variable code block is correct and readable
- [ ] Link to CLI environment variables documentation resolves correctly