### PR TITLE
Add speakable schema to blog posts

### DIFF
--- a/layouts/partials/schema/collectors/blog-entity.html
+++ b/layouts/partials/schema/collectors/blog-entity.html
@@ -122,7 +122,7 @@
 {{ $schema = merge $schema (dict
   "speakable" (dict
     "@type" "SpeakableSpecification"
-    "cssSelector" (slice "article h1" "article section > p:first-of-type")
+    "cssSelector" (slice "article h1" "article > section:first-of-type > p:first-of-type")
   )
 ) }}
 

--- a/layouts/partials/schema/collectors/blog-entity.html
+++ b/layouts/partials/schema/collectors/blog-entity.html
@@ -118,4 +118,12 @@
   "mainEntityOfPage" (dict "@id" (printf "%s#webpage" .Permalink))
 ) }}
 
+{{/* Add speakable selectors for voice assistants and AEO */}}
+{{ $schema = merge $schema (dict
+  "speakable" (dict
+    "@type" "SpeakableSpecification"
+    "cssSelector" (slice "article h1" "article section > p:first-of-type")
+  )
+) }}
+
 {{ return $schema }}


### PR DESCRIPTION
## Summary

- Extends the `BlogPosting` JSON-LD emitted by `layouts/partials/schema/collectors/blog-entity.html` with a `SpeakableSpecification`.
- The `cssSelector` targets `article h1` and the first paragraph of the post body, so voice assistants (Google Assistant) and AI answer engines have a clear signal for what to read/quote from a post.
- Small AEO improvement — no visible UI change, no content changes, no new dependencies.

## Why

Our blog posts already emit rich structured data (dates, author, publisher, keywords, word count, reading time, breadcrumbs, video). `speakable` is one of the few remaining low-cost fields Google documents for articles and is directly relevant to AI answer engines and voice surfaces, which are an increasingly important discovery channel for our content.

## Test plan

- [ ] `make build` completes without Hugo template errors
- [ ] View source of any blog post (e.g. the latest one) and confirm the `@graph` entry for the post includes a `speakable` object with `@type: "SpeakableSpecification"` and a two-element `cssSelector` array
- [ ] Paste the rendered page through [Google's Rich Results Test](https://search.google.com/test/rich-results) and confirm no new errors on the `BlogPosting` item
- [ ] Confirm the two selectors actually match the rendered DOM: `article h1` (post title) and `article section > p:first-of-type` (opening paragraph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)