### PR TITLE
Fix secrets docs: encryption uses a per-value nonce, not salt

### DIFF
--- a/content/docs/iac/concepts/secrets/_index.md
+++ b/content/docs/iac/concepts/secrets/_index.md
@@ -199,7 +199,7 @@ It is possible to mark resource outputs as containing secrets. In this case, Pul
 Some configuration data is sensitive, such as database passwords or service tokens. For such cases, passing the `--secret` flag to the `config set` command encrypts the data and stores the resulting ciphertext instead of plain text.
 
 {{% notes "info" %}}
-By default, the Pulumi CLI uses a per-stack encryption key managed by Pulumi Cloud, and a per-value salt, to encrypt values. To use an alternative encryption provider, refer to [Configuring Secrets Encryption](#configuring-secrets-encryption).
+By default, the Pulumi CLI uses a per-stack encryption key managed by Pulumi Cloud, and a per-value nonce, to encrypt values. To use an alternative encryption provider, refer to [Configuring Secrets Encryption](#configuring-secrets-encryption).
 {{% /notes %}}
 
 For example, this command sets a configuration variable named `dbPassword` to the plain-text value `S3cr37`:


### PR DESCRIPTION
## Summary

The secrets handling docs described the per-value component of AES-256-GCM encryption as a "salt" when it is actually a "nonce" (number used once). These are distinct cryptographic concepts:

- A **salt** is used in key derivation functions (like PBKDF2) to ensure the same password produces different keys.
- A **nonce** (number used once) is a unique value generated per encryption operation in authenticated encryption modes like AES-256-GCM.

The source code is explicit that this is a nonce:

- [`crypt.go#L157-L158`](https://github.com/pulumi/pulumi/blob/e8d341245d3d7e42f9f8366c8b057c29cac83a1e/sdk/go/common/resource/config/crypt.go#L157-L158): *"The nonce is stored with the value itself as a pair of base64 values separated by a colon"*
- [`crypt.go#L231-L248`](https://github.com/pulumi/pulumi/blob/e8d341245d3d7e42f9f8366c8b057c29cac83a1e/sdk/go/common/resource/config/crypt.go#L231-L248): The `encryptAES256GCGM` function generates a random 12-byte nonce per value and returns it alongside the ciphertext.