### PR TITLE
Remove hardcoded utm_source from /gads landing pages

### DIFF
--- a/content/gads/akuity/index.md
+++ b/content/gads/akuity/index.md
@@ -3,7 +3,6 @@ title: "Akuity Alternative | Pulumi"
 meta_desc: IaC plus GitOps in one platform. Manage cloud and Kubernetes infrastructure end-to-end. Python, TypeScript, Go, or C#. 170+ providers.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-akuity
 heading: "Akuity Alternative"
 subheading: |
     Pulumi is a free, open source infrastructure as code tool, and works best with Pulumi Cloud to

--- a/content/gads/ansible/index.md
+++ b/content/gads/ansible/index.md
@@ -3,7 +3,6 @@ title: "Ansible Alternative | Pulumi"
 meta_desc: Cloud infrastructure provisioning in real programming languages, not YAML playbooks. State management, drift detection, 170+ providers. Free tier.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-ansible
 aliases:
     - /gads/gads-template
 

--- a/content/gads/aws/index.md
+++ b/content/gads/aws/index.md
@@ -3,7 +3,6 @@ title: "AWS Infrastructure as Code | Pulumi"
 meta_desc: "Manage AWS with Python, TypeScript, Go, or C#. Full API coverage, same-day updates, built-in best practices with Crosswalk. Free tier, no resource caps."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-aws
 
 heading: "AWS Infrastructure as Code"
 subheading: |

--- a/content/gads/azure-resource-manager/index.md
+++ b/content/gads/azure-resource-manager/index.md
@@ -3,7 +3,6 @@ title: "Azure Resource Manager Alternative | Pulumi"
 meta_desc: Move beyond ARM templates and Bicep. Write Azure infrastructure in C#, Python, TypeScript, or Go. Multi-cloud ready with 170+ providers.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-azure-resource-manager
 
 heading: "Azure Resource Manager Alternative"
 subheading: |

--- a/content/gads/azure/index.md
+++ b/content/gads/azure/index.md
@@ -3,7 +3,6 @@ title: "Azure Infrastructure"
 meta_desc: Azure infrastructure as code in C#, Python, TypeScript, or Go. Native Azure provider, full API coverage. Multi-cloud ready. Free tier.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-azure
 aliases:
     - /azure-resource-manager
     - /azure-infrastructure

--- a/content/gads/backstage/index.md
+++ b/content/gads/backstage/index.md
@@ -3,7 +3,6 @@ title: "Backstage Alternative | Pulumi"
 meta_desc: Developer portal with built-in IaC provisioning. Templates, catalogs, policies, and secrets in one platform. No assembly required.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-backstage
 
 heading: "Backstage Alternative"
 subheading: |

--- a/content/gads/cdk/index.md
+++ b/content/gads/cdk/index.md
@@ -4,7 +4,6 @@ meta_desc: "Like AWS CDK but without CloudFormation. Direct cloud deployment, mu
 layout: gads-template
 block_external_search_index: true
 hide_platform_details: true
-utm_source: gads-cdk
 aliases:
     - /gads/gads-template
 

--- a/content/gads/chef/index.md
+++ b/content/gads/chef/index.md
@@ -3,7 +3,6 @@ title: "Chef Alternative | Pulumi"
 meta_desc: Cloud IaC instead of cookbook-based configuration. Python, TypeScript, Go, or C# with state management, testing, and 170+ providers.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-chef
 
 heading: "Chef Alternative"
 subheading: |

--- a/content/gads/chkk/index.md
+++ b/content/gads/chkk/index.md
@@ -3,7 +3,6 @@ title: "Chkk Alternative | Pulumi"
 meta_desc: Go beyond reliability checks. Full IaC with policy as code, secrets, compliance, and 170+ cloud providers. Open source. Free tier.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-chkk
 
 heading: "Chkk Alternative"
 subheading: |

--- a/content/gads/cloudformation/index.md
+++ b/content/gads/cloudformation/index.md
@@ -4,7 +4,6 @@ meta_desc: "Stop wrestling with CloudFormation JSON. Write AWS infrastructure in
 layout: gads-template
 block_external_search_index: true
 hide_platform_details: true
