### PR TITLE
[deployments] Document PULUMI_CI_OPERATION env var

### DIFF
--- a/content/docs/deployments/deployments/using/settings.md
+++ b/content/docs/deployments/deployments/using/settings.md
@@ -179,6 +179,7 @@ By default, there are a set of environment variables set by the process automati
 - `PULUMI_CI_ORGANIZATION`: Current account organization
 - `PULUMI_CI_PROJECT`: Current project name
 - `PULUMI_CI_STACK`: Current stack name
+- `PULUMI_CI_OPERATION`: Current Pulumi operation (`update`, `preview`, `destroy`, `refresh`, `detect-drift`, or `remediate-drift`)
 
 These can be overridden or extended by configuring custom environment variables:
 


### PR DESCRIPTION
Add `PULUMI_CI_OPERATION` to the list of `PULUMI_CI_*` environment
variables exposed by the Deployments runner. The variable is populated
with the current Pulumi operation (`update`, `preview`, `destroy`,
`refresh`, `detect-drift`, or `remediate-drift`), letting pre-run scripts
branch on the operation type without parsing the OIDC token.

Fixes https://github.com/pulumi/pulumi-service/issues/42210
