### PR TITLE
[redirects] Add 301 redirects from /jobs to /careers

### DIFF
--- a/scripts/redirects/general-broken-links-redirects.txt
+++ b/scripts/redirects/general-broken-links-redirects.txt
@@ -74,3 +74,7 @@ images/logo/logo-white-white.svg|/logos/brand/logo-white-white.svg
 images/logo/logo-white.svg|/logos/brand/logo-white.svg
 images/logo/logo.svg|/logos/brand/logo.svg
 images/logo/pulumi_mark_on_light.svg|/logos/brand/pulumi_mark_on_light.svg
+jobs/index.html|/careers/
+company/jobs/index.html|/careers/
+careers/jobs/index.html|/careers/
+company/pulumi/jobs/index.html|/careers/


### PR DESCRIPTION
## Summary

- ~143 unique visitors per quarter hit a 404 trying to reach the careers page via `/jobs`. 86% are direct navigation (typing the URL), with additional traffic from Google and internal referrals.
- Add S3 redirects from `/jobs`, `/company/jobs`, `/careers/jobs`, and `/company/pulumi/jobs` to `/careers/`

## Test plan

- Verify the redirect entries follow the existing format in `scripts/redirects/general-broken-links-redirects.txt`
  - See http://www-testing-pulumi-docs-origin-pr-18564-fd31ea2f.s3-website.us-west-2.amazonaws.com/jobs
- Redirects are processed by `scripts/make-s3-redirects.sh` during CI/CD deployment; no local test needed