### PR TITLE
Fix CamelCase schema aliases

### DIFF
--- a/content/docs/reference/cloud-rest-api/schema/_content.gotmpl
+++ b/content/docs/reference/cloud-rest-api/schema/_content.gotmpl
@@ -36,13 +36,13 @@
         "openapi_schema" true
         "schema_name" $name
         "notoc" true
-        "aliases" $aliases
     }}
 
     {{ $.AddPage (dict
         "path" $slug
         "title" $name
         "kind" "page"
+        "aliases" $aliases
         "params" $params
     ) }}
 {{ end }}{{/* range $names */}}


### PR DESCRIPTION
## Summary

- Moves `aliases` from inside `params` to the top-level `$.AddPage` dict in the schema content adapter, matching how the tag page template already passes aliases

Hugo's `$.AddPage` expects `aliases` as a top-level key. When nested inside `params`, Hugo silently ignores them — so CamelCase schema URLs like `/schema/AppStack/` returned 404 instead of redirecting to `/schema/appstack/`.

## Test plan

- [x] Verify `/docs/reference/cloud-rest-api/schema/AppStack/` redirects to `/docs/reference/cloud-rest-api/schema/appstack/` (currently 404s on #18551 preview)
- [x] Verify lowercase schema URLs still work (e.g. `/docs/reference/cloud-rest-api/schema/appstack/`)
- [x] Verify site builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)