### PR TITLE
fix(what-is): make CTA heading and text readable on light background

### DIFF
--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -43,9 +43,9 @@
 <section id="get-started" class="container px-6 lg:px-0 mx-auto my-16">
     <div class="w-full bg-violet-50 card p-6 lg:p-16 lg:pt-24 text-center">
         <div class="max-w-xl mx-auto">
-                <h2 class="text-white hidden lg:block px-0 lg:px-16">Get started today</h2>
-                <h4 class="text-white mt-0 lg:hidden">Get started today</h4>
-                <p class="text-white">Pulumi is open source and free to get started. Deploy your first stack today.</p>
+                <h2 class="text-gray-900 hidden lg:block px-0 lg:px-16">Get started today</h2>
+                <h4 class="text-gray-900 mt-0 lg:hidden">Get started today</h4>
+                <p class="text-gray-700">Pulumi is open source and free to get started. Deploy your first stack today.</p>
                 <div class="mt-16">
                     <a class="btn" href="{{ site.Params.cta.primary.href }}" data-role="cta-get-started">{{ site.Params.cta.primary.label }}</a>
                 </div>


### PR DESCRIPTION
## Summary

- The "Get started today" CTA card at the bottom of `/what-is/*` pages uses a light violet background (`bg-violet-50`), but the heading and paragraph were styled `text-white` — effectively invisible.
- Switch to `text-gray-900` for the heading and `text-gray-700` for the paragraph in [layouts/what-is/single.html](https://github.com/pulumi/docs/blob/alex/fix-what-is-cta-text-contrast/layouts/what-is/single.html) so they're legible.

Reported on https://www.pulumi.com/what-is/what-is-yaml/ and affects every page that uses the `what-is/single.html` layout.

## Test plan

- [ ] Visit a `/what-is/*` page locally (e.g. http://localhost:1313/what-is/what-is-yaml/) and confirm the "Get started today" heading and subheading are visible above the CTA button.
- [ ] Verify both the desktop (`h2`) and mobile (`h4`) variants render in dark text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)