### PR TITLE
Document resource identity semantics and Python input type expectations

### DIFF
--- a/content/docs/iac/concepts/inputs-outputs/_index.md
+++ b/content/docs/iac/concepts/inputs-outputs/_index.md
@@ -346,3 +346,9 @@ var example = new Instance("example", InstanceArgs.builder()
 
 {{% /choosable %}}
 {{< /chooser >}}
+
+## Resource identity and inputs
+
+When you pass one resource's output to another resource's input, you are almost always passing the resource's **physical ID** — the provider-assigned identifier that Pulumi exposes as `resource.id`. This is distinct from the resource's URN (which is Pulumi-internal) and the logical name (which is what you write in your code).
+
+Understanding which form of resource identity to use in a given context — physical ID vs. URN vs. resource reference — prevents the most common type-mismatch errors when wiring resources together. See [Resource names and identity](/docs/iac/concepts/resources/names/) for a full explanation of all four identity forms and a quick-reference table showing when to use each one.

--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Resource Names"
-meta_desc: A resource in Pulumi has a logical name (in Pulumi) and a physical name (in the cloud provider). Learn more about resource names and how to use them here.
+title_tag: "Resource Names and Identity"
+meta_desc: A resource in Pulumi has a logical name, physical name, physical ID, and URN. Learn about these four forms of resource identity and when to use each one.
 title: Names
-h1: Resource names
+h1: Resource names and identity
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
@@ -17,16 +17,19 @@ aliases:
 - /docs/concepts/resources/names/
 ---
 
-Each resource in Pulumi has a [logical name](#logicalname) and a [physical name](#autonaming).  The logical name is how the resource is known inside Pulumi, and establishes a notion of identity within Pulumi even when the physical resource might need to change (for example, during a replacement).  The physical name is the name used for the resource in the cloud provider that a Pulumi program is deploying to.
+Each resource in Pulumi carries four distinct forms of identity that serve different purposes. Understanding when to use each one is essential to reading and writing Pulumi programs correctly:
 
-Pulumi [auto-names](#autonaming) most resources by default, using the logical name and a random suffix to construct a unique physical name for a resource.  Users can provide explicit names to override this default.  Users can also [customize or disable auto-naming](#autonaming-configuration) globally, per provider, or per resource type.
+- **Logical name** — the name you give the resource in your program. Pulumi uses it for state tracking and URN generation.
+- **Physical name** — the name Pulumi assigns in the cloud provider, usually derived from the logical name plus a random suffix.
+- **Physical ID** — the identifier the cloud provider returns after creating the resource (e.g., an AWS ARN or a GCP self-link). Exposed as `resource.id`.
+- **URN** — a Pulumi-internal globally unique identifier derived from the stack, project, resource type, and logical name. Exposed as `resource.urn`.
 
-Each resource also has a [Uniform Resource Name (URN)](#urns) which is a unique name derived from both the logical name of the resource and the type of the resource and, in the case of components, its parents.
+The sections below explain each form in detail. For a quick reference on which identity form to use in a given context, see the [identity summary table](#identity-summary).
+
+Pulumi [auto-names](#autonaming) most resources by default, using the logical name and a random suffix to construct a unique physical name for a resource. You can provide explicit names to override this default, and you can [customize or disable auto-naming](#autonaming-configuration) globally, per provider, or per resource type.
 
 {{% notes type="warning" %}}
-
-Be careful when you change a resource’s name because changing the name of a resource will create a new resource and delete the old/original resource. If you’d like to rename a resource without destroying the old one, refer to the [aliases](/docs/concepts/options/aliases/) resource option.
-
+Be careful when you change a resource's name because changing the name of a resource will create a new resource and delete the old/original resource. If you'd like to rename a resource without destroying the old one, refer to the [aliases](/docs/concepts/options/aliases/) resource option.
 {{% /notes %}}
 
 ## Logical Names {#logicalname}
@@ -449,3 +452,137 @@ Any change to the URN of a resource causes the old and new resources to be treat
 Both of these operations will lead to a different URN, and thus require the `create` and `delete` operations instead of an `update` or `replace` operation that you would use for an existing resource.
 
 Resources constructed as children of a component resource must include the component resource's name as part of their names (e.g., as a prefix). This ensures uniqueness across multiple instances of the component resource and ensures that if the component is renamed, the child resources are renamed as well.
+
+## Physical IDs {#physicalid}
+
+In addition to its logical name, physical name, and URN, every resource that Pulumi creates in a cloud provider is assigned a **physical ID** by that provider once creation is complete. This ID is exposed as the `id` output property on every resource.
+
+Unlike the logical name (which you choose) or the URN (which Pulumi derives), the physical ID is assigned by the provider and is specific to that provider's conventions:
+
+- AWS resources use ARNs (`arn:aws:s3:::my-bucket`) or short identifiers (`i-0abc1234def5678`), depending on the resource type.
+- Azure resources use long ARM IDs (`/subscriptions/<sub>/resourceGroups/<rg>/providers/...`).
+- GCP resources use self-link URLs (`https://www.googleapis.com/compute/v1/projects/...`).
+- Generic resources often use simple strings or numeric IDs.
+
+Because `id` is an output, it is wrapped in Pulumi's `Output<T>` type and is not known until the resource has been created or updated. You access it just like any other output — by passing it directly to another resource's input or by using `apply` when you need to transform the value in code.
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+import * as aws from "@pulumi/aws";
+
+const bucket = new aws.s3.Bucket("my-bucket");
+
+// bucket.id is an Output<string> — the AWS-assigned bucket name.
+const replica = new aws.s3.BucketReplication("replica", {
+    bucket: bucket.id,   // Pass Output<string> directly — no .apply() needed.
+    // ...
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+import pulumi
+import pulumi_aws as aws
+
+bucket = aws.s3.Bucket("my-bucket")
+
+# bucket.id is an Output[str] — the AWS-assigned bucket name.
+replica = aws.s3.BucketReplication(
+    "replica",
+    bucket=bucket.id,   # Pass Output[str] directly — no apply() needed.
+)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+bucket, err := s3.NewBucket(ctx, "my-bucket", nil)
+if err != nil {
+    return err
+}
+
+// bucket.ID() returns pulumi.IDOutput — the AWS-assigned bucket name.
+_, err = s3.NewBucketReplication(ctx, "replica", &s3.BucketReplicationArgs{
+    Bucket: bucket.ID(), // Pass IDOutput directly.
+})
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+var bucket = new Aws.S3.Bucket("my-bucket");
+
+// bucket.Id is an Output<string> — the AWS-assigned bucket name.
+var replica = new Aws.S3.BucketReplication("replica", new()
+{
+    Bucket = bucket.Id,  // Pass Output<string> directly.
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+var bucket = new Bucket("my-bucket");
+
+// bucket.id() returns Output<String> — the AWS-assigned bucket name.
+var replica = new BucketReplication("replica", BucketReplicationArgs.builder()
+    .bucket(bucket.id())
+    .build());
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+resources:
+  my-bucket:
+    type: aws:s3:Bucket
+  replica:
+    type: aws:s3:BucketReplication
+    properties:
+      bucket: ${my-bucket.id}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+The physical ID is particularly important when you want to adopt an existing cloud resource into a Pulumi stack. The [`import` resource option](/docs/iac/concepts/resources/options/import/) and the `get` static method both accept a physical ID to look up the resource's current state in the provider.
+
+```python
+# Import an existing S3 bucket by its provider-assigned ID.
+existing = aws.s3.Bucket.get("existing-bucket", id="my-bucket-name-abc123")
+```
+
+See [Importing resources](/docs/iac/adopting-pulumi/import/) for a full discussion of adoption workflows.
+
+## Resource identity summary {#identity-summary}
+
+Pulumi uses four distinct forms of resource identity, each suited to a different purpose. Understanding which form to use in a given context prevents the most common type-mismatch errors.
+
+| Identity form | Where it comes from | Typical value | When to use it |
+|---|---|---|---|
+| **Logical name** | Your code — the first constructor argument | `"my-bucket"` | Passed to the resource constructor. Drives the URN and often the physical name prefix. |
+| **Physical name** | Provider, influenced by your logical name and auto-naming | `"my-bucket-d7c3a1f"` | Used in provider API calls. Read back via provider-specific output properties (e.g., `bucket`, `name`). |
+| **Physical ID** | Provider — returned after the resource is created | `"arn:aws:s3:::my-bucket-d7c3a1f"` or `"my-bucket-d7c3a1f"` | Pass to `import`, `get`, and provider APIs that accept a resource reference by ID. Access via `resource.id`. |
+| **URN** | Pulumi — derived from project, stack, type, and logical name | `"urn:pulumi:dev::app::aws:s3/bucket:Bucket::my-bucket"` | Pulumi CLI commands (`pulumi state`, `pulumi import`). Rarely used in program code. Access via `resource.urn`. |
+| **Resource reference** | Your program — the variable holding the resource object | `bucket` (the Python/TS/Go variable) | Pass to [`ResourceOptions`](/docs/iac/concepts/resources/options/) fields (`parent`, `dependsOn`, `provider`, `deletedWith`). Never pass a URN or ID here. |
+
+The most frequent source of confusion is the distinction between the physical ID (`resource.id`) and the URN (`resource.urn`). The physical ID is what cloud provider APIs and the Pulumi import system expect. The URN is Pulumi-internal and is almost never needed in application code.
+
+{{% notes type="info" %}}
+The `dependsOn` option accepts a list of **resource references** (the variable itself), not URNs or IDs. Pass `dependsOn=[bucket]` in Python, not `dependsOn=[bucket.urn]`.
+{{% /notes %}}

--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -459,12 +459,12 @@ In addition to its logical name, physical name, and URN, every resource that Pul
 
 Unlike the logical name (which you choose) or the URN (which Pulumi derives), the physical ID is assigned by the provider and is specific to that provider's conventions:
 
-- AWS resources use ARNs (`arn:aws:s3:::my-bucket`) or short identifiers (`i-0abc1234def5678`), depending on the resource type.
+- AWS resources use short identifiers such as bucket names (`my-bucket-d7c3a1f`) or resource-specific IDs (`vpc-0abc1234def5678`, `i-0abc1234def5678`). The ARN is typically a separate `arn` output property, not the `id`.
 - Azure resources use long ARM IDs (`/subscriptions/<sub>/resourceGroups/<rg>/providers/...`).
 - GCP resources use self-link URLs (`https://www.googleapis.com/compute/v1/projects/...`).
 - Generic resources often use simple strings or numeric IDs.
 
-Because `id` is an output, it is wrapped in Pulumi's `Output<T>` type and is not known until the resource has been created or updated. You access it just like any other output — by passing it directly to another resource's input or by using `apply` when you need to transform the value in code.
+Because `id` is an output, it is wrapped in Pulumi's `Output<T>` type and is not known until the resource has been created or updated. You access it just like any other output — by passing it directly to another resource's input or by using `.apply()` when you need to transform the value in code.
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
@@ -476,9 +476,10 @@ import * as aws from "@pulumi/aws";
 const bucket = new aws.s3.Bucket("my-bucket");
 
 // bucket.id is an Output<string> — the AWS-assigned bucket name.
-const replica = new aws.s3.BucketReplication("replica", {
+const obj = new aws.s3.BucketObject("hello.txt", {
     bucket: bucket.id,   // Pass Output<string> directly — no .apply() needed.
-    // ...
+    content: "Hello, Pulumi!",
+    key: "hello.txt",
 });
 ```
 
@@ -493,9 +494,11 @@ import pulumi_aws as aws
 bucket = aws.s3.Bucket("my-bucket")
 
 # bucket.id is an Output[str] — the AWS-assigned bucket name.
-replica = aws.s3.BucketReplication(
-    "replica",
+obj = aws.s3.BucketObject(
+    "hello.txt",
     bucket=bucket.id,   # Pass Output[str] directly — no apply() needed.
+    content="Hello, Pulumi!",
+    key="hello.txt",
 )
 ```
 
@@ -510,8 +513,10 @@ if err != nil {
 }
 
 // bucket.ID() returns pulumi.IDOutput — the AWS-assigned bucket name.
-_, err = s3.NewBucketReplication(ctx, "replica", &s3.BucketReplicationArgs{
-    Bucket: bucket.ID(), // Pass IDOutput directly.
+_, err = s3.NewBucketObject(ctx, "hello.txt", &s3.BucketObjectArgs{
+    Bucket:  bucket.ID(), // Pass IDOutput directly.
+    Content: pulumi.String("Hello, Pulumi!"),
+    Key:     pulumi.String("hello.txt"),
 })
 ```
 
@@ -523,9 +528,11 @@ _, err = s3.NewBucketReplication(ctx, "replica", &s3.BucketReplicationArgs{
 var bucket = new Aws.S3.Bucket("my-bucket");
 
 // bucket.Id is an Output<string> — the AWS-assigned bucket name.
-var replica = new Aws.S3.BucketReplication("replica", new()
+var obj = new Aws.S3.BucketObject("hello.txt", new()
 {
-    Bucket = bucket.Id,  // Pass Output<string> directly.
+    BucketName = bucket.Id,  // Pass Output<string> directly.
+    Content = "Hello, Pulumi!",
+    Key = "hello.txt",
 });
 ```
 
@@ -537,8 +544,10 @@ var replica = new Aws.S3.BucketReplication("replica", new()
 var bucket = new Bucket("my-bucket");
 
 // bucket.id() returns Output<String> — the AWS-assigned bucket name.
-var replica = new BucketReplication("replica", BucketReplicationArgs.builder()
-    .bucket(bucket.id())
+var obj = new BucketObject("hello.txt", BucketObjectArgs.builder()
+    .bucket(bucket.id())   // Pass Output<String> directly.
+    .content("Hello, Pulumi!")
+    .key("hello.txt")
     .build());
 ```
 
@@ -550,10 +559,12 @@ var replica = new BucketReplication("replica", BucketReplicationArgs.builder()
 resources:
   my-bucket:
     type: aws:s3:Bucket
-  replica:
-    type: aws:s3:BucketReplication
+  hello-txt:
+    type: aws:s3:BucketObject
     properties:
       bucket: ${my-bucket.id}
+      content: "Hello, Pulumi!"
+      key: hello.txt
 ```
 
 {{% /choosable %}}
@@ -577,12 +588,12 @@ Pulumi uses four distinct forms of resource identity, each suited to a different
 |---|---|---|---|
 | **Logical name** | Your code — the first constructor argument | `"my-bucket"` | Passed to the resource constructor. Drives the URN and often the physical name prefix. |
 | **Physical name** | Provider, influenced by your logical name and auto-naming | `"my-bucket-d7c3a1f"` | Used in provider API calls. Read back via provider-specific output properties (e.g., `bucket`, `name`). |
-| **Physical ID** | Provider — returned after the resource is created | `"arn:aws:s3:::my-bucket-d7c3a1f"` or `"my-bucket-d7c3a1f"` | Pass to `import`, `get`, and provider APIs that accept a resource reference by ID. Access via `resource.id`. |
+| **Physical ID** | Provider — returned after the resource is created | `"my-bucket-d7c3a1f"` (S3), `"vpc-0abc1234def5678"` (VPC), `"/subscriptions/.../resourceGroups/..."` (Azure) | Pass to `import`, `get`, and provider APIs that accept a resource reference by ID. Access via `resource.id`. |
 | **URN** | Pulumi — derived from project, stack, type, and logical name | `"urn:pulumi:dev::app::aws:s3/bucket:Bucket::my-bucket"` | Pulumi CLI commands (`pulumi state`, `pulumi import`). Rarely used in program code. Access via `resource.urn`. |
-| **Resource reference** | Your program — the variable holding the resource object | `bucket` (the Python/TS/Go variable) | Pass to [`ResourceOptions`](/docs/iac/concepts/resources/options/) fields (`parent`, `dependsOn`, `provider`, `deletedWith`). Never pass a URN or ID here. |
+| **Resource reference** | Your program — the variable holding the resource object | `bucket` (the Python/TS/Go variable) | Pass to [`ResourceOptions`](/docs/iac/concepts/resources/options/) fields (`parent`, `depends_on`, `provider`, `deleted_with`). Never pass a URN or ID here. |
 
 The most frequent source of confusion is the distinction between the physical ID (`resource.id`) and the URN (`resource.urn`). The physical ID is what cloud provider APIs and the Pulumi import system expect. The URN is Pulumi-internal and is almost never needed in application code.
 
 {{% notes type="info" %}}
-The `dependsOn` option accepts a list of **resource references** (the variable itself), not URNs or IDs. Pass `dependsOn=[bucket]` in Python, not `dependsOn=[bucket.urn]`.
+The `dependsOn` option accepts a list of **resource references** (the variable itself), not URNs or IDs. In Python the field is `depends_on` — pass `depends_on=[bucket]`, not `depends_on=[bucket.urn]`.
 {{% /notes %}}

--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -530,7 +530,7 @@ var bucket = new Aws.S3.Bucket("my-bucket");
 // bucket.Id is an Output<string> — the AWS-assigned bucket name.
 var obj = new Aws.S3.BucketObject("hello.txt", new()
 {
-    BucketName = bucket.Id,  // Pass Output<string> directly.
+    Bucket = bucket.Id,  // Pass Output<string> directly.
     Content = "Hello, Pulumi!",
     Key = "hello.txt",
 });

--- a/content/docs/iac/languages-sdks/python/_index.md
+++ b/content/docs/iac/languages-sdks/python/_index.md
@@ -63,6 +63,14 @@ repo2 = aws.ecr.Repository("repo2-with-args",
     ))
 ```
 
+### Resource identity
+
+Every Pulumi resource exposes four forms of identity — its logical name, physical name, physical ID (`resource.id`), and URN (`resource.urn`) — and each form is appropriate for a different context. Passing the wrong form is the most common source of type errors when wiring Python resources together.
+
+For example, the `parent` and `depends_on` fields in `ResourceOptions` expect the **resource object itself**, not a string ID or URN. Conversely, most resource input properties that reference other resources (such as `vpc_id` on a subnet) expect the upstream resource's **`id` output** — an `Output[str]` — not the URN or the variable.
+
+See [Resource identity in Python](/docs/iac/languages-sdks/python/resource-identity/) for a complete guide to each identity form, common type-mismatch pitfalls, and debugging advice.
+
 ### Blocking and Asynchronous Code
 
 A Python Pulumi program is single threaded and the Pulumi runtime creates an

--- a/content/docs/iac/languages-sdks/python/resource-identity.md
+++ b/content/docs/iac/languages-sdks/python/resource-identity.md
@@ -1,0 +1,219 @@
+---
+title_tag: "Resource Identity in Python | Languages & SDKs"
+meta_desc: How to work with resource identity in Python — logical names, physical IDs, URNs, and resource references — with common pitfalls and troubleshooting guidance.
+title: Resource identity
+h1: Resource identity in Python
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Resource identity
+        parent: iac-languages-python
+        weight: 4
+    languages:
+        parent: python
+        weight: 6
+aliases:
+- /docs/languages-sdks/python/resource-identity/
+---
+
+Pulumi resources carry [four distinct forms of identity](/docs/iac/concepts/resources/names/#identity-summary): a logical name, a physical name, a physical ID, and a URN. Each form serves a different purpose, and passing the wrong one to an argument is the most common source of type-mismatch errors in Python Pulumi programs. This page explains how each form works in Python and how to diagnose problems when something looks wrong.
+
+## How resource identity maps to Python
+
+When you construct a resource in Python, you supply the **logical name** as the first positional argument. Everything else — physical name, physical ID, URN — is produced by Pulumi or the cloud provider at deploy time.
+
+```python
+import pulumi
+import pulumi_aws as aws
+
+# "main-vpc" is the logical name. It feeds into the URN and influences
+# the physical name (e.g., "main-vpc-3f8a2b1").
+vpc = aws.ec2.Vpc("main-vpc", cidr_block="10.0.0.0/16")
+```
+
+After the resource is created, you can access the four identity forms as output properties:
+
+```python
+# Physical ID: the AWS-assigned VPC ID (e.g., "vpc-0abc123def456789").
+# This is an Output[str], not a plain string.
+vpc_id: pulumi.Output[str] = vpc.id
+
+# URN: Pulumi-internal identifier.
+# Format: urn:pulumi:<stack>::<project>::<type>::<logical-name>
+vpc_urn: pulumi.Output[str] = vpc.urn
+```
+
+Both `id` and `urn` are `Output[str]` values — they are not available as plain strings at program definition time because the cloud provider does not assign them until the resource is actually created or updated.
+
+## Passing identity to other resources
+
+The most common operations — wiring resources together and setting options — each expect a specific form of identity.
+
+### Physical ID: wiring resource inputs
+
+When one resource needs to reference another resource (for example, placing a subnet inside a VPC), pass the upstream resource's **`id` output** to the downstream resource's input:
+
+```python
+subnet = aws.ec2.Subnet(
+    "main-subnet",
+    vpc_id=vpc.id,          # Output[str] — the VPC's AWS-assigned ID
+    cidr_block="10.0.1.0/24",
+    availability_zone="us-east-1a",
+)
+```
+
+Pulumi automatically resolves `Output[str]` values and establishes the correct creation order between the two resources. You do not need to call `.apply()` for simple pass-through cases like this.
+
+### Resource references: ResourceOptions fields
+
+Fields in [`ResourceOptions`](/docs/iac/concepts/resources/options/) — `parent`, `dependsOn`, `provider`, `deletedWith` — accept the **resource object itself**, not a URN or ID:
+
+```python
+# CORRECT: pass the resource variable to parent and dependsOn.
+subnet = aws.ec2.Subnet(
+    "main-subnet",
+    vpc_id=vpc.id,
+    cidr_block="10.0.1.0/24",
+    opts=pulumi.ResourceOptions(
+        parent=vpc,         # Resource object — NOT vpc.urn, NOT vpc.id
+        depends_on=[vpc],   # List of resource objects — NOT [vpc.urn]
+    ),
+)
+```
+
+```python
+# INCORRECT — a common mistake.
+subnet = aws.ec2.Subnet(
+    "main-subnet",
+    vpc_id=vpc.id,
+    cidr_block="10.0.1.0/24",
+    opts=pulumi.ResourceOptions(
+        parent=vpc.urn,     # Wrong — urn is a string output, not a resource
+        depends_on=[vpc.id], # Wrong — id is a string output, not a resource
+    ),
+)
+```
+
+### Importing existing resources
+
+To adopt an existing cloud resource into your Pulumi stack, use the `import` resource option with the resource's **physical ID**:
+
+```python
+# The id= argument is the provider-assigned ID, not the Pulumi URN.
+existing_bucket = aws.s3.Bucket(
+    "existing-bucket",
+    opts=pulumi.ResourceOptions(import_="my-bucket-name-abc123"),
+)
+```
+
+The static `.get()` method on a resource class also takes a physical ID:
+
+```python
+# Look up an existing resource by its provider-assigned ID.
+existing_vpc = aws.ec2.Vpc.get("imported-vpc", id="vpc-0abc123def456789")
+```
+
+For a complete walk-through of the import workflow, see [Importing resources](/docs/iac/adopting-pulumi/import/).
+
+## Common type-mismatch errors
+
+### Passing a URN where a physical ID is expected
+
+```python
+# WRONG: vpc.urn is Pulumi's internal URN, not the AWS VPC ID.
+subnet = aws.ec2.Subnet("main-subnet", vpc_id=vpc.urn, ...)
+
+# RIGHT: use vpc.id, which holds the AWS-assigned VPC ID.
+subnet = aws.ec2.Subnet("main-subnet", vpc_id=vpc.id, ...)
+```
+
+The URN looks like `urn:pulumi:dev::app::aws:ec2/vpc:Vpc::main-vpc`. Cloud provider APIs never accept a URN — they accept provider-specific IDs such as `vpc-0abc123def456789`.
+
+### Passing a plain string where an Output is needed
+
+If you hard-code a resource ID that you retrieved out-of-band (e.g., from the Pulumi CLI or the cloud console), wrap it in `pulumi.Output.from_input` or just pass the string directly. Pulumi accepts both plain strings and `Output[str]` for inputs:
+
+```python
+# Both of these are valid:
+subnet = aws.ec2.Subnet("main-subnet", vpc_id="vpc-0abc123def456789", ...)
+subnet = aws.ec2.Subnet("main-subnet", vpc_id=pulumi.Output.from_input("vpc-0abc123def456789"), ...)
+```
+
+However, passing a plain string for `parent` or `depends_on` in `ResourceOptions` is not valid — those fields require resource objects.
+
+### Confusing the logical name with the physical name
+
+The logical name you pass to the constructor is **not** the same as the physical name the resource gets in the cloud. Pulumi appends a random suffix to the logical name to generate the physical name (unless you override it). Do not rely on the logical name to equal the cloud resource name.
+
+```python
+# Logical name: "my-function"
+# Physical name (auto-named): "my-function-3a8b7f2" (random suffix added by Pulumi)
+fn = aws.lambda_.Function("my-function", ...)
+
+# If you need the actual Lambda function name as known to AWS, use fn.name:
+pulumi.export("function_name", fn.name)  # Output[str] — the physical name
+```
+
+### Using .apply() unnecessarily for pass-through IDs
+
+A common over-use of `.apply()` is extracting an ID just to pass it directly to another resource:
+
+```python
+# UNNECESSARY — Pulumi accepts Output[str] directly.
+subnet = aws.ec2.Subnet(
+    "main-subnet",
+    vpc_id=vpc.id.apply(lambda id: id),  # No-op apply
+    ...
+)
+
+# CORRECT — pass Output[str] directly.
+subnet = aws.ec2.Subnet("main-subnet", vpc_id=vpc.id, ...)
+```
+
+Reserve `.apply()` for cases where you need to transform the value or embed it in a string. Passing a resource ID directly never requires `.apply()`.
+
+## Debugging state mismatches
+
+### Checking what Pulumi has recorded for a resource
+
+After a deploy, you can inspect a resource's recorded URN and ID using `pulumi stack`:
+
+```bash
+pulumi stack --show-urns
+```
+
+Or query the state file directly:
+
+```bash
+pulumi stack export | python3 -c "import sys,json; [print(r['urn'], r.get('id','')) for r in json.load(sys.stdin)['deployment']['resources']]"
+```
+
+### A resource is being replaced unexpectedly
+
+If Pulumi creates a new resource and deletes the old one when you expected an in-place update, the most common cause is that the logical name, parent, or type changed — any of which changes the URN and forces a replacement. Check whether you unintentionally:
+
+- Changed the first constructor argument (logical name).
+- Moved the resource inside or outside a component.
+- Changed the resource type.
+
+Use [`aliases`](/docs/iac/concepts/resources/options/aliases/) to preserve the old URN when you need to refactor without replacing resources.
+
+### `get()` returns stale state
+
+The `.get()` static method reads the resource's current state from the cloud provider, not from the Pulumi state file. If the Pulumi state file and the provider are out of sync, use `pulumi refresh` to reconcile them before calling `.get()`.
+
+### `import` fails with "resource already exists"
+
+When using `import` via `ResourceOptions(import_=...)`, if Pulumi says the resource already exists in the stack, you may already have a resource with the same logical name in state. Check `pulumi stack` to see if the resource is already tracked. If it is, remove the `import_` option — the resource is already managed.
+
+## Quick reference: identity in Python
+
+| What you need | Where to get it | Python expression |
+|---|---|---|
+| Logical name | Your code | The first argument you passed: `"main-vpc"` |
+| Physical name | Provider output | `resource.name` (resource-specific; not all resources expose this) |
+| Physical ID | Provider output | `resource.id` — always an `Output[str]` |
+| URN | Pulumi output | `resource.urn` — always an `Output[str]` |
+| Resource reference | Your program variable | `resource` (the variable itself) |
+
+For the full conceptual explanation of these four identity forms and a cross-language reference table, see [Resource names and identity](/docs/iac/concepts/resources/names/).

--- a/content/docs/iac/languages-sdks/python/resource-identity.md
+++ b/content/docs/iac/languages-sdks/python/resource-identity.md
@@ -20,18 +20,7 @@ Pulumi resources carry [four distinct forms of identity](/docs/iac/concepts/reso
 
 ## How resource identity maps to Python
 
-When you construct a resource in Python, you supply the **logical name** as the first positional argument. Everything else — physical name, physical ID, URN — is produced by Pulumi or the cloud provider at deploy time.
-
-```python
-import pulumi
-import pulumi_aws as aws
-
-# "main-vpc" is the logical name. It feeds into the URN and influences
-# the physical name (e.g., "main-vpc-3f8a2b1").
-vpc = aws.ec2.Vpc("main-vpc", cidr_block="10.0.0.0/16")
-```
-
-After the resource is created, you can access the four identity forms as output properties:
+The first positional argument you pass to a resource constructor is the **logical name** — Pulumi uses it for state tracking, URN generation, and as the prefix for the auto-generated physical name. After the resource is created, you can access the remaining identity forms as output properties:
 
 ```python
 # Physical ID: the AWS-assigned VPC ID (e.g., "vpc-0abc123def456789").
@@ -66,10 +55,10 @@ Pulumi automatically resolves `Output[str]` values and establishes the correct c
 
 ### Resource references: ResourceOptions fields
 
-Fields in [`ResourceOptions`](/docs/iac/concepts/resources/options/) — `parent`, `dependsOn`, `provider`, `deletedWith` — accept the **resource object itself**, not a URN or ID:
+Fields in [`ResourceOptions`](/docs/iac/concepts/resources/options/) — `parent`, `depends_on`, `provider`, `deleted_with` — accept the **resource object itself**, not a URN or ID:
 
 ```python
-# CORRECT: pass the resource variable to parent and dependsOn.
+# CORRECT: pass the resource variable to parent and depends_on.
 subnet = aws.ec2.Subnet(
     "main-subnet",
     vpc_id=vpc.id,
@@ -162,7 +151,7 @@ A common over-use of `.apply()` is extracting an ID just to pass it directly to 
 # UNNECESSARY — Pulumi accepts Output[str] directly.
 subnet = aws.ec2.Subnet(
     "main-subnet",
-    vpc_id=vpc.id.apply(lambda id: id),  # No-op apply
+    vpc_id=vpc.id.apply(lambda value: value),  # No-op apply
     ...
 )
 


### PR DESCRIPTION
This PR addresses issue #17739 by documenting the four forms of Pulumi resource identity and adding Python-specific guidance for working with them correctly.

## Changes

### `content/docs/iac/concepts/resources/names.md`

Expanded the resource names concepts page — now titled "Resource names and identity" — with two new sections:

- **Physical IDs** (`#physicalid`): Explains the `resource.id` output, how physical IDs differ from URNs and logical names, and when to use them (imports, `get()`, resource input wiring). Includes a six-language code example.
- **Resource identity summary** (`#identity-summary`): A reference table mapping each identity form (logical name, physical name, physical ID, URN, resource reference) to its source, a typical value, and the contexts where it is appropriate.

The page intro was also updated to introduce all four identity forms upfront, so readers can orient themselves before diving into the individual sections.

### `content/docs/iac/languages-sdks/python/resource-identity.md` (new file)

A new Python SDK subpage covering:

- How the four identity forms map to Python expressions (`resource.id`, `resource.urn`, etc.)
- Code examples for wiring resource inputs, using `ResourceOptions` fields, and calling `import`/`get()`
- A "Common type-mismatch errors" section covering the most frequent mistakes: URN where ID is expected, unnecessary `.apply()` calls, confusing logical name with physical name
- A "Debugging state mismatches" section with CLI commands and explanations for unexpected replacement behavior
- A quick-reference table

### `content/docs/iac/languages-sdks/python/_index.md`

Added a "Resource identity" subsection to the Programming Model section linking to the new subpage.

### `content/docs/iac/concepts/inputs-outputs/_index.md`

Added a "Resource identity and inputs" section at the end of the page, explaining that output-to-input wiring typically passes physical IDs and linking to the identity summary.

Fixes #17739

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*