### PR TITLE
docs: rename `pulumi cloud api` to `pulumi api`

### DIFF
--- a/content/docs/administration/access-identity/access-tokens.md
+++ b/content/docs/administration/access-identity/access-tokens.md
@@ -22,7 +22,7 @@ aliases:
 
 Use access tokens to sign into the Pulumi Cloud via the CLI or automate your usage of the Pulumi Cloud using the REST API. Learn more about the REST API in the [Pulumi Cloud REST API docs](/docs/reference/cloud-rest-api/).
 
-The token you use for `pulumi login` also authorizes the [`pulumi cloud api`](/docs/iac/cli/cloud-api/) command, which calls any REST API endpoint directly from the CLI without needing to set the `Authorization` header yourself.
+The token you use for `pulumi login` also authorizes the [`pulumi api`](/docs/iac/cli/api/) command, which calls any REST API endpoint directly from the CLI without needing to set the `Authorization` header yourself.
 
 Pulumi offers three types of access tokens:
 

--- a/content/docs/iac/automation-api/_index.md
+++ b/content/docs/iac/automation-api/_index.md
@@ -28,7 +28,7 @@ Automation API requires the Pulumi CLI to be installed and available in your `PA
 {{% /notes %}}
 
 {{% notes type="tip" %}}
-Automation API drives the Pulumi engine itself, running updates, previews, refreshes, and destroys from a program. If you instead need to read or modify Pulumi Cloud resources (for example, stack metadata, access tokens, or [Insights](/docs/insights/) data) without running a Pulumi program, use [`pulumi cloud api`](/docs/iac/cli/cloud-api/), the CLI command for calling the [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) directly.
+Automation API drives the Pulumi engine itself, running updates, previews, refreshes, and destroys from a program. If you instead need to read or modify Pulumi Cloud resources (for example, stack metadata, access tokens, or [Insights](/docs/insights/) data) without running a Pulumi program, use [`pulumi api`](/docs/iac/cli/api/), the CLI command for calling the [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) directly.
 {{% /notes %}}
 
 ## Getting started

--- a/content/docs/iac/cli/_index.md
+++ b/content/docs/iac/cli/_index.md
@@ -47,7 +47,7 @@ The most common commands in the CLI that you'll be using are as follows:
 * [`pulumi up`](/docs/iac/cli/commands/pulumi_up/): preview and deploy changes to your program and/or infrastructure
 * [`pulumi preview`](/docs/iac/cli/commands/pulumi_preview/): preview your changes explicitly before deploying
 * [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy/): destroy your program and its infrastructure when you're done
-* [`pulumi cloud api`](/docs/iac/cli/cloud-api/): call any [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) endpoint directly from the CLI, with stable exit codes and a JSON error envelope for scripts and agents
+* [`pulumi api`](/docs/iac/cli/api/): call any [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) endpoint directly from the CLI, with stable exit codes and a JSON error envelope for scripts and agents
 
 ## Complete Reference
 

--- a/content/docs/iac/cli/api.md
+++ b/content/docs/iac/cli/api.md
@@ -22,8 +22,8 @@ The command is modeled after [`gh api`](https://cli.github.com/manual/gh_api): y
 `pulumi api` ships in three forms:
 
 * [`pulumi api <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_api/) issues a single HTTP request against the named endpoint.
-* [`pulumi api list`](/docs/iac/cli/commands/pulumi_api_list/) (alias: `ls`) lists every endpoint exposed by the [Pulumi Cloud OpenAPI spec](/docs/reference/cloud-rest-api/). Output is a TTY-friendly table by default; pass `--format=json` to get a stable, scriptable envelope.
-* [`pulumi api describe <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_api_describe/) prints the parameters, request body, and response schemas for a single operation. Default output is a human-readable text render; pass `--format=markdown` for a piping-friendly markdown document or `--format=json` for the stable JSON envelope.
+* [`pulumi api list`](/docs/iac/cli/commands/pulumi_api_list/) (alias: `ls`) lists every endpoint exposed by the [Pulumi Cloud OpenAPI spec](/docs/reference/cloud-rest-api/). Output is a TTY-friendly table by default; pass `--output=json` to get a stable, scriptable envelope.
+* [`pulumi api describe <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_api_describe/) prints the parameters, request body, and response schemas for a single operation. Default output is a human-readable text render; pass `--output=markdown` for a piping-friendly markdown document or `--output=json` for the stable JSON envelope.
 
 ## Authentication
 
