### PR TITLE
Document property columns in Resource Explorer

### DIFF
--- a/content/docs/insights/discovery/_index.md
+++ b/content/docs/insights/discovery/_index.md
@@ -43,7 +43,7 @@ The Resource Search interface provides:
 - **Advanced search**: Query resources by name, type, stack, project, properties, and more using a rich query syntax
 - **Filtering and grouping**: Organize resources by dragging column headers to create custom views
 - **Column customization**: Show or hide information to focus on what matters
-- **Property columns**: Promote any resource property—such as `tags.Environment` or `instanceType`—into a sortable, filterable, and groupable column (Team, Enterprise, and Business Critical editions)
+- **Property columns**: Promote any resource property into a sortable, filterable, and groupable column (Team, Enterprise, and Business Critical editions)
 - **Favorites**: Save and share custom views with your team
 - **AI assist**: Use natural language queries to find resources (e.g., "How many VPCs do I have?")
 

--- a/content/docs/insights/discovery/_index.md
+++ b/content/docs/insights/discovery/_index.md
@@ -43,6 +43,7 @@ The Resource Search interface provides:
 - **Advanced search**: Query resources by name, type, stack, project, properties, and more using a rich query syntax
 - **Filtering and grouping**: Organize resources by dragging column headers to create custom views
 - **Column customization**: Show or hide information to focus on what matters
+- **Property columns**: Promote any resource property—such as `tags.Environment` or `instanceType`—into a sortable, filterable, and groupable column (Team, Enterprise, and Business Critical editions)
 - **Favorites**: Save and share custom views with your team
 - **AI assist**: Use natural language queries to find resources (e.g., "How many VPCs do I have?")
 

--- a/content/docs/insights/discovery/search.md
+++ b/content/docs/insights/discovery/search.md
@@ -404,7 +404,7 @@ Property columns are only available to organizations using Team, Enterprise, and
 If you would like to use them, [contact us](/contact?form=sales) to upgrade.
 {{% /notes %}}
 
