### PR TITLE
Fix broken links reported by DocsBot

### DIFF
--- a/content/blog/introducing-bun-as-a-runtime-for-pulumi/index.md
+++ b/content/blog/introducing-bun-as-a-runtime-for-pulumi/index.md
@@ -141,7 +141,7 @@ Bun makes it easy to go full ESM and it's the [recommended module format](https:
 }
 ```
 
-With [ECMAScript module (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) syntax, one thing that gets easier is working with async code. In a CommonJS Pulumi program, if you need to await a data source or other async call before declaring resources, the program must be wrapped in an [async entrypoint function](https://github.com/docs/iac/languages-sdks/javascript/#enabling-async-support). With ESM and Bun, [top-level await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await) just works, so you can skip the wrapper function entirely and `await` directly at the module level:
+With [ECMAScript module (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) syntax, one thing that gets easier is working with async code. In a CommonJS Pulumi program, if you need to await a data source or other async call before declaring resources, the program must be wrapped in an [async entrypoint function](/docs/iac/languages-sdks/javascript/#enabling-async-support). With ESM and Bun, [top-level await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await) just works, so you can skip the wrapper function entirely and `await` directly at the module level:
 
 ```typescript
 import * as aws from "@pulumi/aws";

--- a/content/blog/pulumi-insights-ai-cli/index.md
+++ b/content/blog/pulumi-insights-ai-cli/index.md
@@ -62,7 +62,7 @@ We've also taken our first step towards integrating Pulumi AI into the CLI.  Wit
 pulumi ai web "deploy metabase on AWS with a managed postgres database"
 ```
 
-This opens a browser to [this conversation](/ai/conversations/7a4fc573-c34f-4aa7-be3a-448605f98d12?autoSubmit=true&language=TypeScript&prompt=deploy+metabase+on+AWS+in+a+container+with+a+managed+postgres+database), which walks through all the steps required to accomplish this task.
+This opens a browser to a guided Pulumi AI conversation that walks through all the steps required to accomplish this task.
 
 ![pulumi ai](https://www.pulumi.com/uploads/content/blog/pulumi-insights-ai-cli/pulumiaiweb.gif)
 

--- a/content/docs/iac/cli/exit-codes.md
+++ b/content/docs/iac/cli/exit-codes.md
@@ -31,7 +31,7 @@ The exact non-zero value of a failing exit code gives us some information about 
 | Configuration and validation error | 2         | The CLI cannot run or complete the command because of invalid or missing arguments, configuration, or schema validation, or because required confirmation flags (such as `--yes`) are not provided in non-interactive mode. |
 | Authentication or authorization error | 3         | The CLI cannot authenticate or is not authorized to perform the requested operation, for example when login is required, credentials are missing, or access is forbidden. |
 | Resource or deployment error      | 4         | A resource operation fails during deployment, preview, refresh, destroy, or import. This includes errors returned by resource providers and underlying cloud platforms. |
-| Policy failure                    | 5         | A [policy pack](/docs/iac/policy/policy-as-code/) or organization policy blocks the operation even though the program and providers succeeded. |
+| Policy failure                    | 5         | A [policy pack](/docs/insights/policy/) or organization policy blocks the operation even though the program and providers succeeded. |
 | Stack not found                   | 6         | The requested stack does not exist, cannot be found, or no stack is selected. |
 | No changes                        | 7         | An expectation about changes is not met, such as when `--expect-no-changes` is used but changes are detected. |
 | Canceled run                      | 8         | The operation is canceled before completion, for example due to `pulumi cancel`, a user interrupt (such as Ctrl+C), or cancellation initiated through the Automation API. |

--- a/content/docs/iac/guides/migration/converters.md
+++ b/content/docs/iac/guides/migration/converters.md
@@ -49,4 +49,4 @@ The `pulumi convert` command is designed to address a variety of migration and c
 In addition to the converter plugins, Pulumi offers the following tools and resources:
 
 * [Generate typed Pulumi SDKs for Kubernetes CustomResources](/docs/iac/clouds/kubernetes/crd2pulumi/)
-* [Migrate from AWS CloudFormation to Pulumi](/docs/iac/guides/migration/migrating-to-pulumi/from-aws/)
+* [Migrate from AWS CloudFormation to Pulumi](/docs/iac/guides/migration/migrating-to-pulumi/from-cloudformation/)


### PR DESCRIPTION
Fixes #18428.

## Changes
- `content/docs/iac/cli/exit-codes.md`: policy-as-code link → `/docs/insights/policy/`
- `content/docs/iac/guides/migration/converters.md`: CloudFormation link → `from-cloudformation/`
- `content/blog/pulumi-insights-ai-cli/index.md`: drop expired (HTTP 410) AI conversation link
- `content/blog/introducing-bun-as-a-runtime-for-pulumi/index.md`: fix `github.com/docs/...` typo to relative `/docs/...` link