### PR TITLE
Update ESC External Secrets Operator refreshInterval from 10s to 1h

### DIFF
--- a/content/blog/cloud-native-secret-management-with-pulumi-esc-and-external-secrets-operator/index.md
+++ b/content/blog/cloud-native-secret-management-with-pulumi-esc-and-external-secrets-operator/index.md
@@ -369,7 +369,7 @@ const externalSecretPodInfo = new k8s.apiextensions.CustomResource("external-sec
                 }
             }
         ],
-        refreshInterval: "10s",
+        refreshInterval: "1h",
         secretStoreRef: {
             kind: clusterSecretStore.kind,
             name: clusterSecretStore.metadata.name,

--- a/content/blog/pulumi-in-a-cloud-native-world/index.md
+++ b/content/blog/pulumi-in-a-cloud-native-world/index.md
@@ -260,7 +260,7 @@ kind: ExternalSecret
 metadata:
   name: pulumi-operator-secrets
 spec:
-  refreshInterval: 20s
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: secret-store

--- a/content/tutorials/esc-external-secret-operator/index.md
+++ b/content/tutorials/esc-external-secret-operator/index.md
@@ -110,7 +110,7 @@ spec:
   - secretKey: esc-secret
     remoteRef:
       key: hello
-  refreshInterval: 20s
+  refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
     name: secret-store
@@ -228,7 +228,7 @@ const externalSecret = new kubernetes.apiextensions.CustomResource("external-sec
                 }
             }
         ],
-        refreshInterval: "20s",
+        refreshInterval: "1h",
         secretStoreRef: {
             kind: clusterSecretStore.kind,
             name: clusterSecretStore.metadata.name,
@@ -305,7 +305,7 @@ external_secret = kubernetes.apiextensions.CustomResource(
     metadata=kubernetes.meta.v1.ObjectMetaArgs(name="secret", namespace="default"),
     spec={
         "data": [{"secretKey": "esc-secret", "remoteRef": {"key": "hello"}}],
-        "refreshInterval": "20s",
+        "refreshInterval": "1h",
         "secretStoreRef": {
             "kind": cluster_secret_store.kind,
             "name": cluster_secret_store.metadata.name,
@@ -416,7 +416,7 @@ func main() {
 							},
 						},
 					},
-					"refreshInterval": pulumi.String("20s"),
+					"refreshInterval": pulumi.String("1h"),
 					"secretStoreRef": pulumi.Map{
 						"kind": clusterSecretStore.Kind,
 						"name": clusterSecretStore.Metadata.Name(),

--- a/content/tutorials/esc-external-secret-operator/index.md
+++ b/content/tutorials/esc-external-secret-operator/index.md
@@ -461,7 +461,7 @@ kind: PushSecret
 metadata:
   name: push-secret-example
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   selector:
     secret:
       name: <NAME_OF_THE_KUBERNETES_SECRET>
@@ -505,7 +505,7 @@ metadata:
   name: pushsecret-example # Customisable
   namespace: default # Same of the SecretStores
 spec:
-  refreshInterval: 10s
+  refreshInterval: 1h
   selector:
     secret:
       name: test-cred


### PR DESCRIPTION
## Summary
- Updates `refreshInterval` from `10s` to `1h` in ESC External Secrets Operator examples across the blog post and tutorial
- A 10s refresh interval is unnecessarily aggressive for examples and could encourage bad defaults in production

## Test plan
- [ ] Verify the blog post renders correctly
- [ ] Verify the tutorial renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)