### PR TITLE
Fix aws-iampolicy-jsonparse-csharp

### DIFF
--- a/static/programs/aws-iampolicy-jsonparse-csharp/Program.cs
+++ b/static/programs/aws-iampolicy-jsonparse-csharp/Program.cs
@@ -36,7 +36,7 @@ return await Deployment.RunAsync(() =>
         .Apply(policy =>
         {
             // Empty the policy's Statements list.
-            policy["Statement"] = Output.Create(new List<Dictionary<string, object?>> { });
+            policy["Statement"] = new List<object?>();
             return policy;
         });
 


### PR DESCRIPTION
Removes incorrect Output.Create wrappers Assigns a plain empty list instead of wrapping it in Output.Create, matching the behavior of all other language versions of this example.

Fixes #14511

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