-utm_source: gads-cloudformation
 aliases:
     - /gads/gads-template
 

--- a/content/gads/crossplane/index.md
+++ b/content/gads/crossplane/index.md
@@ -4,7 +4,6 @@ meta_desc: "Cloud + Kubernetes in one workflow. Real languages instead of YAML C
 layout: gads-template
 block_external_search_index: true
 hide_platform_details: true
-utm_source: gads-crossplane
 aliases:
     - /gads/gads-template
 

--- a/content/gads/env0/index.md
+++ b/content/gads/env0/index.md
@@ -3,7 +3,6 @@ title: "Env0 Alternative | Pulumi"
 meta_desc: "Why add a management layer when the platform includes it? IaC, deployments, policies, secrets, cost visibility. One platform."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-env0
 hide_platform_details: true
 aliases:
     - /gads/gads-template

--- a/content/gads/firefly/index.md
+++ b/content/gads/firefly/index.md
@@ -3,7 +3,6 @@ title: "Firefly Alternative | Pulumi"
 meta_desc: Fix drift by design, not by cleanup. Full IaC platform with policy, state management, and preview. Python, TypeScript, Go, or C#. Free tier.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-firefly
 heading: "Firefly Alternative"
 subheading: |
     Pulumi is a free, open source infrastructure as code tool, and works best with Pulumi Cloud to

--- a/content/gads/gads-template.md
+++ b/content/gads/gads-template.md
@@ -3,7 +3,6 @@ title: "Alternative | Pulumi"
 meta_desc: Infrastructure as Code in Python, TypeScript, Go, or C#. 170+ cloud providers, policy as code, secrets management. Open source. Free tier.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-template
 aliases:
     - /gads/gads-template
 

--- a/content/gads/github/index.md
+++ b/content/gads/github/index.md
@@ -3,7 +3,6 @@ title: "Infrastructure Automation for GitHub | Pulumi"
 meta_desc: Infrastructure automation that integrates with GitHub. IaC in Python, TypeScript, Go, or C# with GitOps workflows and 170+ cloud providers.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-github
 heading: "Infrastructure Automation for GitHub"
 subheading: |
     Pulumi is a free, open source infrastructure as code tool, and works best with Pulumi Cloud to

--- a/content/gads/google-cloud-deployment-manager/index.md
+++ b/content/gads/google-cloud-deployment-manager/index.md
@@ -3,7 +3,6 @@ title: "Google Cloud Deployment Manager Alternative | Pulumi"
 meta_desc: Move beyond GCP Deployment Manager. Write Google Cloud infrastructure in Python, TypeScript, Go, or C#. Full GCP API coverage, 170+ providers.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-google-cloud-deployment-manager
 
 heading: "Google Cloud Deployment Manager Alternative"
 subheading: |

--- a/content/gads/humanitec/index.md
+++ b/content/gads/humanitec/index.md
@@ -3,7 +3,6 @@ title: "Humanitec Alternative | Pulumi"
 meta_desc: "Developer self-service without a proprietary abstraction layer. Open source IaC engine, reusable components, real programming languages."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-humanitec
 hide_platform_details: true
 
 heading: "Humanitec Alternative"

--- a/content/gads/infrastructure-as-code/index.md
+++ b/content/gads/infrastructure-as-code/index.md
@@ -3,7 +3,6 @@ title: "Infrastructure as Code | Pulumi"
 meta_desc: "Modern infrastructure as code in Python, TypeScript, Go, or C#. 170+ cloud providers, policy as code, secrets management. Open source. Free tier."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-infrastructure-as-code
 
 heading: "Infrastructure as Code"
 subheading: |

--- a/content/gads/infrastructure-engineers/index.md
+++ b/content/gads/infrastructure-engineers/index.md
@@ -3,7 +3,6 @@ title: "Infrastructure as Code | Pulumi"
 meta_desc: "Infrastructure as Code in Python, TypeScript, Go, or C#. Ship infrastructure 3-5x faster with real programming languages, full IDE support, and testing. Free tier."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-infrastructure-engineers
 
 heading: "Infrastructure as Code"
 subheading: |

