### PR TITLE
fix(examples): use FQDN in ACM certificate C# and Java examples

### DIFF
--- a/static/programs/aws-acm-certificate-csharp/Program.cs
+++ b/static/programs/aws-acm-certificate-csharp/Program.cs
@@ -6,7 +6,7 @@ return await Deployment.RunAsync(() =>
 {
     var cert = new Certificate("cert", new CertificateArgs
     {
-        DomainName = "example",
+        DomainName = "example.com",
         ValidationMethod = "DNS",
     });
 });

--- a/static/programs/aws-acm-certificate-java/src/main/java/myproject/App.java
+++ b/static/programs/aws-acm-certificate-java/src/main/java/myproject/App.java
@@ -11,7 +11,7 @@ public class App {
         Pulumi.run(ctx -> {
             var cert = new Certificate("cert",
                 CertificateArgs.builder()
-                    .domainName("example")
+                    .domainName("example.com")
                     .validationMethod("DNS")
                     .build());
         });


### PR DESCRIPTION
Fixes bare hostname "example" → "example.com" in the C# and Java aws-acm-certificate examples. ACM requires a fully qualified domain name; the other four language variants already used "example.com".

Fixes https://github.com/pulumi/docs/issues/14513
