### PR TITLE
fix(templates): restore missing space in "Available in" line

### DIFF
--- a/layouts/partials/templates/languages.html
+++ b/layouts/partials/templates/languages.html
@@ -19,14 +19,13 @@
     "yaml" "YAML"
     "bun" "Bun"
 -}}
+{{- $items := slice -}}
+{{- range $languages -}}
+    {{- $key := . | lower -}}
+    {{- $label := index $names $key | default (humanize .) -}}
+    {{- $items = $items | append $label -}}
+{{- end -}}
 <p class="mt-3 mb-0 text-sm text-gray-700 dark:text-gray-400">
-    Available in
-    {{- $items := slice -}}
-    {{- range $languages -}}
-        {{- $key := . | lower -}}
-        {{- $label := index $names $key | default (humanize .) -}}
-        {{- $items = $items | append $label -}}
-    {{- end -}}
-    {{ delimit $items ", " }}
+    Available in {{ delimit $items ", " }}
 </p>
 {{- end -}}


### PR DESCRIPTION
## Summary

- The `Available in` byline on template pages was rendering as `Available inTypeScript, Python, Go, C#, YAML` — no space between "in" and the first language.
- Cause: Hugo whitespace-trim markers (`{{-` / `-}}`) around the items range were eating the newline/indentation between the literal `Available in` text and the `{{ delimit }}` call, so they collapsed together at render time.
- Fix: hoist the items computation above the `<p>` so the visible markup is a clean `Available in {{ delimit $items ", " }}`. Behavior is identical otherwise — the partial still no-ops when `template.languages` isn't set.

Affects any page that uses `layouts/templates/template.html` (template index/landing pages under `/content/templates/...`).

## Test plan

- [ ] `make serve` and load a templates page (e.g. `/templates/container-service/`); confirm the byline now reads "Available in TypeScript, Python, Go, C#" with a single space.
- [ ] Confirm a template page without `template.languages` in frontmatter still renders no byline.
- [ ] `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)