### PR TITLE
ci: validate pulumi/esc-action fix (pin to 197ccaa)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,9 +11,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Add to Docs
         uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Add to Docs
         uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/bucket-cleanup-testing.yml
+++ b/.github/workflows/bucket-cleanup-testing.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/bucket-cleanup-testing.yml
+++ b/.github/workflows/bucket-cleanup-testing.yml
@@ -18,9 +18,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -17,9 +17,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,9 +23,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - uses: actions/checkout@v6
 
@@ -100,9 +98,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - uses: actions/checkout@v6
 
@@ -99,6 +101,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/check-lighthouse.yml
+++ b/.github/workflows/check-lighthouse.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/check-lighthouse.yml
+++ b/.github/workflows/check-lighthouse.yml
@@ -31,9 +31,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - uses: actions/checkout@v6
       - name: Install Node
         uses: actions/setup-node@v6

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - uses: actions/checkout@v6
       - name: Install Node
         uses: actions/setup-node@v6

--- a/.github/workflows/check-search-urls.yml
+++ b/.github/workflows/check-search-urls.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - uses: actions/checkout@v6
 
       - name: Install Node

--- a/.github/workflows/check-search-urls.yml
+++ b/.github/workflows/check-search-urls.yml
@@ -16,9 +16,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - uses: actions/checkout@v6
 
       - name: Install Node

--- a/.github/workflows/claude-social-review.yml
+++ b/.github/workflows/claude-social-review.yml
@@ -194,9 +194,7 @@ jobs:
       - name: Fetch secrets from ESC
         if: steps.gate.outputs.should_skip != 'true'
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - name: Configure AWS Credentials
         if: steps.gate.outputs.should_skip != 'true'

--- a/.github/workflows/claude-social-review.yml
+++ b/.github/workflows/claude-social-review.yml
@@ -195,6 +195,8 @@ jobs:
         if: steps.gate.outputs.should_skip != 'true'
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - name: Configure AWS Credentials
         if: steps.gate.outputs.should_skip != 'true'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - name: Check repository write access
         id: check-access

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,9 +33,7 @@ jobs:
 
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - name: Check repository write access
         id: check-access

--- a/.github/workflows/customer-managed-workflow-agent-cli.yml
+++ b/.github/workflows/customer-managed-workflow-agent-cli.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the customer-managed-workflow-agent version
@@ -48,6 +50,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: set the customer-managed-workflow-agent version
         run: |
           echo "CMWA_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -93,6 +97,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/customer-managed-workflow-agent-cli.yml
+++ b/.github/workflows/customer-managed-workflow-agent-cli.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the customer-managed-workflow-agent version
@@ -49,9 +47,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: set the customer-managed-workflow-agent version
         run: |
           echo "CMWA_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -96,9 +92,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the esc version
@@ -45,6 +47,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: set the esc version
         run: |
           echo "ESC_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -119,6 +123,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -18,9 +18,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the esc version
@@ -46,9 +44,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: set the esc version
         run: |
           echo "ESC_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -122,9 +118,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/post-deployment-health-check.yml
+++ b/.github/workflows/post-deployment-health-check.yml
@@ -151,6 +151,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - name: Send Slack notification
         uses: docker://sholung/action-slack-notify:v2.3.0

--- a/.github/workflows/post-deployment-health-check.yml
+++ b/.github/workflows/post-deployment-health-check.yml
@@ -150,9 +150,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - name: Send Slack notification
         uses: docker://sholung/action-slack-notify:v2.3.0

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -18,9 +18,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - uses: actions/checkout@v6
 
@@ -93,9 +91,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - uses: actions/checkout@v6
 
@@ -92,6 +94,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: pull-request
@@ -43,6 +45,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: Update latest version
@@ -67,6 +71,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: pull-request
@@ -44,9 +42,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: Update latest version
@@ -70,9 +66,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the pulumi version
@@ -47,9 +45,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: set the pulumi version
         run: |
           echo "PULUMI_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -163,9 +159,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the pulumi version
@@ -46,6 +48,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: set the pulumi version
         run: |
           echo "PULUMI_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -160,6 +164,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pulumi-dotnet-sdk.yml
+++ b/.github/workflows/pulumi-dotnet-sdk.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the pulumi-dotnet version
@@ -51,6 +53,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: set the pulumi-dotnet version
         run: |
           echo "DOTNET_SDK_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -112,6 +116,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pulumi-dotnet-sdk.yml
+++ b/.github/workflows/pulumi-dotnet-sdk.yml
@@ -24,9 +24,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the pulumi-dotnet version
@@ -52,9 +50,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: set the pulumi-dotnet version
         run: |
           echo "DOTNET_SDK_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -115,9 +111,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pulumi-java-sdk.yml
+++ b/.github/workflows/pulumi-java-sdk.yml
@@ -23,9 +23,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the java sdk version
@@ -51,9 +49,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: set the java sdk version
         run: |
           echo "JAVA_SDK_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -115,9 +111,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/pulumi-java-sdk.yml