--- a/content/gads/kubernetes/index.md
+++ b/content/gads/kubernetes/index.md
@@ -3,7 +3,6 @@ title: "Kubernetes Infrastructure as Code | Pulumi"
 meta_desc: "Manage Kubernetes clusters and workloads with Python, TypeScript, Go, or C#. Deploy to EKS, AKS, GKE, or any cluster. Full Helm and YAML support."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-kubernetes
 
 heading: "Kubernetes Infrastructure as Code"
 subheading: |

--- a/content/gads/multicloud/index.md
+++ b/content/gads/multicloud/index.md
@@ -3,7 +3,6 @@ title: "Multicloud | Pulumi"
 meta_desc: "One codebase, any cloud. Manage AWS, Azure, GCP, and Kubernetes infrastructure with Python, TypeScript, Go, or C#. 170+ providers."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-multicloud
 
 heading: "Multicloud infrastructure"
 subheading: |

--- a/content/gads/opentofu/index.md
+++ b/content/gads/opentofu/index.md
@@ -4,7 +4,6 @@ meta_desc: "You chose open source for the license. Now choose real languages ove
 layout: gads-template
 block_external_search_index: true
 hide_platform_details: true
-utm_source: gads-opentofu
 aliases:
     - /gads/gads-template
 

--- a/content/gads/platform-teams/index.md
+++ b/content/gads/platform-teams/index.md
@@ -3,7 +3,6 @@ title: "Platform Engineering | Pulumi"
 meta_desc: "Build internal developer platforms that let engineers provision infrastructure safely. Policies, guardrails, templates, and full auditability built in."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-platform-teams
 
 heading: "Platform engineering"
 subheading: |

--- a/content/gads/port/index.md
+++ b/content/gads/port/index.md
@@ -3,7 +3,6 @@ title: "Port Alternative | Pulumi"
 meta_desc: "Self-service infrastructure with provisioning, policies, and secrets built in. Not just a catalog. IaC engine plus developer portal."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-port
 hide_platform_details: true
 
 heading: "Port Alternative"

--- a/content/gads/puppet/index.md
+++ b/content/gads/puppet/index.md
@@ -3,7 +3,6 @@ title: "Puppet Alternative | Pulumi"
 meta_desc: Cloud IaC instead of server configuration management. Python, TypeScript, Go, or C# with state management, testing, and 170+ providers.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-puppet
 
 heading: "Puppet Alternative"
 subheading: |

--- a/content/gads/python-iac/index.md
+++ b/content/gads/python-iac/index.md
@@ -3,7 +3,6 @@ title: "Infrastructure as Code in Python | Pulumi"
 meta_desc: "Infrastructure as Code in Python. Define AWS, Azure, GCP resources with type checking, testing, and full IDE support. 170+ providers. Free tier."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-python-iac
 
 heading: "Infrastructure as Code in Python"
 subheading: |

--- a/content/gads/saltstack/index.md
+++ b/content/gads/saltstack/index.md
@@ -3,7 +3,6 @@ title: "SaltStack Alternative | Pulumi"
 meta_desc: Move from SaltStack to cloud-native IaC. Declarative infrastructure in Python, TypeScript, Go, or C# with state management and drift detection.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-saltstack
 
 heading: "SaltStack Alternative"
 subheading: |

--- a/content/gads/spacelift/index.md
+++ b/content/gads/spacelift/index.md
@@ -3,7 +3,6 @@ title: "Spacelift Alternative | Pulumi"
 meta_desc: "IaC engine plus management platform in one. No bolt-on orchestration layer needed. Python, TypeScript, Go, or C#. 170+ providers."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-spacelift
 hide_platform_details: true
 aliases:
     - /gads/gads-template

--- a/content/gads/system-initiative/index.md
+++ b/content/gads/system-initiative/index.md
@@ -3,7 +3,6 @@ title: "System Initiative Alternative | Pulumi"
 meta_desc: Production-ready IaC today. Python, TypeScript, Go, or C# with 170+ cloud providers. Trusted by BMW and Snowflake. Free tier.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-system-initiative
 heading: "System Initiative Alternative"
 subheading: |
     Pulumi is a free, open source infrastructure as code tool, and works best with Pulumi Cloud to

