### PR TITLE
Fix duplicate menu entry for Serverless Framework

### DIFF
--- a/content/docs/iac/guides/migration/migrating-to-pulumi/from-serverless.md
+++ b/content/docs/iac/guides/migration/migrating-to-pulumi/from-serverless.md
@@ -6,6 +6,7 @@ h1: "Migrating from Serverless Framework to Pulumi"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
+        identifier: iac-migration-serverless
         name: Serverless Framework
         parent: iac-guides-migration-from
         weight: 6


### PR DESCRIPTION
## Summary

- Add explicit `identifier` to the migration page's Serverless Framework menu entry to disambiguate it from the comparison page, which shares the same name in the `iac` menu.
- Eliminates the Hugo warning: `duplicate menu entry with identifier "Serverless Framework" in menu "iac"`.

## Test plan

- [ ] Verify `make build` produces no duplicate menu entry warning
- [ ] Verify both Serverless Framework pages appear correctly in the left nav