### PR TITLE
Advertise markdown variants of docs pages in <head>

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,6 +29,9 @@
     <link rel="preload" href="/fonts/inter-semibold.woff2" as="font" type="font/woff2" crossorigin />
 
     <link rel="llms-txt" href="/llms.txt" />
+    {{ with .OutputFormats.Get "markdown" }}
+    <link rel="alternate" type="text/markdown" href="{{ .Permalink }}" />
+    {{ end }}
 
     <!-- Our CSS and JS bundles. -->
     {{ partial "assets" . }}


### PR DESCRIPTION
## Summary

Adds `<link rel="alternate" type="text/markdown" href="...">` to every page that has a markdown output format (currently all of `/docs/`). Tells AI agents the markdown variant exists, matching the pattern Mintlify and Vercel use.

The `.md` endpoints already ship (e.g. https://www.pulumi.com/docs/iac/concepts/stacks/index.md) — this just makes them discoverable without an agent needing to guess the URL pattern.

The tag is emitted via `{{ with .OutputFormats.Get "markdown" }}`, so it only renders on pages that actually have a markdown output. Non-docs pages (blog, marketing, homepage) correctly omit it.

## Test plan

- [x] Verified locally that `/docs/iac/concepts/stacks/` emits `<link rel="alternate" type="text/markdown" href=".../docs/iac/concepts/stacks/index.md" />`
- [x] Verified locally that `/docs/` (landing) emits the tag
- [x] Verified locally that `/blog/` does NOT emit the tag (no `.md` variant exists)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)