### PR TITLE
Update Puluminaries list: move inactive members to Alumni

### DIFF
--- a/data/team/team/clark-doan.toml
+++ b/data/team/team/clark-doan.toml
@@ -1,7 +1,7 @@
 id = "clark-doan"
 name = "Clark Doan"
 status = "guest"
-role = "puluminary"
+role = "alumni-puluminary"
 title = "Senior Platform Engineer"
 company = "Nvidia"
 

--- a/data/team/team/dmitry-figol.toml
+++ b/data/team/team/dmitry-figol.toml
@@ -3,7 +3,7 @@ name = "Dmitry Figol"
 title = "Senior Cloud Infrastructure Architect"
 company= "AWS"
 status = "guest"
-role = "puluminary"
+role = "alumni-puluminary"
 [social]
 linkedin = "dmfigol"
 x = "dmfigol"

--- a/data/team/team/henrique-rodrigues.toml
+++ b/data/team/team/henrique-rodrigues.toml
@@ -3,7 +3,7 @@ name = "Henrique Rodrigues"
 title = "Staff Platform Engineer"
 company = "bp"
 status = "guest"
-role = "puluminary"
+role = "alumni-puluminary"
 
 [social]
 github = "Sodki"

--- a/data/team/team/marina-novikova.toml
+++ b/data/team/team/marina-novikova.toml
@@ -1,6 +1,6 @@
 id = "marina-novikova"
 name = "Marina Novikova"
-title = "Senior Partner Solution Architect"
+title = "Senior Partner Solutions Architect"
 company = "AWS"
 status = "guest"
 role = "puluminary"

--- a/data/team/team/matt-stephenson.toml
+++ b/data/team/team/matt-stephenson.toml
@@ -2,7 +2,7 @@ id = "matt-stephenson"
 name = "Matt Stephenson"
 title = "Senior Principal Software Engineer"
 status = "guest"
-role = "puluminary"
+role = "alumni-puluminary"
 [social]
 github = "mattstep"
 linkedin = "jmstephenson"

--- a/data/team/team/sam-cogan.toml
+++ b/data/team/team/sam-cogan.toml
@@ -3,7 +3,7 @@ name = "Sam Cogan"
 title = "Solutions Architect"
 company = "Microsoft"
 status = "guest"
-role = "puluminary"
+role = "alumni-puluminary"
 [social]
 github = "sam-cogan"
 x = "samcogan"

--- a/data/team/team/tyler-mulligan.toml
+++ b/data/team/team/tyler-mulligan.toml
@@ -1,7 +1,7 @@
 id = "tyler-mulligan"
 name = "Tyler Mulligan"
 status = "guest"
-role = "puluminary"
+role = "alumni-puluminary"
 title = "Senior DevOps Engineer"
 company = "SANS Institute"
 


### PR DESCRIPTION
## Summary

- Moves 6 members from active Puluminaries to Alumni (role changed from `puluminary` to `alumni-puluminary`):
  - Clark Doan
  - Dmitry Figol
  - Henrique Rodrigues
  - Matt Stephenson
  - Sam Cogan
  - Tyler Mulligan
- Fixes a typo in Marina Novikova's title: `Senior Partner Solution Architect` → `Senior Partner Solutions Architect`

Active Puluminaries kept: Jason "Jay" Smith, Dinesh Sharma, Thomas Meckel, Alexandre Nédélec, Jan-Peter Alten, Simen A. W. Olsen, Daniel Ward, Paul Hicks, Nico Thomas, Marina Novikova.

## Test plan

- [ ] Verify the `/community/puluminaries/` page renders the 10 active members
- [ ] Verify the 6 moved members now appear under the Alumni section