### PR TITLE
Add OPA instructions to policy pack authoring guide

### DIFF
--- a/content/docs/insights/policy/policy-packs/authoring.md
+++ b/content/docs/insights/policy/policy-packs/authoring.md
@@ -427,8 +427,9 @@ package aws
 # description: Limits the number of S3 buckets per stack.
 stack_deny_too_many_buckets[msg] {
     buckets := [r | r := input.resources[_]; r.type == "aws:s3/bucket:Bucket"]
-    count(buckets) > 3
-    msg := sprintf("Stack has %d S3 buckets, maximum allowed is 3", [count(buckets)])
+    n := count(buckets)
+    n > 3
+    msg := sprintf("Stack has %d S3 buckets, maximum allowed is 3", [n])
 }
 ```
 
@@ -951,7 +952,7 @@ deny_large_instances[msg] {
 }
 ```
 
-Pass configuration values using the standard Pulumi policy configuration. Each rule's `properties` are injected as `data.config.<rule_name>`:
+Pass configuration values using the standard Pulumi policy configuration. The values inside the `"properties"` object are injected as `data.config.<rule_name>`. The `"properties"` wrapper key is required in the configuration JSON:
 
 ```json
 {


### PR DESCRIPTION
Several sections of the policy pack authoring guide only included TypeScript and Python instructions. This PR adds OPA (Rego) tabs and examples to close those gaps, cross-referenced against the [pulumi-policy-opa](https://github.com/pulumi/pulumi-policy-opa) repository for accuracy.

## Changes
- **Running locally**: Expanded from a 3-line stub to a full step-by-step walkthrough with example output
- **Custom configuration**: Added OPA tab showing `data.config` pattern and `config-schema.json` for schema validation
- **Dynamic providers**: Added OPA tab for validating dynamic resources via `input.type`
- **Stack validation**: Added explanation and example of `stack_deny`/`stack_warn` rule prefixes with `input.resources`
- **Stack tags**: Added info note that stack tags are not accessible in OPA policies