### PR TITLE
Add documentation describing the new 'pulumi cloud api' command

### DIFF
--- a/content/docs/administration/access-identity/access-tokens.md
+++ b/content/docs/administration/access-identity/access-tokens.md
@@ -22,6 +22,8 @@ aliases:
 
 Use access tokens to sign into the Pulumi Cloud via the CLI or automate your usage of the Pulumi Cloud using the REST API. Learn more about the REST API in the [Pulumi Cloud REST API docs](/docs/reference/cloud-rest-api/).
 
+The token you use for `pulumi login` also authorizes the [`pulumi cloud api`](/docs/iac/cli/cloud-api/) command, which calls any REST API endpoint directly from the CLI without needing to set the `Authorization` header yourself.
+
 Pulumi offers three types of access tokens:
 
 1. **Personal tokens**, which carry the permissions of the individual user who created them. Personal tokens are available to all Pulumi Cloud users.

--- a/content/docs/iac/automation-api/_index.md
+++ b/content/docs/iac/automation-api/_index.md
@@ -27,6 +27,10 @@ Automation API allows you to embed Pulumi within your application code, making i
 Automation API requires the Pulumi CLI to be installed and available in your `PATH` environment variable.
 {{% /notes %}}
 
+{{% notes type="tip" %}}
+Automation API drives the Pulumi engine itself, running updates, previews, refreshes, and destroys from a program. If you instead need to read or modify Pulumi Cloud resources (for example, stack metadata, access tokens, or [Insights](/docs/insights/) data) without running a Pulumi program, use [`pulumi cloud api`](/docs/iac/cli/cloud-api/), the CLI command for calling the [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) directly.
+{{% /notes %}}
+
 ## Getting started
 
 To learn how to use Automation API, see [Getting Started with Automation API](/docs/using-pulumi/automation-api/getting-started-automation-api/).

--- a/content/docs/iac/cli/_index.md
+++ b/content/docs/iac/cli/_index.md
@@ -47,6 +47,7 @@ The most common commands in the CLI that you'll be using are as follows:
 * [`pulumi up`](/docs/iac/cli/commands/pulumi_up/): preview and deploy changes to your program and/or infrastructure
 * [`pulumi preview`](/docs/iac/cli/commands/pulumi_preview/): preview your changes explicitly before deploying
 * [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy/): destroy your program and its infrastructure when you're done
+* [`pulumi cloud api`](/docs/iac/cli/cloud-api/): call any [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) endpoint directly from the CLI, with stable exit codes and a JSON error envelope for scripts and agents
 
 ## Complete Reference
 

