### PR TITLE
Add Neo integrations documentation

### DIFF
--- a/content/docs/ai/_index.md
+++ b/content/docs/ai/_index.md
@@ -51,6 +51,10 @@ sections:
     heading: Previews
     link: /docs/ai/running-previews/
     description: Generate infrastructure previews with approval gates.
+  - emoji: 🔌
+    heading: Integrations
+    link: /docs/ai/integrations/
+    description: Connect Neo to third-party services like Datadog, Honeycomb, and Linear.
 
 - type: flat
   heading: Have questions?

--- a/content/docs/ai/integrations/_index.md
+++ b/content/docs/ai/integrations/_index.md
@@ -1,0 +1,74 @@
+---
+title: Integrations
+title_tag: Neo Integrations
+h1: Neo Integrations
+meta_desc: Bring context from issue trackers, observability platforms, and wikis into Neo tasks so it can act on what your team already knows.
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    ai:
+        name: Integrations
+        parent: ai-home
+        weight: 55
+        identifier: ai-integrations
+---
+
+Neo integrations bring context from your existing tools into infrastructure tasks. Neo can read directly from the services your team already uses, such as issue trackers, observability platforms, wikis, and databases, and apply that context to infrastructure tasks.
+
+Integrations are configured at the organization level by an administrator. Once enabled, they are available to all tasks in the organization.
+
+## What you can do with integrations
+
+A few examples:
+
+- **Pick up work from your issue tracker.** Connect Linear or Jira and ask Neo to implement an issue. Neo reads the issue description, acceptance criteria, and comments, then writes the infrastructure changes to match.
+- **Follow your runbooks.** Connect Confluence or Notion and point Neo at an operational runbook. Neo follows the documented steps, adapting them to your current environment.
+- **Investigate with real observability data.** Connect Honeycomb or Datadog and ask Neo to diagnose a performance problem. Neo queries actual traces and metrics from your environment to narrow down the cause.
+- **Debug with production error context.** Connect Sentry and ask Neo to fix a failing deployment. Neo pulls the error details, stack traces, and affected releases to inform its approach.
+- **Manage application infrastructure together.** Connect Supabase and let Neo coordinate database changes alongside your Pulumi infrastructure code.
+
+## Available integrations
+
+The following integrations are available in the Neo integration catalog:
+
+| Integration | Description |
+|---|---|
+| **Atlassian** | Jira issues, Confluence spaces, and project management |
+| **Datadog** | Cloud-scale monitoring and analytics for infrastructure and applications |
+| **Honeycomb** | Query traces, analyze performance, and investigate production issues |
+| **Linear** | Issue tracking, project management, and team workflows |
+| **Notion** | Connected workspace for notes, docs, and project management |
+| **Sentry** | Application monitoring, error tracking, and performance insights |
+| **Supabase** | Database management, authentication, and edge functions |
+
+Each integration connects Neo to the service's [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server, which means Neo can use the full set of tools that service exposes through MCP.
+
+## Enabling an integration
+
+Organization administrators configure integrations in Neo Settings:
+
+1. Navigate to **Neo Settings** in the Pulumi Cloud left navigation
+1. Select the **Integrations** tab
+1. Find the integration you want to enable and select **Configure**
+1. Enter the required credentials for the integration
+1. Select **Save**
+
+The credentials you provide depend on the integration. Some require an API key, while others use OAuth to connect your organization's account. Each integration's configuration form includes guidance on where to find or generate the required credentials.
+
+### Credential storage
+
+Integration credentials are stored securely in [Pulumi ESC](/docs/esc/) (Environments, Secrets, and Configuration). When a task needs to connect to an integration, Neo resolves the credentials at task time from ESC, constructs the appropriate authentication headers, and connects to the service. Credentials are never embedded in task state.
+
+## Disabling an integration
+
+To remove an integration from your organization:
+
+1. Navigate to **Neo Settings** → **Integrations**
+1. Find the integration you want to disable and select **Remove**
+
+Disabling an integration deletes its credentials from ESC and immediately prevents any new tasks from using it. Tasks that are already running will lose access to the integration on their next tool call.
+
+## How integrations work at task time
+
+When Neo starts a task, it connects to each enabled integration's MCP server using the stored credentials. From there, Neo can use any tools the MCP server provides. For example, with the Honeycomb integration enabled, Neo can query traces to investigate a performance issue that came up during an infrastructure review. With Linear enabled, Neo can look up the details of an issue referenced in a task description.
+
+The integration connection is transparent. Neo decides when to use an integration based on the context of your conversation, just as it decides when to use any other tool.

