### PR TITLE
feat: enable Origin Shield on docs CloudFront origin

### DIFF
--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -1611,7 +1611,7 @@ Delivery: CloudWatch Logs infrastructure v2
 
 **Compression:** Enabled (gzip, brotli)
 
-**Origin Shield:** Enabled on docs (S3 main) and guides origins in `us-west-2` to improve cache hit ratio and reduce origin load.
+**Origin Shield:** Enabled on the docs (S3 main) origin in `us-west-2` to improve cache hit ratio and reduce origin load. Registry and guides origins have their own CloudFront distributions and should configure Origin Shield in their respective repos.
 
 **Price Class:** All (global distribution)
 

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -1611,6 +1611,8 @@ Delivery: CloudWatch Logs infrastructure v2
 
 **Compression:** Enabled (gzip, brotli)
 
+**Origin Shield:** Enabled on docs (S3 main) and guides origins in `us-west-2` to improve cache hit ratio and reduce origin load.
+
 **Price Class:** All (global distribution)
 
 **Custom Error Responses:**

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -675,10 +675,8 @@ if (config.registryStack) {
                 httpsPort: 443,
                 originSslProtocols: ["TLSv1.2"],
             },
-            originShield: {
-                enabled: true,
-                originShieldRegion: "us-west-2",
-            },
+            // Origin Shield for registry should be configured in pulumi/registry,
+            // not here, since the registry has its own CloudFront distribution.
         }
     );
     registryBehaviors.push(
@@ -719,7 +717,11 @@ if (config.guidesStack) {
                 httpPort: 80,
                 httpsPort: 443,
                 originSslProtocols: ["TLSv1.2"],
-            }
+            },
+            originShield: {
+                enabled: true,
+                originShieldRegion: "us-west-2",
+            },
         }
     );
     guidesBehaviors.push(

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -674,7 +674,11 @@ if (config.registryStack) {
                 httpPort: 80,
                 httpsPort: 443,
                 originSslProtocols: ["TLSv1.2"],
-            }
+            },
+            originShield: {
+                enabled: true,
+                originShieldRegion: "us-west-2",
+            },
         }
     );
     registryBehaviors.push(
@@ -763,6 +767,10 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
                 httpPort: 80,
                 httpsPort: 443,
                 originSslProtocols: ["TLSv1.2"],
+            },
+            originShield: {
+                enabled: true,
+                originShieldRegion: "us-west-2",
             },
         },
         {

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -718,10 +718,8 @@ if (config.guidesStack) {
                 httpsPort: 443,
                 originSslProtocols: ["TLSv1.2"],
             },
-            originShield: {
-                enabled: true,
-                originShieldRegion: "us-west-2",
-            },
+            // Origin Shield for guides should be configured in pulumi/guides,
+            // not here, since guides has its own CloudFront distribution.
         }
     );
     guidesBehaviors.push(


### PR DESCRIPTION
## Summary
- Enables CloudFront Origin Shield on the docs (S3 main) origin
- Uses `us-west-2` to match the S3 bucket region for lowest latency
- Adds a centralized caching layer that collapses duplicate requests to the origin
- Adds comments on registry and guides origins noting Origin Shield should be configured in their respective repos (pulumi/registry, pulumi/guides) since they have their own CloudFront distributions
- Updates BUILD-AND-DEPLOY.md to document Origin Shield configuration

## Impact
- Customers report origin load reductions of ~60% and p90 latency reductions of ~67%
- Improves cache hit ratio by adding an extra cache layer between regional edge caches and the origin
- Cost: ~$0.0035 per 10,000 requests (modest for a static docs site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)