### PR TITLE
Fix deprecated GCP resources in gcp-simple-webserver examples

### DIFF
--- a/content/docs/iac/concepts/resources/options/hooks.md
+++ b/content/docs/iac/concepts/resources/options/hooks.md
@@ -57,7 +57,7 @@ export = async () => {
   const userData = `#!/bin/bash
 echo "Hello, World!" > index.html
 echo '{"ok": true}' > health.json
-nohup python -m SimpleHTTPServer 80 &`
+nohup python3 -m http.server 80 &`
 
   // Define a resource hook that will run after create and update and not return
   // until the health check passes.
@@ -142,7 +142,7 @@ from pulumi_aws import ec2
 user_data = """#!/bin/bash
 echo "Hello, World!" > index.html
 echo '{"ok": true}' > health.json
-nohup python -m SimpleHTTPServer 80 &"""
+nohup python3 -m http.server 80 &"""
 
 
 # Define a resource hook that will run after create and update and not return
@@ -285,7 +285,7 @@ func main() {
 		userData := `#!/bin/bash
 echo "Hello, World!" > index.html
 echo '{"ok": true}' > health.json
-nohup python -m SimpleHTTPServer 80 &`
+nohup python3 -m http.server 80 &`
 
 		instanceType := "t2.micro"
 
@@ -380,7 +380,7 @@ class MyStack : Stack
         var userData = @"#!/bin/bash
 echo ""Hello, World!"" > index.html
 echo '{""ok"": true}' > health.json
-nohup python -m SimpleHTTPServer 80 &";
+nohup python3 -m http.server 80 &";
 
         // Define a resource hook that will run after create and update and not return
         // until the health check passes.

--- a/content/docs/iac/guides/testing/unit.md
+++ b/content/docs/iac/guides/testing/unit.md
@@ -61,7 +61,7 @@ export const group = new aws.ec2.SecurityGroup("web-secgrp", {
     ],
 });
 
