### PR TITLE
Decouple Pulumi CLI docs from monolithic SDK workflow

### DIFF
--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -1,0 +1,125 @@
+permissions: write-all # Equivalent to default permissions + id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
+
+name: Pulumi CLI docs
+on:
+  repository_dispatch:
+    types:
+      - pulumi-cli-docs
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Pulumi CLI version (e.g. 3.150.0, without leading 'v')"
+        required: true
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    needs: build-pulumi-cli-docs
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: checkout docs repo
+        uses: actions/checkout@v6
+      - name: set the pulumi version
+        run: |
+          echo "PULUMI_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
+      - name: pull-request
+        id: create-pr
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "pulumi-cli-docs/${{ github.run_id }}-${{ github.run_number }}"
+          destination_branch: "master"
+          pr_title: "Regen docs pulumi@${{ env.PULUMI_VERSION }}"
+          pr_body: "Automated PR"
+          pr_label: "automation/pulumi-cli-docs"
+          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+      # Auto-merge intentionally disabled during testing of the decoupled workflow.
+      # Restore the `automation/merge` label above and uncomment this step before
+      # requesting review on the decouple-docs-generation PR.
+      # - name: Enable auto-merge
+      #   if: steps.create-pr.outputs.pr_created == 'true'
+      #   run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+  build-pulumi-cli-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: set the pulumi version
+        run: |
+          echo "PULUMI_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
+      - name: checkout docs repo
+        uses: actions/checkout@v6
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        with:
+          pulumi-version: ${{ env.PULUMI_VERSION }}
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.157.0'
+          extended: true
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            infrastructure/yarn.lock
+            theme/yarn.lock
+            theme/stencil/yarn.lock
+      - run: make ensure
+      - name: generate markdown
+        run: |
+          PULUMI_EXPERIMENTAL=true pulumi gen-markdown ./content/docs/iac/cli/commands
+      - name: Update latest version
+        run: |
+          echo -n "${{ env.PULUMI_VERSION }}" > ./static/latest-version
+      - name: Update versions
+        run: node scripts/get-versions.js
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+      - name: Update version lists
+        run: |
+          NL=$'\n'
+          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/get-started/download-install/versions.md
+      - name: git status
+        run: git status && git diff
+      - name: commit changes
+        run: |
+          git config --local user.email "bot@pulumi.com"
+          git config --local user.name "pulumi-bot"
+          git checkout -b pulumi-cli-docs/${{ github.run_id }}-${{ github.run_number }}
+          git add content/
+          git add data/
+          git add static/
+          git commit -m "Regenerating CLI docs for Pulumi@${{ env.PULUMI_VERSION}}"
+          git push origin pulumi-cli-docs/${{ github.run_id }}-${{ github.run_number }}
+  notify:
+    if: failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [pull-request, build-pulumi-cli-docs]
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: Slack Notification
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "Pulumi CLI docs build failure in pulumi/docs repo"
+          SLACK_USERNAME: docsbot
+          SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -6,11 +6,11 @@ env:
   ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
-name: Pulumi CLI docs
+name: Pulumi CLI docs (WIP - do not use)
 on:
-  repository_dispatch:
-    types:
-      - pulumi-cli-docs
+  # WIP: Manual trigger only. Do not add repository_dispatch or wire this into
+  # pulumi-cli.yml until end-to-end verification is complete. Tracked in
+  # https://github.com/pulumi/docs/issues/18934.
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -6,30 +6,16 @@ env:
   ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
-name: Pulumi SDK docs (TypeScript + Python)
+name: cli docs build
 on:
   repository_dispatch:
     types:
       - pulumi-cli
 
 jobs:
-  dispatch-pulumi-cli-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@v1
-      - name: Dispatch Pulumi CLI docs workflow
-        env:
-          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-        run: |
-          gh workflow run pulumi-cli-docs.yml \
-            --repo ${{ github.repository }} \
-            --ref master \
-            -f version=${{ github.event.client_payload.ref }}
   pull-request:
     runs-on: ubuntu-latest
-    needs: build-pulumi-sdk-docs
+    needs: build-pulumi-cli-docs
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -45,16 +31,16 @@ jobs:
         with:
           source_branch: "pulumi/${{ github.run_id }}-${{ github.run_number }}"
           destination_branch: "master"
