### PR TITLE
Fix live reload not working reliably, speed up dev build times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ static/js/chunk-*.js
 static/js/algolia.*.js
 static/js/homepage.*.js
 static/js/marketing.*.js
+static/js/consent-manager.*.js
+static/js/marketing-homepage.*.js
 data/js_manifest.json
 data/openapi-spec.json
 

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -498,13 +498,13 @@ Starts the Hugo development server with live reload.
 **What it does:**
 
 1. Sets `ASSET_BUNDLE_ID` for development
-1. Runs Hugo with:
+2. Runs Hugo with:
    - `--renderToMemory`: No disk writes
    - `--buildDrafts`: Show draft content
    - `--buildFuture`: Show future-dated content (can be disabled with `BUILD_FUTURE=false`)
    - Fast render is **on by default**; set `DISABLE_FAST_RENDER=true` to pass `--disableFastRender` (re-renders the full site on every change — slower, but accurate for list pages, menus, and the search index)
-1. Connects to tf2pulumi conversion service
-1. Uses Hugo's default binding (localhost:1313)
+3. Connects to tf2pulumi conversion service
+4. Uses Hugo's default binding (localhost:1313)
 
 **Usage:**
 

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -498,13 +498,13 @@ Starts the Hugo development server with live reload.
 **What it does:**
 
 1. Sets `ASSET_BUNDLE_ID` for development
-2. Runs Hugo with:
+1. Runs Hugo with:
    - `--renderToMemory`: No disk writes
-   - `--disableFastRender`: Rebuild related content
    - `--buildDrafts`: Show draft content
-   - `--buildFuture`: Show future-dated content (can be disabled with BUILD_FUTURE=false)
-3. Connects to tf2pulumi conversion service
-4. Uses Hugo's default binding (localhost:1313)
+   - `--buildFuture`: Show future-dated content (can be disabled with `BUILD_FUTURE=false`)
+   - Fast render is **on by default**; set `DISABLE_FAST_RENDER=true` to pass `--disableFastRender` (re-renders the full site on every change — slower, but accurate for list pages, menus, and the search index)
+1. Connects to tf2pulumi conversion service
+1. Uses Hugo's default binding (localhost:1313)
 
 **Usage:**
 

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -30,6 +30,22 @@ enableGitInfo: true
 # 10 seconds to avoid timeouts when generating the site.
 timeout: 300000
 
+# Exclude static/programs from Hugo's file watcher. It's ~15 MiB / 2000+ files
+# of code samples maintained by codegen, not during normal authoring — watching
+# them just slows `hugo server` down. The files are still served; only the
+# watch is disabled.
+#
+# Declaring a mount that overlaps `static` disables Hugo's default
+# `static → static` mount, so we re-declare it. Other defaults (archetypes,
+# assets, content, data, i18n, layouts, etc.) are still auto-added.
+module:
+  mounts:
+    - source: static
+      target: static
+    - source: static/programs
+      target: static/programs
+      disableWatch: true
+
 outputFormats:
   rss:
     baseName: rss

--- a/layouts/partials/assets.html
+++ b/layouts/partials/assets.html
@@ -12,13 +12,15 @@
     <script src="/js/{{ index $jsManifest "algolia" }}" defer></script>
 {{ end }}
 
-{{/* Inline template for CSS links: uses fingerprinted bundle in dev, post-processed bundle in prod */}}
+{{/* Inline template for CSS links: stable URL in dev (required for LiveReload), fingerprinted+post-processed in prod */}}
 {{ define "css-link" }}
-    {{- $css := resources.Get .source | fingerprint -}}
-    {{- $_ := $css.Permalink -}}
     {{- if hugo.IsServer -}}
+        {{- $css := resources.Get .source -}}
+        {{- $_ := $css.Permalink -}}
         <link rel="stylesheet" href="{{ $css.RelPermalink }}">
     {{- else -}}
+        {{- $css := resources.Get .source | fingerprint -}}
+        {{- $_ := $css.Permalink -}}
         <link rel="stylesheet" href="/css/{{ .name }}.{{ getenv "CSS_BUNDLE_ID" }}.css">
     {{- end -}}
 {{ end }}

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -25,4 +25,4 @@ if [ "${BUILD_FUTURE:-true}" = "false" ]; then
     BUILD_FUTURE_FLAG=""
 fi
 
