### PR TITLE
Add GitHub Actions workflow to automate .NET SDK docs generation

### DIFF
--- a/.github/workflows/pulumi-dotnet-sdk.yml
+++ b/.github/workflows/pulumi-dotnet-sdk.yml
@@ -1,0 +1,102 @@
+permissions: write-all # Equivalent to default permissions + id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
+
+name: dotnet sdk docs build
+on:
+  repository_dispatch:
+    types:
+      - pulumi-dotnet-sdk
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    needs: build-dotnet-sdk-docs
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: checkout docs repo
+        uses: actions/checkout@v6
+      - name: set the pulumi-dotnet version
+        run: |
+          echo "DOTNET_SDK_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+      - name: pull-request
+        id: create-pr
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "pulumi-dotnet/${{ github.run_id }}-${{ github.run_number }}"
+          destination_branch: "master"
+          pr_title: "Regen .NET SDK docs pulumi-dotnet@${{ env.DOTNET_SDK_VERSION }}"
+          pr_body: "Automated PR"
+          pr_label: "automation/dotnet-sdk-docs,automation/merge"
+          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pr_created == 'true'
+        run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+  build-dotnet-sdk-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: set the pulumi-dotnet version
+        run: |
+          echo "DOTNET_SDK_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+      - name: checkout docs repo
+        uses: actions/checkout@v6
+        with:
+          path: docs
+      - name: checkout pulumi-dotnet repo
+        uses: actions/checkout@v6
+        with:
+          repository: pulumi/pulumi-dotnet
+          path: pulumi-dotnet
+          ref: ${{ github.event.client_payload.ref }}
+      - name: Install dotnet
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.x"
+      - name: Install docfx
+        run: dotnet tool install -g docfx
+      - run: make ensure
+        working-directory: docs
+      - name: Generate .NET SDK docs
+        run: ./scripts/run_docfx.sh
+        working-directory: docs
+      - name: git status
+        run: git status && git diff
+        working-directory: docs
+      - name: commit changes
+        run: |
+          git config --local user.email "bot@pulumi.com"
+          git config --local user.name "pulumi-bot"
+          git checkout -b pulumi-dotnet/${{ github.run_id }}-${{ github.run_number }}
+          git add static-prebuilt/
+          git commit -m "Regenerating .NET SDK docs for pulumi-dotnet@${{ env.DOTNET_SDK_VERSION }}"
+          git push origin pulumi-dotnet/${{ github.run_id }}-${{ github.run_number }}
+        working-directory: docs
+  notify:
+    if: failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [pull-request, build-dotnet-sdk-docs]
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: Slack Notification
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "dotnet sdk docs build failure in pulumi/docs repo :meow_sad:"
+          SLACK_USERNAME: docsbot
+          SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png


### PR DESCRIPTION
Adds pulumi-dotnet-sdk.yml, triggered by repository_dispatch from pulumi/pulumi-dotnet on release, to regenerate docfx-built API reference docs and open an auto-merge PR.

Fixes #8800.