--- a/content/gads/terraform-migration/index.md
+++ b/content/gads/terraform-migration/index.md
@@ -3,7 +3,6 @@ title: "Migrate from Terraform | Pulumi"
 meta_desc: "Migrate from Terraform to Python, TypeScript, Go, or C#. Free tf2pulumi converter. Pulumi Cloud manages existing Terraform state. Migrate at your pace."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-terraform-migration
 
 heading: "Migrate from Terraform"
 subheading: |

--- a/content/gads/terraform/index.md
+++ b/content/gads/terraform/index.md
@@ -3,7 +3,6 @@ title: "Terraform Alternative | Pulumi"
 meta_desc: "Use Python, TypeScript, Go, or C# instead of HCL. Free migration tools, no resource caps on the free tier, 170+ cloud providers."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-terraform
 hide_platform_details: true
 aliases:
     - /gads/gads-template

--- a/content/gads/terragrunt/index.md
+++ b/content/gads/terragrunt/index.md
@@ -3,7 +3,6 @@ title: "Terragrunt Alternative | Pulumi"
 meta_desc: "Native modularity without wrapper tools. Built-in stacks, components, and multi-environment support. Python, TypeScript, Go, or C#."
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-terragrunt
 hide_platform_details: true
 
 heading: "Terragrunt Alternative"

--- a/content/gads/wiz/index.md
+++ b/content/gads/wiz/index.md
@@ -3,7 +3,6 @@ title: "Secure Infrastructure Automation | Pulumi"
 meta_desc: Shift-left cloud security with policy as code. Prevent infrastructure risks at build time, not after deployment. 170+ providers. Free tier.
 layout: gads-template
 block_external_search_index: true
-utm_source: gads-wiz
 heading: "Secure Infrastructure Automation"
 subheading: |
     Pulumi is a free, open source infrastructure as code tool, and works best with Pulumi Cloud to

--- a/layouts/gads/gads-neo.html
+++ b/layouts/gads/gads-neo.html
@@ -368,7 +368,7 @@
                     {{ range $button := $item.buttons }}
                     {{ if or (eq $button.action "Start Free") (eq $button.action "Book a Demo") }}
                         {{ if eq $button.action "Start Free" }}
-                        <a href="{{ $button.link }}?utm_source=gads-neo" class="z-10 btn-{{ $button.type }}">Try Neo for FREE</a>
+                        <a href="{{ $button.link }}" class="z-10 btn-{{ $button.type }}">Try Neo for FREE</a>
                         {{ end }}
                         <!-- Book a Demo is removed per requirements -->
                     {{ else }}

--- a/layouts/gads/gads-template.html
+++ b/layouts/gads/gads-template.html
@@ -3,13 +3,7 @@
 {{ end }}
 
 {{ define "main" }}
-    {{/* Build CTA href with optional utm_source */}}
-    {{ $utm_source := .Params.utm_source | default "" }}
     {{ $cta_href := site.Params.cta.primary.href }}
-    {{ if $utm_source }}
-        {{ $separator := cond (strings.Contains $cta_href "?") "&" "?" }}
-        {{ $cta_href = printf "%s%sutm_source=%s" $cta_href $separator $utm_source }}
-    {{ end }}
 
     <section id="overview" class="my-8 relative">
         <div class="container mx-auto text-center">
@@ -26,7 +20,7 @@
             {{ if in .RelPermalink "/gads/neo" }}
             <a href="https://app.pulumi.com/signup" class="btn-primary">Try Neo for FREE</a>
             {{ else }}
-            {{ partial "cta-get-started" (dict "class" "btn-primary" "utm_source" $utm_source) }}
+            {{ partial "cta-get-started" (dict "class" "btn-primary") }}
             {{ end }}
         </div>
     </section>

