### PR TITLE
fix: reduce CloudFront error cache TTL from 5min to 10s

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -1034,7 +1034,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         {
             errorCode: 404,
             responseCode: 404,
-            errorCachingMinTtl: fiveMinutes,
+            errorCachingMinTtl: 10,
             responsePagePath: "/404.html",
         },
         // Map 403 Forbidden errors to 404 Not Found.
@@ -1044,7 +1044,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         {
             errorCode: 403,
             responseCode: 404,
-            errorCachingMinTtl: fiveMinutes,
+            errorCachingMinTtl: 10,
             responsePagePath: "/404.html",
         },
     ],


### PR DESCRIPTION
## Summary
- Reduces `errorCachingMinTtl` for 404 and 403 custom error responses from 5 minutes (300s) to 10 seconds
- During deploys, when CloudFront switches its origin to a new S3 bucket, transient 404s can get cached at edge locations. With a 5-minute error cache TTL, the homepage stays down until the cache expires. 10 seconds limits the blast radius of these transient errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)