### PR TITLE
Document reviewStackLabels for conditionally creating review stacks

### DIFF
--- a/content/docs/deployments/deployments/review-stacks.md
+++ b/content/docs/deployments/deployments/review-stacks.md
@@ -323,3 +323,16 @@ const prMigrationSettings = new pulumiservice.DeploymentSettings("prMigrationSet
 });
 
 ```
+
+### Gating review stacks by GitHub label
+
+By default, every pull request against a configured branch creates a review stack. To restrict this to a subset of pull requests, set `reviewStackLabels` on the GitHub Deployment Settings to a list of labels. Review stacks are only created for pull requests carrying at least one matching label (case-sensitive); labels added after the pull request is opened also trigger creation. Applies to GitHub only.
+
+```typescript
+github: {
+    pullRequestTemplate: true,
+    repository: "pulumi/deployment-automation",
+    // only create review stacks for PRs with one of these labels
+    reviewStackLabels: ["review-stack, reviewStack, rs"],
+},
+```

--- a/content/docs/deployments/deployments/review-stacks.md
+++ b/content/docs/deployments/deployments/review-stacks.md
@@ -326,7 +326,7 @@ const prMigrationSettings = new pulumiservice.DeploymentSettings("prMigrationSet
 
 ### Gating review stacks by GitHub label
 
-By default, every pull request against a configured branch creates a review stack. To restrict this to a subset of pull requests, set `reviewStackLabels` on the GitHub Deployment Settings to a list of labels. Review stacks are then created only for pull requests carrying at least one matching label. Matching is case-sensitive, and labels added after a pull request is opened also trigger creation.
+By default, every pull request against a configured branch creates a review stack. Set `reviewStackLabels` in your GitHub deployment settings to limit review stack creation to pull requests that carry at least one of the specified labels. Matching is case-sensitive. Labels added after a pull request is opened will also trigger creation.
 
 The following example shows how to configure this pattern using the [Pulumi Cloud Service provider](/registry/packages/pulumiservice):
 

--- a/content/docs/deployments/deployments/review-stacks.md
+++ b/content/docs/deployments/deployments/review-stacks.md
@@ -326,13 +326,26 @@ const prMigrationSettings = new pulumiservice.DeploymentSettings("prMigrationSet
 
 ### Gating review stacks by GitHub label
 
-By default, every pull request against a configured branch creates a review stack. To restrict this to a subset of pull requests, set `reviewStackLabels` on the GitHub Deployment Settings to a list of labels. Review stacks are only created for pull requests carrying at least one matching label (case-sensitive); labels added after the pull request is opened also trigger creation. Applies to GitHub only.
+By default, every pull request against a configured branch creates a review stack. To restrict this to a subset of pull requests, set `reviewStackLabels` on the GitHub Deployment Settings to a list of labels. Review stacks are then created only for pull requests carrying at least one matching label. Matching is case-sensitive, and labels added after a pull request is opened also trigger creation.
+
+The following example shows how to configure this pattern using the [Pulumi Cloud Service provider](/registry/packages/pulumiservice):
 
 ```typescript
-github: {
-    pullRequestTemplate: true,
-    repository: "pulumi/deployment-automation",
-    // only create review stacks for PRs with one of these labels
-    reviewStackLabels: ["review-stack, reviewStack, rs"],
-},
+const reviewSettings = new pulumiservice.DeploymentSettings("reviewSettings", {
+	organization: pulumi.getOrganization(),
+	project: "your project",
+	stack: "pr",
+	github: {
+		pullRequestTemplate: true,
+		repository: "pulumi/deployment-automation",
+        // only create review stacks for PRs with one of these labels
+        reviewStackLabels: ["review-stack", "reviewStack", "rs"],
+	},
+	sourceContext: {
+		git: {
+			branch: "refs/heads/main",
+			repoDir: "pulumi-pet-shop",
+		},
+	},
+});
 ```


### PR DESCRIPTION
Documents new functionality for configuring a gating review stack creation by requiring a PR having a specific label on it.