### PR TITLE
Fix auto-approve not triggering for labeled PRs

### DIFF
--- a/.github/workflows/auto-approve-for-auto-merge.yml
+++ b/.github/workflows/auto-approve-for-auto-merge.yml
@@ -1,6 +1,8 @@
 name: Auto approve
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   auto-approve:


### PR DESCRIPTION
## Summary

- Add `labeled` to the `pull_request` event types for the auto-approve workflow
- Without it, when `pulumi-bot` creates a PR and adds `automation/merge` in a separate API call, the label isn't in the `opened` event's webhook payload and the job's `if` condition evaluates to false — the job is skipped and no second run is triggered

## Test plan

- [ ] Verify the next `pulumi-bot` PR with `automation/merge` gets auto-approved