--- a/layouts/partials/cta-get-started.html
+++ b/layouts/partials/cta-get-started.html
@@ -10,23 +10,15 @@
 
   Usage:
     {{ partial "cta-get-started" (dict "class" "btn-primary" "style" "width:fit-content") }}
-    {{ partial "cta-get-started" (dict "class" "btn-primary" "utm_source" "gads-terraform") }}
 
   Parameters:
     - class: CSS class for the button (default: "btn-primary")
     - style: Optional inline style
-    - utm_source: Optional UTM source parameter to append to the URL
 */}}
 
 {{ $class := .class | default "btn-primary" }}
 {{ $style := .style | default "" }}
 {{ $label := site.Params.cta.primary.label | default "Get Started" }}
-{{ $baseHref := site.Params.cta.primary.href | default "/docs/get-started/" }}
-{{ $utm_source := .utm_source | default "" }}
-{{ $href := $baseHref }}
-{{ if $utm_source }}
-    {{ $separator := cond (strings.Contains $baseHref "?") "&" "?" }}
-    {{ $href = printf "%s%sutm_source=%s" $baseHref $separator $utm_source }}
-{{ end }}
+{{ $href := site.Params.cta.primary.href | default "/docs/get-started/" }}
 
 <a href="{{ $href }}" class="{{ $class }}" data-role="cta-get-started"{{ with $style }} style="{{ . }}"{{ end }}>{{ $label }}</a>

--- a/layouts/partials/gads-header.html
+++ b/layouts/partials/gads-header.html
@@ -16,7 +16,7 @@
                     {{ if in .RelPermalink "/gads/neo" }}
                     <a data-track="header-signup" href="https://app.pulumi.com/pulumi/neo?prefer_signup=true" class="btn-primary">Try Neo for FREE</a>
                     {{ else }}
-                    {{ partial "cta-get-started" (dict "class" "btn-primary" "utm_source" (.Params.utm_source | default "")) }}
+                    {{ partial "cta-get-started" (dict "class" "btn-primary") }}
                     {{ end }}
                 </div>
             </div>


### PR DESCRIPTION
## Summary

Removes the hardcoded `utm_source: gads-*` frontmatter field from all 33 `/gads/` landing pages and strips the associated logic from four template files (`layouts/gads/gads-template.html`, `layouts/gads/gads-neo.html`, `layouts/partials/gads-header.html`, `layouts/partials/cta-get-started.html`). CTA links on these pages now fall through to the plain site-wide signup URL (`site.Params.cta.primary.href`) without an appended `utm_source`.

### Why

The `utm_source=gads-<page>` value was a static, per-page attribution that didn't add useful analytics signal beyond what paid-campaign UTMs (`utm_campaign`, `utm_term`, etc., passed in via the ad URL) already provide. Keeping it meant every CTA click on a `/gads/` page overwrote or shadowed the campaign-supplied attribution, and it required maintaining a separate frontmatter field on every new landing page.

Note: the `utm_term`-based dynamic keyword insertion in `gads-template.html` (which reads from the visitor's URL, not from frontmatter) is unchanged — that's a runtime read, not a hardcoded value.

### Changes

- Dropped `utm_source:` line from 33 files under `content/gads/`
- Removed the `$utm_source` / conditional `$cta_href` construction in `layouts/gads/gads-template.html`
- Removed the `utm_source` parameter from the `cta-get-started` partial itself (`layouts/partials/cta-get-started.html`) and updated its callers in `gads-template.html` and `gads-header.html`
- Removed the hardcoded `?utm_source=gads-neo` from the "Try Neo for FREE" anchor in `layouts/gads/gads-neo.html`

## Test plan

- [ ] Preview deploy renders `/gads/aws/`, `/gads/terraform/`, and `/gads/neo/` without template errors
- [ ] CTA buttons on those pages link to `https://app.pulumi.com/signup` (no `?utm_source=...`)
- [ ] The Neo-specific CTA path (`/gads/neo`) still routes to the Neo signup URL
- [ ] Dynamic keyword insertion still works when the page is loaded with a `?utm_term=...` query string

🤖 Generated with [Claude Code](https://claude.com/claude-code)