### PR TITLE
Remove invalid Host directive from robots.txt

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -10,4 +10,3 @@ Disallow: /docs/search/$
 Disallow: /registry/packages/azure-native-v2
 
 Sitemap: https://www.pulumi.com/sitemap-index.xml
-Host: www.pulumi.com


### PR DESCRIPTION
## Summary
- Removes the `Host: www.pulumi.com` line from `layouts/robots.txt`.
- The `Host` directive was a Yandex-specific extension that is not part of the robots.txt standard and was deprecated by Yandex in 2018. It has no effect for Googlebot, Bingbot, or other crawlers.

## Test plan
- [ ] Verify `make build` produces `public/robots.txt` without the `Host` line
- [ ] Confirm `Sitemap:` directive is still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)