### PR TITLE
fix(theme): fix cookie consent banner styling for Tailwind v4

### DIFF
--- a/theme/src/scss/main.scss
+++ b/theme/src/scss/main.scss
@@ -463,55 +463,59 @@ $sitenav-offset: calc($sitenav-height + 16px);
     section.newsletter-input pulumi-hubspot-form input.hs-input {
         @apply rounded;
     }
+}
 
-    #segment-consent-manager:empty {
-        @apply hidden;
+// Cookie consent banner styles must be OUTSIDE @layer components.
+// The Segment consent manager (static/js/consent-manager.js) injects its own
+// Emotion CSS without any @layer. In Tailwind v4, @layer components has lower
+// specificity than unlayered styles, so our overrides were being lost.
+#segment-consent-manager:empty {
+    @apply hidden;
+}
+#segment-consent-manager {
+
+    @apply text-black fixed bottom-0 right-0 left-0 m-4 border-2 border-violet-600 rounded-lg shadow-lg;
+    z-index: 99999;
+
+    @include screen-lg {
+        @apply w-1/3 right-auto m-4 overflow-hidden;
     }
-    #segment-consent-manager {
 
-        @apply text-black fixed bottom-0 right-0 left-0 m-4 border-2 border-violet-600 rounded-lg shadow-lg;
-        z-index: 99999;
+    div {
+       @apply bg-white;
+    }
 
-        @include screen-lg {
-            @apply w-1/3 right-auto m-4 overflow-hidden;
+    p {
+        @apply text-black text-left text-sm pr-2;
+
+        a {
+            text-decoration: none;
+            color: map-get($blue, 600);
+        }
+    }
+
+    button {
+        @apply font-bold no-underline;
+    }
+
+    button[aria-label="Close"] {
+        @apply text-violet-800 mt-4 top-0 right-0 text-lg;
+    }
+
+    .manage-cookies-btn {
+        @apply mt-2 bg-violet-600 text-white font-bold border-2 border-violet-600 no-underline p-3 rounded-md text-center;
+        @include transition;
+
+        &.disabled {
+            opacity: 0.3;
         }
 
-        div {
-           @apply bg-white;
+        &:hover {
+            @apply bg-violet-100 text-violet-700;
         }
 
-        p {
-            @apply text-black text-left text-sm pr-2;
-
-            a {
-                text-decoration: none;
-                color: map-get($blue, 600);
-            }
-        }
-
-        button {
-            @apply font-bold no-underline;
-        }
-
-        button[aria-label="Close"] {
-            @apply text-violet-800 mt-4 top-0 right-0 text-lg;
-        }
-
-        .manage-cookies-btn {
-            @apply mt-2 bg-violet-600 text-white font-bold border-2 border-violet-600 no-underline p-3 rounded-md;
-            @include transition;
-
-            &.disabled {
-                opacity: 0.3;
-            }
-
-            &:hover {
-                @apply bg-violet-100 text-violet-700;
-            }
-
-            &:focus {
-                @apply bg-violet-100 text-violet-200;
-            }
+        &:focus {
+            @apply bg-violet-100 text-violet-200;
         }
     }
 }


### PR DESCRIPTION
Fixes the cookie consent banner styling that broke after the Tailwind CSS v4 upgrade.

## Problem

The Tailwind v4 upgrade (PR #17829) placed consent manager styles inside `@layer components`. In Tailwind v4, `@layer components` uses real CSS `@layer`, giving these styles lower specificity than unlayered styles. The Segment consent manager library injects its own Emotion CSS without any `@layer`, causing it to override our custom styling.

## Changes

- Moved `#segment-consent-manager` styles outside `@layer components` so they have equal specificity to the library's Emotion CSS
- Centered the "Manage cookies" button text

## Screenshot after fix (simulated EU location)

<img width="2545" height="1333" alt="image" src="https://github.com/user-attachments/assets/530d02ca-4ebb-4ce1-b81f-4930412c41a3" />


Fixes #17996