### PR TITLE
Fix broken links: update /docs/cli/commands/ to /docs/iac/cli/commands/ and fix external links

### DIFF
--- a/content/blog/announcing-public-preview-update-plans/index.md
+++ b/content/blog/announcing-public-preview-update-plans/index.md
@@ -12,7 +12,7 @@ canonical_url: "https://www.pulumi.com/docs/iac/concepts/update-plans/"
 ---
 
 > [!INFO]
-> Update Plans now no longer require the `PULUMI_EXPERIMENTAL` environment variable. For the most up-to-date information about using Update Plans, please see the [Update Plans documentation](/docs/cli/commands/pulumi_preview#save-a-plan-file).
+> Update Plans now no longer require the `PULUMI_EXPERIMENTAL` environment variable. For the most up-to-date information about using Update Plans, please see the [Update Plans documentation](/docs/iac/cli/commands/pulumi_preview#save-a-plan-file).
 
 Pulumi’s previews are an important part of any workflow where you want to see the changes that will be made to your infrastructure before actually making the changes (with `pulumi up`). However, today there is no guarantee that the `pulumi up` operation will do only what was previewed; if the program, or your infrastructure, changes between the preview and the update, the update might make additional changes to bring your infrastructure back in line with what’s defined in your program. We’ve [heard from many of you](https://github.com/pulumi/pulumi/issues/2318) that you need a strong guarantee about exactly which changes an update will make to your infrastructure, especially in critical and production environments.
 

--- a/content/blog/announcing-pulumi-service-provider/index.md
+++ b/content/blog/announcing-pulumi-service-provider/index.md
@@ -45,7 +45,7 @@ The rest of the community agreed too, as this is one of our top customer product
 
 The Pulumi Service Provider builds on top of the [Pulumi Service REST API](/docs/pulumi-cloud/cloud-rest-api/) which is another feature available to our customers to programmatically configuring the Pulumi Service. The Pulumi Service REST API is includes functionality to interact with and manipulate any kind of metadata managed by Pulumi. That includes Projects and Stacks, Previews and Updates, Organizations and Audit Logs. We have already seen Cloud Engineering teams using the Pulumi REST API to build all sorts of custom functionality. These new capabilities are especially powerful when used in combination with the [Automation API](/automation/).
 
-The [Pulumi Service Provider](/registry/packages/pulumiservice/) can be used in any Pulumi language, TypeScript, Python, Go, .NET, Java and YAML. It supports configuration of [Teams](/docs/pulumi-cloud/access-management/teams/), [Access Tokens](/docs/pulumi-cloud/accounts/), [Stack Tags](/docs/cli/commands/pulumi_stack_tag/) and [Webhooks](/docs/pulumi-cloud/webhooks/) using infrastructure as code.
+The [Pulumi Service Provider](/registry/packages/pulumiservice/) can be used in any Pulumi language, TypeScript, Python, Go, .NET, Java and YAML. It supports configuration of [Teams](/docs/pulumi-cloud/access-management/teams/), [Access Tokens](/docs/pulumi-cloud/accounts/), [Stack Tags](/docs/iac/cli/commands/pulumi_stack_tag/) and [Webhooks](/docs/pulumi-cloud/webhooks/) using infrastructure as code.
 
 ## What resources are available?
 
@@ -53,7 +53,7 @@ Based on feedback from customers, we've picked the following resources to suppor
 
 * [Webhooks](/docs/pulumi-cloud/webhooks/)
 * [Teams](/docs/pulumi-cloud/access-management/teams/)
-* [StackTags](/docs/cli/commands/pulumi_stack_tag/)
+* [StackTags](/docs/iac/cli/commands/pulumi_stack_tag/)
 * [AccessTokens](/docs/pulumi-cloud/accounts/)
 
 ## How do I get started?

--- a/content/blog/azure-native-v3/index.md
+++ b/content/blog/azure-native-v3/index.md
@@ -108,7 +108,7 @@ Use the Pulumi CLI to add just the packages and versions you need:
 pulumi package add azure-native storage v20240101
 ```
 
-For more details on the `package add` command, see the [CLI documentation](/docs/cli/commands/pulumi_package_add/).
+For more details on the `package add` command, see the [CLI documentation](/docs/iac/cli/commands/pulumi_package_add/).
 
 Step 2: Import and use the versioned package
 

--- a/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
+++ b/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
@@ -17,7 +17,7 @@ infrastructure is just a few steps away for you and your teams.
 To make it easy to use Pulumi with Azure, we are announcing an
 open-source task extension for Azure Pipelines! The task extension will
 manage the installation of the Pulumi CLI, and run the [Pulumi
-commands](/docs/cli/commands/) you specify against
+commands](/docs/iac/cli/commands/) you specify against
 your stack.
 
 You can install the task extension directly from the [Visual Studio

--- a/content/blog/developer-portal-platform-teams/index.md
+++ b/content/blog/developer-portal-platform-teams/index.md
@@ -27,7 +27,7 @@ __Developer Portals__:  Every platform team we work with is looking to expose re
 
 * 🆕 Organization Templates and New Project Wizard:  Pulumi Cloud now supports registering your own custom templates for your organization, and enabling developers in your organization to provision them entirely via point-and-click in Pulumi Cloud with the new New Project Wizard.  This offers a great out-of-the box developer portal experience for any team using Pulumi Cloud.
 * 🆕 Pulumi Backstage Plugin:  For teams using Backstage, they can now integrate Pulumi directly within their Backstage instance, via support for a new Pulumi plugin as well as new Pulumi scaffolder actions.
-* 🆕 `pulumi new` support for private templates: By default, `pulumi new` provides a number of templates provided by Pulumi, but it can also use your own [private templates](/docs/cli/commands/pulumi_new/).
+* 🆕 `pulumi new` support for private templates: By default, `pulumi new` provides a number of templates provided by Pulumi, but it can also use your own [private templates](/docs/iac/cli/commands/pulumi_new/).
 
 __Policy and Compliance__: Platform teams need robust and flexible solutions for establishing policy and compliance guardrails for their cloud infrastructure. Pulumi’s existing CrossGuard policy-as-code framework provides the richest option for defining and enforcing policy across all infrastructure in an organization, using the full capabilities of your favorite languages.  Today, we are extending that support with two important new features for platform teams:
 

--- a/content/blog/docker-build/index.md
+++ b/content/blog/docker-build/index.md
@@ -510,7 +510,7 @@ The new Docker Build provider matches the Docker CLI behavior. Thus, it does **n
 
 {{% notes %}}
 
-The new Docker Build provider builds images by default during [previews](https://www.pulumi.com/docs/cli/commands/pulumi_preview/) to reduce the risk of merging broken images as part of CI pipelines. You can change the default behavior by specifying a [`buildOnPreview`](https://www.pulumi.com/registry/packages/docker-build/api-docs/image/#buildonpreview_nodejs) flag.
+The new Docker Build provider builds images by default during [previews](https://www.pulumi.com/docs/iac/cli/commands/pulumi_preview/) to reduce the risk of merging broken images as part of CI pipelines. You can change the default behavior by specifying a [`buildOnPreview`](https://www.pulumi.com/registry/packages/docker-build/api-docs/image/#buildonpreview_nodejs) flag.
 
 {{% /notes %}}
 

--- a/content/blog/dynamic-providers/index.md
+++ b/content/blog/dynamic-providers/index.md
@@ -19,7 +19,7 @@ A provider manages the CRUD (Create, Read, Update, Delete) life-cycle of a resou
 
 A resource provider is made up of two different pieces:
 
-1. A resource plugin, which is the binary used by the deployment engine to manage a resource. These plugins are stored in the plugin cache (located in `~/.pulumi/plugins`) and can be managed using the [`pulumi plugin`](https://www.pulumi.com/docs/cli/commands/pulumi_plugin/) set of commands.
+1. A resource plugin, which is the binary used by the deployment engine to manage a resource. These plugins are stored in the plugin cache (located in `~/.pulumi/plugins`) and can be managed using the [`pulumi plugin`](https://www.pulumi.com/docs/iac/cli/commands/pulumi_plugin/) set of commands.
 
 1. An SDK which provides bindings for each type of resource the provider can manage.
 

--- a/content/blog/esc-kubernetes-cluster-and-app/index.md
+++ b/content/blog/esc-kubernetes-cluster-and-app/index.md
@@ -749,7 +749,7 @@ nginx   3/3     3            3           103s
 ```
 
 {{% notes type="info" %}}
-ESC environments can be used with the `pulumi` CLI using the [pulumi env](/docs/cli/commands/pulumi_env/) command, or with
+ESC environments can be used with the `pulumi` CLI using the [pulumi env](/docs/iac/cli/commands/pulumi_env/) command, or with
 the new standalone [esc CLI](/docs/esc-cli).
 {{% /notes %}}
 

--- a/content/blog/fullstack-pulumi-mern-stack-digitalocean/index.md
+++ b/content/blog/fullstack-pulumi-mern-stack-digitalocean/index.md
@@ -505,7 +505,7 @@ Quickly, to recap, here's what we've done so far:
 * We mapped the tiers of that app to their corresponding App Platform components.
 * We wrote a Pulumi program to codify that mapping as an App Platform spec and a managed MongoDB cluster to go along with it.
 
-When you deploy this app in a moment with [`pulumi up`](/docs/cli/commands/pulumi_up), Pulumi will provision a new MongoDB cluster (which usually takes a few minutes), and then once that's available, DigitalOcean will take our spec and use it to fetch the components of the app from GitHub at the specified branch and build them. From that point forward, any commit you make to that branch will trigger DigitalOcean to fetch, rebuild, and redeploy the app automatically.
+When you deploy this app in a moment with [`pulumi up`](/docs/iac/cli/commands/pulumi_up), Pulumi will provision a new MongoDB cluster (which usually takes a few minutes), and then once that's available, DigitalOcean will take our spec and use it to fetch the components of the app from GitHub at the specified branch and build them. From that point forward, any commit you make to that branch will trigger DigitalOcean to fetch, rebuild, and redeploy the app automatically.
 
 Make sure you've installed the DigitalOcean GitHub app as described above---you should see it listed at <https://github.com/settings/installations>:
 
@@ -643,7 +643,7 @@ Resources:
 Duration: 1m27s
 ```
 
-And when you're finished experimenting, you can tear everything down in just a few seconds with a [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+And when you're finished experimenting, you can tear everything down in just a few seconds with a [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy
@@ -671,7 +671,7 @@ From here, you might think about:
 
 * Adding a [`digitalocean.DnsRecord`](/registry/packages/digitalocean/api-docs/dnsrecord) to give your app a [custom domain name](https://docs.digitalocean.com/products/networking/dns/).
 
-* Creating a second stack with [`pulumi stack init`](/docs/cli/commands/pulumi_stack_init) and adjusting the program to make the source `branch` configurable---a `production` stack, say, designed to deploy in response to commits to a `release` branch.
+* Creating a second stack with [`pulumi stack init`](/docs/iac/cli/commands/pulumi_stack_init) and adjusting the program to make the source `branch` configurable---a `production` stack, say, designed to deploy in response to commits to a `release` branch.
 
 * Using Pulumi's [GitHub Action](/docs/iac/packages-and-automation/continuous-delivery/github-actions/) to run previews and updates as part of a pull-request based workflow.
 

--- a/content/blog/how-to-create-and-share-a-pulumi-template/index.md
+++ b/content/blog/how-to-create-and-share-a-pulumi-template/index.md
@@ -314,7 +314,7 @@ As you can see, creating a template is both simple and powerful, and I hope this
 * [Pulumi Templates](/templates/)
 * The [pulumi/templates repository](https://github.com/pulumi/templates) on GitHub
 * [Pulumi project file reference](/docs/reference/pulumi-yaml)
-* [`pulumi new` reference](/docs/cli/commands/pulumi_new/)
+* [`pulumi new` reference](/docs/iac/cli/commands/pulumi_new/)
 * [Deploy with Pulumi button reference](/docs/pulumi-cloud/pulumi-button/)
 
 And as always, be sure to stop by [Pulumi Community Slack](https://slack.pulumi.com/) to let us know know how it goes.

--- a/content/blog/how-webiny-built-a-serverless-application-framework/index.md
+++ b/content/blog/how-webiny-built-a-serverless-application-framework/index.md
@@ -75,7 +75,7 @@ So, the search began, and soon enough, we discovered Pulumi. And as it turned ou
 
 - different options when it comes to storing cloud infrastructure state files: a managed SaaS ([pulumi.com](https://app.pulumi.com/signin)) with a console and self-hosted, (for example [Amazon S3](https://aws.amazon.com/s3/))
 - ability to deploy cloud infrastructure into multiple environments using its concept of [stacks](/docs/concepts/stack/)
-- advanced features like [Policy as Code](/docs/using-pulumi/crossguard/get-started/) and [watch mode](/docs/cli/commands/pulumi_watch/)
+- advanced features like [Policy as Code](/docs/using-pulumi/crossguard/get-started/) and [watch mode](/docs/iac/cli/commands/pulumi_watch/)
 - great documentation
 - a vibrant community of developers and a responsive team behind the product
 

--- a/content/blog/improved-preview-experience/index.md
+++ b/content/blog/improved-preview-experience/index.md
@@ -10,7 +10,7 @@ tags:
     - features
 ---
 
-Today we are announcing a minor but significant improvement to the Pulumi [preview](/docs/cli/commands/pulumi_preview/)
+Today we are announcing a minor but significant improvement to the Pulumi [preview](/docs/iac/cli/commands/pulumi_preview/)
 experience.
 
 <!--more-->

--- a/content/blog/infrastructure-testing-concepts/index.md
+++ b/content/blog/infrastructure-testing-concepts/index.md
@@ -58,7 +58,7 @@ Cloud engineering applies software testing principles to infrastructure where we
 
 ### Static tests
 
-Infrastructure templating languages such as YAML or JSON have limited static validation capabilities; primarily, they are limited to linting: validating and formatting the code. Pulumi's approach of deploying infrastructure with programming languages lets you use built-in tools in IDEs that perform static tests, highlight errors in your code, and offer other features such as code completion, enumerations, and syntax checking. [Pulumi's preview](/docs/cli/commands/pulumi_preview) also performs static checking before deploying a resource.
+Infrastructure templating languages such as YAML or JSON have limited static validation capabilities; primarily, they are limited to linting: validating and formatting the code. Pulumi's approach of deploying infrastructure with programming languages lets you use built-in tools in IDEs that perform static tests, highlight errors in your code, and offer other features such as code completion, enumerations, and syntax checking. [Pulumi's preview](/docs/iac/cli/commands/pulumi_preview) also performs static checking before deploying a resource.
 
 ### Unit tests
 

--- a/content/blog/kubernetes-architecture-templates/index.md
+++ b/content/blog/kubernetes-architecture-templates/index.md
@@ -43,7 +43,7 @@ $ mkdir app
 $ mkdir infra
 ```
 
-In the `infra` directory, we'll add [the GKE template](/templates/kubernetes/gcp) first. We're [using the `--generate-only` flag](/docs/cli/commands/pulumi_new#options) to avoid creating the default virtual environment and the various extra stack information since we're using Poetry and will be running everything from the root directory later:
+In the `infra` directory, we'll add [the GKE template](/templates/kubernetes/gcp) first. We're [using the `--generate-only` flag](/docs/iac/cli/commands/pulumi_new#options) to avoid creating the default virtual environment and the various extra stack information since we're using Poetry and will be running everything from the root directory later:
 
 ```bash
 $ cd infra

--- a/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
+++ b/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
@@ -50,7 +50,7 @@ packages.
 [Install pulumi CLI](/docs/get-started/)
 and set up your [AWS credentials](/docs/iac/get-started/aws/).
 Initialize a new [Pulumi project](/docs/concepts/projects/)
-and [Pulumi stack](/docs/cli/commands/pulumi_stack/) from
+and [Pulumi stack](/docs/iac/cli/commands/pulumi_stack/) from
 available programming [language
 templates](https://github.com/pulumi/templates). We will use the
 `aws-typescript` template here and install all library

--- a/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
+++ b/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
@@ -182,7 +182,7 @@ const demoTravisCIPusher = new CredentialPusher(
 
 ### Demo
 
-To demonstrate the access keys rotation, we can examine the log files generated from AWS Lambda. These can be accessed from the command-line using the [`pulumi logs`](/docs/cli/commands/pulumi_logs) command.
+To demonstrate the access keys rotation, we can examine the log files generated from AWS Lambda. These can be accessed from the command-line using the [`pulumi logs`](/docs/iac/cli/commands/pulumi_logs) command.
 
 Here's a summary of the output for clarity:
 

--- a/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
+++ b/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
@@ -295,7 +295,7 @@ and that too might contain sensitive information. For example, a Pulumi resource
 
 Pulumi [has support](/docs/concepts/resources#additionalsecretoutputs) to mark that resource
 output as "secret" and make sure that it is encrypted within the checkpoint file. (So if you were to look at the checkpoint file
-contents via [`pulumi stack export`](/docs/cli/commands/pulumi_stack_export), you would not be able to recover
+contents via [`pulumi stack export`](/docs/iac/cli/commands/pulumi_stack_export), you would not be able to recover
 the data.
 
 Just like for secret configuration values, the default for stacks hosted on the Pulumi Service is to encrypt
@@ -310,7 +310,7 @@ data stored in the Pulumi Service were available, it would be useless without yo
 If that's the case, then you can use a configurable secrets provider, and swap out the default "Pulumi Service managed" encryption
 scheme for your own. (And we won't take it personally, promise.)
 
-When you create a new stack using [pulumi stack init](/docs/cli/commands/pulumi_stack_init/), you can optionally
+When you create a new stack using [pulumi stack init](/docs/iac/cli/commands/pulumi_stack_init/), you can optionally
 specify a `--secrets-provider` flag. That will determine where and how secrets get managed on your stack.
 
 For example, to use your own KMS key for encrypting data, you can pass the secrets provider

--- a/content/blog/managing-github-with-pulumi/index.md
+++ b/content/blog/managing-github-with-pulumi/index.md
@@ -87,7 +87,7 @@ $ export GITHUB_OWNER=pulumi
 
 Now, Pulumi is _great_ at creating new infrastructure from scratch via code. But this wasn’t a from-scratch situation. We had to migrate existing resources---GitHub teams---to Pulumi, without disrupting anyone’s access.
 
-Enter [Pulumi Import](/docs/cli/commands/pulumi_import/).
+Enter [Pulumi Import](/docs/iac/cli/commands/pulumi_import/).
 
 What Pulumi Import does, in a nutshell, is find existing infrastructure by unique ID (in the GitHub provider’s case, the team ID), and add them to a Pulumi Stack. You can find the specific import instructions on the registry documentation for each resource. In this case we want the [GitHub import instructions](/registry/packages/github/api-docs/team#import).
 
@@ -160,7 +160,7 @@ Resources:
 
 Since `pulumi preview` shows no changes, we now know that our code reflects the existing infrastructure. It’s a bit funny to think about your program working well when it does nothing, but this was a huge first step in preserving existing infrastructure and ensuring all of our coworkers could continue their daily work uninterrupted!
 
-To finish up, we [unprotect the resource](/docs/cli/commands/pulumi_state_unprotect/):
+To finish up, we [unprotect the resource](/docs/iac/cli/commands/pulumi_state_unprotect/):
 
 ```bash
 $ pulumi state unprotect 'urn:pulumi:prod::team-mgmt::github:index/team:Team::animals'
@@ -479,7 +479,7 @@ jobs:
          stack-name: pulumi/prod
 ```
 
-Note that we are calling `refresh: true` in both Workflows, which uses [Pulumi Refresh](/docs/cli/commands/pulumi_refresh/) to make sure that the existing GitHub resources are aligned with the resource state in our Stack.
+Note that we are calling `refresh: true` in both Workflows, which uses [Pulumi Refresh](/docs/iac/cli/commands/pulumi_refresh/) to make sure that the existing GitHub resources are aligned with the resource state in our Stack.
 
 Now, anyone with access to the GitHub management repo can:
 

--- a/content/blog/mlops-the-ai-challenge-is-cloud-not-code/index.md
+++ b/content/blog/mlops-the-ai-challenge-is-cloud-not-code/index.md
@@ -67,7 +67,7 @@ Choose one of the following deployment platforms. (You can actually choose more 
 - [Azure](https://azure.microsoft.com/en-us)
   - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [Runpod.io](https://runpod.io)
-  - [Runpod api key](https://docs.runpod.io/graphql-api)
+  - [Runpod api key](https://docs.runpod.io/get-started/api-keys)
 
 Now, for the real fun, let's start the timer and deploy our own chatbot! Note that the instructions below are for Runpod; instructions for the other two deployment platforms are found in [the GitHub repository](https://github.com/pulumiverse/katwalk).
 

--- a/content/blog/move-resources-between-stacks/index.md
+++ b/content/blog/move-resources-between-stacks/index.md
@@ -11,7 +11,7 @@ tags:
     - CLI
 ---
 
-Today we're announcing the [`pulumi state move`](/docs/cli/commands/pulumi_state_move/) command, which can be used to move resources that are managed by Pulumi between different stacks and/or projects. With the `pulumi state move` command, you can refactor your Pulumi Infrastructure as Code without any disruption to your deployed cloud infrastructure, enabling you to evolve and scale with confidence.
+Today we're announcing the [`pulumi state move`](/docs/iac/cli/commands/pulumi_state_move/) command, which can be used to move resources that are managed by Pulumi between different stacks and/or projects. With the `pulumi state move` command, you can refactor your Pulumi Infrastructure as Code without any disruption to your deployed cloud infrastructure, enabling you to evolve and scale with confidence.
 
 <!--more-->
 

--- a/content/blog/pulumi-2020-update/index.md
+++ b/content/blog/pulumi-2020-update/index.md
@@ -31,7 +31,7 @@ We've also added support for core Pulumi features, including [aliases](/docs/con
 
 [CrossGuard, our Policy as Code framework](/docs/using-pulumi/crossguard/), is now ready to take for a serious test drive. CrossGuard lets you to write policies in real code and enforce them during updates. Policies can check for anything; however, common checks include security, compliance, cost management, and general and team best practices. You can write your policy packages or use off-the-shelf policy packs like our [AWSGuard](/docs/using-pulumi/crossguard/awsguard/) package.
 
-CrossGuard is open source and the functionality is behind [the new `pulumi policy` command](/docs/cli/commands/pulumi_policy), as well as [the new `--policy-pack` flag](/docs/cli/commands/pulumi_up#options) for the `preview` and `up` commands. You can use these features with any edition of Pulumi, without restriction, including the offline backends.
+CrossGuard is open source and the functionality is behind [the new `pulumi policy` command](/docs/iac/cli/commands/pulumi_policy), as well as [the new `--policy-pack` flag](/docs/iac/cli/commands/pulumi_up#options) for the `preview` and `up` commands. You can use these features with any edition of Pulumi, without restriction, including the offline backends.
 
 If you choose to use CrossGuard with the Enterprise Edition of Pulumi, however, you'll get some added functionality. This includes server-side enforcement of policies and organizational policies, including "policy groups" which let you group and apply many policies together to your stacks, such as applying different policies to production than development environments.
 
@@ -53,7 +53,7 @@ The remaining areas of focus between now and launch include:
 
 In addition to the major areas above, we've continued to ship many other improvements. Here are some of our favorite ones:
 
-* [Stack export for the CLI and in the service](/docs/cli/commands/pulumi_stack_export/), enabling you to export any past version of a stack's state file. This helps you debug, restore, or roll back changes, or even just for historical reporting purposes.
+* [Stack export for the CLI and in the service](/docs/iac/cli/commands/pulumi_stack_export/), enabling you to export any past version of a stack's state file. This helps you debug, restore, or roll back changes, or even just for historical reporting purposes.
 
 * [Many quality-of-life improvements in the Pulumi SaaS Console](/blog/pulumi-service-improvements_02-2020/), including stack tagging, grouping, and sorting; deep linking into CI/CD systems; infrastructure configuration pretty-printing; reverse stack membership lookups; performance improvements; and more.
 

--- a/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
+++ b/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
@@ -427,7 +427,7 @@ Check out the video clip below for a demo.
 
 ## Documentation
 
-Full CLI Documentation is [available](https://www.pulumi.com/docs/cli/commands/pulumi_import/), showing all of the different
+Full CLI Documentation is [available](https://www.pulumi.com/docs/iac/cli/commands/pulumi_import/), showing all of the different
 import command flags. The flags include writing directly to a file and the ability to ensure
 a resource is not protected on import. Examples of importing resources can be found on their specific resource documentation
 pages. Such an example for importing a VPC can be found in the [VPC import documentation](https://www.pulumi.com/registry/packages/aws/api-docs/ec2/vpc/#import).

--- a/content/blog/pulumi-insights-ai-cli/index.md
+++ b/content/blog/pulumi-insights-ai-cli/index.md
@@ -72,4 +72,4 @@ With these new CLI commands, Pulumi Insights is available at your fingertips in 
 
 * [Pulumi Insights](/docs/pulumi-cloud/insights/)
 * [Pulumi AI](/ai)
-* [Pulumi CLI](/docs/cli/commands/)
+* [Pulumi CLI](/docs/iac/cli/commands/)

--- a/content/blog/pulumi-release-notes-69/index.md
+++ b/content/blog/pulumi-release-notes-69/index.md
@@ -60,7 +60,7 @@ Learn more in the [RetainOnDelete blog post](/blog/retainondelete/) and in the [
 
 ### New `pulumi state rename` command
 
-In some cases users may need to rename existing resources, which historically has been done by editing the checkpoint file directly. We’ve now made this even easier by offering a CLI command to rename resources. You can now use [`pulumi state rename`](/docs/cli/commands/pulumi_state_rename) to rename resources in an easy and safe manner. This feature will also be useful for customers migrating to the Azure AD provider without replacing resources.
+In some cases users may need to rename existing resources, which historically has been done by editing the checkpoint file directly. We’ve now made this even easier by offering a CLI command to rename resources. You can now use [`pulumi state rename`](/docs/iac/cli/commands/pulumi_state_rename) to rename resources in an easy and safe manner. This feature will also be useful for customers migrating to the Azure AD provider without replacing resources.
 
 Learn more in the [add `pulumi state` GitHub issue](https://github.com/pulumi/pulumi/issues/2060).
 

--- a/content/blog/pulumi-release-notes-77/index.md
+++ b/content/blog/pulumi-release-notes-77/index.md
@@ -116,7 +116,7 @@ We also made a handful of improvements to `pulumi convert`. See the [v0.5.5 rele
 
 ### Allow `pulumi refresh` to resolve pending creates
 
-[`pulumi refresh`](/docs/cli/commands/pulumi_refresh) can be used to bring Pulumi state back inline with external state. If something is changed in the actual state and Pulumi is not made aware of it or if Pulumi is terminated mid-operation you could end up with pending operations. Now when running `pulumi refresh` interactively, it will provide you with new options to deal with the pending operations. These new interactive options are as follows:
+[`pulumi refresh`](/docs/iac/cli/commands/pulumi_refresh) can be used to bring Pulumi state back inline with external state. If something is changed in the actual state and Pulumi is not made aware of it or if Pulumi is terminated mid-operation you could end up with pending operations. Now when running `pulumi refresh` interactively, it will provide you with new options to deal with the pending operations. These new interactive options are as follows:
 
 - **import**: the flag `--import-pending-creates` has been added to allow scripting to resolve pending creates via `pulumi refresh`. It takes a list of URN IDs to be imported.
 - **clear**: to assist with the use case of removing all pending creates, the flag `--clear-pending-creates` has been added.
@@ -163,7 +163,7 @@ Learn more in the [Add options to configure logging and tracing merge request](h
 
 ### Use `pulumi destroy -s <stack>` outside a Pulumi project dir
 
-You can now specify a stack when using [`pulumi destroy`](/docs/cli/commands/pulumi_destroy) while outside of the project directory.
+You can now specify a stack when using [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy) while outside of the project directory.
 
 Learn more in the [`pulumi destroy -s <stack>` GitHub issue](https://github.com/pulumi/pulumi/issues/2440).
 
@@ -205,7 +205,7 @@ Look for the star icon next to any stack name and select it to start building yo
 
 ### Pulumi Service Provider improvements
 
-The Pulumi Service Provider builds on top of the Pulumi Service REST API which is another feature available to our customers to programmatically configuring the Pulumi Service. At launch, the Pulumi Service Provider had resource support for Teams, Webhooks, StackTags and AccessTokens. We have recently also added support for [TeamStackPermissions](/docs/cli/commands/pulumi_destroy/), enabling users to add stacks to Teams and [Provider](/docs/cli/commands/pulumi_destroy/) to control Provider resources.
+The Pulumi Service Provider builds on top of the Pulumi Service REST API which is another feature available to our customers to programmatically configuring the Pulumi Service. At launch, the Pulumi Service Provider had resource support for Teams, Webhooks, StackTags and AccessTokens. We have recently also added support for [TeamStackPermissions](/docs/iac/cli/commands/pulumi_destroy/), enabling users to add stacks to Teams and [Provider](/docs/iac/cli/commands/pulumi_destroy/) to control Provider resources.
 
 As always, please feel free to submit feature requests and bug reports to [Pulumi Service Provider GitHub Repo](https://github.com/pulumi/pulumi-pulumiservice/issues). We look forward to seeing what you build with the Pulumi Service Provider!
 

--- a/content/blog/pulumi-release-notes-80/index.md
+++ b/content/blog/pulumi-release-notes-80/index.md
@@ -99,7 +99,7 @@ Automation API now supports parallel execution of NodeJS inline programs in addi
 
 ### New --remove flag for `pulumi destroy`
 
-A [`pulumi destroy`](/docs/cli/commands/pulumi_destroy) operation destroys all existing resources in the stack, but not the stack itself. If you then wanted to delete the stack itself, once all the resources were destroyed, you would run a [`pulumi stack rm`]. A community member, [mrod-io](https://github.com/mrod-io) added a flag for `pulumi destroy` for when you want to remove the stack after its resources are destroyed: `pulumi destroy --remove`.
+A [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy) operation destroys all existing resources in the stack, but not the stack itself. If you then wanted to delete the stack itself, once all the resources were destroyed, you would run a [`pulumi stack rm`]. A community member, [mrod-io](https://github.com/mrod-io) added a flag for `pulumi destroy` for when you want to remove the stack after its resources are destroyed: `pulumi destroy --remove`.
 
 **See it in action below:**
 

--- a/content/blog/pulumi-release-notes-m61/index.md
+++ b/content/blog/pulumi-release-notes-m61/index.md
@@ -408,7 +408,7 @@ Thanks [@jancespivo](https://github.com/jancespivo) for contributing this change
 
 ### Automation API in .NET can use plugin installation options `exact` and `server`
 
-When running Pulumi interactively, you can use the [`pulumi plugin install` command](/docs/cli/commands/pulumi_plugin_install) to manually install plugins required by your program, possibly from a server where you host your own plugins. You can now do the same task in the .NET Automation API:
+When running Pulumi interactively, you can use the [`pulumi plugin install` command](/docs/iac/cli/commands/pulumi_plugin_install) to manually install plugins required by your program, possibly from a server where you host your own plugins. You can now do the same task in the .NET Automation API:
 
 ```csharp
 await workspace.InstallPluginAsync("myplugin", "v0.0.1", options: new PluginInstallOptions
@@ -423,7 +423,7 @@ Thanks [@orionstudt](https://github.com/orionstudt) for contributing this change
 
 ### Schema checker for Pulumi Packages
 
-When authoring a Pulumi Package, it can be helpful to validate that your [schema](/docs/iac/packages-and-automation/pulumi-packages/schema/) is correct. Now, you can validate your schema by running the [`pulumi schema check` command](/docs/cli/commands/pulumi_schema_check).
+When authoring a Pulumi Package, it can be helpful to validate that your [schema](/docs/iac/packages-and-automation/pulumi-packages/schema/) is correct. Now, you can validate your schema by running the [`pulumi schema check` command](/docs/iac/cli/commands/pulumi_schema_check).
 
 [Learn more in this GitHub PR](https://github.com/pulumi/pulumi/pull/7865)
 

--- a/content/blog/pulumi-service-improvements_02-2020/index.md
+++ b/content/blog/pulumi-service-improvements_02-2020/index.md
@@ -18,7 +18,7 @@ In this post, we showcase what's new!
 
 Pulumi has had support for [stack tags](/docs/concepts/stack#stack-tags) for a while, enabling
 you to add attributes to your stacks with custom data such as the `account-id` or `environment`. But previously the data was
-only available on the command-line, via the `pulumi stack tag` command ([documentation](/docs/cli/commands/pulumi_stack_tag/).
+only available on the command-line, via the `pulumi stack tag` command ([documentation](/docs/iac/cli/commands/pulumi_stack_tag/).
 
 We've added first-class support for stack tags in the Pulumi Service as well. You can create, update, and delete tags from within the console.
 
@@ -58,7 +58,7 @@ While in most cases your [stack's checkpoint data](/docs/iac/concepts/state-and-
 you don't need to worry about; in some advanced scenarios, you may need to inspect or edit it manually.
 
 You can now download a stack’s checkpoint file directly from the Pulumi Service. You can get the
-same data from the command-line, using `pulumi stack export` ([documentation](/docs/cli/commands/pulumi_stack_export/),
+same data from the command-line, using `pulumi stack export` ([documentation](/docs/iac/cli/commands/pulumi_stack_export/),
 which now supports a `--version` flag to export older checkpoint files too.
 
 {{< figure alt="Download stack checkpoints from the Pulumi Service" src="./download-checkpoint-file.png" class="md:max-w-lg" >}}

--- a/content/blog/pulumi-universal-iac/index.md
+++ b/content/blog/pulumi-universal-iac/index.md
@@ -381,7 +381,7 @@ Every package in the Pulumi Registry supports all Pulumi programming languages, 
 
 Pulumi’s users love managing __*all*__ of their cloud infrastructure using Pulumi, and that includes managing the state of the [Pulumi Service](/product/pulumi-service/) itself.
 
-Today, we released a new [Pulumi provider for the Pulumi Service](/registry/packages/pulumiservice/), supporting configuration of [Teams](/docs/pulumi-cloud/access-management/teams/), [Access Tokens](https://www.pulumi.com/docs/pulumi-cloud/accounts/#access-tokens), [Stack Tags](/docs/cli/commands/pulumi_stack_tag/) and [Webhooks](/docs/pulumi-cloud/webhooks/) using infrastructure as code.
+Today, we released a new [Pulumi provider for the Pulumi Service](/registry/packages/pulumiservice/), supporting configuration of [Teams](/docs/pulumi-cloud/access-management/teams/), [Access Tokens](https://www.pulumi.com/docs/pulumi-cloud/accounts/#access-tokens), [Stack Tags](/docs/iac/cli/commands/pulumi_stack_tag/) and [Webhooks](/docs/pulumi-cloud/webhooks/) using infrastructure as code.
 
 For example, you can create a webhook that is notified whenever a Pulumi Update completes, and log it using an AWS Lambda, with just a few lines of code using the new Pulumi Service provider along with the API Gateway package.
 

--- a/content/blog/pulumi-watch-mode-with-rust/index.md
+++ b/content/blog/pulumi-watch-mode-with-rust/index.md
@@ -147,5 +147,5 @@ infrastructure as code. Implementing watch mode in Rust applied that principle t
 maintaining performance, moving the feature to a well-maintained footing, and expanding support to
 every platform Pulumi supports.
 
-Give [`pulumi watch`](/docs/cli/commands/pulumi_watch) a try with our
+Give [`pulumi watch`](/docs/iac/cli/commands/pulumi_watch) a try with our
 [getting started guide](/docs/get-started/)!

--- a/content/blog/repairing-state-with-pulumi-refresh/index.md
+++ b/content/blog/repairing-state-with-pulumi-refresh/index.md
@@ -64,7 +64,7 @@ If the Pulumi CLI process is terminated between steps 2 and 3, then Pulumi does 
 
 ## The Solution
 
-As of [#10394](https://github.com/pulumi/pulumi/pull/10394), the solution to both problems is [pulumi refresh](https://www.pulumi.com/docs/cli/commands/pulumi_refresh/). The `pulumi refresh` command modifies Pulumi's state so it matches the state of the underlying providers. Most discrepancies can be resolved automatically by checking Pulumi's state against the underlying resource provider. For our AWS bucket example, Pulumi would ask the aws-native provider if bucket `my-bucket-6e3d099` exists and what tags it has.
+As of [#10394](https://github.com/pulumi/pulumi/pull/10394), the solution to both problems is [pulumi refresh](https://www.pulumi.com/docs/iac/cli/commands/pulumi_refresh/). The `pulumi refresh` command modifies Pulumi's state so it matches the state of the underlying providers. Most discrepancies can be resolved automatically by checking Pulumi's state against the underlying resource provider. For our AWS bucket example, Pulumi would ask the aws-native provider if bucket `my-bucket-6e3d099` exists and what tags it has.
 
 This works for all resources that Pulumi knows about. This set includes Pulumi managed resources that were changed manually, or for pending UPDATE, DELETE, READ and IMPORT operations. Pulumi does not know the resource ID for pending CREATE operations (it might not exist), so it can not resolve everything for you. It needs a little bit of help. For each pending CREATE, Pulumi will ask you what to do:
 
@@ -75,7 +75,7 @@ created resource, and Pulumi will bring that resource under management.
 
 If no resource was created, you can select `clear` to tell Pulumi to clear the pending CREATE. It will recreate the resource for you the next time you run `pulumi up`.
 
-You can learn more by going to the [`pulumi refresh` documentation](https://www.pulumi.com/docs/cli/commands/pulumi_refresh/) or by running `pulumi refresh --help`.
+You can learn more by going to the [`pulumi refresh` documentation](https://www.pulumi.com/docs/iac/cli/commands/pulumi_refresh/) or by running `pulumi refresh --help`.
 
 ### Command Details
 

--- a/content/blog/shared-config-with-aws-systems-manager-parameter-store/index.md
+++ b/content/blog/shared-config-with-aws-systems-manager-parameter-store/index.md
@@ -56,7 +56,7 @@ $ cd shared-config
 $ pulumi new aws-yaml
 ```
 
-When the new-project wizard completes, add two new settings for the `dev` stack with [`pulumi config set`](/docs/cli/commands/pulumi_config_set):
+When the new-project wizard completes, add two new settings for the `dev` stack with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
 
 ```bash
 $ pulumi config set motd 'Hello from Pulumi!'

--- a/content/blog/six-things-about-pulumi-service/index.md
+++ b/content/blog/six-things-about-pulumi-service/index.md
@@ -31,7 +31,7 @@ Let’s get started!
 
 The first thing we'll cover is the [Pulumi stack tags](/docs/concepts/stack#stack-tags) feature. Stack tags are key/value pairs that are associated with your Pulumi stack. You can use them for any number of purposes, from keeping things organized to even flagging whether or not it's okay for a script to reclaim the stack's resources.
 
-While you can create, edit, and remove stack tags using the Pulumi CLI (see [`pulumi stack tag`](/docs/cli/commands/pulumi_stack_tag)), you can also do so in the Pulumi Console:
+While you can create, edit, and remove stack tags using the Pulumi CLI (see [`pulumi stack tag`](/docs/iac/cli/commands/pulumi_stack_tag)), you can also do so in the Pulumi Console:
 
 ![Adding and removing stack tags in the Service ](https://user-images.githubusercontent.com/274700/150612443-b0b187e1-6329-42ca-816f-01de1bc5d4ff.gif)
 

--- a/content/blog/stack-init-teams-flag/index.md
+++ b/content/blog/stack-init-teams-flag/index.md
@@ -13,7 +13,7 @@ tags:
     - "cli-flags"
 ---
 
-We've been hearing feedback from our customers that they need ways to manage permissions for their stacks at scale. Today we are announcing a `--teams` flag for [`pulumi stack init`](/docs/cli/commands/pulumi_stack_init), which allows customers to assign Teams to stacks from the CLI. This flag offers a third programmatic method for assigning permissions, supplementing [Pulumi Service REST API](/docs/reference/service-rest-api) or the [Pulumi Service Provider](/registry/packages/pulumiservice). Developers can now initialize their stacks with the right permissions directly from the CLI.
+We've been hearing feedback from our customers that they need ways to manage permissions for their stacks at scale. Today we are announcing a `--teams` flag for [`pulumi stack init`](/docs/iac/cli/commands/pulumi_stack_init), which allows customers to assign Teams to stacks from the CLI. This flag offers a third programmatic method for assigning permissions, supplementing [Pulumi Service REST API](/docs/reference/service-rest-api) or the [Pulumi Service Provider](/registry/packages/pulumiservice). Developers can now initialize their stacks with the right permissions directly from the CLI.
 
 <!--more-->
 
@@ -22,7 +22,7 @@ consist of stacks, which are separate deployments of the same infrastructure. St
 also be configured with separate inputs. Organization admins can leverage RBAC
 to grant access permissions at the organization or Pulumi Teams levels. Pulumi Teams and RBAC are available for Enterprise and Business Critical customers.
 
-Stacks are often created via the CLI with the [`pulumi stack init` command](https://www.pulumi.com/docs/cli/commands/pulumi_stack_init/#options).
+Stacks are often created via the CLI with the [`pulumi stack init` command](https://www.pulumi.com/docs/iac/cli/commands/pulumi_stack_init/#options).
 This command initializes a new stack. If you're using the
 [Pulumi Service](https://www.pulumi.com/docs/iac/concepts/state-and-backends/#pulumi-service-backend) as your backend, you can view your newly created stack in the Pulumi Service console. If your organization uses teams, you will want to give your teammates access to the stack.
 

--- a/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
+++ b/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
@@ -81,7 +81,7 @@ The VPC test is slightly more complex. For the most part, it is simply checking 
 `cluster.core.vpcId` property and ensuring it doesn't equal the default VPC ID, which
 we fetch with `aws.ec2.getVpc`. However, because we might be creating the custom VPC in the
 program itself, it's possible we won't know the ID during previews. (A [preview](
-/docs/cli/commands/pulumi_preview) is when
+/docs/iac/cli/commands/pulumi_preview) is when
 Pulumi shows you a dry-run of your deployment without actually doing it yet.) That's why
 we check `pulumi.runtime.isDryRun` and let things slide, with a little warning message.
 We could always be conservative and fail the test, but in this case, we'll actually permit the

--- a/content/blog/welcoming-gitlab-users-to-pulumi/index.md
+++ b/content/blog/welcoming-gitlab-users-to-pulumi/index.md
@@ -91,9 +91,9 @@ to sign-in.
 Yes. Signing-in with a GitLab account will create a new account. That
 means, your stacks and activity will stay with the other account. You
 can migrate them by performing a
-[`pulumi stack export`](/docs/cli/commands/pulumi_stack_export)
+[`pulumi stack export`](/docs/iac/cli/commands/pulumi_stack_export)
 from your source stack and then importing it using
-[`pulumi stack import`](/docs/cli/commands/pulumi_stack_import)
+[`pulumi stack import`](/docs/iac/cli/commands/pulumi_stack_import)
 in a new stack in your GitLab-based account.
 
 If you would like to add your GitLab identity to your _existing_ Pulumi account, you can

--- a/content/docs/iac/cli/_index.md
+++ b/content/docs/iac/cli/_index.md
@@ -41,12 +41,12 @@ The Pulumi CLI is open source and free to use:
 
 The most common commands in the CLI that you'll be using are as follows:
 
-* [`pulumi new`](/docs/cli/commands/pulumi_new/): creates a new project using a template
-* [`pulumi stack`](/docs/cli/commands/pulumi_stack/): manage your stacks (at least one is required to perform an update)
-* [`pulumi config`](/docs/cli/commands/pulumi_config/): configure variables such as keys, regions, and so on
-* [`pulumi up`](/docs/cli/commands/pulumi_up/): preview and deploy changes to your program and/or infrastructure
-* [`pulumi preview`](/docs/cli/commands/pulumi_preview/): preview your changes explicitly before deploying
-* [`pulumi destroy`](/docs/cli/commands/pulumi_destroy/): destroy your program and its infrastructure when you're done
+* [`pulumi new`](/docs/iac/cli/commands/pulumi_new/): creates a new project using a template
+* [`pulumi stack`](/docs/iac/cli/commands/pulumi_stack/): manage your stacks (at least one is required to perform an update)
+* [`pulumi config`](/docs/iac/cli/commands/pulumi_config/): configure variables such as keys, regions, and so on
+* [`pulumi up`](/docs/iac/cli/commands/pulumi_up/): preview and deploy changes to your program and/or infrastructure
+* [`pulumi preview`](/docs/iac/cli/commands/pulumi_preview/): preview your changes explicitly before deploying
+* [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy/): destroy your program and its infrastructure when you're done
 
 ## Complete Reference
 

--- a/content/docs/iac/cli/commands/_index.md
+++ b/content/docs/iac/cli/commands/_index.md
@@ -15,12 +15,12 @@ menu:
 
 The most common commands in the CLI that you'll be using are as follows:
 
-* [`pulumi new`](/docs/cli/commands/pulumi_new/): creates a new project using a template
-* [`pulumi stack`](/docs/cli/commands/pulumi_stack/): manage your stacks (at least one is required to perform an update)
-* [`pulumi config`](/docs/cli/commands/pulumi_config/): configure variables such as keys, regions, and so on
-* [`pulumi up`](/docs/cli/commands/pulumi_up/): preview and deploy changes to your program and/or infrastructure
-* [`pulumi preview`](/docs/cli/commands/pulumi_preview/): preview your changes explicitly before deploying
-* [`pulumi destroy`](/docs/cli/commands/pulumi_destroy/): destroy your program and its infrastructure when you're done
+* [`pulumi new`](/docs/iac/cli/commands/pulumi_new/): creates a new project using a template
+* [`pulumi stack`](/docs/iac/cli/commands/pulumi_stack/): manage your stacks (at least one is required to perform an update)
+* [`pulumi config`](/docs/iac/cli/commands/pulumi_config/): configure variables such as keys, regions, and so on
+* [`pulumi up`](/docs/iac/cli/commands/pulumi_up/): preview and deploy changes to your program and/or infrastructure
+* [`pulumi preview`](/docs/iac/cli/commands/pulumi_preview/): preview your changes explicitly before deploying
+* [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy/): destroy your program and its infrastructure when you're done
 
 ## Complete Reference
 

--- a/content/docs/iac/cli/commands/pulumi_history.md
+++ b/content/docs/iac/cli/commands/pulumi_history.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /docs/cli/commands/pulumi_stack_history/
+redirect_to: /docs/iac/cli/commands/pulumi_stack_history/
 ---

--- a/content/docs/iac/clouds/aws/guides/lambda.md
+++ b/content/docs/iac/clouds/aws/guides/lambda.md
@@ -556,7 +556,7 @@ authors and manages the serverless functions attached to them. For more informat
 
 ## Easy Lambda log consumption
 
-Lambda functions automatically emit logs to Amazon CloudWatch. The [`pulumi logs`](/docs/cli/commands/pulumi_logs/) CLI command allows
+Lambda functions automatically emit logs to Amazon CloudWatch. The [`pulumi logs`](/docs/iac/cli/commands/pulumi_logs/) CLI command allows
 you to monitor your infrastructure's CloudWatch logs in real time. For Lambda functions, this means
 you can run `pulumi logs -f` (`--force`) to stream all of the logs from all of the Lambdas that belong to the current stack.
 

--- a/content/docs/iac/comparisons/cloud-templates/cloudformation/_index.md
+++ b/content/docs/iac/comparisons/cloud-templates/cloudformation/_index.md
@@ -180,7 +180,7 @@ For more information on managing secrets with Pulumi, see [Secrets](/docs/concep
 
 ### Drift Detection and Correction {#drift-detection}
 
-Both Pulumi and CloudFormation support _drift detection_, which allows you to detect and correct configuration changes that occur outside of the IaC-managed workflow --- for example, as a result of a change made manually in the AWS Console or with the AWS CLI. Whereas CloudFormation's drift detection happens within the CloudFormation service, in Pulumi, it's built into the Pulumi CLI, and can be performed either on demand with `pulumi refresh` or as part of the normal deployment workflow by passing the `--refresh` option. For more information, see [`pulumi up`](/docs/cli/commands/pulumi_up) and [`pulumi refresh`](/docs/cli/commands/pulumi_refresh).
+Both Pulumi and CloudFormation support _drift detection_, which allows you to detect and correct configuration changes that occur outside of the IaC-managed workflow --- for example, as a result of a change made manually in the AWS Console or with the AWS CLI. Whereas CloudFormation's drift detection happens within the CloudFormation service, in Pulumi, it's built into the Pulumi CLI, and can be performed either on demand with `pulumi refresh` or as part of the normal deployment workflow by passing the `--refresh` option. For more information, see [`pulumi up`](/docs/iac/cli/commands/pulumi_up) and [`pulumi refresh`](/docs/iac/cli/commands/pulumi_refresh).
 
 ### Stack Configuration and Deployment Environments {#configuration}
 

--- a/content/docs/iac/comparisons/terraform/terminology.md
+++ b/content/docs/iac/comparisons/terraform/terminology.md
@@ -42,7 +42,7 @@ If you're already familiar with Terraform, learning Pulumi terminology and comma
 | Module | [Component](/docs/concepts/resources/components/) |
 | Resource | [Resource](/docs/concepts/resources/) |
 | Interpolation | [Interpolation](/docs/concepts/inputs-outputs#outputs-and-strings) |
-| Run | [Up](/docs/cli/commands/pulumi_up/) |
+| Run | [Up](/docs/iac/cli/commands/pulumi_up/) |
 | Output Values | [Outputs](/docs/concepts/inputs-outputs/) |
 | State | [State](/docs/concepts/state/) |
 | State Version | [Update Events](/docs/reference/service-rest-api#list-update-events) |

--- a/content/docs/iac/concepts/functions/get-functions.md
+++ b/content/docs/iac/concepts/functions/get-functions.md
@@ -18,7 +18,7 @@ aliases:
 - /docs/concepts/resources/get/
 ---
 
-You can use the static `get` function, which is available on all resource types, to look up an existing resource that is not managed by Pulumi. The `get` function is different from the [`import` CLI command](/docs/cli/commands/pulumi_import): `pulumi import` is used to bring an existing resource under management by Pulumi. `get` is used to allow the attributes of an existing resource to be used within a Pulumi program. A resource read with the `get` function will never be updated or deleted by Pulumi during an update.
+You can use the static `get` function, which is available on all resource types, to look up an existing resource that is not managed by Pulumi. The `get` function is different from the [`import` CLI command](/docs/iac/cli/commands/pulumi_import): `pulumi import` is used to bring an existing resource under management by Pulumi. `get` is used to allow the attributes of an existing resource to be used within a Pulumi program. A resource read with the `get` function will never be updated or deleted by Pulumi during an update.
 
 Two values are passed to the `get` function:
 

--- a/content/docs/iac/concepts/how-pulumi-works.md
+++ b/content/docs/iac/concepts/how-pulumi-works.md
@@ -47,10 +47,10 @@ The deployment engine is embedded in the `pulumi` CLI itself.
 
 A resource provider is made up of two different pieces:
 
-1. A _resource plugin_ is the binary used by the deployment engine to manage a resource. These plugins are stored in the _plugin cache_ (located in `~/.pulumi/plugins`) and can be managed using the [`pulumi plugin`](/docs/cli/commands/pulumi_plugin) set of commands.
+1. A _resource plugin_ is the binary used by the deployment engine to manage a resource. These plugins are stored in the _plugin cache_ (located in `~/.pulumi/plugins`) and can be managed using the [`pulumi plugin`](/docs/iac/cli/commands/pulumi_plugin) set of commands.
 2. An _SDK_ which provides bindings for each type of resource the provider can manage.
 
-Like the language runtime itself, the SDKs are available as regular packages. For example, there is a [`@pulumi/aws`](https://www.npmjs.com/package/@pulumi/aws) package for Node available on npm and a [`pulumi_aws`](https://pypi.org/project/pulumi-aws) package for Python available on PyPI.  When these packages are added to your project, they run [`pulumi plugin install`](/docs/cli/commands/pulumi_plugin_install) behind the scenes to download the resource plugin from Pulumi.com.
+Like the language runtime itself, the SDKs are available as regular packages. For example, there is a [`@pulumi/aws`](https://www.npmjs.com/package/@pulumi/aws) package for Node available on npm and a [`pulumi_aws`](https://pypi.org/project/pulumi-aws) package for Python available on PyPI.  When these packages are added to your project, they run [`pulumi plugin install`](/docs/iac/cli/commands/pulumi_plugin_install) behind the scenes to download the resource plugin from Pulumi.com.
 
 ## Putting it all together
 

--- a/content/docs/iac/concepts/projects/_index.md
+++ b/content/docs/iac/concepts/projects/_index.md
@@ -22,7 +22,7 @@ aliases:
 - /docs/concepts/projects/
 ---
 
-A Pulumi project is any folder that contains a `Pulumi.yaml` project file. At runtime, the nearest parent folder containing a `Pulumi.yaml` file determines the current project. Projects are created with the [`pulumi new`](/docs/cli/commands/pulumi_new/) command.
+A Pulumi project is any folder that contains a `Pulumi.yaml` project file. At runtime, the nearest parent folder containing a `Pulumi.yaml` file determines the current project. Projects are created with the [`pulumi new`](/docs/iac/cli/commands/pulumi_new/) command.
 
 ## The project file (Pulumi.yaml) {#pulumi-yaml}
 

--- a/content/docs/iac/concepts/providers/dynamic-providers.md
+++ b/content/docs/iac/concepts/providers/dynamic-providers.md
@@ -358,8 +358,8 @@ The `delete` operation is invoked if the URN exists in the previous state but no
 The `read` method is invoked in three scenarios:
 
 1. When using the static [`get` method](/docs/iac/concepts/resources/get/) to read an existing resource that is not managed by Pulumi.
-1. When using [`pulumi import`](/docs/cli/commands/pulumi_import/) to import an existing resource into Pulumi management.
-1. When running [`pulumi refresh`](/docs/cli/commands/pulumi_refresh/) to synchronize the state with the actual state of the resource in the cloud provider.
+1. When using [`pulumi import`](/docs/iac/cli/commands/pulumi_import/) to import an existing resource into Pulumi management.
+1. When running [`pulumi refresh`](/docs/iac/cli/commands/pulumi_refresh/) to synchronize the state with the actual state of the resource in the cloud provider.
 
 The method is passed the `id` of the resource, as tracked in the cloud provider, and an optional bag of additional properties that can be used to disambiguate the request, if needed. The `read` method looks up the requested resource, and returns the canonical `id` and output properties of this resource if found. If an error occurs, an exception can be thrown from the `read` method to return this error to the user.
 

--- a/content/docs/iac/concepts/resources/options/protect.md
+++ b/content/docs/iac/concepts/resources/options/protect.md
@@ -20,7 +20,7 @@ The `protect` resource option marks a resource as protected. A protected resourc
 To delete a protected resource, it must first be *unprotected*. There are two ways to unprotect a resource:
 
 * Set `protect: false` and then run `pulumi up`
-* Use the [`pulumi state unprotect`](/docs/cli/commands/pulumi_state_unprotect) command
+* Use the [`pulumi state unprotect`](/docs/iac/cli/commands/pulumi_state_unprotect) command
 
 Once the resource is unprotected, it can be deleted as part of a following update.
 

--- a/content/docs/iac/concepts/secrets/_index.md
+++ b/content/docs/iac/concepts/secrets/_index.md
@@ -557,14 +557,14 @@ $ pulumi stack init my-stack \
 
 ### Changing the secrets provider for a stack
 
-To change the secrets provider for an existing stack use the [`pulumi stack change-secrets-provider`](/docs/cli/commands/pulumi_stack_change-secrets-provider) command.
+To change the secrets provider for an existing stack use the [`pulumi stack change-secrets-provider`](/docs/iac/cli/commands/pulumi_stack_change-secrets-provider) command.
 
 ```bash
 $ pulumi stack change-secrets-provider "<secrets-provider>"
 ```
 
 This will change the encrypted secrets in the provider configuration and the stack's state file to use the new secrets provider.
-The [supported secrets providers](/docs/cli/commands/pulumi_stack_init/) are:
+The [supported secrets providers](/docs/iac/cli/commands/pulumi_stack_init/) are:
 
 - `default`
 - `passphrase`
@@ -589,7 +589,7 @@ config:
 
 Decrypting this ciphertext requires the encryption key that was used to create it. For stacks managed with Pulumi Cloud, these keys are obtained automatically, but only for users with [read access](/docs/deployments/projects-and-stacks/#stack-permissions) to the stack. For DIY backends, the keys must be supplied by the user, either by providing the stack's current passphrase (when using the [`passphrase`](#changing-the-secrets-provider-for-a-stack) provider) or by authenticating with the stack's [encryption provider](#available-encryption-providers).
 
-It's therefore considered safe and good practice to check these files into source control (including the `encryptionSalt`s used with the passphrase provider or `encryptedKey` when one of the other secrets providers), as doing so allows you to version your code and configuration in tandem. If you'd prefer not to check in these files, however, you can easily rebuild them, using the most recently deployed configuration, with [`pulumi config refresh`](/docs/cli/commands/pulumi_config_refresh/).
+It's therefore considered safe and good practice to check these files into source control (including the `encryptionSalt`s used with the passphrase provider or `encryptedKey` when one of the other secrets providers), as doing so allows you to version your code and configuration in tandem. If you'd prefer not to check in these files, however, you can easily rebuild them, using the most recently deployed configuration, with [`pulumi config refresh`](/docs/iac/cli/commands/pulumi_config_refresh/).
 
 ## Managing secrets with Pulumi ESC environments
 

--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -57,7 +57,7 @@ dev
 In some contexts, stack names will be presented in their fully-qualified format (`orgName/projectName/stackName`) even if provided using shorthand (`stackName` or `orgName/stackName`) as input.
 
 {{% notes type="info" %}}
-While stacks with applied configuration settings will often be accompanied by `Pulumi.<stack-name>.yaml` files, these files are not created by `pulumi stack init`. They are created and managed with [`pulumi config`](/docs/cli/commands/pulumi_config/). For information on how to populate your stack configuration files, see [Configuration](/docs/concepts/config/).
+While stacks with applied configuration settings will often be accompanied by `Pulumi.<stack-name>.yaml` files, these files are not created by `pulumi stack init`. They are created and managed with [`pulumi config`](/docs/iac/cli/commands/pulumi_config/). For information on how to populate your stack configuration files, see [Configuration](/docs/concepts/config/).
 {{% /notes %}}
 
 ## Listing stacks
@@ -144,17 +144,17 @@ Use `pulumi stack select` to change stack; `pulumi stack ls` lists known ones
 
 ## Stack tags
 
-Stacks have associated metadata in the form of tags, with each tag consisting of a name and value. A set of built-in tags are automatically assigned and updated each time a stack is updated (such as `pulumi:project`, `pulumi:runtime`, `pulumi:description`, `gitHub:owner`, `gitHub:repo`, `vcs:owner`, `vcs:repo`, and `vcs:kind`). To view a stack's tags, run [`pulumi stack tag ls`](/docs/cli/commands/pulumi_stack_tag_ls).
+Stacks have associated metadata in the form of tags, with each tag consisting of a name and value. A set of built-in tags are automatically assigned and updated each time a stack is updated (such as `pulumi:project`, `pulumi:runtime`, `pulumi:description`, `gitHub:owner`, `gitHub:repo`, `vcs:owner`, `vcs:repo`, and `vcs:kind`). To view a stack's tags, run [`pulumi stack tag ls`](/docs/iac/cli/commands/pulumi_stack_tag_ls).
 
 {{% notes "info" %}}
 Stack tags are only supported with the [Pulumi Cloud backend](/docs/concepts/state/).
 {{% /notes %}}
 
-Custom tags can be assigned to a stack by running [`pulumi stack tag set <name> <value>`](/docs/cli/commands/pulumi_stack_tag_set) and can be used to customize the grouping of stacks in the [Pulumi Cloud](https://app.pulumi.com). For example, if you have many projects with separate stacks for production, staging, and testing environments, it may be useful to group stacks by environment instead of by project. To do this, you could assign a custom tag named `environment` to each stack. For example, running `pulumi stack tag set environment production` assigns a custom `environment` tag with a value of `production` to the active stack. Once you've assigned an `environment` tag to each stack, you'll be able to group by `Tag: environment` in Pulumi Cloud.
+Custom tags can be assigned to a stack by running [`pulumi stack tag set <name> <value>`](/docs/iac/cli/commands/pulumi_stack_tag_set) and can be used to customize the grouping of stacks in the [Pulumi Cloud](https://app.pulumi.com). For example, if you have many projects with separate stacks for production, staging, and testing environments, it may be useful to group stacks by environment instead of by project. To do this, you could assign a custom tag named `environment` to each stack. For example, running `pulumi stack tag set environment production` assigns a custom `environment` tag with a value of `production` to the active stack. Once you've assigned an `environment` tag to each stack, you'll be able to group by `Tag: environment` in Pulumi Cloud.
 
 As a best practice, custom tags should not be prefixed with `pulumi:`, `gitHub:`, or `vcs:` to avoid conflicting with built-in tags that are assigned and updated with fresh values each time a stack is updated.
 
-Tags can be deleted by running [`pulumi stack tag rm <name>`](/docs/cli/commands/pulumi_stack_tag_rm).
+Tags can be deleted by running [`pulumi stack tag rm <name>`](/docs/iac/cli/commands/pulumi_stack_tag_rm).
 
 ## Stack outputs {#outputs}
 
@@ -228,7 +228,7 @@ outputs:
 
 {{< /chooser >}}
 
-From the CLI, you can then use [`pulumi stack output url`](/docs/cli/commands/pulumi_stack_output) to get the value and incorporate into other scripts or tools.
+From the CLI, you can then use [`pulumi stack output url`](/docs/iac/cli/commands/pulumi_stack_output) to get the value and incorporate into other scripts or tools.
 
 The value of a stack export can be a regular value, an [Output](/docs/concepts/inputs-outputs/), or a `Promise` (effectively, the same as an [Input](/docs/concepts/inputs-outputs/)). The actual values are resolved after `pulumi up` completes.
 

--- a/content/docs/iac/concepts/state-and-backends.md
+++ b/content/docs/iac/concepts/state-and-backends.md
@@ -80,13 +80,13 @@ To choose a DIY backend, use the `pulumi login` command [as documented below](#u
 
 ## Logging into and out of State Backends
 
-The [`login` command](/docs/cli/commands/pulumi_login) logs you into a backend:
+The [`login` command](/docs/iac/cli/commands/pulumi_login) logs you into a backend:
 
 ```sh
 $ pulumi login
 ```
 
-The [`logout` command](/docs/cli/commands/pulumi_logout) logs you out of the current backend.
+The [`logout` command](/docs/iac/cli/commands/pulumi_logout) logs you out of the current backend.
 
 ```sh
 $ pulumi logout
@@ -120,7 +120,7 @@ If you forget to log in, you will be automatically prompted to do so before you 
 
 After logging in, your credentials are recorded in the `~/.pulumi/credentials.json` file, and all subsequent operations will use the chosen backend. From time to time, you will see a helpful URL to your update or stack pages. For example, after an update completes, you will see a link to that update's details. You can always go there to see a full history of updates.
 
-If you ever want to check what user is logged in, use the [`whoami` command](/docs/cli/commands/pulumi_whoami). To additionally see what  backend is currently being used, pass the `--verbose` (or `-v`) flag:
+If you ever want to check what user is logged in, use the [`whoami` command](/docs/iac/cli/commands/pulumi_whoami). To additionally see what  backend is currently being used, pass the `--verbose` (or `-v`) flag:
 
 ```bash
 $ pulumi whoami -v
@@ -302,7 +302,7 @@ Existing DIY backends will continue to use the global namespace for stacks. You 
 
 It is possible to start with one backend and then later migrate to another. This is common if you have began your project with Pulumi using a DIY backend but later decided to adopt Pulumi Cloud for easier use within your team. This section describes how to perform this operation, however, if you would like our assistance with a migration, [please get in touch](/contact/).
 
-The state for a stack includes information about its backend as well as other unique information such as its encryption provider. As such, moving a stack between backends isn't as simple as merely copying its state file. The [`pulumi stack rename` command](/docs/cli/commands/pulumi_stack_rename) can be used for simple renames within the same backend; however, Pulumi also supports migrating stacks between backends using the `pulumi stack export` and `pulumi stack import` commands, which understand how to perform the necessary translations.
+The state for a stack includes information about its backend as well as other unique information such as its encryption provider. As such, moving a stack between backends isn't as simple as merely copying its state file. The [`pulumi stack rename` command](/docs/iac/cli/commands/pulumi_stack_rename) can be used for simple renames within the same backend; however, Pulumi also supports migrating stacks between backends using the `pulumi stack export` and `pulumi stack import` commands, which understand how to perform the necessary translations.
 
 As an example, imagine you'd like to migrate a stack named `my-app-production` from a DIY backend to the Pulumi Cloud backend. To perform the migration, run the following sequence commands:
 
@@ -411,10 +411,10 @@ To learn more about available encryption providers and how to customize your sta
 
 ### Exporting and Importing State
 
-The `pulumi stack export` and `pulumi stack import` commands can be used to export the latest or a specific version of a stack's state. This can be used to inspect or even manually edit the contents for advanced use cases. For more information on usage, [refer to the CLI documentation](/docs/cli/commands/pulumi_stack/).
+The `pulumi stack export` and `pulumi stack import` commands can be used to export the latest or a specific version of a stack's state. This can be used to inspect or even manually edit the contents for advanced use cases. For more information on usage, [refer to the CLI documentation](/docs/iac/cli/commands/pulumi_stack/).
 
 ### Editing State Manually
 
 Although Pulumi was designed to shield you from manually needing to manage state, there are some circumstances where you will want or need to. This includes certain catastrophic failure scenarios, adding, deleting, renaming resources, and other advanced scenarios.
 
-The Pulumi state file uses a relatively easy to understand JSON format. The precise JSON format these state files use is not documented, but is defined in the [APIType source code](https://github.com/pulumi/pulumi/tree/master/sdk/go/common/apitype/). The [`state` command](/docs/cli/commands/pulumi_state) also includes some helpful commands to edit your state.
+The Pulumi state file uses a relatively easy to understand JSON format. The precise JSON format these state files use is not documented, but is defined in the [APIType source code](https://github.com/pulumi/pulumi/tree/master/sdk/go/common/apitype/). The [`state` command](/docs/iac/cli/commands/pulumi_state) also includes some helpful commands to edit your state.

--- a/content/docs/iac/get-started/aws/destroy-stack.md
+++ b/content/docs/iac/get-started/aws/destroy-stack.md
@@ -92,7 +92,7 @@ At this stage, your stack still exists, but all cloud resources have been delete
 ## Remove the stack
 
 The final step is to remove the stack itself. Destroy keeps the stack around so that you still have the full
-history of what happened to the stack. Running [`pulumi stack rm`](/docs/cli/commands/pulumi_stack_rm) will
+history of what happened to the stack. Running [`pulumi stack rm`](/docs/iac/cli/commands/pulumi_stack_rm) will
 delete it entirely, including all history and state snapshots. Be careful, this step cannot be undone!
 
 {{% choosable "os" "macos,linux" %}}

--- a/content/docs/iac/get-started/azure/destroy-stack.md
+++ b/content/docs/iac/get-started/azure/destroy-stack.md
@@ -85,7 +85,7 @@ At this stage, your stack still exists, but all cloud resources have been delete
 ## Remove the stack
 
 The final step is to remove the stack itself. Destroy keeps the stack around so that you still have the full
-history of what happened to the stack. Running [`pulumi stack rm`](/docs/cli/commands/pulumi_stack_rm) will
+history of what happened to the stack. Running [`pulumi stack rm`](/docs/iac/cli/commands/pulumi_stack_rm) will
 delete it entirely, including all history and state snapshots. Be careful, this step cannot be undone!
 
 {{% choosable "os" "macos,linux" %}}

--- a/content/docs/iac/get-started/gcp/destroy-stack.md
+++ b/content/docs/iac/get-started/gcp/destroy-stack.md
@@ -86,7 +86,7 @@ At this stage, your stack still exists, but all cloud resources have been delete
 ## Remove the stack
 
 The final step is to remove the stack itself. Destroy keeps the stack around so that you still have the full
-history of what happened to the stack. Running [`pulumi stack rm`](/docs/cli/commands/pulumi_stack_rm) will
+history of what happened to the stack. Running [`pulumi stack rm`](/docs/iac/cli/commands/pulumi_stack_rm) will
 delete it entirely, including all history and state snapshots. Be careful, this step cannot be undone!
 
 {{% choosable "os" "macos,linux" %}}

--- a/content/docs/iac/get-started/kubernetes/destroy-stack.md
+++ b/content/docs/iac/get-started/kubernetes/destroy-stack.md
@@ -86,7 +86,7 @@ At this stage, your stack still exists, but all cloud resources have been delete
 ## Remove the stack
 
 The final step is to remove the stack itself. Destroy keeps the stack around so that you still have the full
-history of what happened to the stack. Running [`pulumi stack rm`](/docs/cli/commands/pulumi_stack_rm) will
+history of what happened to the stack. Running [`pulumi stack rm`](/docs/iac/cli/commands/pulumi_stack_rm) will
 delete it entirely, including all history and state snapshots. Be careful, this step cannot be undone!
 
 {{% choosable "os" "macos,linux" %}}

--- a/content/docs/iac/guides/continuous-delivery/jenkins.md
+++ b/content/docs/iac/guides/continuous-delivery/jenkins.md
@@ -32,7 +32,7 @@ altered to fit into any existing type of deployment setup.
 - A working installation of a recent version of Jenkins.
 - An account in the [Pulumi Cloud](https://app.pulumi.com).
 - The [latest version of Pulumi](/docs/install/).
-- Setup a new project and [stack](/docs/concepts/) using one of our [Get Started](/docs/get-started/) guides or by running [`pulumi new`](/docs/cli/commands/pulumi_new)
+- Setup a new project and [stack](/docs/concepts/) using one of our [Get Started](/docs/get-started/) guides or by running [`pulumi new`](/docs/iac/cli/commands/pulumi_new)
 and choosing one of the many templates that are available.
 - A bare repo and set the remote URL to be your GitHub project.
 
@@ -43,13 +43,13 @@ You can download an [example project](https://github.com/pulumi/examples/tree/84
 ## Stack and Branch Mappings
 
 The scripts below act on a hypothetical stack: `homer/acme/product-catalog-service-stack`.
-You can create a new stack by running [`pulumi stack init`](/docs/cli/commands/pulumi_stack_init) if you have already created a project.
+You can create a new stack by running [`pulumi stack init`](/docs/iac/cli/commands/pulumi_stack_init) if you have already created a project.
 The source code for the stack is in a repository in GitHub and uses TypeScript as the language.
 
 **Note**: The names used above are purely for demonstration purposes only.
 You may choose a naming convention that best suits your organization.
 
-Alternatively, you can also run `pulumi new [template]` to create a [template project](/docs/cli/commands/pulumi_new/).
+Alternatively, you can also run `pulumi new [template]` to create a [template project](/docs/iac/cli/commands/pulumi_new/).
 
 ## PULUMI_ACCESS_TOKEN
 

--- a/content/docs/iac/guides/continuous-delivery/octopus-deploy.md
+++ b/content/docs/iac/guides/continuous-delivery/octopus-deploy.md
@@ -23,7 +23,7 @@ aliases:
 - A working installation of Octopus or a hosted instance from [https://octopus.com](https://octopus.com).
 - An account in the [Pulumi Cloud](https://app.pulumi.com).
 - The [latest version of Pulumi](/docs/install/).
-- Setup a new project and [stack](/docs/concepts/stack/) using one of our [Get Started](/docs/get-started/) guides or by running [`pulumi new`](/docs/cli/commands/pulumi_new)
+- Setup a new project and [stack](/docs/concepts/stack/) using one of our [Get Started](/docs/get-started/) guides or by running [`pulumi new`](/docs/iac/cli/commands/pulumi_new)
 and choosing one of the many templates that are available.
 - Optionally, also create a CI pipeline from a source control repository of your choice to be the source of packages. You will learn more about packages and how to create them later in this guide.
 
@@ -34,7 +34,7 @@ For the sake of this walkthrough, we will try to deploy an [AWS example](https:/
 ## Stack and Branch Mappings
 
 The steps below act on a hypothetical stack: `my-org/my-project/aws-ts-hello-fargate`.
-You can create a new stack by running [`pulumi stack init`](/docs/cli/commands/pulumi_stack_init) from the folder containing the `Pulumi.yaml` file.
+You can create a new stack by running [`pulumi stack init`](/docs/iac/cli/commands/pulumi_stack_init) from the folder containing the `Pulumi.yaml` file.
 
 **Note**: The names used above are purely for demonstration purposes only.
 You may choose a naming convention that best suits your organization.

--- a/content/docs/iac/guides/continuous-delivery/spinnaker.md
+++ b/content/docs/iac/guides/continuous-delivery/spinnaker.md
@@ -52,7 +52,7 @@ purposes only. You may choose a different name that best suits your use case.
 
 * Depending on your use-case, you may want to create the Pulumi Stack ahead of time.
 * You can create a new stack in the [Pulumi Cloud](https://app.pulumi.com/site/new-project).
-* Alternatively, you can also run `pulumi new [template]` to create a [template project](/docs/cli/commands/pulumi_new/)
+* Alternatively, you can also run `pulumi new [template]` to create a [template project](/docs/iac/cli/commands/pulumi_new/)
 on your machine and push it to your Version Control System (VCS) repository.
 
 The source code used as an [example](https://github.com/pulumi/examples/tree/master/kubernetes-ts-nginx) in this guide

--- a/content/docs/iac/guides/continuous-delivery/teamcity.md
+++ b/content/docs/iac/guides/continuous-delivery/teamcity.md
@@ -24,7 +24,7 @@ This page details how to use [JetBrains TeamCity](https://www.jetbrains.com/team
 - An account in the [Pulumi Cloud](https://app.pulumi.com).
 - [Latest version of Pulumi](/docs/install/).
 - Setup a new project and [stack](/docs/concepts/stack/) using one of our
-[Get Started](/docs/get-started/) guides or by running [`pulumi new`](/docs/cli/commands/pulumi_new)
+[Get Started](/docs/get-started/) guides or by running [`pulumi new`](/docs/iac/cli/commands/pulumi_new)
 and choosing one of the many templates that are available.
 
 ## Sample Project

--- a/content/docs/iac/guides/migration/converters.md
+++ b/content/docs/iac/guides/migration/converters.md
@@ -18,7 +18,7 @@ aliases:
 
 The `pulumi convert` command allows you to translate supported sources to the various [languages that Pulumi supports](/docs/languages-sdks/), such as TypeScript, JavaScript, Go, Python, C#, or Java. Conversion sources are supported via [Pulumi plugins](/docs/iac/concepts/plugins/#converter-plugins), and include the ability to convert code from other IaC tools like Terraform and Azure Bicep. Pulumi YAML programs can also be converted to any other supported Pulumi language.
 
-For the detailed usage of this command and options, refer to the [pulumi convert CLI documentation.](https://www.pulumi.com/docs/cli/commands/pulumi_convert/)
+For the detailed usage of this command and options, refer to the [pulumi convert CLI documentation.](https://www.pulumi.com/docs/iac/cli/commands/pulumi_convert/)
 
 ### Supported source languages
 

--- a/content/docs/iac/guides/migration/import/_index.md
+++ b/content/docs/iac/guides/migration/import/_index.md
@@ -26,7 +26,7 @@ The first scenario is sometimes called _coexistence_, and you can learn more abo
 
 There are two ways to import an existing cloud resource into a Pulumi project:
 
-1. With the [`pulumi import`](/docs/cli/commands/pulumi_import) CLI command. This command imports the resource into the currently selected [stack](/docs/concepts/stack/) and generates code describing the resource's current configuration for you to add to your Pulumi program.
+1. With the [`pulumi import`](/docs/iac/cli/commands/pulumi_import) CLI command. This command imports the resource into the currently selected [stack](/docs/concepts/stack/) and generates code describing the resource's current configuration for you to add to your Pulumi program.
 
 1. In code, with the [`import` resource option](/docs/concepts/options/import/). This option is expressed as an additional property on a resource declaration that you write into your Pulumi program yourself.
 
@@ -68,11 +68,11 @@ $ pulumi import <type> <name> <id>
 
 * The third argument, `id`, is the value to use for the resource lookup in the cloud provider. This value should correspond to the designated lookup property specified in the Import section of the resource's API documentation in the Registry.
 
-For help identifying a resource's type token and lookup property, see [Where to find the type token and lookup property](#where-to-find) above. To learn more about the additional options available on the `pulumi import` command, see the [`import` command documentation](/docs/cli/commands/pulumi_import/).
+For help identifying a resource's type token and lookup property, see [Where to find the type token and lookup property](#where-to-find) above. To learn more about the additional options available on the `pulumi import` command, see the [`import` command documentation](/docs/iac/cli/commands/pulumi_import/).
 
 ### Example
 
-In this example, a previously provisioned Amazon S3 bucket named `company-infra-logs` is imported into a Pulumi stack named `dev` (the currently [selected](/docs/cli/commands/pulumi_stack_select/) stack) and given a resource name of `infra-logs`:
+In this example, a previously provisioned Amazon S3 bucket named `company-infra-logs` is imported into a Pulumi stack named `dev` (the currently [selected](/docs/iac/cli/commands/pulumi_stack_select/) stack) and given a resource name of `infra-logs`:
 
 ```bash
 $ pulumi import aws:s3/bucket:Bucket infra-logs company-infra-logs

--- a/content/docs/iac/languages-sdks/java/_index.md
+++ b/content/docs/iac/languages-sdks/java/_index.md
@@ -103,7 +103,7 @@ The Java Pulumi SDK is available to Go/Java developers in source form on [GitHub
 
 ### Plugin Acquisition
 
-Pulumi will try to auto-detect which [plugins](/docs/cli/commands/pulumi_plugin/?language=java) your program is using by analyzing your Java project dependencies and then auto-install them. For example, if a program references `com.pulumi.aws` it will automatically issue the equivalent of `$ pulumi plugin install resource aws`.
+Pulumi will try to auto-detect which [plugins](/docs/iac/cli/commands/pulumi_plugin/?language=java) your program is using by analyzing your Java project dependencies and then auto-install them. For example, if a program references `com.pulumi.aws` it will automatically issue the equivalent of `$ pulumi plugin install resource aws`.
 
 ### Running Pulumi with Maven and Gradle
 

--- a/content/docs/iac/languages-sdks/yaml/_index.md
+++ b/content/docs/iac/languages-sdks/yaml/_index.md
@@ -95,7 +95,7 @@ project and set up starter resources for the chosen cloud. The `yaml` template i
 
 By default, `pulumi new` provides a number of templates provided by Pulumi, but it can also use your own custom templates.
 
-To learn more about building and working with custom templates, see [Custom Templates](/docs/idp/concepts/templates) and the [`pulumi new`](/docs/cli/commands/pulumi_new/) docs.
+To learn more about building and working with custom templates, see [Custom Templates](/docs/idp/concepts/templates) and the [`pulumi new`](/docs/iac/cli/commands/pulumi_new/) docs.
 
 ## Pulumi Programming Model
 

--- a/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
+++ b/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
@@ -255,7 +255,7 @@ resources:
 
 ### Outputs and Stack References
 
-The value of [`outputs`](https://www.pulumi.com/docs/concepts/stack/#outputs) is an object whose keys are the logical names of the outputs that are available from outside the Pulumi stack (via [`pulumi stack output`](https://www.pulumi.com/docs/cli/commands/pulumi_stack_output/)), and whose values are potentially computed expressions that resolve to the values of the desired outputs.
+The value of [`outputs`](https://www.pulumi.com/docs/concepts/stack/#outputs) is an object whose keys are the logical names of the outputs that are available from outside the Pulumi stack (via [`pulumi stack output`](https://www.pulumi.com/docs/iac/cli/commands/pulumi_stack_output/)), and whose values are potentially computed expressions that resolve to the values of the desired outputs.
 
 ```yaml
 outputs:

--- a/content/docs/insights/policy/policy-packs/authoring.md
+++ b/content/docs/insights/policy/policy-packs/authoring.md
@@ -220,7 +220,7 @@ Create your first policy pack:
 
     Each resource is passed as `input` with metadata fields like `__name` (logical name), `__urn`, and `type`, plus all resource properties at the top level.
 
-    Use [OPA metadata annotations](https://www.openpolicyagent.org/docs/latest/annotations/) (`# METADATA` comment blocks) to provide a `title`, `description`, and remediation guidance (`custom.message`) for each rule. The analyzer extracts these annotations and reports them to Pulumi:
+    Use [OPA metadata annotations](https://www.openpolicyagent.org/docs/latest/policy-reference/#annotations) (`# METADATA` comment blocks) to provide a `title`, `description`, and remediation guidance (`custom.message`) for each rule. The analyzer extracts these annotations and reports them to Pulumi:
 
     ```rego
     package aws

--- a/content/docs/support/pulumi-cloud-faq.md
+++ b/content/docs/support/pulumi-cloud-faq.md
@@ -237,9 +237,9 @@ to sign-in.
 Yes. Signing-in with a GitLab account will create a new account. That
 means, your stacks and activity will stay with the other account. You
 can migrate them by performing a
-[`pulumi stack export`](/docs/cli/commands/pulumi_stack_export)
+[`pulumi stack export`](/docs/iac/cli/commands/pulumi_stack_export)
 from your source stack and then importing it using
-[`pulumi stack import`](/docs/cli/commands/pulumi_stack_import)
+[`pulumi stack import`](/docs/iac/cli/commands/pulumi_stack_import)
 in a new stack in your GitLab-based account.
 
 If you would like to add your GitLab identity to your _existing_ Pulumi account, you can

--- a/content/templates/container-service/aws/index.md
+++ b/content/templates/container-service/aws/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -66,7 +66,7 @@ memory
 image
 : Specifies the location of the Dockerfile used to build the container image that is run. Defaults to the Dockerfile in the `app` folder.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ### Using your own container image
 
@@ -79,7 +79,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/container-service/azure/index.md
+++ b/content/templates/container-service/azure/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -78,7 +78,7 @@ imageName
 imageTag
 : The tag applied to published container images. Defaults to `latest`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below:
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below:
 
 ```bash
 $ pulumi config set someProp ../some/value
@@ -87,7 +87,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/container-service/gcp/index.md
+++ b/content/templates/container-service/gcp/index.md
@@ -38,7 +38,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-You must supply an existing project ID and choose a region before deploying the container service. You can input both through the new-project wizard. The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+You must supply an existing project ID and choose a region before deploying the container service. You can input both through the new-project wizard. The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -77,7 +77,7 @@ imageName
 appPath
 : Specifies the location of the Dockerfile used to build the container image that is run. Defaults to the `./app` folder, which contains a "Hello World" example app.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below:
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below:
 
 ```bash
 $ pulumi config set someProp ../some/value
@@ -86,7 +86,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/kubernetes-application/helm-chart/index.md
+++ b/content/templates/kubernetes-application/helm-chart/index.md
@@ -39,7 +39,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. By default, it will install an Nginx ingress controller with Helm. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. By default, it will install an Nginx ingress controller with Helm. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -59,7 +59,7 @@ Projects created with the Helm Chart template expose the following [configuratio
 k8sNamespace
 : The name of the namespace to be created in your existing cluster. Defaults to `nginx-ingress`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ```bash
 $ pulumi config set someProp ../some/value
@@ -70,7 +70,7 @@ You can customize the Helm chart by passing values to it in your Pulumi code. An
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/kubernetes-application/web-application/index.md
+++ b/content/templates/kubernetes-application/web-application/index.md
@@ -39,7 +39,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. By default, it will install Nginx. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. By default, it will install Nginx. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -65,7 +65,7 @@ namespace
 replicas
 : The number of replicated Pods to be created in your new Deployment. Defaults to `1`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ```bash
 $ pulumi config set someProp ../some/value
@@ -74,7 +74,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/kubernetes/aws/index.md
+++ b/content/templates/kubernetes/aws/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -74,11 +74,11 @@ vpcNetworkCidr
 : The network CIDR to use for the VPC. Defaults to `10.0.0.0/16`.
 
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`).
-or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set).
+or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set).
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/kubernetes/azure/index.md
+++ b/content/templates/kubernetes/azure/index.md
@@ -41,7 +41,7 @@ mgmtGroupId
 sshPubKey
 : Contents of your public key which will be used for SSH access to the cluster nodes you will deploy.
 
-Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -79,7 +79,7 @@ prefixForDns
 nodeVmSize
 : The VM instance type used to run your nodes. Defaults to `Standard_DS2_v2`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below:
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below:
 
 ```bash
 $ pulumi config set someProp ../some/value
@@ -88,7 +88,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/kubernetes/gcp/index.md
+++ b/content/templates/kubernetes/gcp/index.md
@@ -41,7 +41,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 You must supply an existing project ID to deploy the cluster. You can input the project ID through the new-project wizard. No additional configuration is required.
 
-Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -79,7 +79,7 @@ gcp:region
 nodesPerZone
 : The desired number of nodes per zone in the nodepool. Defaults to `1`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below:
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below:
 
 ```bash
 $ pulumi config set someProp ../some/value
@@ -88,7 +88,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/serverless-application/aws/index.md
+++ b/content/templates/serverless-application/aws/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it’s done, you’l
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -62,7 +62,7 @@ None of these settings is required; by default, the AWS Serverless template is s
 
 If you already have a website you'd like to deploy, you can do so by replacing contents of the `www` folder and redeploying with `pulumi up`.
 
-Alternatively, you can configure the stack to deploy from another folder on your machine by using [`pulumi config set`](/docs/cli/commands/pulumi_config_set) to change the value of the `path` setting:
+Alternatively, you can configure the stack to deploy from another folder on your machine by using [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) to change the value of the `path` setting:
 
 ```bash
 $ pulumi config set path ../my-website/dist
@@ -75,7 +75,7 @@ You can customize the placeholder website's functionality by editing the Lambda 
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/serverless-application/azure/index.md
+++ b/content/templates/serverless-application/azure/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -69,7 +69,7 @@ indexDocument
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set).
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set).
 
 ```bash
 $ pulumi config set sitePath ../my-existing-website/build
@@ -78,7 +78,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/serverless-application/gcp/index.md
+++ b/content/templates/serverless-application/gcp/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -69,7 +69,7 @@ indexDocument
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ```bash
 $ pulumi config set www_path ../my-existing-website/build
@@ -78,7 +78,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/static-website/aws/index.md
+++ b/content/templates/static-website/aws/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -72,7 +72,7 @@ indexDocument
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ### Using your own web content
 
@@ -749,7 +749,7 @@ Integration details vary by provider, so we suggest exploring the Pulumi API doc
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/static-website/azure/index.md
+++ b/content/templates/static-website/azure/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -72,7 +72,7 @@ indexDocument
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ### Using your own web content
 
@@ -85,7 +85,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/static-website/gcp/index.md
+++ b/content/templates/static-website/gcp/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -72,7 +72,7 @@ indexDocument
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ### Using your own web content
 
@@ -85,7 +85,7 @@ $ pulumi up
 
 ## Tidying up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/virtual-machine/aws/index.md
+++ b/content/templates/virtual-machine/aws/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -66,11 +66,11 @@ instanceType
 vpcNetworkCidr
 : The network CIDR to use for the VPC. Defaults to `10.0.0.0/16`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ## Cleaning up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/virtual-machine/azure/index.md
+++ b/content/templates/virtual-machine/azure/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -78,11 +78,11 @@ servicePort
 sshPublicKey
 : The public key data to use for SSH authentication.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ## Cleaning up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/templates/virtual-machine/gcp/index.md
+++ b/content/templates/virtual-machine/gcp/index.md
@@ -33,7 +33,7 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/cli/commands/pulumi_up):
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
 ```bash
 $ pulumi up
@@ -72,11 +72,11 @@ instanceTag
 servicePort
 : The HTTP service port to expose on the VM. Defaults to `80`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/cli/commands/pulumi_config_set) as shown below.
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) as shown below.
 
 ## Cleaning up
 
-You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/cli/commands/pulumi_destroy):
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy):
 
 ```bash
 $ pulumi destroy

--- a/content/tutorials/cli-authentication/index.md
+++ b/content/tutorials/cli-authentication/index.md
@@ -24,7 +24,7 @@ weight: 999
 
 # A brief summary of the tutorial. It appears at the top of the tutorial page. Markdown is fine.
 summary: |
-    The [`pulumi login`](/docs/cli/commands/pulumi_login/) command is used to login to the Pulumi Cloud from the [Pulumi CLI](/docs/cli/). Logging in to the Pulumi Cloud enables you to manage your state, resources, and secrets in a secure way. In this tutorial, we'll demonstrate how to authenticate to the Pulumi Cloud using the Pulumi CLI.
+    The [`pulumi login`](/docs/iac/cli/commands/pulumi_login/) command is used to login to the Pulumi Cloud from the [Pulumi CLI](/docs/cli/). Logging in to the Pulumi Cloud enables you to manage your state, resources, and secrets in a secure way. In this tutorial, we'll demonstrate how to authenticate to the Pulumi Cloud using the Pulumi CLI.
 
 # A list of three to five things the reader will have learned by the end of the tutorial.
 youll_learn:
@@ -84,7 +84,7 @@ In both the browser and the CLI, you will receive a message to indicate that you
 
 ## Logging out of the CLI
 
-When you want to logout of the Pulumi CLI, run the [pulumi logout](/docs/cli/commands/pulumi_logout/) command. You will receive the following output that indicates you were logged out successfully:
+When you want to logout of the Pulumi CLI, run the [pulumi logout](/docs/iac/cli/commands/pulumi_logout/) command. You will receive the following output that indicates you were logged out successfully:
 
 ```bash
 $ pulumi logout
@@ -95,7 +95,7 @@ Logged out of https://api.pulumi.com
 
 In this tutorial, you learned how to authenticate to the Pulumi CLI using the browser and using a Pulumi access token. To learn more about using the CLI to create and manage resources in Pulumi, take a look at the following resources:
 
-- Learn more about the available CLI commands in the [Pulumi CLI documentation](/docs/cli/commands/).
+- Learn more about the available CLI commands in the [Pulumi CLI documentation](/docs/iac/cli/commands/).
 - Learn more about configuring Pulumi providers to work with Pulumi in the following resources:
   - [AWS Configuration](/docs/iac/get-started/aws/begin/#configure-pulumi-to-access-your-aws-account)
   - [Azure Configuration](/docs/iac/get-started/azure/begin/#configure-pulumi-to-access-your-microsoft-azure-account)

--- a/content/tutorials/inspecting-infrastructure/index.md
+++ b/content/tutorials/inspecting-infrastructure/index.md
@@ -54,7 +54,7 @@ The commands found in this tutorial can be run against any projects or stacks th
 
 {{< /notes >}}
 
-To start, login to the [Pulumi CLI](/docs/cli/commands/pulumi_login/) and ensure it is [configured to use your AWS account](/docs/iac/get-started/aws/begin/#configure-pulumi-to-access-your-aws-account). Next, [create a new project](/docs/iac/get-started/aws/create-project/) and replace the default program code with the following:
+To start, login to the [Pulumi CLI](/docs/iac/cli/commands/pulumi_login/) and ensure it is [configured to use your AWS account](/docs/iac/get-started/aws/begin/#configure-pulumi-to-access-your-aws-account). Next, [create a new project](/docs/iac/get-started/aws/create-project/) and replace the default program code with the following:
 
 {{< example-program path="aws-s3bucket-bucketpolicy" >}}
 
@@ -74,7 +74,7 @@ In this section, you will run a number of commands in the Pulumi CLI that will e
 
 ### pulumi stack
 
-The [pulumi stack](/docs/cli/commands/pulumi_stack/) command is used to provide a quick overview of the current stack's status and configuration. Running this command will list the management details, resources, and [output](/docs/concepts/inputs-outputs/#outputs) names and values of the current stack.
+The [pulumi stack](/docs/iac/cli/commands/pulumi_stack/) command is used to provide a quick overview of the current stack's status and configuration. Running this command will list the management details, resources, and [output](/docs/concepts/inputs-outputs/#outputs) names and values of the current stack.
 
 Run the `pulumi stack` command as shown below:
 
@@ -82,7 +82,7 @@ Run the `pulumi stack` command as shown below:
 
 ### pulumi stack graph
 
-The [pulumi stack graph <filename>](/docs/cli/commands/pulumi_stack_graph/) command is used to visualize the dependency graph of a Pulumi stack. This graphical representation can help users to understand the relationships and dependencies between resources in their infrastructure.
+The [pulumi stack graph <filename>](/docs/iac/cli/commands/pulumi_stack_graph/) command is used to visualize the dependency graph of a Pulumi stack. This graphical representation can help users to understand the relationships and dependencies between resources in their infrastructure.
 
 Run the `pulumi stack graph <filename>` command as shown below, making sure to replace `<filename>` with the name of the file that you want the graph to be exported to:
 
@@ -96,7 +96,7 @@ The output of the file will be in [Graphviz DOT format](https://graphviz.org/doc
 
 ### pulumi stack output
 
-The [pulumi stack output](/docs/cli/commands/pulumi_stack_output/) command is used to list all output names and values that are exported from a stack. This command helps to facilitate automation workflows and integration with other tools and scripts by providing easy access to important output values.
+The [pulumi stack output](/docs/iac/cli/commands/pulumi_stack_output/) command is used to list all output names and values that are exported from a stack. This command helps to facilitate automation workflows and integration with other tools and scripts by providing easy access to important output values.
 
 Run the `pulumi stack output` command as shown below:
 
@@ -108,7 +108,7 @@ You can return the value of just a single output by adding the name of the desir
 
 ### pulumi stack export
 
-The [pulumi stack export](/docs/cli/commands/pulumi_stack_export/) command is used to export the current state of a stack in JSON format to standard out. This state definition contains all the information about the resources, their states, and the configuration of the stack. The exported state can be used for things like backup, migration, or debugging purposes.
+The [pulumi stack export](/docs/iac/cli/commands/pulumi_stack_export/) command is used to export the current state of a stack in JSON format to standard out. This state definition contains all the information about the resources, their states, and the configuration of the stack. The exported state can be used for things like backup, migration, or debugging purposes.
 
 Run the `pulumi stack export` command as shown below:
 
@@ -116,7 +116,7 @@ Run the `pulumi stack export` command as shown below:
 
 ### pulumi preview
 
-The [pulumi preview](/docs/cli/commands/pulumi_preview/) command is an important tool for understanding the changes that will be made to your infrastructure before actually applying them. It does a dry run of the update, showing a detailed preview of the resources that will be created, updated, or deleted without making any actual changes to your cloud resources.
+The [pulumi preview](/docs/iac/cli/commands/pulumi_preview/) command is an important tool for understanding the changes that will be made to your infrastructure before actually applying them. It does a dry run of the update, showing a detailed preview of the resources that will be created, updated, or deleted without making any actual changes to your cloud resources.
 
 Before running this command, you will need to make a change to your Pulumi program. Change the name of your S3 bucket resource and then save your file.
 
@@ -128,7 +128,7 @@ Now run the `pulumi preview` command to display a preview of the updates that wi
 
 ### pulumi console
 
-The [pulumi console](/docs/cli/commands/pulumi_console/) command opens the current stack in the Pulumi Console, providing a graphical user interface to view and manage your Pulumi stack and resources. From there, you can view detailed information about the stack such as its resources, outputs, and configuration values.
+The [pulumi console](/docs/iac/cli/commands/pulumi_console/) command opens the current stack in the Pulumi Console, providing a graphical user interface to view and manage your Pulumi stack and resources. From there, you can view detailed information about the stack such as its resources, outputs, and configuration values.
 
 {{< video title="Running the pulumi console command" src="https://www.pulumi.com/uploads/aws-cli-pulumi-console.mp4" autoplay="true" loop="true" >}}
 
@@ -140,5 +140,5 @@ The [pulumi console](/docs/cli/commands/pulumi_console/) command opens the curre
 
 In this tutorial, you used a variety of Pulumi CLI commands to view more details about your infrastructure. To learn more about creating and managing resources in Pulumi, take a look at the following resources:
 
-- Learn more about the available CLI commands in the [Pulumi CLI documentation](/docs/cli/commands/).
+- Learn more about the available CLI commands in the [Pulumi CLI documentation](/docs/iac/cli/commands/).
 - Learn more about stack outputs and references in the [Stack Outputs and References](/tutorials/stack-outputs-and-references/) tutorial.

--- a/content/tutorials/managing-config-and-secrets/index.md
+++ b/content/tutorials/managing-config-and-secrets/index.md
@@ -45,7 +45,7 @@ estimated_time: 10
 
 ## Create a new project
 
-To start, login to the [Pulumi CLI](/docs/cli/commands/pulumi_login/). Next, create a new project by running the `pulumi new <language>` command, making sure to replace `<language>` with the supported language of your choice:
+To start, login to the [Pulumi CLI](/docs/iac/cli/commands/pulumi_login/). Next, create a new project by running the `pulumi new <language>` command, making sure to replace `<language>` with the supported language of your choice:
 
 ```bash
 # example using python

--- a/content/tutorials/move-resources-between-stacks/index.md
+++ b/content/tutorials/move-resources-between-stacks/index.md
@@ -392,6 +392,6 @@ In this tutorial, you created a Pulumi Random resource and AWS S3 resources. You
 To learn more about creating and managing resources in Pulumi, take a look a the following resources:
 
 - Learn more about Pulumi state and backends in the [Managing Pulumi State and Backend Options documentation](/docs/iac/concepts/state-and-backends/).
-- Learn more about the `pulumi state` command and its subcommands in the [Pulumi State CLI documentation](/docs/cli/commands/pulumi_state/).
+- Learn more about the `pulumi state` command and its subcommands in the [Pulumi State CLI documentation](/docs/iac/cli/commands/pulumi_state/).
 - Learn more about Pulumi stacks in the [Stacks concept documentation](/docs/concepts/stack/).
-- Learn more about the `pulumi stack` command and its subcommands in the [Pulumi Stack CLI documentation](https://www.pulumi.com/docs/cli/commands/pulumi_stack/).
+- Learn more about the `pulumi stack` command and its subcommands in the [Pulumi Stack CLI documentation](https://www.pulumi.com/docs/iac/cli/commands/pulumi_stack/).


### PR DESCRIPTION
Fixes #18084

The DocsBot link checker detected 28 broken links across docs, blog posts, and tutorials as of 2026-03-19. This PR resolves all of them.

## Changes

### Internal CLI command links (84 files)

84 files were referencing CLI commands via the old `/docs/cli/commands/` path, which no longer resolves following the IAC docs reorganization. All 174 occurrences have been updated to `/docs/iac/cli/commands/`, which is the current canonical path.

The affected files span:
- Blog posts referencing `pulumi up`, `pulumi config`, `pulumi destroy`, `pulumi preview`, `pulumi refresh`, `pulumi watch`, `pulumi stack`, `pulumi state`, and others
- Tutorial pages
- Core docs pages

### External broken links (2 files)

**RunPod API docs** (`content/blog/mlops-the-ai-challenge-is-cloud-not-code/index.md`):
- `https://docs.runpod.io/graphql-api` → `https://docs.runpod.io/get-started/api-keys` (the old URL returns 404; the new one covers RunPod API key setup, which is what the link was referencing)

**OPA annotations docs** (`content/docs/insights/policy/policy-packs/authoring.md`):
- `https://www.openpolicyagent.org/docs/latest/annotations/` → `https://www.openpolicyagent.org/docs/latest/policy-reference/#annotations` (the old URL returns 404; annotations are now documented in the policy reference page)

### Verified as not broken

The `materialize.com` link flagged in the issue (`content/case-studies/materialize.md`) returns HTTP 200 and required no change.

---
🧠 *This PR was created by [minime](https://github.com/minimebot) on behalf of @joeduffy.*