### PR TITLE
Update home-page Cypress tests for new main nav

### DIFF
--- a/cypress/e2e/site.cy.js
+++ b/cypress/e2e/site.cy.js
@@ -20,28 +20,27 @@ describe("www.pulumi.com", () => {
     describe("home page", () => {
 
         beforeEach(() => {
+            // Force a desktop viewport so the new nav's desktop affordances render
+            // (the nav-desktop breakpoint is 1200px).
+            cy.viewport(1280, 800);
             cy.visit("/");
         });
 
         it("loads and applies CSS", () => {
             // Checking the computed background-color value validates that the CSS bundle
             // was properly loaded and applied.
-            cy.get(".header-container")
+            cy.get("header.sticky")
                 .invoke("css", "background-color")
                 .should("equal", "rgb(255, 255, 255)");
         });
 
         it("loads and applies JavaScript", () => {
-            // Checking the carousel validates that the JS bundle was loaded and applied
-            // (excluding Stencil components, which are bundled separately).
-            cy.get(".header-container")
-                .should("not.have.class", "is-pinned");
-
-            cy.wait(6000)
-            cy.scrollTo(0, 250);
-
-            cy.get(".header-container")
-                .should("have.class", "is-pinned");
+            // Clicking a nav trigger button toggles aria-expanded via the header-nav
+            // bundle's click handler — proves that bundle was loaded and ran.
+            cy.get("[data-nav-trigger-button]").first()
+                .should("have.attr", "aria-expanded", "false")
+                .click()
+                .should("have.attr", "aria-expanded", "true");
         });
     });
 


### PR DESCRIPTION
### Proposed changes

The new main nav replaced `.header-container` on the home page with a Tailwind-styled `<header class="sticky ... bg-white">` and dropped the JS-driven `is-pinned` scroll behavior in favor of pure CSS sticky, which broke the home-page Cypress tests in CI. This PR updates the CSS check to target `header.sticky` and replaces the `is-pinned` scroll assertion with a click on `[data-nav-trigger-button]` that confirms `aria-expanded` flips — proving `header-nav.js` loaded and ran. Also forces a 1280×800 viewport so the desktop nav (which only renders at ≥1200px) is present.

Verified locally against `make serve`: all 3 specs in `site.cy.js` pass.