### PR TITLE
Switch verbiage to requesting a PoC for self-host trials.

### DIFF
--- a/content/docs/administration/onboarding-guide/choose-subscription.md
+++ b/content/docs/administration/onboarding-guide/choose-subscription.md
@@ -63,12 +63,6 @@ Self-hosted Pulumi Cloud is only available for Business Critical customers.
 
 Choose [self-hosted Pulumi Cloud](https://www.pulumi.com/product/self-hosted/) if you need complete control over your hosting environment. This is ideal for air-gapped environments or customers who require an isolated version of the Pulumi platform. You can deploy anywhere: on-premises, in your cloud account, or any infrastructure you control.
 
-{{% notes type="info" %}}
-
-To get started with self-hosted Pulumi Cloud, follow the guides to set up your [state backend](https://www.pulumi.com/docs/iac/concepts/state-and-backends/#logging-into-the-aws-s3-backend) and [self-hosting infrastructure](https://www.pulumi.com/docs/administration/self-hosting/)
-
-{{% /notes %}}
-
 ## Choose your billing approach
 
 Pulumi offers flexible billing options to match your organization's procurement preferences.

--- a/content/docs/administration/self-hosting/_index.md
+++ b/content/docs/administration/self-hosting/_index.md
@@ -26,7 +26,7 @@ sections:
 - type: flat
   heading: Overview
   description_md: |
-    Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+    Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 
     The self-hosted version provides all the same capabilities as the SaaS offering at [app.pulumi.com](https://app.pulumi.com). You manage data backups, keep the service running, and maintain updates, while gaining full control over the deployment environment.
 

--- a/content/docs/administration/self-hosting/airgapped.md
+++ b/content/docs/administration/self-hosting/airgapped.md
@@ -16,7 +16,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 For organizations operating in highly regulated industries or environments with strict security requirements, deploying cloud infrastructure in an air-gapped environment is often a requirement. Such environments do not have network connectivity with the outside world, which many of Pulumi's default workflows assume.

--- a/content/docs/administration/self-hosting/changelog.md
+++ b/content/docs/administration/self-hosting/changelog.md
@@ -17,7 +17,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 ## 2025

--- a/content/docs/administration/self-hosting/components/_index.md
+++ b/content/docs/administration/self-hosting/components/_index.md
@@ -18,7 +18,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 | Component                                                         | Repository                                                                                 |

--- a/content/docs/administration/self-hosting/components/api.md
+++ b/content/docs/administration/self-hosting/components/api.md
@@ -17,7 +17,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the Self-Hosted Pulumi Cloud, sign up for the [30 day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the Self-Hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends](/docs/concepts/state/).
 {{% /notes %}}

--- a/content/docs/administration/self-hosting/components/console.md
+++ b/content/docs/administration/self-hosting/components/console.md
@@ -17,7 +17,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the Self-Hosted Pulumi Cloud, sign up for the [30 day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the Self-Hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends](/docs/concepts/state/).
 {{% /notes %}}

--- a/content/docs/administration/self-hosting/components/deployments.md
+++ b/content/docs/administration/self-hosting/components/deployments.md
@@ -17,7 +17,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the Self-Hosted Pulumi Cloud, sign up for the [30 day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the Self-Hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends](/docs/concepts/state/).
 {{% /notes %}}

--- a/content/docs/administration/self-hosting/components/search.md
+++ b/content/docs/administration/self-hosting/components/search.md
@@ -17,7 +17,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the Self-Hosted Pulumi Cloud, sign up for the [30 day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the Self-Hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends](/docs/concepts/state/).
 {{% /notes %}}

--- a/content/docs/administration/self-hosting/network.md
+++ b/content/docs/administration/self-hosting/network.md
@@ -19,7 +19,7 @@ aliases:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 Self-hosted Pulumi Cloud comprises [three containers](/docs/administration/self-hosting/components): the API, Console, and Migrations. These containers require several kinds of incoming and outgoing network access as well as access to various services depending on where you're deploying it to.

--- a/content/docs/administration/self-hosting/operations/_index.md
+++ b/content/docs/administration/self-hosting/operations/_index.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 This guide provides best practices for deploying and operating Pulumi Cloud in a self-hosted configuration with high availability (HA) and disaster recovery (DR). These recommendations are derived from how Pulumi operates its own managed service and adapted for self-hosted deployments.

--- a/content/docs/administration/self-hosting/operations/architecture.md
+++ b/content/docs/administration/self-hosting/operations/architecture.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 This page describes the high-level architecture of a self-hosted Pulumi Cloud deployment. For detailed configuration of individual components, see [Components](/docs/administration/self-hosting/components/).

--- a/content/docs/administration/self-hosting/operations/backup-recovery.md
+++ b/content/docs/administration/self-hosting/operations/backup-recovery.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 A reliable backup and recovery strategy is essential for self-hosted Pulumi Cloud. This page covers database backups, object storage protection, and recovery procedures.

--- a/content/docs/administration/self-hosting/operations/compute-sizing.md
+++ b/content/docs/administration/self-hosting/operations/compute-sizing.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 The API service and console are stateless containers. This page documents recommended container resource allocations and minimum infrastructure requirements.

--- a/content/docs/administration/self-hosting/operations/database.md
+++ b/content/docs/administration/self-hosting/operations/database.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 Pulumi Cloud uses MySQL 8.0 for metadata, stack state references, and user/organization data. This page covers best practices for database configuration in production self-hosted deployments.

--- a/content/docs/administration/self-hosting/operations/monitoring.md
+++ b/content/docs/administration/self-hosting/operations/monitoring.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 Effective monitoring is critical for maintaining a reliable self-hosted Pulumi Cloud deployment. This page covers a recommended alerting strategy and the key metrics to watch.

--- a/content/docs/administration/self-hosting/operations/networking.md
+++ b/content/docs/administration/self-hosting/operations/networking.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 This page covers network architecture, multi-AZ deployment, auto-scaling, load balancing, and DNS configuration for production self-hosted deployments.

--- a/content/docs/administration/self-hosting/operations/object-storage.md
+++ b/content/docs/administration/self-hosting/operations/object-storage.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 Pulumi Cloud uses object storage for checkpoint (state) files, policy packs, and other data. This page covers the storage architecture and best practices for production deployments.

--- a/content/docs/administration/self-hosting/operations/security-hardening.md
+++ b/content/docs/administration/self-hosting/operations/security-hardening.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 This page covers security hardening recommendations for production self-hosted Pulumi Cloud deployments. For authentication configuration, see [SAML SSO](/docs/administration/self-hosting/saml-sso/).

--- a/content/docs/administration/self-hosting/operations/upgrades.md
+++ b/content/docs/administration/self-hosting/operations/upgrades.md
@@ -13,7 +13,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 This page covers how to safely update your self-hosted Pulumi Cloud deployment. For version-specific changes, see the [Changelog](/docs/administration/self-hosting/changelog/).

--- a/content/docs/esc/administration/self-hosting.md
+++ b/content/docs/esc/administration/self-hosting.md
@@ -16,7 +16,7 @@ menu:
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud with ESC, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
+Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud with ESC, [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
 Pulumi ESC is available in a self-hosted model, providing the same secrets and configuration management capabilities as the managed Pulumi Cloud. ESC helps teams securely manage infrastructure configurations, enforce best practices, and simplify access controls. All ESC features including hierarchical environments, fine-grained access controls, and integrations with identity providers are fully available in the self-hosted deployment.

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -691,7 +691,7 @@ faq:
         - question: Is Pulumi SOC 2 compliant?
           answer: Yes, Pulumi has completed the SOC 2 Type 2 compliance process. Pulumi is committed to operational excellence for our customers.
         - question: Can I host Pulumi Cloud in my cloud or datacenter?
-          answer: Yes, we offer a self-hosted Pulumi Cloud for companies that have specific data control requirements and want to maintain complete control over hosting Pulumi Cloud. This option is available in Business Critical Edition. You can get started with a [30-day free trial here](/product/self-hosted/#self-hosted-trial).
+          answer: Yes, we offer a self-hosted Pulumi Cloud for companies that have specific data control requirements and want to maintain complete control over hosting Pulumi Cloud. This option is available in Business Critical Edition. You can [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) to get started.
         - question: How do I convince my boss?
           answer: |
             Do you want to use Pulumi in your organization, but aren't sure how to bring it up with your boss? We've created a sample email to help you explain its benefits. Feel free to use the full letter or pieces of it. We are always happy to meet to learn more about your needs and explain these benefits in person — just [contact us](/contact/?form=sales).


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- Switch to requesting a PoC for self-host trials. Brings site in line with https://github.com/pulumi/docs/pull/17941
- Remove tech docs tip/link from onboarding guide. The switching state link no longer exists and the deep dive into self-hosting link infers  one can go straight to installing self-host.