-Property columns let you promote any resource input or output property into a column in the results grid. Once added, a property column behaves like any built-in column: you can sort, filter, and group by its values across all resources returned by your query.
+Property columns let you promote any resource property into a column in the results grid. Once added, a property column behaves like any built-in column: you can sort, filter, and group by its values across all resources returned by your query.
 
 Property columns use the same [property path](/docs/reference/property-paths/) syntax as [property queries](#property-queries). For example, `tags.Environment` exposes the value of the `Environment` tag on each resource, and `instanceType` exposes the instance type of compute resources. Nested and bracketed paths (such as `tags["name containing spaces"]`) are supported.
 
@@ -421,7 +421,7 @@ The new column is appended to the right of the existing columns. Resources that 
 
 ### Adding a column from the detail view
 
-Click the name cell in a row to drill into the Detailed view for that resource. Each listed input and output property in the Detailed view has a **Create property column** action in its row. Selecting this action adds a column for the property without having to type the path manually. This is useful when you have already located a property of interest on one resource and want to see its value across every resource in the grid.
+Click the name cell in a row to drill into the Detailed view for that resource. The Action column menu for each property has a **Create property column** action. Selecting this action adds a column for the property without having to type the path manually. This is useful when you have already located a property of interest on one resource and want to see its value across every resource in the grid.
 
 The behavior of **Create property column** depends on the type of the property value:
 

--- a/content/docs/insights/discovery/search.md
+++ b/content/docs/insights/discovery/search.md
@@ -396,6 +396,49 @@ In the example above, the query has been restricted to the "dev" stack.
 
 Clicking the "X" within the search bar will remove all previously selected filters.
 
+## Property columns
+
+{{% notes "info" %}}
+Property columns are only available to organizations using Team, Enterprise and Business Critical editions.
+
+If you would like to use them, [contact us](/contact?form=sales) to upgrade.
+{{% /notes %}}
+
+Property columns let you promote any resource input or output property into a first-class column in the results grid. Once added, a property column behaves like any built-in column: you can sort, filter, and group by its values across all resources returned by your query.
+
+Property columns use the same [property path](/docs/reference/property-paths/) syntax as [property queries](#property-queries). For example, `tags.Environment` exposes the value of the `Environment` tag on each resource, and `instanceType` exposes the instance type of compute resources. Nested and bracketed paths (such as `tags["name containing spaces"]`) are supported.
+
+### Creating a property column
+
+To add a property column from the results grid:
+
+1. Click the gear icon above the grid to open the settings menu.
+1. Select **Create property column**.
+1. Enter a property path (for example, `tags.Environment` or `instanceType`) in the dialog that appears.
+1. Confirm to add the column.
+
+The new column is appended to the right of the existing columns. Resources that do not have a value for the given property show an empty cell for that column.
+
+### Adding a column from the detail view
+
+When you expand a resource row to view its details, each listed input and output property displays an **Add as column** action next to its value. Clicking this action creates a property column for that property path without having to type it manually — useful when you have already located a property of interest on one resource and want to see its value across every resource in the grid.
+
+### Sorting, filtering, and grouping
+
+Property columns support the same interactions as built-in columns:
+
+- **Sort**: Click the property column header to sort results ascending or descending by property value.
+- **Filter**: Open the column filter to narrow results to one or more specific property values.
+- **Group by**: Drag the property column header into the Row Groups Header to group resources by property value. Expanding a group drills into the matching resources, just as it does for built-in columns.
+
+### Hiding and showing property columns
+
+Property columns can be hidden from the grid without being removed by toggling them off in the column chooser, the same as any built-in column. Re-adding a hidden property column via **Create property column** or **Add as column** makes it visible again.
+
+### Sharing views with property columns
+
+Property column configuration is persisted in the page URL. Sharing the URL with another member of your organization opens the grid with the same set of property columns, along with any active filters, sort order, and grouping. This makes property columns suitable for building and sharing repeatable views such as "all compute resources by instance type" or "all resources by environment tag".
+
 ## Download a CSV
 
 {{% notes "info" %}}

--- a/content/docs/insights/discovery/search.md
+++ b/content/docs/insights/discovery/search.md
@@ -399,12 +399,12 @@ Clicking the "X" within the search bar will remove all previously selected filte
 ## Property columns
 
 {{% notes "info" %}}
-Property columns are only available to organizations using Team, Enterprise and Business Critical editions.
+Property columns are only available to organizations using Team, Enterprise, and Business Critical editions.
 
 If you would like to use them, [contact us](/contact?form=sales) to upgrade.
 {{% /notes %}}
 
-Property columns let you promote any resource input or output property into a first-class column in the results grid. Once added, a property column behaves like any built-in column: you can sort, filter, and group by its values across all resources returned by your query.
+Property columns let you promote any resource input or output property into a column in the results grid. Once added, a property column behaves like any built-in column: you can sort, filter, and group by its values across all resources returned by your query.
 
 Property columns use the same [property path](/docs/reference/property-paths/) syntax as [property queries](#property-queries). For example, `tags.Environment` exposes the value of the `Environment` tag on each resource, and `instanceType` exposes the instance type of compute resources. Nested and bracketed paths (such as `tags["name containing spaces"]`) are supported.
 
@@ -444,7 +444,7 @@ To delete a property column entirely, drag the column header out of the grid and
 
 ### Sharing views with property columns
 
-Property column configuration is persisted in the page URL. Sharing the URL with another member of your organization opens the grid with the same set of property columns, along with any active filters, sort order, and grouping. This makes property columns suitable for building and sharing repeatable views such as "all compute resources by instance type" or "all resources by environment tag".
+The set of property columns is persisted in the page URL. Share the URL with another member of your organization and they will open the grid with the same property columns, filters, sort order, and grouping applied. This makes property columns suitable for building and sharing repeatable views such as "all compute resources by instance type" or "all resources by environment tag".
 
 ## Download a CSV
 

--- a/content/docs/insights/discovery/search.md
+++ b/content/docs/insights/discovery/search.md
@@ -421,12 +421,12 @@ The new column is appended to the right of the existing columns. Resources that 
 
 ### Adding a column from the detail view
 
-Click the name cell in a row to drill into the Detailed view for that resource. Each listed input and output property in the Detailed view has a **Create property column** action in its row. Selecting this action adds a column for the property without having to type the path manually — useful when you have already located a property of interest on one resource and want to see its value across every resource in the grid.
+Click the name cell in a row to drill into the Detailed view for that resource. Each listed input and output property in the Detailed view has a **Create property column** action in its row. Selecting this action adds a column for the property without having to type the path manually. This is useful when you have already located a property of interest on one resource and want to see its value across every resource in the grid.
 
 The behavior of **Create property column** depends on the type of the property value:
 
 - If the property is a single value (for example, a string or number), the column is created immediately for that property path.
-- If the property is an object with children (for example, a `tags` map), a dialog opens so you can enter the path to the specific child or grandchild property you want as the column — for instance, `tags.Environment` rather than the entire `tags` object.
+- If the property is an object with children (for example, a `tags` map), a dialog opens so you can enter the path to the specific child or grandchild property you want as the column. For example, use `tags.Environment` rather than the entire `tags` object.
 
 ### Sorting, filtering, and grouping
 
@@ -440,7 +440,7 @@ Property columns support the same interactions as built-in columns:
 
 To hide a property column without removing it, open the settings menu on the main Resources grid and select **Choose columns**, then toggle the column off. The column stays in the set of available columns and can be re-enabled from the same menu. This works for both property columns and built-in columns.
 
-To delete a property column entirely, drag the column header out of the grid and drop it outside. This hides the column and removes it from the set of available columns, so it will no longer appear in **Choose columns**. Only property columns can be deleted — built-in columns cannot be removed from the available set.
+To delete a property column entirely, drag the column header out of the grid and drop it outside. This hides the column and removes it from the set of available columns, so it will no longer appear in **Choose columns**. Only property columns can be deleted; built-in columns cannot be removed from the available set.
 
 ### Sharing views with property columns
 

--- a/content/docs/insights/discovery/search.md
+++ b/content/docs/insights/discovery/search.md
@@ -412,7 +412,7 @@ Property columns use the same [property path](/docs/reference/property-paths/) s
 
 To add a property column from the results grid:
 
-1. Click the gear icon above the grid to open the settings menu.
+1. Click the settings icon above the grid to open the settings menu.
 1. Select **Create property column**.
 1. Enter a property path (for example, `tags.Environment` or `instanceType`) in the dialog that appears.
 1. Confirm to add the column.
@@ -421,7 +421,12 @@ The new column is appended to the right of the existing columns. Resources that 
 
 ### Adding a column from the detail view
 
-When you expand a resource row to view its details, each listed input and output property displays an **Add as column** action next to its value. Clicking this action creates a property column for that property path without having to type it manually — useful when you have already located a property of interest on one resource and want to see its value across every resource in the grid.
+Click the name cell in a row to drill into the Detailed view for that resource. Each listed input and output property in the Detailed view has a **Create property column** action in its row. Selecting this action adds a column for the property without having to type the path manually — useful when you have already located a property of interest on one resource and want to see its value across every resource in the grid.
+
+The behavior of **Create property column** depends on the type of the property value:
+
+- If the property is a single value (for example, a string or number), the column is created immediately for that property path.
+- If the property is an object with children (for example, a `tags` map), a dialog opens so you can enter the path to the specific child or grandchild property you want as the column — for instance, `tags.Environment` rather than the entire `tags` object.
 
 ### Sorting, filtering, and grouping
 
@@ -431,9 +436,11 @@ Property columns support the same interactions as built-in columns:
 - **Filter**: Open the column filter to narrow results to one or more specific property values.
 - **Group by**: Drag the property column header into the Row Groups Header to group resources by property value. Expanding a group drills into the matching resources, just as it does for built-in columns.
 
-### Hiding and showing property columns
+### Hiding and deleting property columns
 
-Property columns can be hidden from the grid without being removed by toggling them off in the column chooser, the same as any built-in column. Re-adding a hidden property column via **Create property column** or **Add as column** makes it visible again.
+To hide a property column without removing it, open the settings menu on the main Resources grid and select **Choose columns**, then toggle the column off. The column stays in the set of available columns and can be re-enabled from the same menu. This works for both property columns and built-in columns.
+
+To delete a property column entirely, drag the column header out of the grid and drop it outside. This hides the column and removes it from the set of available columns, so it will no longer appear in **Choose columns**. Only property columns can be deleted — built-in columns cannot be removed from the available set.
 
 ### Sharing views with property columns
 


### PR DESCRIPTION
## Summary

- Adds a **Property columns** section to `content/docs/insights/discovery/search.md` documenting the new dynamic property columns feature in Insights Resource Explorer (pulumi/pulumi-service#40053).
- Adds a matching bullet to the **Key capabilities** list in `content/docs/insights/discovery/_index.md`.

The new section covers:
- Creating a property column from the settings menu → **Create property column** dialog, using the same property-path syntax as property queries.
- Adding a column from the expanded resource detail view via the **Create property column** action on each input/output property row.
- Sort, filter, and group-by behavior (identical to built-in columns, including the Row Groups Header).
- Column-chooser visibility via **Choose columns** (hide / re-show).
- Deletion by dragging the column header out of the grid.
- URL persistence for shared views.
- Tier gating (Team, Enterprise, Business Critical) via the same info callout already used for property queries.

No screenshots are added -- the written descriptions are detailed enough to stand on their own and avoid the drift risk that comes with UI screenshots.

## Test plan

- [ ] \`make serve\` and visit \`/docs/insights/discovery/search/#property-columns\` to confirm the new section renders.
- [ ] Confirm the anchor link from the new section back to \`#property-queries\` works.
- [ ] Confirm the bullet on \`/docs/insights/discovery/\` reads cleanly in the key capabilities list.
- [ ] Verify wording against the final UI once pulumi/pulumi-service#40053 ships (labels: "Create property column", "Choose columns", "Row Groups Header" -- update if any rename before release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)