### PR TITLE
Fix .NET SDK docs 404 by reordering CloudFront cache behaviors

### DIFF
--- a/.github/workflows/post-deployment-health-check.yml
+++ b/.github/workflows/post-deployment-health-check.yml
@@ -121,7 +121,7 @@ jobs:
           check_endpoint "/registry" "Registry landing"
           check_endpoint "/docs/reference/pkg/nodejs/pulumi/pulumi/" "Node.js SDK"
           check_endpoint "/docs/reference/pkg/python/pulumi/" "Python SDK"
-          check_endpoint "/docs/reference/pkg/dotnet/Pulumi/Pulumi.html" ".NET SDK"
+          check_endpoint "/docs/reference/pkg/dotnet/pulumi/pulumi.html" ".NET SDK"
           check_endpoint "/docs/reference/pkg/java/" "Java SDK"
           check_endpoint "/docs/iac/get-started/" "Getting started"
           check_endpoint "/docs/cli/commands/" "CLI reference"

--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -57,7 +57,7 @@ iac:
     identifier: iac-languages-go-sdk
   - name: SDK docs ↗
     parent: iac-languages-dotnet
-    url: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
+    url: /docs/reference/pkg/dotnet/pulumi/pulumi.html
     weight: 1
     identifier: iac-languages-dotnet-sdk
   - name: SDK docs ↗
@@ -322,7 +322,7 @@ reference:
     identifier: reference-sdks-go
   - name: .NET ↗
     parent: reference-sdks
-    url: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
+    url: /docs/reference/pkg/dotnet/pulumi/pulumi.html
     weight: 4
     identifier: reference-sdks-dotnet
   - name: Java ↗

