### PR TITLE
Fix incorrect argument property in packages docs

### DIFF
--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -116,6 +116,7 @@ Alternatively, a package value can be an object with the following properties:
 | `source` | string | Yes | No | The source of the package. Can be a path to a local plugin, a URL to a Git repository, or a pulumi plugin name. |
 | `version` | string | No | No | The version of the package. |
 | `parameters` | List<string> | No | No | A list of parameters for the `source` package. |
+| `checksums` | Map<string, string> | No | No | A map of `os-arch` keys (e.g., `linux-x64`) to checksums used to validate downloaded plugins. |
 | `pluginDownloadURL` | string | No | No | The server to download the plugin from, if a custom download location is needed. |
 
 ### `config` options

--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -103,19 +103,20 @@ This option can be set to `mypy` or `pyright`. (For additional type checkers, fi
 
 `packages` is a map of package names to either `package add` arguments or structured package declarations. It specifies the packages that the program is utilizing. The command `pulumi install` will install these packages and generate the corresponding SDKs for them.
 
-#### Values
+#### String shorthand
 
-| Property | Type | Required | Expression | Description |
-| - | - | - | - | - |
-| `argument` | string | No | No | A string in the same format as it would be when passed to [`package add`](/docs/iac/cli/commands/pulumi_package_add/) |
+Each package value can be a plain string in the same format as the argument to [`pulumi package add`](/docs/iac/cli/commands/pulumi_package_add/), for example `"aws@6.0.0"`. The string is split on `@` into a source and optional version.
 
-#### Package declarations
+#### Structured declarations
+
+Alternatively, a package value can be an object with the following properties:
 
 | Property | Type | Required | Expression | Description |
 | - | - | - | - | - |
 | `source` | string | Yes | No | The source of the package. Can be a path to a local plugin, a URL to a Git repository, or a pulumi plugin name. |
 | `version` | string | No | No | The version of the package. |
-| `parameters` | List<string> | No | No | A list of parameters for the `source` package |
+| `parameters` | List<string> | No | No | A list of parameters for the `source` package. |
+| `pluginDownloadURL` | string | No | No | The server to download the plugin from, if a custom download location is needed. |
 
 ### `config` options
 


### PR DESCRIPTION
## Summary

The project file reference listed a non-existent `argument` property for the `packages` option in Pulumi.yaml. This property does not exist in the source code.

**What was wrong:** The docs showed a table with an `argument` property under "Values" for packages. No such field exists in [`PackageSpec`](https://github.com/pulumi/pulumi/blob/8bd51fc536c18f74d31afecac30024d0ec4797a8/sdk/go/common/workspace/project.go#L111-L130) or its [marshalled form](https://github.com/pulumi/pulumi/blob/8bd51fc536c18f74d31afecac30024d0ec4797a8/sdk/go/common/workspace/project.go#L173-L179). If a user wrote `argument: "aws@6.0.0"` in their Pulumi.yaml it would be silently ignored.

**What the code actually does:** The [unmarshalling logic](https://github.com/pulumi/pulumi/blob/8bd51fc536c18f74d31afecac30024d0ec4797a8/sdk/go/common/workspace/project.go#L198-L227) accepts either:
1. A plain string (e.g., `"aws@6.0.0"`) which is split on `@` into `source` and `version`
2. A structured object with fields: `source`, `version`, `parameters`, `checksums`, `pluginDownloadURL`

**This PR:**
- Replaces the non-existent `argument` property with documentation of the string shorthand format
- Adds the missing `pluginDownloadURL` field to the structured declarations table