### PR TITLE
docs(components): refresh concepts page to focus on consumption

### DIFF
--- a/content/docs/iac/concepts/components/_index.md
+++ b/content/docs/iac/concepts/components/_index.md
@@ -308,7 +308,7 @@ Notice that components are instantiated exactly like any other Pulumi resource: 
 
 When you run `pulumi up`, components appear as a resource tree in the CLI output. Child resources are displayed nested under their parent component, giving you visibility into everything the component created on your behalf:
 
-```plain
+```output
 Updating (dev):
      Type                            Name              Status
  +   pulumi:pulumi:Stack             my-stack          created
@@ -624,7 +624,7 @@ When designing component arguments:
 
 ## Creating child resources
 
-Component resources often contain child resources. The names of child resources are often derived from the component resources's name to ensure uniqueness. For example, you might use the component resource's name as a prefix. Also, when constructing a resource, children must be registered as such. To do this, pass the component resource itself as the `parent` option.
+Component resources often contain child resources. The names of child resources are often derived from the component resource's name to ensure uniqueness. For example, you might use the component resource's name as a prefix. Also, when constructing a resource, children must be registered as such. To do this, pass the component resource itself as the `parent` option.
 
 This example demonstrates both the naming convention and how to designate the component resource as the parent:
 


### PR DESCRIPTION
Restructure the Components concepts page to lead with what components are and how to consume them. The page previously focused almost entirely on authoring; it now opens with a clear definition, explains that components are part of packages, covers all four consumption patterns (local, single-language packages, pulumi package add, pre-published SDKs), and includes a concrete awsx.ec2.Vpc example with arguments and resource options. Authoring content is preserved and a new Additional resources section links to guides.

Fixes #16962.