@@ -70,7 +70,7 @@ If a path template and a request body field share a parameter name, the first ma
 | `--silent` | Suppress the response body on success. Errors are still printed. |
 | `--verbose` | Dump the resolved request and the full response to stderr. |
 | `--dry-run` | Print the resolved request without sending it. |
-| `--format` | Drive content negotiation. Default uses the operation's primary response content type (usually JSON). `json` or `markdown` request that format via the `Accept` header — rejected if the operation's spec doesn't declare it. `raw` keeps the operation's default `Accept` and passes the response body through unchanged. |
+| `--output` | Drive content negotiation. Default uses the operation's primary response content type (usually JSON). `json` or `markdown` request that format via the `Accept` header — rejected if the operation's spec doesn't declare it. `raw` keeps the operation's default `Accept` and passes the response body through unchanged. |
 
 Both requests and responses use gzip compression in transit. The CLI routes responses by content type: it pretty-prints JSON, passes text and markdown through as-is, and streams binary responses unchanged.
 
@@ -156,7 +156,7 @@ cat tags.json | pulumi api UpdateStackTags --input -
 Filter the JSON response with `jq`:
 
 ```bash
-pulumi api /api/user --format=json | jq '.githubLogin'
+pulumi api /api/user --output=json | jq '.githubLogin'
 ```
 
 Walk every page of a paginated endpoint:
@@ -170,9 +170,9 @@ pulumi api ListUserStacks --paginate | jq -r '.stacks[].stackName'
 Browse the API surface and inspect a specific operation:
 
 ```bash
-pulumi api list --format=json | jq '.operations[] | select(.tag == "Stacks")'
+pulumi api list --output=json | jq '.operations[] | select(.tag == "Stacks")'
 
-pulumi api describe CreateOrgToken --format=markdown
+pulumi api describe CreateOrgToken --output=markdown
 ```
 
 Preview the resolved request without sending it:

--- a/content/docs/iac/cli/api.md
+++ b/content/docs/iac/cli/api.md
@@ -1,37 +1,39 @@
 ---
 title: Calling the Cloud API
 title_tag: "Pulumi CLI: Calling the Pulumi Cloud REST API"
-meta_desc: Use pulumi cloud api to call any Pulumi Cloud REST API endpoint from the CLI, with stable exit codes and a JSON error envelope for scripts and agents.
+meta_desc: Use pulumi api to call any Pulumi Cloud REST API endpoint from the CLI, with stable exit codes and a JSON error envelope for scripts and agents.
 h1: Calling the Pulumi Cloud REST API from the CLI
 menu:
   iac:
     parent: iac-cli
-    identifier: iac-cli-cloud-api
+    identifier: iac-cli-api
     weight: 60
+aliases:
+- /docs/iac/cli/cloud-api/
 meta_image: /images/docs/meta-images/docs-meta.png
 ---
 
