### PR TITLE
Add 'Infrastructure as code' link to the footer

### DIFF
--- a/data/footer.yml
+++ b/data/footer.yml
@@ -77,6 +77,9 @@ columns:
       - label: Kubernetes
         href: /kubernetes/
         track: footer-kubernetes
+      - label: Infrastructure as code
+        href: /what-is/what-is-infrastructure-as-code/
+        track: footer-what-is-infrastructure-as-code
       - label: AI/ML workloads
         href: /solutions/ai/
         track: footer-artificial-intelligence


### PR DESCRIPTION
To give the 'What is infrastructure as code?' page an SEO bump, this PR adds a link to the footer alongside our other use-case-driven links.
