### PR TITLE
fix: remove invalid breadcrumb property from Event schema

### DIFF
--- a/layouts/partials/schema/collectors/event-entity.html
+++ b/layouts/partials/schema/collectors/event-entity.html
@@ -97,9 +97,4 @@
   "publisher" (dict "@id" "https://www.pulumi.com/#organization")
 ) }}
 
-{{/* Add breadcrumb reference if it exists */}}
-{{ $schema = merge $schema (dict
-  "breadcrumb" (dict "@id" (printf "%s#breadcrumb" .Permalink))
-) }}
-
 {{ return $schema }}


### PR DESCRIPTION
## Summary
- Removes the `breadcrumb` property from the Event schema.org entity, which is not a valid property for the `Event` type
- The `breadcrumb` property is only valid on `WebPage` and its subtypes per schema.org
- The `graph-builder.html` already correctly assigns `breadcrumb` to the `WebPage` entity in the `@graph`, so this was redundant

Fixes schema validation error reported on `/events/getting-started-with-iac-aws-typescript/` (and all other event pages).

## Test plan
- [ ] Validate event pages no longer produce schema.org errors for `breadcrumb` on `Event`
- [ ] Verify breadcrumb still appears correctly on the `WebPage` entity in JSON-LD output

🤖 Generated with [Claude Code](https://claude.com/claude-code)