### PR TITLE
feat: enable HTTP/3 (QUIC) on CloudFront distribution

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -1018,6 +1018,8 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     // "100" is the least broad, and also the least expensive.
     priceClass: "PriceClass_All",
 
+    httpVersion: "http2and3",
+
     // Customize error pages.
     // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html
     customErrorResponses: [


### PR DESCRIPTION
## Summary
- Enables HTTP/3 (QUIC) support on the CloudFront distribution by setting `httpVersion: "http2and3"`
- CloudFront defaults to HTTP/2 only; this adds HTTP/3 for clients that support it
- Backward-compatible: clients negotiate the best protocol they support, falling back to HTTP/2

## Impact
- Up to 10% improvement in TTFB, up to 15% improvement in page load times (per AWS benchmarks)
- Reduced handshake failures via QUIC 0-RTT reconnection
- Biggest wins on mobile and lossy networks
- No additional cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)