-const userData = `#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &`;
+const userData = `#!/bin/bash echo "Hello, World!" > index.html nohup python3 -m http.server 80 &`;
 
 export const server = new aws.ec2.Instance("web-server-www", {
     instanceType: "t2.micro",
@@ -85,7 +85,7 @@ group = ec2.SecurityGroup('web-secgrp', ingress=[
     { "protocol": "tcp", "from_port": 80, "to_port": 80, "cidr_blocks": ["0.0.0.0/0"] },
 ])
 
-user_data = '#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &'
+user_data = '#!/bin/bash echo "Hello, World!" > index.html nohup python3 -m http.server 80 &'
 
 server = ec2.Instance('web-server-www;',
     instance_type="t2.micro",
@@ -133,7 +133,7 @@ func createInfrastructure(ctx *pulumi.Context) (*infrastructure, error) {
 		return nil, err
 	}
 
-	const userData = `#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &`
+	const userData = `#!/bin/bash echo "Hello, World!" > index.html nohup python3 -m http.server 80 &`
 
 	server, err := ec2.NewInstance(ctx, "web-server-www", &ec2.InstanceArgs{
 		InstanceType:   pulumi.String("t2-micro"),
@@ -175,7 +175,7 @@ public class WebserverStack : Stack
             }
         });
 
-        var userData = "#!/bin/bash echo \"Hello, World!\" > index.html nohup python -m SimpleHTTPServer 80 &";
+        var userData = "#!/bin/bash echo \"Hello, World!\" > index.html nohup python3 -m http.server 80 &";
 
         var server = new Instance("web-server-www", new InstanceArgs
         {
@@ -220,7 +220,7 @@ public class App {
                     .build())
             .build());
 
-        var userData = "#!/bin/bash echo \"Hello, World!\" > index.html nohup python -m SimpleHTTPServer 80 &";
+        var userData = "#!/bin/bash echo \"Hello, World!\" > index.html nohup python3 -m http.server 80 &";
 
         var server = new Instance("web-server-www", InstanceArgs.builder()
             .instanceType("t2.micro")
@@ -260,7 +260,7 @@ resources:
       securityGroups:
         - ${web-secgrp.name}
       ami: ami-c55673a0
-      userData: "#!/bin/bash echo \"Hello, World!\" > index.html nohup python -m SimpleHTTPServer 80 &"
+      userData: "#!/bin/bash echo \"Hello, World!\" > index.html nohup python3 -m http.server 80 &"
 ```
 
 {{% /choosable %}}
@@ -1397,7 +1397,7 @@ X InstanceHasNameTag [387ms]
 
 X InstanceMustNotUseInlineUserData [17ms]
   Error Message:
-   Expected tags to be <null>, but found "#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &".
+   Expected tags to be <null>, but found "#!/bin/bash echo "Hello, World!" > index.html nohup python3 -m http.server 80 &".
 
 X SecurityGroupMustNotHaveSshPortsOpenToInternet [11ms]
   Error Message:

--- a/content/product/packages.md
+++ b/content/product/packages.md
@@ -236,7 +236,7 @@ details:
                         final var userData =
                                 "#!/bin/bash\n" +
                                         "echo \"Hello, World!\" > index.html\n" +
-                                        "nohup python -m SimpleHTTPServer 80 &";
+                                        "nohup python3 -m http.server 80 &";
 
                         final var server = new Instance("web-server-www", InstanceArgs.builder()
                                 .tags(Map.of("Name", "web-server-www"))
@@ -290,7 +290,7 @@ details:
                         userData: |-
                             #!/bin/bash
                             echo 'Hello, World from ${WebSecGrp.arn}!' > index.html
-                            nohup python -m SimpleHTTPServer 80 &
+                            nohup python3 -m http.server 80 &
                         vpcSecurityGroupIds:
                             - ${WebSecGrp}
                 outputs:

--- a/content/templates/virtual-machine/gcp/index.md
+++ b/content/templates/virtual-machine/gcp/index.md
@@ -61,7 +61,7 @@ $ open $(pulumi stack output url)
 Projects created with the Virtual Machine template expose the following [configuration](/docs/concepts/config) settings:
 
 machineType
-: The Compute Engine machine type to use for the VM. Defaults to `f1-micro`.
+: The Compute Engine machine type to use for the VM. Defaults to `e2-micro`.
 
 osImage
 : The OS image type to use for the VM. Defaults to `debian-11`.

--- a/scripts/programs/ignore.txt
+++ b/scripts/programs/ignore.txt
@@ -44,7 +44,6 @@ azure-native-import-resource-group-go
 gcp-import-service-account-typescript
 aws-s3bucket-bucketpolicy-csharp
 deepseek-ollama-csharp
-gcp-simple-webserver-yaml
 azure-native-import-resource-group-csharp
 
 # Terraform reference projects are not Pulumi programs.

--- a/static/programs/gcp-simple-webserver-csharp/Program.cs
+++ b/static/programs/gcp-simple-webserver-csharp/Program.cs
@@ -10,7 +10,7 @@ return await Deployment.RunAsync(() =>
     var project = "pulumi-devrel"; // REPLACE
     var startupScript = @"#!/bin/bash
     echo ""Hello, World!"" > index.html
-    nohup python -m SimpleHTTPServer 80 &";
+    nohup python3 -m http.server 80 &";
     // Create a VPC network.
     var vpcNetwork = new Gcp.Compute.Network("vpc-network", new()
     {
@@ -28,7 +28,7 @@ return await Deployment.RunAsync(() =>
     // [1] Create a compute instance.
     var computeInstance = new Gcp.Compute.Instance("webserver-instance", new()
     {
-        MachineType ="f1-micro",
+        MachineType ="e2-micro",
         Project = project,
         Zone=zone,
         MetadataStartupScript=startupScript,
@@ -36,7 +36,7 @@ return await Deployment.RunAsync(() =>
         {
             InitializeParams = new Gcp.Compute.Inputs.InstanceBootDiskInitializeParamsArgs
             {
-                Image="debian-cloud/debian-9-stretch-v20181210"
+                Image="debian-cloud/debian-12"
             }
         },
         NetworkInterfaces= new[]

--- a/static/programs/gcp-simple-webserver-go/main.go
+++ b/static/programs/gcp-simple-webserver-go/main.go
@@ -14,7 +14,7 @@ func main() {
 
 		startupScript := `#!/bin/bash
 		echo "Hello, World!" > index.html
-		nohup python -m SimpleHTTPServer 80 &`
+		nohup python3 -m http.server 80 &`
 
 		// Create a VPC network.
 		vpcNetwork, err := compute.NewNetwork(ctx, "vpc-network", &compute.NetworkArgs{
@@ -42,11 +42,11 @@ func main() {
 		_, err = compute.NewInstance(ctx, "webserver-instance", &compute.InstanceArgs{
 			Project: pulumi.String(project),
 			Zone: pulumi.String(zone),
-			MachineType: pulumi.String("f1-micro"),
+			MachineType: pulumi.String("e2-micro"),
 			MetadataStartupScript: pulumi.String(startupScript),
 			BootDisk: &compute.InstanceBootDiskArgs{
 				InitializeParams: &compute.InstanceBootDiskInitializeParamsArgs{
-					Image: pulumi.String("debian-cloud/debian-9-stretch-v20181210"),
+					Image: pulumi.String("debian-cloud/debian-12"),
 				},
 			},
 			NetworkInterfaces: compute.InstanceNetworkInterfaceArray{

--- a/static/programs/gcp-simple-webserver-python/__main__.py
+++ b/static/programs/gcp-simple-webserver-python/__main__.py
@@ -7,7 +7,7 @@ project = "pulumi-devrel" # REPLACE
 
 startup_script = """#!/bin/bash
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &"""
+nohup python3 -m http.server 80 &"""
 
 # Create a VPC network.
 vpc_network = compute.Network("vpc-network",
@@ -28,13 +28,13 @@ ip_address = compute.address.Address("ip-address",
 # [1] Create a compute instance.
 compute_instance = compute.Instance(
     "webserver-instance",
-    machine_type="f1-micro",
+    machine_type="e2-micro",
     project=project,
     zone=zone,
     metadata_startup_script=startup_script,
     boot_disk=compute.InstanceBootDiskArgs(
         initialize_params=compute.InstanceBootDiskInitializeParamsArgs(
-            image="debian-cloud/debian-9-stretch-v20181210"
+            image="debian-cloud/debian-12"
         )
     ),
     network_interfaces=[compute.InstanceNetworkInterfaceArgs(

--- a/static/programs/gcp-simple-webserver-typescript/index.ts
+++ b/static/programs/gcp-simple-webserver-typescript/index.ts
@@ -7,7 +7,7 @@ const project = "pulumi-devrel"; // REPLACE
 
 const startupScript = `#!/bin/bash
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &`;
+nohup python3 -m http.server 80 &`;
 
 // Create a VPC network.
 const vpcNetwork = new gcp.compute.Network("vpc-network", {
@@ -27,13 +27,13 @@ const ipAddress = new gcp.compute.Address("ip-address", {
 
 // [1] Create a compute instance.
 const computeInstance = new gcp.compute.Instance("webserver-instance", {
-    machineType: "f1-micro",
+    machineType: "e2-micro",
     project: project,
     zone: zone,
     metadataStartupScript: startupScript,
     bootDisk: {
         initializeParams: {
-            image: "debian-cloud/debian-9-stretch-v20181210",
+            image: "debian-cloud/debian-12",
         },
     },
     networkInterfaces: [

--- a/static/programs/gcp-simple-webserver-yaml/Pulumi.yaml
+++ b/static/programs/gcp-simple-webserver-yaml/Pulumi.yaml
@@ -11,7 +11,7 @@ resources:
   # Create a VPC network.
   vpcNetwork:
     type: gcp:compute:Network
-    name: vpcNetwork
+    name: vpc-network
     properties:
       autoCreateSubnetworks: true
 
@@ -28,16 +28,16 @@ resources:
   # [1] Create a compute instance.
   computeInstance:
     type: gcp:compute:Instance
-    name: webserverInstance
+    name: webserver-instance
     properties:
-      machineType: f1-micro
+      machineType: e2-micro
       metadataStartupScript: |
         #!/bin/bash
         echo "Hello, World!" > index.html
-        nohup python -m SimpleHTTPServer 80 &
+        nohup python3 -m http.server 80 &
       bootDisk:
         initializeParams:
-          image: debian-cloud/debian-9-stretch-v20181210
+          image: debian-cloud/debian-12
       networkInterfaces:
         - accessConfigs:
             - natIp: ${ipAddress.address}


### PR DESCRIPTION
Replace EOL machine type (f1-micro→e2-micro), EOL OS image (debian-9→debian-12), and Python 2 startup script
(SimpleHTTPServer→python3 http.server) across all language variants. Also update references in active docs and remove the yaml variant from the test ignore list.

Fixes #14518
