### PR TITLE
esc: add fn::final with fn::secret example (#18449)

### DIFF
--- a/content/docs/esc/environments/syntax/builtin-functions/fn-final.md
+++ b/content/docs/esc/environments/syntax/builtin-functions/fn-final.md
@@ -57,3 +57,45 @@ values:
   "not_final": "new_value"
 }
 ```
+
+## Composing fn::final with fn::secret
+
+`fn::final` accepts any value, including other built-in function expressions. Wrapping `fn::secret` in `fn::final` is a useful pattern for platform teams that need to distribute a shared secret to downstream environments while ensuring those environments cannot override it.
+
+### Parent environment (myproj/platform)
+
+```yaml
+values:
+  frozenSecret:
+    fn::final:
+      fn::secret: my_plaintext_secret
+```
+
+When this environment is saved, ESC encrypts the plaintext argument to `fn::secret` and replaces it with a ciphertext literal, so the stored form becomes:
+
+```yaml
+values:
+  frozenSecret:
+    fn::final:
+      fn::secret:
+        ciphertext: ZXN...
+```
+
+### Child environment (myproj/app)
+
+```yaml
+imports:
+  - myproj/platform
+values:
+  frozenSecret: different_value  # Warning, cannot override final value
+```
+
+### Evaluated result
+
+```json
+{
+  "frozenSecret": "[secret]"
+}
+```
+
+The evaluated value carries both the secret marker (so consumers redact it from output) and the final marker (so child environments cannot override it).

--- a/content/docs/esc/environments/syntax/builtin-functions/fn-final.md
+++ b/content/docs/esc/environments/syntax/builtin-functions/fn-final.md
@@ -60,7 +60,7 @@ values:
 
 ## Composing fn::final with fn::secret
 
-`fn::final` accepts any value, including other built-in function expressions. Wrapping `fn::secret` in `fn::final` is a useful pattern for platform teams that need to distribute a shared secret to downstream environments while ensuring those environments cannot override it.
+`fn::final` accepts any value, including other built-in function expressions. Wrapping `fn::secret` in `fn::final` lets platform teams distribute a shared secret to downstream environments while ensuring those environments cannot override it.
 
 ### Parent environment (myproj/platform)
 
@@ -71,7 +71,7 @@ values:
       fn::secret: my_plaintext_secret
 ```
 
-When this environment is saved, ESC encrypts the plaintext argument to `fn::secret` and replaces it with a ciphertext literal, so the stored form becomes:
+When the environment is saved, ESC encrypts the plaintext argument and replaces it with a ciphertext literal. The stored form becomes:
 
 ```yaml
 values:


### PR DESCRIPTION
Fixes #18449.

The `fn::final` reference page currently demonstrates only the parent/child override-blocking behavior. This PR adds a second section showing how to compose `fn::final` with `fn::secret`, which is a common real-world pattern: a platform team distributes a shared secret to downstream environments and ensures no child environment can override it.

## What changed

A new section "Composing fn::final with fn::secret" was added to `content/docs/esc/environments/syntax/builtin-functions/fn-final.md`. It covers:

- The parent environment definition using the plaintext form of `fn::secret` nested inside `fn::final`
- The stored (encrypted) form after ESC processes the environment at save time
- A child environment that attempts to override the value (resulting in a warning)
- The evaluated result, including the note that the value carries both the secret and final markers

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*