--- a/content/docs/ai/integrations/_index.md
+++ b/content/docs/ai/integrations/_index.md
@@ -19,9 +19,9 @@ Integrations are configured at the organization level by an administrator. Once 
 ## What you can do with integrations
 
 - **Pick up work from your issue tracker.** Connect Linear or Jira and ask Neo to implement an issue. Neo reads the issue description, acceptance criteria, and comments, then writes the infrastructure changes to match.
-- **Follow your runbooks.** Connect Confluence or Notion and point Neo at an operational runbook. Neo follows the documented steps, adapting them to your current environment.
+- **Follow your runbooks.** Connect Confluence and point Neo at an operational runbook. Neo follows the documented steps, adapting them to your current environment.
 - **Investigate with real observability data.** Connect Honeycomb or Datadog and ask Neo to diagnose a performance problem. Neo queries actual traces and metrics from your environment to narrow down the cause.
-- **Debug with production error context.** Connect Sentry and ask Neo to fix a failing deployment. Neo pulls the error details, stack traces, and affected releases to inform its approach.
+- **Respond to incidents.** Connect PagerDuty and let Neo look up active incidents, on-call schedules, and escalation policies while it investigates.
 - **Manage application infrastructure together.** Connect Supabase and let Neo coordinate database changes alongside your Pulumi infrastructure code.
 
 ## Enabling an integration
@@ -32,13 +32,13 @@ Each integration connects Neo to the service's [Model Context Protocol (MCP)](ht
 
 ### Credential storage
 
-Integration credentials are stored securely in [Pulumi ESC](/docs/esc/) (Environments, Secrets, and Configuration). When a task needs to connect to an integration, Neo resolves the credentials at task time from ESC, constructs the appropriate authentication headers, and connects to the service. Credentials are never embedded in task state.
+Integration credentials are encrypted at rest in the Pulumi Service using a per-organization encryption key. When a task needs to connect to an integration, the service decrypts the credentials at task time, constructs the appropriate authentication headers, and connects to the service on Neo's behalf. Credentials are never exposed to the language model and are never embedded in task state.
 
 ## Disabling an integration
 
 To remove an integration from your organization, navigate to **Neo Settings**, select **Integrations**, find the integration, and select **Remove**.
 
-Disabling an integration deletes its credentials from ESC and immediately prevents any new tasks from using it. Tasks that are already running will lose access to the integration on their next tool call.
+Disabling an integration deletes its stored credentials and immediately prevents any new tasks from using it. Tasks that are already running will lose access to the integration on their next tool call.
 
 ## How integrations work at task time
 
@@ -73,7 +73,7 @@ The integration connection is transparent. Neo decides when to use an integratio
     - **Read**: Required for all Honeycomb MCP operations. Make sure to grant read for both MCP and Environments.
     - **Write**: Required for the `create_board` tool.
 1. Copy the **Key ID** and **Key Secret**. You will not be able to see them again.
-1. In Neo, enter the API key in the format `<key_id>:<secret_key>`
+1. In Neo, enter the **Key ID** and **Key Secret** in the corresponding fields
 
 ### Linear
 
@@ -85,16 +85,14 @@ Linear API keys are personal tokens. All actions Neo takes through this integrat
 1. Select **New API Key**, give it a name, and configure the permissions and team access for your use case
 1. In Neo, enter the **API Key**
 
-### Notion
+### PagerDuty
 
-Notion uses OAuth to connect your organization's account. Select **Connect** and follow the authorization flow.
-
-### Sentry
-
-Sentry uses OAuth to connect your organization's account. Select **Connect** and follow the authorization flow.
+1. In PagerDuty, open your user profile and select **User Settings**
+1. Select **Create API User Token**, give it a name (e.g., "Neo Integration"), and copy the token
+1. In Neo, enter the **User API Token**
 
 ### Supabase
 
