### PR TITLE
fix: route docs fingerprinted assets to docs origin, not registry

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -686,13 +686,16 @@ if (config.registryStack) {
             originRequestPolicyId: allViewerExceptHostHeaderId,
             forwardedValues: undefined,
         },
-        // Fingerprinted assets (e.g. /fingerprinted/logos/pkg/aws.<hash>.svg)
+        // Registry package logos (e.g. /fingerprinted/logos/pkg/aws.<hash>.svg)
         // are served from the registry origin with year-long immutable caching.
+        // Use /fingerprinted/logos/pkg/* (not /fingerprinted/*) so docs-site
+        // fingerprinted assets (icons, brand logos, customer logos, product
+        // images) fall through to the default docs origin.
         // See pulumi/registry#10488 for context.
         {
             ...baseCacheBehavior,
             targetOriginId: registryCDN,
-            pathPattern: "/fingerprinted/*",
+            pathPattern: "/fingerprinted/logos/pkg/*",
             cachePolicyId: oneYearCachePolicy.id,
             originRequestPolicyId: allViewerExceptHostHeaderId,
             responseHeadersPolicyId: ImmutableCachePolicy.id,
@@ -946,6 +949,16 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         {
             ...baseCacheBehavior,
             pathPattern: "/fonts/*",
+            defaultTtl: oneYear,
+            maxTtl: oneYear,
+            responseHeadersPolicyId: ImmutableCachePolicy.id,
+        },
+        // Docs-site fingerprinted assets (icons, brand logos, customer logos,
+        // product images) use content-hashed filenames and are served with
+        // immutable 1-year caching from the default docs origin.
+        {
+            ...baseCacheBehavior,
+            pathPattern: "/fingerprinted/*",
             defaultTtl: oneYear,
             maxTtl: oneYear,
             responseHeadersPolicyId: ImmutableCachePolicy.id,


### PR DESCRIPTION
## Summary

- **Production bug**: Every fingerprinted image on pulumi.com is 404 (58+ broken images on the homepage alone — logos, icons, product screenshots all missing)
- **Root cause**: The `/fingerprinted/*` CloudFront behavior targets `registryCDN`, but docs-site fingerprinted assets (icons, brand logos, customer logos, product images) live in the docs S3 bucket. All requests are routed to the registry origin, which doesn't have them.
- **Fix**: Narrow the registry behavior to `/fingerprinted/logos/pkg/*` (the only fingerprinted path the registry serves) and add a catch-all `/fingerprinted/*` behavior targeting the default docs origin.

### Verification

Files exist in S3 (confirmed via direct origin bucket access) but CloudFront returns 404:
```
$ curl -sI "https://www.pulumi.com/fingerprinted/logos/brand/logo-on-white.<hash>.svg" → 404
$ curl -s "http://<origin-bucket>.s3-website.us-west-2.amazonaws.com/fingerprinted/logos/brand/logo-on-white.<hash>.svg" → 200
```

## Test plan

- [ ] Verify `pulumi preview` shows the CloudFront behavior changes (path pattern update + new behavior)
- [ ] After deploy, confirm fingerprinted images return 200 from `www.pulumi.com`
- [ ] Confirm registry package logos (`/fingerprinted/logos/pkg/*`) still load correctly
- [ ] Visual check that homepage logos, icons, and product images render

🤖 Generated with [Claude Code](https://claude.com/claude-code)