### PR TITLE
Fix mobile header: restore close icon, remove empty top bar, lock scroll, prevent layout shift

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,7 @@
 <nav class="top-nav-bar transition-all">
     <div class="top-nav-container lg:container lg:px-4 flex-wrap justify-end">
         {{ partial "banner" . }}
-        <div class="w-full p-4">
+        <div class="hidden lg:block w-full p-4">
             <ul class="hidden w-full lg:flex justify-end items-center order-first lg:order-last">
                 <li class="github-widget mr-8">
                     <a data-track="header-github-pulumi" class="github-button" href="https://github.com/pulumi/pulumi"
@@ -357,7 +357,7 @@
                     <label class="mobile-menu-closed" for="mobile-menu">
                         {{ partial "icon" (dict "icon" "hamburger-closed") }}
                     </label>
-                    <label class="mobile-menu-open hidden" for="mobile-menu">
+                    <label class="mobile-menu-open" for="mobile-menu">
                         {{ partial "icon" (dict "icon" "hamburger-open") }}
                     </label>
                 </span>

--- a/theme/src/scss/_header.scss
+++ b/theme/src/scss/_header.scss
@@ -350,13 +350,17 @@ pulumi-user-toggle:not(.hydrated) [slot="signed-in"] {
         @apply hidden;
     }
 
+    .mobile-menu-icon .mobile-menu-open {
+        display: none;
+    }
+
     .mobile-menu-toggle:checked + .mobile-menu-icon {
         .mobile-menu-closed {
-            @apply hidden;
+            display: none;
         }
 
         .mobile-menu-open {
-            @apply block;
+            display: block;
         }
     }
 
@@ -526,6 +530,29 @@ pulumi-user-toggle:not(.hydrated) [slot="signed-in"] {
 
         label {
             @apply cursor-pointer;
+        }
+    }
+}
+
+html:has(.mobile-menu-toggle:checked) {
+    overflow: hidden;
+
+    .header-container {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+
+        &.is-pinned {
+            top: -1px;
+        }
+    }
+
+    @include screen-lg {
+        overflow: auto;
+
+        .header-container {
+            position: sticky;
         }
     }
 }

--- a/theme/src/ts/misc.ts
+++ b/theme/src/ts/misc.ts
@@ -165,6 +165,10 @@ export function generateOnThisPage() {
 (function () {
     const observer = new IntersectionObserver(
         ([e]) => {
+            const mobileMenuToggle = document.getElementById("mobile-menu") as HTMLInputElement | null;
+            if (mobileMenuToggle?.checked) {
+                return;
+            }
             e.target.classList.toggle("is-pinned", e.intersectionRatio < 1);
             const pinnedSearchContainerEl = document.querySelector(".header-pinned") as HTMLElement;
             const dotOverlay = document.querySelector(".hide-on-pinned") as HTMLElement;


### PR DESCRIPTION
### Proposed changes

Four small, related fixes to the mobile site header, touching `layouts/partials/header.html`, `theme/src/scss/_header.scss`, and `theme/src/ts/misc.ts`.

- **Restore the close (X) icon when the burger menu is open.** The open-state `<label>` carried the Tailwind `hidden` class. Tailwind v4 puts `.hidden` in the `utilities` layer, which beats the `display: block` override in the `components` layer regardless of selector specificity, so the X never rendered. Removed `hidden` from the markup and replaced `@apply hidden/block` with plain `display: none/block` so the toggle override stays in the same layer as its default.

Before
<img width="500" height="800" alt="Screenshot 2026-04-20 at 5 07 25 PM" src="https://github.com/user-attachments/assets/5c97eac7-9679-41df-bc4a-146b76a91333" />

After
<img width="428" height="779" alt="Screenshot 2026-04-20 at 5 06 47 PM" src="https://github.com/user-attachments/assets/a59421fa-daac-41db-abee-1568584e8e95" />


- **Remove ~32px of empty space above the header on mobile.** The `.top-nav-bar` wraps its desktop-only links UL in a `<div class="w-full p-4">`. On mobile the UL is `hidden`, but the wrapper's 16px top+bottom padding still reserves 32px. Added `hidden lg:block` so the wrapper only takes space at the breakpoint where its content is visible.


Before
<img width="428" height="594" alt="Screenshot 2026-04-20 at 5 08 24 PM" src="https://github.com/user-attachments/assets/14012200-6588-441b-9c96-020790112e7a" />

After
<img width="427" height="568" alt="Screenshot 2026-04-20 at 5 08 54 PM" src="https://github.com/user-attachments/assets/126e0356-4419-4bd8-aa45-eea1373191cb" />


- **Lock body scroll while the mobile menu is open.** Previously the page behind the menu could still scroll. Added `html:has(.mobile-menu-toggle:checked) { overflow: hidden }`. Because `overflow: hidden` on `<html>` breaks `position: sticky`, the rule also pins `.header-container` with `position: fixed` while the menu is open so it stays in the viewport regardless of scroll position.

- **Prevent a 1px layout shift when opening the menu.** The header's sticky uses `top: -1px` for IntersectionObserver-based pinned-state detection. When the menu opens, the header grows to `100vh` and the IO fired and added `is-pinned`, which shifted the fixed header up by 1px. The observer now early-returns when the mobile menu toggle is checked, so `is-pinned` doesn't flip based on menu state.