### PR TITLE
Add documentation for upgrading Pulumi packages

### DIFF
--- a/content/docs/iac/concepts/packages/_index.md
+++ b/content/docs/iac/concepts/packages/_index.md
@@ -60,6 +60,10 @@ pulumi package add example.com/org/repo.git/path@version
 
 After adding a local package, run `pulumi install` to complete the installation.
 
+{{% notes type="info" %}}
+Running `pulumi package add` registers the package in your `Pulumi.yaml` file. You should commit this file to source control so that your teammates can run `pulumi install` to install the same packages after cloning the repository.
+{{% /notes %}}
+
 Some common use cases for local packages include:
 
 1. Using the [Any Terraform provider](/registry/packages/terraform-provider/) to generate a local SDK for a Terraform provider. (This feature allows you to consume any Terraform provider in a Pulumi program.)
@@ -78,6 +82,66 @@ In order to consume a Pulumi package, there may be additional runtime requiremen
 {{% notes type="info" %}}
 Packages in the Pulumi Registry are typically written in Go and are compiled, and therefore do not require a runtime. This includes all packages for popular cloud and SaaS providers.
 {{% /notes %}}
+
+## Upgrading packages
+
+How you upgrade a Pulumi package depends on whether the package has published SDKs or uses locally generated SDKs.
+
+### Upgrading published SDK packages
+
+For packages with published SDKs (most packages in the [Pulumi Registry](/registry/)), use your language's standard package manager to upgrade:
+
+{{< chooser language "typescript,python,go,csharp" >}}
+{{% choosable language typescript %}}
+
+```bash
+npm install @pulumi/aws@latest
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```bash
+pip install --upgrade pulumi-aws
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```bash
+# Replace v7 with the major version used in your go.mod
+go get github.com/pulumi/pulumi-aws/sdk/v7@latest
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```bash
+dotnet add package Pulumi.Aws
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+
+Check each package's page in the [Pulumi Registry](/registry/) for the latest version and any upgrade notes.
+
+### Upgrading local packages
+
+For [local packages](/docs/iac/guides/building-extending/packages/local-packages/) (packages added with `pulumi package add`), re-run the `pulumi package add` command with the desired version:
+
+```bash
+# Upgrade a Terraform provider to a specific version
+pulumi package add terraform-provider hashicorp/random 3.7.1
+
+# Upgrade a component from a git repository to a new tag
+pulumi package add example.com/org/repo.git/path@v2.0.0
+```
+
+This regenerates the SDK and updates the package entry in your `Pulumi.yaml` file. After upgrading, run `pulumi install` to install the updated dependencies.
+
+To check which versions of local packages your project currently uses, inspect the `packages` section of your `Pulumi.yaml` file.
+
+For more details, see [Updating local packages](/docs/iac/guides/building-extending/packages/local-packages/#updating-local-packages).
 
 ## The Pulumi Registry
 

--- a/content/docs/iac/guides/building-extending/packages/local-packages.md
+++ b/content/docs/iac/guides/building-extending/packages/local-packages.md
@@ -161,19 +161,57 @@ When working with locally generated SDKs, you need to decide whether to commit t
 
 ## Updating local packages
 
-As underlying providers evolve with new features or bug fixes, you'll need to update your local packages to take advantage of these improvements. To update a local package:
+As underlying providers evolve with new features or bug fixes, you'll need to update your local packages to take advantage of these improvements.
 
-```bash
-pulumi package add <provider|schema|path> [provider-parameter...] [flags]
+### How local package versions are tracked
+
+When you run `pulumi package add`, the command registers the package and its version in your project's `Pulumi.yaml` file. For example, after adding a Terraform provider:
+
+```yaml
+packages:
+  random:
+    source: terraform-provider
+    version: 0.10.0
+    parameters:
+      - hashicorp/random
+      - 3.7.1
 ```
 
-1. Re-run the `pulumi package add` command with the updated source.
-1. This will regenerate the SDK with the latest schema.
-1. Update your imports and code as needed if there are breaking changes.
+You should commit `Pulumi.yaml` to source control so that your teammates can reproduce the same environment. When a collaborator clones your repository, they run [`pulumi install`](/docs/iac/cli/commands/pulumi_install/) to install all packages defined in `Pulumi.yaml`, including generating any local SDKs.
 
-For packages from Git repositories, specify a version tag or commit hash to control which version is used.
+### Upgrading a local package
 
-After regenerating the SDK, run [`pulumi install`](/docs/iac/cli/commands/pulumi_install/) to install all dependencies, including the updated local package.
+To upgrade a local package, re-run the `pulumi package add` command with the updated source or version:
+
+```bash
+# Upgrade a Terraform provider to a new version
+pulumi package add terraform-provider hashicorp/random 3.7.1
+
+# Upgrade a component from a git repository to a new tag
+pulumi package add example.com/org/repo.git/path@v2.0.0
+
+# Regenerate from an updated local schema file
+pulumi package add ./my/schema.json
+```
+
+This will:
+
+1. Regenerate the SDK with the latest schema.
+1. Update the package entry in your `Pulumi.yaml` file.
+
+After regenerating the SDK, run [`pulumi install`](/docs/iac/cli/commands/pulumi_install/) to install all dependencies, including the updated local package. Update your imports and code as needed if there are breaking changes.
+
+### Checking your current version
+
+To see which version of a local package your project is using, inspect the `packages` section of your `Pulumi.yaml` file. You can also run [`pulumi package info <package-name>`](/docs/iac/cli/commands/pulumi_package_info/) to view details about an installed package.
+
+### Team workflow
+
+A typical workflow for teams using local packages:
+
+1. A developer upgrades a package by running `pulumi package add` with the new version.
+1. The developer commits the updated `Pulumi.yaml` to source control. (If the team has chosen to [check in the generated SDK](#option-2-check-in-the-generated-sdk), the updated SDK should also be committed.)
+1. Other team members pull the changes and run `pulumi install` to regenerate the SDK and install dependencies locally.
 
 ## Versioning considerations
 


### PR DESCRIPTION
Adds an "Upgrading packages" section to the packages concept page covering both published SDK packages (via standard package managers) and local packages (via pulumi package add). Enhances the local packages guide with version tracking, upgrade workflow, and team collaboration guidance.

Closes #16404.
