### PR TITLE
Add S3 bucket for social media post state tracking

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -183,6 +183,24 @@ const uploadsBucketAcl = new aws.s3.BucketAcl("uploads-bucket-acl", {
     dependsOn: [uploadsBucketPublicAccessBlock, uploadsBucketOwnershipControls],
 });
 
+// Bucket for tracking social media post state (idempotency).
+const socialStateBucket = new aws.s3.Bucket("social-post-state", {
+    bucket: "pulumi-social-post-state",
+});
+
+new aws.s3.BucketVersioningV2("social-post-state-versioning", {
+    bucket: socialStateBucket.id,
+    versioningConfiguration: { status: "Enabled" },
+});
+
+new aws.s3.BucketPublicAccessBlock("social-post-state-public-access-block", {
+    bucket: socialStateBucket.id,
+    blockPublicAcls: true,
+    blockPublicPolicy: true,
+    ignorePublicAcls: true,
+    restrictPublicBuckets: true,
+});
+
 const bundlesBucket = new aws.s3.Bucket("bundles-bucket", {
     forceDestroy: true,
 });


### PR DESCRIPTION
Adds a versioned, private S3 bucket (`pulumi-social-post-state`) to the docs infrastructure. Used by the social media scheduling script (#17890) to track which posts have been published, preventing duplicate posts across deploys.

Small, standalone change that can merge ahead of the main scheduling PR so the bucket exists before the script runs.