### PR TITLE
De-LLM-ify pr-review approval comments

### DIFF
--- a/.claude/commands/pr-review/SKILL.md
+++ b/.claude/commands/pr-review/SKILL.md
@@ -265,7 +265,7 @@ Display the preview showing:
 - The chosen action
 - The **`Auto-merge after approval` toggle** with its computed default state (see toggle defaults below)
 - For "Make changes and approve": file-by-file changes (trivial fixes summary + suggested-fix list)
-- The exact comment text that will be posted (using templates from `pr-review:references:message-templates`)
+- The exact comment text that will be posted (using templates from `pr-review:references:message-templates`). The posted comment must obey the voice/length rules at the top of that file: Step 6's rich local package is for the reviewer's eyes, **not** a draft for the public comment. Never disclose scrutiny level, AI-suspect status, or fact-check narration in the posted text, and never tack on a self-merge footer -- the auto-merge toggle handles that silently.
 - The full list of `gh` commands that will run
 
 **Auto-merge toggle defaults**:

--- a/.claude/commands/pr-review/SKILL.md
+++ b/.claude/commands/pr-review/SKILL.md
@@ -129,6 +129,12 @@ If files under `static/programs/` are changed:
 
 3. Store pass/fail results for the Step 6 unified package.
 
+#### 4e: PR description accuracy
+
+Compare the PR description (from Step 2) against the actual diff. Inaccuracies — files mentioned that weren't changed, changes described that aren't in the diff, significant changes omitted, incorrect characterization of what the changes do — are **trivial-fix candidates**, not style/structure findings. Collect them for the Step 6 trivial-fix preview; do not include them in the style findings or let them influence the assessment.
+
+For each inaccuracy, draft a corrected description that accurately reflects the diff. The corrected description will be applied via `gh pr edit --body` in Step 9 if not vetoed.
+
 **Large diffs (>100 lines)**: Summarize findings by category rather than line-by-line.
 
 **Silent step** — store all findings for Step 6. Do not display anything to the user yet.
@@ -209,13 +215,14 @@ Render in this order, top to bottom:
 7. **Trivial fixes preview** (only if any candidates) — itemized so the user can see exactly what will change before Step 8 confirmation:
 
    ```
-   Trivial fix candidates (3):
+   Trivial fix candidates (4):
      [1] content/docs/foo.md:12   — heading case: "Deploy To AWS" → "Deploy to AWS"
      [2] content/docs/foo.md (EOF) — add EOF newline
      [3] content/docs/bar.md:42   — strip trailing whitespace
+     [4] PR description            — inaccuracy: says "updates bar.md" but bar.md was not changed
    ```
 
-   Each candidate gets a numeric index so the user can veto specific fixes in Step 8. Categories the agent considers: trailing whitespace removal, missing EOF newlines, heading case (only when unambiguous — proper nouns like Pulumi/TypeScript/Azure are preserved), missing aliases on moved files, missing language specifier on fenced code blocks.
+   Each candidate gets a numeric index so the user can veto specific fixes in Step 8. Categories the agent considers: trailing whitespace removal, missing EOF newlines, heading case (only when unambiguous — proper nouns like Pulumi/TypeScript/Azure are preserved), missing aliases on moved files, missing language specifier on fenced code blocks, PR description inaccuracies (description text that misrepresents the diff — corrected via `gh pr edit --body`).
 
    Suppressed entirely when AI-suspect, replaced with:
 
@@ -316,10 +323,11 @@ With merge toggle OFF, omit the `gh pr merge` step from Approve and Make changes
 
 1. Save current branch name
 2. `gh pr checkout {{arg}}`
