### PR TITLE
Change global CTA label to Get Started and remove experiment imports

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -88,7 +88,7 @@ params:
     # CTA configuration
     cta:
         primary:
-            label: "Try Pulumi Cloud for Free"
+            label: "Get Started"
             label_short: "Sign Up"
             href: "https://app.pulumi.com/signup"
         secondary:

--- a/layouts/partials/cta-get-started.html
+++ b/layouts/partials/cta-get-started.html
@@ -5,7 +5,7 @@
     params:
       cta:
         primary:
-          label: "Try Pulumi Cloud for Free"
+          label: "Get Started"
           href: "https://app.pulumi.com/signup"
 
   Usage:

--- a/theme/src/ts/main.ts
+++ b/theme/src/ts/main.ts
@@ -25,8 +25,5 @@ import "./algolia/autocomplete";
 import "./external-links";
 import "./neo-mode";
 
-import "./experiments/terraform-compare";
-import "./experiments/cta-activations-direct-vs-docs";
-
 // Register all Stencil components.
 defineCustomElements();


### PR DESCRIPTION
Updates the site-wide CTA label from "Try Pulumi Cloud for Free" to "Get Started" and removes the terraform-compare and cta-activations-direct-vs-docs experiment imports from the theme entrypoint. Experiment code is preserved for future reference.

## Changes
- Updated primary CTA label in `config/_default/config.yml`
- Updated matching comment in `layouts/partials/cta-get-started.html`
- Removed experiment imports from `theme/src/ts/main.ts`