### PR TITLE
feat: add curated /llms-full.txt for LLM consumption

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -38,6 +38,11 @@ outputFormats:
     baseName: "llms"
     isPlainText: true
     permalinkable: false
+  llmsfull:
+    mediaType: "text/plain"
+    baseName: "llms-full"
+    isPlainText: true
+    permalinkable: false
   markdown:
     mediaType: "text/markdown"
     baseName: "index"
@@ -64,6 +69,7 @@ outputs:
     - HTML
     - JSON
     - txtfull
+    - llmsfull
   section:
     - HTML
   page:

--- a/layouts/index.llmsfull.txt
+++ b/layouts/index.llmsfull.txt
@@ -1,0 +1,59 @@
+{{/*
+  llms-full.txt — curated, LLM-optimized concatenation of Pulumi docs.
+  Targets ~200K tokens. Scope is the conceptual mental model + CLI
+  surface area, not how-tos / language tutorials / cloud-specific guides
+  (those are searchable and repetitive across languages).
+
+  CLI command pages are auto-generated reference; we strip the per-flag
+  Options section and keep the Synopsis + usage pattern only.
+*/}}
+# Pulumi Documentation (Curated Full Content)
+
+> Concatenated markdown source for the most LLM-relevant Pulumi documentation: core concepts (IaC + ESC), CLI reference (synopsis only), Automation API, language SDK overview, AI, IDP, Deployments, and Insights. Excludes how-to guides, language-specific tutorials, cloud-specific walkthroughs, and detailed CLI flag references — those are best fetched on demand from individual pages or via the docs sitemap.
+
+For per-page markdown, request `Accept: text/markdown` against any docs URL. For the full sitemap, see https://www.pulumi.com/docs/cli-sitemap.json.
+
+Each page below is delimited by a line of three dashes.
+
+{{- $includes := slice
+  "docs/iac/concepts"
+  "docs/iac/cli"
+  "docs/iac/automation-api"
+  "docs/iac/languages-sdks"
+  "docs/esc/concepts"
+  "docs/esc/environments"
+  "docs/ai"
+  "docs/idp/concepts"
+  "docs/deployments"
+  "docs/insights"
+}}
+{{- $excludes := slice
+  "docs/deployments/deployments"
+  "docs/deployments/get-started"
+  "docs/insights/policy"
+  "docs/insights/discovery"
+  "docs/insights/self-hosted"
+}}
+{{- range where site.RegularPages "Section" "docs" }}
+{{- $p := . }}
+{{- $path := strings.TrimPrefix "/" $p.RelPermalink }}
+{{- $path = strings.TrimSuffix "/" $path }}
+{{- $match := false }}
+{{- range $includes }}{{ if hasPrefix $path . }}{{ $match = true }}{{ end }}{{ end }}
+{{- range $excludes }}{{ if hasPrefix $path . }}{{ $match = false }}{{ end }}{{ end }}
+{{- if and $match (not $p.Params.llms_exclude) (ne $p.Title "") }}
+
+---
+
+# {{ $p.Title }}
+
+Source: {{ $p.Permalink }}
+
+{{ if hasPrefix $path "docs/iac/cli/commands/" }}
+{{- /* CLI commands: keep synopsis + usage pattern, drop Options/flags. */ -}}
+{{- index (split $p.RawContent "## Options") 0 -}}
+{{ else }}
+{{- $p.RawContent -}}
+{{ end }}
+{{- end }}
+{{- end }}

--- a/layouts/index.llmsfull.txt
+++ b/layouts/index.llmsfull.txt
@@ -54,7 +54,8 @@ Source: {{ $p.Permalink }}
 {{- /* CLI commands: keep synopsis + usage pattern, drop Options/flags. */ -}}
 {{- $raw = index (split $raw "## Options") 0 -}}
 {{- end }}
-{{- /* Strip raw HTML tags and collapse the resulting blank-line runs. */ -}}
+{{- /* Strip Hugo shortcode delimiters, raw HTML tags, then collapse blank-line runs. */ -}}
+{{- $raw = replaceRE "\\{\\{[<%][^}]*[%>]\\}\\}" "" $raw -}}
 {{- $raw = replaceRE "<[^>]+>" "" $raw -}}
 {{- $raw = htmlUnescape $raw -}}
 {{- $raw = replaceRE "\n[ \t]*\n[ \t]*(\n[ \t]*)+" "\n\n" $raw -}}

--- a/layouts/index.llmsfull.txt
+++ b/layouts/index.llmsfull.txt
@@ -49,11 +49,15 @@ Each page below is delimited by a line of three dashes.
 
 Source: {{ $p.Permalink }}
 
-{{ if hasPrefix $path "docs/iac/cli/commands/" }}
+{{ $raw := $p.RawContent }}
+{{- if hasPrefix $path "docs/iac/cli/commands/" }}
 {{- /* CLI commands: keep synopsis + usage pattern, drop Options/flags. */ -}}