-Requires:
-
-- **Access Token**: On **supabase.com**, open **Account Preferences**, then **Access Tokens**
+1. On **supabase.com**, open **Account Preferences**, then **Access Tokens**
+1. Select **Generate New Token**, give it a name, and copy the token
+1. In Neo, enter the **Access Token**

--- a/content/docs/ai/integrations/_index.md
+++ b/content/docs/ai/integrations/_index.md
@@ -12,7 +12,7 @@ menu:
         identifier: ai-integrations
 ---
 
-Neo integrations bring context from your existing tools into infrastructure work. Neo can read directly from the services your team already uses — issue trackers, observability platforms, incident response tools, wikis, and databases — and apply that context to infrastructure tasks.
+Neo integrations bring context from your existing tools into infrastructure work. Neo reads directly from issue trackers, observability platforms, incident response tools, wikis, and databases, then applies that context to infrastructure tasks.
 
 Integrations are configured at the organization level by an administrator. Once enabled, they are available to all tasks in the organization.
 
@@ -30,7 +30,7 @@ To enable an integration, navigate to **Neo Settings**, select **Integrations**,
 
 Each integration connects Neo to the service's [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server, which means Neo can use the full set of tools that service exposes through MCP.
 
-### Credential storage
+## Credential storage
 
 Integration credentials are encrypted at rest in the Pulumi Service using a per-organization encryption key. When a task needs to connect to an integration, the service decrypts the credentials at task time, constructs the appropriate authentication headers, and connects to the service on Neo's behalf. Credentials are never exposed to the language model and are never embedded in task state.
 
@@ -38,7 +38,7 @@ Integration credentials are encrypted at rest in the Pulumi Service using a per-
 
 To remove an integration from your organization, navigate to **Neo Settings**, select **Integrations**, find the integration, and select **Remove**.
 
-Disabling an integration deletes its stored credentials and immediately prevents any new tasks from using it. Tasks that are already running will lose access to the integration on their next tool call.
+Disabling an integration deletes its stored credentials and immediately prevents any new tasks from using it. Tasks that are already running will lose access to the integration the next time Neo tries to use it.
 
 ## How integrations work at task time
 
@@ -48,13 +48,13 @@ The integration connection is transparent. Neo decides when to use an integratio
 
 ## Per-task control
 
-By default, every task inherits all integrations the organization has enabled. If you want to narrow Neo's focus for a specific task — for example, running a deployment review without giving Neo access to your issue tracker — you can toggle individual integrations off from the task composer before starting the conversation. The toggles only affect the current task; the org-level configuration is unchanged.
+By default, every task inherits all integrations the organization has enabled. If you want to narrow Neo's focus for a specific task (for example, running a deployment review without giving Neo access to your issue tracker), you can toggle individual integrations off from the task composer before starting the conversation. The toggles only affect the current task; the org-level configuration is unchanged.
 
 ## If an integration fails
 
 Integrations are resolved independently at the start of each message. If credentials for one integration can't be retrieved, or its MCP server is unreachable, Neo logs a warning, skips that integration, and continues the task with the remaining ones. A single broken integration won't stop a task from running.
 
-If Neo tries to use an integration that isn't available — for example, because the credentials were removed or expired — it will surface the failure in the conversation and continue with its other tools.
+If Neo tries to use an integration that isn't available (for example, because the credentials were removed or expired), it will surface the failure in the conversation and continue with its other tools.
 
 ## Configuration
 

--- a/content/docs/ai/integrations/_index.md
+++ b/content/docs/ai/integrations/_index.md
@@ -97,11 +97,19 @@ Linear API keys are personal tokens. All actions Neo takes through this integrat
 
 ### PagerDuty
 
+{{% notes type="info" %}}
+PagerDuty User API Tokens are tied to a single user account. All actions Neo takes through this integration are attributed to the user who created the token, regardless of who creates the Neo task. For shared use, consider creating a dedicated PagerDuty user (e.g. `pulumi-bot`) whose token Neo can use.
+{{% /notes %}}
+
 1. In PagerDuty, open your user profile and select **User Settings**
 1. Select **Create API User Token**, give it a name (e.g., "Neo Integration"), and copy the token
 1. In Neo, enter the **User API Token**
 
 ### Supabase
