### PR TITLE
fix: preserve IDP homepage image aspect ratio

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -196,7 +196,7 @@
                     </div>
                 </div>
                 <div class="flex items-center justify-center mb-8 lg:mb-0 w-full lg:w-1/2 order-1 lg:order-2">
-                    {{ partial "fingerprinted-img.html" (dict "src" .Params.idp.image "alt" .Params.idp.alt "class" "h-96" "width" "1728" "height" "1572") }}
+                    {{ partial "fingerprinted-img.html" (dict "src" .Params.idp.image "alt" .Params.idp.alt "class" "h-96 w-auto" "width" "1728" "height" "1572") }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- PR #18097 added `width` and `height` attributes to homepage images for CLS reduction
- The IDP image has a `h-96` class that constrains height to 384px, but without `w-auto` the browser stretches the width to fill the container, distorting the aspect ratio
- Adds `w-auto` so the width scales proportionally with the fixed height

🤖 Generated with [Claude Code](https://claude.com/claude-code)