### PR TITLE
Update secondary CTA button labels

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -92,7 +92,7 @@ params:
             label_short: "Sign Up"
             href: "https://app.pulumi.com/signup"
         secondary:
-            label: "Contact Sales"
+            label: "Contact Us"
             href: "/contact/?form=sales"
 
     canonicalURL: https://www.pulumi.com

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -332,7 +332,7 @@
                             </div>
                             <div class="flex flex-col justify-center align-center text-center lg:mr-14 lg:ml-4">
                                 <a href="{{ site.Params.cta.secondary.href }}"
-                                    class="btn-secondary py-3 px-6 whitespace-nowrap">{{ site.Params.cta.secondary.label }}</a>
+                                    class="btn-secondary py-3 px-6 whitespace-nowrap">Book a Demo</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Changes the site-wide secondary CTA button label from "Contact Sales" to "Contact Us"
- Hardcodes the home page bottom CTA (under "Ready to try Pulumi?") to "Book a Demo" instead of using the configured value

## Test plan
- [x] Verify the secondary CTA in the site header/nav reads "Contact Us"
- [x] Verify the bottom CTA on the home page reads "Book a Demo"
- [x] Confirm both buttons still link to `/contact/?form=sales`

🤖 Generated with [Claude Code](https://claude.com/claude-code)