### PR TITLE
Improve header nav keyboard and screen reader accessibility

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,11 +2,12 @@
 <html lang="en-US" prefix="og: http://ogp.me/ns#">
     {{ partial "head.html" . }}
     <body class="section-{{ .Section }}">
+        <a href="#main" class="fixed left-2 top-2.5 z-[100] inline-flex h-9 -translate-y-16 items-center rounded-lg border border-gray-200 bg-white px-4 text-sm font-regular text-gray-950 no-underline outline-none transition-all hover:border-gray-300 focus:translate-y-0 focus-visible:border-violet-400 focus-visible:ring-3 focus-visible:ring-violet-400/50">Skip to main content</a>
         <pulumi-root></pulumi-root>
         {{ partial "header.html" . }}
         {{ block "hero" . }}
         {{ end }}
-        <main>
+        <main id="main" tabindex="-1" class="focus:outline-none">
             {{ block "main" . }}
             {{ end }}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="en-US" prefix="og: http://ogp.me/ns#">
     {{ partial "head.html" . }}
     <body class="section-{{ .Section }}">
-        <a href="#main" class="fixed left-2 top-2.5 z-[100] inline-flex h-9 -translate-y-16 items-center rounded-lg border border-gray-200 bg-white px-4 text-sm font-regular text-gray-950 no-underline outline-none transition-all hover:border-gray-300 focus:translate-y-0 focus-visible:border-violet-400 focus-visible:ring-3 focus-visible:ring-violet-400/50">Skip to main content</a>
+        <a href="#main" class="fixed left-2 top-2.5 z-[100] inline-flex h-9 -translate-y-16 items-center rounded-lg border border-gray-200 bg-white px-4 text-sm font-regular text-gray-950 no-underline outline-none hover:border-gray-300 focus:translate-y-0 focus-visible:border-violet-400 focus-visible:ring-3 focus-visible:ring-violet-400/50">Skip to main content</a>
         <pulumi-root></pulumi-root>
         {{ partial "header.html" . }}
         {{ block "hero" . }}

--- a/layouts/partials/header/nav-desktop.html
+++ b/layouts/partials/header/nav-desktop.html
@@ -9,7 +9,6 @@
             data-nav-trigger-button
             data-nav-index="{{ $dropdownIdx }}"
             aria-expanded="false"
-            aria-haspopup="menu"
             aria-controls="nav-desktop-popup"
             class="group/trigger inline-flex h-9 items-center rounded-md px-4 py-2 text-sm font-regular text-gray-950 whitespace-nowrap outline-none transition-all hover:bg-gray-100/70 focus:bg-gray-100/70 focus-visible:ring-3 focus-visible:ring-violet-400/50 focus-visible:outline-1 data-[open=true]:bg-gray-100/70">
             {{ $item.label }}
@@ -19,7 +18,7 @@
         {{ else }}
           <a href="{{ $item.href }}"
             {{ with $item.track }}data-track="{{ . }}"{{ end }}
-            class="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-regular text-gray-950 whitespace-nowrap transition-all hover:bg-gray-100/70 focus:bg-gray-100/70 focus-visible:ring-3 focus-visible:ring-violet-400/50">
+            class="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-regular text-gray-950 whitespace-nowrap outline-none transition-all hover:bg-gray-100/70 focus:bg-gray-100/70 focus-visible:ring-3 focus-visible:ring-violet-400/50 focus-visible:outline-1">
             {{ $item.label }}
           </a>
         {{ end }}

--- a/layouts/partials/header/nav-mobile-sheet.html
+++ b/layouts/partials/header/nav-mobile-sheet.html
@@ -23,7 +23,7 @@
   <div class="flex flex-col gap-1.5 p-4">
     <h2 id="nav-mobile-sheet-title" class="sr-only">Navigation</h2>
     <button type="button" data-nav-sheet-close aria-label="Close navigation"
-      class="absolute top-4 right-4 inline-flex size-8 items-center justify-center rounded-md text-gray-950 transition-all hover:bg-gray-100/70 focus-visible:ring-3 focus-visible:ring-violet-400/50">
+      class="absolute top-4 right-4 inline-flex size-8 items-center justify-center rounded-md text-gray-950 outline-none transition-all hover:bg-gray-100/70 focus-visible:ring-3 focus-visible:ring-violet-400/50 focus-visible:outline-1 focus-visible:outline-transparent">
       {{ partial "icon.html" (dict "name" "x" "class" "size-4") }}
     </button>
   </div>
@@ -36,11 +36,11 @@
           <button type="button" data-nav-collapsible-trigger
             aria-expanded="false"
             aria-controls="{{ $panelId }}"
