### PR TITLE
Add Content-Signal directive to robots.txt

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,11 +1,12 @@
 User-agent: *
+# Explicitly opt in to AI training, search indexing, and AI grounding/RAG use.
+# Non-standard directive proposed by Cloudflare; honored by crawlers that support it.
+# Must sit inside the User-agent group with no preceding blank line (a blank
+# line ends a record per RFC 9309).
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 {{- if ne hugo.Environment "production" }}
 Disallow: *
 {{ end }}
-
-# Explicitly opt in to AI training, search indexing, and AI grounding/RAG use.
-# Non-standard directive proposed by Cloudflare; honored by crawlers that support it.
-Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 # Disallow certain pages that are perceived as soft-404s.
 Disallow: /docs/search/$

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -3,6 +3,10 @@ User-agent: *
 Disallow: *
 {{ end }}
 
+# Explicitly opt in to AI training, search indexing, and AI grounding/RAG use.
+# Non-standard directive proposed by Cloudflare; honored by crawlers that support it.
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
 # Disallow certain pages that are perceived as soft-404s.
 Disallow: /docs/search/$
 


### PR DESCRIPTION
## Summary

Adds the `Content-Signal: ai-train=yes, search=yes, ai-input=yes` directive to `layouts/robots.txt`, explicitly opting our content into AI training, search indexing, and AI grounding/RAG use.

## What is Content-Signal?

`Content-Signal` is a non-standard robots.txt directive [proposed by Cloudflare in late 2025](https://blog.cloudflare.com/content-signals-policy/) to give site operators a machine-readable way to express permissions around how crawled content is used. The three signals we're setting:

- **`ai-train=yes`** — permits use of crawled content for training AI models.
- **`search=yes`** — permits use for traditional search indexing.
- **`ai-input=yes`** — permits use as input to generative AI systems at inference time (RAG, grounding, answer generation).

Crawlers that honor the directive treat it as explicit permission signaling. Crawlers that don't simply ignore it — there is no downside to including it.

## Why opt in?

Pulumi benefits when LLMs surface our docs in answers: it's a developer discovery channel. Explicitly signaling "yes, you can train on and ground with our content" aligns with that interest, and costs nothing.

## Reference

See [resend.com/robots.txt](https://resend.com/robots.txt) for an example of the same directive in use.

## Caveats

- Non-standard directive — the spec could evolve. If it does, updating a single line is trivial.
- Only affects crawlers that honor robots.txt in the first place. Bad actors who scrape regardless are unaffected either way.

## Test plan

- [ ] Verify rendered `robots.txt` includes the `Content-Signal` line in preview
- [ ] Confirm existing `Disallow` rules and `Sitemap` line are unchanged
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)