### PR TITLE
Document NPW cloud filter for org templates

### DIFF
--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -163,7 +163,7 @@ Schemas are only valid for project property keys. For setting the value of a pro
 | `displayName` | optional | A user-friendly name for the template. This should follow `Title Case` format and be succinct. This field is only supported by Pulumi CLI >= 3.95. |
 | `description` | optional | Description of the template. |
 | `config` | required | Config to request when using this template with `pulumi new`. |
-| `metadata` | optional | A map of user-defined tags to attach to the template. This field is only supported by Pulumi CLI >= 3.95. |
+| `metadata` | optional | A map of user-defined tags to attach to the template. The Pulumi Cloud [New Project Wizard](/docs/idp/concepts/new-project-wizard/) recognizes a `cloud` key for filtering templates by target cloud — see [Organization templates](/docs/idp/concepts/organization-templates/#new-project-wizard-cloud-filter) for accepted values. This field is only supported by Pulumi CLI >= 3.95. |
 
 #### `config`
 

--- a/content/docs/idp/concepts/organization-templates.md
+++ b/content/docs/idp/concepts/organization-templates.md
@@ -103,6 +103,25 @@ Templates can include a `README.md` file in the same directory as the `Pulumi.ya
 
 Templates can include any other files needed for the project (source code, configuration files, etc.). These files are copied when a project is created from the template.
 
+### New Project Wizard cloud filter
+
+The [New Project Wizard](/docs/idp/concepts/new-project-wizard/) card view includes a "Filter by cloud" dropdown that groups templates by their target cloud. To make a template appear under one of these filters, set `template.metadata.cloud` in the template's `Pulumi.yaml`:
+
+```yaml
+name: my-aws-template
+runtime: nodejs
+template:
+  description: My AWS project template
+  metadata:
+    cloud: aws
+```
+
+A few constraints to keep in mind:
+
+- **Recognized values**: The wizard recognizes only `aws`, `azure`, `gcp`, and `kubernetes`. Any other value is ignored, and the template will not appear under a cloud filter.
+- **Single value**: `cloud` is a string, not a list. A multi-cloud template can be filtered under at most one cloud, so pick its primary cloud or leave the field unset.
+- **Unset templates**: Templates without `template.metadata.cloud` do not appear under any cloud filter. They still appear when the filter is set to "All".
+
 ## Publishing Registry-backed Templates
 
 Registry-backed templates are published to your organization's Private Registry using the Pulumi CLI.


### PR DESCRIPTION
Documents how `template.metadata.cloud` controls the New Project Wizard "Filter by cloud" dropdown for organization templates.

## Changes
- Added a "New Project Wizard cloud filter" subsection to the Organization Templates page covering recognized values (`aws`, `azure`, `gcp`, `kubernetes`), the single-string constraint, and behavior when the field is unset.
- Expanded the `template.metadata` row in the project file reference to point readers at the new section.

Closes #13571.