### PR TITLE
Add warning about workspaces.prefix and no stacks

### DIFF
--- a/content/docs/iac/get-started/terraform/terraform-state-backend.md
+++ b/content/docs/iac/get-started/terraform/terraform-state-backend.md
@@ -44,8 +44,13 @@ When you migrate state, each Terraform workspace maps to a Pulumi stack. The wor
 
 If you use Terraform [workspace prefixes](https://developer.hashicorp.com/terraform/language/backend/remote#workspace-prefix) instead of a single named workspace, Pulumi Cloud supports the `workspaces.prefix` configuration as well. Each workspace matching the prefix maps to a separate stack under the same project.
 
-{{% notes "warning" %}}
-If no stacks exist yet under your `workspaces.prefix` in Pulumi Cloud, migration may fail with a workspace error. To work around this, first configure `workspaces.name` pointing to a specific workspace/stack, run `terraform init` to create that stack, then update your configuration to use `workspaces.prefix` and run `terraform init` again.
+{{% notes type="warning" %}}
+If no stacks exist yet under your `workspaces.prefix` in Pulumi Cloud, migration may fail with a workspace error. To work around this:
+
+1. Configure `workspaces.name` pointing to a specific stack.
+1. Run `terraform init` to create that stack.
+1. Update your configuration to use `workspaces.prefix`.
+1. Run `terraform init` again.
 {{% /notes %}}
 
 ## Migrate from a standard backend (S3, Azure Blob, GCS, local)

--- a/content/docs/iac/get-started/terraform/terraform-state-backend.md
+++ b/content/docs/iac/get-started/terraform/terraform-state-backend.md
@@ -44,6 +44,10 @@ When you migrate state, each Terraform workspace maps to a Pulumi stack. The wor
 
 If you use Terraform [workspace prefixes](https://developer.hashicorp.com/terraform/language/backend/remote#workspace-prefix) instead of a single named workspace, Pulumi Cloud supports the `workspaces.prefix` configuration as well. Each workspace matching the prefix maps to a separate stack under the same project.
 
+{{% notes "warning" %}}
+If no stacks exist yet under your `workspaces.prefix` in Pulumi Cloud, migration may fail with a workspace error. To work around this, first configure `workspaces.name` pointing to a specific workspace/stack, run `terraform init` to create that stack, then update your configuration to use `workspaces.prefix` and run `terraform init` again.
+{{% /notes %}}
+
 ## Migrate from a standard backend (S3, Azure Blob, GCS, local)
 
 If your Terraform state is currently stored in S3, Azure Blob Storage, GCS, a local file, or any other standard backend, migration is a single command.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

If using `workspaces.prefix` and no stacks exist, an error may occur due to an upstream issue. Note this and offer a workaround.