### PR TITLE
Free runner disk space for example code tests

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f13873cdfa15788a463838342cd2f914a1be # v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           swap-storage: false

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - pulumi-service-ubuntu-24.04-4core
+          - ubuntu-latest
         go-version:
           - 1.26.x
         node-version:
@@ -46,6 +46,13 @@ jobs:
           - 11
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f13873cdfa15788a463838342cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          swap-storage: false
+          dotnet: false
+
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -1172,10 +1172,11 @@ The repository uses 24 GitHub Actions workflows organized into categories. All w
 - Pull requests to master
 - Manual: `workflow_dispatch`
 
-**Platform:** Custom Pulumi runner (pulumi-service-ubuntu-24.04-4core)
+**Platform:** GitHub-hosted runner (ubuntu-latest), with [jlumbroso/free-disk-space](https://github.com/jlumbroso/free-disk-space) to reclaim disk space before tests run
 
 **Setup:**
 
+- Disk space reclaimed via `jlumbroso/free-disk-space` (`tool-cache: false`, `dotnet: false` to preserve caches used by later setup steps)
 - Multi-language runtimes:
   - Go 1.26
   - Node.js 20


### PR DESCRIPTION
Switches the example code test workflow back from the paid `pulumi-service-ubuntu-24.04-4core` runner to `ubuntu-latest` and adds `jlumbroso/free-disk-space` as the first step in the `test` job to reclaim disk space before tests run.

Matches the pattern already used in `pulumi/examples` (`.github/workflows/test-examples.yml`, `providers` job). The action is configured with `tool-cache: false` and `dotnet: false` to preserve caches that later `setup-*` steps rely on.

I ran the full test workflow against this, it seems to work fine.

Fixes #14403