+
+{{% notes type="info" %}}
+Supabase Access Tokens are tied to a single user account — Supabase does not offer service-account credentials for the MCP server. All actions Neo takes through this integration are attributed to the user who created the token, regardless of who creates the Neo task. For shared use, consider creating a dedicated Supabase user (e.g. `pulumi-bot`) whose token Neo can use.
+{{% /notes %}}
 
 1. On **supabase.com**, open **Account Preferences**, then **Access Tokens**
 1. Select **Generate New Token**, give it a name, and copy the token

--- a/content/docs/ai/integrations/_index.md
+++ b/content/docs/ai/integrations/_index.md
@@ -12,14 +12,14 @@ menu:
         identifier: ai-integrations
 ---
 
-Neo integrations bring context from your existing tools into infrastructure tasks. Neo can read directly from the services your team already uses, such as issue trackers, observability platforms, wikis, and databases, and apply that context to infrastructure tasks.
+Neo integrations bring context from your existing tools into infrastructure work. Neo can read directly from the services your team already uses — issue trackers, observability platforms, incident response tools, wikis, and databases — and apply that context to infrastructure tasks.
 
 Integrations are configured at the organization level by an administrator. Once enabled, they are available to all tasks in the organization.
 
 ## What you can do with integrations
 
 - **Pick up work from your issue tracker.** Connect Linear or Jira and ask Neo to implement an issue. Neo reads the issue description, acceptance criteria, and comments, then writes the infrastructure changes to match.
-- **Follow your runbooks.** Connect Confluence and point Neo at an operational runbook. Neo follows the documented steps, adapting them to your current environment.
+- **Follow your runbooks.** Connect Atlassian and point Neo at a Confluence runbook. Neo follows the documented steps, adapting them to your current environment.
 - **Investigate with real observability data.** Connect Honeycomb or Datadog and ask Neo to diagnose a performance problem. Neo queries actual traces and metrics from your environment to narrow down the cause.
 - **Respond to incidents.** Connect PagerDuty and let Neo look up active incidents, on-call schedules, and escalation policies while it investigates.
 - **Manage application infrastructure together.** Connect Supabase and let Neo coordinate database changes alongside your Pulumi infrastructure code.
@@ -93,7 +93,11 @@ Linear API keys are personal tokens. All actions Neo takes through this integrat
 {{% /notes %}}
 
 1. In Linear, open **Settings**, then **Security & Access**
-1. Select **New API Key**, give it a name, and configure the permissions and team access for your use case
+1. Select **New API Key**, give it a name, and choose the permissions Neo needs:
+    - **Read**: required for all integrations Neo performs through Linear
+    - **Create issues** and **Create comments**: required if you want Neo to file or comment on issues
+    - **Write** or **Admin**: required if you want Neo to update or delete existing issues
+1. Optionally limit the key to specific teams using the team-access controls
 1. In Neo, enter the **API Key**
 
 ### PagerDuty
@@ -103,7 +107,9 @@ PagerDuty User API Tokens are tied to a single user account. All actions Neo tak
 {{% /notes %}}
 
 1. In PagerDuty, open your user profile and select **User Settings**
-1. Select **Create API User Token**, give it a name (e.g., "Neo Integration"), and copy the token
+1. Select **Create API User Token** and give it a name (e.g., "Neo Integration"). The token inherits the user's existing PagerDuty permissions, so its access matches whatever the user can already see in the PagerDuty UI.
+1. Check **Read-only API Key** if you don't want Neo to be able to create or modify incidents, schedules, or escalation policies
+1. Copy the token
 1. In Neo, enter the **User API Token**
 
 ### Supabase

--- a/content/docs/ai/integrations/_index.md
+++ b/content/docs/ai/integrations/_index.md
@@ -73,7 +73,8 @@ If Neo tries to use an integration that isn't available — for example, because
 1. In **Organization Settings**, open **Service Accounts** and create a service account with read-only access
 1. On the service account's details page, create an **App Key** and make sure to include the MCP read scope
 1. In **Organization Settings**, open **API Keys** and create an **API Key**
