### PR TITLE
feat: automate Java SDK docs generation

### DIFF
--- a/.github/workflows/pulumi-java-sdk.yml
+++ b/.github/workflows/pulumi-java-sdk.yml
@@ -1,0 +1,121 @@
+permissions: write-all # Equivalent to default permissions + id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
+
+name: java sdk docs build
+on:
+  repository_dispatch:
+    types:
+      - pulumi-java-sdk
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    needs: build-java-sdk-docs
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: checkout docs repo
+        uses: actions/checkout@v6
+      - name: set the java sdk version
+        run: |
+          echo "JAVA_SDK_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+      - name: pull-request
+        id: create-pr
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "pulumi-java/${{ github.run_id }}-${{ github.run_number }}"
+          destination_branch: "master"
+          pr_title: "Regen Java SDK docs pulumi-java@${{ env.JAVA_SDK_VERSION }}"
+          pr_body: "Automated PR"
+          pr_label: "automation/java-sdk-docs,automation/merge"
+          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pr_created == 'true'
+        run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+  build-java-sdk-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: set the java sdk version
+        run: |
+          echo "JAVA_SDK_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+      - name: checkout docs repo
+        uses: actions/checkout@v6
+        with:
+          path: docs
+      - name: checkout pulumi-java repo
+        uses: actions/checkout@v6
+        with:
+          repository: pulumi/pulumi-java
+          path: pulumi-java
+          ref: ${{ github.event.client_payload.ref }}
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.157.0'
+          extended: true
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{matrix.nodeversion}}
+          cache: 'yarn'
+          cache-dependency-path: |
+            docs/yarn.lock
+            docs/infrastructure/yarn.lock
+            docs/theme/yarn.lock
+            docs/theme/stencil/yarn.lock
+      - run: make ensure
+        working-directory: docs
+      - name: Generate Java SDK docs
+        run: ./scripts/gen_javadoc.sh
+        working-directory: docs
+        env:
+          JAVA_REPO: ${{ github.workspace }}/pulumi-java
+      - name: git status
+        run: git status && git diff
+        working-directory: docs
+      - name: commit changes
+        run: |
+          git config --local user.email "bot@pulumi.com"
+          git config --local user.name "pulumi-bot"
+          git checkout -b pulumi-java/${{ github.run_id }}-${{ github.run_number }}
+          git add static-prebuilt/
+          git commit -m "Regenerating Java SDK docs for pulumi-java@${{ env.JAVA_SDK_VERSION }}"
+          git push origin pulumi-java/${{ github.run_id }}-${{ github.run_number }}
+        working-directory: docs
+    strategy:
+      matrix:
+        nodeversion:
+          - "24.x"
+  notify:
+    if: failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [pull-request, build-java-sdk-docs]
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: Slack Notification
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "java sdk docs build failure in pulumi/docs repo :meow_sad:"
+          SLACK_USERNAME: docsbot
+          SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/scripts/gen_javadoc.sh
+++ b/scripts/gen_javadoc.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-REPO=~/pulumi-java
+REPO="${JAVA_REPO:-$HOME/pulumi-java}"
 SRC=$REPO/sdk/java/pulumi/build/docs/javadoc
 DEST=./static-prebuilt/docs/reference/pkg/java
 


### PR DESCRIPTION
Adds GitHub Actions workflow triggered on pulumi-java releases and updates gen_javadoc.sh to use JAVA_REPO env var.

Closes #16581.
