### PR TITLE
Document PULUMI_TFE_DOMAIN for self-hosted operators

### DIFF
--- a/content/docs/administration/self-hosting/components/api.md
+++ b/content/docs/administration/self-hosting/components/api.md
@@ -75,6 +75,7 @@ between the API and the database. The API also supports [exporting OpenTelemetry
 | PULUMI_DATABASE_NAME     | The name of the database on the database server.                                                                                             |
 | PULUMI_API_DOMAIN        | The internet or network-local domain using which the API service can be reached, e.g. `pulumiapi.acmecorp.com`. Default is `localhost:8080`. |
 | PULUMI_CONSOLE_DOMAIN    | The internet or network-local domain using which the Console can be reached, e.g. `pulumiconsole.acmecorp.com`. Default is `localhost:3000`. |
+| PULUMI_TFE_DOMAIN        | (Optional) The domain for the TFE-compatible state backend API, e.g. `tfe.acmecorp.com`. When set, the service exposes a Terraform/OpenTofu-compatible state API on this domain at `/api/v2`. When unset, the TFE-compatible API is disabled. Requires a DNS record pointing this domain at the same load balancer as the API. |
 | PULUMI_ENGINE_EVENTS_SCHEMA_V2 | Set this environment variable to `true` for fresh installs. **If you have an existing installation and the environment variable is currently not set or set to `false`, contact [Pulumi support](/support/) before setting it to `true`.** |
 | PULUMI_ENGINE_EVENTS_LEGACY_WRITE | Set this environment variable to `false` for fresh installs. **If you have an existing installation and the environment variable is currently not set or set to `true` in your installation, contact [Pulumi support](/support/) before setting it to `false`.** |
 

--- a/content/docs/administration/self-hosting/operations/networking.md
+++ b/content/docs/administration/self-hosting/operations/networking.md
@@ -68,7 +68,8 @@ When scaling in or deploying updates, ensure containers have time to finish in-f
 
 ## DNS
 
-Configure two DNS records pointing to your load balancer:
+Configure DNS records pointing to your load balancer:
 
 - `api.{domain}` - for CLI and API access
 - `app.{domain}` - for web console access
+- `tfe.{domain}` - (optional) for the TFE-compatible state backend API, required only if [`PULUMI_TFE_DOMAIN`](/docs/administration/self-hosting/components/api/#environment-variables-for-core-infrastructure) is set


### PR DESCRIPTION
## Summary

- Add `PULUMI_TFE_DOMAIN` to the self-hosted API component env vars table (`components/api.md`)
- Add optional `tfe.{domain}` DNS record to the networking operations guide (`operations/networking.md`)

Companion to https://github.com/pulumi/pulumi-service/pull/42418 which moves the TFE-compatible state API to a dedicated subdomain. Self-hosted operators need to know about the new env var to enable the feature and the DNS record to route traffic.

## Test plan

- [ ] Verify rendered markdown looks correct in the Hugo preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)