### PR TITLE
feat: add Dynamic Keyword Insertion to gads pages

### DIFF
--- a/layouts/gads/gads-template.html
+++ b/layouts/gads/gads-template.html
@@ -315,11 +315,11 @@
         'gcp':'GCP','gke':'GKE'
       };
 
-      var words = formattedKeyword.split(/\s+/).map(function(word, i){
+      var words = formattedKeyword.split(/\s+/).map(function(word){
         var lower = word.toLowerCase();
         if (acronyms[lower]) return acronyms[lower];
-        if (i === 0 && word === lower && word.length) {
-          return word.charAt(0).toUpperCase() + word.slice(1);
+        if (word.length) {
+          return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
         }
         return word;
       });


### PR DESCRIPTION
## Summary

- Moves the Dynamic Keyword Insertion (DKI) logic from Google Tag Manager into the codebase directly
- Replaces the placeholder GTM integration script in `gads-template.html` with the actual DKI script
- The script reads the `utm_term` URL parameter (passed by Google Ads via `{keyword}` ValueTrack), formats it with proper acronym casing (AWS, CDK, IaC, etc.) and title-casing, then injects it into the `#dki-placeholder` span on each gads landing page
- When no `utm_term` is present, the default text from the page frontmatter remains unchanged (e.g., "a Terraform alternative")

## How it works

1. Google Ads sets up final URLs with `?utm_term={keyword}` so the matched keyword lands in the URL
2. On page load, the script reads `utm_term` from the query string
3. Formats the keyword: replaces dashes/underscores with spaces, maps known acronyms (AWS, CDK, GCP, etc.), title-cases the first word
4. Injects the formatted text into `#dki-placeholder` (present in 29 gads content pages)
5. If no `utm_term` or no placeholder element exists, the script exits silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)