### PR TITLE
Re-enable Java Fargate programs in testing

### DIFF
--- a/scripts/programs/ignore.txt
+++ b/scripts/programs/ignore.txt
@@ -11,11 +11,6 @@
 #
 
 
-# Java examples of LoadBalancedFargateService erroneously complain about missing container declarations.
-# https://github.com/pulumi/pulumi-awsx/issues/820
-awsx-vpc-fargate-service-java
-awsx-load-balanced-fargate-ecr-java
-awsx-load-balanced-fargate-nginx-java
 
 # API Gateway authorizer parameter `providerArns` is mistyped.
 # https://github.com/pulumi/pulumi-aws-apigateway/issues/121


### PR DESCRIPTION
The underlying awsx bug (pulumi/pulumi-awsx#820) that caused these programs to erroneously fail has been resolved. Remove them from ignore.txt so CI validates them again.

Fixes #18018
