### PR TITLE
Remove redundant TOC from PKO page

### DIFF
--- a/content/docs/integrations/clouds/kubernetes/pulumi-kubernetes-operator.md
+++ b/content/docs/integrations/clouds/kubernetes/pulumi-kubernetes-operator.md
@@ -36,39 +36,13 @@ The Pulumi Kubernetes Operator provides [custom resources][k8s-ext-pattern] to:
 Deploying Pulumi stacks using Kubernetes provides the capability to build
 out CI/CD and other automation systems, and to manage your infrastructure alongside your Kubernetes workloads or in dedicated control-plane clusters.
 
-To work with the operator, we'll need to follow these steps.
-
-- [Overview](#overview)
-- [Install the Pulumi Kubernetes Operator](#install-the-pulumi-kubernetes-operator)
-  - [Using Helm](#using-helm)
-  - [Dev Install](#dev-install)
-- [Create a Service Account](#create-a-service-account)
-- [Configure Pulumi Cloud Access](#configure-pulumi-cloud-access)
-- [Use Pulumi ESC for centralized configuration](#use-pulumi-esc-for-centralized-configuration)
-- [Create a Stack Resource](#create-a-stack-resource)
-  - [Using a Git repository](#using-a-git-repository)
-  - [Using a Flux source](#using-a-flux-source)
-  - [Using a Program object](#using-a-program-object)
-- [Explore other Features](#explore-other-features)
-  - [Stack Configuration Values](#stack-configuration-values)
-  - [Structured configuration](#structured-configuration)
-  - [Environment Variables](#environment-variables)
-  - [Drift Detection](#drift-detection)
-  - [State Refresh](#state-refresh)
-  - [Stack Cleanup](#stack-cleanup)
-  - [Stack Prerequisites](#stack-prerequisites)
-  - [External Triggers](#external-triggers)
-  - [Preview mode](#preview-mode)
-- [Use With Argo CD](#use-with-argo-cd)
-- [More Information](#more-information)
-  - [Examples](#examples)
-  - [Getting Help](#getting-help)
-
 [k8s-ext-pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [stack]: /docs/concepts/stack/
 [Pulumi YAML]: /docs/iac/languages-sdks/yaml/
 
 ## Install the Pulumi Kubernetes Operator
+
+To work with the operator, we'll need to follow these steps.
 
 ### Using Helm
 

--- a/content/docs/integrations/clouds/kubernetes/pulumi-kubernetes-operator.md
+++ b/content/docs/integrations/clouds/kubernetes/pulumi-kubernetes-operator.md
@@ -18,8 +18,7 @@ aliases:
 - /docs/iac/packages-and-automation/continuous-delivery/pulumi-kubernetes-operator/
 ---
 
-This page details how to use the [Pulumi Kubernetes
-Operator](https://github.com/pulumi/pulumi-kubernetes-operator) (PKO) to automate the deployment of Pulumi [stacks][stack]. The Pulumi program for a stack can come from a [Program resource][], from a Git repository, or from a [Flux source][flux-source], and may be authored in any supported Pulumi language (TypeScript, Python, Go, .NET, Java, YAML).
+This page details how to use the [Pulumi Kubernetes Operator](https://github.com/pulumi/pulumi-kubernetes-operator) (PKO) to automate the deployment of Pulumi [stacks][stack]. The Pulumi program for a stack can come from a [Program resource][], from a Git repository, or from a [Flux source][flux-source], and may be authored in any supported Pulumi language (TypeScript, Python, Go, .NET, Java, YAML).
 
 [Program resource]: https://github.com/pulumi/pulumi-kubernetes-operator/blob/master/docs/programs.md
 [flux-source]: https://fluxcd.io/flux/components/source/
@@ -33,16 +32,15 @@ The Pulumi Kubernetes Operator provides [custom resources][k8s-ext-pattern] to:
 - Write [Pulumi YAML][] programs as Kubernetes objects
 - Run Pulumi deployment operations
 
-Deploying Pulumi stacks using Kubernetes provides the capability to build
-out CI/CD and other automation systems, and to manage your infrastructure alongside your Kubernetes workloads or in dedicated control-plane clusters.
+Deploying Pulumi stacks using Kubernetes provides the capability to build out CI/CD and other automation systems, and to manage your infrastructure alongside your Kubernetes workloads or in dedicated control-plane clusters.
+
+Follow the sections below to install the operator, configure cluster access, and create your first stack.
 
 [k8s-ext-pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [stack]: /docs/concepts/stack/
 [Pulumi YAML]: /docs/iac/languages-sdks/yaml/
 
 ## Install the Pulumi Kubernetes Operator
-
-To work with the operator, we'll need to follow these steps.
 
 ### Using Helm
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

I don't think we display the TOC like this elsewhere. Seemed redundant, removed it.