### PR TITLE
chore(gads): remove dead key_features_below from terraform and IaC pages

### DIFF
--- a/content/gads/infrastructure-as-code/index.md
+++ b/content/gads/infrastructure-as-code/index.md
@@ -218,42 +218,6 @@ stats:
         number: "170+"
         description: "Cloud and service integrations"
 
-key_features_below:
-    items:
-        - title: "The fastest and easiest way to use Pulumi IaC at scale"
-          sub_title: "Pulumi Cloud"
-          description: |
-             A fully-managed service for Pulumi IaC plus so much more. Manage and store infrastructure state & secrets, collaborate within teams, view and search infrastructure, and manage security and compliance using Pulumi Cloud.
-          image: "/images/product/pulumi-cloud-iac-stylized-01.png"
-          features:
-              - title: Pulumi IaC
-                description: |
-                    Utilize open-source IaC in TypeScript, Python, Go, C#, Java and YAML. Build and distribute reusable components for 170+ cloud & SaaS providers.
-              - title: Pulumi ESC
-                description: |
-                    Centralized secrets management & orchestration. Tame secrets sprawl and configuration complexity securely across all your cloud infrastructure and applications.
-              - title: Automate deployment workflows
-                description: |
-                    Orchestrate secure deployment workflows through GitHub or an API.
-              - title: Search and analytics
-                description: |
-                    View resources from any cloud in one place. Search for resources across clouds with simple queries and filters.
-              - title: Pulumi Automation API
-                description: |
-                    Build custom deployment and CI/CD workflows that integrate with Pulumi Developer Portal, custom portals, or CLIs.
-              - title: Developer portals
-                description: |
-                    Create internal developer portals to distribute infrastructure templates using Pulumi or the Backstage-plugin.
-              - title: Identity and access control
-                description: |
-                    Manage teams with SCIM, SAML SSO, GitHub, GitLab, or Atlassian. Set permissions and access tokens.
-              - title: Policy enforcement
-                description: |
-                    Build policy packs from 150 policies or write your own. Leverage compliance-ready policies for any cloud to increase compliance posture and remediation policies to correct violations.
-              - title: Audit logs
-                description: |
-                    Track and store user actions and change history with option to export logs.
-
 case_studies:
     title: Customers innovating with Pulumi Cloud
     items:

--- a/content/gads/terraform/index.md
+++ b/content/gads/terraform/index.md
@@ -200,42 +200,6 @@ stats:
         number: "170+"
         description: "Cloud and service integrations"
 
-key_features_below:
-    items:
-        - title: "The fastest and easiest way to use Pulumi IaC at scale"
-          sub_title: "Pulumi Cloud"
-          description: |
-             A fully-managed service for Pulumi IaC plus so much more. Manage and store infrastructure state & secrets, collaborate within teams, view and search infrastructure, and manage security and compliance using Pulumi Cloud.
-          image: "/images/product/pulumi-cloud-iac-stylized-01.png"
-          features:
-              - title: Pulumi IaC
-                description: |
-                    Utilize open-source IaC in TypeScript, Python, Go, C#, Java and YAML. Build and distribute reusable components for 170+ cloud & SaaS providers.
-              - title: Pulumi ESC
-                description: |
-                    Centralized secrets management & orchestration. Tame secrets sprawl and configuration complexity securely across all your cloud infrastructure and applications.
-              - title: Automate deployment workflows
-                description: |
-                    Orchestrate secure deployment workflows through GitHub or an API.
-              - title: Search and analytics
-                description: |
-                    View resources from any cloud in one place. Search for resources across clouds with simple queries and filters.
-              - title: Pulumi Automation API
-                description: |
-                    Build custom deployment and CI/CD workflows that integrate with Pulumi Developer Portal, custom portals, or CLIs.
-              - title: Developer portals
-                description: |
-                    Create internal developer portals to distribute infrastructure templates using Pulumi or the Backstage-plugin.
-              - title: Identity and access control
-                description: |
-                    Manage teams with SCIM, SAML SSO, GitHub, GitLab, or Atlassian. Set permissions and access tokens.
-              - title: Policy enforcement
-                description: |
-                    Build policy packs from 150 policies or write your own. Leverage compliance-ready policies for any cloud to increase compliance posture and remediation policies to correct violations.
-              - title: Audit logs
-                description: |
-                    Track and store user actions and change history with option to export logs.
-
 case_studies:
     title: Customers innovating with Pulumi Cloud
     items:


### PR DESCRIPTION
## Summary

- Both [content/gads/terraform/index.md](https://github.com/pulumi/docs/blob/master/content/gads/terraform/index.md) and [content/gads/infrastructure-as-code/index.md](https://github.com/pulumi/docs/blob/master/content/gads/infrastructure-as-code/index.md) set `hide_platform_details: true`, which causes `layouts/gads/gads-template.html` to skip rendering the `key_features_below` section entirely (see [gads-template.html:214](https://github.com/pulumi/docs/blob/master/layouts/gads/gads-template.html#L214)).
- The Pulumi Cloud feature block in each file's frontmatter has therefore been dead config — it has never rendered on these pages and has silently diverged from the canonical Pulumi Cloud copy elsewhere on the site.
- Removes 36 lines from each file (72 lines total). No rendered output changes.

## Test plan

- [x] `make lint` passes
- [x] Served locally; both pages return HTTP 200
- [x] Confirmed no `key-features-below` section in rendered HTML for either page
- [ ] Reviewer spot-checks the deploy preview for `/gads/terraform/` and `/gads/infrastructure-as-code/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)