### PR TITLE
docs(source-based-plugin): add name parameter to componentProviderHost example

### DIFF
--- a/content/docs/iac/guides/building-extending/packages/source-based-plugin.md
+++ b/content/docs/iac/guides/building-extending/packages/source-based-plugin.md
@@ -387,7 +387,7 @@ import { componentProviderHost } from "@pulumi/pulumi/provider/experimental";
 import { StaticSite } from "./static-site";
 import { Database } from "./database";
 
-componentProviderHost({ components: [StaticSite, Database] });
+componentProviderHost({ components: [StaticSite, Database], name: "my-package" });
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
## Summary

- Fixes the TypeScript code example in the source-based plugin guide to include the required `name` parameter when calling `componentProviderHost`

## Test plan

- [ ] Verify the updated code example renders correctly in the docs site