### PR TITLE
Update functions docs with language-specific descriptions

### DIFF
--- a/content/docs/iac/concepts/functions/_index.md
+++ b/content/docs/iac/concepts/functions/_index.md
@@ -26,7 +26,33 @@ For example, you might use a provider function to get the latest virtual machine
 
 ## Get functions
 
-**[Get functions](/docs/iac/concepts/functions/get-functions/)** are static functions available on all Pulumi resource types that allow you to reference an existing resource that is not managed by Pulumi. Unlike the `pulumi import` command which brings resources under Pulumi management, get functions simply allow you to read the properties of existing resources.
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+
+{{% choosable language "typescript,csharp,java" %}}
+
+**[Get functions](/docs/iac/concepts/functions/get-functions/)** are static methods available on all Pulumi resource classes that allow you to reference an existing resource that is not managed by Pulumi. Unlike the `pulumi import` command which brings resources under Pulumi management, get functions simply allow you to read the properties of existing resources.
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+**[Get functions](/docs/iac/concepts/functions/get-functions/)** are class methods available on all Pulumi resource classes that allow you to reference an existing resource that is not managed by Pulumi. Unlike the `pulumi import` command which brings resources under Pulumi management, get functions simply allow you to read the properties of existing resources.
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+**[Get functions](/docs/iac/concepts/functions/get-functions/)** are package-level functions available for all Pulumi resource types that allow you to reference an existing resource that is not managed by Pulumi. Unlike the `pulumi import` command which brings resources under Pulumi management, get functions simply allow you to read the properties of existing resources.
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+**[Get functions](/docs/iac/concepts/functions/get-functions/)** are available on all Pulumi resource types (via the `get:` stanza) and allow you to reference an existing resource that is not managed by Pulumi. Unlike the `pulumi import` command which brings resources under Pulumi management, get functions simply allow you to read the properties of existing resources.
+
+{{% /choosable %}}
+
+{{< /chooser >}}
 
 Get functions are useful when you know an unmanaged resource's identity and need to reference properties of the unmanaged resource in resources that _are_ managed by Pulumi.
 

--- a/content/docs/iac/concepts/functions/_index.md
+++ b/content/docs/iac/concepts/functions/_index.md
@@ -28,15 +28,9 @@ For example, you might use a provider function to get the latest virtual machine
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
-{{% choosable language "typescript,csharp,java" %}}
+{{% choosable language "typescript,python,csharp,java" %}}
 
 **[Get functions](/docs/iac/concepts/functions/get-functions/)** are static methods available on all Pulumi resource classes that allow you to reference an existing resource that is not managed by Pulumi. Unlike the `pulumi import` command which brings resources under Pulumi management, get functions simply allow you to read the properties of existing resources.
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-**[Get functions](/docs/iac/concepts/functions/get-functions/)** are class methods available on all Pulumi resource classes that allow you to reference an existing resource that is not managed by Pulumi. Unlike the `pulumi import` command which brings resources under Pulumi management, get functions simply allow you to read the properties of existing resources.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/functions/get-functions.md
+++ b/content/docs/iac/concepts/functions/get-functions.md
@@ -20,15 +20,9 @@ aliases:
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
-{{% choosable language "typescript,csharp,java" %}}
+{{% choosable language "typescript,python,csharp,java" %}}
 
 You can use the static `get` method, which is available on all resource classes, to look up an existing resource that is not managed by Pulumi.
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-You can use the `get` class method, which is available on all resource classes, to look up an existing resource that is not managed by Pulumi.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/functions/get-functions.md
+++ b/content/docs/iac/concepts/functions/get-functions.md
@@ -18,7 +18,35 @@ aliases:
 - /docs/concepts/resources/get/
 ---
 
-You can use the static `get` function, which is available on all resource types, to look up an existing resource that is not managed by Pulumi. The `get` function is different from the [`import` CLI command](/docs/iac/cli/commands/pulumi_import): `pulumi import` is used to bring an existing resource under management by Pulumi. `get` is used to allow the attributes of an existing resource to be used within a Pulumi program. A resource read with the `get` function will never be updated or deleted by Pulumi during an update.
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+
+{{% choosable language "typescript,csharp,java" %}}
+
+You can use the static `get` method, which is available on all resource classes, to look up an existing resource that is not managed by Pulumi.
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+You can use the `get` class method, which is available on all resource classes, to look up an existing resource that is not managed by Pulumi.
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+You can use the `Get` function (e.g., `ec2.GetSecurityGroup`), which is available as a package-level function for all resource types, to look up an existing resource that is not managed by Pulumi.
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+You can use the `get` stanza, which is available on all resource types, to look up an existing resource that is not managed by Pulumi.
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+The `get` function is different from the [`import` CLI command](/docs/iac/cli/commands/pulumi_import): `pulumi import` is used to bring an existing resource under management by Pulumi. `get` is used to allow the attributes of an existing resource to be used within a Pulumi program. A resource read with the `get` function will never be updated or deleted by Pulumi during an update.
 
 Two values are passed to the `get` function:
 

