### PR TITLE
Add dateModified schema.org markup to what-is pages

### DIFF
--- a/layouts/partials/schema/collectors/article-entity.html
+++ b/layouts/partials/schema/collectors/article-entity.html
@@ -17,7 +17,31 @@
   "inLanguage" "en-US"
 }}
 
-{{/* Note: Dates omitted for documentation pages - they're evergreen content without meaningful publication dates */}}
+{{/* Add dates with proper fallback handling */}}
+{{ $publishDate := .PublishDate }}
+{{ $modifiedDate := .Lastmod }}
+
+{{/* Fix invalid dates */}}
+{{ if or (not $publishDate) (eq ($publishDate.Format "2006-01-02") "0001-01-01") }}
+  {{ if and .GitInfo .GitInfo.AuthorDate }}
+    {{ $publishDate = .GitInfo.AuthorDate }}
+  {{ else }}
+    {{ $publishDate = now }}
+  {{ end }}
+{{ end }}
+
+{{ if or (not $modifiedDate) (eq ($modifiedDate.Format "2006-01-02") "0001-01-01") }}
+  {{ if and .GitInfo .GitInfo.AuthorDate }}
+    {{ $modifiedDate = .GitInfo.AuthorDate }}
+  {{ else }}
+    {{ $modifiedDate = $publishDate }}
+  {{ end }}
+{{ end }}
+
+{{ $schema = merge $schema (dict
+  "datePublished" ($publishDate.Format "2006-01-02T15:04:05Z07:00")
+  "dateModified" ($modifiedDate.Format "2006-01-02T15:04:05Z07:00")
+) }}
 
 {{/* Add description */}}
 {{ with (or .Params.meta_desc .Summary) }}

--- a/layouts/partials/schema/collectors/faq-entity.html
+++ b/layouts/partials/schema/collectors/faq-entity.html
@@ -130,6 +130,32 @@
   {{/* Add mainEntity with questions */}}
   {{ $schema = merge $schema (dict "mainEntity" $questions) }}
 
+  {{/* Add dates with proper fallback handling */}}
+  {{ $publishDate := .PublishDate }}
+  {{ $modifiedDate := .Lastmod }}
+
+  {{/* Fix invalid dates */}}
+  {{ if or (not $publishDate) (eq ($publishDate.Format "2006-01-02") "0001-01-01") }}
+    {{ if and .GitInfo .GitInfo.AuthorDate }}
+      {{ $publishDate = .GitInfo.AuthorDate }}
+    {{ else }}
+      {{ $publishDate = now }}
+    {{ end }}
+  {{ end }}
+
+  {{ if or (not $modifiedDate) (eq ($modifiedDate.Format "2006-01-02") "0001-01-01") }}
+    {{ if and .GitInfo .GitInfo.AuthorDate }}
+      {{ $modifiedDate = .GitInfo.AuthorDate }}
+    {{ else }}
+      {{ $modifiedDate = $publishDate }}
+    {{ end }}
+  {{ end }}
+
+  {{ $schema = merge $schema (dict
+    "datePublished" ($publishDate.Format "2006-01-02T15:04:05Z07:00")
+    "dateModified" ($modifiedDate.Format "2006-01-02T15:04:05Z07:00")
+  ) }}
+
   {{/* Add publisher reference */}}
   {{ $schema = merge $schema (dict
     "publisher" (dict "@id" "https://www.pulumi.com/#organization")


### PR DESCRIPTION
## Summary

- Adds `datePublished` and `dateModified` schema.org properties to the `article-entity.html` and `faq-entity.html` schema collectors
- What-is pages (which use these collectors) were previously missing date signals in their structured data, hurting SEO freshness scoring
- Uses the same fallback chain already proven in `blog-entity.html`: frontmatter date → git author date → `now`

## Test plan

- [x] `make build` passes with no errors
- [x] Verified `dateModified` appears in rendered JSON-LD for a what-is page (`/what-is/what-is-infrastructure-as-code/`)
- [ ] Spot-check additional what-is pages in the deployed preview to confirm schema renders correctly
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results) on a preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)