### PR TITLE
fix: allow academy.pulumi.com in frame-ancestors CSP

### DIFF
--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -2124,7 +2124,7 @@ Production CloudFront distribution applies security headers via response headers
 
 - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
 - `X-Frame-Options: DENY`
-- `Content-Security-Policy: frame-ancestors 'self' *.learnworlds.com`
+- `Content-Security-Policy: frame-ancestors 'self' *.learnworlds.com academy.pulumi.com`
 - `X-XSS-Protection: 1; mode=block`
 - `X-Content-Type-Options: nosniff`
 - `Referrer-Policy: strict-origin-when-cross-origin`

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -560,7 +560,7 @@ const baseSecurityHeadersConfig = {
     contentSecurityPolicy: {
         // Allow embedding from LearnWorlds (LMS). X-Frame-Options is ignored by modern
         // browsers when frame-ancestors is present in CSP.
-        contentSecurityPolicy: "frame-ancestors 'self' *.learnworlds.com",
+        contentSecurityPolicy: "frame-ancestors 'self' *.learnworlds.com academy.pulumi.com",
         override: false,
     },
     // These remaining options are derived from:


### PR DESCRIPTION
## Summary

The LMS has moved from `pulumi.learnworlds.com` to `academy.pulumi.com`. The current CSP only whitelists `*.learnworlds.com` in `frame-ancestors`, so LMS embeds of pulumi.com content are now being blocked.

This PR adds `academy.pulumi.com` to the directive and keeps `*.learnworlds.com` as a fallback during the cutover. Follow-up to #18408.

## Changes

- `infrastructure/index.ts` — `frame-ancestors 'self' *.learnworlds.com academy.pulumi.com`
- `BUILD-AND-DEPLOY.md` — documented value tracks the code

## Test plan

- [ ] Stack deploys cleanly
- [ ] After deploy: `curl -sI https://www.pulumi.com/ | grep -i content-security-policy` shows both hosts
- [ ] @MitchellGerdisch reloads the LMS pages that were failing and confirms embeds render with no CSP error in the browser console

cc @MitchellGerdisch for review.