### PR TITLE
fix: route /fingerprinted/* to registry origin for SVG logos

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -675,6 +675,19 @@ if (config.registryStack) {
             originRequestPolicyId: allViewerExceptHostHeaderId,
             forwardedValues: undefined,
         },
+        // Fingerprinted assets (e.g. /fingerprinted/logos/pkg/aws.<hash>.svg)
+        // are served from the registry origin with year-long immutable caching.
+        // See pulumi/registry#10488 for context.
+        {
+            ...baseCacheBehavior,
+            targetOriginId: registryCDN,
+            pathPattern: "/fingerprinted/*",
+            defaultTtl: oneYear,
+            maxTtl: oneYear,
+            originRequestPolicyId: allViewerExceptHostHeaderId,
+            responseHeadersPolicyId: ImmutableCachePolicy.id,
+            forwardedValues: undefined,
+        },
     )
 }
 


### PR DESCRIPTION
## Summary

pulumi/registry#10488 moved package SVG logos into Hugo's asset pipeline with content-hash fingerprinting, serving them at `/fingerprinted/logos/pkg/<name>.<hash>.svg`. The registry's own CloudFront handles these paths correctly, but the main `pulumi.com` distribution only routes `/registry/*` to the registry origin. Requests for `/fingerprinted/*` fall through to the docs origin, which doesn't have these files — causing **404s for every package logo** on the registry.

This adds a `/fingerprinted/*` CloudFront behavior targeting the registry origin with year-long immutable caching, matching the registry-side cache policy.

**Companion PR**: pulumi/registry#10558 fixes a secondary bug where `package-card.html` wasn't updated to use the new `icon.html` calling convention from #10488.

cc @sicarul

## Changes
- Added `/fingerprinted/*` ordered cache behavior targeting the registry CDN origin
- Uses `ImmutableCachePolicy` (1-year, immutable) and `allViewerExceptHostHeaderId` origin request policy, consistent with the registry-side CloudFront config