### PR TITLE
Exclude noindex taxonomy pages from sitemap, index tutorial collections

### DIFF
--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,7 +1,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-  {{ if not (or .Params.private .Params.block_external_search_index) }}
+  {{ if not (or .Params.private .Params.block_external_search_index (and .Data.Singular (ne .Data.Singular "collection"))) }}
   <url>
     <loc>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -55,9 +55,11 @@
     <!--
         We use taxonomy pages for tags and authors for our blog posts. These
         pages end up cannibalising other pages on our site that rank for key terms.
-        To avoid this, we add the `noidex` tag to tell search engines not index taxonomy pages.
+        To avoid this, we add the `noindex` tag to tell search engines not index taxonomy pages.
+        Tutorial collection pages (/tutorials/*) are excluded as they serve as
+        valuable landing pages.
     -->
-    {{ if .Data.Singular }}
+    {{ if and .Data.Singular (ne .Data.Singular "collection") }}
         <meta name="robots" content="noindex" />
     {{ end }}
 


### PR DESCRIPTION
## Summary

Google Search Console flagged ~200 taxonomy pages (blog tags, author pages) that have `noindex` meta tags but are still included in the sitemap. This sends conflicting signals to search engines — the sitemap says "index me" while the page says "don't index me."

- **Sitemap** (`layouts/_default/sitemap.xml`): Exclude taxonomy pages (tags, authors) from the sitemap using the same `.Data.Singular` check that `head.html` uses to apply `noindex`. Tutorial collection pages (`/tutorials/*`) are exempted since they function as landing pages.
- **Head** (`layouts/partials/head.html`): Remove `noindex` from tutorial collection pages (`/tutorials/aws/`, `/tutorials/gcp/`, etc.) so they can be indexed — these are curated landing pages for high-intent searches like "pulumi aws tutorials." Also fixes a typo in the comment ("noidex" → "noindex").

### Affected URL patterns

| Pattern | Before | After |
|---|---|---|
| `/blog/tag/*` | noindexed, **in sitemap** | noindexed, **excluded from sitemap** |
| `/blog/author/*` | noindexed, **in sitemap** | noindexed, **excluded from sitemap** |
| `/tutorials/*` | noindexed, in sitemap | **indexed**, in sitemap |

### Context

The full list of affected URLs (from Google Search Console):

<details>
<summary>~200 URLs flagged as "Indexed, though blocked by robots tag"</summary>

- `/blog/tag/python/`, `/blog/tag/aws/`, `/blog/tag/kubernetes/`, `/blog/tag/terraform/`, `/blog/tag/ai/`, etc.
- `/blog/author/joe-duffy/`, `/blog/author/lee-briggs/`, `/blog/author/christian-nunciato/`, etc.
- `/tutorials/aws/`, `/tutorials/gcp/`, `/tutorials/kubernetes/`, `/tutorials/azure/`, `/tutorials/pulumi-esc/`, `/tutorials/learn-pulumi/`

</details>

## Test plan

- [ ] Verify `make build` succeeds
- [ ] Check generated sitemap excludes `/blog/tag/*` and `/blog/author/*` URLs
- [ ] Check generated sitemap includes `/tutorials/*` URLs
- [ ] Verify `/tutorials/aws/` page does NOT have `<meta name="robots" content="noindex" />`
- [ ] Verify `/blog/tag/aws/` page still has `<meta name="robots" content="noindex" />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)