-The [`pulumi cloud api`](/docs/iac/cli/commands/pulumi_cloud_api/) command lets you call any [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) endpoint directly from the CLI. It runs non-interactively, is safe to script, and reuses the credentials you already use with `pulumi login`, so you don't need to manage a separate token to call the API.
+The [`pulumi api`](/docs/iac/cli/commands/pulumi_api/) command lets you call any [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/) endpoint directly from the CLI. It runs non-interactively, is safe to script, and reuses the credentials you already use with `pulumi login`, so you don't need to manage a separate token to call the API.
 
 The command is modeled after [`gh api`](https://cli.github.com/manual/gh_api): you pass a path, an operation ID, or a `METHOD path` row and the CLI handles authentication, headers, path-template substitution, and content negotiation for you.
 
 ## Subcommands
 
-`pulumi cloud api` ships in three forms:
+`pulumi api` ships in three forms:
 
-* [`pulumi cloud api <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_cloud_api/) issues a single HTTP request against the named endpoint.
-* [`pulumi cloud api list`](/docs/iac/cli/commands/pulumi_cloud_api_list/) (alias: `ls`) lists every endpoint exposed by the [Pulumi Cloud OpenAPI spec](/docs/reference/cloud-rest-api/). Output is a TTY-friendly table by default; pass `--format=json` to get a stable, scriptable envelope.
-* [`pulumi cloud api describe <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_cloud_api_describe/) prints the parameters, request body, and response schemas for a single operation. Default output is a human-readable text render; pass `--format=markdown` for a piping-friendly markdown document or `--format=json` for the stable JSON envelope.
+* [`pulumi api <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_api/) issues a single HTTP request against the named endpoint.
+* [`pulumi api list`](/docs/iac/cli/commands/pulumi_api_list/) (alias: `ls`) lists every endpoint exposed by the [Pulumi Cloud OpenAPI spec](/docs/reference/cloud-rest-api/). Output is a TTY-friendly table by default; pass `--format=json` to get a stable, scriptable envelope.
+* [`pulumi api describe <path-or-operation-id>`](/docs/iac/cli/commands/pulumi_api_describe/) prints the parameters, request body, and response schemas for a single operation. Default output is a human-readable text render; pass `--format=markdown` for a piping-friendly markdown document or `--format=json` for the stable JSON envelope.
 
 ## Authentication
 
-`pulumi cloud api` uses the same access token as the rest of the Pulumi CLI. Anything that authorizes `pulumi login` — a personal, organization, or team [access token](/docs/administration/access-identity/access-tokens/), `PULUMI_ACCESS_TOKEN`, or an OIDC-issued token — also authorizes API calls.
+`pulumi api` uses the same access token as the rest of the Pulumi CLI. Anything that authorizes `pulumi login` — a personal, organization, or team [access token](/docs/administration/access-identity/access-tokens/), `PULUMI_ACCESS_TOKEN`, or an OIDC-issued token — also authorizes API calls.
 
-If a request requires authentication and the CLI is not authenticated, `pulumi cloud api` exits with code `3` and an error envelope identifying the auth failure. A `401` or `403` response from the API maps to the same exit code.
+If a request requires authentication and the CLI is not authenticated, `pulumi api` exits with code `3` and an error envelope identifying the auth failure. A `401` or `403` response from the API maps to the same exit code.
 
 ## Path-template substitution
 
-Most Pulumi Cloud endpoints take an organization, project, or stack as part of the URL — for example, `/api/orgs/{orgName}/members`. `pulumi cloud api` resolves each template variable in the following order:
+Most Pulumi Cloud endpoints take an organization, project, or stack as part of the URL — for example, `/api/orgs/{orgName}/members`. `pulumi api` resolves each template variable in the following order:
 
 1. A literal value typed directly into the URL (no template variable to fill).
 1. A matching `-F` or `-f` field (consumed for the path and not forwarded as a query or body parameter).
@@ -40,20 +42,20 @@ Most Pulumi Cloud endpoints take an organization, project, or stack as part of t
 When a stack is selected, you can usually call:
 
 ```bash
-pulumi cloud api ListOrganizationMembers
+pulumi api ListOrganizationMembers
 ```
 
 and the CLI fills `{orgName}` from the selected stack automatically. When no project context is available, supply the values with `-F`:
 
 ```bash
-pulumi cloud api GetStack -F orgName=acme -F projectName=web -F stackName=prod
+pulumi api GetStack -F orgName=acme -F projectName=web -F stackName=prod
 ```
 
 If a path template and a request body field share a parameter name, the first matching `-F` is consumed for the path. Any subsequent `-F` with the same key is sent in the body, so you can pass `-F` twice to fill both. To keep the body fully separate, use `--body` or `--input` instead.
 
 ## Request flags
 
-`pulumi cloud api` accepts a `gh api`-style flag set for shaping the request:
+`pulumi api` accepts a `gh api`-style flag set for shaping the request:
 
 | Flag | Purpose |
 |---|---|
@@ -80,7 +82,7 @@ Pass `--refresh-spec` to any subcommand to force a re-fetch.
 
 ## Exit codes and error envelope
 
-`pulumi cloud api` uses the standard [Pulumi CLI exit-code mapping](/docs/iac/cli/exit-codes/). The values it can emit are:
+`pulumi api` uses the standard [Pulumi CLI exit-code mapping](/docs/iac/cli/exit-codes/). The values it can emit are:
 
 | Exit code | Meaning |
 |----------:|---------|
@@ -100,25 +102,25 @@ On failure, the CLI writes errors to stderr as a single-line JSON envelope with 
 Inspect the currently authenticated user:
 
 ```bash
-pulumi cloud api /api/user
+pulumi api /api/user
 ```
 
 Call by URL path with template variables filled from `-F`:
 
 ```bash
-pulumi cloud api /api/orgs/{orgName}/members -F orgName=acme
+pulumi api /api/orgs/{orgName}/members -F orgName=acme
 ```
 
 Call by operation ID — `orgName` is taken from the current Pulumi project:
 
 ```bash
-pulumi cloud api ListOrganizationMembers
+pulumi api ListOrganizationMembers
 ```
 
 Pass path variables explicitly when no project context is available:
 
 ```bash
-pulumi cloud api GetStack -F orgName=acme -F projectName=web -F stackName=prod
+pulumi api GetStack -F orgName=acme -F projectName=web -F stackName=prod
 ```
 
 ### Bodies and fields
@@ -126,7 +128,7 @@ pulumi cloud api GetStack -F orgName=acme -F projectName=web -F stackName=prod
 Create a resource via `POST`; body fields are auto-detected from the operation:
 
 ```bash
-pulumi cloud api CreateOrgToken -F orgName=acme \
+pulumi api CreateOrgToken -F orgName=acme \
   -F name=ci-bot -F description="CI deploy token" \
   -F admin=false -F expires=0
 ```
@@ -134,19 +136,19 @@ pulumi cloud api CreateOrgToken -F orgName=acme \
 Send a nested JSON body by mixing scalar fields with an inline JSON literal:
 
 ```bash
-pulumi cloud api CreateStack -F orgName=acme -F projectName=web \
+pulumi api CreateStack -F orgName=acme -F projectName=web \
   -F stackName=prod -F 'tags={"env":"prod","team":"platform"}'
 ```
 
 Pass an entire request body inline, or read it from a file or stdin:
 
 ```bash
-pulumi cloud api UpdateStackTags -F orgName=acme -F projectName=web -F stackName=prod \
+pulumi api UpdateStackTags -F orgName=acme -F projectName=web -F stackName=prod \
   --body '{"env":"prod","team":"platform"}'
 
-pulumi cloud api UpdateStackTags --input ./tags.json
+pulumi api UpdateStackTags --input ./tags.json
 
-cat tags.json | pulumi cloud api UpdateStackTags --input -
+cat tags.json | pulumi api UpdateStackTags --input -
 ```
 
 ### Filtering and pagination
@@ -154,13 +156,13 @@ cat tags.json | pulumi cloud api UpdateStackTags --input -
 Filter the JSON response with `jq`:
 
 ```bash
-pulumi cloud api /api/user --format=json | jq '.githubLogin'
+pulumi api /api/user --format=json | jq '.githubLogin'
 ```
 
 Walk every page of a paginated endpoint:
 
 ```bash
-pulumi cloud api ListUserStacks --paginate | jq -r '.stacks[].stackName'
+pulumi api ListUserStacks --paginate | jq -r '.stacks[].stackName'
 ```
 
 ### Discovery and dry-run
@@ -168,21 +170,21 @@ pulumi cloud api ListUserStacks --paginate | jq -r '.stacks[].stackName'
 Browse the API surface and inspect a specific operation:
 
 ```bash
-pulumi cloud api list --format=json | jq '.operations[] | select(.tag == "Stacks")'
+pulumi api list --format=json | jq '.operations[] | select(.tag == "Stacks")'
 
-pulumi cloud api describe CreateOrgToken --format=markdown
+pulumi api describe CreateOrgToken --format=markdown
 ```
 
 Preview the resolved request without sending it:
 
 ```bash
-pulumi cloud api CreateOrgToken -F orgName=acme \
+pulumi api CreateOrgToken -F orgName=acme \
   -F name=ci-bot -F description="CI" -F admin=false -F expires=0 --dry-run
 ```
 
 ## See also
 
-* [`pulumi cloud api` command reference](/docs/iac/cli/commands/pulumi_cloud_api/)
+* [`pulumi api` command reference](/docs/iac/cli/commands/pulumi_api/)
 * [Pulumi Cloud REST API](/docs/reference/cloud-rest-api/)
 * [Pulumi Cloud access tokens](/docs/administration/access-identity/access-tokens/)
 * [Pulumi CLI exit codes](/docs/iac/cli/exit-codes/)

--- a/content/docs/reference/cloud-rest-api/_index.md
+++ b/content/docs/reference/cloud-rest-api/_index.md
@@ -1,6 +1,6 @@
 ---
 title_tag: "Pulumi Cloud: REST API Reference"
-meta_desc: Overview of the Pulumi Cloud REST API. Query organization, stack, and state data; call any endpoint from the pulumi cloud api CLI.
+meta_desc: Overview of the Pulumi Cloud REST API. Query organization, stack, and state data; call any endpoint from the pulumi api CLI.
 title: "REST API Docs"
 h1: Pulumi Cloud REST API
 meta_image: /images/docs/meta-images/docs-meta.png
@@ -30,7 +30,7 @@ aliases:
 
 You can call any endpoint two ways:
 
-* **From the CLI** — use [`pulumi cloud api`](/docs/iac/cli/cloud-api/), which inherits your existing CLI credentials, fills `{orgName}`/`{projectName}`/`{stackName}` from the selected stack, and returns a stable JSON error envelope and exit codes that scripts and agents can rely on. Run `pulumi cloud api list` to browse endpoints and `pulumi cloud api describe <path-or-operation-id>` to inspect a specific operation.
+* **From the CLI** — use [`pulumi api`](/docs/iac/cli/api/), which inherits your existing CLI credentials, fills `{orgName}`/`{projectName}`/`{stackName}` from the selected stack, and returns a stable JSON error envelope and exit codes that scripts and agents can rely on. Run `pulumi api list` to browse endpoints and `pulumi api describe <path-or-operation-id>` to inspect a specific operation.
 * **Directly over HTTPS** — pair an [access token](/docs/administration/access-identity/access-tokens/) with the standard `Accept` and `Content-Type` headers and call the endpoint with `curl` or any HTTP client.
 
 ## API documentation by category

--- a/content/docs/reference/cloud-rest-api/api-basics/_index.md
+++ b/content/docs/reference/cloud-rest-api/api-basics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: API Basics
 title_tag: "Pulumi Cloud REST API: API Basics"
-meta_desc: The Pulumi Cloud REST API endpoint, authentication, and required headers, plus equivalent calls from the pulumi cloud api CLI command.
+meta_desc: The Pulumi Cloud REST API endpoint, authentication, and required headers, plus equivalent calls from the pulumi api CLI command.
 menu:
     reference:
         parent: cloud-rest-api
@@ -48,7 +48,7 @@ Content-Type: application/json
 
 ## Calling the API from the CLI
 
-The [`pulumi cloud api`](/docs/iac/cli/cloud-api/) command wraps the REST API so you don't have to assemble the headers, base URL, or path-template variables yourself. It uses the same credentials as the rest of the Pulumi CLI, so any token you already use with `pulumi login` is reused automatically.
+The [`pulumi api`](/docs/iac/cli/api/) command wraps the REST API so you don't have to assemble the headers, base URL, or path-template variables yourself. It uses the same credentials as the rest of the Pulumi CLI, so any token you already use with `pulumi login` is reused automatically.
 
 For example, the following two calls are equivalent:
 
@@ -59,7 +59,7 @@ curl -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
      https://api.pulumi.com/api/user
 
 # Same call from the Pulumi CLI
-pulumi cloud api /api/user
+pulumi api /api/user
 ```
 
-`pulumi cloud api list` (alias: `ls`) lists every endpoint in the OpenAPI spec, and `pulumi cloud api describe <path-or-operation-id>` prints the parameter, request, and response schemas for a single operation. See the [`pulumi cloud api` guide](/docs/iac/cli/cloud-api/) for the full set of flags, output formats, and the agent-facing error envelope.
+`pulumi api list` (alias: `ls`) lists every endpoint in the OpenAPI spec, and `pulumi api describe <path-or-operation-id>` prints the parameter, request, and response schemas for a single operation. See the [`pulumi api` guide](/docs/iac/cli/api/) for the full set of flags, output formats, and the agent-facing error envelope.

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -8,18 +8,18 @@ Pulumi is an open source infrastructure as code platform that lets you use famil
 
 If you are an AI agent or programmatic consumer, start with these endpoints. Each has a copy-pasteable example.
 
-- **Pulumi Cloud REST API (via the CLI)** — call any [Pulumi Cloud REST API](https://www.pulumi.com/docs/reference/cloud-rest-api/) endpoint with [`pulumi cloud api`](https://www.pulumi.com/docs/iac/cli/cloud-api/). The command emits a stable JSON error envelope and stable [exit codes](https://www.pulumi.com/docs/iac/cli/exit-codes/) for agent consumers, and `pulumi cloud api list --format=json` returns the full endpoint catalog. Authentication reuses the existing Pulumi CLI credentials.
+- **Pulumi Cloud REST API (via the CLI)** — call any [Pulumi Cloud REST API](https://www.pulumi.com/docs/reference/cloud-rest-api/) endpoint with [`pulumi api`](https://www.pulumi.com/docs/iac/cli/api/). The command emits a stable JSON error envelope and stable [exit codes](https://www.pulumi.com/docs/iac/cli/exit-codes/) for agent consumers, and `pulumi api list --format=json` returns the full endpoint catalog. Authentication reuses the existing Pulumi CLI credentials.
 
-      pulumi cloud api list --format=json
-      pulumi cloud api describe <path-or-operation-id> --format=json
-      pulumi cloud api /api/user
+      pulumi api list --format=json
+      pulumi api describe <path-or-operation-id> --format=json
+      pulumi api /api/user
 
 - **Cloud registry API** — every published package, version-by-version. Public packages need no auth; set `Authorization: token $PULUMI_ACCESS_TOKEN` for private. Works without the CLI.
 
       # CLI (auto-fills lang/os from project runtime + host OS)
-      pulumi cloud api ls | grep registry
-      pulumi cloud api describe ListPackageVersions
-      pulumi cloud api /api/registry/packages/pulumi/pulumi/aws/versions/latest/readme
+      pulumi api ls | grep registry
+      pulumi api describe ListPackageVersions
+      pulumi api /api/registry/packages/pulumi/pulumi/aws/versions/latest/readme
 
       # Direct HTTP (markdown variant via Accept header)
       curl -H "Accept: text/markdown" \
@@ -47,7 +47,7 @@ If you are an AI agent or programmatic consumer, start with these endpoints. Eac
 - **Provider schemas** — full Pulumi schema for any provider, including resource types, input/output shapes, function signatures, and language-specific type mappings. The cloud registry API's `versions/{version}` response includes a `schemaURL` field — follow it for the version-pinned schema. `pulumi package get-schema` accepts `<name>[@version]`, a plugin binary or folder path, or a local `.json` / `.yaml` schema file. The static URL is latest-only.
 
       # Versioned (via cloud registry API)
-      pulumi cloud api /api/registry/packages/pulumi/pulumi/aws/versions/6.0.0 \
+      pulumi api /api/registry/packages/pulumi/pulumi/aws/versions/6.0.0 \
         | jq -r .schemaURL | xargs curl
 
       pulumi package get-schema aws

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -8,10 +8,10 @@ Pulumi is an open source infrastructure as code platform that lets you use famil
 
 If you are an AI agent or programmatic consumer, start with these endpoints. Each has a copy-pasteable example.
 
-- **Pulumi Cloud REST API (via the CLI)** — call any [Pulumi Cloud REST API](https://www.pulumi.com/docs/reference/cloud-rest-api/) endpoint with [`pulumi api`](https://www.pulumi.com/docs/iac/cli/api/). The command emits a stable JSON error envelope and stable [exit codes](https://www.pulumi.com/docs/iac/cli/exit-codes/) for agent consumers, and `pulumi api list --format=json` returns the full endpoint catalog. Authentication reuses the existing Pulumi CLI credentials.
+- **Pulumi Cloud REST API (via the CLI)** — call any [Pulumi Cloud REST API](https://www.pulumi.com/docs/reference/cloud-rest-api/) endpoint with [`pulumi api`](https://www.pulumi.com/docs/iac/cli/api/). The command emits a stable JSON error envelope and stable [exit codes](https://www.pulumi.com/docs/iac/cli/exit-codes/) for agent consumers, and `pulumi api list --output=json` returns the full endpoint catalog. Authentication reuses the existing Pulumi CLI credentials.
 
-      pulumi api list --format=json
-      pulumi api describe <path-or-operation-id> --format=json
+      pulumi api list --output=json
+      pulumi api describe <path-or-operation-id> --output=json
       pulumi api /api/user
 
 - **Cloud registry API** — every published package, version-by-version. Public packages need no auth; set `Authorization: token $PULUMI_ACCESS_TOKEN` for private. Works without the CLI.
@@ -38,7 +38,7 @@ If you are an AI agent or programmatic consumer, start with these endpoints. Eac
       /api/registry/packages/{source}/{publisher}/{name}/versions/{version}/docs/{token}
       /api/registry/packages/{source}/{publisher}/{name}/versions/{version}/examples
 
-  Common parameters: `?lang=typescript|python|go|csharp|java|yaml`, `?os=linux|macos|windows`, `?depth=summary|full` and `?q=<term>` on `nav`, `?limit=` (max 100) on `examples`. For prose: `--format=markdown` (CLI) or `Accept: text/markdown` (HTTP). Tokens for `docs/{token}` are percent-encoded; discover them via `nav?depth=full`.
+  Common parameters: `?lang=typescript|python|go|csharp|java|yaml`, `?os=linux|macos|windows`, `?depth=summary|full` and `?q=<term>` on `nav`, `?limit=` (max 100) on `examples`. For prose: `--output=markdown` (CLI) or `Accept: text/markdown` (HTTP). Tokens for `docs/{token}` are percent-encoded; discover them via `nav?depth=full`.
 
 - **Full docs index (JSON)** — hierarchical sitemap of every documentation page with titles and nesting.
 


### PR DESCRIPTION
## Summary

- Renames the CLI command from `pulumi cloud api` to top-level `pulumi api` across custom docs (breaking change — no backwards-compat fallbacks).
- Renames the `--format` flag to `--output` to match the upstream standardization. See [pulumi/pulumi#23072](https://github.com/pulumi/pulumi/pull/23072#issuecomment-4432494410).
- Moves the CLI guide `content/docs/iac/cli/cloud-api.md` → `api.md` with an alias for SEO on the old URL.
- Updates the LLM agent index (`layouts/index.llms.txt`) and cross-references in `content/docs/reference/cloud-rest-api/`, `content/docs/iac/automation-api/_index.md`, `content/docs/administration/access-identity/access-tokens.md`, and `content/docs/iac/cli/_index.md`.
- Leaves auto-generated CLI command docs in `content/docs/iac/cli/commands/` untouched. They'll be replaced by the next regen run.
- Preserves "Pulumi Cloud API" (Title Case product/REST API name) in `pulumi_login.md`, `mcp-server/index.md`, `dynamic-providers.md`, `deployments.md`, `_content.gotmpl`, and historical blog posts.

## Do not merge until

- [ ] The new auto-generated CLI command docs (`pulumi_api.md`, `pulumi_api_list.md`, `pulumi_api_describe.md`) land in this repo. Until then, custom doc links to `/docs/iac/cli/commands/pulumi_api/`, `pulumi_api_list/`, and `pulumi_api_describe/` will 404.
- [ ] The upstream CLI ships both renames (`pulumi cloud api` → `pulumi api`, `--format` → `--output`).

## Test plan

- [ ] `make build` succeeds locally
- [ ] `make lint` passes
- [ ] After autogen lands: `/docs/iac/cli/api/` renders and all links in it resolve
- [ ] Old URL `/docs/iac/cli/cloud-api/` redirects to `/docs/iac/cli/api/` (SEO alias)
- [ ] `/llms.txt` reflects the new command name and `--output` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)