### PR TITLE
fix(customer-logos): point partials at fingerprinted assets after #18762

### DIFF
--- a/layouts/partials/customer-logos/aptos.html
+++ b/layouts/partials/customer-logos/aptos.html
@@ -1,1 +1,1 @@
-<img src="/logos/customers/aptos.png" alt="Aptos" />
+{{ partial "fingerprinted-img.html" (dict "src" "/logos/customers/aptos.png" "alt" "Aptos") }}

--- a/layouts/partials/customer-logos/atlassian.html
+++ b/layouts/partials/customer-logos/atlassian.html
@@ -1,1 +1,1 @@
-<img src="/logos/customers/atlassian-wordmark.svg" alt="Atlassian" />
+{{ partial "fingerprinted-img.html" (dict "src" "/logos/customers/atlassian-wordmark.svg" "alt" "Atlassian") }}

--- a/layouts/partials/customer-logos/compostable-ai.html
+++ b/layouts/partials/customer-logos/compostable-ai.html
@@ -1,1 +1,1 @@
-<img class="h-full" src="/logos/customers/compostable-ai.svg" alt="Compostable AI" />
+{{ partial "fingerprinted-img.html" (dict "src" "/logos/customers/compostable-ai.svg" "alt" "Compostable AI" "class" "h-full") }}

--- a/layouts/partials/customer-logos/elkjop-nordic.html
+++ b/layouts/partials/customer-logos/elkjop-nordic.html
@@ -1,1 +1,1 @@
-<img width="180" height="60" src="/logos/customers/elkjop-nordic-logo.svg" alt="Elkjop Nordic" class="m-auto" />
+{{ partial "fingerprinted-img.html" (dict "src" "/logos/customers/elkjop-nordic-logo.svg" "alt" "Elkjop Nordic" "class" "m-auto" "width" "180" "height" "60") }}

--- a/layouts/partials/customer-logos/greenpark-sports.html
+++ b/layouts/partials/customer-logos/greenpark-sports.html
@@ -1,1 +1,1 @@
-<img src="/logos/customers/greenpark-sports-wordmark.png" alt="GreenPark Sports" class="m-auto" />
+{{ partial "fingerprinted-img.html" (dict "src" "/logos/customers/greenpark-sports-wordmark.png" "alt" "GreenPark Sports" "class" "m-auto") }}

--- a/layouts/partials/customer-logos/spearAI.html
+++ b/layouts/partials/customer-logos/spearAI.html
@@ -1,1 +1,1 @@
-<img class="h-full" src="/logos/customers/spearAI.svg" alt="Spear AI" />
+{{ partial "fingerprinted-img.html" (dict "src" "/logos/customers/spearAI.svg" "alt" "Spear AI" "class" "h-full") }}

--- a/layouts/partials/customer-logos/supabase.html
+++ b/layouts/partials/customer-logos/supabase.html
@@ -1,1 +1,1 @@
-<img src="/logos/customers/supabase-wordmark.svg" alt="Supabase" />
+{{ partial "fingerprinted-img.html" (dict "src" "/logos/customers/supabase-wordmark.svg" "alt" "Supabase") }}

--- a/layouts/partials/customer-logos/washington-trust.html
+++ b/layouts/partials/customer-logos/washington-trust.html
@@ -1,1 +1,1 @@
-<img src="/logos/customers/washington-trust-wordmark.svg" alt="Washington Trust Bank" />
+{{ partial "fingerprinted-img.html" (dict "src" "/logos/customers/washington-trust-wordmark.svg" "alt" "Washington Trust Bank") }}


### PR DESCRIPTION
## Summary

PR #18762 moved several customer logos from `static/logos/customers/` to `assets/fingerprinted/logos/customers/`, but left the inline partials in `layouts/partials/customer-logos/` hardcoding the old `/logos/customers/...` paths. Those paths now **404 on the live site**.

Concretely: the Atlassian and Elkjop logos are broken on `/gads/chef/` and any other gads landing page that references them in `case_studies`. The `customer-logo.html` dispatcher tries `fingerprinted/logos/customers/<key>.svg` first, but for these eight customers the YAML key (e.g. `atlassian`) doesn't match the filename (`atlassian-wordmark.svg`), so it falls back to the broken inline partial.

## Fix

Updated 8 partials to render via the existing `fingerprinted-img.html` partial so they resolve to the new fingerprinted asset paths:

- `atlassian`, `elkjop-nordic`, `aptos`, `compostable-ai`, `greenpark-sports`, `spearAI`, `supabase`, `washington-trust`

Verified locally that `/gads/chef/` now serves the Atlassian and Elkjop logos via fingerprinted paths (200 instead of 404).

## Test plan

- [ ] CI passes
- [ ] Spot-check `/gads/chef/` (Atlassian + Elkjop logos in social-proof + case-studies)
- [ ] Spot-check any non-gads page that uses `aptos`, `compostable-ai`, `greenpark-sports`, `spearAI`, `supabase`, or `washington-trust` logos

🤖 Generated with [Claude Code](https://claude.com/claude-code)