### PR TITLE
Add provider configuration guide

### DIFF
--- a/content/docs/iac/guides/building-extending/providers/build-a-provider.md
+++ b/content/docs/iac/guides/building-extending/providers/build-a-provider.md
@@ -45,7 +45,7 @@ Pulumi providers are [gRPC](https://grpc.io/) servers that respond to commands f
 
 Beyond the core functions involved with managing resources, there are a number of other aspects to a Pulumi provider. It is necessary to configure the provider, pass secrets, return output values, and store the state of resources. The Pulumi provider interface has built-in facilities for all of those concerns:
 
-- **Configuration and Secrets**: Set via [Pulumi ESC](/docs/esc/) [environments](/docs/esc/environments/) and/or `pulumi config`. Encrypted secrets and configuration values are passed to the provider at runtime.
+- **Configuration and Secrets**: Set via [Pulumi ESC](/docs/esc/) [environments](/docs/esc/environments/) and/or `pulumi config`. Encrypted secrets and configuration values are passed to the provider at runtime. See [Provider configuration](/docs/iac/guides/building-extending/providers/provider-configuration/) for a detailed guide on declaring config keys, secrets, and environment variable defaults.
 - **Outputs**: Providers return outputs from resources, which can be referenced by other resources.
 - **State**: Pulumi maintains resource state to track dependencies and detect changes.
 

--- a/content/docs/iac/guides/building-extending/providers/build-a-provider.md
+++ b/content/docs/iac/guides/building-extending/providers/build-a-provider.md
@@ -6,7 +6,7 @@ h1: Build a Provider
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
-        name: Build a provider
+        name: Build a Provider
         parent: iac-guides-providers
         weight: 30
 aliases:

--- a/content/docs/iac/guides/building-extending/providers/implementers/_index.md
+++ b/content/docs/iac/guides/building-extending/providers/implementers/_index.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Direct provider implementation"
+title_tag: "Direct Provider Implementation"
 meta_desc: "Implement Pulumi providers directly using gRPC bindings, without higher-level SDKs."
-title: Direct provider implementation
-h1: Direct provider implementation
+title: Direct Provider Implementation
+h1: Direct Provider Implementation
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:

--- a/content/docs/iac/guides/building-extending/providers/implementers/_index.md
+++ b/content/docs/iac/guides/building-extending/providers/implementers/_index.md
@@ -6,7 +6,7 @@ h1: Direct Provider Implementation
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
-        name: Direct implementation
+        name: Direct Implementation
         identifier: iac-guides-provider-implementers
         parent: iac-guides-providers
         weight: 50

--- a/content/docs/iac/guides/building-extending/providers/implementers/go.md
+++ b/content/docs/iac/guides/building-extending/providers/implementers/go.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Implement a provider in Go"
+title_tag: "Implement a Provider in Go"
 meta_desc: "Build a Pulumi provider in Go using the gRPC bindings directly, without the higher-level SDK."
-title: Implement a provider in Go
-h1: Implement a provider in Go
+title: Implement a Provider in Go
+h1: Implement a Provider in Go
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:

--- a/content/docs/iac/guides/building-extending/providers/implementers/protocol-reference.md
+++ b/content/docs/iac/guides/building-extending/providers/implementers/protocol-reference.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Provider protocol reference"
+title_tag: "Provider Protocol Reference"
 meta_desc: "Complete reference for the Pulumi provider gRPC protocol, including all RPC methods and their semantics."
-title: Provider protocol reference
-h1: Provider protocol reference
+title: Provider Protocol Reference
+h1: Provider Protocol Reference
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:

--- a/content/docs/iac/guides/building-extending/providers/implementers/protocol-reference.md
+++ b/content/docs/iac/guides/building-extending/providers/implementers/protocol-reference.md
@@ -6,7 +6,7 @@ h1: Provider Protocol Reference
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
-        name: Protocol reference
+        name: Protocol Reference
         parent: iac-guides-provider-implementers
         weight: 10
 ---

--- a/content/docs/iac/guides/building-extending/providers/implementers/python.md
+++ b/content/docs/iac/guides/building-extending/providers/implementers/python.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Implement a provider in Python"
+title_tag: "Implement a Provider in Python"
 meta_desc: "Build a Pulumi provider in Python using the gRPC bindings directly."
-title: Implement a provider in Python
-h1: Implement a provider in Python
+title: Implement a Provider in Python
+h1: Implement a Provider in Python
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:

--- a/content/docs/iac/guides/building-extending/providers/implementers/typescript.md
+++ b/content/docs/iac/guides/building-extending/providers/implementers/typescript.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Implement a provider in TypeScript"
+title_tag: "Implement a Provider in TypeScript"
 meta_desc: "Build a Pulumi provider in TypeScript using the gRPC bindings directly."
-title: Implement a provider in TypeScript
-h1: Implement a provider in TypeScript
+title: Implement a Provider in TypeScript
+h1: Implement a Provider in TypeScript
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:

--- a/content/docs/iac/guides/building-extending/providers/provider-architecture.md
+++ b/content/docs/iac/guides/building-extending/providers/provider-architecture.md
@@ -6,7 +6,7 @@ h1: Provider Architecture
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
-        name: Provider architecture
+        name: Provider Architecture
         parent: iac-guides-providers
         weight: 20
 ---

--- a/content/docs/iac/guides/building-extending/providers/provider-architecture.md
+++ b/content/docs/iac/guides/building-extending/providers/provider-architecture.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Provider architecture"
+title_tag: "Provider Architecture"
 meta_desc: "Understand the layered architecture of Pulumi providers and choose the right level of abstraction for your needs."
-title: Provider architecture
-h1: Provider architecture
+title: Provider Architecture
+h1: Provider Architecture
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:

--- a/content/docs/iac/guides/building-extending/providers/provider-configuration.md
+++ b/content/docs/iac/guides/building-extending/providers/provider-configuration.md
@@ -1,4 +1,5 @@
 ---
+title_tag: "Provider Configuration"
 meta_desc: "Learn how to declare configuration keys for a Pulumi provider, including secrets and environment variable defaults."
 title: Provider Configuration
 h1: Provider Configuration

--- a/content/docs/iac/guides/building-extending/providers/provider-configuration.md
+++ b/content/docs/iac/guides/building-extending/providers/provider-configuration.md
@@ -1,0 +1,105 @@
+---
+meta_desc: "Learn how to declare configuration keys for a Pulumi provider, including secrets and environment variable defaults."
+title: Provider Configuration
+h1: Provider Configuration
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Provider Configuration
+        parent: iac-guides-providers
+        weight: 35
+---
+
+A Pulumi provider can declare its own configuration keys, which users set via `pulumi config`, [Pulumi ESC](/docs/esc/) environments, or environment variables. Declaring configuration in the provider schema (rather than reading it ad hoc inside resource methods) gives you typed access in every language SDK, automatic secret handling, and automatic fallback to environment variables.
+
+This guide uses the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/providers/sdks/pulumi-go-provider-sdk/). For the underlying schema fields, see the [package schema reference](/docs/iac/guides/building-extending/packages/schema/#default).
+
+## Declaring a config type
+
+Define a struct whose fields are tagged with `pulumi:"<name>"`. Register it on the provider builder with `WithConfig`:
+
+```go
+import (
+    "context"
+
+    p "github.com/pulumi/pulumi-go-provider"
+    "github.com/pulumi/pulumi-go-provider/infer"
+)
+
+type Config struct {
+    ClientKey    string `pulumi:"clientKey"`
+    ClientSecret string `pulumi:"clientSecret" provider:"secret"`
+}
+
+func provider() (p.Provider, error) {
+    return infer.NewProviderBuilder().
+        WithNamespace("examples").
+        WithConfig(infer.Config(&Config{})).
+        Build()
+}
+```
+
+The `provider:"secret"` tag marks the value as a secret so Pulumi encrypts it in state and redacts it from logs and CLI output.
+
+## Describing fields and defaults
+
+Implement `Annotate` to attach descriptions, defaults, and environment variable fallbacks. The third (and subsequent) arguments to `SetDefault` are the names of environment variables to probe — Pulumi reads them in order and uses the first one that is set:
+
+```go
+func (c *Config) Annotate(a infer.Annotator) {
+    a.Describe(&c.ClientKey, "The client key for the external system.")
+    a.Describe(&c.ClientSecret, "The client secret for the external system.")
+    a.SetDefault(&c.ClientKey, "", "EXAMPLE_CLIENT_KEY")
+    a.SetDefault(&c.ClientSecret, "", "EXAMPLE_CLIENT_SECRET")
+}
+```
+
+This emits the following into the generated package schema, which every language SDK consumes:
+
+```json
+"clientSecret": {
+    "type": "string",
+    "default": "",
+    "defaultInfo": {
+        "environment": ["EXAMPLE_CLIENT_SECRET"]
+    },
+    "secret": true
+}
+```
+
+The resolution order at runtime is: explicit value passed to the provider constructor, then `pulumi config` value, then each environment variable in `defaultInfo.environment`, then the static `default`.
+
+## Reacting to configuration
+
+If you need to validate the config or build derived state (for example, an authenticated API client), implement `Configure`. It runs once after the user-supplied values are merged with defaults:
+
+```go
+func (c *Config) Configure(ctx context.Context) error {
+    if c.ClientKey == "" {
+        return fmt.Errorf("clientKey is required")
+    }
+    return nil
+}
+```
+
+## Reading config from a resource
+
+Use `infer.GetConfig` from any resource method to retrieve the populated config struct:
+
+```go
+func (w *Widget) Create(
+    ctx context.Context,
+    req infer.CreateRequest[WidgetArgs],
+) (infer.CreateResponse[WidgetState], error) {
+    cfg := infer.GetConfig[Config](ctx)
+    // use cfg.ClientKey, cfg.ClientSecret, ...
+}
+```
+
+## A complete example
+
+The [`configurable`](https://github.com/pulumi/pulumi-go-provider/tree/main/examples/configurable) and [`credentials`](https://github.com/pulumi/pulumi-go-provider/tree/main/examples/credentials) examples in the `pulumi-go-provider` repository demonstrate the full pattern, including enums, optional fields, and post-processing in `Configure`.
+
+## Bridged providers
+
+Providers built with the Terraform bridge declare configuration through the upstream Terraform schema and the bridge's `ProviderInfo.Config` map rather than the mechanism shown here. See the [bridged provider documentation](/docs/iac/guides/building-extending/providers/implementers/) for details.


### PR DESCRIPTION
Adds a new guide documenting how to declare configuration keys for Pulumi providers using the Go Provider SDK, covering typed config structs, secrets, environment variable fallbacks, and reading config from resources.

## Changes
- New page: `provider-configuration.md`
- Cross-link from `build-a-provider.md`

Fixes #11609 