### PR TITLE
Fix incorrect default values for packagemanager and toolchain runtime options

### DIFF
--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -66,10 +66,10 @@ The runtime attribute has an additional property called `options` where you can 
 | - | - | - |
 | `typescript` | Only applies to the `nodejs` runtime | Boolean indicating whether to use `ts-node` or not. |
 | `nodeargs` | Only applies to the `nodejs` runtime | Arguments to pass to `node`. |
-| `packagemanager` | Only applies to the `nodejs` runtime | Packagemanager to use for installing dependencies, `npm` (default), `pnpm`, `yarn` or `bun`. |
+| `packagemanager` | Only applies to the `nodejs` runtime | Package manager to use for installing dependencies, `npm`, `pnpm`, `yarn`, or `bun`. When unset, the package manager is auto-detected from lockfiles in the project directory, falling back to `npm` if none are found. |
 | `buildTarget` | Only applies to the `go` runtime | Path to save the compiled go binary to. |
 | `binary` | applies to the `go`, `dotnet`, and `java` runtimes | Path to a pre-built executable. |
-| `toolchain` | Only applies to the `python` runtime | Toolchain to use for managing virtual environments, `pip` (default), `poetry` or `uv` |
+| `toolchain` | Only applies to the `python` runtime | Toolchain to use for managing virtual environments, `pip`, `poetry`, or `uv`. When unset, the toolchain is auto-detected from lockfiles in the project directory (e.g. `uv.lock` or `poetry.lock`), falling back to `pip` if none are found. |
 | `virtualenv` | Only applies to the `python` runtime with the `pip` or `uv` toolchain. | Virtual environment path. |
 | `typechecker` | Only applies to the `python` runtime | Type checker library to use. |
 | `compiler` | Only applies to the `yaml` runtime | Executable and arguments issued to standard out. |


### PR DESCRIPTION
## Summary

- Fixes the documented default for the Node.js packagemanager runtime option from npm to auto, and adds auto to the list of valid values. The auto mode auto-detects the package manager from lockfiles (yarn.lock, pnpm-lock.yaml, bun.lock), falling back to npm if none are found.
- Fixes the documented default for the Python toolchain runtime option from pip to auto-detection. When unset, Pulumi detects the toolchain from lockfiles (uv.lock or poetry.lock), falling back to pip if none are found.

### Source code references (pulumi/pulumi@cc69f12)

- Node.js packagemanager default is auto: https://github.com/pulumi/pulumi/blob/cc69f12bfc32f1e221a9e613f7e4f9263d6f109b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go#L275
- Node.js valid package manager types including auto: https://github.com/pulumi/pulumi/blob/cc69f12bfc32f1e221a9e613f7e4f9263d6f109b/sdk/nodejs/npm/manager.go#L37-L42
- Node.js auto-detection logic: https://github.com/pulumi/pulumi/blob/cc69f12bfc32f1e221a9e613f7e4f9263d6f109b/sdk/nodejs/npm/manager.go#L184-L242
- Python toolchain default is Auto (iota 0): https://github.com/pulumi/pulumi/blob/cc69f12bfc32f1e221a9e613f7e4f9263d6f109b/sdk/python/toolchain/toolchain.go#L50-L57