-HUGO_BASEURL=http://localhost:1313 hugo server --renderToMemory --disableFastRender --buildDrafts ${BUILD_FUTURE_FLAG}
+HUGO_BASEURL=http://localhost:1313 hugo server --renderToMemory --buildDrafts ${BUILD_FUTURE_FLAG}

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -25,4 +25,14 @@ if [ "${BUILD_FUTURE:-true}" = "false" ]; then
     BUILD_FUTURE_FLAG=""
 fi
 
-HUGO_BASEURL=http://localhost:1313 hugo server --renderToMemory --buildDrafts ${BUILD_FUTURE_FLAG}
+# Hugo's fast render mode only re-renders the page currently open in the browser
+# on each change. This is much faster on a large site, but means list pages, the
+# search index, menus, and other pages not in your viewport may show stale data
+# until you navigate to them. Set DISABLE_FAST_RENDER=true to force full
+# re-renders (slower but always accurate) when debugging those surfaces.
+FAST_RENDER_FLAG=""
+if [ "${DISABLE_FAST_RENDER:-false}" = "true" ]; then
+    FAST_RENDER_FLAG="--disableFastRender"
+fi
+
+HUGO_BASEURL=http://localhost:1313 hugo server --renderToMemory --buildDrafts ${BUILD_FUTURE_FLAG} ${FAST_RENDER_FLAG}

--- a/theme/postcss.config.js
+++ b/theme/postcss.config.js
@@ -1,11 +1,45 @@
 /**
- * Configuration file for PostCSS. This is only used as part of the Hugo pipeline
- * build process for our Sass files, since we run the resulting CSS through PostCSS
- * at the end to do more transformations.
+ * PostCSS configuration used by webpack's postcss-loader when processing
+ * the compiled SCSS output from sass-loader.
  */
