### PR TITLE
Update Engin Diri role to Senior Solutions Architect

### DIFF
--- a/content/events/build-web-scale-cloud-app-golang-iac/index.md
+++ b/content/events/build-web-scale-cloud-app-golang-iac/index.md
@@ -52,7 +52,7 @@ learn:
 # The event presenters
 presenters:
     - name: Engin Diri
-      role: Customer Experience Architect, Pulumi
+      role: Senior Solutions Architect, Pulumi
       photo: /images/team/engin-diri.jpg
 
 # case-sensitive

--- a/content/events/kubernetes-platforms-on-google-cloud/index.md
+++ b/content/events/kubernetes-platforms-on-google-cloud/index.md
@@ -58,7 +58,7 @@ presenters:
     - name: Tim Hiatt
       role: Technical Solutions Consultant, Google Cloud
     - name: Engin Diri
-      role: Customer Experience Architect, Pulumi
+      role: Senior Solutions Architect, Pulumi
       photo: /images/team/engin-diri.jpg
 
 # case-sensitive

--- a/data/team/team/engin-diri.toml
+++ b/data/team/team/engin-diri.toml
@@ -1,7 +1,7 @@
 id = "engin-diri"
 name = "Engin Diri"
 status = "active"
-title = "Customer Experience Architect"
+title = "Senior Solutions Architect"
 weight = 1
 [social]
 github = "dirien"


### PR DESCRIPTION
## Summary
- Update Engin Diri's role from "Customer Experience Architect" to "Senior Solutions Architect" in the team data file and two event pages that still had the old title.

## Test plan
- [ ] Verify the [community engineering page](https://www.pulumi.com/community/community-engineering/engin-diri/) shows the updated role
- [ ] Verify affected event pages render correctly