### PR TITLE
Add upgrade-provider and upstream-patches skills to AI skills page

### DIFF
--- a/content/docs/ai/skills/index.md
+++ b/content/docs/ai/skills/index.md
@@ -51,6 +51,8 @@ Write quality Pulumi programs, components, automation, and secrets management:
 | pulumi-component | Guide for authoring ComponentResource classes |
 | pulumi-automation-api | Best practices for using Pulumi Automation API |
 | pulumi-esc | Guidance for working with Pulumi ESC (Environments, Secrets, and Configuration) |
+| pulumi-upgrade-provider | Automate Pulumi provider repo upgrades with the `upgrade-provider` tool |
+| upstream-patches | Manage upstream Terraform patch stacks in provider repos |
 
 ## Installation
 
@@ -76,7 +78,7 @@ Or install individual plugin groups:
 
 ```bash
 npx skills add pulumi/agent-skills/migration --skill '*'     # 4 migration skills
-npx skills add pulumi/agent-skills/authoring --skill '*'     # 4 authoring skills
+npx skills add pulumi/agent-skills/authoring --skill '*'     # 6 authoring skills
 ```
 
 This works with Claude Code, Cursor, Copilot, Codex, Junie, and other agent tools. To install for a specific agent, use the `--agent` flag:


### PR DESCRIPTION
## Summary

- Add `pulumi-upgrade-provider` and `upstream-patches` skills to the [Agent Skills docs page](/docs/ai/skills/)
- Update the authoring skill count from 4 to 6
- These skills were added in pulumi/agent-skills#20

## Test plan

- [ ] Verify the skills table renders correctly
- [ ] Verify the skill count comment is updated