+++ b/.github/workflows/pulumi-java-sdk.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: checkout docs repo
         uses: actions/checkout@v6
       - name: set the java sdk version
@@ -50,6 +52,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: set the java sdk version
         run: |
           echo "JAVA_SDK_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
@@ -112,6 +116,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/schedule-social.yml
+++ b/.github/workflows/schedule-social.yml
@@ -27,9 +27,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - uses: actions/checkout@v6
         with:
@@ -114,9 +112,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/schedule-social.yml
+++ b/.github/workflows/schedule-social.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - uses: actions/checkout@v6
         with:
@@ -113,6 +115,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - name: Check out the code
         uses: actions/checkout@v6
@@ -141,6 +143,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -55,9 +55,7 @@ jobs:
 
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - name: Check out the code
         uses: actions/checkout@v6
@@ -142,9 +140,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/scheduled-upgrade-programs.yml
+++ b/.github/workflows/scheduled-upgrade-programs.yml
@@ -44,9 +44,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/scheduled-upgrade-programs.yml
+++ b/.github/workflows/scheduled-upgrade-programs.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/scheduled-upstream-sync.yaml
+++ b/.github/workflows/scheduled-upstream-sync.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Checkout target repo
         uses: actions/checkout@v6
         with:
@@ -51,6 +53,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/scheduled-upstream-sync.yaml
+++ b/.github/workflows/scheduled-upstream-sync.yaml
@@ -15,9 +15,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Checkout target repo
         uses: actions/checkout@v6
         with:
@@ -52,9 +50,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -17,9 +17,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - uses: actions/checkout@v6
 
@@ -94,9 +92,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - uses: actions/checkout@v6
 
@@ -93,6 +95,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -12,9 +12,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
 
       - name: Check out the repo
         uses: actions/checkout@v6
@@ -50,9 +48,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
-        with:
-          oidc-auth: true
+        uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:

--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
 
       - name: Check out the repo
         uses: actions/checkout@v6
@@ -49,6 +51,8 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+        with:
+          oidc-auth: true
       - name: Slack Notification
         uses: docker://sholung/action-slack-notify:v2.3.0
         env:


### PR DESCRIPTION
## Summary

Validates the upstream fix in [pulumi/esc-action@197ccaa](https://github.com/pulumi/esc-action/commit/197ccaa42ab49560ce838a3010eb8345ce086896) ("Fix oidc-auth default breaking ESC_ACTION_OIDC_AUTH env-var fallback", from [pulumi/esc-action#43](https://github.com/pulumi/esc-action/pull/43), fixes [pulumi/esc-action#42](https://github.com/pulumi/esc-action/issues/42)) by pinning every esc-action invocation in this repo to that exact SHA.

**A green CI on this PR is the validation signal**: if jobs authenticate successfully against the pinned SHA *without* any consumer-side workaround, the upstream fix is working.

## Background

The `pulumi/esc-action` `v1` tag was moved on 2026-05-13 ~02:26 UTC (when [pulumi/esc-action#41](https://github.com/pulumi/esc-action/pull/41) landed) to a commit that included an earlier regression from [pulumi/esc-action#35](https://github.com/pulumi/esc-action/pull/35) — `oidc-auth` was declared in `action.yml` with `default: 'false'`.

The action's input/env helper is:

```ts
function getInput(name: string, envVar: string): string | undefined {
    const val = core.getInput(name) || process.env[`ESC_ACTION_${envVar}`];
    ...
}
```

Once `core.getInput('oidc-auth')` started returning the non-empty string `'false'` by default, the `|| process.env[...]` fallback never fired — silently disabling OIDC for every consumer that configured the action via the `ESC_ACTION_OIDC_AUTH=true` env-var pattern. `esc` then errored out with:

```
##[error]`esc open` command failed:
Error: could not determine current cloud: PULUMI_ACCESS_TOKEN must be set for login during non-interactive CLI sessions
```

This broke every open PR (#18925, #18923, #18920, ...) and scheduled jobs.

The upstream fix changes the `oidc-auth` default in `action.yml` from `'false'` to `''`, matching the other `oidc-*` inputs, so `core.getInput` returns falsy and the env-var fallback works again.

## What this PR does

1. **Commit 1** added a consumer-side workaround (`with: oidc-auth: true` on every invocation) to unblock CI immediately.
2. **Commit 2** removes that workaround and pins every `pulumi/esc-action@v1` reference to `@197ccaa42ab49560ce838a3010eb8345ce086896` so this PR's CI exercises *only* the upstream fix.

24 workflow files updated; all 30 workflow YAML files parse OK.

## Follow-up

Once the `v1` tag is moved to include the fix, swap the pinned SHA back to `@v1` in a follow-up PR.

## Test plan

- [ ] CI on this PR passes — proves the upstream fix restores the env-var fallback
- [ ] Spot-check `pull-request.yml`, `build-and-deploy.yml`, `pulumi-cli.yml`, and `esc-cli.yml` show the pinned SHA and no `with:` blocks on esc-action steps
- [ ] After validation, follow-up PR to move pin back to `@v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)