-            class="group flex w-full items-center justify-between px-3 py-4 text-base font-semibold text-gray-950 transition-colors hover:text-violet-700 focus-visible:text-violet-700 focus-visible:outline-none">
+            class="group flex w-full items-center justify-between rounded-md px-3 py-4 text-base font-semibold text-gray-950 outline-none transition-colors hover:text-violet-700 focus-visible:text-violet-700 focus-visible:ring-3 focus-visible:ring-violet-400/50 focus-visible:outline-1">
             {{ $item.label }}
             {{ partial "icon.html" (dict "name" "caret-down" "weight" "bold" "class" "size-4 transition-transform duration-200 [[data-open=true]_&]:rotate-180") }}
           </button>
-          <div data-nav-collapsible-panel data-state="closed"
+          <div data-nav-collapsible-panel data-state="closed" inert
             id="{{ $panelId }}"
             class="overflow-hidden max-h-0 opacity-0 transition-all duration-200
                    data-[state=open]:max-h-[2000px] data-[state=open]:opacity-100">
@@ -65,7 +65,7 @@
       {{ else }}
         <a href="{{ $item.href }}" data-nav-sheet-close
           {{ with $item.track }}data-track="{{ . }}"{{ end }}
-          class="block border-b border-gray-100 px-3 py-4 text-base font-semibold text-gray-950 transition-colors hover:text-violet-700 focus-visible:text-violet-700 focus-visible:outline-none">
+          class="block rounded-md border-b border-gray-100 px-3 py-4 text-base font-semibold text-gray-950 outline-none transition-colors hover:text-violet-700 focus-visible:text-violet-700 focus-visible:ring-3 focus-visible:ring-violet-400/50 focus-visible:outline-1">
           {{ $item.label }}
         </a>
       {{ end }}
@@ -75,7 +75,6 @@
   <div class="flex flex-col gap-2 border-t border-gray-100 p-4">
      <a href="{{ $nav.cta.contact.href }}"
       {{ with $nav.cta.contact.track }}data-track="{{ . }}"{{ end }}
-      data-nav-loggedout
       class="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 text-sm font-regular text-gray-950 shadow-xs transition-all hover:border-gray-300">
       {{ $nav.cta.contact.label }}
     </a>

--- a/layouts/partials/header/nav-mobile-trigger.html
+++ b/layouts/partials/header/nav-mobile-trigger.html
@@ -2,6 +2,6 @@
 <button type="button" data-nav-sheet-trigger aria-label="Open navigation"
   aria-expanded="false"
   aria-controls="nav-mobile-sheet"
-  class="inline-flex size-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-950 shadow-xs transition-all hover:border-gray-300 focus-visible:ring-3 focus-visible:ring-violet-400/50">
+  class="inline-flex size-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-950 shadow-xs outline-none transition-all hover:border-gray-300 focus-visible:ring-3 focus-visible:ring-violet-400/50 focus-visible:outline-1 focus-visible:outline-transparent">
   {{ partial "icon.html" (dict "name" "list" "class" "size-4") }}
 </button>

--- a/layouts/partials/header/nav.html
+++ b/layouts/partials/header/nav.html
@@ -6,7 +6,7 @@
   <div class="flex h-16 items-center justify-between gap-4 px-4 md:px-6">
 
     <a href="/" data-track="header-pulumi-logo"
-       class="flex shrink-0 items-center rounded-md transition-opacity hover:opacity-80 focus-visible:ring-3 focus-visible:ring-violet-400/50 focus-visible:outline-1"
+       class="flex shrink-0 items-center rounded-md transition-opacity hover:opacity-80 focus-visible:ring-3 focus-visible:ring-violet-400/50 focus-visible:ring-offset-4 focus-visible:outline-1 focus-visible:outline-transparent"
        aria-label="Pulumi home">
       {{ partial "fingerprinted-img.html" (dict "src" "logos/brand/logo-on-white.svg" "alt" "Pulumi logo" "class" "h-7 w-auto") }}
     </a>

--- a/theme/src/ts/header-nav.ts
+++ b/theme/src/ts/header-nav.ts
@@ -17,6 +17,12 @@
   const contentPanels: HTMLElement[] = navRoot
     ? Array.from(navRoot.querySelectorAll<HTMLElement>('[data-nav-content]'))
     : [];
+  // All top-level nav items in visual order — dropdown triggers AND plain
+  // links — so forward-Tab out of a popup can land on a plain link that
+  // sits between dropdowns instead of skipping it.
+  const topLevelItems: HTMLElement[] = navRoot
+    ? Array.from(navRoot.querySelectorAll<HTMLElement>(':scope > ul > li > a[href], :scope > ul > li > button[data-nav-trigger-button]'))
+    : [];
 
   let currentIdx = -1;
   let isOpen = false;
