### PR TITLE
feat: add ItemList structured data for comparison table pages

### DIFF
--- a/layouts/partials/schema/collectors/comparison-table-entity.html
+++ b/layouts/partials/schema/collectors/comparison-table-entity.html
@@ -1,0 +1,90 @@
+{{/* Returns ItemList entity for comparison tables found on /comparisons/ pages */}}
+
+{{ $entity := dict }}
+
+{{ if strings.Contains .RelPermalink "/comparisons/" }}
+
+  {{/* Extract the competitor name — try h1, title_tag, then title */}}
+  {{ $title := or .Params.h1 .Params.title_tag .Title }}
+  {{ $competitorName := "" }}
+  {{ $productName := "Pulumi" }}
+  {{ if strings.Contains $title "Pulumi vs" }}
+    {{ $competitorName = replaceRE `^.*Pulumi vs\.?\s*` "" $title }}
+  {{ else if strings.Contains $title " vs" }}
+    {{ $parts := split $title " vs" }}
+    {{ if ge (len $parts) 2 }}
+      {{ $productName = index $parts 0 | strings.TrimSpace }}
+      {{ $competitorName = index $parts 1 | replaceRE `^\.?\s*` "" | strings.TrimSpace }}
+    {{ end }}
+  {{ end }}
+
+  {{ if and $competitorName (strings.Contains .RawContent "| Feature |") }}
+
+    {{/* Extract from "| Feature |" onward */}}
+    {{ $afterHeader := replaceRE `(?s)^.*?\| Feature \|` "| Feature |" .RawContent }}
+
+    {{/* Extract all table lines */}}
+    {{ $allTableLines := findRE `(?m)^\|.+\|` $afterHeader }}
+
+    {{ if ge (len $allTableLines) 3 }}
+
+      {{ $dataLines := $allTableLines | after 2 }}
+
+      {{/* Use Scratch to accumulate rows inside range */}}
+      {{ $.Scratch.Set "compRows" slice }}
+
+      {{ range $dataLines }}
+        {{ $line := . | strings.TrimSpace }}
+        {{ if not (findRE `^\|[\s\-:|]+\|$` $line) }}
+          {{ $cells := split $line "|" }}
+          {{ if ge (len $cells) 4 }}
+            {{ $feature := index $cells 1 | strings.TrimSpace }}
+            {{ $feature = replaceRE `\[([^\]]+)\]\([^)]+\)` "$1" $feature }}
+            {{ $val1 := index $cells 2 | strings.TrimSpace }}
+            {{ $val2 := index $cells 3 | strings.TrimSpace }}
+            {{ $val1 = replaceRE `<[^>]+>` " " $val1 }}
+            {{ $val2 = replaceRE `<[^>]+>` " " $val2 }}
+            {{ $val1 = replaceRE `\[([^\]]+)\]\([^)]+\)` "$1" $val1 }}
+            {{ $val2 = replaceRE `\[([^\]]+)\]\([^)]+\)` "$1" $val2 }}
+            {{ $existing := $.Scratch.Get "compRows" }}
+            {{ $.Scratch.Set "compRows" ($existing | append (dict "feature" $feature "product" $val1 "competitor" $val2)) }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+
+      {{ $rows := $.Scratch.Get "compRows" }}
+      {{ $.Scratch.Delete "compRows" }}
+
+      {{ if len $rows }}
+
+        {{/* Build ItemList with ListItem entries */}}
+        {{ $.Scratch.Set "compItems" slice }}
+        {{ range $i, $row := $rows }}
+          {{ $position := add $i 1 }}
+          {{ $existing := $.Scratch.Get "compItems" }}
+          {{ $.Scratch.Set "compItems" ($existing | append (dict
+            "@type" "ListItem"
+            "position" $position
+            "name" $row.feature
+            "description" (printf "%s: %s | %s: %s" $productName $row.product $competitorName $row.competitor)
+          )) }}
+        {{ end }}
+
+        {{ $items := $.Scratch.Get "compItems" }}
+        {{ $.Scratch.Delete "compItems" }}
+
+        {{ $entity = dict
+          "@type" "ItemList"
+          "@id" "#comparison-table"
+          "name" (printf "%s vs. %s Feature Comparison" $productName $competitorName)
+          "description" (printf "Side-by-side feature comparison of %s and %s for infrastructure as code" $productName $competitorName)
+          "numberOfItems" (len $items)
+          "itemListElement" $items
+        }}
+
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return $entity }}

