### PR TITLE
fix(ci): skip social scheduling workflow in docs-private

### DIFF
--- a/.github/workflows/schedule-social.yml
+++ b/.github/workflows/schedule-social.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   schedule-social:
+    if: github.repository == 'pulumi/docs'
     name: Schedule social media posts
     runs-on: ubuntu-latest
     environment: production
@@ -54,7 +55,7 @@ jobs:
         run: uv run scripts/social/schedule-posts.py
 
   notify:
-    if: failure()
+    if: failure() && github.repository == 'pulumi/docs'
     name: Send slack notification
     runs-on: ubuntu-latest
     environment: production


### PR DESCRIPTION
The `schedule-social` workflow fails on every push to master in docs-private because the IAM role's OIDC trust policy only allows `pulumi/docs`. This adds `github.repository == 'pulumi/docs'` guards to both jobs so they're skipped in forks instead of failing and spamming #docs-ops with Slack notifications.

(I also just disabled the workflow at the repo level)