### PR TITLE
Rename and refocus "How Pulumi works" page as "Pulumi architecture"

### DIFF
--- a/content/docs/iac/concepts/how-pulumi-works.md
+++ b/content/docs/iac/concepts/how-pulumi-works.md
@@ -1,12 +1,12 @@
 ---
 title_tag: Pulumi Architecture
 meta_desc: "An in-depth look at Pulumi's internal architecture: the language host, deployment engine, and resource providers, and how they interact when you run pulumi up."
-title: Pulumi architecture
-h1: Pulumi architecture
+title: Pulumi Architecture
+h1: Pulumi Architecture
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
-        name: Pulumi architecture
+        name: Pulumi Architecture
         weight: 10
         parent: iac-concepts
     concepts:
@@ -245,7 +245,7 @@ return await Deployment.RunAsync(() =>
         {
             { "owner", "media-team" },
         },
-    }););
+    });
     var contentBucket = new Aws.S3.Bucket("content-bucket");
 });
 ```
@@ -369,7 +369,7 @@ return await Deployment.RunAsync(() =>
         {
             { "owner", "media-team" },
         },
-    }););
+    });
     var appBucket = new Aws.S3.Bucket("app-bucket");
 });
 ```


### PR DESCRIPTION
- Rename page title/nav to "Pulumi architecture" to distinguish from the intro-level "How does Pulumi work?" section in the concepts index
- Replace duplicated intro paragraphs with a notes callout and concise one-sentence overview linking to resource providers docs
- Add links at first mention for resource providers, state, and stacks
- Remove "Declarative and imperative approach" closing section (belongs in the introduction, not an architecture reference)
