### PR TITLE
Restructure publishing-packages docs to cover private registry workflow

### DIFF
--- a/content/docs/iac/guides/building-extending/_index.md
+++ b/content/docs/iac/guides/building-extending/_index.md
@@ -48,7 +48,7 @@ Package and distribute your components and providers for use across teams and pr
 
 **[Local Packages](/docs/iac/guides/building-extending/packages/local-packages/)** - Develop and test packages locally before publishing them to registries.
 
-**[Publishing Packages](/docs/iac/guides/building-extending/packages/publishing-packages/)** - Distribute your packages to npm, NuGet, PyPI, and other registries for team and community use.
+**[Publishing Packages](/docs/iac/guides/building-extending/packages/publishing-packages/)** - Publish packages to your organization's private registry or the public Pulumi Registry.
 
 **[Schema](/docs/iac/guides/building-extending/packages/schema/)** - Define package schemas that drive SDK generation and documentation for all supported languages.
 

--- a/content/docs/iac/guides/building-extending/packages/publishing-packages.md
+++ b/content/docs/iac/guides/building-extending/packages/publishing-packages.md
@@ -1,6 +1,6 @@
 ---
 title_tag: "Publishing Packages"
-meta_desc: "Learn how to create and publish a Pulumi Package to share a custom component, provider, or bridge an existing Terraform provider into the Pulumi ecosystem."
+meta_desc: "Learn how to publish Pulumi packages to your organization's private registry or the public Pulumi Registry."
 title: Publishing packages
 h1: Publishing Pulumi packages
 meta_image: /images/docs/meta-images/docs-meta.png
@@ -21,21 +21,56 @@ aliases:
 - /docs/iac/build-with-pulumi/publishing-packages/
 ---
 