@@ -110,7 +116,8 @@
 
   // Slide new content in, old content out, rest hidden.
   // Non-active panels get pointer-events:none so their (invisible) stacked
-  // children don't intercept clicks meant for the active panel.
+  // children don't intercept clicks meant for the active panel, and `inert`
+  // so their links are skipped by Tab and removed from the a11y tree.
   function slideContent(nextIdx: number, prevIdx: number): void {
     const dir = prevIdx >= 0 && prevIdx < nextIdx ? 1 : -1;
     contentPanels.forEach((c, i) => {
@@ -119,6 +126,7 @@
         c.style.opacity = '0';
         c.style.transform = `translateX(${dir * SLIDE_PX}px)`;
         c.style.pointerEvents = 'auto';
+        c.removeAttribute('inert');
         c.offsetHeight; // reflow
         c.style.transition = `opacity ${DUR_MORPH} ${EASE}, transform ${DUR_MORPH} ${EASE}`;
         c.style.opacity = '1';
@@ -128,13 +136,21 @@
         c.style.opacity = '0';
         c.style.transform = `translateX(${-dir * SLIDE_PX}px)`;
         c.style.pointerEvents = 'none';
+        c.setAttribute('inert', '');
       } else {
         c.style.transition = 'none';
         c.style.opacity = '0';
         c.style.transform = 'translateX(0)';
         c.style.pointerEvents = 'none';
+        c.setAttribute('inert', '');
       }
     });
+  }
+
+  function panelItems(idx: number): HTMLElement[] {
+    const panel = contentPanels[idx];
+    if (!panel) return [];
+    return Array.from(panel.querySelectorAll<HTMLElement>('a[href], button:not([disabled])'));
   }
 
   function popupLeftFor(idx: number): number {
@@ -264,8 +280,28 @@
 
       btn.addEventListener('keydown', (e: KeyboardEvent) => {
         if (e.key === 'Escape') {
-          closeDropdowns(true);
-          btn.focus();
+          if (isOpen) closeDropdowns(true);
+          return;
+        }
+        if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          if (isOpen && currentIdx === idx) {
+            if (e.key === 'ArrowDown') {
+              panelItems(idx)[0]?.focus();
+            } else {
+              closeDropdowns(true);
+            }
+          } else {
+            openDropdown(idx);
+            panelItems(idx)[0]?.focus();
+          }
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          if (!isOpen || currentIdx !== idx) openDropdown(idx);
+          const items = panelItems(idx);
+          items[items.length - 1]?.focus();
         }
       });
     });