-{{- index (split $p.RawContent "## Options") 0 -}}
-{{ else }}
-{{- $p.RawContent -}}
-{{ end }}
+{{- $raw = index (split $raw "## Options") 0 -}}
+{{- end }}
+{{- /* Strip raw HTML tags and collapse the resulting blank-line runs. */ -}}
+{{- $raw = replaceRE "<[^>]+>" "" $raw -}}
+{{- $raw = htmlUnescape $raw -}}
+{{- $raw = replaceRE "\n[ \t]*\n[ \t]*(\n[ \t]*)+" "\n\n" $raw -}}
+{{- $raw -}}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

Adds a single concatenated markdown file at `/llms-full.txt` covering the most LLM-relevant Pulumi documentation, scoped to **~197K tokens / 223 pages / 843 KB** so it fits comfortably in modern long-context windows alongside user input.

The existing `/llms.txt` is an *index* (links + descriptions). This is the *content* — a single fetch that gives an LLM the full Pulumi mental model.

## What's included and why

The scope is opinionated: cover what an LLM needs to **reason about Pulumi** rather than what a human needs to **look up**. Reference material that's better fetched on demand (per-page markdown via `Accept: text/markdown`, or the docs sitemap) is intentionally omitted.

| Section | Tokens | Pages | Why included |
|---|---|---|---|
| `iac/concepts` | 113K | 46 | Core mental model: stacks, state & backends, configuration, secrets, inputs/outputs, every resource option, providers, functions, projects, plugins, architecture. This is the bulk of what an LLM needs to write correct Pulumi code. |
| `iac/cli` (synopsis-only) | 23K | 127 | All 127 CLI commands so the model knows the full surface area, but with the per-flag `## Options` section stripped — the synopsis + usage pattern is enough for reasoning, and the full flag dump would 4x this section. |
| `esc/environments` | 24K | 32 | ESC environments mental model. |
| `iac/languages-sdks` | 10K | 4 | Language support overview. |
| `iac/automation-api` | 7K | 2 | Programmatic Pulumi usage. |
| `idp/concepts` | 6K | 6 | IDP conceptual surface. |
| `deployments` (top-level) | 8K | 3 | Pulumi Deployments overview, projects-and-stacks, webhooks, button. |
| `ai` | 5K | 2 | MCP server, skills. |
| `esc/concepts` | 2K | 1 | ESC introduction. |
| **Total** | **~197K** | **223** | |

## What's excluded and why

| Section | Tokens cut | Reason |
|---|---|---|
| `iac/guides` | 181K | How-to guides — language- and scenario-specific, searchable on demand, low reasoning value per token. |
| `iac/get-started` | 94K | Getting-started tutorials repeat across five languages; the model already knows how to scaffold a project. |
| `iac/clouds` | 87K | AWS/Azure/GCP/Kubernetes walkthroughs — LLMs already have strong priors on these clouds; Pulumi-specific guidance is in `iac/concepts` and the registry. |
| `iac/cli` Options sections | 60K | Per-flag reference dumps; available on individual command pages. |
| `esc/integrations` | 37K | Per-integration setup, lookup-style content. |
| `insights/policy` + `insights/discovery` | 45K | Detail kept out; only `insights/_index` is included. |
| `esc/guides`, `esc/cli`, `esc/development` | 36K | Same logic as `iac/guides`. |
| `idp/guides`, `deployments/deployments`, `deployments/get-started` | ~45K | How-tos and getting-started repetition. |
| `administration`, `support`, `version-control`, `reference`, `comparisons` | — | Org/billing/historical content with no LLM reasoning value. |

For anything not covered here, individual pages already support `Accept: text/markdown` content negotiation, and the full hierarchy is in `/docs/cli-sitemap.json`.

## Mechanism

- New `llmsfull` Hugo output format in `config/_default/config.yml` (`baseName: llms-full`, `mediaType: text/plain`).
- Added to `outputs.home` so it renders alongside HTML/JSON/`txtfull`.
- Template: `layouts/index.llmsfull.txt`. Iterates `site.RegularPages` filtered to the docs section, applies an include + exclude prefix list, respects an opt-out `llms_exclude` page parameter (already honored by `llms.txt`), and emits per page:

  ```
  ---

  # {Title}

  Source: {Permalink}

  {RawContent}
  ```

- CLI command pages get a special-cased treatment that splits `RawContent` on `## Options` and keeps only the first half.

## Known v1 limitations

- **Shortcode leakage**: uses Hugo `.RawContent`, so unexpanded shortcodes (`{{</* install-pulumi /*/>}}`, choosers, etc.) appear as source. LLMs can usually parse around them, but it's noise. Upgrading to a rendered-markdown pipeline (matching the per-page `Accept: text/markdown` output) is a follow-up.
- **Single file**: 843 KB / ~197K tokens is fine for fetch + paste, but bandwidth-conscious consumers may eventually want per-product splits (`llms-full-iac.txt`, `llms-full-esc.txt`).
- **No discovery wiring yet**: `llms.txt` does not yet advertise `/llms-full.txt`. Happy to add that pointer in this PR if reviewers want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)