### PR TITLE
[Supersonic Page Speed] Improve CDN caching headers and add GrowthBook preconnect

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -469,6 +469,7 @@ const logsBucketPolicy = new aws.s3.BucketPolicy("logs-bucket-policy", {
 });
 
 const fiveMinutes = 60 * 5;
+const tenMinutes = fiveMinutes * 2;
 const thirtyMinutes = fiveMinutes * 6;
 const oneHour = fiveMinutes * 12;
 const oneWeek = oneHour * 24 * 7;
@@ -526,11 +527,6 @@ const baseSecurityHeadersConfig = {
     }
 };
 
-// Most of the site
-const SecurityHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy('security-headers', {
-    securityHeadersConfig: baseSecurityHeadersConfig,
-});
-
 // Copilot lives in an iframe
 const CopilotSecurityHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy('copilot-security-headers', {
     securityHeadersConfig: {
@@ -552,6 +548,28 @@ const BrandLogoCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('brand-log
         items: [{
             header: "Cache-Control",
             value: "public, max-age=1800",
+            override: true,
+        }],
+    },
+});
+
+const DefaultCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('default-cache-headers', {
+    securityHeadersConfig: baseSecurityHeadersConfig,
+    customHeadersConfig: {
+        items: [{
+            header: "Cache-Control",
+            value: "max-age=60, stale-while-revalidate=300",
+            override: true,
+        }],
+    },
+});
+
+const OneHourCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('one-hour-cache-headers', {
+    securityHeadersConfig: baseSecurityHeadersConfig,
+    customHeadersConfig: {
+        items: [{
+            header: "Cache-Control",
+            value: "public, max-age=3600",
             override: true,
         }],
     },
@@ -586,10 +604,10 @@ const baseCacheBehavior: aws.types.input.cloudfront.DistributionDefaultCacheBeha
     },
 
     minTtl: 0,
-    defaultTtl: thirtyMinutes,
-    maxTtl: thirtyMinutes,
+    defaultTtl: tenMinutes,
+    maxTtl: tenMinutes,
     lambdaFunctionAssociations: config.doEdgeRedirects ? [getEdgeRedirectAssociation()] : [],
-    responseHeadersPolicyId: SecurityHeadersPolicy.id,
+    responseHeadersPolicyId: DefaultCachePolicy.id,
 };
 
 const registryOrigins: aws.types.input.cloudfront.DistributionOrigin[] = [];
@@ -754,8 +772,8 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             ...baseCacheBehavior,
             targetOriginId: originBucket.arn,
             pathPattern: "/*/rss.xml",
-            defaultTtl: oneHour,
-            maxTtl: oneHour,
+            defaultTtl: tenMinutes,
+            maxTtl: tenMinutes,
             forwardedValues: {
                 cookies: {
                     forward: "none",
@@ -785,6 +803,13 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         {
             ...baseCacheBehavior,
             pathPattern: "/css/homepage.*.css",
+            defaultTtl: oneYear,
+            maxTtl: oneYear,
+            responseHeadersPolicyId: ImmutableCachePolicy.id,
+        },
+        {
+            ...baseCacheBehavior,
+            pathPattern: "/css/marketing-homepage.*.css",
             defaultTtl: oneYear,
             maxTtl: oneYear,
             responseHeadersPolicyId: ImmutableCachePolicy.id,
@@ -829,6 +854,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             pathPattern: "/logos/*",
             defaultTtl: oneHour,
             maxTtl: oneHour,
+            responseHeadersPolicyId: OneHourCachePolicy.id,
         },
         {
             ...baseCacheBehavior,

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,6 +20,9 @@
         {{- end }}
     </script>
 
+    <!-- Preconnect to third-party origins. -->
+    <link rel="preconnect" href="https://cdn.growthbook.io" crossorigin />
+
     <!-- Preload critical fonts. -->
     <link rel="preload" href="/fonts/roboto-mono-regular.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/inter-regular.woff2" as="font" type="font/woff2" crossorigin />


### PR DESCRIPTION
## Summary

Improves page load performance by optimizing CloudFront caching configuration and adding a resource hint for GrowthBook's CDN.

### CDN caching changes (`infrastructure/index.ts`)

- **Reduced default CloudFront TTL from 30 min to 10 min** -- Pages and assets were cached too long at the edge, causing delays when new content (especially blog posts) was published. The lower TTL means fresh content propagates faster.
- **Added browser `Cache-Control` header to default behavior** -- Previously, the default behavior only had security headers and no `Cache-Control`, so browsers fell back to heuristic caching with 304 revalidation round-trips. Now sends `max-age=60, stale-while-revalidate=300`, which gives browsers a 1-minute fresh window and allows stale responses for up to 5 minutes while revalidating in the background.
- **Reduced RSS feed TTL from 1 hour to 10 min** -- RSS consumers (feed readers, aggregators) now pick up new posts much faster.
- **Added immutable cache behavior for `/css/marketing-homepage.*.css`** -- This fingerprinted CSS bundle was missing a dedicated CloudFront behavior, so it fell through to the default 30-min TTL instead of getting the 1-year immutable cache that all other fingerprinted bundles have.
- **Added `Cache-Control: public, max-age=3600` to `/logos/*`** -- The `/logos/*` behavior had a 1-hour CloudFront edge TTL but no browser `Cache-Control` header, so browsers were making unnecessary revalidation requests. Now explicitly tells browsers to cache logos for 1 hour.
- **Removed unused `SecurityHeadersPolicy`** -- This security-headers-only response headers policy was replaced by `DefaultCachePolicy` (which includes both security headers and cache-control). The orphaned CloudFront resource is deleted.

### Preconnect hint (`layouts/partials/head.html`)

- **Added `<link rel="preconnect" href="https://cdn.growthbook.io" crossorigin />`** -- The GrowthBook SDK fetches feature flags from `cdn.growthbook.io` at runtime. The preconnect hint tells the browser to start DNS + TCP + TLS handshake early, shaving ~100-300ms off the first GrowthBook request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)