### PR TITLE
Render OpenAPI request/response examples from per-property examples

### DIFF
--- a/layouts/partials/openapi/endpoint.html
+++ b/layouts/partials/openapi/endpoint.html
@@ -84,9 +84,7 @@
         {{ end }}
     {{ end }}
 
-        {{/* Request/response examples hidden for now — revisit once example
-             quality is validated across the full public spec. */}}
-        {{/* {{ template "openapi/request-example.html" (dict "method" .method "path" .path "details" .details) }} */}}
+        {{ template "openapi/request-example.html" (dict "method" .method "path" .path "details" .details) }}
 
         <h4>Responses</h4>
         {{/* Split responses: inline-rendered (all 2xx + any 4xx/5xx with a JSON schema) vs. stock errors (4xx/5xx with no schema, rendered as compact chip row). */}}
@@ -129,7 +127,7 @@
                     {{ if isset $responseDetails.content "application/json" }}
                         {{ $schema := index $responseDetails.content "application/json" "schema" }}
                         {{ template "openapi/response-schema.html" (dict "schema" $schema "openapi" $.openapi) }}
-                        {{/* {{ template "openapi/examples.html" (dict "responseDetails" $responseDetails "responseCode" $responseCode "openapi" $.openapi) }} */}}
+                        {{ template "openapi/examples.html" (dict "responseDetails" $responseDetails "responseCode" $responseCode) }}
                     {{ end }}
                 {{ end }}
             </div>

--- a/layouts/partials/openapi/request-example.html
+++ b/layouts/partials/openapi/request-example.html
@@ -16,23 +16,27 @@
     {{- $url = printf "%s?%s" $url (delimit $queryParts "&") }}
 {{- end }}
 
-{{/* Build the curl command line by line. */}}
+{{/* Read the request body example from the native OpenAPI 3 mediaType.example slot. */}}
+{{- $bodyData := "" }}
+{{- with .details.requestBody }}
+    {{- with index .content "application/json" }}
+        {{- if .example }}
+            {{- $bodyData = .example | jsonify (dict "indent" "  ") }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- $lines := slice "curl \\" }}
 {{- $lines = $lines | append "  -H \"Accept: application/vnd.pulumi+8\" \\" }}
-{{- $lines = $lines | append "  -H \"Content-Type: application/json\" \\" }}
+{{- if $bodyData }}
+    {{- $lines = $lines | append "  -H \"Content-Type: application/json\" \\" }}
+{{- end }}
 {{- $lines = $lines | append "  -H \"Authorization: token $PULUMI_ACCESS_TOKEN\" \\" }}
 {{- if ne $method "GET" }}
     {{- $lines = $lines | append (printf "  --request %s \\" $method) }}
 {{- end }}
-{{- with .details.requestBody }}
-    {{- $jsonContent := index .content "application/json" }}
-    {{- with $jsonContent }}
-        {{- $bodyData := "{}" }}
-        {{- if .example }}
-            {{- $bodyData = .example | jsonify }}
-        {{- end }}
-        {{- $lines = $lines | append (printf "  --data '%s' \\" $bodyData) }}
-    {{- end }}
+{{- if $bodyData }}
+    {{- $lines = $lines | append (printf "  --data '%s' \\" $bodyData) }}
 {{- end }}
 {{- $lines = $lines | append (printf "  %s" $url) }}
 <pre><code>{{ delimit $lines "\n" }}</code></pre>


### PR DESCRIPTION
## Summary

Reintroduces cURL request bodies and example response JSON on the generated REST API pages, previously removed in #18551.

Reads route-level examples from the native OpenAPI 3 `mediaType.example` slot : no Hugo-side synthesis, no traversal of schema property trees. The upstream service spec populates that slot via `@PulumiRouteProperty(requestExample = """...""", responseExample = """...""")` text blocks (pulumi/pulumi-service#41680). Whatever shows up in the spec is what renders.

## What this changes

* `layouts/partials/openapi/endpoint.html`: uncomments the `template "openapi/request-example.html"` and `template "openapi/examples.html"` call sites that were disabled in #18551.
* `layouts/partials/openapi/request-example.html`: renders a cURL block with `--data '...'` when the operation's `application/json` request body has an `example`; otherwise renders the cURL without a body.
* `layouts/partials/openapi/examples.html`: renders `application/json` response `example` (or iterates `examples` if plural is used) as pretty JSON.

Total: one file deleted (the prior-draft synthesizer), three edited.

## Not in this PR

* Populating examples in the spec : that's upstream in pulumi/pulumi-service#41680.
* The convention doc describing how service-side authors should write text-block examples : also in pulumi/pulumi-service#41680.

## Draft

Held as draft until the service-side PR (pulumi/pulumi-service#41680) lands and the public spec starts carrying route-level examples. Once that ships, this PR becomes a mechanical "turn it on" merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)