### PR TITLE
docs(yaml): reconcile YAML config schema with project file reference

### DIFF
--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -121,6 +121,10 @@ Alternatively, a package value can be an object with the following properties:
 
 ### `config` options
 
+{{% notes %}}
+This is the project-level `config` schema parsed by the Pulumi engine. It applies to programs in every language — TypeScript, JavaScript, Python, Go, .NET, Java, and YAML — including the `config` block of a Pulumi YAML program. See the [Pulumi YAML reference](/docs/iac/languages-sdks/yaml/yaml-language-reference/#config) for a YAML-flavored example.
+{{% /notes %}}
+
 `config` is a map of config property keys to either values or structured declarations.
 
 Non-object values are allowed to be set directly. Anything more complex must be defined using the structured
@@ -138,7 +142,7 @@ Schemas are only valid for project property keys. For setting the value of a pro
 
 | Name | Required | Description |
 | - | - | - |
-| `type` | required | The type of this config property, either `string`, `boolean`, `integer`, `array`, or `object`. |
+| `type` | optional | The type of this config property, either `string`, `boolean`, `integer`, `array`, or `object`. Either `type` or `default` is required; when omitted, the type is inferred from `default`. |
 | `description` | optional | A description for this config property. |
 | `secret` | optional | True if this config property should be a secure secret value. |
 | `default` | optional | The default value for this config property, must match the given type. |

--- a/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
+++ b/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
@@ -23,7 +23,7 @@ Pulumi supports programs written in YAML or JSON.  In both cases, the programs (
 
 | Property | Type | Required | Expression | Description |
 | - | - | - | - | - |
-| `config` | [config options](/docs/reference/pulumi-yaml/#config-options) | No | No | Config specifies the [Pulumi config](/docs/concepts/config/) inputs to the deployment. |
+| `config` | [config options](#config) | No | No | Config specifies the [Pulumi config](/docs/concepts/config/) inputs to the deployment. |
 | `resources` | map[string]Resource | No | No | Resources declares the [Pulumi resources](/docs/concepts/resources/) that will be deployed and managed by the program |
 | `variables` | map[string]Expression | No | Yes | Variables specifies intermediate values of the program, the values of variables are expressions that can be re-used. |
 | `outputs` | map[string]Expression | No | Yes | Outputs specifies the [Pulumi stack outputs](/docs/concepts/stack#outputs) of the program and how they are computed from the `resources` is a value of the appropriate type for the template to use if no value is specified. |
@@ -38,17 +38,24 @@ The supported expression forms for each of these is detailed below.
 
 ### Config
 
-`config` is a map of config property keys to either values or structured declarations ([see here](/docs/reference/pulumi-yaml/#config-options)).
+{{% notes %}}
+Pulumi YAML programs declare config using the same project-level `config` schema documented in the [Pulumi project file reference](/docs/iac/concepts/projects/project-file/#config-options). The schema is shown again here for convenience, alongside YAML-flavored examples.
+{{% /notes %}}
 
-In beta, Pulumi YAML projects used the `configuration` key. This will eventually be deprecated; switching from `configuration` to `config` will not break existing projects.
+`config` is a map of config property keys to either values or structured declarations. The value of `config` is an object whose keys are logical names by which the config input will be referenced in expressions within the program, and whose values are elements of the schema below. Each item in this object represents an independent config input. Either `type` or `default` is required; when `type` is omitted, the type is inferred from `default`.
 
-The value of `config` is an object whose keys are logical names by which the config input will be referenced in expressions within the program, and whose values are elements of the schema below. Each item in this object represents an independent config input. Either `type` or `default` is required.
+A config key can also map directly to a scalar value as a shorthand for a structured declaration with only `default` set. For example, `replicas: 3` is equivalent to `replicas: { default: 3 }`.
 
 | Property | Type | Required | Expression | Description |
 | - | - | - | - | - |
-| `type` | string | No | No | The data type for the config value. Valid types are: `String`, `Number`, `Integer`, `Boolean`, `Object`, `List<String>`, `List<Number>`, `List<Integer>`, `List<Boolean>`, and `List<Object>`. |
-| `default` | any | No | No | Default is a value of the appropriate type for the template to use if no value is specified. |
-| `secret` | bool | No | No | Secret specifies if the config value should be encrypted as a secret. |
+| `type` | string | No | No | The data type for the config value. Valid types are: `string`, `boolean`, `integer`, `array`, and `object`. |
+| `items` | object | Required if `type` is `array` | No | A nested structured declaration of the type of the items in the array. |
+| `default` | any | No | No | A default value of the appropriate type for the program to use if no value is set on the stack. |
+| `secret` | bool | No | No | When `true`, the config value is encrypted as a secret. Secret values must be set with `pulumi config set --secret`. |
+
+{{% notes type="warning" %}}
+In beta, Pulumi YAML projects used a top-level `configuration` key, which accepted a different schema with Title-Case types — `String`, `Number`, `Integer`, `Boolean`, `Object`, and the generic forms `List<String>`, `List<Number>`, `List<Integer>`, `List<Boolean>`, and `List<Object>`. Programs that still use `configuration` continue to work, but the YAML runtime emits a deprecation warning when it loads `Pulumi.yaml`. New programs should use `config` with the schema above; the `array` + `items` form replaces `List<T>`, and `number` is not a separate type (use `integer`).
+{{% /notes %}}
 
 The following example demonstrates several common config declarations, including scalar types, secrets, lists, and objects:
 
@@ -56,26 +63,34 @@ The following example demonstrates several common config declarations, including
 name: my-project
 runtime: yaml
 config:
+  # Shorthand for a default value (type inferred from the value)
+  greeting: hello
   # A required string value (no default)
   environment:
-    type: String
-  # A number with a default
+    type: string
+  # An integer with a default
   replicas:
-    type: Number
+    type: integer
     default: 3
-  # A secret string (encrypted at rest)
+  # A boolean flag with a default
+  enableLogging:
+    type: boolean
+    default: true
+  # A required secret string (set with `pulumi config set --secret`)
   databasePassword:
-    type: String
+    type: string
     secret: true
   # A list of strings
   allowedRegions:
-    type: List<String>
+    type: array
+    items:
+      type: string
     default:
       - us-east-1
       - us-west-2
   # An object (map of string keys to any values)
   apiConfig:
-    type: Object
+    type: object
     default:
       endpoint: https://api.example.com
       timeout: 30


### PR DESCRIPTION
## Summary

- Aligns the YAML language reference with the canonical project-level `config` schema documented in `project-file.md`, resolving the long-standing inconsistencies flagged in #12417 (mismatched type names, drifted property tables, and a stale anchor link).
- Replaces the YAML page's Title-Case type list (`String`, `Number`, `List<String>`, etc.) with the lowercase types the engine actually accepts today: `string`, `integer`, `boolean`, `array`, and `object`, plus the `items` form that replaces `List<T>`.
- Moves the legacy `configuration` key guidance into a warning callout that documents the full deprecated schema, so existing users can still recognize their programs while new programs get steered to the supported form.
- Adds a note on `project-file.md` clarifying that the `config` schema there is the canonical, engine-parsed schema used by every language (including YAML), with a cross-link to the YAML page for YAML-flavored examples.

## Test plan

- [ ] `make lint` clean (project's markdownlint-cli2 over built output)
- [ ] Visual spot-check via `make serve`: rendered `{{% notes %}}` callouts on both pages, in-page `#config` anchor from the top property table, and cross-links between the two pages
- [ ] Spot-check that the example YAML program still parses with `pulumi preview` against a scratch project

## Changes

### Modified files

- `content/docs/iac/languages-sdks/yaml/yaml-language-reference.md` — Fix the top-of-page `config` link to use the in-page `#config` anchor; rewrite the Config section to mirror the project-level schema (lowercase types, `items` row, secret guidance); move the `configuration` deprecation into a warning callout with the full legacy type list; refresh the example program to use the supported schema and add a `boolean` example.
- `content/docs/iac/concepts/projects/project-file.md` — Add a note above `### config options` clarifying that this schema is parsed by the engine and applies to every language, with a link to the YAML reference.

Closes #12417

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