-          pr_title: "Regen SDK docs pulumi@${{ env.PULUMI_VERSION }}"
+          pr_title: "Regen docs pulumi@${{ env.PULUMI_VERSION }}"
           pr_body: "Automated PR"
-          pr_label: "automation/pulumi-sdk-docs,automation/merge"
+          pr_label: "automation/pulumi-cli-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
         if: steps.create-pr.outputs.pr_created == 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-  build-pulumi-sdk-docs:
+  build-pulumi-cli-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch secrets from ESC
@@ -73,6 +59,18 @@ jobs:
           repository: pulumi/pulumi
           path: pulumi
           ref: v${{ github.event.client_payload.ref }}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        with:
+          pulumi-version: ${{ env.PULUMI_VERSION }}
+      - name: Install go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.goversion }}
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3
         with:
@@ -95,6 +93,10 @@ jobs:
           python-version: ${{matrix.pythonversion}}
       - name: Install Pipenv
         run: pip3 install pipenv
+      - name: Install dotnet
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{matrix.dotnetverson}}
       - run: make ensure
         working-directory: docs
       - name: run yarn install in nodejs sdk
@@ -106,6 +108,24 @@ jobs:
       - name: generate python docs
         run: ./scripts/generate_python_docs.sh
         working-directory: docs
+      - name: generate markdown
+        run: |
+          PULUMI_EXPERIMENTAL=true pulumi gen-markdown ./content/docs/iac/cli/commands
+        working-directory: docs
+      - name: Update latest version
+        run: |
+          echo -n "${{ env.PULUMI_VERSION }}" > ./static/latest-version
+        working-directory: docs
+      - name: Update versions
+        run: node scripts/get-versions.js
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+        working-directory: docs
+      - name: Update version lists
+        run: |
+          NL=$'\n'
+          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/get-started/download-install/versions.md
+        working-directory: docs
       - name: git status
         run: git status && git diff
         working-directory: docs
@@ -114,12 +134,19 @@ jobs:
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b pulumi/${{ github.run_id }}-${{ github.run_number }}
+          git add content/
+          git add data/
           git add static-prebuilt/
-          git commit -m "Regenerating SDK docs for Pulumi@${{ env.PULUMI_VERSION}}"
+          git add static/
+          git commit -m "Regenerating docs for Pulumi@${{ env.PULUMI_VERSION}}"
           git push origin pulumi/${{ github.run_id }}-${{ github.run_number }}
         working-directory: docs
     strategy:
       matrix:
+        dotnetversion:
+          - 3.1.301
+        goversion:
+          - 1.26.x
         pythonversion:
           - "3.13"
         nodeversion:
@@ -128,7 +155,7 @@ jobs:
     if: failure()
     name: Send slack notification
     runs-on: ubuntu-latest
-    needs: [pull-request, build-pulumi-sdk-docs]
+    needs: [pull-request, build-pulumi-cli-docs]
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -138,7 +165,7 @@ jobs:
         env:
           SLACK_CHANNEL: docs-ops
           SLACK_COLOR: "#F54242"
-          SLACK_MESSAGE: "Pulumi SDK docs (TS+Python) build failure in pulumi/docs repo"
+          SLACK_MESSAGE: "cli docs build failure in pulumi/docs repo :meow_sad:"
           SLACK_USERNAME: docsbot
           SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
           SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/.github/workflows/pulumi-cli.yml
+++ b/.github/workflows/pulumi-cli.yml
@@ -6,16 +6,30 @@ env:
   ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
-name: cli docs build
+name: Pulumi SDK docs (TypeScript + Python)
 on:
   repository_dispatch:
     types:
       - pulumi-cli
 
 jobs:
+  dispatch-pulumi-cli-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: Dispatch Pulumi CLI docs workflow
+        env:
+          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+        run: |
+          gh workflow run pulumi-cli-docs.yml \
+            --repo ${{ github.repository }} \
+            --ref master \
+            -f version=${{ github.event.client_payload.ref }}
   pull-request:
     runs-on: ubuntu-latest
