### PR TITLE
Add April 2026 self-hosted changelog entry for ESC SSRF protection

### DIFF
--- a/content/docs/administration/self-hosting/changelog.md
+++ b/content/docs/administration/self-hosting/changelog.md
@@ -24,10 +24,10 @@ Self-hosting is only available with **Pulumi Business Critical**. If you would l
 
 ### April
 
-* Added SSRF protection to Pulumi ESC providers to prevent requests to internal network addresses
+* Added SSRF (server-side request forgery) protection to Pulumi ESC providers to prevent requests to private, loopback, and link-local IP addresses
 
 {{< notes type="warning" >}}
-Breaking Change: ESC providers now block requests to private, loopback, and link-local IP addresses by default. If you run dependent services (for example, local secret stores or webhooks) on the same host or private network as your self-hosted Pulumi Cloud, you may need to disable SSRF protection by setting the `PULUMI_DISABLE_ESC_SSRF_PROTECTION=true` environment variable on the API service.
+Breaking Change: ESC providers now block requests to private, loopback, and link-local IP addresses by default. If you run dependent services (for example, local secret stores or webhooks) on the same host or private network as your self-hosted Pulumi Cloud, you may need to disable SSRF protection by setting the `PULUMI_DISABLE_ESC_SSRF_PROTECTION=true` environment variable.
 {{< /notes >}}
 
 ## 2025

--- a/content/docs/administration/self-hosting/changelog.md
+++ b/content/docs/administration/self-hosting/changelog.md
@@ -20,6 +20,16 @@ aliases:
 Self-hosting is only available with **Pulumi Business Critical**. If you would like to evaluate the self-hosted Pulumi Cloud, sign up for the [30-day trial](/product/self-hosted#self-hosted-trial) or [contact us](/contact/).
 {{% /notes %}}
 
+## 2026
+
+### April
+
+* Added SSRF protection to Pulumi ESC providers to prevent requests to internal network addresses
+
+{{< notes type="warning" >}}
+Breaking Change: ESC providers now block requests to private, loopback, and link-local IP addresses by default. If you run dependent services (for example, local secret stores or webhooks) on the same host or private network as your self-hosted Pulumi Cloud, you may need to disable SSRF protection by setting the `PULUMI_DISABLE_ESC_SSRF_PROTECTION=true` environment variable on the API service.
+{{< /notes >}}
+
 ## 2025
 
 ### November


### PR DESCRIPTION
## Summary

- Adds a new April 2026 entry to the self-hosted changelog covering SSRF protection added to Pulumi ESC providers ([pulumi/pulumi-service#41398](https://github.com/pulumi/pulumi-service/pull/41398)).
- Documents the `PULUMI_DISABLE_ESC_SSRF_PROTECTION` escape hatch ([pulumi/pulumi-service#43159](https://github.com/pulumi/pulumi-service/pull/43159)) as a breaking-change warning for admins running dependent services on private networks.

## Test plan

- [ ] Verify the entry renders correctly under https://www.pulumi.com/docs/administration/self-hosting/changelog/
- [ ] Confirm the breaking-change callout phrasing matches the actual scope of the env var (set on API service vs. ESC service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)