### PR TITLE
fix: Normalize markdown whitespace and add .md redirect support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,7 @@ indent_size = 4
 
 [*.{yaml,yml}]
 indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md text eol=lf

--- a/scripts/make-s3-redirects.js
+++ b/scripts/make-s3-redirects.js
@@ -6,8 +6,20 @@ const redirectsFile = process.argv[3] || "./public/redirects.txt";
 const region = process.argv[4] || "us-west-2"
 
 async function doRedirects(bucket, region) {
-    const redirects = fs.readFileSync(redirectsFile, "utf-8").trim().split("\n");
-    console.log(`Processing ${redirects.length} redirects...`);
+    let redirects = fs.readFileSync(redirectsFile, "utf-8").trim().split("\n");
+
+    // For docs pages that have the markdown output format enabled, also create
+    // redirect entries for .md URLs so the CLI gets proper 301s instead of 404s.
+    const mdRedirects = [];
+    for (const line of redirects) {
+        const [key] = line.split("|");
+        if (key.startsWith("docs/") && key.endsWith(".html")) {
+            mdRedirects.push(line.replace(key, key.replace(/\.html$/, ".md")));
+        }
+    }
+    redirects = redirects.concat(mdRedirects);
+
+    console.log(`Processing ${redirects.length} redirects (${mdRedirects.length} .md duplicates)...`);
 
     const client = new S3Client({ region, endpoint: `https://s3.${region}.amazonaws.com` });
 


### PR DESCRIPTION
Upstream fixes to support the `pulumi docs` CLI command, reducing workaround code the CLI needs for fetching markdown content.

## Changes

- **`.gitattributes`** (new) — Enforces LF line endings for `.md` files at the Git level, preventing CRLF from entering the repo.
- **`.editorconfig`** — Adds `[*.md]` section enforcing spaces over tabs. Existing files with tabs will be cleaned up incrementally.
- **`scripts/translate-redirects.js`** — Generates `.md` redirect entries alongside HTML redirects for docs paths, so moved pages return proper 301s for markdown URLs.

## CLI code this unblocks removing

| Fix | CLI code |
|-----|----------|
| LF enforcement | `strings.ReplaceAll(raw, "\r\n", "\n")` in `FetchDoc` |
| Space indentation | `strings.ReplaceAll(raw, "\t", "    ")` in `FetchDoc` |
| `.md` redirects | `resolveRedirect`, `extractContentPath`, `metaRefreshRe` |