### PR TITLE
fix: use cache policy for /fingerprinted/* CloudFront behavior

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -971,14 +971,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
             maxTtl: oneHour,
             responseHeadersPolicyId: OneHourCachePolicy.id,
         },
-        {
-            ...baseCacheBehavior,
-            pathPattern: "/fingerprinted/*",
-            defaultTtl: oneYear,
-            maxTtl: oneYear,
-            responseHeadersPolicyId: ImmutableCachePolicy.id,
-        },
-
         // Web-component loaders must not be cached, because the names of the files they
         // load will change between builds.
         {


### PR DESCRIPTION
Follow-up to #18348 which failed during production deploy with:

> InvalidArgument: The parameter Origin request policy cannot be attached without a cache policy.

CloudFront requires a `cachePolicyId` (not legacy `defaultTtl`/`maxTtl`) when an `originRequestPolicy` is attached. This creates a one-year cache policy and uses it for the `/fingerprinted/*` behavior.

**Context**: pulumi/registry#10488 moved package SVG logos into Hugo's fingerprinted asset pipeline. The `/fingerprinted/*` behavior routes those requests to the registry origin. See pulumi/registry#10558 for a related fix.

cc @sicarul

## Changes
- Added `oneYearCachePolicy` CloudFront cache policy (mirrors the `thirtyMinuteCachePolicy` pattern but with 1-year TTL)
- Updated `/fingerprinted/*` behavior to use `cachePolicyId` instead of legacy TTL fields