--- a/content/docs/iac/concepts/functions/provider-functions.md
+++ b/content/docs/iac/concepts/functions/provider-functions.md
@@ -262,13 +262,13 @@ The direct form returns `(T, error)` synchronously. These functions are typicall
 
 {{% choosable language csharp %}}
 
-The direct form returns a `Task<T>`. These functions are typically named `GetX.Invoke()`.
+The direct form returns a `Task<T>`. These functions are typically named `GetX.InvokeAsync()`.
 
 {{% /choosable %}}
 
 {{% choosable language java %}}
 
-The direct form returns a `CompletableFuture<T>`. These functions are typically named `ModuleFunctions.getX()`.
+The direct form returns a `CompletableFuture<T>`. These functions are typically named `ModuleFunctions.getXPlain()`.
 
 {{% /choosable %}}
 
@@ -282,7 +282,47 @@ The direct form is invoked using `fn::invoke`. The result is resolved synchronou
 
 ### Output form
 
-The **output form** accepts Pulumi Inputs (or plain values) as arguments and returns a Pulumi Output as a result. For more information on these types, see [Inputs and Outputs](/docs/concepts/inputs-outputs/). These functions are typically named, e.g., `getXOutput()`.
+The **output form** accepts Pulumi Inputs (or plain values) as arguments and returns a Pulumi Output as a result. For more information on these types, see [Inputs and Outputs](/docs/concepts/inputs-outputs/).
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+
+{{% choosable language typescript %}}
+
+The output form returns an `Output<T>`. These functions are typically named `getXOutput()`.
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+The output form returns an `Output[T]`. These functions are typically named `get_x_output()`.
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+The output form returns a `LookupXResultOutput`. These functions are typically named `LookupXOutput()`.
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+The output form returns an `Output<T>`. These functions are typically named `GetX.Invoke()`.
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+The output form returns an `Output<T>`. These functions are typically named `ModuleFunctions.getX()`.
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+YAML does not distinguish between direct and output forms; both are invoked using `fn::invoke`.
+
+{{% /choosable %}}
+
+{{< /chooser >}}
 
 The [Pulumi Registry](/registry) contains authoritative documentation for all provider functions.
 

--- a/content/docs/iac/concepts/functions/provider-functions.md
+++ b/content/docs/iac/concepts/functions/provider-functions.md
@@ -226,11 +226,11 @@ resources:
 
 {{% /choosable %}}
 
-{{% /chooser %}}
+{{< /chooser >}}
 
 {{% notes type="info" %}}
 Bridged providers, which take a Terraform provider as an underlying dependency, expose Terraform data sources in the upstream Terraform provider as provider functions in the corresponding Pulumi provider.
-{{% / notes %}}
+{{% /notes %}}
 
 ## Direct form and output form
 
@@ -361,4 +361,4 @@ Pulumi recommends you choose the output form of a function unless you have a spe
 1. Syntactically, it's slightly more terse.
 
 Assuming there is no specific reason to choose one or the other, the choice between the two forms is ultimately a preference: there is no significant difference in either performance or code maintainability between the two forms.
-{{% / notes %}}
+{{% /notes %}}

--- a/content/docs/iac/concepts/functions/provider-functions.md
+++ b/content/docs/iac/concepts/functions/provider-functions.md
@@ -236,8 +236,53 @@ Bridged providers, which take a Terraform provider as an underlying dependency, 
 
 Provider functions are exposed in each language as regular functions, in two variations:
 
- 1. The **direct form** accepts plain arguments (e.g., `string`, as opposed to `pulumi.Input<string>`) and returns an asynchronous value (e.g., a `Promise` in Node.js, a `Task` in Python, etc.) or blocks until the result is available. These functions are typically named, e.g., `getX()`.
- 1. The **output form** accepts Pulumi Inputs (or plain values) as arguments and returns a Pulumi Output as a result. For more information on these types, see [Inputs and Outputs](/docs/concepts/inputs-outputs/). These functions are typically named, e.g., `getXOutput()`.
+### Direct form
+
+The **direct form** accepts plain arguments (e.g., `string`, as opposed to `pulumi.Input<string>`):
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+
+{{% choosable language typescript %}}
+
+The direct form returns a `Promise<T>`. These functions are typically named `getX()`.
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+The direct form returns the result synchronously. These functions are typically named `get_x()`.
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+The direct form returns `(T, error)` synchronously. These functions are typically named `LookupX()`.
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+The direct form returns a `Task<T>`. These functions are typically named `GetX.Invoke()`.
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+The direct form returns a `CompletableFuture<T>`. These functions are typically named `ModuleFunctions.getX()`.
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+The direct form is invoked using `fn::invoke`. The result is resolved synchronously.
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+### Output form
+
+The **output form** accepts Pulumi Inputs (or plain values) as arguments and returns a Pulumi Output as a result. For more information on these types, see [Inputs and Outputs](/docs/concepts/inputs-outputs/). These functions are typically named, e.g., `getXOutput()`.
 
 The [Pulumi Registry](/registry) contains authoritative documentation for all provider functions.
 