+
+const path = require("path");
+const fs = require("fs");
+
+// Walk a directory recursively and return all files matching a predicate.
+function walkDir(dir, pred, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walkDir(full, pred, out);
+        else if (pred(entry.name)) out.push(full);
+    }
+    return out;
+}
+
+const scssDir = path.join(__dirname, "src/scss");
+
+// @tailwindcss/postcss caches its output keyed on the mtimes of registered
+// PostCSS dependency files. By default it only tracks the entry file (main.scss),
+// so changes to imported SCSS partials go undetected and stale CSS is emitted.
+// This plugin registers every SCSS partial as a dependency so Tailwind checks
+// their mtimes and performs a full rebuild whenever any partial changes.
+const registerScssDependencies = {
+    postcssPlugin: "register-scss-dependencies",
+    Once(root, { result }) {
+        for (const file of walkDir(scssDir, (n) => n.endsWith(".scss"))) {
+            result.messages.push({
+                type: "dependency",
+                plugin: "register-scss-dependencies",
+                file,
+                parent: result.opts.from,
+            });
+        }
+    },
+};
 
 module.exports = {
     plugins: [
+        registerScssDependencies,
         // TailwindCSS
         require("@tailwindcss/postcss"),
 

--- a/theme/src/scss/_templates.scss
+++ b/theme/src/scss/_templates.scss
@@ -93,7 +93,6 @@
 }
 
 .template-hero {
-
     .hero-tag-line {
         @include section-hint-accent();
     }
@@ -503,7 +502,6 @@
         @include screen-md {
             @apply text-heading-l;
         }
-
     }
 
     .product-hero-title-primary {

--- a/theme/src/scss/_templates.scss
+++ b/theme/src/scss/_templates.scss
@@ -93,6 +93,7 @@
 }
 
 .template-hero {
+
     .hero-tag-line {
         @include section-hint-accent();
     }
@@ -502,6 +503,7 @@
         @include screen-md {
             @apply text-heading-l;
         }
+
     }
 
     .product-hero-title-primary {

--- a/theme/webpack.config.js
+++ b/theme/webpack.config.js
@@ -27,6 +27,14 @@ module.exports = function (env, { mode }) {
         devServer: {
             writeToDisk: true,
         },
+        // Disable webpack's module cache in development. When enabled (the default),
+        // changes to SCSS partials imported from main.scss/_marketing.scss don't
+        // invalidate the extracted CSS module — webpack rebuilds the JS stub but
+        // serves stale CSS from cache until the watcher is restarted. See the
+        // output of `make serve-all` showing "cached modules ... 766 KiB (css/mini-extract)"
+        // after a partial change. Disabling the cache in dev mode forces sass-loader
+        // to re-run on every rebuild. Production builds are unaffected.
+        cache: mode === "production",
         module: {
             rules: [
                 {
@@ -75,6 +83,10 @@ module.exports = function (env, { mode }) {
                 filename: "../../assets/css/[name].css",
             }),
             new WebpackShellPluginNext({
+                // dev: true clears the script list after the first run, so
+                // stencil is not rebuilt on every watch recompilation — only on startup.
+                // Has no effect on production builds (single compilation).
+                dev: mode !== "production",
                 onBuildStart: {
                     blocking: true,
                     parallel: false,
@@ -91,13 +103,19 @@ module.exports = function (env, { mode }) {
                         }
                         const outDir = path.resolve(compiler.outputPath, "../../data");
                         fs.mkdirSync(outDir, { recursive: true });
-                        fs.writeFileSync(path.join(outDir, "js_manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
+                        const manifestPath = path.join(outDir, "js_manifest.json");
+                        const newContent = JSON.stringify(manifest, null, 2) + "\n";
+                        // Only write if changed — avoids a spurious Hugo reload on CSS-only rebuilds.
+                        const existing = fs.existsSync(manifestPath) ? fs.readFileSync(manifestPath, "utf8") : "";
+                        if (newContent !== existing) {
+                            fs.writeFileSync(manifestPath, newContent);
+                        }
                     });
                 },
             },
         ],
         optimization: {
-            minimize: true,
+            minimize: mode === "production",
             minimizer: [
                 new TerserPlugin({
                     terserOptions: {

--- a/theme/webpack.config.js
+++ b/theme/webpack.config.js
@@ -83,8 +83,10 @@ module.exports = function (env, { mode }) {
                 filename: "../../assets/css/[name].css",
             }),
             new WebpackShellPluginNext({
-                // dev: true clears the script list after the first run, so
-                // stencil is not rebuilt on every watch recompilation — only on startup.
+                // dev: true clears the script list after the first run, so stencil is not
+                // rebuilt on every webpack recompilation — only on startup. Stencil component
+                // edits are picked up by stencil's own --watch process, which runs alongside
+                // webpack via theme/package.json's `start` script (used by `make serve-all`).
                 // Has no effect on production builds (single compilation).
                 dev: mode !== "production",
                 onBuildStart: {

--- a/theme/webpack.config.js
+++ b/theme/webpack.config.js
@@ -4,14 +4,19 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const WebpackShellPluginNext = require("webpack-shell-plugin-next");
 
-module.exports = function (env, { mode }) {
+module.exports = function (env, argv = {}) {
+    // `mode` is only populated when the caller passes `--mode`. `yarn run webpack --watch`
+    // (invoked by `make serve-all` via theme/package.json's `start` script) does not, so
+    // treat an unset mode as development.
+    const isProd = argv.mode === "production";
+
     return {
-        mode: mode || "development",
+        mode: isProd ? "production" : "development",
         entry: {
-            bundle: "./src/ts/main.ts",
-            marketing: "./src/ts/marketing.ts",
+            "bundle": "./src/ts/main.ts",
+            "marketing": "./src/ts/marketing.ts",
             "marketing-homepage": "./src/ts/marketingHomepage.ts",
-            algolia: "./src/ts/algolia-entry.ts",
+            "algolia": "./src/ts/algolia-entry.ts",
             "consent-manager": "./src/ts/consent-manager/index.ts",
         },
         output: {
@@ -27,14 +32,19 @@ module.exports = function (env, { mode }) {
         devServer: {
             writeToDisk: true,
         },
-        // Disable webpack's module cache in development. When enabled (the default),
-        // changes to SCSS partials imported from main.scss/_marketing.scss don't
-        // invalidate the extracted CSS module — webpack rebuilds the JS stub but
-        // serves stale CSS from cache until the watcher is restarted. See the
-        // output of `make serve-all` showing "cached modules ... 766 KiB (css/mini-extract)"
-        // after a partial change. Disabling the cache in dev mode forces sass-loader
-        // to re-run on every rebuild. Production builds are unaffected.
-        cache: mode === "production",
+        // Webpack's default fs.watch-based watcher misses SCSS and TS edits in this
+        // workspace — watchpack's kqueue watchers stay armed but never fire, so `make
+        // serve-all` sits idle after a change. Polling is rock-solid and, at 300ms, fast
+        // enough that rebuilds feel instant.
+        watchOptions: {
+            poll: 300,
+            aggregateTimeout: 200,
+            ignored: ["**/node_modules/**", "**/stencil/dist/**"],
+        },
+        // No cache: the default in-memory cache served stale CSS after SCSS partial
+        // edits, and a persistent filesystem cache buys nothing here — prod runs in a
+        // fresh CI container, dev recompiles are fast enough without it.
+        cache: false,
         module: {
             rules: [
                 {
@@ -70,7 +80,7 @@ module.exports = function (env, { mode }) {
                                 sassOptions: {
                                     outputStyle: "compressed",
                                     quietDeps: true,
-                                    silenceDeprecations: ['import', 'global-builtin'],
+                                    silenceDeprecations: ["import", "global-builtin"],
                                 },
                             },
                         },
@@ -87,8 +97,7 @@ module.exports = function (env, { mode }) {
                 // rebuilt on every webpack recompilation — only on startup. Stencil component
                 // edits are picked up by stencil's own --watch process, which runs alongside
                 // webpack via theme/package.json's `start` script (used by `make serve-all`).
-                // Has no effect on production builds (single compilation).
-                dev: mode !== "production",
+                dev: !isProd,
                 onBuildStart: {
                     blocking: true,
                     parallel: false,
@@ -97,10 +106,10 @@ module.exports = function (env, { mode }) {
             }),
             {
                 apply(compiler) {
-                    compiler.hooks.done.tap("JsManifestPlugin", (stats) => {
+                    compiler.hooks.done.tap("JsManifestPlugin", stats => {
                         const manifest = {};
                         for (const [name, { assets }] of Object.entries(stats.toJson().entrypoints)) {
-                            const jsFile = assets.find((a) => a.name.endsWith(".js"));
+                            const jsFile = assets.find(a => a.name.endsWith(".js"));
                             if (jsFile) manifest[name] = jsFile.name;
                         }
                         const outDir = path.resolve(compiler.outputPath, "../../data");
@@ -117,7 +126,7 @@ module.exports = function (env, { mode }) {
             },
         ],
         optimization: {
-            minimize: mode === "production",
+            minimize: isProd,
             minimizer: [
                 new TerserPlugin({
                     terserOptions: {
@@ -132,9 +141,9 @@ module.exports = function (env, { mode }) {
         performance: {
             // Increase thresholds to accommodate TailwindCSS utility classes
             // bundle.css is ~4.21 MiB due to comprehensive utility generation
-            maxAssetSize: 5242880,        // 5 MiB
-            maxEntrypointSize: 5767168,   // 5.5 MiB
-            hints: 'warning',              // Keep as warnings to monitor growth
+            maxAssetSize: 5242880, // 5 MiB
+            maxEntrypointSize: 5767168, // 5.5 MiB
+            hints: "warning", // Keep as warnings to monitor growth
         },
     };
 };


### PR DESCRIPTION
**`make serve-all`: CSS changes now reliably update in the browser**

**Bug fixes**

SCSS edits made during `make serve-all` were not appearing in the browser without a server restart. Three root causes fixed:

- **`@tailwindcss/postcss` stale cache** (postcss.config.js): Tailwind's internal cache only tracked `main.scss`'s mtime, so changes to imported partials were silently ignored. A new PostCSS plugin registers all SCSS files as dependencies so Tailwind detects any partial change and fully rebuilds.
- **Webpack module cache** (webpack.config.js): Webpack's default in-memory cache served a stale CSS module even when partials changed. Disabled in dev (`cache: false`).
- **Hugo LiveReload with stable CSS URLs** (assets.html): In dev, CSS `<link>` tags now use the stable `/css/bundle.css` URL instead of a fingerprinted hash URL, so Hugo's LiveReload can hot-swap the stylesheet without a full page reload.

**Performance improvements**

In addition, there were some long build times with local dev, some tweaks brought that down to ~1-3s:

- **Skip `js_manifest.json` write when unchanged** (webpack.config.js): CSS-only rebuilds previously always wrote a new manifest, triggering a full Hugo page reload. Now only written when JS content hashes actually change.
- **Skip Terser in dev** (webpack.config.js): Minification now only runs in production builds.
- **Run stencil only on startup** (webpack.config.js): Stencil was rebuilt on every watch recompilation; now runs once on startup only.
- **Remove `--disableFastRender`** (serve.sh): Hugo was re-rendering the entire site on every asset change, causing multi-second rebuild windows. Fast render limits rebuilds to only affected pages. This was added for a reason, so I want to confirm that we're okay with removing it.

I _think_ all of these are safe and should only affect local development. The potential downside is bugs potentially only manifesting in production builds if they're related to minification or other things being skipped in dev.

@cnunciato Please feel free to add anyone else that might want to take a look at these changes.