-1. In Neo, enter the **API Key** and **App Key**
+1. Identify your Datadog site — it's the domain you use to access Datadog (for example, `datadoghq.com` is `us1`, `datadoghq.eu` is `eu1`). Supported codes: `us1`, `us3`, `us5`, `eu1`, `ap1`, `ap2`.
+1. In Neo, enter the **Datadog site** code, **API Key**, and **App Key**
 
 ### Honeycomb
 

--- a/content/docs/ai/integrations/_index.md
+++ b/content/docs/ai/integrations/_index.md
@@ -18,41 +18,17 @@ Integrations are configured at the organization level by an administrator. Once 
 
 ## What you can do with integrations
 
-A few examples:
-
 - **Pick up work from your issue tracker.** Connect Linear or Jira and ask Neo to implement an issue. Neo reads the issue description, acceptance criteria, and comments, then writes the infrastructure changes to match.
 - **Follow your runbooks.** Connect Confluence or Notion and point Neo at an operational runbook. Neo follows the documented steps, adapting them to your current environment.
 - **Investigate with real observability data.** Connect Honeycomb or Datadog and ask Neo to diagnose a performance problem. Neo queries actual traces and metrics from your environment to narrow down the cause.
 - **Debug with production error context.** Connect Sentry and ask Neo to fix a failing deployment. Neo pulls the error details, stack traces, and affected releases to inform its approach.
 - **Manage application infrastructure together.** Connect Supabase and let Neo coordinate database changes alongside your Pulumi infrastructure code.
 
-## Available integrations
-
-The following integrations are available in the Neo integration catalog:
-
-| Integration | Description |
-|---|---|
-| **Atlassian** | Jira issues, Confluence spaces, and project management |
-| **Datadog** | Cloud-scale monitoring and analytics for infrastructure and applications |
-| **Honeycomb** | Query traces, analyze performance, and investigate production issues |
-| **Linear** | Issue tracking, project management, and team workflows |
-| **Notion** | Connected workspace for notes, docs, and project management |
-| **Sentry** | Application monitoring, error tracking, and performance insights |
-| **Supabase** | Database management, authentication, and edge functions |
-
-Each integration connects Neo to the service's [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server, which means Neo can use the full set of tools that service exposes through MCP.
-
 ## Enabling an integration
 
-Organization administrators configure integrations in Neo Settings:
+To enable an integration, navigate to **Neo Settings**, select **Integrations**, select the integration, and provide the required credentials.
 
-1. Navigate to **Neo Settings** in the Pulumi Cloud left navigation
-1. Select the **Integrations** tab
-1. Find the integration you want to enable and select **Configure**
-1. Enter the required credentials for the integration
-1. Select **Save**
-
-The credentials you provide depend on the integration. Some require an API key, while others use OAuth to connect your organization's account. Each integration's configuration form includes guidance on where to find or generate the required credentials.
+Each integration connects Neo to the service's [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server, which means Neo can use the full set of tools that service exposes through MCP.
 
 ### Credential storage
 