--- a/layouts/partials/schema/collectors/comparison-table-entity.html
+++ b/layouts/partials/schema/collectors/comparison-table-entity.html
@@ -2,31 +2,22 @@
 
 {{ $entity := dict }}
 
-{{ if strings.Contains .RelPermalink "/comparisons/" }}
+{{ if and (strings.Contains .RelPermalink "/comparisons/") (strings.Contains .RawContent "| Feature |") }}
 
-  {{/* Extract the competitor name — try h1, title_tag, then title */}}
-  {{ $title := or .Params.h1 .Params.title_tag .Title }}
-  {{ $competitorName := "" }}
-  {{ $productName := "Pulumi" }}
-  {{ if strings.Contains $title "Pulumi vs" }}
-    {{ $competitorName = replaceRE `^.*Pulumi vs\.?\s*` "" $title }}
-  {{ else if strings.Contains $title " vs" }}
-    {{ $parts := split $title " vs" }}
-    {{ if ge (len $parts) 2 }}
-      {{ $productName = index $parts 0 | strings.TrimSpace }}
-      {{ $competitorName = index $parts 1 | replaceRE `^\.?\s*` "" | strings.TrimSpace }}
-    {{ end }}
-  {{ end }}
+  {{/* Extract from "| Feature |" onward */}}
+  {{ $afterHeader := replaceRE `(?s)^.*?\| Feature \|` "| Feature |" .RawContent }}
 
-  {{ if and $competitorName (strings.Contains .RawContent "| Feature |") }}
+  {{/* Extract all table lines */}}
+  {{ $allTableLines := findRE `(?m)^\|.+\|` $afterHeader }}
 
-    {{/* Extract from "| Feature |" onward */}}
-    {{ $afterHeader := replaceRE `(?s)^.*?\| Feature \|` "| Feature |" .RawContent }}
+  {{ if ge (len $allTableLines) 3 }}
 
-    {{/* Extract all table lines */}}
-    {{ $allTableLines := findRE `(?m)^\|.+\|` $afterHeader }}
+    {{/* Extract column names from the table header row (always in correct column order) */}}
+    {{ $headerCells := split (index $allTableLines 0) "|" }}
+    {{ $productName := index $headerCells 2 | strings.TrimSpace }}
+    {{ $competitorName := index $headerCells 3 | strings.TrimSpace }}
 
-    {{ if ge (len $allTableLines) 3 }}
+    {{ if $competitorName }}
 
       {{ $dataLines := $allTableLines | after 2 }}
 

--- a/layouts/partials/schema/collectors/comparison-table-entity.html
+++ b/layouts/partials/schema/collectors/comparison-table-entity.html
@@ -4,11 +4,13 @@
 
 {{ if and (strings.Contains .RelPermalink "/comparisons/") (strings.Contains .RawContent "| Feature |") }}
 
-  {{/* Extract from "| Feature |" onward */}}
+  {{/* Extract from "| Feature |" onward, then truncate to just the first table block
+       so later tables on the page (e.g., Crossplane's "When to Choose") don't pollute the ItemList */}}
   {{ $afterHeader := replaceRE `(?s)^.*?\| Feature \|` "| Feature |" .RawContent }}
+  {{ $firstTable := index (split $afterHeader "\n\n") 0 }}
 
   {{/* Extract all table lines */}}
-  {{ $allTableLines := findRE `(?m)^\|.+\|` $afterHeader }}
+  {{ $allTableLines := findRE `(?m)^\|.+\|` $firstTable }}
 
   {{ if ge (len $allTableLines) 3 }}
 
@@ -31,12 +33,15 @@
           {{ if ge (len $cells) 4 }}
             {{ $feature := index $cells 1 | strings.TrimSpace }}
             {{ $feature = replaceRE `\[([^\]]+)\]\([^)]+\)` "$1" $feature }}
