### PR TITLE
Fix inaccessible carousel links flagged by PageSpeed Insights

### DIFF
--- a/layouts/partials/stacked-carousel.html
+++ b/layouts/partials/stacked-carousel.html
@@ -26,7 +26,7 @@ optional flags:
         <div class="carousel-left-primary">
             {{ range .logos }}
                 {{ if .link }}
-                    <a href="{{ .link }}">
+                    <a href="{{ .link }}" aria-label="{{ .name | humanize | title }} case study">
                         <div class="w-24 h-12 m-4">{{ partial "customer-logo.html" (dict "logo" .name "hoverable" true) }}</div>
                     </a>
                 {{ else }}
@@ -34,10 +34,10 @@ optional flags:
                 {{ end }}
             {{ end }}
         </div>
-        <div class="carousel-left-primary carousel-left-secondary">
+        <div class="carousel-left-primary carousel-left-secondary" aria-hidden="true">
             {{ range .logos }}
                 {{ if .link }}
-                    <a href="{{ .link }}">
+                    <a href="{{ .link }}" tabindex="-1">
                         <div class="w-24 h-12 m-4">{{ partial "customer-logo.html" (dict "logo" .name "hoverable" true) }}</div>
                     </a>
                 {{ else }}
@@ -50,7 +50,7 @@ optional flags:
         <div class="carousel-left-primary-mobile">
             {{ range .logos }}
                 {{ if .link }}
-                    <a href="{{ .link }}">
+                    <a href="{{ .link }}" aria-label="{{ .name | humanize | title }} case study">
                         <div class="w-24 h-12 m-4">{{ partial "customer-logo.html" (dict "logo" .name "hoverable" true) }}</div>
                     </a>
                 {{ else }}
@@ -58,10 +58,10 @@ optional flags:
                 {{ end }}
             {{ end }}
         </div>
-        <div class="carousel-left-primary-mobile carousel-left-secondary-mobile">
+        <div class="carousel-left-primary-mobile carousel-left-secondary-mobile" aria-hidden="true">
             {{ range .logos }}
                 {{ if .link }}
-                    <a href="{{ .link }}">
+                    <a href="{{ .link }}" tabindex="-1">
                         <div class="w-24 h-12 m-4">{{ partial "customer-logo.html" (dict "logo" .name "hoverable" true) }}</div>
                     </a>
                 {{ else }}


### PR DESCRIPTION
## Summary

- Adds `aria-label` attributes to case study logo links in the stacked carousel so screen readers announce the customer name (e.g., "Snowflake case study") instead of an empty "link"
- Marks duplicate/secondary carousel divs (used for infinite scroll animation) with `aria-hidden="true"` and `tabindex="-1"` to prevent assistive technology from traversing redundant copies

## Context

Google PageSpeed Insights flagged ~39 `<a href="/case-studies/">` elements inside `.carousel-left-primary-mobile` as having no discernible link text. These links wrap SVG customer logos with no text content or alt text, making them invisible to screen readers.

## Test plan

- [ ] Verify the homepage carousel renders correctly on desktop and mobile
- [ ] Run a screen reader (e.g., VoiceOver) and confirm logo links now announce customer names
- [ ] Re-run PageSpeed Insights / Lighthouse and confirm the "Links do not have discernible names" audit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)