### PR TITLE
Exempt link checker from WAF rate limiting

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -97,6 +97,25 @@ if (config.enableWaf) {
         description: `Rate limiting for ${config.websiteDomain}`,
         defaultAction: { allow: {} },
         rules: [{
+            name: "allow-link-checker",
+            priority: 0,
+            action: { allow: {} },
+            statement: {
+                byteMatchStatement: {
+                    searchString: "pulumi+blc/0.1",
+                    fieldToMatch: {
+                        singleHeader: { name: "user-agent" },
+                    },
+                    positionalConstraint: "EXACTLY",
+                    textTransformations: [{ priority: 0, type: "NONE" }],
+                },
+            },
+            visibilityConfig: {
+                cloudwatchMetricsEnabled: true,
+                metricName: "cdn-waf-allow-link-checker",
+                sampledRequestsEnabled: true,
+            },
+        }, {
             name: "rate-limit-per-ip",
             priority: 1,
             action: { block: {} },


### PR DESCRIPTION
The WAF rate limit rule (500 req/5min) has been silently blocking the daily link checker since March 27. BLC enqueues all ~2,500 sitemap URLs concurrently, blows past the limit almost immediately, and the `excludeAcceptable` filters hide most of the ~2,466 page-fetch failures — only 3 make it to Slack.

Adds a priority-0 WAF rule that matches the link checker's exact user agent (`pulumi+blc/0.1`) and allows those requests through before the rate limit rule evaluates.

## Changes
- Added `allow-link-checker` WAF rule at priority 0 in `infrastructure/index.ts`

cc @sicarul