+            {{ $feature = replaceRE `\*+([^*]+)\*+` "$1" $feature }}
             {{ $val1 := index $cells 2 | strings.TrimSpace }}
             {{ $val2 := index $cells 3 | strings.TrimSpace }}
             {{ $val1 = replaceRE `<[^>]+>` " " $val1 }}
             {{ $val2 = replaceRE `<[^>]+>` " " $val2 }}
             {{ $val1 = replaceRE `\[([^\]]+)\]\([^)]+\)` "$1" $val1 }}
             {{ $val2 = replaceRE `\[([^\]]+)\]\([^)]+\)` "$1" $val2 }}
+            {{ $val1 = replaceRE `\*+([^*]+)\*+` "$1" $val1 }}
+            {{ $val2 = replaceRE `\*+([^*]+)\*+` "$1" $val2 }}
             {{ $existing := $.Scratch.Get "compRows" }}
             {{ $.Scratch.Set "compRows" ($existing | append (dict "feature" $feature "product" $val1 "competitor" $val2)) }}
           {{ end }}

--- a/layouts/partials/schema/graph-builder.html
+++ b/layouts/partials/schema/graph-builder.html
@@ -170,6 +170,14 @@
   {{ $graph = $graph | append $software }}
 {{ end }}
 
+{{/* Add comparison table schema for comparison pages */}}
+{{ if not .IsHome }}
+  {{ $comparisonTable := partial "schema/collectors/comparison-table-entity.html" . }}
+  {{ if and $comparisonTable (ne $comparisonTable (dict)) }}
+    {{ $graph = $graph | append $comparisonTable }}
+  {{ end }}
+{{ end }}
+
 {{/* Add video schema if page contains YouTube videos */}}
 {{ if not .IsHome }}
   {{ $videoEntity := partial "schema/collectors/video-entity.html" . }}

--- a/layouts/partials/schema/graph-builder.html
+++ b/layouts/partials/schema/graph-builder.html
@@ -29,6 +29,15 @@
   {{ $webpage = merge $webpage (dict "mainEntity" (dict "@id" "#main-content")) }}
 {{ end }}
 
+{{/* Collect comparison table schema before finalizing WebPage so hasPart can be wired */}}
+{{ $comparisonTable := dict }}
+{{ if not .IsHome }}
+  {{ $comparisonTable = partial "schema/collectors/comparison-table-entity.html" . }}
+  {{ if and $comparisonTable (ne $comparisonTable (dict)) }}
+    {{ $webpage = merge $webpage (dict "hasPart" (dict "@id" "#comparison-table")) }}
+  {{ end }}
+{{ end }}
+
 {{/* Add WebPage to graph */}}
 {{ $graph = $graph | append $webpage }}
 
@@ -170,12 +179,9 @@
   {{ $graph = $graph | append $software }}
 {{ end }}
 
-{{/* Add comparison table schema for comparison pages */}}
-{{ if not .IsHome }}
-  {{ $comparisonTable := partial "schema/collectors/comparison-table-entity.html" . }}
-  {{ if and $comparisonTable (ne $comparisonTable (dict)) }}
-    {{ $graph = $graph | append $comparisonTable }}
-  {{ end }}
+{{/* Add comparison table to graph (collected earlier to wire hasPart into WebPage) */}}
+{{ if and $comparisonTable (ne $comparisonTable (dict)) }}
+  {{ $graph = $graph | append $comparisonTable }}
 {{ end }}
 
 {{/* Add video schema if page contains YouTube videos */}}


### PR DESCRIPTION
## Summary
- Adds a new schema collector (`comparison-table-entity.html`) that parses Markdown feature-comparison tables on `/comparisons/` pages and emits JSON-LD `ItemList` structured data
- Wires the collector into `graph-builder.html` so it's included in the page's schema graph

## Test plan
- [ ] Verify `make build` succeeds
- [ ] Spot-check a comparison page (e.g., Pulumi vs Terraform) and confirm the `ItemList` JSON-LD block appears in the page source
- [ ] Confirm non-comparison pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)