### PR TITLE
Restore split hero layout for event pages (/kubecon, /google-cloud-next)

### DIFF
--- a/content/google-cloud-next/_index.md
+++ b/content/google-cloud-next/_index.md
@@ -9,13 +9,14 @@ aliases:
   - /google-next
 
 hero:
+  layout: split
   title: Let's talk Google Cloud infrastructure
   description: |
     Join us to learn how teams are managing Google Cloud infrastructure at scale with programming languages, policy as code, and purpose-built AI. Stop by for a conversation, demo, or to play a game or two.
   date_and_location: April 22-24, 2026, Mandalay Bay, Las Vegas
   booth: Booth 3624
-  cta_text: Book a booth demo
-  cta_link: "#demo-workshop"
+  cta_primary_text: Book a booth demo
+  cta_primary_link: "#demo-workshop"
   cta_secondary_text: Attend a workshop
   cta_secondary_link: "#demo-workshop"
   image: /images/google-next/google-next-hero-2026.png

--- a/content/kubecon/_index.md
+++ b/content/kubecon/_index.md
@@ -7,13 +7,14 @@ layout: event-page
 aliases: kubecon-europe
 
 hero:
+  layout: split
   title: Tame Kubernetes complexity with code
   description: |
     Learn how teams are moving beyond YAML with programming languages like TypeScript, Python, and Go to build platforms that scale. Also, free plushies.
   date_and_location: March 23-26, Amsterdam RAI
   booth: Booth 784
-  cta_text: Book a technical demo
-  cta_link: https://info.pulumi.com/book-demo-kubecon-2026
+  cta_primary_text: Book a technical demo
+  cta_primary_link: https://info.pulumi.com/book-demo-kubecon-2026
   cta_secondary_text: Get $500 in AWS credits
   cta_secondary_link: "#aws-credits"
   image: /images/kubecon/kubecon-hero-2026.png

--- a/layouts/partials/template-partials/template-hero.html
+++ b/layouts/partials/template-partials/template-hero.html
@@ -24,6 +24,9 @@
     - badge_highlight_text: Optional badge text highlighted in purple (split layout only).
     - badge_text: Optional pill badge text displayed above the heading (split layout only).
     - badge_link: Optional URL for the badge pill.
+    - tag_line: Optional tag line text displayed in violet above the heading (split layout only).
+    - date_and_location: Optional event date and location string (split layout only).
+    - booth: Optional booth number (split layout only, displayed after date_and_location).
     - anchor: Optional anchor for section id
 
     Parameters — code composite (renders instead of image when code_snippets is set):
@@ -57,6 +60,9 @@
 {{ $badgeHighlightText := .badge_highlight_text }}
 {{ $badgeText := .badge_text }}
 {{ $badgeLink := .badge_link }}
+{{ $tagLine := .tag_line }}
+{{ $dateAndLocation := .date_and_location }}
+{{ $booth := .booth }}
 
 {{ $codeSnippets := .code_snippets }}
 {{ $codeTitle := .code_title }}
@@ -89,6 +95,11 @@
                 <span class="text-gray-900 whitespace-nowrap">{{ $badgeText }} <span class="text-gray-800">&rsaquo;</span></span>
             </a>
             {{ end }}
+            {{ if $tagLine }}
+            <div class="text-left mb-2">
+                <span class="hero-tag-line">{{ $tagLine }}</span>
+            </div>
+            {{ end }}
             {{ if or $titlePrimary $title }}
             <h1 class="product-hero-heading text-left mb-6">
                 {{ if and $titlePrimary $titleSecondary }}
@@ -105,6 +116,18 @@
                 <span class="product-hero-title">{{ $title }}</span>
                 {{ end }}
             </h1>
+            {{ end }}
+            {{ if or $dateAndLocation $booth }}
+            <p class="hero-event-details mb-8">
+                {{ if $dateAndLocation }}
+                <span><i class="far fa-calendar mr-3"></i></span>
+                <span class="hero-date-and-location"><a href="#location">{{ $dateAndLocation }}</a></span>
+                {{ end }}
+                {{ if and $dateAndLocation $booth }}
+                <span class="hero-bullet mx-2">•</span>
+                <span class="hero-booth-number">{{ $booth }}</span>
+                {{ end }}
+            </p>
             {{ end }}
             {{ if $description }}
             <p class="product-hero-description mb-10 text-left">{{ $description | markdownify }}</p>


### PR DESCRIPTION
The template-hero refactor in #18447 defaulted layout to "centered", breaking the side-by-side hero on event pages.

## Changes
- Added `layout: split` to hero frontmatter for both event pages
- Updated CTA field names to match new template (`cta_text` → `cta_primary_text`)
- Restored `tag_line`, `date_and_location`, and `booth` field support in the split layout of `template-hero.html`

## Before & After

<img width="1832" height="1527" alt="image" src="https://github.com/user-attachments/assets/9e3d2327-9984-44bf-a704-804099bbe6d4" />

<img width="1832" height="1527" alt="image" src="https://github.com/user-attachments/assets/3dfe96af-24ff-4cca-ab22-5b84ee018efd" />
