### PR TITLE
Debounce scroll handlers to reduce forced reflows

### DIFF
--- a/theme/src/ts/docs-main.ts
+++ b/theme/src/ts/docs-main.ts
@@ -59,8 +59,18 @@ function handleResize() {
     setMainNavHeight();
 }
 
+let scrollRafPending = false;
+function onScroll() {
+    if (scrollRafPending) return;
+    scrollRafPending = true;
+    requestAnimationFrame(() => {
+        scrollRafPending = false;
+        setDocsMainNavPosition();
+    });
+}
+
 window.addEventListener("resize", handleResize);
-window.addEventListener("scroll", setDocsMainNavPosition);
+window.addEventListener("scroll", onScroll, { passive: true });
 window.addEventListener("load", handleResize);
 handleResize();
 

--- a/theme/src/ts/misc.ts
+++ b/theme/src/ts/misc.ts
@@ -138,6 +138,7 @@ export function generateOnThisPage() {
     if (found) {
         tocs.forEach(toc => toc.style.display = "");
 
+        let tocRafPending = false;
         const setActiveItem = () => {
             let active = null;
             for (const heading of headingItems) {
@@ -147,8 +148,16 @@ export function generateOnThisPage() {
                 heading.listItems.forEach(li => li.classList.toggle("active", heading === active));
             }
         };
+        const onScrollToc = () => {
+            if (tocRafPending) return;
+            tocRafPending = true;
+            requestAnimationFrame(() => {
+                tocRafPending = false;
+                setActiveItem();
+            });
+        };
 
-        window.addEventListener("scroll", setActiveItem);
+        window.addEventListener("scroll", onScrollToc, { passive: true });
         setActiveItem();
     }
 }


### PR DESCRIPTION
## Summary

- Wraps two scroll event handlers in `requestAnimationFrame` to batch layout reads and prevent forced reflows flagged by PageSpeed Insights (~254ms total reflow time)
- **`docs-main.ts`**: `setDocsMainNavPosition` reads `getBoundingClientRect()` and `offsetHeight` — now debounced to once per animation frame
- **`misc.ts`**: `setActiveItem` (table of contents highlight) reads `offsetTop` on all headings — now debounced to once per animation frame
- Both scroll listeners are now marked `{ passive: true }` to allow the browser to optimize scroll performance

The remaining forced reflow sources (HubSpot analytics ~2ms, `[unattributed]` ~6ms) are from third-party scripts and browser internals that cannot be addressed here.

## Test plan

- [ ] Verify docs left nav still follows scroll position correctly on docs pages
- [ ] Verify table of contents "active" highlighting still tracks the current section on scroll
- [ ] Verify no visual regressions on the homepage or docs pages
- [ ] Re-run PageSpeed Insights to confirm reduced forced reflow time

🤖 Generated with [Claude Code](https://claude.com/claude-code)