### PR TITLE
fix: remove invalid publisher property from Event schema

### DIFF
--- a/layouts/partials/schema/collectors/event-entity.html
+++ b/layouts/partials/schema/collectors/event-entity.html
@@ -92,9 +92,4 @@
   {{ end }}
 {{ end }}
 
-{{/* Add publisher reference */}}
-{{ $schema = merge $schema (dict
-  "publisher" (dict "@id" "https://www.pulumi.com/#organization")
-) }}
-
 {{ return $schema }}


### PR DESCRIPTION
## Summary
- Removes the invalid `publisher` property from the Event structured data schema

The `publisher` property is not recognized by [schema.org for the Event type](https://schema.org/Event), causing a warning in Google's rich results validator:

> The property `publisher` is not recognized by the schema (e.g. schema.org) for an object of type Event.

Example affected page: [/events/getting-started-with-iac-aws-typescript](https://www.pulumi.com/events/getting-started-with-iac-aws-typescript)

## Test plan
- [ ] Validate an events page with [Google's Rich Results Test](https://search.google.com/test/rich-results) and confirm no `publisher` warning for Event objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)