### PR TITLE
Fix pricing page FAQ tabs broken by Tailwind v4

### DIFF
--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -212,23 +212,20 @@
         <span id="faq-billing"></span>
 
         <ul id="faq-headers" class="hidden lg:flex list-none mt-10">
-            <li class="px-10 py-3 mr-3 border-b-4 border-solid border-blue-600" data-faq-label="pricing">
-                <h4><a href="#faq-pricing" class="text-black">Pricing</a></h4>
+            <li class="px-10 py-3 mr-3" data-faq-label="pricing">
+                <h4><a href="#faq-pricing">Pricing</a></h4>
             </li>
             <li class="px-10 py-3 mr-3" data-faq-label="product">
-                <h4><a href="#faq-product" class="text-gray-500">Product</a></h4>
+                <h4><a href="#faq-product">Product</a></h4>
             </li>
             <li class="px-10 py-3" data-faq-label="billing">
-                <h4><a href="#faq-billing" class="text-gray-500">Billing and Support</a></h4>
+                <h4><a href="#faq-billing">Billing and Support</a></h4>
             </li>
         </ul>
 
         {{ range $index, $category := .Params.faq }}
             <p class="text-2xl font-bold lg:hidden mt-12 pl-5">{{ $category.category }}</p>
             {{ $listClass := "list-none p-0 mx-5 xl:ml-12" }}
-            {{ if not (eq $index 0)  }}
-                {{ $listClass = "list-none p-0 mx-5 xl:ml-12 lg:hidden" }}
-            {{ end }}
             <ul class="{{ $listClass }}" data-faq-type="faq-{{ .id }}">
                 {{ range $question := $category.items }}
                     <li class="accordion-item text-2xl py-3">
@@ -277,4 +274,15 @@
             </div>
         </div>
     </section>
+
+    <script>
+        document.querySelectorAll("#faq-headers a").forEach(function (a) {
+            a.addEventListener("click", function (e) {
+                e.preventDefault();
+                var y = window.scrollY;
+                location.hash = a.getAttribute("href");
+                window.scrollTo(0, y);
+            });
+        });
+    </script>
 {{ end }}

--- a/theme/src/scss/marketing/_pricing.scss
+++ b/theme/src/scss/marketing/_pricing.scss
@@ -81,11 +81,44 @@
 }
 
 .pricing-faq {
+    // Default state: Pricing tab active. All default styling must live in the same
+    // @layer (components) as the :target overrides below. Tailwind v4 places utility
+    // classes in @layer utilities, which always beats @layer components, so inline
+    // utility classes (e.g., lg:hidden, border-b-4) would prevent :target from
+    // toggling styles.
+    ul[data-faq-type]:not([data-faq-type="faq-pricing"]) {
+        @include screen-lg {
+            display: none;
+        }
+    }
+
+    // Use explicit CSS properties for borders instead of @apply. Tailwind v4's
+    // @apply border-b-4 emits a longhand (border-bottom-style: var(--tw-border-style))
+    // that conflicts with the shorthand reset from @apply border-none, causing
+    // specificity issues between rules in the same @layer.
+    #faq-headers {
+        li {
+            border-bottom: 4px solid transparent;
+
+            a {
+                @apply text-gray-500;
+            }
+        }
+
+        li[data-faq-label="pricing"] {
+            border-bottom-color: var(--color-blue-600);
+
+            a {
+                @apply text-black;
+            }
+        }
+    }
+
     @each $filter-type in "product" "billing" "pricing" {
         #faq-#{$filter-type}:target {
             ~ #faq-headers {
                 li {
-                    @apply border-none;
+                    border-bottom-color: transparent;
 
                     a {
                         @apply text-gray-500;
@@ -93,32 +126,22 @@
                 }
 
                 li[data-faq-label="#{$filter-type}"] {
-                    @apply border-b-4 border-solid border-blue-600;
+                    border-bottom-color: var(--color-blue-600);
 
                     a {
                         @apply text-black;
-                    }
-                }
-
-                @if $filter-type != "pricing" {
-                    li[data-faq-label="pricing"] {
-                        @apply border-none;
-
-                        a {
-                            @apply text-gray-500;
-                        }
                     }
                 }
             }
 
             @if $filter-type != "pricing" {
                 ~ ul[data-faq-type="faq-pricing"] {
-                    @apply hidden;
+                    display: none;
                 }
             }
 
             ~ ul[data-faq-type="faq-#{$filter-type}"] {
-                @apply block;
+                display: block;
             }
         }
     }


### PR DESCRIPTION
## Summary
- The FAQ tabs (Pricing, Product, Billing) on the pricing page stopped working after the Tailwind v4 upgrade. Tailwind v4 places utility classes in `@layer utilities`, which always beats `@layer components` where the SCSS `:target` rules live. Inline utilities like `lg:hidden`, `border-b-4`, and `text-gray-500` were overriding the tab-switching CSS.
- Moved all tab-state styling from inline HTML utilities into SCSS using explicit CSS properties (`border-bottom-color`, `display`) to stay within the same layer as the `:target` rules.
- Added a small script to preserve scroll position when clicking FAQ tabs, preventing the page from jumping to the anchor targets.

## Test plan
- [ ] Visit `/pricing/` and scroll down to the FAQ section
- [ ] Click each tab (Pricing, Product, Billing) and verify the correct section appears
- [ ] Verify the active tab has a blue underline and the inactive tabs are gray
- [ ] Verify clicking a tab does not scroll the page
- [ ] Check on mobile that all FAQ sections are visible (no tab filtering on small screens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)