@@ -60,10 +36,7 @@ Integration credentials are stored securely in [Pulumi ESC](/docs/esc/) (Environ
 
 ## Disabling an integration
 
-To remove an integration from your organization:
-
-1. Navigate to **Neo Settings** → **Integrations**
-1. Find the integration you want to disable and select **Remove**
+To remove an integration from your organization, navigate to **Neo Settings**, select **Integrations**, find the integration, and select **Remove**.
 
 Disabling an integration deletes its credentials from ESC and immediately prevents any new tasks from using it. Tasks that are already running will lose access to the integration on their next tool call.
 
@@ -72,3 +45,56 @@ Disabling an integration deletes its credentials from ESC and immediately preven
 When Neo starts a task, it connects to each enabled integration's MCP server using the stored credentials. From there, Neo can use any tools the MCP server provides. For example, with the Honeycomb integration enabled, Neo can query traces to investigate a performance issue that came up during an infrastructure review. With Linear enabled, Neo can look up the details of an issue referenced in a task description.
 
 The integration connection is transparent. Neo decides when to use an integration based on the context of your conversation, just as it decides when to use any other tool.
+
+## Configuration
+
+### Atlassian (Jira & Confluence)
+
+1. In **admin.atlassian.com**, open **Rovo MCP**
+    - Enable **API token authentication**
+    - Add `https://*.pulumi.com/**` as an allowed domain
+1. Open **Directory**, then **Service Accounts**
+1. Create a service account and give it user access to each product you want Neo to access
+1. Create a credential for the service account with type **API** and assign the necessary roles
+1. In Neo, enter the **Service Account API Token** and your **Site URL** (e.g., `https://yoursite.atlassian.net`)
+
+### Datadog
+
+1. In **Organization Settings**, open **Service Accounts** and create a service account with read-only access
+1. On the service account's details page, create an **App Key** and make sure to include the MCP read scope
+1. In **Organization Settings**, open **API Keys** and create an **API Key**
+1. In Neo, enter the **API Key** and **App Key**
+
+### Honeycomb
+
+1. In Honeycomb, navigate to **Account**, then **Team Settings**, then **API Keys**
+1. Select **Create Management API Key** and give it a name (e.g., "MCP Integration")
+1. Choose the **Model Context Protocol** and **Environments** scopes, then grant permissions:
+    - **Read**: Required for all Honeycomb MCP operations. Make sure to grant read for both MCP and Environments.
+    - **Write**: Required for the `create_board` tool.
+1. Copy the **Key ID** and **Key Secret**. You will not be able to see them again.
+1. In Neo, enter the API key in the format `<key_id>:<secret_key>`
+
+### Linear
+
+{{% notes type="info" %}}
+Linear API keys are personal tokens. All actions Neo takes through this integration are attributed to the user who created the token, regardless of who creates the Neo task. OAuth support is planned for a future release.
+{{% /notes %}}
+
+1. In Linear, open **Settings**, then **Security & Access**
+1. Select **New API Key**, give it a name, and configure the permissions and team access for your use case
+1. In Neo, enter the **API Key**
+
+### Notion
+
+Notion uses OAuth to connect your organization's account. Select **Connect** and follow the authorization flow.
+
+### Sentry
+
+Sentry uses OAuth to connect your organization's account. Select **Connect** and follow the authorization flow.
+
+### Supabase
+
+Requires:
+
+- **Access Token**: On **supabase.com**, open **Account Preferences**, then **Access Tokens**

--- a/content/docs/ai/integrations/_index.md
+++ b/content/docs/ai/integrations/_index.md
@@ -46,6 +46,16 @@ When Neo starts a task, it connects to each enabled integration's MCP server usi
 
 The integration connection is transparent. Neo decides when to use an integration based on the context of your conversation, just as it decides when to use any other tool.
 
+## Per-task control
+
+By default, every task inherits all integrations the organization has enabled. If you want to narrow Neo's focus for a specific task — for example, running a deployment review without giving Neo access to your issue tracker — you can toggle individual integrations off from the task composer before starting the conversation. The toggles only affect the current task; the org-level configuration is unchanged.
+
+## If an integration fails
+
+Integrations are resolved independently at the start of each message. If credentials for one integration can't be retrieved, or its MCP server is unreachable, Neo logs a warning, skips that integration, and continues the task with the remaining ones. A single broken integration won't stop a task from running.
+
+If Neo tries to use an integration that isn't available — for example, because the credentials were removed or expired — it will surface the failure in the conversation and continue with its other tools.
+
 ## Configuration
 
 ### Atlassian (Jira & Confluence)

--- a/content/docs/ai/settings/_index.md
+++ b/content/docs/ai/settings/_index.md
@@ -146,9 +146,9 @@ You can place `AGENTS.md` files in subdirectories for more specific instructions
 
 ## Integrations
 
-Neo can connect to third-party services like Atlassian, Datadog, Honeycomb, Linear, and Supabase, giving tasks the ability to query external tools alongside your infrastructure. Integrations are configured in the **Integrations** tab of Neo Settings, where administrators can enable services and provide credentials.
+Neo can connect to third-party services like issue trackers, observability platforms, and wikis, giving tasks the ability to query external tools alongside your infrastructure. Integrations are configured in the **Integrations** tab of Neo Settings, where administrators can enable services and provide credentials.
 
-See [Integrations](/docs/ai/integrations/) for the full list of available integrations, setup instructions, and details on per-task integration selection.
+See [Integrations](/docs/ai/integrations/) for the full list of available integrations, setup instructions, and credential storage details.
 
 ## Slash commands
 

--- a/content/docs/ai/settings/_index.md
+++ b/content/docs/ai/settings/_index.md
@@ -146,7 +146,7 @@ You can place `AGENTS.md` files in subdirectories for more specific instructions
 
 ## Integrations
 
-Neo can connect to third-party services like issue trackers, observability platforms, and wikis, giving tasks the ability to query external tools alongside your infrastructure. Integrations are configured in the **Integrations** tab of Neo Settings, where administrators can enable services and provide credentials.
+Neo can connect to third-party services like issue trackers, observability platforms, incident response tools, wikis, and databases, giving tasks the ability to query external tools alongside your infrastructure. Integrations are configured in the **Integrations** tab of Neo Settings, where administrators can enable services and provide credentials.
 
 See [Integrations](/docs/ai/integrations/) for the full list of available integrations, setup instructions, and credential storage details.
 

--- a/content/docs/ai/settings/_index.md
+++ b/content/docs/ai/settings/_index.md
@@ -2,7 +2,7 @@
 title: Settings
 title_tag: Neo Settings
 h1: Neo Settings
-meta_desc: Configure Neo for your organization with Custom Instructions, Repository Instructions (AGENTS.md), Slash Commands, access controls, and task modes.
+meta_desc: Configure Neo with Custom Instructions, Repository Instructions, Slash Commands, integrations, access controls, and task modes.
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     ai:
@@ -143,6 +143,12 @@ You can place `AGENTS.md` files in subdirectories for more specific instructions
 - Focus on conventions that can't be enforced by automated tools
 - Keep instructions actionable and specific
 - Review and update as your project's practices evolve
+
+## Integrations
+
+Neo can connect to third-party services like Atlassian, Datadog, Honeycomb, Linear, and Supabase, giving tasks the ability to query external tools alongside your infrastructure. Integrations are configured in the **Integrations** tab of Neo Settings, where administrators can enable services and provide credentials.
+
+See [Integrations](/docs/ai/integrations/) for the full list of available integrations, setup instructions, and details on per-task integration selection.
 
 ## Slash commands
 

--- a/content/docs/ai/settings/_index.md
+++ b/content/docs/ai/settings/_index.md
@@ -2,7 +2,7 @@
 title: Settings
 title_tag: Neo Settings
 h1: Neo Settings
-meta_desc: Configure Neo with Custom Instructions, Repository Instructions, Slash Commands, integrations, access controls, and task modes.
+meta_desc: Configure Neo with Custom Instructions, Repository Instructions, Slash Commands, Integrations, access controls, and task modes.
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     ai:

--- a/content/docs/ai/tasks/_index.md
+++ b/content/docs/ai/tasks/_index.md
@@ -71,6 +71,10 @@ At any time, you can ask Neo to run a [pulumi preview](/docs/iac/cli/commands/pu
 
 If a task results in code modifications, Neo will offer to open a [pull request](/docs/ai/pull-requests/) once you are satisfied with the implementation. PRs can also be modified after they have been opened.
 
+## Integrations
+
+If your organization has [integrations](/docs/ai/integrations/) enabled, Neo can read from external services like issue trackers, observability platforms, and runbooks during tasks.
+
 ## Context, sharing, and history
 
 ### Setting entity context


### PR DESCRIPTION
## Summary

- Adds new integrations page at `/docs/ai/integrations/` documenting the integration catalog feature
- Covers available integrations (Atlassian, Datadog, Honeycomb, Linear, Notion, Sentry, Supabase), admin setup, credential storage, and usage examples
- Adds integration references to the AI landing page, settings page, and tasks page

Docs companion to the integration catalog backend work on pulumi/pulumi-service.