-3. Apply trivial fixes that **survived the user's veto in Step 8**, using Edit. The agent applies these directly rather than via a script because several categories (notably heading case) require language understanding to avoid corrupting proper nouns like Pulumi, TypeScript, Azure, Kubernetes, etc. — a regex can't tell "Working With Pulumi" (preserve "Pulumi") from "Deploy To AWS" (lowercase "to"). When in doubt, skip the fix and surface it to the user. Suppressed entirely when `AI_SUSPECT=true`.
-4. Apply contradicted-claim suggested fixes via Edit
-5. Show diff to user
-6. Commit with author trailer:
+3. Apply surviving PR description fixes via `gh pr edit {{arg}} --body "$CORRECTED_BODY"` (this doesn't touch the branch, so it goes before file edits)
+4. Apply trivial fixes that **survived the user's veto in Step 8**, using Edit. The agent applies these directly rather than via a script because several categories (notably heading case) require language understanding to avoid corrupting proper nouns like Pulumi, TypeScript, Azure, Kubernetes, etc. — a regex can't tell "Working With Pulumi" (preserve "Pulumi") from "Deploy To AWS" (lowercase "to"). When in doubt, skip the fix and surface it to the user. Suppressed entirely when `AI_SUSPECT=true`.
+5. Apply contradicted-claim suggested fixes via Edit
+6. Show diff to user
+7. Commit with author trailer:
 
    ```
    <commit message>
@@ -328,10 +336,10 @@ With merge toggle OFF, omit the `gh pr merge` step from Approve and Make changes
    Co-Authored-By: <agent name> <agent email>
    ```
 
-7. Push
-8. Approve with comment
-9. If toggle ON: `gh pr merge {{arg}} --auto --squash`
-10. **Always** return to original branch (even on error)
+8. Push
+9. Approve with comment
+10. If toggle ON: `gh pr merge {{arg}} --auto --squash`
+11. **Always** return to original branch (even on error)
 
 Continue to Step 10.
 

--- a/.claude/commands/pr-review/references/action-preview-templates.md
+++ b/.claude/commands/pr-review/references/action-preview-templates.md
@@ -85,10 +85,11 @@ The merge toggle is shown only when the chosen action is `Approve` or `Make chan
 Action: Make changes and approve
 [ ] Auto-merge after approval (squash)   ← OFF by default for human PRs
 
-Trivial fix candidates (3) — will be applied unless vetoed:
+Trivial fix candidates (4) — will be applied unless vetoed:
   [1] content/docs/foo.md:12   — heading case: "Deploy To AWS" → "Deploy to AWS"
   [2] content/docs/foo.md (EOF) — add EOF newline
   [3] content/docs/bar.md:42   — strip trailing whitespace
+  [4] PR description            — inaccuracy: says "updates bar.md" but bar.md was not changed
 
 Contradicted-claim fixes (will be applied):
   content/docs/cli/logout.md:42 — "removes credentials for the current backend"
@@ -100,14 +101,15 @@ Comment body that will be posted:
 I will:
 1. Save current branch
 2. Check out PR: gh pr checkout {{arg}}
-3. Apply each non-vetoed trivial fix via Edit
-4. Apply contradicted-claim suggested fixes via Edit
-5. Show diff
-6. Commit: "Apply review fixes\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
-7. Push changes
-8. Approve with comment above
-9. [If toggle ON] gh pr merge {{arg}} --auto --squash
-10. Return to original branch
+3. Apply surviving PR description fixes: gh pr edit {{arg}} --body "$CORRECTED_BODY"
+4. Apply each non-vetoed trivial fix via Edit
+5. Apply contradicted-claim suggested fixes via Edit
+6. Show diff
+7. Commit: "Apply review fixes\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+8. Push changes
+9. Approve with comment above
+10. [If toggle ON] gh pr merge {{arg}} --auto --squash
+11. Return to original branch
 ```
 
 ### Trivial fix candidates
@@ -121,6 +123,7 @@ Categories the agent considers:
 - Sentence-case headings (only when unambiguous — preserve proper nouns)
 - Missing aliases on moved files
 - Missing language specifier on fenced code blocks (only when unambiguous from context)
+- PR description inaccuracies (description text that misrepresents the diff — applied via `gh pr edit --body`, not file edit)
 
 Each candidate is itemized in the preview with a numeric index so the user can veto specific fixes.
 
@@ -215,7 +218,7 @@ Edit comment is always reachable through the AskUserQuestion `Other` field even 
 2. Parse the response:
    - Numeric indices (`1`, `1,3`, `2 4`) → drop those candidates by index
    - `all` → drop every trivial fix candidate
-   - `all <category>` (`all heading-case`, `all trailing-ws`, `all eof`, `all alias`, `all lang-spec`) → drop every candidate in that category
+   - `all <category>` (`all heading-case`, `all trailing-ws`, `all eof`, `all alias`, `all lang-spec`, `all desc-inaccuracy`) → drop every candidate in that category
 3. Re-display **only the updated trivial fix candidates section** (not the full preview), then re-ask the confirmation question. The user can veto more fixes, toggle merge, edit the comment, or proceed.
 
 ### Suppress finding(s)

--- a/.claude/commands/pr-review/references/message-templates.md
+++ b/.claude/commands/pr-review/references/message-templates.md
@@ -5,57 +5,108 @@ description: Review comment templates for different contributor types and action
 
 # Message Templates
 
-Select template based on contributor type (from Step 1).
+The posted comment is not a review transcript. It is a short note from a maintainer to a contributor. Everything the local reviewer learned during Steps 4--6 (findings, fact-check results, scrutiny level, AI-suspect status) stays local unless it's a concrete thing the author needs to act on.
 
-**Bot templates**: Professional/technical tone, no emojis
+## Voice and length (read this first)
+
+Hard rules for every approval comment, every contributor type:
+
+- **Length cap.** Internal approvals: 2 sentences max. External approvals: 3 sentences max (the extra sentence is only for first-time-contributor welcome language). Bot approvals: 1 sentence. If you're writing a third sentence for an internal PR, delete something.
+- **Never disclose the review process or scrutiny level.** Do not mention fact-checking, claims verified, files read, scrutiny level, AI-suspect status, flags, trailers, or anything about *how* the review was conducted. The author must not learn that their PR was flagged or reviewed at heightened scrutiny. That is strictly internal. If you catch yourself writing "Reviewed with...", "Spot-checked...", "Verified that...", "Confirmed...", stop and delete it.
+- **Never list what you checked.** Approval itself communicates that everything passed. Naming every file, API surface, ticket, or cross-reference you looked at is noise. Mention a specific thing only when it's a real concern the author must act on -- not to prove you did the work.
+- **Never mention the self-merge convention.** Phrases like "I'll leave the merge to you" or "per our convention" are forbidden. The auto-merge toggle defaults OFF for human PRs; the contributor already knows to merge their own. Saying it out loud just pads the comment.
+- **Never narrate what the merge state is.** "Auto-merge enabled" adds nothing -- GitHub's UI shows that. Same for "CI green" and similar status restatements.
+- **No sycophancy.** Cut "nice catch," "great work," "excellent improvement," "well done," "awesome PR," and every variant. A plain "LGTM" reads warmer than fake praise because it is honest. Thank external contributors once, briefly, and move on.
+- **No LLM tells.** No em-dashes (use `--` or rewrite the sentence), no tricolons ("clean, correct, and concise"), no "Overall, ...", no "I'd note that...", no "That said, ...", no hedged openers, no formulaic structure. Match a terse human maintainer's voice.
+- **Concerns go in one short line, or not at all.** If there is something the author should eyeball before merging, say it in one sentence. No setup, no "one thing to watch for," no bulleted pre-merge checklist. If there is no real concern, do not invent one.
+
+These rules apply even on PRs that triggered heightened scrutiny or AI-suspect. Those signals shape what *you* look at; they never shape what the contributor reads.
 
 ## Template Matrix
 
 | Action | External | Internal | Bot |
 |--------|----------|----------|-----|
-| **Approve** | "Thank you! [≤1 sentence praise if warranted]. Welcome! 🎉" | "LGTM! [feedback/suggestions]" | **Dependabot**: "Security patch approved [testing notes]" (security), "High-risk update reviewed. Checklist: [items]" (high), "Update reviewed for quarterly batch" (med/low)<br>**Other**: "Automated changes approved." |
-| **Approve and merge** | "Thank you! [≤1 sentence praise]. Auto-merge enabled. 🎉" | "LGTM! Auto-merge enabled." | **Dependabot**: "Security patch approved. Auto-merge enabled." (security), "High-risk update tested. Auto-merge enabled." (high), "Update approved. Auto-merge enabled." (med/low)<br>**Other**: "Automated changes approved. Auto-merge enabled." |
-| **Make changes and approve** | "Applied minor style/formatting fixes. Thank you! 🙏" | "Applied style/formatting fixes. LGTM!" | N/A (excluded for bots) |
-| **Request changes** | Opening: "Thank you!"<br>Acknowledge positives (≤1 sentence)<br>Issues with line numbers<br>Suggestion blocks<br>Close: "Mention @claude if you need help" | Professional opening<br>Issues with line numbers<br>Suggestion blocks<br>Clear action items | Technical issue description<br>Line numbers<br>What needs changing<br>No suggestion blocks<br>Close: "This automated PR may need closing and regeneration after fixing source configuration." |
-| **Close PR** | "Thank you for contributing!"<br>Clear, kind closing reason<br>Acknowledge valuable aspects<br>Suggest alternatives<br>"We appreciate your interest in Pulumi!" | Clear closing reason | **Dependabot quarterly**: "Closing to batch with other low/medium-risk updates in quarterly review. See [Dependency Management](https://github.com/pulumi/docs/blob/master/BUILD-AND-DEPLOY.md#dependency-management)."<br>**Dependabot other**: "Closing this update. [Technical reason: conflicts, superseded, etc.]"<br>**Other bots**: "Closing. [Technical reason]" |
+| **Approve** | `Thanks! LGTM. 🎉` (+ one welcome sentence only if it's a first-time contributor) | `LGTM.` (+ at most one sentence if there's a genuine concern or non-obvious suggestion) | **Dependabot**: `Security patch approved.` (security) / `High-risk update reviewed.` (high) / `Approved for quarterly batch.` (med/low)<br>**Other**: `Approved.` |
+| **Approve and merge** | Same as Approve. Do not add "Auto-merge enabled." | Same as Approve. Do not add "Auto-merge enabled." | **Dependabot**: same as Approve. Do not add merge narration.<br>**Other**: `Approved.` |
+| **Make changes and approve** | `Applied minor style fixes. Thanks! 🙏` | `Applied style fixes. LGTM.` | N/A (excluded for bots) |
+| **Request changes** | Brief thanks, then line-anchored issues with suggestion blocks, then `Mention @claude if you need help.` | Line-anchored issues with suggestion blocks. No filler. | Technical issue description, line numbers, what needs changing. No suggestion blocks. Close with: `This automated PR may need closing and regeneration after fixing source configuration.` |
+| **Close PR** | `Thanks for contributing!` then one-sentence reason, then (if applicable) one-sentence alternative. | One-sentence reason. | **Dependabot quarterly**: `Closing to batch with other quarterly updates. See [Dependency Management](https://github.com/pulumi/docs/blob/master/BUILD-AND-DEPLOY.md#dependency-management).`<br>**Dependabot other / other bots**: `Closing. [one-sentence technical reason]` |
+
+## Good and bad examples
+
+These contrast a concrete bad comment (the kind this skill used to produce) with the rewrite that follows the rules above.
+
+### Internal approve, clean PR
+
+**Bad** (verbose, narrates process, discloses scrutiny, lists checks, closes with self-merge footer):
+
+> Reviewed with heightened scrutiny (AI-suspect flag triggered by commit trailers). Spot-checked the per-language API surfaces against upstream source -- Python `component_provider_host`, TS `componentProviderHost`, C# `Pulumi.Experimental.Provider.ComponentProviderHost.Serve`, Java `com.pulumi.provider.internal.ComponentProviderHost`, and the Go `pulumi-go-provider` builder chain -- all five match the docs exactly. The referenced tracking issues pulumi/pulumi#22616 and #22617 both exist and describe the claimed behavior. Nice catch on fixing the stale Python signature from the old cross-language-components page (kwargs → positional). Left-nav reorder, alias for the deleted page, and anchor target `#native-language-packages` all check out.
+>
+> One thing to eyeball on the preview before merging: walk the five chooser tabs in the Walkthrough and Per-language authoring sections to make sure nothing's misaligned. Otherwise this is ready -- I'll leave the merge to you per our convention.
+
+**Good**:
+
+> LGTM. Worth walking the five chooser tabs in the Walkthrough and Per-language authoring sections on the preview before merging.
+
+### Internal approve, nothing to flag
+
+**Bad**: any comment longer than `LGTM.`
+
+**Good**:
+
+> LGTM.
+
+### External approve, first-time contributor
+
+**Bad**:
+
+> Thank you so much for your first contribution to Pulumi! I reviewed the changes carefully and everything looks great -- the formatting is clean, the example compiles, and the cross-references all resolve. Welcome to the community, and we look forward to more contributions from you! 🎉
+
+**Good**:
+
+> Thanks! LGTM. Welcome to Pulumi. 🎉
+
+### Internal approve with one real concern
+
+**Bad**:
+
+> Overall this is in good shape. I verified the new command syntax against the CLI source and the examples all parse correctly. That said, I noticed that the `--stack` flag example on line 42 may not behave as described when no stack is selected -- worth double-checking. Otherwise ready to merge when you are.
+
+**Good**:
+
+> LGTM. Double-check the `--stack` example on line 42 -- I don't think it behaves that way when no stack is selected.
+
+## Anti-examples (things to never write)
+
+Every one of these is banned. If you draft a comment and find any of them, delete and rewrite.
+
+- **Process narration**: "Reviewed with...", "Spot-checked...", "Verified that...", "Confirmed that...", "Cross-referenced...", "Ran the fact-check across..."
+- **Scrutiny disclosure**: "Reviewed with heightened scrutiny," "AI-suspect flag triggered," "given the trailers," "extra careful pass because..." -- any mention of scrutiny level or AI-suspect in the posted comment.
+- **Check inventory**: "Checked X, Y, Z -- all match," "The referenced tickets both exist," "All five language examples resolve," any enumeration of what you looked at.
+- **Sycophancy**: "Nice catch," "Great work," "Excellent," "Love this," "Huge improvement," "Really clean PR."
+- **Self-merge footer**: "I'll leave the merge to you," "per our convention," "merge when ready," "ready whenever you are."
+- **Merge-state narration**: "Auto-merge enabled," "CI is green," "This will merge once checks pass."
+- **Padded pre-merge checklist**: "One thing to eyeball before merging: ...," "A few things to watch for: ...," any multi-item list framed as a favor.
+- **LLM tells**: em-dashes as punctuation, tricolons, "Overall, ...", "That said, ...", "I'd note that...", hedged openers like "This looks mostly good, but..."
 
 ## Tone Guidelines
 
-### External Contributors
+### External contributors
 
-Warm and welcoming tone with explicit gratitude, appropriate emojis (🎉, 🙏), and community-building language.
+Warm but brief. One "Thanks!" is the whole warmth budget. Emojis (🎉, 🙏) are fine on first-time contributions, sparing otherwise.
 
-**Example**: "Thank you for your first contribution to Pulumi! This documentation improvement is excellent. Welcome! 🎉"
+### Internal contributors
 
-### Internal Contributors
+Terse and professional. `LGTM.` is the default. Add one sentence only when there's a real thing to say.
 
-Professional and efficient tone. Brief acknowledgments, technical focus, "LGTM" acceptable. Direct and clear.
+### Bot PRs
 
-**Example**: "LGTM! Nice improvements to the error handling section."
+Factual, no emojis, one line. For Dependabot, the risk tier can appear as a single word ("security patch," "high-risk update," "quarterly batch") -- nothing more.
 
-### Bot PRs (All Types)
+## Implementation notes
 
-Technical and factual tone. No emojis. State what was checked/tested, mention risk level for Dependabot.
-
-**Example**: "High-risk update reviewed. Testing checklist completed: ✅ make serve-all passed, ✅ PR deployment verified, ✅ Lambda@Edge functions operating normally."
-
-## Dependabot Template Patterns
-
-| Risk Level | Action | Template Pattern |
-|-----------|--------|------------------|
-| **Security (HIGH)** | Approve | "Security patch approved. Testing completed: [checklist]. Critical security update merged despite high-risk classification." |
-| **Security (HIGH)** | Approve and merge | "Security patch approved. Auto-merge enabled. Testing completed: [checklist]." |
-| **High (Non-Security)** | Approve | "High-risk update reviewed. Testing checklist completed: [checklist]. Safe to merge after additional checks pass." |
-| **High (Non-Security)** | Approve and merge | "High-risk update tested. Auto-merge enabled. Checklist: [checklist]." |
-| **Medium/Low** | Approve | "Update reviewed for quarterly batch. Basic checks passed: [checklist]." |
-| **Medium/Low** | Approve and merge | "Update approved. Auto-merge enabled. Lint checks passed." |
-| **Quarterly Close** | Close PR | "Closing to batch with other quarterly updates. We'll merge accumulated updates after comprehensive testing. See [Dependency Management](https://github.com/pulumi/docs/blob/master/BUILD-AND-DEPLOY.md#dependency-management)." |
-
-## Implementation Notes
-
-- Always use confirmed/edited content from preview step
-- Base template selection on contributor type detected in Step 1
-- For Dependabot: Check risk tier and labels to select appropriate variation
-- Include specific testing results when approving HIGH risk updates
-- Keep bot messages factual and concise
-- Adjust tone but maintain professionalism across all contributor types
+- Always use the confirmed/edited content from the Step 8 preview.
+- Base template selection on the contributor type from Step 1.
+- For Dependabot, pick the single-word risk descriptor from the table above.
+- Keep bot messages factual and one line.
+- Voice and length rules override any other instinct. If a template cell and the voice rules seem to conflict, the voice rules win.


### PR DESCRIPTION
Tightens the pr-review skill so approval comments sound like a terse human maintainer, not a review transcript.

## Changes
- `message-templates.md`: new "Voice and length" section with sentence caps and hard bans on process narration, scrutiny disclosure, check inventories, sycophancy, self-merge footers, and LLM tells. Good/bad examples and anti-examples list.
- `SKILL.md`: Step 8 reminder that the local Step 6 package is not a draft for the posted comment.