### PR TITLE
fix: add consent-manager JS to PurgeCSS content scan

### DIFF
--- a/scripts/minify-css.js
+++ b/scripts/minify-css.js
@@ -23,7 +23,7 @@ const bundles = [
     {
         name: "bundle",
         input: "public/css/bundle.*.css",
-        content: ["public/**/*.html", "public/js/bundle.*.js", "public/js/algolia.*.js"],
+        content: ["public/**/*.html", "public/js/bundle.*.js", "public/js/algolia.*.js", "public/js/consent-manager.*.js"],
         safelist: [
             ...sharedSafelist,
             /^icon-/,
@@ -47,13 +47,13 @@ const bundles = [
         // produces assets/css/marketing-homepage.css for Hugo dev mode.
         name: "marketing-homepage",
         input: "public/css/marketing.*.css",
-        content: ["public/index.html", "public/js/bundle.*.js"],
+        content: ["public/index.html", "public/js/bundle.*.js", "public/js/consent-manager.*.js"],
         safelist: [...sharedSafelist],
     },
     {
         name: "homepage",
         input: "public/css/homepage.*.css",
-        content: ["public/index.html", "public/js/bundle.*.js"],
+        content: ["public/index.html", "public/js/bundle.*.js", "public/js/consent-manager.*.js"],
         safelist: [...sharedSafelist],
     },
 ];


### PR DESCRIPTION
## Summary
- PurgeCSS strips all consent banner button styles in production because `consent-manager.*.js` is not in the content scan globs
- Added `consent-manager.*.js` to the `bundle`, `homepage`, and `marketing-homepage` PurgeCSS content arrays in `scripts/minify-css.js`

## Context
After replacing the Segment consent manager with vanilla TS (#18194), the consent banner buttons lost all styling (borders, backgrounds, padding) in production. The CSS source is correct and works locally (`make serve`), but the production build's PurgeCSS step (`scripts/minify-css.js`) never scans the separate `consent-manager.{hash}.js` webpack entry, so it removes all 17 `consent-*` classes as unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)