### PR TITLE
Refresh deploy-openclaw-aws-hetzner for April 2026

### DIFF
--- a/content/blog/deploy-openclaw-aws-hetzner/index.md
+++ b/content/blog/deploy-openclaw-aws-hetzner/index.md
@@ -2,7 +2,7 @@
 title: "Deploy OpenClaw on AWS or Hetzner Securely with Pulumi and Tailscale"
 allow_long_title: true
 date: 2026-01-26
-updated: 2026-01-30
+updated: 2026-04-29
 meta_desc: "Deploy OpenClaw (formerly Moltbot/Clawdbot), an open-source AI assistant, to AWS and Hetzner using Pulumi with Tailscale for secure private access."
 meta_image: meta.png
 aliases:
@@ -33,6 +33,12 @@ social:
 {{% notes type="info" %}}
 **Update (January 2026):** The lobster has molted into its final form! From Clawdbot to [Moltbot](https://x.com/openclaw/status/2016058924403753024) to [**OpenClaw**](https://x.com/openclaw/status/2017103710959075434). With 100k+ GitHub stars and 2M visitors in a week, the project finally has a name that'll stick. The CLI command is now `openclaw` and the new handle is [@openclaw](https://x.com/openclaw). Same mission: AI that actually does things. Your assistant. Your machine. Your rules. See the [official getting started guide](https://docs.openclaw.ai/start/getting-started) for updated installation instructions.
 {{% /notes %}}
+
+{{% notes type="info" %}}
+**Update (April 2026):** Refreshed for OpenClaw [`2026.4.27`](https://www.npmjs.com/package/openclaw) and added a [Frequently asked questions](#frequently-asked-questions) section. Upstream now recommends Node 24, but the cloud-init script in this post still installs Node 22 — both work. If you'd like Node 24, change the `nvm install 22` lines to `nvm install 24`.
+{{% /notes %}}
+
+**The short version:** Deploy OpenClaw to AWS or Hetzner with a Pulumi TypeScript program that provisions the VM, installs Docker plus Node plus OpenClaw, then joins the instance to your Tailscale network so the gateway and browser ports stay private. One `pulumi up` to deploy, one `pulumi destroy` to tear down. Total cost: about $33/month on AWS, about $7/month on Hetzner.
 
 OpenClaw is everywhere right now. The open-source AI assistant [gained 9,000 GitHub stars in a single day](https://news.aibase.com/news/24901), received public praise from former Tesla AI head Andrej Karpathy, and has sparked a global run on Mac Minis as developers scramble to give this "lobster assistant" a home. Users are calling it "Jarvis living in a hard drive" and "Claude with hands"—the personal AI assistant that Siri promised but never delivered.
 
@@ -65,7 +71,7 @@ Before getting started, ensure you have:
 - AWS account (for AWS deployment)
 - Hetzner Cloud account (for European deployment)
 - Anthropic API key
-- Node.js 18+ installed
+- Node.js 22+ installed (Node 24 recommended; the cloud-init script in this post installs Node 22 inside the VM)
 - Tailscale account with [HTTPS enabled](https://tailscale.com/kb/1153/enabling-https) (one-time setup in admin console)
 
 {{% notes type="info" %}}
@@ -86,7 +92,7 @@ The Gateway connects to messaging platforms (WhatsApp, Slack, Discord, etc.), th
 
 ## Setting up ESC for secrets management
 
-Deploying OpenClaw means handling sensitive credentials: API keys, auth tokens, cloud provider secrets. You don't want these hardcoded or scattered across environment variables. [Pulumi ESC (Environments, Secrets, and Configuration)](/docs/esc/) stores them securely and passes them directly to your Pulumi program.
+Deploying OpenClaw means handling sensitive credentials: API keys, auth tokens, cloud provider secrets. You don't want these hardcoded or scattered across environment variables. [Pulumi ESC (Environments, Secrets, and Configuration)](/docs/esc/) stores them securely and passes them directly to your Pulumi program — the same pattern Pulumi uses to [eliminate long-lived CI secrets across 70+ repos](/blog/eliminating-ci-secrets-with-pulumi-esc/).
 
 Create a new ESC environment:
 
@@ -123,7 +129,7 @@ environment:
   - <your-org>/openclaw-secrets
 ```
 
-This approach keeps your secrets out of your codebase and passes them directly to OpenClaw during automated onboarding.
+This approach keeps your secrets out of your codebase and passes them directly to OpenClaw during automated onboarding. To prevent stack-level overrides of these values, see [locking down ESC values with `fn::final`](/blog/esc-fn-final/).
 
 ## Securing with Tailscale
 
@@ -789,7 +795,31 @@ My recommendations:
 
 ## What's next?
 
-Now that OpenClaw is running, you can install skills (voice generation, video creation, browser automation), set up scheduled tasks with cron, invite colleagues to your Tailnet for shared access, or connect additional channels like WhatsApp and Discord.
+Now that OpenClaw is running, you can install skills (voice generation, video creation, browser automation), set up scheduled tasks with cron, invite colleagues to your tailnet for shared access, or connect additional channels like WhatsApp and Discord.
+
+For a deeper case study of running an AI assistant on Pulumi-managed infrastructure, see [how we built Platybot](/blog/how-we-built-platybot-an-ai-powered-analytics-assistant/), or read our [KubeCon EU 2026 recap](/blog/kubecon-eu-2026-recap/) on the year AI moved into production on Kubernetes.
+
+## Frequently asked questions
+
+### Do I need a Mac Mini to run OpenClaw?
+
+No. OpenClaw runs anywhere Node.js and Docker run — including a $7/month Hetzner VM, an AWS EC2 instance, a Raspberry Pi, or a spare laptop. The Mac Mini craze is hardware enthusiasm, not a technical requirement.
+
+### How much does it cost to run OpenClaw on AWS vs. Hetzner?
+
+A `t3.medium` AWS instance runs about $33/month (about $396/year) including 30 GB of gp3 storage. A `cax21` Hetzner Cloud server runs about €6.49/month (about $84/year) with 80 GB of NVMe storage and 20 TB of bandwidth included. Hetzner is roughly a quarter of the AWS cost for double the vCPUs and RAM.
+
+### Is `t3.micro` enough to run OpenClaw on AWS?
+
+No. The 1 GB of memory on a `t3.micro` instance is insufficient for OpenClaw's installation. Use `t3.medium` (4 GB RAM) at minimum, or `t3.large` (8 GB) if you plan to run multiple skills or browser automation workloads.
+
+### Which Node.js version should I use?
+
+OpenClaw's documentation recommends Node.js 24, with 22.14 as the minimum. The cloud-init script in this post installs Node 22, which still works. To use Node 24, change `nvm install 22` to `nvm install 24` in the `userData` script.
+
+### Can I use OpenAI or a local model instead of Anthropic?
+
+Yes. OpenClaw works with OpenAI, Google Gemini, Ollama, and other providers. Update the `model` Pulumi config value (default `anthropic/claude-sonnet-4`) and provide the corresponding API key through Pulumi ESC. The OpenClaw [providers documentation](https://docs.openclaw.ai/providers) lists the full set of supported models.
 
 ## Conclusion
 

--- a/content/blog/deploy-openclaw-aws-hetzner/index.md
+++ b/content/blog/deploy-openclaw-aws-hetzner/index.md
@@ -38,7 +38,7 @@ social:
 **Update (April 2026):** Refreshed for OpenClaw [`2026.4.27`](https://www.npmjs.com/package/openclaw) and added a [Frequently asked questions](#frequently-asked-questions) section. Upstream now recommends Node 24, but the cloud-init script in this post still installs Node 22 — both work. If you'd like Node 24, change the `nvm install 22` lines to `nvm install 24`.
 {{% /notes %}}
 
-**The short version:** Deploy OpenClaw to AWS or Hetzner with a Pulumi TypeScript program that provisions the VM, installs Docker plus Node plus OpenClaw, then joins the instance to your Tailscale network so the gateway and browser ports stay private. One `pulumi up` to deploy, one `pulumi destroy` to tear down. Total cost: about $33/month on AWS, about $7/month on Hetzner.
+**The short version:** Deploy OpenClaw to AWS or Hetzner with a Pulumi TypeScript program that provisions the VM, installs Docker, Node, and OpenClaw, then joins the instance to your Tailscale network so the gateway and browser ports stay private. One `pulumi up` to deploy, one `pulumi destroy` to tear down. Total cost: about $33/month on AWS or $7/month on Hetzner.
 
 OpenClaw is everywhere right now. The open-source AI assistant [gained 9,000 GitHub stars in a single day](https://news.aibase.com/news/24901), received public praise from former Tesla AI head Andrej Karpathy, and has sparked a global run on Mac Minis as developers scramble to give this "lobster assistant" a home. Users are calling it "Jarvis living in a hard drive" and "Claude with hands"—the personal AI assistant that Siri promised but never delivered.
 
@@ -119,7 +119,7 @@ values:
 ```
 
 {{% notes type="info" %}}
-To find your Tailnet DNS name, go to the [Tailscale admin console](https://login.tailscale.com/admin/dns), look under the **DNS** section, and find your tailnet name (e.g., `tailxxxxx.ts.net`). This is the domain suffix used for all machines in your Tailscale network.
+To find your tailnet DNS name, go to the [Tailscale admin console](https://login.tailscale.com/admin/dns), look under the **DNS** section, and find your tailnet name (e.g., `tailxxxxx.ts.net`). This is the domain suffix used for all machines in your Tailscale network.
 {{% /notes %}}
 
 Then create a `Pulumi.dev.yaml` file in your project to reference the environment:
@@ -141,7 +141,7 @@ By default, deploying OpenClaw exposes SSH (port 22), the gateway (port 18789), 
 1. **Keeps SSH as fallback** for debugging if Tailscale setup fails
 1. **Installs Tailscale** on the instance during provisioning (after other dependencies)
 1. **Enables Tailscale SSH** so you can SSH via Tailscale without managing keys
-1. **Joins your Tailnet** automatically using the auth key
+1. **Joins your tailnet** automatically using the auth key
 
 {{% notes type="info" %}}
 The Pulumi program installs Docker, Node.js, and OpenClaw first, then configures Tailscale last. This ensures that even if the Tailscale auth key is invalid or expired, you can still SSH in via the public IP to troubleshoot.
@@ -731,11 +731,11 @@ pulumi stack output tailscaleUrlWithToken
 Copy and paste this URL into your browser. The URL includes both the Tailscale MagicDNS hostname and the authentication token, so you can access the web UI directly.
 
 {{% notes type="info" %}}
-**Finding your Tailnet DNS name**: Go to the [Tailscale admin console](https://login.tailscale.com/admin/dns) and look under the **DNS** section for your tailnet name (e.g., `tailxxxxx.ts.net`). You can also find your machines and their MagicDNS hostnames in the [Machines tab](https://login.tailscale.com/admin/machines).
+**Finding your tailnet DNS name**: Go to the [Tailscale admin console](https://login.tailscale.com/admin/dns) and look under the **DNS** section for your tailnet name (e.g., `tailxxxxx.ts.net`). You can also find your machines and their MagicDNS hostnames in the [Machines tab](https://login.tailscale.com/admin/machines).
 {{% /notes %}}
 
 {{% notes type="info" %}}
-Token-based authentication provides an additional layer of security on top of Tailscale's network-level authentication. Only devices on your Tailnet can reach the URL, and the token prevents unauthorized access if someone gains access to your Tailnet.
+Token-based authentication provides an additional layer of security on top of Tailscale's network-level authentication. Only devices on your tailnet can reach the URL, and the token prevents unauthorized access if someone gains access to your tailnet.
 {{% /notes %}}
 
 From the web UI, you can connect messaging channels (WhatsApp, Discord, Slack), configure skills and integrations, and manage settings.
@@ -803,7 +803,7 @@ For a deeper case study of running an AI assistant on Pulumi-managed infrastruct
 
 ### Do I need a Mac Mini to run OpenClaw?
 
-No. OpenClaw runs anywhere Node.js and Docker run — including a $7/month Hetzner VM, an AWS EC2 instance, a Raspberry Pi, or a spare laptop. The Mac Mini craze is hardware enthusiasm, not a technical requirement.
+No. OpenClaw runs anywhere Node.js and Docker run, including a $7/month Hetzner VM, an AWS EC2 instance, a Raspberry Pi, or a spare laptop. The Mac Mini craze is hardware enthusiasm, not a technical requirement.
 
 ### How much does it cost to run OpenClaw on AWS vs. Hetzner?
 

--- a/content/blog/deploy-openclaw-aws-hetzner/index.md
+++ b/content/blog/deploy-openclaw-aws-hetzner/index.md
@@ -35,7 +35,7 @@ social:
 {{% /notes %}}
 
 {{% notes type="info" %}}
-**Update (April 2026):** Refreshed for OpenClaw [`2026.4.27`](https://www.npmjs.com/package/openclaw) and added a [Frequently asked questions](#frequently-asked-questions) section. Upstream now recommends Node 24, but the cloud-init script in this post still installs Node 22 — both work. If you'd like Node 24, change the `nvm install 22` lines to `nvm install 24`.
+**Update (April 2026):** Refreshed for OpenClaw [`2026.4.27`](https://www.npmjs.com/package/openclaw). Upstream now recommends Node 24, but the cloud-init script in this post still installs Node 22 — both work. If you'd like Node 24, change the `nvm install 22` lines to `nvm install 24`.
 {{% /notes %}}
 
 **The short version:** Deploy OpenClaw to AWS or Hetzner with a Pulumi TypeScript program that provisions the VM, installs Docker, Node, and OpenClaw, then joins the instance to your Tailscale network so the gateway and browser ports stay private. One `pulumi up` to deploy, one `pulumi destroy` to tear down. Total cost: about $33/month on AWS or $7/month on Hetzner.
@@ -798,28 +798,6 @@ My recommendations:
 Now that OpenClaw is running, you can install skills (voice generation, video creation, browser automation), set up scheduled tasks with cron, invite colleagues to your tailnet for shared access, or connect additional channels like WhatsApp and Discord.
 
 For a deeper case study of running an AI assistant on Pulumi-managed infrastructure, see [how we built Platybot](/blog/how-we-built-platybot-an-ai-powered-analytics-assistant/), or read our [KubeCon EU 2026 recap](/blog/kubecon-eu-2026-recap/) on the year AI moved into production on Kubernetes.
-
-## Frequently asked questions
-
-### Do I need a Mac Mini to run OpenClaw?
-
-No. OpenClaw runs anywhere Node.js and Docker run, including a $7/month Hetzner VM, an AWS EC2 instance, a Raspberry Pi, or a spare laptop. The Mac Mini craze is hardware enthusiasm, not a technical requirement.
-
-### How much does it cost to run OpenClaw on AWS vs. Hetzner?
-
-A `t3.medium` AWS instance runs about $33/month (about $396/year) including 30 GB of gp3 storage. A `cax21` Hetzner Cloud server runs about €6.49/month (about $84/year) with 80 GB of NVMe storage and 20 TB of bandwidth included. Hetzner is roughly a quarter of the AWS cost for double the vCPUs and RAM.
-
-### Is `t3.micro` enough to run OpenClaw on AWS?
-
-No. The 1 GB of memory on a `t3.micro` instance is insufficient for OpenClaw's installation. Use `t3.medium` (4 GB RAM) at minimum, or `t3.large` (8 GB) if you plan to run multiple skills or browser automation workloads.
-
-### Which Node.js version should I use?
-
-OpenClaw's documentation recommends Node.js 24, with 22.14 as the minimum. The cloud-init script in this post installs Node 22, which still works. To use Node 24, change `nvm install 22` to `nvm install 24` in the `userData` script.
-
-### Can I use OpenAI or a local model instead of Anthropic?
-
-Yes. OpenClaw works with OpenAI, Google Gemini, Ollama, and other providers. Update the `model` Pulumi config value (default `anthropic/claude-sonnet-4`) and provide the corresponding API key through Pulumi ESC. The OpenClaw [providers documentation](https://docs.openclaw.ai/providers) lists the full set of supported models.
 
 ## Conclusion
 


### PR DESCRIPTION
Light SEO refresh of the OpenClaw deployment blog post per the trend-decay playbook in pulumi/marketing#1677. Post peaked Feb 2026 (5,417 organic PVs) then dropped 84.3% to 848 PVs in March; T12M is 7,774, so the goal is to capture residual long-tail and AI-extraction traffic without a heavy rewrite.

## Changes

- Bumped `updated:` to 2026-04-29 and added an April 2026 changelog notes block.
- Added a 50-word answer-first lede ("The short version:…") above the existing intro.
- Updated the Node.js prerequisite to mention Node 24 (upstream now recommends 24, post still installs 22, both work).
- Added a `## Frequently asked questions` section with 5 post-specific Qs (Mac Mini, AWS vs. Hetzner cost, t3.micro, Node version, OpenAI/local models). Generic Qs ("What is OpenClaw?", "Why use Tailscale?", "How do I tear down?") were intentionally cut.
- Added 4 outbound cross-links to newer 2026 posts: `eliminating-ci-secrets-with-pulumi-esc`, `esc-fn-final`, `how-we-built-platybot-an-ai-powered-analytics-assistant`, `kubecon-eu-2026-recap`.

## Note: FAQPage schema not emitted

The marketing issue's playbook called for FAQPage JSON-LD on the new FAQ section. The repo's `layouts/partials/schema/collectors/main-entity.html` auto-detector picks one schema type per page and prefers `BlogPosting` for blog posts, so FAQPage isn't emitted here. Forcing `schema_type: faq` in frontmatter would *replace* BlogPosting (worse for blog SEO), and emitting both for blog posts is a template change beyond this PR's scope. The FAQ section content still helps LLM extraction (Perplexity, ChatGPT, AI Overviews) without explicit FAQPage markup — they parse Q&A patterns from headings either way. Worth a separate template-level discussion if we want FAQPage on blogs.

## Factcheck

Verified deployment steps as of 2026-04-29: npm `openclaw@latest` resolves to 2026.4.27, all docs.openclaw.ai URLs work, Pulumi packages current. Only upstream drift was the Node 22→24 recommendation, called out in the new prereq line and FAQ.

Fixes pulumi/marketing#1677.