### PR TITLE
Fix missing Get Started CTA in header nav

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -524,7 +524,7 @@
                 </ul>
 
                 <div class="cta-container my-2">
-                    <header-cta button-class="header-btn-primary flex"></header-cta>
+                    <a class="header-btn-primary flex" data-track="header-signup" data-role="cta-get-started" href="{{ site.Params.cta.primary.href }}?utm_source=header-button" title="{{ site.Params.cta.primary.label }}">{{ site.Params.cta.primary.label }}</a>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
## Summary

- The `<header-cta>` Stencil web component was deleted in #18096 (Supersonic Page Speed cleanup), but its usage in `layouts/partials/header.html` was not replaced — leaving an unregistered custom element that renders nothing.
- Replaced with a plain `<a>` tag that pulls label/href from `site.Params.cta.primary`.

## Context

The deleted component (`theme/stencil/src/components/header-cta/header-cta.tsx`) checked the `pulumi_web_user_info` cookie and rendered either a "Dashboard" link (logged-in) or a "Sign Up" CTA (logged-out). The `button-class` prop was passed through as the CSS class on the `<a>` tag for gradient button styling.

The replacement is a static link that always shows "Get Started". The logged-in/logged-out toggle logic was already effectively dead — the `user-toggle` component has it commented out, citing pulumi/pulumi-hugo#3089. The CTA experiment script (`cta-activations-direct-vs-docs.ts`) still works since it targets `data-role="cta-get-started"`, which the replacement preserves.

## Test plan

- [ ] Verify the "Get Started" CTA button appears in the desktop header nav
- [ ] Verify the button links to `https://app.pulumi.com/signup?utm_source=header-button`
- [ ] Verify the gradient button styling renders correctly
- [ ] Verify the CTA experiment (`?cta-activations-direct-vs-docs=1`) still swaps the button to point to `/docs/get-started/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)