### PR TITLE
Replace card-style links with standard Related topics section on resources page

### DIFF
--- a/content/docs/iac/concepts/resources/_index.md
+++ b/content/docs/iac/concepts/resources/_index.md
@@ -124,44 +124,12 @@ The `args` argument is an object with a set of named property input values that 
 
 The [`options`](/docs/concepts/options) argument is optional, but lets you control certain aspects of the resource. For example, you can show explicit dependencies, use a custom provider configuration, or import an existing infrastructure.
 
-## Resource Details
+## Related topics
 
-The following topics provide more details on the core concepts for working with resources in Pulumi:
-
-<div class="md:flex flex-row mt-6 mb-6">
-    <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/resources/names/"><i class="fas fa-font pr-2"></i>Resource Names</a></h3>
-        <p>Learn more about resource names and how to use them.</p>
-    </div>
-    <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/options/"><i class="fas fa-cogs pr-2"></i>Resource Options</a></h3>
-        <p>Learn how to use resource options to modify the way that resources are managed by Pulumi.</p>
-    </div>
-</div>
-<div class="md:flex flex-row mt-6 mb-6">
-    <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/resources/components/"><i class="fas fa-project-diagram pr-2"></i>Components</a></h3>
-        <p>Learn what a component resource is, how to author a new component resource, how to create child resources, and more.</p>
-    </div>
-    <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/iac/concepts/providers/"><i class="fas fa-server pr-2"></i>Providers</a></h3>
-        <p>Learn how a resource provider handles communications with a cloud service to create, read, update, and delete the resources you define in your Pulumi programs.</p>
-    </div>
-</div>
-<div class="md:flex flex-row mt-6 mb-6">
-    <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/iac/concepts/providers/dynamic-providers/"><i class="fas fa-file-alt pr-2"></i>Dynamic Providers</a></h3>
-        <p>Learn how to use dynamic providers and use cases for them.</p>
-    </div>
-    <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/resources/get/"><i class="fas fa-cloud-download-alt pr-2"></i>Getter Functions</a></h3>
-        <p>Learn how a Pulumi resource uses its `get` function to retrieve a reference to an existing instance of the resource.</p>
-    </div>
-</div>
-
-<div class="md:flex flex-row mt-6 mb-6">
-    <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/resources/functions/"><i class="fas fa-file-alt pr-2"></i>Provider Functions</a></h3>
-        <p>Learn how to use the functions included with Pulumi packages.</p>
-    </div>
-</div>
+- [Resource Names](/docs/concepts/resources/names/) - Learn more about resource names and how to use them.
+- [Resource Options](/docs/concepts/options/) - Learn how to use resource options to modify the way that resources are managed by Pulumi.
+- [Components](/docs/concepts/resources/components/) - Learn what a component resource is, how to author a new component resource, how to create child resources, and more.
+- [Providers](/docs/iac/concepts/providers/) - Learn how a resource provider handles communications with a cloud service to create, read, update, and delete the resources you define in your Pulumi programs.
+- [Dynamic Providers](/docs/iac/concepts/providers/dynamic-providers/) - Learn how to use dynamic providers and use cases for them.
+- [Getter Functions](/docs/concepts/resources/get/) - Learn how a Pulumi resource uses its `get` function to retrieve a reference to an existing instance of the resource.
+- [Provider Functions](/docs/concepts/resources/functions/) - Learn how to use the functions included with Pulumi packages.


### PR DESCRIPTION
Replaces the non-standard HTML card/button layout in the "Resource Details" section of `/docs/iac/concepts/resources/` with a plain markdown list under "Related topics", consistent with the style used elsewhere in the docs.

Closes #18700

Generated with [Claude Code](https://claude.ai/code)