-This guide will take you through the process to create and publish a [Pulumi Package](/docs/iac/concepts/packages) to the [Pulumi Registry](/registry). You can use this guide to publish the following types of Pulumi Packages:
+Pulumi packages can be published to two different registries depending on your use case:
+
+- **Your organization's [Private Registry](/docs/idp/concepts/private-registry/)** in Pulumi Cloud, for components and providers used within your organization.
+- **The public [Pulumi Registry](/registry/)**, for open-source packages shared with the Pulumi community.
+
+## Publish to your organization's private registry
+
+Pulumi Cloud's [Private Registry](/docs/idp/concepts/private-registry/) lets platform teams publish components for discovery and reuse across their organization. Published components appear in a browsable gallery with auto-generated API documentation.
+
+### Before you begin
+
+1. You need a [Pulumi Cloud](https://app.pulumi.com) account on the Enterprise or Business Critical plan.
+1. Your component must be pushed to a GitHub or GitLab repository that Pulumi can access. Private repositories are supported.
+1. If you haven't built a component yet, see [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/). To choose the right packaging approach for your needs, see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/).
+
+### Publish your component
+
+Use the [`pulumi package publish`](/docs/iac/cli/commands/pulumi_package_publish/) command to publish a component to your organization's private registry:
+
+```bash
+pulumi package publish github.com/<org>/<component-name>
+```
+
+To publish a specific version, tag your repository and specify the version:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+pulumi package publish github.com/<org>/<component-name>@1.0.0
+```
+
+### Learn more
+
+For the full details on component versioning, README requirements, API docs annotations, authentication with private repositories, and more, see the [Private Registry](/docs/idp/concepts/private-registry/) documentation.
+
+To set up automated publishing via CI/CD, see [Publishing from GitHub Actions](/docs/idp/guides/publishing-from-github-actions/).
+
+## Publish to the public Pulumi Registry
+
+This section covers how to publish a [Pulumi Package](/docs/iac/concepts/packages) to the public [Pulumi Registry](/registry). You can publish the following types of packages:
 
 - A [component](/docs/iac/concepts/components) or related group of components
 - A custom provider where you define the CRUD operations for each resource type
 - A bridged provider, which wraps an existing Terraform provider and leverages its code to perform the CRUD operations for each resource type
 
 {{% notes type="info" %}}
-This guide is for creating packages for public consumption. If you are a looking for information on how to create and publish components for use within your organization, see [Build a Component](/docs/iac/guides/building-extending/components/build-a-component).
-{{% /notes %}}
-
-{{% notes type="info" %}}
 If you are a cloud or SaaS provider interested in publishing a Pulumi provider or component, please [reach out to our partners team](/contact).
 {{% /notes %}}
 
-## Prerequisites
+### Prerequisites
 
 {{% notes type="info" %}}
 This guide assumes you're using GitHub to host your package's source code and GitHub Actions to publish various parts of your package.
@@ -46,13 +81,15 @@ This guide assumes you're using GitHub to host your package's source code and Gi
 - Pulumi Packages are multi-language: you can write your package once in either Go, Python, or TypeScript/JavaScript and then make it available to all Pulumi users, even if they use another language. To develop them, you need to have Git, Go, .NET, Python, and TypeScript installed on your system.
 - To follow the whole guide, you need a GitHub account. However, using GitHub is not a requirement; you may still find this guide useful even if you use another system to store your source code.
 
-## Create a repository and author your package
+### Create a repository and author your package
 
 To get started, create a repository for your Pulumi Package. We recommend hosting your Pulumi Package in a public repository on GitHub. We also recommend following the naming conventions below to help the community find the source code for your packages.
 
-### Select a template
+#### Select a template
 
-We've created some template repositories for you to use as a starting point for your package. Click the link for the boilerplate repository template that you want to use, then click "Use this template" to make a copy of it.
+We've created some template repositories for you to use as a starting point for your package. These templates are for **provider-based packages**. If you are building a cross-language component (recommended for most platform teams), see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) for the recommended approach.
+
+Click the link for the boilerplate repository template that you want to use, then click "Use this template" to make a copy of it.
 
 - Author a custom Pulumi provider: [`pulumi/pulumi-provider-boilerplate`](https://github.com/pulumi/pulumi-provider-boilerplate)
 - Bridge an existing Terraform Provider to use with Pulumi: [`pulumi/pulumi-tf-provider-boilerplate`](https://github.com/pulumi/pulumi-tf-provider-boilerplate)
@@ -61,7 +98,7 @@ We've created some template repositories for you to use as a starting point for 
 If you need access to a Terraform provider, but don't need the full customization of a published provider, the ["Any Terraform Provider" Pulumi Provider](/registry/packages/terraform-provider) can provide instant access via locally generating SDKs.
 {{% /notes %}}
 
-### Name your provider and repository
+#### Name your provider and repository
 
 When you publish to the [Pulumi Package Registry](https://www.pulumi.com/registry/), you will need to pick a unique name. This is normally named after the cloud provider or service the provider configures.
 
@@ -70,15 +107,15 @@ Your repository name should start with `pulumi-` followed by the name of your pr
 - If you're bridging a Terraform provider, re-use the Terraform provider's name - replacing `terraform-provider-` with `pulumi-` e.g. use `pulumi-auth0` for bridging `terraform-provider-auth0`.
 - If you're building a component on top of an existing provider, consider using the provider name followed by the component name. For example, if building an API Gateway component using the AWS provider, name your project `pulumi-aws-apigateway`.
 
-## Author your resources or components
+### Author your resources or components
 
 See the instructions in your new repository's `README.md` file for specific instructions on how to author your package. We also have guides you can follow for building [components](/docs/iac/concepts/resources/components/) and [providers](/docs/iac/concepts/providers/) without the template repos.
 
-## Write documentation
+### Write documentation
 
 We recommend writing documentation to help others in the Pulumi community use your package. In your repository, there should be a `docs/` folder containing markdown files (the templates include a few suggested pages). The files should correspond to the various tabs on a package page in Pulumi Registry (like the [Azure Native](/registry/packages/azure-native/) package). Use the guidance in the following sections to author content in these pages.
 
-### Overview, installation, & configuration
+#### Overview, installation, & configuration
 
 Specifically, you should author a few pages:
 
@@ -89,7 +126,7 @@ Specifically, you should author a few pages:
 We recommend keeping the contents of `README.md` and `_index.md` similar or the same, save for the YAML metadata/front-matter that's in `_index.md`.
 {{% /notes %}}
 
-### Package metadata
+#### Package metadata
 
 Metadata for your package is generated from the [`schema.json`](/docs/iac/using-pulumi/extending-pulumi/schema) in your repository. To make sure your package looks great in the Pulumi Registry, don't forget to add metadata like:
 
@@ -107,15 +144,15 @@ Metadata for your package is generated from the [`schema.json`](/docs/iac/using-
 Pulumi will interpolate `${VERSION}`, `${OS}` and `${ARCH}` with their respective values if found in `pluginDownloadURL`.
 {{% /notes %}}
 
-### API docs
+#### API docs
 
 API docs for your package are automatically generated from the `schema.json` in your repository. Many Pulumi users learn to use a Pulumi Package via the API docs, since they appear automatically in many IDEs' auto-complete and inline documentation features, like Visual Studio Code's IntelliSense feature. Investing in API docs for your package is one of the best ways to improve its usability. Check out the [`pulumi-eks` schema](https://github.com/pulumi/pulumi-eks/blob/master/provider/cmd/pulumi-resource-eks/schema.json) to see how it translates to the [Pulumi Registry](/registry/packages/eks/api-docs/) for an example of great API docs.
 
-### How-to guides
+#### How-to guides
 
 You can also create how-to guides for your packages by contributing them to the [`pulumi/examples`](https://github.com/pulumi/examples) repository on GitHub.
 
-## Publish your package
+### Publish your package
 
 Once you've authored and tested your package locally, you can publish it to make it available to the Pulumi community. You must publish several artifacts:
 
@@ -143,7 +180,7 @@ managers (npm, NuGet, Pip, GitHub) host the SDKs, but we need to know where the 
 `pulumi plugin install ${NAME} ${VERSION} --server ${pluginDownloadURL}`. If `pluginDownloadURL` is not supplied, then the Pulumi
 CLI assumes the plugin is hosted at `get.pulumi.com`.
 
-### Support for GitHub releases
+#### Support for GitHub releases
 
 Since [release 3.35.3](https://github.com/pulumi/pulumi/releases/tag/v3.35.3), Pulumi understands a special form of `pluginDownloadURL` to download plugins via GitHub releases
 
@@ -157,7 +194,7 @@ github://${github api host}/{organization}[/{repository}]
 
 For example the [Pulumiverse Astra](https://github.com/pulumiverse/pulumi-astra) package would specify `github://api.github.com/pulumiverse`.
 
-### Support for Gitlab releases
+#### Support for Gitlab releases
 
 Since [release 3.56.0](https://github.com/pulumi/pulumi/releases/tag/v3.56.0), Pulumi understands a special form of `pluginDownloadURL` to download plugins via Gitlab releases
 
@@ -168,7 +205,7 @@ gitlab://${gitlab api host}/{<project_id>}
 - `gitlab api host`: the address of a Gitlab API, for Gitlab SaaS this is `gitlab.com`
 - `project_id`: the Gitlab project ID to use. The project ID can be found right below the project name on the project page.
 
-## Publish the documentation
+### Publish the documentation
 
 All package documentation in the Pulumi Registry is published via the [`pulumi/registry` repository on GitHub](https://github.com/pulumi/registry). To publish your package to the Pulumi Registry:
 
@@ -187,7 +224,3 @@ From there, a Pulumi employee will work with you to get your Pulumi Package publ
 1. Review your pull request and trigger the automation that builds the package listing and the API docs from your schema.
 1. Merge upon approval of your PR
 1. On merging, CI will automatically publish your package listing and API docs to pulumi.com/registry.
-
-## Congratulations
-
-Congratulations on publishing your Pulumi Package!

--- a/content/docs/idp/concepts/private-registry.md
+++ b/content/docs/idp/concepts/private-registry.md
@@ -2,7 +2,7 @@
 title_tag: Private Registry | Pulumi IDP
 title: Private Registry
 h1: "Private Registry"
-meta_desc: Learn about Pulumi Private Registry for managing infrastructure components and templates.
+meta_desc: Learn how to publish and manage components and templates in Pulumi's Private Registry.
 aliases:
   - /docs/idp/get-started/private-registry/
 menu:
@@ -12,65 +12,51 @@ menu:
     weight: 10
 ---
 
-Pulumi Private Registry is the source of truth for an organization's infrastructure building blocks like components and templates -- the same [components](/docs/iac/concepts/resources/components/) and [templates](/docs/idp/concepts/organization-templates/) that power golden path workflows in Pulumi. Platform engineers can codify organizational standards in their building blocks using features like [Pulumi ESC](/docs/esc/) and [Pulumi IaC Policies](/docs/insights/get-started/add-policies/), ensuring that all infrastructure users provision is compliant from the beginning.
-
-Developers leverage templates and components in their preferred workflows, whether it be incorporating components into Pulumi programs, scaffolding a low-code program with components and YAML, or using the Pulumi console for [no-code deployments](/docs/idp/concepts/no-code-stacks/). The private registry is also a resource for developers to discover components and templates, browse their APIs, and use READMEs to understand how to use them.
-
-## Registry views
-
-The Platform menu includes two package views:
-
-### Registry
-
-![Platform menu showing Registry tab](/docs/idp/concepts/platform-menu.png)
-
-Browse all packages available to your organization, including public providers and components from [pulumi.com/registry](https://www.pulumi.com/registry/) plus your organization's private packages. Features include:
-
-- View documentation for any version of a package
-- See usage data showing how packages are adopted across your organization
-- Filter by usage status to find packages that need attention
-
-### Private Components
-
-This tab shows only the component packages published by your organization via `pulumi package publish`.
-
-### Usage tracking
-
-![Package list showing usage columns and filters](/docs/idp/concepts/usage-columns.png)
-
-Both package list views display usage columns for each package: how many stacks are on the latest version, how many are on older versions, and the total number of stacks using the package. You can filter the list to show only used packages, unused packages, or packages where stacks are running older versions.
-
-Each package page also includes a "Used by" tab showing which stacks use that package, including the stack name, project, version in use, and last update timestamp. This helps you assess the impact of changes before updating versions and identify stacks that may need upgrading.
-
-## Component Publishing
-
-[Pulumi Components](/docs/iac/concepts/resources/components/) are a way to encapsulate resources in a reusable manner. Components are also a powerful way for platform teams to integrate security, compliance, and operational requirements into golden paths so that developers don't need to worry about it. Once a component is pushed to GitHub or GitLab, it is published to an organization's private registry using the `publish` CLI command. Pulumi automatically introspects the component schema and generates API docs, which are displayed in the registry.
+Pulumi Private Registry is the source of truth for an organization's infrastructure building blocks like [components](/docs/iac/concepts/resources/components/) and [templates](/docs/idp/concepts/organization-templates/). Platform engineers publish components to the private registry so that developers can discover them, browse auto-generated API documentation, and use them in their Pulumi programs.
 
 For detailed information about different component packaging approaches, see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/).
 
-### Publishing Components
+## Before you begin
 
-If you're new to Pulumi components, the [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/) guide is a great resource for getting started. Once you've authored your component, push it to a GitHub or GitLab repository that Pulumi can access. Private repositories are supported, but the repository must be open to inbound requests.
+1. You need a [Pulumi Cloud](https://app.pulumi.com) account on the Enterprise or Business Critical plan.
+1. You need the [Pulumi CLI](/docs/install/) installed.
+1. Your component must be pushed to a GitHub or GitLab repository that Pulumi can access. Private repositories are supported — see [Authenticating with private repositories](#authenticating-with-private-repositories).
+1. If you haven't built a component yet, see [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/).
 
-The `publish` CLI command is used to publish components to the private registry.
+## Quick start
+
+The following example publishes a component from a GitHub repository to your organization's private registry:
+
+```bash
+# Tag a version in your component repository
+git tag v1.0.0
+git push origin v1.0.0
+
+# Publish to your organization's private registry
+pulumi package publish github.com/<org>/<component-name>@1.0.0
+```
+
+That's it. Pulumi introspects your component, generates API documentation, and makes it available in your organization's private registry. The sections below cover each step in detail.
+
+## Publish a component
+
+The [`pulumi package publish`](/docs/iac/cli/commands/pulumi_package_publish/) command publishes a component to the private registry:
 
 ```bash
 pulumi package publish <provider|schema>
 ```
 
-For example, if your github organization is ACME and you are publishing the `k8s-cluster` component, you'd run:
+For example, if your GitHub organization is ACME and you are publishing the `k8s-cluster` component:
 
 ```bash
 pulumi package publish github.com/acme/k8s-cluster
 ```
 
-#### Component Versioning
+## Versioning
 
 Pulumi uses git tags for versioning components. By default, the latest version tag will be used. The tag must adhere to [the semantic versioning standard](https://semver.org/) plus a "v" prefix (e.g. `v1.2.3`).
 
-To publish a specific version, append an `@` followed by the semver version (excluding the "v") after the git source.
-
-To create a version, push it to your "origin" git remote and publish to Pulumi's private registry, you'd run:
+To publish a specific version, append an `@` followed by the semver version (excluding the "v") after the git source:
 
 ```bash
 git tag v1.2.3
@@ -78,7 +64,7 @@ git push origin v1.2.3
 pulumi package publish github.com/acme/k8s-cluster@1.2.3
 ```
 
-#### Component README
+## README
 
 A README is required when publishing a component. Pulumi renders markdown README files in the private registry. They're a great way to provide context for a component. By default, the Pulumi CLI looks for a README in the component's root directory. The `--readme` flag can be used to specify a custom source.
 
@@ -86,11 +72,30 @@ A README is required when publishing a component. Pulumi renders markdown README
 pulumi package publish github.com/acme/k8s-cluster --readme README_LOCATION
 ```
 
-#### Component API Docs
+## Authenticating with private repositories
 
-In addition to the component README, when a new component or component version is published, API documentation is automatically generated listing the component's inputs and outputs.
+If your repository is private, a valid `GITHUB_TOKEN` or `GITLAB_TOKEN` is required for all commands, including `publish`, `get schema`, and when using the component in a program (`pulumi install`, `pulumi up`, etc.).
 
-Additionally, input and output descriptions are generated based on annotations in the code as follows:
+By default, the Pulumi CLI will look for a token in the `GITHUB_TOKEN` and `GITLAB_TOKEN` environment variables.
+
+```bash
+GITHUB_TOKEN="$(gh auth token)"
+pulumi package publish github.com/acme/k8s-cluster
+```
+
+## Specifying an organization
+
+If you're part of multiple organizations and do not have a [default organization](/docs/iac/cli/commands/pulumi_org_set-default/) set, you must specify the org by using the `--publisher` flag.
+
+```bash
+pulumi package publish github.com/acme/k8s-cluster --publisher ORG_NAME
+```
+
+## API documentation
+
+When a new component or component version is published, API documentation is automatically generated listing the component's inputs and outputs.
+
+Input and output descriptions are generated based on annotations in the code as follows:
 
 {{< chooser language "typescript,python,go,csharp,java" >}}
 
@@ -166,26 +171,40 @@ func (f *PetAbstractedOutputs) Annotate(a infer.Annotator) {
 
 {{< /chooser >}}
 
-## Component Options
+## Troubleshooting
 
-### Specifying an Organization
+| Problem | Solution |
+|---------|----------|
+| `error: no README found` | Add a `README.md` to your component's root directory, or use the `--readme` flag to specify a custom location. |
+| `error: no version tag found` | Tag your repository with a semver tag (e.g. `git tag v1.0.0`) and push it (`git push origin v1.0.0`). |
+| Authentication failures with private repos | Set the `GITHUB_TOKEN` or `GITLAB_TOKEN` environment variable. For GitHub, use `GITHUB_TOKEN="$(gh auth token)"`. |
+| Wrong organization | Use the `--publisher` flag to specify the correct organization, or set a default with `pulumi org set-default`. |
 
-If you're part of multiple organizations and do not have a [default organization](/docs/iac/cli/commands/pulumi_org_set-default/) set, you must specify the org by using the `--publisher` flag.
+## Browsing the registry
 
-```bash
-pulumi package publish github.com/acme/k8s-cluster --publisher ORG_NAME
-```
+The Platform menu in the Pulumi Cloud console includes two package views:
 
-### Authenticating with Private Repositories
+### Registry
 
- If your repository is private, a valid `GITHUB_TOKEN` or `GITLAB_TOKEN` is required for all commands, including `publish`, `get schema`, and when using the component in a program -- `pulumi install`, `pulumi up`, etc.
+![Platform menu showing Registry tab](/docs/idp/concepts/platform-menu.png)
 
- By default, the Pulumi CLI will look for a token in the `GITHUB_TOKEN` and `GITLAB_TOKEN` environment variables.
+Browse all packages available to your organization, including public providers and components from [pulumi.com/registry](https://www.pulumi.com/registry/) plus your organization's private packages. Features include:
 
-```bash
-GITHUB_TOKEN="$(gh auth token)"
-pulumi package publish COMPONENT_LOCATION
-```
+- View documentation for any version of a package
+- See usage data showing how packages are adopted across your organization
+- Filter by usage status to find packages that need attention
+
+### Private components
+
+This tab shows only the component packages published by your organization via `pulumi package publish`.
+
+### Usage tracking
+
+![Package list showing usage columns and filters](/docs/idp/concepts/usage-columns.png)
+
+Both package list views display usage columns for each package: how many stacks are on the latest version, how many are on older versions, and the total number of stacks using the package. You can filter the list to show only used packages, unused packages, or packages where stacks are running older versions.
+
+Each package page also includes a "Used by" tab showing which stacks use that package, including the stack name, project, version in use, and last update timestamp. This helps you assess the impact of changes before updating versions and identify stacks that may need upgrading.
 
 ## Templates
 


### PR DESCRIPTION
The publishing-packages page was exclusively about the public Pulumi Registry, leaving users who want to publish components to their private registry without guidance. Users searching for "how to publish a package" landed here and hit a dead end.

## Changes
- Added a "Publish to your organization's private registry" section with `pulumi package publish` workflow, placed before the public registry content
- Restructured existing public registry content under its own "Publish to the public Pulumi Registry" heading
- Added cross-references to Packaging Components, Private Registry, and Publishing from GitHub Actions docs
- Clarified that boilerplate templates are for provider-based packages, with link to cross-language component approach
- Updated parent index page description to mention both registries
- Removed dismissive note box that sent private registry users to Build a Component (which doesn't cover publishing)