@@ -266,13 +311,13 @@ While the direct and output forms of a provider function will both return the sa
 
 There are several common scenarios where either direct form or output form must or should be used:
 
-* **If you need a provider function's result to determine whether a resource should be created at all**, you must use the provider function's the direct form. The direct form of a function executes _while_ the Pulumi engine is formulating the dependency graph (that is, determining what resources need to be created, updated, or deleted), so in order to figure out whether a resource belongs in the graph at all, that decision has to always be calculated up front.
-* **If you need resources to be created or updated before the function is invoked**, you should use the provider function's output form. (It is _possible_ to use the direct form in this case, but it requires wrapping the call in an `apply`, which can be awkward from a readability standpoint.) Dependencies in the output form of a function are tracked identically to resources: all inputs to the function must be resolved before the function executes. If you need to specify a dependency that isn't already implied by an input to the function's arguments, you can use the `dependsOn` function option to specify additional dependencies (just like you can with resources).
+* **If you need a provider function's result to determine whether a resource should be created at all, you must use the direct form.** The direct form of a function executes _while_ the Pulumi engine is formulating the dependency graph (that is, determining what resources need to be created, updated, or deleted), so in order to figure out whether a resource belongs in the graph at all, that decision has to always be calculated up front.
+* **If you need resources to be created or updated before the function is invoked, you should use the output form.** (It is _possible_ to use the direct form in this case, but it requires wrapping the call in an `apply`, which can be awkward from a readability standpoint.) Dependencies in the output form of a function are tracked identically to resources: all inputs to the function must be resolved before the function executes. If you need to specify a dependency that isn't already implied by an input to the function's arguments, you can use the `dependsOn` function option to specify additional dependencies (just like you can with resources).
 
 {{% notes type="info" %}}
 Pulumi recommends you choose the output form of a function unless you have a specific need for the direct form. We make this recommendation because:
 
-1. The output form reduces mental overhead in that it allows your program to stick with a single asynchronous programming mental model (Pulumi inputs and outputs) as opposed to also having to worry about Promises (TypeScript), TaskResults (.NET), etc.
+1. The output form reduces mental overhead in that it allows your program to stick with a single programming model (Pulumi Inputs and Outputs) as opposed to also having to manage language-specific return types (e.g., `Promise` in TypeScript, `Task` in .NET, `CompletableFuture` in Java, or synchronous returns in Python and Go).
 1. Syntactically, it's slightly more terse.
 
 Assuming there is no specific reason to choose one or the other, the choice between the two forms is ultimately a preference: there is no significant difference in either performance or code maintainability between the two forms.

--- a/content/docs/iac/concepts/functions/provider-functions.md
+++ b/content/docs/iac/concepts/functions/provider-functions.md
@@ -256,7 +256,7 @@ The direct form returns the result synchronously. These functions are typically 
 
 {{% choosable language go %}}
 
-The direct form returns `(T, error)` synchronously. These functions are typically named `LookupX()`.
+The direct form returns `(T, error)` synchronously. These functions are typically named `LookupX()` or `GetX()`.
 
 {{% /choosable %}}
 
@@ -300,7 +300,7 @@ The output form returns an `Output[T]`. These functions are typically named `get
 
 {{% choosable language go %}}
 
-The output form returns a `LookupXResultOutput`. These functions are typically named `LookupXOutput()`.
+The output form returns a `LookupXResultOutput` or `GetXResultOutput`. These functions are typically named `LookupXOutput()` or `GetXOutput()`.
 
 {{% /choosable %}}
 


### PR DESCRIPTION
Add language-specific chooser blocks to the functions concept pages so each language shows accurate terminology (e.g. static methods in TS/C#/Java, class methods in Python, package-level functions in Go, get stanzas in YAML).

## Changes
- Add chooser blocks to functions index, get functions, and provider functions pages
- Fix broken list rendering in direct/output form section
- Fix wording and bolding in choosing section

Fixes #15457