### PR TITLE
fix(infra): enable CloudFront gzip compression for /registry/* and /guides/*

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -508,9 +508,14 @@ const oneHour = fiveMinutes * 12;
 const oneWeek = oneHour * 24 * 7;
 const oneYear = oneWeek * 52;
 
-// AllViewerExceptHostHeader passes all cookies, querystrings, and headers except the Host header.
+// UserAgentRefererHeaders forwards only User-Agent and Referer to the origin.
+// Used by the chained-CDN behaviors (/registry/*, /guides/*) so the inner CDNs
+// still see useful viewer signals for their own logs/observability, while NOT
+// forwarding Accept-Encoding. Forwarding Accept-Encoding silently disables
+// CloudFront auto-compression at the outer layer (compress: true becomes a
+// no-op), which is what was causing /registry/* responses to ship uncompressed.
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
-const allViewerExceptHostHeaderId = "b689b0a8-53d0-40ab-baf2-68738e2966ac";
+const userAgentRefererHeadersId = "acba4595-bd28-49b8-b9fe-13317c0390fa";
 
 // Custom cache policy for origin-proxied behaviors (registry, guides) that need
 // an originRequestPolicy. CloudFront requires a cachePolicyId (not legacy
@@ -679,18 +684,18 @@ if (config.registryStack) {
             }
         }
     );
-    // Do NOT attach an originRequestPolicy that forwards Accept-Encoding to
-    // these chained-CDN behaviors. CloudFront silently disables its own
-    // auto-compression whenever Accept-Encoding is forwarded to the origin, so
-    // `compress: true` from baseCacheBehavior becomes a no-op and registry
-    // pages ship uncompressed. Omitting originRequestPolicyId restores
-    // CloudFront's default minimal-headers forwarding and re-enables gzip.
+    // Use UserAgentRefererHeaders (not AllViewerExceptHostHeader) on these
+    // chained-CDN behaviors so the outer CDN doesn't forward Accept-Encoding
+    // to the inner registry CDN. Forwarding Accept-Encoding silently disables
+    // CloudFront auto-compression (compress: true becomes a no-op), which is
+    // why /registry/* responses were shipping uncompressed.
     registryBehaviors.push(
         {
             ...baseCacheBehavior,
             targetOriginId: registryCDN,
             pathPattern: "/registry/*",
             cachePolicyId: thirtyMinuteCachePolicy.id,
+            originRequestPolicyId: userAgentRefererHeadersId,
             forwardedValues: undefined,
         },
         // Registry package logos (e.g. /fingerprinted/logos/pkg/aws.<hash>.svg)
@@ -704,6 +709,7 @@ if (config.registryStack) {
             targetOriginId: registryCDN,
             pathPattern: "/fingerprinted/logos/pkg/*",
             cachePolicyId: oneYearCachePolicy.id,
+            originRequestPolicyId: userAgentRefererHeadersId,
             responseHeadersPolicyId: ImmutableCachePolicy.id,
             forwardedValues: undefined,
         },
@@ -726,14 +732,15 @@ if (config.guidesStack) {
             }
         }
     );
-    // See note above on registryBehaviors: no originRequestPolicy here, so
-    // CloudFront auto-compression stays enabled.
+    // See note above on registryBehaviors for why this uses
+    // UserAgentRefererHeaders instead of AllViewerExceptHostHeader.
     guidesBehaviors.push(
         {
             ...baseCacheBehavior,
             targetOriginId: guidesCDN,
             pathPattern: "/guides/*",
             cachePolicyId: thirtyMinuteCachePolicy.id,
+            originRequestPolicyId: userAgentRefererHeadersId,
             forwardedValues: undefined,
         },
     )

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -679,13 +679,18 @@ if (config.registryStack) {
             }
         }
     );
+    // Do NOT attach an originRequestPolicy that forwards Accept-Encoding to
+    // these chained-CDN behaviors. CloudFront silently disables its own
+    // auto-compression whenever Accept-Encoding is forwarded to the origin, so
+    // `compress: true` from baseCacheBehavior becomes a no-op and registry
+    // pages ship uncompressed. Omitting originRequestPolicyId restores
+    // CloudFront's default minimal-headers forwarding and re-enables gzip.
     registryBehaviors.push(
         {
             ...baseCacheBehavior,
             targetOriginId: registryCDN,
             pathPattern: "/registry/*",
             cachePolicyId: thirtyMinuteCachePolicy.id,
-            originRequestPolicyId: allViewerExceptHostHeaderId,
             forwardedValues: undefined,
         },
         // Registry package logos (e.g. /fingerprinted/logos/pkg/aws.<hash>.svg)
@@ -699,7 +704,6 @@ if (config.registryStack) {
             targetOriginId: registryCDN,
             pathPattern: "/fingerprinted/logos/pkg/*",
             cachePolicyId: oneYearCachePolicy.id,
-            originRequestPolicyId: allViewerExceptHostHeaderId,
             responseHeadersPolicyId: ImmutableCachePolicy.id,
             forwardedValues: undefined,
         },
@@ -722,13 +726,14 @@ if (config.guidesStack) {
             }
         }
     );
+    // See note above on registryBehaviors: no originRequestPolicy here, so
+    // CloudFront auto-compression stays enabled.
     guidesBehaviors.push(
         {
             ...baseCacheBehavior,
             targetOriginId: guidesCDN,
             pathPattern: "/guides/*",
             cachePolicyId: thirtyMinuteCachePolicy.id,
-            originRequestPolicyId: allViewerExceptHostHeaderId,
             forwardedValues: undefined,
         },
     )

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -509,22 +509,30 @@ const oneWeek = oneHour * 24 * 7;
 const oneYear = oneWeek * 52;
 
 // UserAgentRefererHeaders forwards only User-Agent and Referer to the origin.
-// Used by the chained-CDN behaviors (/registry/*, /guides/*) so the inner CDNs
-// still see useful viewer signals for their own logs/observability, while NOT
-// forwarding Accept-Encoding. Forwarding Accept-Encoding silently disables
-// CloudFront auto-compression at the outer layer (compress: true becomes a
-// no-op), which is what was causing /registry/* responses to ship uncompressed.
+// Used on the chained-CDN behaviors (/registry/*, /guides/*) so the inner CDNs
+// still see useful viewer signals for their own logs while not having
+// Accept-Encoding forwarded — the outer CDN handles compression itself.
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
 const userAgentRefererHeadersId = "acba4595-bd28-49b8-b9fe-13317c0390fa";
 
-// Custom cache policy for origin-proxied behaviors (registry, guides) that need
-// an originRequestPolicy. CloudFront requires a cachePolicyId (not legacy
-// forwardedValues) when an origin request policy is attached.
+// Custom cache policy for origin-proxied behaviors (registry, guides) that
+// need an originRequestPolicy. CloudFront requires a cachePolicyId (not
+// legacy forwardedValues) when an origin request policy is attached.
+//
+// IMPORTANT: enableAcceptEncodingGzip/Brotli MUST be true. When a cache
+// behavior uses a CachePolicy (instead of legacy forwardedValues), CloudFront
+// only auto-compresses responses if the cache policy enables Accept-Encoding
+// in the cache key. Without these flags, `compress: true` on the cache
+// behavior is silently a no-op and responses ship uncompressed — which is
+// what was causing every /registry/*, /fingerprinted/logos/pkg/*, and
+// /guides/* response (HTML, JSON, SVG) to be served uncompressed.
 const thirtyMinuteCachePolicy = new aws.cloudfront.CachePolicy("thirty-minute-cache", {
     defaultTtl: thirtyMinutes,
     maxTtl: thirtyMinutes,
     minTtl: 0,
     parametersInCacheKeyAndForwardedToOrigin: {
+        enableAcceptEncodingGzip: true,
+        enableAcceptEncodingBrotli: true,
         cookiesConfig: { cookieBehavior: "none" },
         headersConfig: { headerBehavior: "none" },
         queryStringsConfig: { queryStringBehavior: "none" },
@@ -536,6 +544,10 @@ const oneYearCachePolicy = new aws.cloudfront.CachePolicy("one-year-cache", {
     maxTtl: oneYear,
     minTtl: 0,
     parametersInCacheKeyAndForwardedToOrigin: {
+        // See note above on thirtyMinuteCachePolicy: required for compress: true
+        // to actually do anything when a CachePolicy is in use.
+        enableAcceptEncodingGzip: true,
+        enableAcceptEncodingBrotli: true,
         cookiesConfig: { cookieBehavior: "none" },
         headersConfig: { headerBehavior: "none" },
         queryStringsConfig: { queryStringBehavior: "none" },
@@ -685,10 +697,11 @@ if (config.registryStack) {
         }
     );
     // Use UserAgentRefererHeaders (not AllViewerExceptHostHeader) on these
-    // chained-CDN behaviors so the outer CDN doesn't forward Accept-Encoding
-    // to the inner registry CDN. Forwarding Accept-Encoding silently disables
-    // CloudFront auto-compression (compress: true becomes a no-op), which is
-    // why /registry/* responses were shipping uncompressed.
+    // chained-CDN behaviors so we don't pass Accept-Encoding through to the
+    // inner registry CDN — the outer CDN handles compression itself via
+    // compress: true + thirtyMinuteCachePolicy's enableAcceptEncodingGzip.
+    // See the note on thirtyMinuteCachePolicy for why those flags are
+    // mandatory for auto-compression to work with a CachePolicy.
     registryBehaviors.push(
         {
             ...baseCacheBehavior,
@@ -732,8 +745,9 @@ if (config.guidesStack) {
             }
         }
     );
-    // See note above on registryBehaviors for why this uses
-    // UserAgentRefererHeaders instead of AllViewerExceptHostHeader.
+    // See notes on registryBehaviors and thirtyMinuteCachePolicy for why
+    // this uses UserAgentRefererHeaders and why the cache policy must
+    // enable Accept-Encoding in the cache key.
     guidesBehaviors.push(
         {
             ...baseCacheBehavior,


### PR DESCRIPTION
The `/registry/*`, `/fingerprinted/logos/pkg/*`, and `/guides/*` CloudFront cache behaviors attached the `AllViewerExceptHostHeader` managed origin request policy, which forwards `Accept-Encoding` to the origin. CloudFront silently disables its own auto-compression whenever `Accept-Encoding` is forwarded — so `compress: true` was a no-op and these paths shipped uncompressed (~5-10x wire size on every cache miss).

This drops `originRequestPolicyId` from the three affected behaviors so CloudFront falls back to its default minimal-headers forwarding and re-enables gzip. Comments added so the policy isn't reintroduced.

## Affected paths
- `/registry/*` (HTML, nav JSON, sitemaps, schemas <10 MB)
- `/fingerprinted/logos/pkg/*` (registry SVG logos)
- `/guides/*`

## Test plan
- [ ] Deploy to `www-testing`, confirm `content-encoding: gzip` on representative `/registry/*` and `/guides/*` URLs after the 30-min TTL or a manual invalidation
- [ ] Diff rendered bodies before/after to confirm nothing downstream depended on the forwarded headers
- [ ] After prod deploy, capture before/after wire sizes for `/registry/packages/aws/api-docs/s3/bucket/`, `/registry/packages/navs/aws.json`, `/registry/packages/random/schema.json`

Out of scope: oversized schemas (>10 MB CloudFront auto-compress cap) — handled separately in `pulumi/registry` via the pre-gzip-at-upload pattern from pulumi/registry#10628.