### PR TITLE
Remove hardcoded utm_source from pricing, header CTA, and event pages

### DIFF
--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -56,23 +56,21 @@
                                     <div class="text-center text-xs text-gray-700">{{ $tier.note | markdownify }}</div>
                                 </div>
                                 {{ if eq $index 0 }}
-                                    {{ $individualHref := site.Params.cta.primary.href }}
-                                    {{ $separator := cond (strings.Contains $individualHref "?") "&" "?" }}
                                     <div class="flex flex-wrap flex-col justify-center align-center items-center text-center my-4 h-14 lg:h-24 xl:h-14">
-                                        <a class="text-white text-s bg-violet-600 border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-500 text-nowrap" href="{{ $individualHref }}{{ $separator }}utm_source=individual" data-role="cta-get-started">{{ site.Params.cta.primary.label_short }}</a>
+                                        <a class="text-white text-s bg-violet-600 border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-500 text-nowrap" href="{{ site.Params.cta.primary.href }}" data-role="cta-get-started">{{ site.Params.cta.primary.label_short }}</a>
                                     </div>
                                 {{ else if eq $index 1 }}
                                     <div class="flex flex-wrap justify-center items-center text-center my-4 h-14 lg:h-24 xl:h-14">
-                                        <a class="text-white text-s bg-violet-600 border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-500 text-nowrap" href="https://app.pulumi.com/signup?create-organization=1&utm_source=team">Start a free trial</a>
+                                        <a class="text-white text-s bg-violet-600 border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-500 text-nowrap" href="https://app.pulumi.com/signup?create-organization=1">Start a free trial</a>
                                     </div>
                                 {{ else if eq $index 2 }}
                                     <div class="flex flex-wrap justify-center items-center text-center my-4 h-14 lg:h-24 xl:h-14">
-                                        <a class="text-white text-s bg-violet-600 border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-500 text-nowrap mr-1 mb-0 lg:mb-1 xl:mb-0" href="https://app.pulumi.com/signup?create-organization=1&utm_source=enterprise">Start a free trial</a>
-                                        <a href="/contact/?form=sales&utm_source=enterprise" class="text-violet-600 text-s border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-100">Contact sales</a>
+                                        <a class="text-white text-s bg-violet-600 border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-500 text-nowrap mr-1 mb-0 lg:mb-1 xl:mb-0" href="https://app.pulumi.com/signup?create-organization=1">Start a free trial</a>
+                                        <a href="/contact/?form=sales" class="text-violet-600 text-s border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-100">Contact sales</a>
                                     </div>
                                 {{ else }}
                                     <div class="flex flex-wrap justify-center items-center text-center my-4 h-14 lg:h-24 xl:h-14">
-                                        <a class="text-white text-s bg-violet-600 border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-500 text-nowrap mr-1 mb-0 lg:mb-1 xl:mb-0" href="/contact/?form=sales&utm_source=business-critical">Contact sales</a>
+                                        <a class="text-white text-s bg-violet-600 border-2 border-violet-600 rounded-lg py-2 px-2 hover:bg-violet-500 text-nowrap mr-1 mb-0 lg:mb-1 xl:mb-0" href="/contact/?form=sales">Contact sales</a>
                                     </div>
                                 {{ end }}
                                 <div class="border-dotted border-2 border-gray-200 rounded-lg px-4">
@@ -260,11 +258,11 @@
                             <h2 class="mb-12 text-center">Ready to try Pulumi Cloud?</h2>
                             <div class="flex flex-col lg:flex-row self-stretch items-center lg:justify-between">
                                 <div class="flex flex-col justify-center align-center text-center w-full md:w-2/4 lg:ml-14 lg:mr-4 mb-14 lg:mb-0 z-0">
-                                    <a href="https://app.pulumi.com/signup?create-organization=1&utm_source=team" id="pricingStartTrialBottomCTA" class="btn-primary py-3">Start trial</a>
+                                    <a href="https://app.pulumi.com/signup?create-organization=1" id="pricingStartTrialBottomCTA" class="btn-primary py-3">Start trial</a>
                                     <p class="text-xs pt-1 my-0">14-day trial. No credit card needed.</p>
                                 </div>
                                 <div class="flex flex-col justify-center align-center text-center w-full md:w-2/4 lg:mr-14 lg:ml-4">
-                                    <a href="/contact/?form=sales&utm_source=team" class="btn-secondary py-3 px-6">Talk to a human</a>
+                                    <a href="/contact/?form=sales" class="btn-secondary py-3 px-6">Talk to a human</a>
                                     <p class="text-xs pt-1 my-0">Contact us for a demo & quote.</p>
                                 </div>
                             </div>

--- a/layouts/page/reinvent.html
+++ b/layouts/page/reinvent.html
@@ -29,8 +29,8 @@
                         <p>Watch Neo handle patching, policy checks, drift remediation, and cost cleanups powered by Amazon Bedrock - so you can focus on strategy instead of toil.</p>
                     </div>
                     <div class="card-cta-btn text-center">
