### PR TITLE
Update trusted customer count from 3,700 to 4,000

### DIFF
--- a/EVENT-PAGE-TEMPLATE-GUIDE.md
+++ b/EVENT-PAGE-TEMPLATE-GUIDE.md
@@ -44,7 +44,7 @@ Displays a horizontal banner of company/partner logos with optional text above.
 
 **Frontmatter:**
 ```yaml
-logos_text: "Trusted by over 3,700 innovative companies."  # optional
+logos_text: "Trusted by over 4,000 innovative companies."  # optional
 logos:
   - src: "/logos/customers/company1.svg"
     alt: "Company 1"

--- a/content/_index.md
+++ b/content/_index.md
@@ -77,7 +77,7 @@ insights:
     One pane of glass for all your clouds. Search infrastructure with natural language. Enforce policies automatically. Track compliance in real-time. Find vulnerabilities before they become incidents.
 
 customer_logos:
-  title: Trusted by over 3,700 innovative companies
+  title: Trusted by over 4,000 innovative companies
   logos:
     - name: bmw
       link: /case-studies/

--- a/content/enterprise/_index.md
+++ b/content/enterprise/_index.md
@@ -10,7 +10,7 @@ overview:
         Snowflake, Mercedes-Benz, NVIDIA, and Lemonade are among a rapidly growing number of enterprises worldwide that leverage Pulumi's Platform to enable modern cloud transformation, accelerate innovation, build their IDP while meeting the most rigorous security and compliance requirements.
 
 customer_logos:
-  title: Trusted by over 3,700 innovative companies
+  title: Trusted by over 4,000 innovative companies
   logos:
     - name: bmw
       link: /case-studies/

--- a/content/gads/akuity/index.md
+++ b/content/gads/akuity/index.md
@@ -170,7 +170,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/ansible/index.md
+++ b/content/gads/ansible/index.md
@@ -173,7 +173,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/aws/index.md
+++ b/content/gads/aws/index.md
@@ -209,7 +209,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/azure-resource-manager/index.md
+++ b/content/gads/azure-resource-manager/index.md
@@ -171,7 +171,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/azure/index.md
+++ b/content/gads/azure/index.md
@@ -185,7 +185,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/backstage/index.md
+++ b/content/gads/backstage/index.md
@@ -171,7 +171,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/cdk/index.md
+++ b/content/gads/cdk/index.md
@@ -178,7 +178,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/chef/index.md
+++ b/content/gads/chef/index.md
@@ -171,7 +171,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/chkk/index.md
+++ b/content/gads/chkk/index.md
@@ -171,7 +171,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/cloudformation/index.md
+++ b/content/gads/cloudformation/index.md
@@ -178,7 +178,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/crossplane/index.md
+++ b/content/gads/crossplane/index.md
@@ -178,7 +178,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/env0/index.md
+++ b/content/gads/env0/index.md
@@ -179,7 +179,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/firefly/index.md
+++ b/content/gads/firefly/index.md
@@ -170,7 +170,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/gads-template.md
+++ b/content/gads/gads-template.md
@@ -173,7 +173,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/github/index.md
+++ b/content/gads/github/index.md
@@ -170,7 +170,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/google-cloud-deployment-manager/index.md
+++ b/content/gads/google-cloud-deployment-manager/index.md
@@ -171,7 +171,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/humanitec/index.md
+++ b/content/gads/humanitec/index.md
@@ -177,7 +177,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/infrastructure-as-code/index.md
+++ b/content/gads/infrastructure-as-code/index.md
@@ -213,7 +213,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/infrastructure-engineers/index.md
+++ b/content/gads/infrastructure-engineers/index.md
@@ -178,7 +178,7 @@ stats:
         number: "350,000+"
         description: developers
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: organizations
     integration:
         number: "170+"

--- a/content/gads/kubernetes/index.md
+++ b/content/gads/kubernetes/index.md
@@ -222,7 +222,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/multicloud/index.md
+++ b/content/gads/multicloud/index.md
@@ -178,7 +178,7 @@ stats:
         number: "350,000+"
         description: developers
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: organizations
     integration:
         number: "170+"

--- a/content/gads/opentofu/index.md
+++ b/content/gads/opentofu/index.md
@@ -178,7 +178,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/platform-teams/index.md
+++ b/content/gads/platform-teams/index.md
@@ -178,7 +178,7 @@ stats:
         number: "350,000+"
         description: developers
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: organizations
     integration:
         number: "170+"

--- a/content/gads/port/index.md
+++ b/content/gads/port/index.md
@@ -177,7 +177,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/puppet/index.md
+++ b/content/gads/puppet/index.md
@@ -171,7 +171,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/python-iac/index.md
+++ b/content/gads/python-iac/index.md
@@ -111,7 +111,7 @@ stats:
         number: "350,000+"
         description: developers
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: organizations
     integration:
         number: "170+"

--- a/content/gads/saltstack/index.md
+++ b/content/gads/saltstack/index.md
@@ -171,7 +171,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/spacelift/index.md
+++ b/content/gads/spacelift/index.md
@@ -179,7 +179,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/system-initiative/index.md
+++ b/content/gads/system-initiative/index.md
@@ -170,7 +170,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/terraform-migration/index.md
+++ b/content/gads/terraform-migration/index.md
@@ -171,7 +171,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/terraform/index.md
+++ b/content/gads/terraform/index.md
@@ -195,7 +195,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/terragrunt/index.md
+++ b/content/gads/terragrunt/index.md
@@ -338,7 +338,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/gads/wiz/index.md
+++ b/content/gads/wiz/index.md
@@ -170,7 +170,7 @@ stats:
         number: "350,000+"
         description: "Community members"
     company:
-        number: "3,700+"
+        number: "4,000+"
         description: "Companies in production"
     integration:
         number: "170+"

--- a/content/google-cloud-next/_index.md
+++ b/content/google-cloud-next/_index.md
@@ -23,7 +23,7 @@ hero:
   tag_line: "Join us at Google Cloud Next 2026 | Booth 3624"
   anchor: hero
 
-logos_text: Trusted by over 3,700 innovative companies
+logos_text: Trusted by over 4,000 innovative companies
 logos_anchor: customers
 logos:
   - src: /logos/customers/snowflake-logo.svg

--- a/content/kubecon/_index.md
+++ b/content/kubecon/_index.md
@@ -21,7 +21,7 @@ hero:
   tag_line: "Join us at KubeCon Europe 2026"
   anchor: hero
 
-logos_text: Trusted by over 3,700 innovative companies
+logos_text: Trusted by over 4,000 innovative companies
 logos_anchor: customers
 logos:
   - src: /logos/customers/deloitte.svg

--- a/layouts/partials/template-partials/template-counter-cards.html
+++ b/layouts/partials/template-partials/template-counter-cards.html
@@ -2,7 +2,7 @@
     Template Counter Cards Partial
 
     Horizontal row of stat cards: large number + label.
-    E.g., "350,000+ Engineers", "3,700+ Companies", "1,000+ Providers".
+    E.g., "350,000+ Engineers", "4,000+ Companies", "1,000+ Providers".
 
     Parameters:
     - cards: Array of card objects


### PR DESCRIPTION
## Summary
- Updates "3,700" / "3,700+" customer count to "4,000" / "4,000+" across all marketing pages
- Covers homepage, enterprise page, kubecon/google-cloud-next event pages, and all `content/gads/` landing pages
- Also updates the example in `EVENT-PAGE-TEMPLATE-GUIDE.md` and the comment in `template-counter-cards.html`

Skipped blog posts (historical content per AGENTS.md) and an unrelated LinkedIn URL that happened to contain "3700".

## Test plan
- [ ] Spot-check homepage renders "Trusted by over 4,000 innovative companies"
- [ ] Spot-check a few gads/ landing pages show "4,000+" in counter cards
- [ ] CI lint/build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)