-    needs: build-pulumi-cli-docs
+    needs: build-pulumi-sdk-docs
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -31,16 +45,16 @@ jobs:
         with:
           source_branch: "pulumi/${{ github.run_id }}-${{ github.run_number }}"
           destination_branch: "master"
-          pr_title: "Regen docs pulumi@${{ env.PULUMI_VERSION }}"
+          pr_title: "Regen SDK docs pulumi@${{ env.PULUMI_VERSION }}"
           pr_body: "Automated PR"
-          pr_label: "automation/pulumi-cli-docs,automation/merge"
+          pr_label: "automation/pulumi-sdk-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
         if: steps.create-pr.outputs.pr_created == 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-  build-pulumi-cli-docs:
+  build-pulumi-sdk-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch secrets from ESC
@@ -59,18 +73,6 @@ jobs:
           repository: pulumi/pulumi
           path: pulumi
           ref: v${{ github.event.client_payload.ref }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v3.0.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
-        with:
-          pulumi-version: ${{ env.PULUMI_VERSION }}
-      - name: Install go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.goversion }}
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3
         with:
@@ -93,10 +95,6 @@ jobs:
           python-version: ${{matrix.pythonversion}}
       - name: Install Pipenv
         run: pip3 install pipenv
-      - name: Install dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{matrix.dotnetverson}}
       - run: make ensure
         working-directory: docs
       - name: run yarn install in nodejs sdk
@@ -108,24 +106,6 @@ jobs:
       - name: generate python docs
         run: ./scripts/generate_python_docs.sh
         working-directory: docs
-      - name: generate markdown
-        run: |
-          PULUMI_EXPERIMENTAL=true pulumi gen-markdown ./content/docs/iac/cli/commands
-        working-directory: docs
-      - name: Update latest version
-        run: |
-          echo -n "${{ env.PULUMI_VERSION }}" > ./static/latest-version
-        working-directory: docs
-      - name: Update versions
-        run: node scripts/get-versions.js
-        env:
-          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-        working-directory: docs
-      - name: Update version lists
-        run: |
-          NL=$'\n'
-          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/get-started/download-install/versions.md
-        working-directory: docs
       - name: git status
         run: git status && git diff
         working-directory: docs
@@ -134,19 +114,12 @@ jobs:
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b pulumi/${{ github.run_id }}-${{ github.run_number }}
-          git add content/
-          git add data/
           git add static-prebuilt/
-          git add static/
-          git commit -m "Regenerating docs for Pulumi@${{ env.PULUMI_VERSION}}"
+          git commit -m "Regenerating SDK docs for Pulumi@${{ env.PULUMI_VERSION}}"
           git push origin pulumi/${{ github.run_id }}-${{ github.run_number }}
         working-directory: docs
     strategy:
       matrix:
-        dotnetversion:
-          - 3.1.301
-        goversion:
-          - 1.26.x
         pythonversion:
           - "3.13"
         nodeversion:
@@ -155,7 +128,7 @@ jobs:
     if: failure()
     name: Send slack notification
     runs-on: ubuntu-latest
-    needs: [pull-request, build-pulumi-cli-docs]
+    needs: [pull-request, build-pulumi-sdk-docs]
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -165,7 +138,7 @@ jobs:
         env:
           SLACK_CHANNEL: docs-ops
           SLACK_COLOR: "#F54242"
-          SLACK_MESSAGE: "cli docs build failure in pulumi/docs repo :meow_sad:"
+          SLACK_MESSAGE: "Pulumi SDK docs (TS+Python) build failure in pulumi/docs repo"
           SLACK_USERNAME: docsbot
           SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
           SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png


### PR DESCRIPTION
Add a standalone Pulumi CLI docs workflow that handles `pulumi gen-markdown` and version-file updates, and have the existing monolithic workflow dispatch to it. The trimmed monolithic workflow now only generates the Pulumi TypeScript + Python SDK docs.

Auto-merge on the new workflow is temporarily disabled so we can verify a test run end-to-end before turning it on. The auto-merge step and `automation/merge` label will be restored before requesting review.

Part 1 of https://github.com/pulumi/docs/issues/18934.
