### PR TITLE
Ignore .context directory in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -52,4 +52,7 @@ origin-bucket-metadata.json
 # Ignore js scripts added to the static folder
 static/js
 
+# Conductor workspace state
+.context
+
 **/.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.context` to `.prettierignore` so the prettier cache-warming step in `make ensure` doesn't fail on Conductor-generated workspace files (e.g. `.context/meta-image/*.json`).
- `.context/` is a gitignored directory Conductor uses for per-workspace state; its contents shouldn't be subject to repo formatting rules.

## Test plan
- [ ] `make ensure` completes without prettier errors when `.context/` contains unformatted JSON.
- [ ] `make lint` still passes on tracked files.