### PR TITLE
Fix typos and grammar across template pages

### DIFF
--- a/content/templates/kubernetes/aws/index.md
+++ b/content/templates/kubernetes/aws/index.md
@@ -73,7 +73,7 @@ eksNodeInstanceType
 vpcNetworkCidr
 : The network CIDR to use for the VPC. Defaults to `10.0.0.0/16`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`).
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`)
 or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set).
 
 ## Tidying up

--- a/content/templates/kubernetes/gcp/index.md
+++ b/content/templates/kubernetes/gcp/index.md
@@ -27,7 +27,7 @@ cloud:
 
 The Kubernetes Cluster template creates an infrastructure as code project in your favorite language and deploys a managed Kubernetes cluster to Google Cloud with Pulumi. The architecture includes a [VPC network](/registry/packages/gcp/api-docs/compute/network) with a [subnet](/registry/packages/gcp/api-docs/compute/subnetwork) and deploys a [Google Kubernetes Engine (GKE) cluster](/registry/packages/gcp/api-docs/container/cluster) that provides a managed Kubernetes control plane and a [nodepool](/registry/packages/gcp/api-docs/container/nodepool) for the cluster. Kubernetes worker nodes are deployed with private IP addresses for improved security. The template gives you a working project out of the box that you can customize easily and extend to suit your needs.
 
-![An architecture diagram of the Pulumi Google Cloud Kubernetestemplate](./architecture.png)
+![An architecture diagram of the Pulumi Google Cloud Kubernetes template](./architecture.png)
 
 ## Using this template
 
@@ -59,7 +59,7 @@ clusterName
 : The name of the GKE cluster.
 
 clusterId
-: The unique ID of the GKE cluster
+: The unique ID of the GKE cluster.
 
 kubeconfig
 : The cluster's kubeconfig file which you can use with `kubectl` to access and communicate with your clusters.

--- a/content/templates/serverless-application/_index.md
+++ b/content/templates/serverless-application/_index.md
@@ -22,7 +22,7 @@ weight: 1
 
 [Infrastructure as code](/what-is/what-is-infrastructure-as-code/) is an efficient and repeatable way of building a serverless application with programming languages and deploying the website to your preferred cloud.
 
-Pulumi’s open source, infrastructure as code SDK that lets you build and deploy static websites with TypeScript/JavaScript, Python, Go, Java, .NET, and YAML. The main benefits include:
+Pulumi’s open source, infrastructure as code SDK lets you build and deploy static websites with TypeScript/JavaScript, Python, Go, Java, .NET, and YAML. The main benefits include:
 
 * **Programming Languages:** Define infrastructure as code in your favorite language instead of domain-specific languages or clicking through cloud consoles.
 

--- a/content/templates/serverless-application/aws/index.md
+++ b/content/templates/serverless-application/aws/index.md
@@ -83,7 +83,7 @@ $ pulumi destroy
 
 ## Learn more
 
-Congratulations! You're now well on your way to managing  production-grade AWS serverless infrastructure with Pulumi --- and there's lots more you can do from here:
+Congratulations! You're now well on your way to managing production-grade AWS serverless infrastructure with Pulumi --- and there's lots more you can do from here:
 
 * Discover more architecture templates in [Templates &rarr;](/templates)
 * Dive into the AWS package by exploring the [API docs in the Registry &rarr;](/registry/packages/aws)

--- a/content/templates/static-website/aws/index.md
+++ b/content/templates/static-website/aws/index.md
@@ -161,9 +161,9 @@ cdn:
 -     defaultTtl: 600
 -     maxTtl: 600
 -     minTtl: 600
-+     defaultTtl: 600
-+     maxTtl: 600
-+     minTtl: 600
++     defaultTtl: 3600
++     maxTtl: 3600
++     minTtl: 3600
 ```
 
 {{% /choosable %}}
@@ -745,7 +745,7 @@ Pulumi supports many third-party DNS providers, all of which are available in th
 * [Akamai](/registry/packages/akamai/)
 * [NS1](/registry/packages/ns1/)
 
-Integration details vary by provider, so we suggest exploring the Pulumi API documentation of your provider of choice to learn more. [See the Registry](/registry/) for a complete list supported providers.
+Integration details vary by provider, so we suggest exploring the Pulumi API documentation of your provider of choice to learn more. [See the Registry](/registry/) for a complete list of supported providers.
 
 ## Tidying up
 

--- a/content/templates/static-website/azure/index.md
+++ b/content/templates/static-website/azure/index.md
@@ -29,7 +29,7 @@ To use this template to deploy a website of your own, make sure you've [installe
 
 {{< templates/pulumi-new >}}
 
-Follow the prompts to complete the new-project wizard. When it's done, you'll have a finished that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
+Follow the prompts to complete the new-project wizard. When it's done, you'll have a finished project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 
 ## Deploying the project
 

--- a/content/templates/virtual-machine/_index.md
+++ b/content/templates/virtual-machine/_index.md
@@ -20,9 +20,9 @@ Virtual Machines are virtualizations/emulations of a computer system that execut
 
 ### Building and deploying virtual machines on AWS, Azure, and Google Cloud
 
-[Infrastructure as code](/what-is/what-is-infrastructure-as-code) is an efficient and repeatable way of building a serverless application with programming languages and deploying the website to your preferred cloud.
+[Infrastructure as code](/what-is/what-is-infrastructure-as-code) is an efficient and repeatable way of building virtual machine infrastructure with programming languages and deploying the website to your preferred cloud.
 
-Pulumi’s open source, infrastructure as code SDK that lets you provision virtual machines with TypeScript/JavaScript, Python, Go, Java, .NET, and YAML. The main benefits include:
+Pulumi’s open source, infrastructure as code SDK lets you provision virtual machines with TypeScript/JavaScript, Python, Go, Java, .NET, and YAML. The main benefits include:
 
 * **Programming Languages:** Define infrastructure as code in your favorite language instead of domain-specific languages or clicking through cloud consoles.
 


### PR DESCRIPTION
## Summary

- Fix double space in serverless-application/aws template
- Add missing word "project" in static-website/azure ("a finished that's ready to deploy")
- Fix broken YAML diff example in static-website/aws (showed 600→600 instead of 600→3600)
- Add missing "of" in "complete list supported providers" in static-website/aws
- Fix copy-paste error where virtual-machine index described "building a serverless application"
- Remove dangling "that" causing sentence fragments in serverless-application and virtual-machine index pages
- Add missing space in "Kubernetestemplate" alt text in kubernetes/gcp
- Add missing period in GKE cluster ID definition list
- Fix premature sentence-ending period before continuation clause in kubernetes/aws

## Test plan

- [ ] Verify affected pages render correctly with `make serve`
- [ ] Spot-check template pages for any remaining issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)