### PR TITLE
Add JetBrains Junie to Agent Skills page

### DIFF
--- a/content/docs/ai/skills/index.md
+++ b/content/docs/ai/skills/index.md
@@ -79,7 +79,11 @@ npx skills add pulumi/agent-skills/migration --skill '*'     # 4 migration skill
 npx skills add pulumi/agent-skills/authoring --skill '*'     # 4 authoring skills
 ```
 
-This works with Claude Code, Cursor, Copilot, Codex, Junie, and other agent tools.
+This works with Claude Code, Cursor, Copilot, Codex, Junie, and other agent tools. To install for a specific agent, use the `--agent` flag:
+
+```bash
+npx skills add pulumi/agent-skills --skill '*' --agent junie
+```
 
 ## Usage Examples
 


### PR DESCRIPTION
Adds JetBrains Junie to the Agent Skills page as a supported agent tool.

## Changes
- Added Junie to the supported agents bullet list with link to docs
- Updated meta description to include Junie
- Added Junie to the universal installation prose