### PR TITLE
docs(get-functions): add warning about resource lookup failures

### DIFF
--- a/content/docs/iac/concepts/functions/get-functions.md
+++ b/content/docs/iac/concepts/functions/get-functions.md
@@ -149,5 +149,5 @@ resources:
 In the example above, Pulumi will never attempt to modify the security group. It queries the attributes of the security group from your cloud account and then uses its name as an input for the new EC2 Instance.
 
 {{% notes type="warning" %}}
-If the resource you are trying to look up does not exist, Pulumi will report an error and the program will fail.
+If the resource that you are trying to look up does not exist, Pulumi will throw an exception or error (depending on the language being used) and the program will terminate.
 {{% /notes %}}


### PR DESCRIPTION
## Summary

- Improved wording in the closing note of the get-functions example
- Added a warning callout explaining that Pulumi throws an exception if the looked-up resource does not exist

## Test plan

- [ ] Verify the warning callout renders correctly on the get-functions page