### PR TITLE
docs: document config namespace updates required after cross-project stack rename (#16958)

### DIFF
--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -100,6 +100,52 @@ mycompany/staging                          4 hours ago              97
 dev                                       n/a                      n/a
 ```
 
+## Rename a stack
+
+To rename an existing stack, run `pulumi stack rename <new-name>`. The new name may be a simple stack name or a fully qualified name in the form `<org>/<project>/<stack>`:
+
+```bash
+$ pulumi stack rename production
+$ pulumi stack rename myorg/myproject/production
+```
+
+Renaming a stack changes the value returned by `pulumi.getStack()` inside your program. If that value is used to name any resources, the next `pulumi up` will attempt to replace those resources. Review the proposed changes carefully before proceeding, and consider whether a rename is the right operation or whether you should create a new stack instead.
+
+### Cross-project renames
+
+When the new stack name includes a different project name (for example, renaming from `myorg/old-project/prod` to `myorg/new-project/prod`), two additional manual steps are required after running `pulumi stack rename`.
+
+**Update the project name in `Pulumi.yaml`.** The `name` field in `Pulumi.yaml` must match the project component of the fully qualified stack name. Edit the file to reflect the new project name before running `pulumi up`:
+
+```yaml
+name: new-project  # was: old-project
+runtime: nodejs
+```
+
+**Update project-namespaced configuration keys.** Pulumi [configuration keys](/docs/concepts/config/) are scoped by project name. Keys set without an explicit namespace are stored with the project name as the prefix, so a key named `database` in a project called `old-project` is recorded as `old-project:database` inside `Pulumi.<stack>.yaml`. After a cross-project rename, those keys still carry the old project prefix and will not be visible to the program running under the new project name.
+
+{{% notes type="warning" %}}
+If you do not update project-namespaced configuration keys after a cross-project rename, the program will silently see those configuration values as unset and may fail at runtime or use unexpected defaults.
+{{% /notes %}}
+
+To update the keys, open `Pulumi.<stack>.yaml` in a text editor and rename each key that begins with the old project name:
+
+```yaml
+# Before
+config:
+  old-project:database: mydb
+  old-project:region: us-west-2
+  aws:region: us-west-2
+
+# After
+config:
+  new-project:database: mydb
+  new-project:region: us-west-2
+  aws:region: us-west-2
+```
+
+Keys that include an explicit namespace other than the project name (such as `aws:region`) are unaffected and do not need to change. Alternatively, you can recreate each value using `pulumi config set` (or `pulumi config set --secret` for sensitive values) after updating `Pulumi.yaml`.
+
 ## Generate an update plan
 
 {{% notes type="warning" %}}

--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -54,7 +54,7 @@ my-org/dev
 dev
 ```
 
-In some contexts, stack names will be presented in their fully-qualified format (`orgName/projectName/stackName`) even if provided using shorthand (`stackName` or `orgName/stackName`) as input.
+In some contexts, stack names will be presented in their fully qualified format (`orgName/projectName/stackName`) even if provided using shorthand (`stackName` or `orgName/stackName`) as input.
 
 {{% notes type="info" %}}
 While stacks with applied configuration settings will often be accompanied by `Pulumi.<stack-name>.yaml` files, these files are not created by `pulumi stack init`. They are created and managed with [`pulumi config`](/docs/iac/cli/commands/pulumi_config/). For information on how to populate your stack configuration files, see [Configuration](/docs/concepts/config/).
@@ -88,7 +88,7 @@ staging                                   n/a                      n/a
 broomellc/test                            2 weeks ago              121
 ```
 
-To select a stack that is part of an organization, use the fully-qualified stack name, either `orgName/stackName` or `orgName/projectName/stackName`:
+To select a stack that is part of an organization, use the fully qualified stack name, either `orgName/stackName` or `orgName/projectName/stackName`:
 
 ```bash
 $ pulumi stack select mycompany/prod

--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -109,20 +109,20 @@ $ pulumi stack rename production
 $ pulumi stack rename myorg/myproject/production
 ```
 
-Renaming a stack changes the value returned by `pulumi.getStack()` inside your program. If that value is used to name any resources, the next `pulumi up` will attempt to replace those resources. Review the proposed changes carefully before proceeding, and consider whether a rename is the right operation or whether you should create a new stack instead.
+Renaming a stack changes the value of the stack name returned to your program (for example, `pulumi.getStack()` in TypeScript/JavaScript or `pulumi.get_stack()` in Python). If that value is used to name any resources, the next `pulumi up` will attempt to replace those resources. Review the proposed changes carefully before proceeding, and consider whether a rename is the right operation or whether you should create a new stack instead.
 
 ### Cross-project renames
 
 When the new stack name includes a different project name (for example, renaming from `myorg/old-project/prod` to `myorg/new-project/prod`), two additional manual steps are required after running `pulumi stack rename`.
 
-**Update the project name in `Pulumi.yaml`.** The `name` field in `Pulumi.yaml` must match the project component of the fully qualified stack name. Edit the file to reflect the new project name before running `pulumi up`:
+1. **Update the project name in `Pulumi.yaml`.** The `name` field in `Pulumi.yaml` must match the project component of the fully qualified stack name. Edit the file to reflect the new project name before running `pulumi up`:
 
-```yaml
-name: new-project  # was: old-project
-runtime: nodejs
-```
+    ```yaml
+    name: new-project  # was: old-project
+    runtime: nodejs
+    ```
 
-**Update project-namespaced configuration keys.** Pulumi [configuration keys](/docs/concepts/config/) are scoped by project name. Keys set without an explicit namespace are stored with the project name as the prefix, so a key named `database` in a project called `old-project` is recorded as `old-project:database` inside `Pulumi.<stack>.yaml`. After a cross-project rename, those keys still carry the old project prefix and will not be visible to the program running under the new project name.
+1. **Update project-namespaced configuration keys.** Pulumi [configuration keys](/docs/concepts/config/) are scoped by project name. Keys set without an explicit namespace are stored with the project name as the prefix, so a key named `database` in a project called `old-project` is recorded as `old-project:database` inside `Pulumi.<stack>.yaml`. After a cross-project rename, those keys still carry the old project prefix and will not be visible to the program running under the new project name.
 
 {{% notes type="warning" %}}
 If you do not update project-namespaced configuration keys after a cross-project rename, the program will silently see those configuration values as unset and may fail at runtime or use unexpected defaults.


### PR DESCRIPTION
## What changed

Adds a new **Rename a stack** section to `content/docs/iac/concepts/stacks.md`, covering:

- Basic `pulumi stack rename` usage
- The `Pulumi.yaml` `name:` field update required for cross-project renames (already noted in the auto-generated CLI help, now surfaced in the concepts docs)
- The critical missing step: project-namespaced configuration keys in `Pulumi.<stack>.yaml` retain the old project prefix after a cross-project rename and must be updated manually
- A `{{% notes type="warning" %}}` callout explaining the silent failure mode
- A before/after YAML example showing how to update the keys

## Why

When a user renames a stack to a different project (e.g. `pulumi stack rename myorg/new-project/prod`), the CLI help text mentions updating `Pulumi.yaml`. However, there is a second required step with no documentation: Pulumi config keys are namespaced by project name, so keys like `old-project:database` in `Pulumi.prod.yaml` become invisible to the program after the rename, causing silent failures.

Issue #16958 was filed to track this gap.

## Testing

Prose-only change to a non-auto-generated concepts page. No code examples that need runtime verification. The `content/docs/iac/cli/commands/` pages were not touched.

Closes #16958

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*