### PR TITLE
Add features tag to product announcement blog posts (last 3 months)

### DIFF
--- a/content/blog/esc-terraform-state-provider/index.md
+++ b/content/blog/esc-terraform-state-provider/index.md
@@ -6,7 +6,7 @@ meta_desc: "The terraform-state provider for Pulumi ESC lets you read outputs fr
 meta_image: meta.png
 feature_image: feature.png
 authors: ["claire-gaestel"]
-tags: ["esc", "terraform"]
+tags: ["esc", "terraform", "features"]
 ---
 
 Many organizations have years of infrastructure built and managed with Terraform.

--- a/content/blog/journaling/index.md
+++ b/content/blog/journaling/index.md
@@ -16,6 +16,7 @@ tags:
     - journaling
     - performance
     - data-integrity
+    - features
 
 social:
     twitter: |

--- a/content/blog/neo-migration/index.md
+++ b/content/blog/neo-migration/index.md
@@ -22,6 +22,7 @@ tags:
     - arm
     - migration
     - ai
+    - features
 
 schema_type: auto
 

--- a/content/blog/new-esc-editor/index.md
+++ b/content/blog/new-esc-editor/index.md
@@ -10,6 +10,7 @@ authors:
     - pablo-terradillos
 tags:
     - esc
+    - features
 schema_type: auto
 social:
     twitter:


### PR DESCRIPTION
4 posts were missing the features tag despite announcing new Pulumi
capabilities: the ESC terraform-state provider, journaling performance
feature, Neo migration capabilities, and the new ESC editor.