### PR TITLE
Fix Event schema issues reported by GWT

### DIFF
--- a/layouts/partials/schema/collectors/event-entity.html
+++ b/layouts/partials/schema/collectors/event-entity.html
@@ -24,28 +24,26 @@
   {{ $schema = merge $schema (dict "duration" .) }}
 {{ end }}
 
-{{/* Add location */}}
-{{ $location := .Params.location }}
-{{ if $location }}
-  {{ if eq $location "virtual" }}
-    {{/* Virtual event */}}
-    {{ $schema = merge $schema (dict
-      "eventAttendanceMode" "https://schema.org/OnlineEventAttendanceMode"
-      "location" (dict
-        "@type" "VirtualLocation"
-        "url" .Permalink
-      )
-    ) }}
-  {{ else }}
-    {{/* Physical location */}}
-    {{ $schema = merge $schema (dict
-      "eventAttendanceMode" "https://schema.org/OfflineEventAttendanceMode"
-      "location" (dict
-        "@type" "Place"
-        "name" $location
-      )
-    ) }}
-  {{ end }}
+{{/* Add location — default to virtual when not specified, since Google requires location for Event schema */}}
+{{ $location := .Params.location | default "virtual" }}
+{{ if eq $location "virtual" }}
+  {{/* Virtual event */}}
+  {{ $schema = merge $schema (dict
+    "eventAttendanceMode" "https://schema.org/OnlineEventAttendanceMode"
+    "location" (dict
+      "@type" "VirtualLocation"
+      "url" .Permalink
+    )
+  ) }}
+{{ else }}
+  {{/* Physical location */}}
+  {{ $schema = merge $schema (dict
+    "eventAttendanceMode" "https://schema.org/OfflineEventAttendanceMode"
+    "location" (dict
+      "@type" "Place"
+      "name" $location
+    )
+  ) }}
 {{ end }}
 
 {{/* Add event status - if external and block_external_search_index is true, might be past */}}

--- a/layouts/partials/schema/collectors/main-entity.html
+++ b/layouts/partials/schema/collectors/main-entity.html
@@ -33,8 +33,8 @@
       {{/* Tutorial pages get HowTo schema */}}
       {{ $entity = partial "schema/collectors/howto-entity.html" . }}
 
-    {{ else if eq .Type "events" }}
-      {{/* Events get Event schema */}}
+    {{ else if and (eq .Type "events") .IsPage }}
+      {{/* Individual event pages get Event schema (not the list page) */}}
       {{ $entity = partial "schema/collectors/event-entity.html" . }}
 
     {{ else if or (strings.Contains (lower .RelPermalink) "/faq") (strings.Contains (lower .Title) "faq") (strings.Contains (lower .Title) "frequently asked") }}


### PR DESCRIPTION
## Summary
- Default missing `location` to "virtual" in event schema markup so all event pages emit the required `location` field — fixes 38 pages flagged as invalid by Google Webmaster Tools
- Skip Event schema on the `/events/` list page (only apply to individual event pages) to avoid invalid Event markup on a non-event page

## Test plan
- [x] Verify event single pages include `VirtualLocation` in JSON-LD when no `location` is set in frontmatter
- [x] Verify `/events/` list page no longer emits Event schema
- [x] Verify events with explicit `location` (e.g. "virtual", "New York, NY") still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)