--- a/content/docs/iac/automation-api/_index.md
+++ b/content/docs/iac/automation-api/_index.md
@@ -105,7 +105,7 @@ Automation API supports cross-language implementations where it runs in a progra
 | <img src="/logos/tech/logo-ts.png" class="h-10" />     | [TypeScript](/docs/reference/pkg/nodejs/pulumi/pulumi/automation/) | Stable                                                            |
 | <img src="/logos/tech/logo-js.png" class="h-10" />     | [JavaScript](/docs/reference/pkg/nodejs/pulumi/pulumi/automation/) | Stable                                                            |
 | <img src="/logos/tech/logo-python.png" class="h-10" /> | [Python](/docs/reference/pkg/python/pulumi/#module-pulumi.automation) | Stable                                                           |
-| <img src="/logos/tech/dotnet.png" class="h-10" />      | [.NET](/docs/reference/pkg/dotnet/Pulumi.Automation/Pulumi.Automation.html) | Stable |
+| <img src="/logos/tech/dotnet.png" class="h-10" />      | [.NET](/docs/reference/pkg/dotnet/pulumi.automation/pulumi.automation.html) | Stable |
 | <img src="/logos/tech/logo-golang.png" class="h-10" /> | [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/auto?tab=doc) | Stable |
 | <img src="/logos/tech/java.svg" class="h-10" /> | [Java](/docs/reference/pkg/java/com/pulumi/automation/package-summary.html) | Stable |
 

--- a/content/docs/iac/concepts/inputs-outputs/_index.md
+++ b/content/docs/iac/concepts/inputs-outputs/_index.md
@@ -233,7 +233,7 @@ For a complete guide and examples for each language, see [Using output helpers](
 - [TypeScript (Node.js)](/docs/reference/pkg/nodejs/pulumi/pulumi/)
 - [Python](/docs/reference/pkg/python/pulumi/)
 - [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi)
-- [.NET](/docs/reference/pkg/dotnet/Pulumi/Pulumi.html)
+- [.NET](/docs/reference/pkg/dotnet/pulumi/pulumi.html)
 - [Java](/docs/reference/pkg/java/)
 - [YAML](/docs/iac/languages-sdks/yaml/yaml-language-reference/#expressions)
 

--- a/content/docs/iac/concepts/inputs-outputs/apply.md
+++ b/content/docs/iac/concepts/inputs-outputs/apply.md
@@ -721,7 +721,7 @@ For more details [view the Go documentation](https://pkg.go.dev/github.com/pulum
 
 {{% choosable language csharp %}}
 
-For more details [view the .NET documentation](/docs/reference/pkg/dotnet/Pulumi/Pulumi.Output.html).
+For more details [view the .NET documentation](/docs/reference/pkg/dotnet/pulumi/pulumi.output.html).
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/inputs-outputs/helpers.md
+++ b/content/docs/iac/concepts/inputs-outputs/helpers.md
@@ -61,7 +61,7 @@ For more details, see the [Go SDK documentation](https://pkg.go.dev/github.com/p
 
 - **`Output.Format()`** — Works like C#'s interpolated string syntax. Pass a C# interpolated string containing `Output<T>` values, and `Output.Format` returns a single `Output<string>`.
 
-For more details, see the [.NET SDK documentation](/docs/reference/pkg/dotnet/Pulumi/Pulumi.Output.html).
+For more details, see the [.NET SDK documentation](/docs/reference/pkg/dotnet/pulumi/pulumi.output.html).
 
 {{% /choosable %}}
 
@@ -126,7 +126,7 @@ For more details, see the [Go SDK documentation](https://pkg.go.dev/github.com/p
 
 - **`Output.JsonSerialize()`** — Accepts an `Output<T>` and returns an `Output<string>` of its JSON representation using `System.Text.Json`.
 
-For more details, see the [.NET SDK documentation](/docs/reference/pkg/dotnet/Pulumi/Pulumi.Output.html).
+For more details, see the [.NET SDK documentation](/docs/reference/pkg/dotnet/pulumi/pulumi.output.html).
 
 {{% /choosable %}}
 
@@ -170,7 +170,7 @@ For more details, see the [Go SDK documentation](https://pkg.go.dev/github.com/p
 
 - **`Output.JsonDeserialize<T>()`** — Accepts an `Output<string>` containing JSON and returns an `Output<T>` of the deserialized value using `System.Text.Json`.
 
-For more details, see the [.NET SDK documentation](/docs/reference/pkg/dotnet/Pulumi/Pulumi.Output.html).
+For more details, see the [.NET SDK documentation](/docs/reference/pkg/dotnet/pulumi/pulumi.output.html).
 
 {{% /choosable %}}
 

--- a/content/docs/iac/languages-sdks/dotnet/_index.md
+++ b/content/docs/iac/languages-sdks/dotnet/_index.md
@@ -229,7 +229,7 @@ Pulumi. [Concepts](/docs/intro/concepts) describes these concepts
 with examples available in Python. These concepts are made available to you in the Pulumi SDK.
 
 The Pulumi SDK is available to .NET developers as a Nuget package. To learn more,
-[refer to the Pulumi SDK Reference Guide](/docs/reference/pkg/dotnet/Pulumi/Pulumi.html).
+[refer to the Pulumi SDK Reference Guide](/docs/reference/pkg/dotnet/pulumi/pulumi.html).
 
 The Pulumi programming model includes a core concept of `Input` and `Output` values, which are used to track how outputs of one resource flow in as inputs to another resource.  This concept is important to understand when getting started with .NET and Pulumi, and the [Inputs and Outputs](/docs/concepts/inputs-outputs/) documentation is recommended to get a feel for how to work with this core part of Pulumi in common cases.
 
@@ -265,11 +265,11 @@ In addition to the standard packages the [Pulumi Registry](/registry/) houses 10
 
 <dl class="tabular">
     <dt>Pulumi SDK</dt>
-    <dd><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.html">Pulumi</a></dd>
+    <dd><a href="/docs/reference/pkg/dotnet/pulumi/pulumi.html">Pulumi</a></dd>
     <dt>Pulumi FSharp SDK</dt>
-    <dd><a href="/docs/reference/pkg/dotnet/Pulumi.FSharp/Pulumi.FSharp.html">Pulumi.FSharp</a></dd>
+    <dd><a href="/docs/reference/pkg/dotnet/pulumi.fsharp/pulumi.fsharp.html">Pulumi.FSharp</a></dd>
     <dt>Pulumi Automation API</dt>
-    <dd><a href="/docs/reference/pkg/dotnet/Pulumi.Automation/Pulumi.Automation.html">Pulumi.Automation</a></dd>
+    <dd><a href="/docs/reference/pkg/dotnet/pulumi.automation/pulumi.automation.html">Pulumi.Automation</a></dd>
 </dl>
 
 ### Dev Versions

--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -49,7 +49,7 @@ sections:
   - emoji: 💠
     heading: .NET (C#, F#, VB) ↗
     description: API reference for the .NET SDK.
-    link: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
+    link: /docs/reference/pkg/dotnet/pulumi/pulumi.html
 
   - emoji: ☕
     heading: Java ↗

--- a/content/docs/reference/pkg/dotnet/_index.md
+++ b/content/docs/reference/pkg/dotnet/_index.md
@@ -7,6 +7,6 @@ title: API Reference (.NET)
 The Pulumi SDK package is used for accessing the core programming model around resources, configuration, and other components
 directly. Additional general purpose packages can be used across all cloud platforms:
 
-* [**Pulumi SDK** (`Pulumi`)](/docs/reference/pkg/dotnet/Pulumi/Pulumi.html)
-* [**Pulumi F# SDK** (`Pulumi.FSharp`)](/docs/reference/pkg/dotnet/Pulumi.FSharp/Pulumi.FSharp.html)
-* [**Pulumi Automation API SDK** (`Pulumi.Automation`)](/docs/reference/pkg/dotnet/Pulumi.Automation/Pulumi.Automation.html)
+* [**Pulumi SDK** (`Pulumi`)](/docs/reference/pkg/dotnet/pulumi/pulumi.html)
+* [**Pulumi F# SDK** (`Pulumi.FSharp`)](/docs/reference/pkg/dotnet/pulumi.fsharp/pulumi.fsharp.html)
+* [**Pulumi Automation API SDK** (`Pulumi.Automation`)](/docs/reference/pkg/dotnet/pulumi.automation/pulumi.automation.html)

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -778,14 +778,8 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         ...guidesBehaviors,
         ...answersBehaviors,
 
-        // Docs pages support Accept: text/markdown content negotiation.
-        {
-            ...baseCacheBehavior,
-            pathPattern: "/docs/*",
-            functionAssociations: [getMarkdownNegotiationFunctionAssociation()],
-            responseHeadersPolicyId: DocsResponseHeadersPolicy.id,
-        },
-
+        // Dotnet SDK docs: lowercase URIs so case-insensitive requests resolve.
+        // Must come BEFORE /docs/* so the more specific pattern matches first.
         {
             ...baseCacheBehavior,
             pathPattern: "/docs/reference/pkg/dotnet/*",
@@ -793,6 +787,14 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
                 eventType: "viewer-request",
                 functionArn: dotnetLowercaseFunction.arn,
             }],
+        },
+
+        // Docs pages support Accept: text/markdown content negotiation.
+        {
+            ...baseCacheBehavior,
+            pathPattern: "/docs/*",
+            functionAssociations: [getMarkdownNegotiationFunctionAssociation()],
+            responseHeadersPolicyId: DocsResponseHeadersPolicy.id,
         },
         {
             ...baseCacheBehavior,

--- a/layouts/shortcodes/pulumi-getproject.html
+++ b/layouts/shortcodes/pulumi-getproject.html
@@ -12,7 +12,7 @@
         <code class="language-go"><a href="https://godoc.org/github.com/pulumi/pulumi/sdk/v3/go/pulumi#Context.Project">context.Project</a></code>
     </pulumi-choosable>
     <pulumi-choosable class="highlight" type="language" value="csharp">
-        <code class="language-csharp"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.DeploymentInstance.html#Pulumi_DeploymentInstance_ProjectName">Deployment.Instance.ProjectName</a></code>
+        <code class="language-csharp"><a href="/docs/reference/pkg/dotnet/pulumi/pulumi.deploymentinstance.html#Pulumi_DeploymentInstance_ProjectName">Deployment.Instance.ProjectName</a></code>
     </pulumi-choosable>
     <pulumi-choosable class="highlight" type="language" value="java">
         <code class="language-java">context.projectName()</code>

--- a/layouts/shortcodes/pulumi-getproject.markdown.md
+++ b/layouts/shortcodes/pulumi-getproject.markdown.md
@@ -12,7 +12,7 @@
 [`context.Project`](https://godoc.org/github.com/pulumi/pulumi/sdk/v3/go/pulumi#Context.Project)
 <!-- /option -->
 <!-- option: csharp -->
-[`Deployment.Instance.ProjectName`](/docs/reference/pkg/dotnet/Pulumi/Pulumi.DeploymentInstance.html#Pulumi_DeploymentInstance_ProjectName)
+[`Deployment.Instance.ProjectName`](/docs/reference/pkg/dotnet/pulumi/pulumi.deploymentinstance.html#Pulumi_DeploymentInstance_ProjectName)
 <!-- /option -->
 <!-- option: java -->
 `context.projectName()`

--- a/scripts/search/main.js
+++ b/scripts/search/main.js
@@ -79,7 +79,7 @@ const additionalObjects = [
         "section": "Docs",
         "title": "Pulumi .NET SDK Documentation (C#, VB, F#)",
         "description": "Documentation for the Pulumi .NET SDK.",
-        "href": "/docs/reference/pkg/dotnet/Pulumi/Pulumi.html",
+        "href": "/docs/reference/pkg/dotnet/pulumi/pulumi.html",
         "keywords": [
             "Pulumi.Pulumi",
             ".net sdk",


### PR DESCRIPTION
The `/docs/reference/pkg/dotnet/*` CloudFront cache behavior was listed after `/docs/*`, so CloudFront matched the broader pattern first and the `dotnet-lowercase-uri` function never fired. This caused all .NET SDK doc URLs with uppercase paths (e.g., `/docs/reference/pkg/dotnet/Pulumi/Pulumi.html`) to 404 since the files were lowercased in #18251.

## Changes
- Move dotnet cache behavior before the `/docs/*` catch-all in `infrastructure/index.ts`
- Update all hardcoded uppercase dotnet SDK URLs across content, menus, layouts, search, and health checks (12 files)

## Verification
- Health check should pass after deploy (currently failing on every run since March 28)
- `curl https://www.pulumi.com/docs/reference/pkg/dotnet/Pulumi/Pulumi.html` should return 200 after infra deploy