### PR TITLE
Fix viewport meta tag to allow zooming for accessibility

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
 
     <!-- GrowthBook / Segment keys -->
     <script>


### PR DESCRIPTION
## Summary

- Changes `maximum-scale` from `1.0` to `5.0` in the site-wide viewport meta tag (`layouts/partials/head.html`)
- Resolves an accessibility issue flagged by Google PageSpeed Insights: `[user-scalable="no"] is used in the <meta name="viewport"> element or the [maximum-scale] attribute is less than 5`
- `maximum-scale=1.0` effectively disables pinch-to-zoom, which is a WCAG 2.1 Level AA failure (Success Criterion 1.4.4 — Resize Text) and prevents users with low vision from using screen magnification

## Test plan

- [ ] Verify the site renders correctly on mobile devices
- [ ] Confirm pinch-to-zoom works as expected
- [ ] Re-run Google PageSpeed Insights to confirm the issue is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)