### PR TITLE
Add Cloud Native Rejekts EU 2026 talk to Engin Diri's page

### DIFF
--- a/content/community/community-engineering/engin-diri.md
+++ b/content/community/community-engineering/engin-diri.md
@@ -8,6 +8,10 @@ layout: community-engineering/single
 aliases:
   - /engin
 talks:
+- event: "Cloud Native Rejekts EU 2026"
+  title: "The Ralph Wiggum Loop: How Autonomous AI Loops Built My Serverless SaaS While I Slept"
+  url: "https://cloud-native-rejekts-eu-2026.sessionize.com/schedule/day/20260321"
+  date: 2026-03-21T10:00:00.000+01:00
 - event: "SCaLE 23x"
   title: "Building AI Platforms Without Losing Your Engineering Principles"
   url: "https://www.socallinuxexpo.org/scale/23x/presentations/building-ai-platforms-without-losing-your-engineering-principles"


### PR DESCRIPTION
## Summary
- Adds "The Ralph Wiggum Loop: How Autonomous AI Loops Built My Serverless SaaS While I Slept" talk from Cloud Native Rejekts EU 2026 (March 21, Amsterdam) to Engin Diri's community engineering page.

## Test plan
- [ ] Verify the talk appears at the top of the talks list on the community engineering page
- [ ] Verify the Sessionize schedule link works