--- a/content/docs/iac/cli/cloud-api.md
+++ b/content/docs/iac/cli/cloud-api.md
@@ -1,0 +1,188 @@
+---
+title: Calling the Cloud API
+title_tag: "Pulumi CLI: Calling the Pulumi Cloud REST API"
+meta_desc: Use pulumi cloud api to call any Pulumi Cloud REST API endpoint from the CLI, with stable exit codes and a JSON error envelope for scripts and agents.
+h1: Calling the Pulumi Cloud REST API from the CLI
+menu:
+  iac:
+    parent: iac-cli
+    identifier: iac-cli-cloud-api
+    weight: 60
+meta_image: /images/docs/meta-images/docs-meta.png
+---
+
+The [`pulumi cloud api`](/docs/iac/cli/commands/pulumi_cloud_api/) command lets you call any [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) endpoint directly from the CLI. It runs non-interactively, is safe to script, and reuses the credentials you already use with `pulumi login`, so you don't need to manage a separate token to call the API.
+
+The command is modeled after [`gh api`](https://cli.github.com/manual/gh_api): you pass a path, an operation ID, or a `METHOD path` row and the CLI handles authentication, headers, path-template substitution, and content negotiation for you.
+
+## Subcommands
+
+`pulumi cloud api` ships in three forms:
+
+* [`pulumi cloud api <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_cloud_api/) issues a single HTTP request against the named endpoint.
+* [`pulumi cloud api list`](/docs/iac/cli/commands/pulumi_cloud_api_list/) (alias: `ls`) lists every endpoint exposed by the [Pulumi Cloud OpenAPI spec](/docs/reference/cloud-rest-api/). Output is a TTY-friendly table by default; pass `--format=json` to get a stable, scriptable envelope.
+* [`pulumi cloud api describe <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_cloud_api_describe/) prints the parameters, request body, and response schemas for a single operation. Default output is a human-readable text render; pass `--format=markdown` for a piping-friendly markdown document or `--format=json` for the stable JSON envelope.
+
+## Authentication
+
+`pulumi cloud api` uses the same access token as the rest of the Pulumi CLI. Anything that authorizes `pulumi login` — a personal, organization, or team [access token](/docs/administration/access-identity/access-tokens/), `PULUMI_ACCESS_TOKEN`, or an OIDC-issued token — also authorizes API calls.
+
+If a request requires authentication and the CLI is not authenticated, `pulumi cloud api` exits with code `3` and an error envelope identifying the auth failure. A `401` or `403` response from the API maps to the same exit code.
+
+## Path-template substitution
+
+Most Pulumi Cloud endpoints take an organization, project, or stack as part of the URL — for example, `/api/orgs/{orgName}/members`. `pulumi cloud api` resolves each template variable in the following order:
+
+1. A literal value typed directly into the URL (no template variable to fill).
+1. A matching `-F` or `-f` field (consumed for the path and not forwarded as a query or body parameter).
+1. The current Pulumi project context: the selected stack's organization, the project name from `Pulumi.yaml`, and the selected stack name.
+
+When a stack is selected, you can usually call:
+
+```bash
+pulumi cloud api ListOrganizationMembers
+```
+
+and the CLI fills `{orgName}` from the selected stack automatically. When no project context is available, supply the values with `-F`:
+
+```bash
+pulumi cloud api GetStack -F orgName=acme -F projectName=web -F stackName=prod
+```
+
+If a path template and a request body field share a parameter name, the first matching `-F` is consumed for the path. Any subsequent `-F` with the same key is sent in the body, so you can pass `-F` twice to fill both. To keep the body fully separate, use `--body` or `--input` instead.
+
+## Request flags
+
+`pulumi cloud api` accepts a `gh api`-style flag set for shaping the request:
+
+| Flag | Purpose |
+|---|---|
+| `-X` / `--method` | HTTP method. Defaults to `GET`, or `POST` when body fields, `--body`, or `--input` are present. |
+| `-F` / `--field` | Typed `key=value`. Numbers, booleans, and `null` are auto-detected; JSON object/array literals are parsed; `@file` reads from a file and `@-` reads from stdin. Routed as query parameters on `GET`/`HEAD` and as JSON body fields otherwise. |
+| `-f` / `--raw-field` | String `key=value` with no type coercion. Sent verbatim. |
+| `-H` / `--header` | Custom HTTP header `Key: Value` (repeatable). User headers win over the encoder's defaults (`Accept`, `Content-Type`); a user-supplied `Authorization` is dropped to keep the resolved CLI token in place. |
+| `--body` | Inline request body sent verbatim. Mutually exclusive with `--input`. |
+| `--input` | Read the request body from a file; `-` reads from stdin. |
+| `--paginate` | Follow continuation cursors and emit a single combined JSON envelope. Capped at 1000 pages; on truncation, network failure, or cancellation, the partial result is flushed so callers always have something to act on. |
+| `-i` / `--include` | Include the HTTP status line and response headers in the output. |
+| `--silent` | Suppress the response body on success. Errors are still printed. |
+| `--verbose` | Dump the resolved request and the full response to stderr. |
+| `--dry-run` | Print the resolved request without sending it. |
+| `--format` | Drive content negotiation. Default uses the operation's primary response content type (usually JSON). `json` or `markdown` request that format via the `Accept` header — rejected if the operation's spec doesn't declare it. `raw` keeps the operation's default `Accept` and passes the response body through unchanged. |
+
+Both requests and responses use gzip compression in transit. The CLI routes responses by content type: it pretty-prints JSON, passes text and markdown through as-is, and streams binary responses unchanged.
+
+## OpenAPI spec caching
+
+The CLI fetches the OpenAPI spec once from `/api/openapi/pulumi-spec.json` and caches it under `$PULUMI_HOME/cloud-api-cache/<host>/spec.json` for 24 hours. When the cached copy is older than the TTL and a refresh fails (network error, 5xx response), the CLI returns the stale cache along with a stderr warning so transient outages don't break `list` and `describe`.
+
+Pass `--refresh-spec` to any subcommand to force a re-fetch.
+
+## Exit codes and error envelope
+
+`pulumi cloud api` uses the standard [Pulumi CLI exit-code mapping](/docs/iac/cli/exit-codes/). The values it can emit are:
+
+| Exit code | Meaning |
+|----------:|---------|
+| `0` | Success. |
+| `1` | Caller error: bad arguments, no matching operation, missing template variable, or partial pagination. |
+| `2` | Invalid flag combination (for example, `--body` and `--input` together). |
+| `3` | Authentication or authorization failure (missing credentials, `401`, or `403`). |
+| `8` | Operation canceled (`SIGINT` or `SIGTERM`). |
+| `255` | Internal CLI error. |
+
+On failure, the CLI writes errors to stderr as a single-line JSON envelope with a stable `code` field. Agents and scripts can parse the envelope to react to specific failure modes; tests pin the schema so it does not drift between releases.
+
+## Examples
+
+### Basic requests
+
+Inspect the currently authenticated user:
+
+```bash
+pulumi cloud api /api/user
+```
+
+Call by URL path with template variables filled from `-F`:
+
+```bash
+pulumi cloud api /api/orgs/{orgName}/members -F orgName=acme
+```
+
+Call by operation ID — `orgName` is taken from the current Pulumi project:
+
+```bash
+pulumi cloud api ListOrganizationMembers
+```
+
+Pass path variables explicitly when no project context is available:
+
+```bash
+pulumi cloud api GetStack -F orgName=acme -F projectName=web -F stackName=prod
+```
+
+### Bodies and fields
+
+Create a resource via `POST`; body fields are auto-detected from the operation:
+
+```bash
+pulumi cloud api CreateOrgToken -F orgName=acme \
+  -F name=ci-bot -F description="CI deploy token" \
+  -F admin=false -F expires=0
+```
+
+Send a nested JSON body by mixing scalar fields with an inline JSON literal:
+
+```bash
+pulumi cloud api CreateStack -F orgName=acme -F projectName=web \
+  -F stackName=prod -F 'tags={"env":"prod","team":"platform"}'
+```
+
+Pass an entire request body inline, or read it from a file or stdin:
+
+```bash
+pulumi cloud api UpdateStackTags -F orgName=acme -F projectName=web -F stackName=prod \
+  --body '{"env":"prod","team":"platform"}'
+
+pulumi cloud api UpdateStackTags --input ./tags.json
+
+cat tags.json | pulumi cloud api UpdateStackTags --input -
+```
+
+### Filtering and pagination
+
+Filter the JSON response with `jq`:
+
+```bash
+pulumi cloud api /api/user --format=json | jq '.githubLogin'
+```
+
+Walk every page of a paginated endpoint:
+
+```bash
+pulumi cloud api ListUserStacks --paginate | jq -r '.stacks[].stackName'
+```
+
+### Discovery and dry-run
+
+Browse the API surface and inspect a specific operation:
+
+```bash
+pulumi cloud api list --format=json | jq '.operations[] | select(.tag == "Stacks")'
+
+pulumi cloud api describe CreateOrgToken --format=markdown
+```
+
+Preview the resolved request without sending it:
+
+```bash
+pulumi cloud api CreateOrgToken -F orgName=acme \
+  -F name=ci-bot -F description="CI" -F admin=false -F expires=0 --dry-run
+```
+
+## See also
+
+* [`pulumi cloud api` command reference](/docs/iac/cli/commands/pulumi_cloud_api/)
+* [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/)
+* [Pulumi Cloud access tokens](/docs/administration/access-identity/access-tokens/)
+* [Pulumi CLI exit codes](/docs/iac/cli/exit-codes/)

--- a/content/docs/reference/cloud-rest-api/_index.md
+++ b/content/docs/reference/cloud-rest-api/_index.md
@@ -1,6 +1,6 @@
 ---
 title_tag: "Pulumi Cloud: REST API Reference"
-meta_desc: An overview of the Pulumi Cloud REST API for querying organization, stack, state, and other information.
+meta_desc: Overview of the Pulumi Cloud REST API. Query organization, stack, and state data; call any endpoint from the pulumi cloud api CLI.
 title: "REST API Docs"
 h1: Pulumi Cloud REST API
 meta_image: /images/docs/meta-images/docs-meta.png
@@ -25,6 +25,13 @@ aliases:
 ---
 
 {{% cloud-rest-api-intro %}}
+
+## Calling the API
+
+You can call any endpoint two ways:
+
+* **From the CLI** — use [`pulumi cloud api`](/docs/iac/cli/cloud-api/), which inherits your existing CLI credentials, fills `{orgName}`/`{projectName}`/`{stackName}` from the selected stack, and returns a stable JSON error envelope and exit codes that scripts and agents can rely on. Run `pulumi cloud api list` to browse endpoints and `pulumi cloud api describe <path-or-operation-id>` to inspect a specific operation.
+* **Directly over HTTPS** — pair an [access token](/docs/administration/access-identity/access-tokens/) with the standard `Accept` and `Content-Type` headers and call the endpoint with `curl` or any HTTP client.
 
 ## API documentation by category
 

--- a/content/docs/reference/cloud-rest-api/api-basics/_index.md
+++ b/content/docs/reference/cloud-rest-api/api-basics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: API Basics
 title_tag: "Pulumi Cloud REST API: API Basics"
-meta_desc: Learn about the Pulumi Cloud REST API endpoint, authentication, and required headers for making API requests.
+meta_desc: The Pulumi Cloud REST API endpoint, authentication, and required headers, plus equivalent calls from the pulumi cloud api CLI command.
 menu:
     reference:
         parent: cloud-rest-api
@@ -45,3 +45,21 @@ The following headers are required for all operations except where explicitly no
 Accept: application/vnd.pulumi+8
 Content-Type: application/json
 ```
+
+## Calling the API from the CLI
+
+The [`pulumi cloud api`](/docs/iac/cli/cloud-api/) command wraps the REST API so you don't have to assemble the headers, base URL, or path-template variables yourself. It uses the same credentials as the rest of the Pulumi CLI, so any token you already use with `pulumi login` is reused automatically.
+
+For example, the following two calls are equivalent:
+
+```bash
+# Direct HTTPS request
+curl -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
+     -H "Accept: application/vnd.pulumi+8" \
+     https://api.pulumi.com/api/user
+
+# Same call from the Pulumi CLI
+pulumi cloud api /api/user
+```
+
+`pulumi cloud api list` (alias: `ls`) lists every endpoint in the OpenAPI spec, and `pulumi cloud api describe <path-or-operation-id>` prints the parameter, request, and response schemas for a single operation. See the [`pulumi cloud api` guide](/docs/iac/cli/cloud-api/) for the full set of flags, output formats, and the agent-facing error envelope.

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -8,6 +8,12 @@ Pulumi is an open source infrastructure as code platform that lets you use famil
 
 If you are an AI agent or programmatic consumer, start with these endpoints. Each has a copy-pasteable example.
 
+- **Pulumi Cloud REST API (via the CLI)** — call any [Pulumi Cloud REST API](https://www.pulumi.com/docs/reference/cloud-rest-api/) endpoint with [`pulumi cloud api`](https://www.pulumi.com/docs/iac/cli/cloud-api/). The command emits a stable JSON error envelope and stable [exit codes](https://www.pulumi.com/docs/iac/cli/exit-codes/) for agent consumers, and `pulumi cloud api list --format=json` returns the full endpoint catalog. Authentication reuses the existing Pulumi CLI credentials.
+
+      pulumi cloud api list --format=json
+      pulumi cloud api describe <path-or-operation-id> --format=json
+      pulumi cloud api /api/user
+
 - **Cloud registry API** — every published package, version-by-version. Public packages need no auth; set `Authorization: token $PULUMI_ACCESS_TOKEN` for private. Works without the CLI.
 
       # CLI (auto-fills lang/os from project runtime + host OS)


### PR DESCRIPTION
### Proposed changes

Adds documentation for the new `pulumi cloud api` command, a non-interactive CLI for calling any Pulumi Cloud REST API endpoint by path, operation ID, or `METHOD path` row. Includes the `list` (alias `ls`) and `describe` subcommands.

- New narrative guide at `/docs/iac/cli/cloud-api/` covering subcommands, authentication, path-template substitution, the full `gh api`-style flag set, OpenAPI spec caching, exit codes / error envelope, and worked examples.
- Cross-links from the CLI overview, the Cloud REST API landing and API Basics pages, the access-tokens admin page, and the Automation API page (clarifying when to use which programmatic interface).
- New agent-facing entry in `/llms.txt` pointing AI consumers at the stable JSON envelope and exit-code contract.

### Unreleased product version (optional)

Pulumi CLI: lands across pulumi/pulumi#22769, #22770, #22771, #22772 (stacked). Hold this PR until the CLI release that pins all four is cut and the version bump (cf. 62f6ed09d9 pattern) regenerates `content/docs/iac/cli/commands/pulumi_cloud_api*.md`.

### Related issues (optional)

Tracks pulumi/pulumi#22769, #22770, #22771, #22772.