@@ -276,6 +312,63 @@
 
     popup.addEventListener('mouseleave', () => {
       closeTimer = setTimeout(() => closeDropdowns(false), HOVER_CLOSE_DELAY);
+    });
+
+    popup.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (currentIdx < 0) return;
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        const trigger = triggerBtns[currentIdx];
+        closeDropdowns(true);
+        trigger?.focus();
+        return;
+      }
+      const items = panelItems(currentIdx);
+      if (items.length === 0) return;
+      const activeIdx = items.indexOf(document.activeElement as HTMLElement);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        items[activeIdx >= 0 ? (activeIdx + 1) % items.length : 0].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        items[activeIdx > 0 ? activeIdx - 1 : items.length - 1].focus();
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        items[0].focus();
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        items[items.length - 1].focus();
+      } else if (e.key === 'Tab' && e.shiftKey && activeIdx === 0) {
+        // The popup sits after the triggers in DOM order, so Shift+Tab from
+        // the first item would land on the last trigger — not the one that
+        // opened this menu. Redirect back to the active trigger and close.
+        e.preventDefault();
+        const trigger = triggerBtns[currentIdx];
+        closeDropdowns(true);
+        trigger?.focus();
+      } else if (e.key === 'Tab' && !e.shiftKey && activeIdx === items.length - 1) {
+        // Forward Tab from the last item: close the popup and focus the next
+        // top-level nav item — dropdown trigger or plain link — so we don't
+        // skip plain-link items that sit between dropdowns. If we're at the
+        // last top-level item, fall through to default Tab so focus exits
+        // the nav to the CTAs.
+        const trigger = triggerBtns[currentIdx];
+        const triggerPos = topLevelItems.indexOf(trigger);
+        const nextItem = triggerPos >= 0 ? topLevelItems[triggerPos + 1] : null;
+        if (nextItem) {
+          e.preventDefault();
+          closeDropdowns(true);
+          nextItem.focus();
+        }
+      }
+    });
+
+    // Close when keyboard focus leaves the nav entirely (e.g. Tab past the
+    // last popup item). The popup is the last child of navRoot, so a forward
+    // Tab from the last item naturally exits the nav.
+    navRoot.addEventListener('focusout', (e: FocusEvent) => {
+      const next = e.relatedTarget as Node | null;
+      if (!next || !navRoot.contains(next)) closeDropdowns(false);
     });
 
     document.addEventListener('click', (e: MouseEvent) => {
@@ -294,12 +387,24 @@
   const overlay = document.querySelector<HTMLElement>('[data-nav-sheet-overlay]');
   const navDesktopMql = window.matchMedia('(min-width: 1200px)');
 
+  // Mark every direct child of <body> inert except the sheet and its overlay,
+  // so Tab cannot escape the dialog. The sheet uses role="dialog"
+  // aria-modal="true", but aria-modal alone does not affect focus order.
+  function setBackgroundInert(on: boolean): void {
+    Array.from(document.body.children).forEach(el => {
+      if (el === sheet || el === overlay) return;
+      if (on) el.setAttribute('inert', '');
+      else el.removeAttribute('inert');
+    });
+  }
+
   function openSheet(): void {
     if (!sheet) return;
     sheet.dataset.state = 'open';
     if (overlay) overlay.dataset.state = 'open';
     if (sheetTrigger) sheetTrigger.setAttribute('aria-expanded', 'true');
     document.body.style.overflow = 'hidden';
+    setBackgroundInert(true);
   }
 
   function closeSheet(): void {
@@ -308,6 +413,8 @@
     if (overlay) overlay.dataset.state = 'closed';
     if (sheetTrigger) sheetTrigger.setAttribute('aria-expanded', 'false');
     document.body.style.overflow = '';
+    setBackgroundInert(false);
+    sheetTrigger?.focus();
   }
 
   if (sheetTrigger) sheetTrigger.addEventListener('click', openSheet);
@@ -334,10 +441,12 @@
       if (open) {
         item.removeAttribute('data-open');
         panel.dataset.state = 'closed';
+        panel.setAttribute('inert', '');
         trigger.setAttribute('aria-expanded', 'false');
       } else {
         item.dataset.open = 'true';
         panel.dataset.state = 'open';
+        panel.removeAttribute('inert');
         trigger.setAttribute('aria-expanded', 'true');
       }
     });

--- a/theme/src/ts/header-nav.ts
+++ b/theme/src/ts/header-nav.ts
@@ -280,6 +280,8 @@
 
       btn.addEventListener('keydown', (e: KeyboardEvent) => {
         if (e.key === 'Escape') {
+          // No btn.focus() here: the trigger already has focus. The popup's
+          // own keydown handler handles Escape from inside the popup.
           if (isOpen) closeDropdowns(true);
           return;
         }
@@ -390,12 +392,19 @@
   // Mark every direct child of <body> inert except the sheet and its overlay,
   // so Tab cannot escape the dialog. The sheet uses role="dialog"
   // aria-modal="true", but aria-modal alone does not affect focus order.
+  // Track which elements we modified so closing the sheet doesn't clear
+  // `inert` from body-level elements that another component owns.
+  let bgInerted: Element[] = [];
   function setBackgroundInert(on: boolean): void {
-    Array.from(document.body.children).forEach(el => {
-      if (el === sheet || el === overlay) return;
-      if (on) el.setAttribute('inert', '');
-      else el.removeAttribute('inert');
-    });
+    if (on) {
+      bgInerted = Array.from(document.body.children).filter(
+        el => el !== sheet && el !== overlay && !el.hasAttribute('inert'),
+      );
+      bgInerted.forEach(el => el.setAttribute('inert', ''));
+    } else {
+      bgInerted.forEach(el => el.removeAttribute('inert'));
+      bgInerted = [];
+    }
   }
 
   function openSheet(): void {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Tightens keyboard and screen-reader behavior on the header nav: a skip-to-main-content link, an `inert`-managed Tab order for the desktop popup, mobile sheet, and mobile collapsibles, full Arrow/Home/End/Escape/Tab handling on desktop dropdowns (including correctly walking past plain-link nav items like Docs/Registry/Blog/Pricing on forward Tab), and focus return to the sheet trigger on close. Also drops `aria-haspopup="menu"` since the popup isn't a menu pattern, polishes focus-visible styles, and shows Contact us above Dashboard in the mobile sheet for signed-in users to match the desktop CTAs.

### Unreleased product version (optional)

### Related issues (optional)