-                        <a href="https://app.pulumi.com/neo?prompt=Build+a+GPU-powered+AI+inference+API+on+AWS+using+[…]ls.&utm_source=events&utm_medium=re-invent&prefer_signup=true" class="btn-primary hidden xl:inline">Build a GPU-powered AI inference API on AWS using Python</a>
-                        <a href="https://app.pulumi.com/neo?prompt=Build+a+GPU-powered+AI+inference+API+on+AWS+using+[…]ls.&utm_source=events&utm_medium=re-invent&prefer_signup=true" class="btn-primary inline xl:hidden">See Neo in Action</a>
+                        <a href="https://app.pulumi.com/neo?prompt=Build+a+GPU-powered+AI+inference+API+on+AWS+using+[…]ls.&prefer_signup=true" class="btn-primary hidden xl:inline">Build a GPU-powered AI inference API on AWS using Python</a>
+                        <a href="https://app.pulumi.com/neo?prompt=Build+a+GPU-powered+AI+inference+API+on+AWS+using+[…]ls.&prefer_signup=true" class="btn-primary inline xl:hidden">See Neo in Action</a>
 
                     </div>
                 </div>

--- a/layouts/partials/pulumi-up/speakers.html
+++ b/layouts/partials/pulumi-up/speakers.html
@@ -24,7 +24,7 @@
         </div>
         {{ if .include_cta }}
             <div class="my-16 flex flex-col flex-wrap sm:flex-row justify-center">
-                <a class="m-4 sm:m-2 btn-primary text-center" target="_blank" href="https://conference.pulumi.com/schedule/?utm_source=PulumiUp&utm_medium=web&utm_campaign=FY2025Q1_Event_PulumiUP">
+                <a class="m-4 sm:m-2 btn-primary text-center" target="_blank" href="https://conference.pulumi.com/schedule/">
                     Attend PulumiUP 2024
                 </a>
             </div>

--- a/theme/stencil/src/components/header-cta/header-cta.tsx
+++ b/theme/stencil/src/components/header-cta/header-cta.tsx
@@ -45,12 +45,12 @@ export class HeaderCta {
 
         if (this.isLoggedIn) {
             return(
-                <a class={this.buttonClass} href="https://app.pulumi.com/signin?utm_source=header-button" title="Dashboard">Dashboard</a>
+                <a class={this.buttonClass} href="https://app.pulumi.com/signin" title="Dashboard">Dashboard</a>
             );
         }
 
         return (
-            <a class={this.buttonClass} data-track="header-signup" data-role="cta-get-started" href={`${this.href}${this.href.includes("?") && "&" || "?"}utm_source=header-button`} title={this.label}>{this.label}</a>
+            <a class={this.buttonClass} data-track="header-signup" data-role="cta-get-started" href={this.href} title={this.label}>{this.label}</a>
         );
     }
 

--- a/theme/stencil/src/components/header-cta/test/header-cta.spec.tsx
+++ b/theme/stencil/src/components/header-cta/test/header-cta.spec.tsx
@@ -9,7 +9,7 @@ describe('header-cta', () => {
     });
     expect(page.root).toEqualHtml(`
       <header-cta>
-        <a class="" data-track="header-signup" data-role="cta-get-started" href="https://app.pulumi.com/signup?utm_source=header-button" title="Sign Up">Sign Up</a>
+        <a class="" data-track="header-signup" data-role="cta-get-started" href="https://app.pulumi.com/signup" title="Sign Up">Sign Up</a>
       </header-cta>
     `);
   });


### PR DESCRIPTION
## Summary

- Strips hardcoded `utm_source` (and friends) from CTAs that point to Pulumi-owned destinations (`app.pulumi.com`, `conference.pulumi.com`, `/contact`).
- Touches: `layouts/page/pricing.html` (7 CTAs), `theme/stencil/src/components/header-cta/header-cta.tsx` + spec, `layouts/page/reinvent.html` (Neo CTA), `layouts/partials/pulumi-up/speakers.html` (PulumiUP schedule link).
- Outbound sponsor links (AWS, GCP, Azure, etc. on `/pulumi-up` and historical blog posts) are intentionally left alone — those UTMs help sponsors attribute Pulumi-driven traffic and don't affect our tracking. Follows the same pattern as #18663.

## Why this matters for GA / Google Ads attribution

UTM parameters on **internal** links overwrite the session's source / medium / campaign in GA4. Concretely: a visitor lands from a Google Ad (`source=google`, `medium=cpc`, with the `gclid` driving Ads conversion attribution), then clicks an internal CTA tagged `?utm_source=team` — GA4 overwrites the session attribution to `source=team`, `medium=(none)`, severing the link back to the originating ad campaign. The conversion still fires, but it's now attributed to a synthetic internal "source" rather than the paid click that drove the visit. This silently corrupts paid-channel ROI reporting and (per Google's own guidance) UTMs should only be used on **external** inbound links — not internal navigation.

References:
- [Analytics Detectives — Fix Internal UTM Tagging in GA4](https://analyticsdetectives.com/blog/fix-internal-utm-tagging-in-ga4)
- [UTMGuard — Internal Linking and UTM Parameters](https://www.utmguard.com/blog/internal-linking-utm-guide)
- [Giant Creates — UTMs and GA4: How Attribution Really Works](https://giantcreates.com/seo/utms-and-ga4-how-attribution-really-works/)

## Test plan

- [ ] Pricing page renders with all four tier CTAs and the bottom "Ready to try Pulumi Cloud?" buttons going to plain `app.pulumi.com/signup?create-organization=1` and `/contact/?form=sales`
- [ ] Global header Sign Up button goes to `https://app.pulumi.com/signup` with no UTM appended
- [ ] When logged in, header Dashboard button goes to `https://app.pulumi.com/signin` with no UTM
- [ ] `/reinvent` Neo CTAs preserve `prompt` and `prefer_signup=true` params, with no UTMs
- [ ] PulumiUP speakers schedule link goes to `https://conference.pulumi.com/schedule/`
- [ ] `header-cta` Stencil spec passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)