### PR TITLE
Tighten REST API tag-list descriptions on cloud-rest-api landing

### DIFF
--- a/assets/openapi/tag-intros/README.md
+++ b/assets/openapi/tag-intros/README.md
@@ -11,9 +11,13 @@ Markdown fragments rendered at the top of each generated tag page under
   `CloudSetup` -> `Cloud Setup` -> `cloud-setup`), so the file for the
   `CloudSetup` tag must be `cloud-setup.md`.
 - YAML frontmatter holds a `meta_desc` field — a 1-2 sentence description
-  of the API area, used as the tag page's `<meta name="description">` and
-  as the list-item description on the cloud-rest-api landing page. Keep
-  `meta_desc` to plain text (no Markdown links) — it renders unescaped.
+  (≤160 chars, so Google search snippets aren't truncated) used as the
+  tag page's `<meta name="description">` and as the list-item description
+  on the cloud-rest-api landing page. Use plain text — `meta_desc` is
+  not processed as Markdown, so links or emphasis appear literally.
+- Avoid a literal `: ` in unquoted `meta_desc` values; YAML parses it as
+  a nested mapping and the build fails. Reword (e.g., use a comma) or
+  quote the value.
 - Body is Markdown. Headings (`##`, `###`) and lists are fine; they render
   inside the page above the auto-generated endpoint sections.
 - Keep the body editorial: purpose of the API area, when to use it, links

--- a/assets/openapi/tag-intros/README.md
+++ b/assets/openapi/tag-intros/README.md
@@ -10,11 +10,27 @@ Markdown fragments rendered at the top of each generated tag page under
   through `urlize` after inserting spaces into CamelCase names (e.g.
   `CloudSetup` -> `Cloud Setup` -> `cloud-setup`), so the file for the
   `CloudSetup` tag must be `cloud-setup.md`.
-- No frontmatter — just Markdown. Headings (`##`, `###`) and lists are fine;
-  they render inside the page above the auto-generated endpoint sections.
-- Keep it editorial: purpose of the API area, when to use it, links to
-  related conceptual docs. Endpoint descriptions belong in the OpenAPI
+- YAML frontmatter holds a `meta_desc` field — a 1-2 sentence description
+  of the API area, used as the tag page's `<meta name="description">` and
+  as the list-item description on the cloud-rest-api landing page. Keep
+  `meta_desc` to plain text (no Markdown links) — it renders unescaped.
+- Body is Markdown. Headings (`##`, `###`) and lists are fine; they render
+  inside the page above the auto-generated endpoint sections.
+- Keep the body editorial: purpose of the API area, when to use it, links
+  to related conceptual docs. Endpoint descriptions belong in the OpenAPI
   spec itself.
+
+Example:
+
+```markdown
+---
+meta_desc: Short 1-2 sentence summary used by SEO and the landing-page list.
+---
+
+Longer editorial intro that renders at the top of the tag page.
+
+See [related concept docs](/docs/...) for getting-started guides.
+```
 
 ## Orphan checks
 

--- a/assets/openapi/tag-intros/access-tokens.md
+++ b/assets/openapi/tag-intros/access-tokens.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Access tokens authenticate users and automation with the Pulumi Cloud API. The Access Tokens API manages personal access tokens (PATs) for individuals and organization-level tokens for team and CI use.
+meta_desc: Authenticate users and automation with Pulumi Cloud. Covers personal access tokens (PATs) for individuals and organization-level tokens for teams and CI.
 ---
 
 Access Tokens are credentials used to authenticate with the Pulumi Cloud API. The Access Tokens API covers both personal access tokens (PATs) for individual users and organization-level tokens for team use.

--- a/assets/openapi/tag-intros/access-tokens.md
+++ b/assets/openapi/tag-intros/access-tokens.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Access tokens authenticate users and automation with the Pulumi Cloud API. The Access Tokens API manages personal access tokens (PATs) for individuals and organization-level tokens for team and CI use.
+---
+
 Access Tokens are credentials used to authenticate with the Pulumi Cloud API. The Access Tokens API covers both personal access tokens (PATs) for individual users and organization-level tokens for team use.

--- a/assets/openapi/tag-intros/ai.md
+++ b/assets/openapi/tag-intros/ai.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The AI API provides AI-assisted Pulumi capabilities, including generating Pulumi project templates from natural-language prompts.
+meta_desc: Generate Pulumi project templates from natural-language prompts and access other AI-assisted Pulumi capabilities.
 ---
 
 The AI API exposes AI-assisted capabilities in Pulumi Cloud. Today the surface focuses on generating Pulumi project templates from natural-language prompts.

--- a/assets/openapi/tag-intros/ai.md
+++ b/assets/openapi/tag-intros/ai.md
@@ -1,0 +1,5 @@
+---
+meta_desc: The AI API provides AI-assisted Pulumi capabilities, including generating Pulumi project templates from natural-language prompts.
+---
+
+The AI API exposes AI-assisted capabilities in Pulumi Cloud. Today the surface focuses on generating Pulumi project templates from natural-language prompts.

--- a/assets/openapi/tag-intros/audit-logs.md
+++ b/assets/openapi/tag-intros/audit-logs.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Audit Logs record user actions and system events within Pulumi Cloud. The Audit Logs API retrieves and exports log entries for compliance, security, and monitoring.
+---
+
 Audit Logs provide a record of user actions and system events within Pulumi Cloud. The Audit Logs API allows you to retrieve and export audit log entries for compliance, security, and monitoring purposes.

--- a/assets/openapi/tag-intros/audit-logs.md
+++ b/assets/openapi/tag-intros/audit-logs.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Audit Logs record user actions and system events within Pulumi Cloud. The Audit Logs API retrieves and exports log entries for compliance, security, and monitoring.
+meta_desc: Retrieve and export Pulumi Cloud audit log entries (user actions and system events) for compliance, security, and monitoring.
 ---
 
 Audit Logs provide a record of user actions and system events within Pulumi Cloud. The Audit Logs API allows you to retrieve and export audit log entries for compliance, security, and monitoring purposes.

--- a/assets/openapi/tag-intros/cloud-setup.md
+++ b/assets/openapi/tag-intros/cloud-setup.md
@@ -1,1 +1,5 @@
+---
+meta_desc: The Cloud Setup API helps you configure cloud provider credentials and integrations for use with Pulumi. Endpoints cover initial provider setup workflows for AWS, Azure, and GCP.
+---
+
 The Cloud Setup API helps you configure cloud provider credentials and integrations for use with Pulumi. Endpoints cover initial provider setup workflows for AWS, Azure, and GCP.

--- a/assets/openapi/tag-intros/cloud-setup.md
+++ b/assets/openapi/tag-intros/cloud-setup.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Cloud Setup API helps you configure cloud provider credentials and integrations for use with Pulumi. Endpoints cover initial provider setup workflows for AWS, Azure, and GCP.
+meta_desc: Configure cloud provider credentials and integrations for use with Pulumi. Covers initial provider setup workflows for AWS, Azure, and GCP.
 ---
 
 The Cloud Setup API helps you configure cloud provider credentials and integrations for use with Pulumi. Endpoints cover initial provider setup workflows for AWS, Azure, and GCP.

--- a/assets/openapi/tag-intros/data-export.md
+++ b/assets/openapi/tag-intros/data-export.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Data Export downloads resource data from Pulumi Cloud for offline analysis or integration with other systems. The Data Export API exposes an endpoint for exporting resource search results.
+---
+
 Data Export allows you to download resource data from Pulumi Cloud for offline analysis or integration with other systems. The Data Export API provides an endpoint for exporting resource search results.

--- a/assets/openapi/tag-intros/data-export.md
+++ b/assets/openapi/tag-intros/data-export.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Data Export downloads resource data from Pulumi Cloud for offline analysis or integration with other systems. The Data Export API exposes an endpoint for exporting resource search results.
+meta_desc: Download Pulumi Cloud resource data for offline analysis or integration with other systems via an endpoint that exports resource search results.
 ---
 
 Data Export allows you to download resource data from Pulumi Cloud for offline analysis or integration with other systems. The Data Export API provides an endpoint for exporting resource search results.

--- a/assets/openapi/tag-intros/deployment-runners.md
+++ b/assets/openapi/tag-intros/deployment-runners.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Deployment Runners execute Pulumi deployments in private, controlled environments. The Deployment Runners API manages agent pools, which group runners that handle Pulumi operations for your organization.
+---
+
 Deployment Runners execute Pulumi deployments in private, controlled environments. The Deployment Runners API allows you to manage agent pools, which are groups of deployment runners that handle Pulumi operations for your organization.

--- a/assets/openapi/tag-intros/deployment-runners.md
+++ b/assets/openapi/tag-intros/deployment-runners.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Deployment Runners execute Pulumi deployments in private, controlled environments. The Deployment Runners API manages agent pools, which group runners that handle Pulumi operations for your organization.
+meta_desc: Manage agent pools for Deployment Runners, which execute Pulumi deployments in private, controlled environments for your organization.
 ---
 
 Deployment Runners execute Pulumi deployments in private, controlled environments. The Deployment Runners API allows you to manage agent pools, which are groups of deployment runners that handle Pulumi operations for your organization.

--- a/assets/openapi/tag-intros/deployments.md
+++ b/assets/openapi/tag-intros/deployments.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Deployments API configures and manages Pulumi Deployments, which run Pulumi updates and other operations through Pulumi Cloud. Endpoints cover deployment settings, triggering deployments, and viewing status, logs, and history.
+meta_desc: Configure and manage Pulumi Deployments to run updates and other operations through Pulumi Cloud, including settings, triggers, status, logs, and history.
 ---
 
 The Deployments API allows you to configure and manage Pulumi Deployments,

--- a/assets/openapi/tag-intros/deployments.md
+++ b/assets/openapi/tag-intros/deployments.md
@@ -1,3 +1,7 @@
+---
+meta_desc: The Deployments API configures and manages Pulumi Deployments, which run Pulumi updates and other operations through Pulumi Cloud. Endpoints cover deployment settings, triggering deployments, and viewing status, logs, and history.
+---
+
 The Deployments API allows you to configure and manage Pulumi Deployments,
 which enable you to execute Pulumi updates and other operations through the
 Pulumi Cloud. With this API, you can configure deployment settings for your

--- a/assets/openapi/tag-intros/environments.md
+++ b/assets/openapi/tag-intros/environments.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Pulumi ESC (Environments, Secrets, and Configuration) provides a centralized way to manage infrastructure configuration. The Environments API creates and manages environments used by your Pulumi deployments.
+meta_desc: Create and manage environments for Pulumi ESC (Environments, Secrets, and Configuration), the centralized way to manage infrastructure configuration.
 ---
 
 Pulumi ESC (Environments, Secrets, and Configuration) provides a centralized

--- a/assets/openapi/tag-intros/environments.md
+++ b/assets/openapi/tag-intros/environments.md
@@ -1,3 +1,7 @@
+---
+meta_desc: Pulumi ESC (Environments, Secrets, and Configuration) provides a centralized way to manage infrastructure configuration. The Environments API creates and manages environments used by your Pulumi deployments.
+---
+
 Pulumi ESC (Environments, Secrets, and Configuration) provides a centralized
 way to manage infrastructure configuration. The Environments API allows you
 to create, manage, and use environments for your Pulumi deployments.

--- a/assets/openapi/tag-intros/insights-accounts.md
+++ b/assets/openapi/tag-intros/insights-accounts.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Pulumi Insights enables visibility into cloud resources and compliance monitoring. The Insights Accounts API creates, lists, and manages accounts for various cloud providers.
+---
+
 Pulumi Insights enables visibility into cloud resources and compliance monitoring. The Insights Accounts API allows you to create, list, and manage accounts for various cloud providers.

--- a/assets/openapi/tag-intros/insights-accounts.md
+++ b/assets/openapi/tag-intros/insights-accounts.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Pulumi Insights enables visibility into cloud resources and compliance monitoring. The Insights Accounts API creates, lists, and manages accounts for various cloud providers.
+meta_desc: Create, list, and manage Pulumi Insights accounts for various cloud providers, the entry point for cloud resource visibility and compliance monitoring.
 ---
 
 Pulumi Insights enables visibility into cloud resources and compliance monitoring. The Insights Accounts API allows you to create, list, and manage accounts for various cloud providers.

--- a/assets/openapi/tag-intros/insights.md
+++ b/assets/openapi/tag-intros/insights.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Pulumi Insights provides visibility into cloud resources, compliance monitoring, and policy enforcement across your organization. The Insights API covers account and integration management, resource search and inventory, and policy result inspection.
+meta_desc: Get visibility into cloud resources and policies across your organization. Covers account management, resource search and inventory, and policy results.
 ---
 
 Pulumi Insights provides visibility into cloud resources, compliance

--- a/assets/openapi/tag-intros/insights.md
+++ b/assets/openapi/tag-intros/insights.md
@@ -1,3 +1,7 @@
+---
+meta_desc: Pulumi Insights provides visibility into cloud resources, compliance monitoring, and policy enforcement across your organization. The Insights API covers account and integration management, resource search and inventory, and policy result inspection.
+---
+
 Pulumi Insights provides visibility into cloud resources, compliance
 monitoring, and policy enforcement across your organization. The Insights
 API covers account and integration management, resource search and

--- a/assets/openapi/tag-intros/miscellaneous.md
+++ b/assets/openapi/tag-intros/miscellaneous.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Utility endpoints for checking service capabilities, retrieving the CLI version, exchanging OAuth tokens, and fetching the OpenAPI specification.
+---
+
 Utility endpoints for checking service capabilities, retrieving the CLI version, exchanging OAuth tokens, and fetching the OpenAPI specification.

--- a/assets/openapi/tag-intros/miscellaneous.md
+++ b/assets/openapi/tag-intros/miscellaneous.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Utility endpoints for checking service capabilities, retrieving the CLI version, exchanging OAuth tokens, and fetching the OpenAPI specification.
+meta_desc: Utility endpoints for service capabilities, the CLI version, OAuth token exchange, and the OpenAPI specification.
 ---
 
 Utility endpoints for checking service capabilities, retrieving the CLI version, exchanging OAuth tokens, and fetching the OpenAPI specification.

--- a/assets/openapi/tag-intros/neo.md
+++ b/assets/openapi/tag-intros/neo.md
@@ -1,1 +1,5 @@
+---
+meta_desc: The Neo API creates and manages AI agent tasks in Pulumi Cloud. Endpoints cover creating tasks, monitoring status, responding to agent requests, and retrieving task events.
+---
+
 The Neo API provides endpoints for creating and managing AI agent tasks in Pulumi Cloud. Use these endpoints to create tasks, monitor their status, respond to agent requests, and retrieve task events.

--- a/assets/openapi/tag-intros/neo.md
+++ b/assets/openapi/tag-intros/neo.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Neo API creates and manages AI agent tasks in Pulumi Cloud. Endpoints cover creating tasks, monitoring status, responding to agent requests, and retrieving task events.
+meta_desc: Create and manage AI agent tasks in Pulumi Cloud, including monitoring status, responding to agent requests, and retrieving task events.
 ---
 
 The Neo API provides endpoints for creating and managing AI agent tasks in Pulumi Cloud. Use these endpoints to create tasks, monitor their status, respond to agent requests, and retrieve task events.

--- a/assets/openapi/tag-intros/oauth-token-exchange.md
+++ b/assets/openapi/tag-intros/oauth-token-exchange.md
@@ -1,1 +1,5 @@
+---
+meta_desc: The OAuth Token Exchange API exchanges external identity tokens (such as those from OIDC providers) for Pulumi access tokens, enabling automated workflows to authenticate with Pulumi Cloud without storing long-lived credentials.
+---
+
 The OAuth Token Exchange API allows you to exchange external identity tokens (like those from OIDC providers) for Pulumi access tokens. This enables automated workflows to authenticate with Pulumi Cloud without storing long-lived credentials.

--- a/assets/openapi/tag-intros/oauth-token-exchange.md
+++ b/assets/openapi/tag-intros/oauth-token-exchange.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The OAuth Token Exchange API exchanges external identity tokens (such as those from OIDC providers) for Pulumi access tokens, enabling automated workflows to authenticate with Pulumi Cloud without storing long-lived credentials.
+meta_desc: Exchange OIDC and other external identity tokens for Pulumi access tokens, so workflows authenticate with Pulumi Cloud without long-lived credentials.
 ---
 
 The OAuth Token Exchange API allows you to exchange external identity tokens (like those from OIDC providers) for Pulumi access tokens. This enables automated workflows to authenticate with Pulumi Cloud without storing long-lived credentials.

--- a/assets/openapi/tag-intros/oidc-issuers.md
+++ b/assets/openapi/tag-intros/oidc-issuers.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: OpenID Connect (OIDC) issuers authenticate workloads with Pulumi Cloud using identity tokens from external providers like GitHub Actions. The OIDC Issuers API registers and manages OIDC issuers for your organization.
+meta_desc: Register and manage OpenID Connect (OIDC) issuers, used to authenticate workloads with Pulumi Cloud via identity tokens from providers like GitHub Actions.
 ---
 
 OpenID Connect (OIDC) issuers provide a way to authenticate with Pulumi Cloud using identity tokens from external providers like GitHub Actions. The OIDC Issuers API allows you to register and manage OIDC issuers for your organization.

--- a/assets/openapi/tag-intros/oidc-issuers.md
+++ b/assets/openapi/tag-intros/oidc-issuers.md
@@ -1,1 +1,5 @@
+---
+meta_desc: OpenID Connect (OIDC) issuers authenticate workloads with Pulumi Cloud using identity tokens from external providers like GitHub Actions. The OIDC Issuers API registers and manages OIDC issuers for your organization.
+---
+
 OpenID Connect (OIDC) issuers provide a way to authenticate with Pulumi Cloud using identity tokens from external providers like GitHub Actions. The OIDC Issuers API allows you to register and manage OIDC issuers for your organization.

--- a/assets/openapi/tag-intros/organizations.md
+++ b/assets/openapi/tag-intros/organizations.md
@@ -1,3 +1,7 @@
+---
+meta_desc: The Organizations API manages Pulumi Cloud organizations, including members, teams, access tokens, and webhooks. Organizations are the primary management boundary in Pulumi Cloud.
+---
+
 The Organizations API allows you to manage Pulumi Cloud organizations,
 including members, teams, access tokens, and webhooks. Organizations are
 the primary management boundary in Pulumi Cloud.

--- a/assets/openapi/tag-intros/organizations.md
+++ b/assets/openapi/tag-intros/organizations.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Organizations API manages Pulumi Cloud organizations, including members, teams, access tokens, and webhooks. Organizations are the primary management boundary in Pulumi Cloud.
+meta_desc: Manage Pulumi Cloud organizations and their members, teams, access tokens, and webhooks. Organizations are the primary management boundary in Pulumi Cloud.
 ---
 
 The Organizations API allows you to manage Pulumi Cloud organizations,

--- a/assets/openapi/tag-intros/policy-groups.md
+++ b/assets/openapi/tag-intros/policy-groups.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Policy Groups are collections of policy packs that enforce governance rules on stacks. The Policy Groups API creates, manages, and applies policy groups to stacks.
+---
+
 Policy Groups are collections of policy packs that can be applied to stacks to enforce governance rules. The Policy Groups API allows you to create, manage, and apply policy groups to stacks.

--- a/assets/openapi/tag-intros/policy-groups.md
+++ b/assets/openapi/tag-intros/policy-groups.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Policy Groups are collections of policy packs that enforce governance rules on stacks. The Policy Groups API creates, manages, and applies policy groups to stacks.
+meta_desc: Create, manage, and apply Policy Groups, which are collections of policy packs that enforce governance rules on stacks.
 ---
 
 Policy Groups are collections of policy packs that can be applied to stacks to enforce governance rules. The Policy Groups API allows you to create, manage, and apply policy groups to stacks.

--- a/assets/openapi/tag-intros/policy-packs.md
+++ b/assets/openapi/tag-intros/policy-packs.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Policy Packs are collections of policies that define governance rules for infrastructure deployments. The Policy Packs API creates, manages, and applies policy packs across your organization.
+---
+
 Policy Packs are collections of policies that define governance rules for infrastructure deployments. The Policy Packs API allows you to create, manage, and apply policy packs to enforce governance rules across your organization.

--- a/assets/openapi/tag-intros/policy-packs.md
+++ b/assets/openapi/tag-intros/policy-packs.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Policy Packs are collections of policies that define governance rules for infrastructure deployments. The Policy Packs API creates, manages, and applies policy packs across your organization.
+meta_desc: Create, manage, and apply Policy Packs, which are collections of policies that define governance rules for infrastructure across your organization.
 ---
 
 Policy Packs are collections of policies that define governance rules for infrastructure deployments. The Policy Packs API allows you to create, manage, and apply policy packs to enforce governance rules across your organization.

--- a/assets/openapi/tag-intros/policy-results.md
+++ b/assets/openapi/tag-intros/policy-results.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Policy Results, part of Pulumi Insights, surfaces policy issues detected during stack updates and resource scanning. The Policy Results API retrieves policy issues across your organization for governance and compliance monitoring.
+meta_desc: Retrieve policy issues detected during stack updates and resource scanning, part of Pulumi Insights, for governance and compliance monitoring.
 ---
 
 Policy Results is a part of Pulumi Insights that provides information about policy issues detected during stack updates and resource scanning. The Policy Results API allows you to retrieve information about policy issues across your organization, enabling governance and compliance monitoring.

--- a/assets/openapi/tag-intros/policy-results.md
+++ b/assets/openapi/tag-intros/policy-results.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Policy Results, part of Pulumi Insights, surfaces policy issues detected during stack updates and resource scanning. The Policy Results API retrieves policy issues across your organization for governance and compliance monitoring.
+---
+
 Policy Results is a part of Pulumi Insights that provides information about policy issues detected during stack updates and resource scanning. The Policy Results API allows you to retrieve information about policy issues across your organization, enabling governance and compliance monitoring.

--- a/assets/openapi/tag-intros/registry-preview.md
+++ b/assets/openapi/tag-intros/registry-preview.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Preview endpoints for the next-generation Pulumi Registry, covering listing, retrieving, publishing, and deleting package, template, and policy pack versions under the new source/publisher/name identifier scheme.
+meta_desc: Preview endpoints for the next-generation Pulumi Registry, covering package, template, and policy pack versions under the new identifier scheme.
 ---
 
 Preview endpoints for the next-generation Pulumi Registry. These cover listing, retrieving, publishing, and deleting package, template, and policy pack versions under the new `source/publisher/name` identifier scheme.

--- a/assets/openapi/tag-intros/registry-preview.md
+++ b/assets/openapi/tag-intros/registry-preview.md
@@ -1,0 +1,7 @@
+---
+meta_desc: Preview endpoints for the next-generation Pulumi Registry, covering listing, retrieving, publishing, and deleting package, template, and policy pack versions under the new source/publisher/name identifier scheme.
+---
+
+Preview endpoints for the next-generation Pulumi Registry. These cover listing, retrieving, publishing, and deleting package, template, and policy pack versions under the new `source/publisher/name` identifier scheme.
+
+These endpoints are in preview and may change. See the [Registry](/docs/reference/cloud-rest-api/registry/) API for the current stable surface.

--- a/assets/openapi/tag-intros/registry.md
+++ b/assets/openapi/tag-intros/registry.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Pulumi Registry hosts reusable packages, templates, and policy packs for infrastructure deployments. The Registry API lists, retrieves, publishes, and manages packages, templates, and policy packs in the Registry.
+meta_desc: List, retrieve, publish, and manage packages, templates, and policy packs in the Pulumi Registry, the host for reusable infrastructure components.
 ---
 
 The Pulumi Registry hosts reusable packages, templates, and policy packs

--- a/assets/openapi/tag-intros/registry.md
+++ b/assets/openapi/tag-intros/registry.md
@@ -1,3 +1,7 @@
+---
+meta_desc: The Pulumi Registry hosts reusable packages, templates, and policy packs for infrastructure deployments. The Registry API lists, retrieves, publishes, and manages packages, templates, and policy packs in the Registry.
+---
+
 The Pulumi Registry hosts reusable packages, templates, and policy packs
 for infrastructure deployments. The Registry API allows you to list,
 retrieve, publish, and manage packages, templates, and policy packs in the

--- a/assets/openapi/tag-intros/resource-search.md
+++ b/assets/openapi/tag-intros/resource-search.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Resource Search finds and filters resources managed by Pulumi across your organization. The Resource Search API queries resources using structured filters and retrieves detailed resource metadata.
+meta_desc: Find and filter resources managed by Pulumi across your organization using structured filters, and retrieve detailed resource metadata.
 ---
 
 Resource Search lets you find and filter resources managed by Pulumi across your organization. The Resource Search API allows you to query resources using structured filters and retrieve detailed resource metadata.

--- a/assets/openapi/tag-intros/resource-search.md
+++ b/assets/openapi/tag-intros/resource-search.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Resource Search finds and filters resources managed by Pulumi across your organization. The Resource Search API queries resources using structured filters and retrieves detailed resource metadata.
+---
+
 Resource Search lets you find and filter resources managed by Pulumi across your organization. The Resource Search API allows you to query resources using structured filters and retrieve detailed resource metadata.

--- a/assets/openapi/tag-intros/resources-under-management.md
+++ b/assets/openapi/tag-intros/resources-under-management.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Resources Under Management (RUM) reports the cloud resources managed by Pulumi across your organization. The RUM API tracks resource counts over time with various time aggregations.
+meta_desc: Track Resources Under Management (RUM), the cloud resources managed by Pulumi across your organization, over time with various aggregations.
 ---
 
 Resources Under Management (RUM) provides information about the cloud resources managed by Pulumi across your organization. The RUM API allows you to track resource counts over time with various time aggregations.

--- a/assets/openapi/tag-intros/resources-under-management.md
+++ b/assets/openapi/tag-intros/resources-under-management.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Resources Under Management (RUM) reports the cloud resources managed by Pulumi across your organization. The RUM API tracks resource counts over time with various time aggregations.
+---
+
 Resources Under Management (RUM) provides information about the cloud resources managed by Pulumi across your organization. The RUM API allows you to track resource counts over time with various time aggregations.

--- a/assets/openapi/tag-intros/schedules.md
+++ b/assets/openapi/tag-intros/schedules.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Schedules automate recurring operations on your Pulumi stacks. The Schedules API creates and manages drift detection, time-to-live (TTL), and custom scheduled operations.
+---
+
 Schedules allow you to automate recurring operations on your Pulumi stacks. The Schedules API provides endpoints for creating and managing drift detection, time-to-live (TTL), and custom scheduled operations.

--- a/assets/openapi/tag-intros/schedules.md
+++ b/assets/openapi/tag-intros/schedules.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Schedules automate recurring operations on your Pulumi stacks. The Schedules API creates and manages drift detection, time-to-live (TTL), and custom scheduled operations.
+meta_desc: Automate recurring operations on Pulumi stacks, including drift detection, time-to-live (TTL), and custom scheduled operations.
 ---
 
 Schedules allow you to automate recurring operations on your Pulumi stacks. The Schedules API provides endpoints for creating and managing drift detection, time-to-live (TTL), and custom scheduled operations.

--- a/assets/openapi/tag-intros/services.md
+++ b/assets/openapi/tag-intros/services.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Services group and organize related resources in Pulumi Cloud. The Services API creates and manages collections of resources that work together to provide a specific capability.
+meta_desc: Group and organize related Pulumi Cloud resources into Services, which are collections of resources that work together to provide a specific capability.
 ---
 
 Services are a way to group and organize related resources in Pulumi Cloud. The Services API allows you to create, manage, and organize collections of resources that work together to provide a specific capability.

--- a/assets/openapi/tag-intros/services.md
+++ b/assets/openapi/tag-intros/services.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Services group and organize related resources in Pulumi Cloud. The Services API creates and manages collections of resources that work together to provide a specific capability.
+---
+
 Services are a way to group and organize related resources in Pulumi Cloud. The Services API allows you to create, manage, and organize collections of resources that work together to provide a specific capability.

--- a/assets/openapi/tag-intros/stack-config.md
+++ b/assets/openapi/tag-intros/stack-config.md
@@ -1,1 +1,5 @@
+---
+meta_desc: The Stack Config API manages cloud-persisted stack configuration for service-managed stacks. For stack config variables set during updates, see the Stack Updates API.
+---
+
 The Stack Config API manages cloud-persisted stack configuration. These endpoints apply to service-managed stacks only. For stack config variables set during updates, see the [Stack Updates](/docs/reference/cloud-rest-api/stack-updates/) API.

--- a/assets/openapi/tag-intros/stack-config.md
+++ b/assets/openapi/tag-intros/stack-config.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Stack Config API manages cloud-persisted stack configuration for service-managed stacks. For stack config variables set during updates, see the Stack Updates API.
+meta_desc: Manage cloud-persisted stack configuration for service-managed stacks. For stack config variables set during updates, see the Stack Updates API.
 ---
 
 The Stack Config API manages cloud-persisted stack configuration. These endpoints apply to service-managed stacks only. For stack config variables set during updates, see the [Stack Updates](/docs/reference/cloud-rest-api/stack-updates/) API.

--- a/assets/openapi/tag-intros/stack-policy.md
+++ b/assets/openapi/tag-intros/stack-policy.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Stack Policy API retrieves the policy groups and policy packs associated with a Pulumi stack. Policies define governance rules enforced during stack updates.
+meta_desc: Retrieve the policy groups and policy packs associated with a Pulumi stack. Policies define governance rules enforced during stack updates.
 ---
 
 Stack Policy APIs allow you to retrieve information about policy groups and policy packs associated with a Pulumi stack. Policies define governance rules that are enforced during stack updates.

--- a/assets/openapi/tag-intros/stack-policy.md
+++ b/assets/openapi/tag-intros/stack-policy.md
@@ -1,1 +1,5 @@
+---
+meta_desc: The Stack Policy API retrieves the policy groups and policy packs associated with a Pulumi stack. Policies define governance rules enforced during stack updates.
+---
+
 Stack Policy APIs allow you to retrieve information about policy groups and policy packs associated with a Pulumi stack. Policies define governance rules that are enforced during stack updates.

--- a/assets/openapi/tag-intros/stack-tags.md
+++ b/assets/openapi/tag-intros/stack-tags.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Stack Tags are key-value metadata attached to Pulumi stacks. Use them for organization, filtering, and to store additional information about your stacks.
+meta_desc: Attach key-value metadata to Pulumi stacks for organization, filtering, and storing additional information.
 ---
 
 Stack Tags are key-value metadata attached to Pulumi stacks. They can be used for organization, filtering, and to store additional information about your stacks.

--- a/assets/openapi/tag-intros/stack-tags.md
+++ b/assets/openapi/tag-intros/stack-tags.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Stack Tags are key-value metadata attached to Pulumi stacks. Use them for organization, filtering, and to store additional information about your stacks.
+---
+
 Stack Tags are key-value metadata attached to Pulumi stacks. They can be used for organization, filtering, and to store additional information about your stacks.

--- a/assets/openapi/tag-intros/stack-updates.md
+++ b/assets/openapi/tag-intros/stack-updates.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: Stack Updates are operations that create, update, or delete resources in a Pulumi stack. The Stack Updates API lists updates, checks status, and views detailed events for each operation.
+meta_desc: List Pulumi stack update operations (create, update, or delete resources), check status, and view detailed events for each operation.
 ---
 
 Stack Updates are operations that create, update, or delete resources in a Pulumi stack. The Stack Updates API allows you to list updates, check status, and view detailed events for each operation.

--- a/assets/openapi/tag-intros/stack-updates.md
+++ b/assets/openapi/tag-intros/stack-updates.md
@@ -1,1 +1,5 @@
+---
+meta_desc: Stack Updates are operations that create, update, or delete resources in a Pulumi stack. The Stack Updates API lists updates, checks status, and views detailed events for each operation.
+---
+
 Stack Updates are operations that create, update, or delete resources in a Pulumi stack. The Stack Updates API allows you to list updates, check status, and view detailed events for each operation.

--- a/assets/openapi/tag-intros/stacks.md
+++ b/assets/openapi/tag-intros/stacks.md
@@ -1,3 +1,7 @@
+---
+meta_desc: The Stacks API creates and manages Pulumi stacks, which are isolated, independently configurable instances of a Pulumi program. Endpoints cover stack lifecycle, configuration, tags, and update history.
+---
+
 The Stacks API lets you create and manage Pulumi stacks — isolated,
 independently configurable instances of a Pulumi program. The endpoints
 cover stack lifecycle (create, list, get, transfer, delete), stack

--- a/assets/openapi/tag-intros/stacks.md
+++ b/assets/openapi/tag-intros/stacks.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Stacks API creates and manages Pulumi stacks, which are isolated, independently configurable instances of a Pulumi program. Endpoints cover stack lifecycle, configuration, tags, and update history.
+meta_desc: Create and manage Pulumi stacks, the isolated and independently configurable instances of a Pulumi program. Covers lifecycle, config, tags, and update history.
 ---
 
 The Stacks API lets you create and manage Pulumi stacks — isolated,

--- a/assets/openapi/tag-intros/users.md
+++ b/assets/openapi/tag-intros/users.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Users API manages user profiles, identity linking, and account settings for the authenticated Pulumi user.
+meta_desc: Manage user profiles, identity linking, and account settings for the authenticated Pulumi user.
 ---
 
 The Users API covers user profile management, identity linking, and account settings for the authenticated Pulumi user.

--- a/assets/openapi/tag-intros/users.md
+++ b/assets/openapi/tag-intros/users.md
@@ -1,1 +1,5 @@
+---
+meta_desc: The Users API manages user profiles, identity linking, and account settings for the authenticated Pulumi user.
+---
+
 The Users API covers user profile management, identity linking, and account settings for the authenticated Pulumi user.

--- a/assets/openapi/tag-intros/vcs-integrations.md
+++ b/assets/openapi/tag-intros/vcs-integrations.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: VCS Integrations connect Pulumi Cloud to version control providers like GitHub, GitLab, and Bitbucket. The VCS Integrations API manages these connections and configures deployment triggers.
+meta_desc: Connect Pulumi Cloud to version control providers like GitHub, GitLab, and Bitbucket, and configure deployment triggers.
 ---
 
 VCS Integrations connect Pulumi Cloud to version control providers like GitHub, GitLab, and Bitbucket. The VCS Integrations API allows you to manage these connections and configure deployment triggers.

--- a/assets/openapi/tag-intros/vcs-integrations.md
+++ b/assets/openapi/tag-intros/vcs-integrations.md
@@ -1,1 +1,5 @@
+---
+meta_desc: VCS Integrations connect Pulumi Cloud to version control providers like GitHub, GitLab, and Bitbucket. The VCS Integrations API manages these connections and configures deployment triggers.
+---
+
 VCS Integrations connect Pulumi Cloud to version control providers like GitHub, GitLab, and Bitbucket. The VCS Integrations API allows you to manage these connections and configure deployment triggers.

--- a/assets/openapi/tag-intros/webhooks.md
+++ b/assets/openapi/tag-intros/webhooks.md
@@ -1,5 +1,5 @@
 ---
-meta_desc: The Webhooks API creates and manages webhooks for organizations and stacks. Webhooks notify external services of events such as stack updates, deployments, or policy violations.
+meta_desc: Create and manage webhooks for organizations and stacks that notify external services of events like stack updates, deployments, or policy violations.
 ---
 
 The Webhooks API allows you to create and manage webhooks for organizations and stacks. Webhooks notify external services of events happening within your Pulumi organization, such as stack updates, deployments, or policy violations.

--- a/assets/openapi/tag-intros/webhooks.md
+++ b/assets/openapi/tag-intros/webhooks.md
@@ -1,1 +1,5 @@
+---
+meta_desc: The Webhooks API creates and manages webhooks for organizations and stacks. Webhooks notify external services of events such as stack updates, deployments, or policy violations.
+---
+
 The Webhooks API allows you to create and manage webhooks for organizations and stacks. Webhooks notify external services of events happening within your Pulumi organization, such as stack updates, deployments, or policy violations.

--- a/content/docs/reference/cloud-rest-api/_content.gotmpl
+++ b/content/docs/reference/cloud-rest-api/_content.gotmpl
@@ -172,10 +172,29 @@
         {{ $weight = 99 }}
     {{ end }}
 
+    {{/*
+        Pull meta_desc from the tag-intro sidecar's YAML frontmatter
+        (assets/openapi/tag-intros/<slug>.md). Also feeds the list-item
+        description on the cloud-rest-api landing page via the
+        openapi-tag-list shortcode. Fall back to a generic string if the
+        intro is missing or has no meta_desc field.
+    */}}
+    {{ $metaDesc := printf "API reference for %s endpoints in the Pulumi Cloud REST API." $display }}
+    {{ if in $introSlugs $slug }}
+        {{ $intro := os.ReadFile (printf "%s/%s.md" $introDir $slug) }}
+        {{ $parts := split $intro "---\n" }}
+        {{ if ge (len $parts) 3 }}
+            {{ $fm := transform.Unmarshal (dict "ext" "yaml") (index $parts 1) }}
+            {{ with $fm.meta_desc }}
+                {{ $metaDesc = . }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+
     {{ $params := dict
         "h1" $display
         "title_tag" (printf "Pulumi Cloud REST API: %s" $display)
-        "meta_desc" (printf "API reference for %s endpoints in the Pulumi Cloud REST API." $display)
+        "meta_desc" $metaDesc
         "meta_image" "/images/docs/meta-images/docs-meta.png"
         "openapi_docs" true
         "filter_tag" $tag

--- a/layouts/partials/openapi/open-api-gen.html
+++ b/layouts/partials/openapi/open-api-gen.html
@@ -16,7 +16,16 @@
             {{ $introSlug := $display | urlize }}
             {{ $introPath := printf "assets/openapi/tag-intros/%s.md" $introSlug }}
             {{ if (fileExists $introPath) }}
-                <div class="openapi-tag-intro">{{ readFile $introPath | markdownify }}</div>
+                {{/* Strip YAML frontmatter (between leading --- delimiters)
+                     before rendering the body — frontmatter holds meta_desc
+                     consumed by the content adapter, not page content. */}}
+                {{ $contents := readFile $introPath }}
+                {{ $parts := split $contents "---\n" }}
+                {{ $body := $contents }}
+                {{ if ge (len $parts) 3 }}
+                    {{ $body = index $parts 2 }}
+                {{ end }}
+                <div class="openapi-tag-intro">{{ $body | markdownify }}</div>
             {{ end }}
         {{ end }}
 

--- a/layouts/partials/openapi/open-api-gen.html
+++ b/layouts/partials/openapi/open-api-gen.html
@@ -18,12 +18,15 @@
             {{ if (fileExists $introPath) }}
                 {{/* Strip YAML frontmatter (between leading --- delimiters)
                      before rendering the body — frontmatter holds meta_desc
-                     consumed by the content adapter, not page content. */}}
+                     consumed by the content adapter, not page content.
+                     Rejoin parts after the second delimiter so a Markdown
+                     horizontal rule (--- on its own line) inside the body
+                     doesn't get truncated. */}}
                 {{ $contents := readFile $introPath }}
                 {{ $parts := split $contents "---\n" }}
                 {{ $body := $contents }}
                 {{ if ge (len $parts) 3 }}
-                    {{ $body = index $parts 2 }}
+                    {{ $body = delimit (after 2 $parts) "---\n" }}
                 {{ end }}
                 <div class="openapi-tag-intro">{{ $body | markdownify }}</div>
             {{ end }}

--- a/layouts/shortcodes/openapi-tag-list.html
+++ b/layouts/shortcodes/openapi-tag-list.html
@@ -10,7 +10,7 @@
     {{ end }}
 {{ end }}
 <ul>
-{{ range $tagPages }}<li><a href="{{ .RelPermalink }}">{{ .Params.h1 }}</a> — {{ .Params.meta_desc }}</li>
+{{ range $tagPages }}<li><a href="{{ .RelPermalink }}">{{ .Params.h1 }}</a>: {{ .Params.meta_desc }}</li>
 {{ end }}
-{{ with $schemaPage }}<li><a href="{{ .RelPermalink }}">{{ .Params.h1 }}</a> — {{ .Params.meta_desc }}</li>{{ end }}
+{{ with $schemaPage }}<li><a href="{{ .RelPermalink }}">{{ .Params.h1 }}</a>: {{ .Params.meta_desc }}</li>{{ end }}
 </ul>


### PR DESCRIPTION
## Summary

* The "API documentation by category" list on https://www.pulumi.com/docs/reference/cloud-rest-api/ previously rendered identical boilerplate for every entry ("API reference for X endpoints in the Pulumi Cloud REST API"). Each item now gets a curated 1-2 sentence description.
* Promote the `assets/openapi/tag-intros/*.md` sidecar files to carry a `meta_desc` field in YAML frontmatter. The content adapter (`_content.gotmpl`) reads it and uses it as both the page's SEO `<meta name="description">` and the landing-page list-item description (rendered via the `openapi-tag-list` shortcode), so there's a single source of truth per tag.
* Switched the list-item separator from em dash to colon.
* Filled in the two missing intros (`AI`, `RegistryPreview`) — also clears the existing `openapi: missing intro` build warnings.

### Before
<img width="938" height="712" alt="Screenshot 2026-04-20 at 3 07 50 PM" src="https://github.com/user-attachments/assets/fa972505-6aa5-4617-b07e-1f5ecfc3e1e9" />

Every entry: `Access Tokens — API reference for Access Tokens endpoints in the Pulumi Cloud REST API.`

### After

<img width="1309" height="768" alt="Screenshot 2026-04-20 at 3 07 33 PM" src="https://github.com/user-attachments/assets/b3d33d1f-6b79-4e98-89a3-2eaf2ab1c95a" />

`Access Tokens: Access tokens authenticate users and automation with the Pulumi Cloud API. The Access Tokens API manages personal access tokens (PATs) for individuals and organization-level tokens for team and CI use.`

## Test plan

* [x] `hugo --buildFuture` succeeds with no openapi-related warnings
* [x] Landing page list renders all 31 entries with `: ` separator and curated descriptions (verified in generated HTML)
* [x] Tag pages emit the curated `meta_desc` as `<meta name="description">` (verified for `cloud-setup`, `registry`)
* [x] Tag page intro bodies render without YAML frontmatter leaking (no stray `<hr>` or raw `meta_desc:` text)
* [ ] Maintainer spot-check: visit `/docs/reference/cloud-rest-api/` after deploy preview is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)