### PR TITLE
Defer GrowthBook SDK init to break critical request chain

### DIFF
--- a/theme/stencil/src/util/util.ts
+++ b/theme/stencil/src/util/util.ts
@@ -1,41 +1,56 @@
 import * as uuid from "uuid";
 import { GrowthBook } from "@growthbook/growthbook";
 
-// Initialize GrowthBook
-export const gb = new GrowthBook({
-    apiHost: "https://cdn.growthbook.io",
-    clientKey: (window as any).growthbook_sdk_key,
-    decryptionKey: (window as any).growthbook_decrypt_key,
-    enableDevMode: (window as any).growthbook_dev_mode,
-});
+// Defer GrowthBook initialization until after page load to avoid a critical
+// request chain (HTML → JS → cdn.growthbook.io fetch) that blocks LCP.
+// GrowthBook is used for experiment tracking, not rendering, so deferring
+// it has no visual impact.
+let gb: GrowthBook | null = null;
 
-gb.init({ streaming: true });
+function initGrowthBook() {
+    if (gb) return;
 
-// Hook up GrowthBook to analytics when ready
-(window as any).analytics.ready(function() {
-    gb.setTrackingCallback((experiment, result) => {
-        (window as any).analytics.track("Experiment Viewed", {
-            experimentId: experiment.key,
-            variationId: result.key,
-        });
+    gb = new GrowthBook({
+        apiHost: "https://cdn.growthbook.io",
+        clientKey: (window as any).growthbook_sdk_key,
+        decryptionKey: (window as any).growthbook_decrypt_key,
+        enableDevMode: (window as any).growthbook_dev_mode,
     });
 
-    gb.setAttributes({
-    // Set Anon/UserId for GB
-    ...gb.getAttributes(),
-        id: (window as any).analytics.user().anonymousId(),
-        userId: (window as any).analytics.user().id(),
-        url: (window as any).location.href,
-        path: (window as any).location.pathname,
-        query: (window as any).location.search,
-        referrer: document.referrer,
-        utmCampaign: getQueryVariable("utm_campaign"),
-        utmSource: getQueryVariable("utm_source"),
-        utmMedium: getQueryVariable("utm_medium"),
-        utmTerm: getQueryVariable("utm_term"),
-        utmContent: getQueryVariable("utm_content"),
-    })
-})
+    gb.init({ streaming: true });
+
+    // Hook up GrowthBook to analytics when ready
+    (window as any).analytics.ready(function () {
+        gb.setTrackingCallback((experiment, result) => {
+            (window as any).analytics.track("Experiment Viewed", {
+                experimentId: experiment.key,
+                variationId: result.key,
+            });
+        });
+
+        gb.setAttributes({
+            // Set Anon/UserId for GB
+            ...gb.getAttributes(),
+            id: (window as any).analytics.user().anonymousId(),
+            userId: (window as any).analytics.user().id(),
+            url: (window as any).location.href,
+            path: (window as any).location.pathname,
+            query: (window as any).location.search,
+            referrer: document.referrer,
+            utmCampaign: getQueryVariable("utm_campaign"),
+            utmSource: getQueryVariable("utm_source"),
+            utmMedium: getQueryVariable("utm_medium"),
+            utmTerm: getQueryVariable("utm_term"),
+            utmContent: getQueryVariable("utm_content"),
+        });
+    });
+}
+
+if (document.readyState === "complete") {
+    initGrowthBook();
+} else {
+    window.addEventListener("load", initGrowthBook);
+}
     
 
 // Extracts a query string variable from the browser's location.


### PR DESCRIPTION
## Summary

- Defers GrowthBook SDK initialization from eager module-level execution to a `window.load` callback
- **Before**: importing `util.ts` (used by multiple Stencil components) immediately created a `GrowthBook` instance and called `gb.init({ streaming: true })`, which fetches from `cdn.growthbook.io` — creating a critical request chain: `HTML → JS bundle → GrowthBook API` (635ms critical path latency)
- **After**: GrowthBook is initialized only after the page finishes loading, breaking the chain entirely
- GrowthBook is only used for experiment tracking (not rendering decisions), so deferring it has no visual impact
- The `gb` export was never imported by any other file — it was purely a side effect in `util.ts`

## Test plan

- [ ] Verify GrowthBook experiment tracking still fires (check network tab for `cdn.growthbook.io` request after page load)
- [ ] Verify Segment `"Experiment Viewed"` events still appear when experiments are active
- [ ] Verify no console errors on page load
- [ ] Re-run PageSpeed Insights to confirm the "Network dependency tree" critical chain is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)