### PR TITLE
Fix CloudFront cache lifetimes for PageSpeed optimization

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -429,7 +429,8 @@ const logsBucketPolicy = new aws.s3.BucketPolicy("logs-bucket-policy", {
 const fiveMinutes = 60 * 5;
 const thirtyMinutes = fiveMinutes * 6;
 const oneHour = fiveMinutes * 12;
-const oneWeek = oneHour * 24 * 7;
+const oneDay = oneHour * 24;
+const oneWeek = oneDay * 7;
 const oneYear = oneWeek * 52;
 
 // AllViewerExceptHostHeader passes all cookies, querystrings, and headers except the Host header.
@@ -484,9 +485,19 @@ const baseSecurityHeadersConfig = {
     }
 };
 
-// Most of the site
+// Most of the site — includes a short browser cache with revalidation so
+// browsers don't refetch every navigation.  The 10-minute max-age keeps
+// content reasonably fresh while eliminating the "no cache lifetime" flag
+// from PageSpeed Insights.
 const SecurityHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy('security-headers', {
     securityHeadersConfig: baseSecurityHeadersConfig,
+    customHeadersConfig: {
+        items: [{
+            header: "Cache-Control",
+            value: "public, max-age=600, stale-while-revalidate=86400",
+            override: false,
+        }],
+    },
 });
 
 // Copilot lives in an iframe
@@ -738,6 +749,13 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         },
         {
             ...baseCacheBehavior,
+            pathPattern: "/css/marketing-homepage.*.css",
+            defaultTtl: oneYear,
+            maxTtl: oneYear,
+            responseHeadersPolicyId: ImmutableCachePolicy.id,
+        },
+        {
+            ...baseCacheBehavior,
             pathPattern: "/js/bundle.*.js",
             defaultTtl: oneYear,
             maxTtl: oneYear,
@@ -760,14 +778,14 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         {
             ...baseCacheBehavior,
             pathPattern: "/icons/*",
-            defaultTtl: oneHour,
-            maxTtl: oneHour,
+            defaultTtl: oneDay,
+            maxTtl: oneDay,
         },
         {
             ...baseCacheBehavior,
             pathPattern: "/logos/*",
-            defaultTtl: oneHour,
-            maxTtl: oneHour,
+            defaultTtl: oneDay,
+            maxTtl: oneDay,
         },
         {
             ...baseCacheBehavior,
@@ -775,6 +793,16 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             defaultTtl: oneYear,
             maxTtl: oneYear,
             responseHeadersPolicyId: ImmutableCachePolicy.id,
+        },
+
+        // consent-manager.js is not fingerprinted but changes infrequently.
+        // Cache at the edge for 1 day; browsers will get the default Cache-Control
+        // from SecurityHeadersPolicy (10 min + stale-while-revalidate).
+        {
+            ...baseCacheBehavior,
+            pathPattern: "/js/consent-manager.js",
+            defaultTtl: oneDay,
+            maxTtl: oneDay,
         },
 
         // Web-component loaders must not be cached, because the names of the files they


### PR DESCRIPTION
## Summary

- Adds a default browser `Cache-Control: public, max-age=600, stale-while-revalidate=86400` header to the `SecurityHeadersPolicy`, so browsers cache all responses for 10 minutes (with 24-hour stale-while-revalidate). Previously no `Cache-Control` header was sent, causing PageSpeed to flag ~177 KiB of first-party assets as having no cache lifetime.
- Adds an immutable cache behavior for `/css/marketing-homepage.*.css` — this file has a content hash in the filename but was missing a matching `orderedCacheBehavior`, falling through to the 30-minute default (~53 KiB savings).
- Increases `/icons/*` and `/logos/*` edge TTLs from 1 hour to 1 day (~20 KiB savings across multiple SVGs).
- Adds an explicit 1-day edge cache for `/js/consent-manager.js` (~53 KiB savings).

Total estimated savings: **~286 KiB** (matching the PageSpeed Insights estimate).

Third-party assets (HubSpot, LinkedIn, Twitter, GitHub buttons, Common Room, evs.analytics) are controlled by those services and cannot be addressed here.

## Test plan

- [ ] Verify `tsc --noEmit` passes in `infrastructure/` (confirmed locally)
- [ ] Deploy to a dev stack and verify `Cache-Control` headers appear on responses using `curl -I`
- [ ] Confirm fingerprinted CSS assets (`/css/marketing-homepage.*.css`) return `Cache-Control: public, max-age=31536000, immutable`
- [ ] Confirm `/icons/*` and `/logos/*` assets have updated TTLs
- [ ] Re-run PageSpeed Insights on the dev deployment to confirm the "Serve static assets with an efficient cache policy" warning is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)