### PR TITLE
fix(customer-logos): add intrinsic dimensions to panther.svg

### DIFF
--- a/assets/fingerprinted/logos/customers/panther.svg
+++ b/assets/fingerprinted/logos/customers/panther.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 294.71">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="1500" height="294.71" viewBox="0 0 1500 294.71">
   <defs>
     <style>
       .cls-1 {

--- a/static/logos/customers/panther.svg
+++ b/static/logos/customers/panther.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 294.71">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="1500" height="294.71" viewBox="0 0 1500 294.71">
   <defs>
     <style>
       .cls-1 {


### PR DESCRIPTION
## Summary

The Panther logo rendered as a blank tile in the homepage **Trusted by 4,000+ innovative companies** case-study card carousel (paired with Starburst). The image element was in the DOM with `0 × 0` dimensions.

## Root cause

`panther.svg` declared only a `viewBox` — no `width`/`height` attributes. Combined with the card's `class="max-h-12 w-auto object-contain"` styling, the browser had no intrinsic size to anchor `w-auto` against, and laid the `<img>` out at zero. Other carousel logos (lemonade, snowflake, unity, etc.) all carry explicit `width`/`height`, which is why they rendered fine.

## Fix

Added intrinsic `width="1500" height="294.71"` to match the existing `viewBox`. Updated both copies (`assets/fingerprinted/...` and `static/...`) so they stay in sync.

## Test plan

- [ ] Run `make serve`, hard-refresh `/`, scroll to the **Trusted by 4,000+ innovative companies** section, and confirm the Panther wordmark renders in the half-card next to Starburst
- [ ] Verify the new fingerprinted URL (`panther.<hash>.svg`) returns HTTP 200 and serves the updated SVG
- [ ] Spot-check `/case-studies/panther-labs/` — same logo asset is referenced from the case-study hero