### PR TITLE
Fix social review concurrency: prevent comments from cancelling runs

### DIFF
--- a/.github/workflows/claude-social-review.yml
+++ b/.github/workflows/claude-social-review.yml
@@ -14,12 +14,19 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: social-review-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   social-review:
+    concurrency:
+      group: >-
+        social-review-${{
+          github.event.pull_request.number
+          || github.event.inputs.pr_number
+          || (github.event_name == 'issue_comment'
+              && contains(github.event.comment.body, '/social-review')
+              && github.event.issue.number)
+          || github.run_id
+        }}
+      cancel-in-progress: true
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&


### PR DESCRIPTION
## Summary

The social review workflow gets cancelled every time another workflow (like Claude Code Review) posts a comment on the same PR. This happens because:

1. Any PR comment fires `issue_comment` 
2. The workflow-level concurrency group evaluates **before** the job `if` condition
3. The group key includes `github.event.issue.number`, matching the in-progress social review's group
4. `cancel-in-progress: true` kills the social review
5. The `issue_comment` job then evaluates `if` → false → skips

The social review never completes on any blog post PR because there's always at least one comment posted by other workflows.

## Fix

Move concurrency to job level and use a conditional expression that only shares a group key for legitimate triggers:

- `pull_request` → `social-review-<PR#>` (dedup works)
- `workflow_dispatch` → `social-review-<PR#>` (dedup works)  
- `/social-review` comments → `social-review-<PR#>` (dedup works)
- All other comments → `social-review-<unique_run_id>` (can't cancel anything)

## Test plan

- [x] Verified `workflow_dispatch` path works end-to-end (PR #18516)
- [x] Verified `pull_request` trigger fires correctly
- [x] Verified the cancellation bug exists (comments kill the run)
- [ ] After merge: open a test blog post PR, verify the review completes despite comment activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)