### PR TITLE
Nest Request Body fields under their heading in OpenAPI docs

### DIFF
--- a/assets/fingerprinted/css/openapi.css
+++ b/assets/fingerprinted/css/openapi.css
@@ -337,6 +337,36 @@
     font-size: 0.9rem;
 }
 
+/* Request body block: bordered card so the body's fields are visually nested
+   under the Request Body heading instead of sitting flush with the section's
+   top-level Request Parameters list. */
+
+.api-request-body {
+    margin: 1rem 0 1.25rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid #eaeaea;
+    border-radius: 4px;
+    background: #fff;
+}
+
+.api-request-body .api-params {
+    margin-top: 0.5rem;
+    border-top: none;
+}
+
+.api-request-body .api-param:first-child {
+    padding-top: 0;
+}
+
+.api-request-body .api-param:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.api-request-body .api-schema-label {
+    margin-top: 0;
+}
+
 /* Response blocks: one per inline-rendered status (2xx, or 4xx/5xx with a
    schema). Stock errors collapse into .api-response-errors below. */
 

--- a/assets/fingerprinted/css/openapi.css
+++ b/assets/fingerprinted/css/openapi.css
@@ -337,45 +337,34 @@
     font-size: 0.9rem;
 }
 
-/* Request body block: bordered card so the body's fields are visually nested
-   under the Request Body heading instead of sitting flush with the section's
-   top-level Request Parameters list. */
+/* Bordered card used for the Request Body and each Response. Both nest a
+   field list (.api-params) under a section heading; sharing the selector
+   keeps them visually in lockstep. */
 
-.api-request-body {
-    margin: 1rem 0 1.25rem;
-    padding: 0.75rem 1rem;
-    border: 1px solid #eaeaea;
-    border-radius: 4px;
-    background: #fff;
-}
-
-.api-request-body .api-params {
-    margin-top: 0.5rem;
-    border-top: none;
-}
-
-.api-request-body .api-param:first-child {
-    padding-top: 0;
-}
-
-.api-request-body .api-param:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
-}
-
-.api-request-body .api-schema-label {
-    margin-top: 0;
-}
-
-/* Response blocks: one per inline-rendered status (2xx, or 4xx/5xx with a
-   schema). Stock errors collapse into .api-response-errors below. */
-
+.api-request-body,
 .api-response {
     margin: 1rem 0 1.25rem;
     padding: 0.75rem 1rem;
     border: 1px solid #eaeaea;
     border-radius: 4px;
     background: #fff;
+}
+
+.api-request-body .api-params,
+.api-response .api-params {
+    margin-top: 0.5rem;
+    border-top: none;
+}
+
+.api-request-body .api-param:first-child,
+.api-response .api-param:first-child {
+    padding-top: 0;
+}
+
+.api-request-body .api-param:last-child,
+.api-response .api-param:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
 }
 
 .api-response-header {
@@ -410,18 +399,8 @@
     color: #5b3fa3;
 }
 
-.api-response .api-params {
-    margin-top: 0.5rem;
-    border-top: none;
-}
-
-.api-response .api-param:first-child {
-    padding-top: 0;
-}
-
-.api-response .api-param:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
+.api-request-body .api-schema-label {
+    margin-top: 0;
 }
 
 /* Status chip: compact pill showing HTTP status code with semantic color. */

--- a/layouts/partials/openapi/endpoint.html
+++ b/layouts/partials/openapi/endpoint.html
@@ -43,47 +43,9 @@
                 {{ $schema := .schema }}
                 {{ if $schema }}
                     <h4>Request Body</h4>
-                    {{ if isset $schema "$ref" }}
-                        {{ $refPath := index $schema "$ref" }}
-                        {{ $refParts := split $refPath "/" }}
-                        {{ $schemaName := index $refParts (sub (len $refParts) 1) }}
-                        {{ $schemaDetails := "" }}
-                        {{ if isset $.openapi.components.schemas $schemaName }}
-                            {{ $schemaDetails = index $.openapi.components.schemas $schemaName }}
-                        {{ end }}
-                        {{ if $schemaDetails }}
-                            <div class="api-request-body">
-                                <div class="api-schema-label">Schema: <a href="/docs/reference/cloud-rest-api/schema/{{ $schemaName | urlize }}/">{{ $schemaName }}</a></div>
-                                {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" $schemaDetails "openapi" $.openapi) }}
-                                {{ if $resolved.properties }}
-                                    <ul class="api-params">
-                                        {{ partial "openapi/property-rows.html" (dict
-                                            "properties" $resolved.properties
-                                            "required" $resolved.required
-                                            "openapi" $.openapi
-                                            "depth" 0
-                                            "maxDepth" 1
-                                        ) }}
-                                    </ul>
-                                {{ end }}
-                            </div>
-                        {{ end }}
-                    {{ else }}
-                        {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" $schema "openapi" $.openapi) }}
-                        {{ if $resolved.properties }}
-                            <div class="api-request-body">
-                                <ul class="api-params">
-                                    {{ partial "openapi/property-rows.html" (dict
-                                        "properties" $resolved.properties
-                                        "required" ($resolved.required | default slice)
-                                        "openapi" $.openapi
-                                        "depth" 0
-                                        "maxDepth" 1
-                                    ) }}
-                                </ul>
-                            </div>
-                        {{ end }}
-                    {{ end }}
+                    <div class="api-request-body">
+                        {{ template "openapi/response-schema.html" (dict "schema" $schema "openapi" $.openapi) }}
+                    </div>
                 {{ end }}
             {{ end }}
         {{ end }}

--- a/layouts/partials/openapi/endpoint.html
+++ b/layouts/partials/openapi/endpoint.html
@@ -52,37 +52,41 @@
                             {{ $schemaDetails = index $.openapi.components.schemas $schemaName }}
                         {{ end }}
                         {{ if $schemaDetails }}
-                            <div class="api-schema-label">Schema: <a href="/docs/reference/cloud-rest-api/schema/{{ $schemaName | urlize }}/">{{ $schemaName }}</a></div>
-                            {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" $schemaDetails "openapi" $.openapi) }}
-                            {{ if $resolved.properties }}
+                            <div class="api-request-body">
+                                <div class="api-schema-label">Schema: <a href="/docs/reference/cloud-rest-api/schema/{{ $schemaName | urlize }}/">{{ $schemaName }}</a></div>
+                                {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" $schemaDetails "openapi" $.openapi) }}
+                                {{ if $resolved.properties }}
+                                    <ul class="api-params">
+                                        {{ partial "openapi/property-rows.html" (dict
+                                            "properties" $resolved.properties
+                                            "required" $resolved.required
+                                            "openapi" $.openapi
+                                            "depth" 0
+                                            "maxDepth" 1
+                                        ) }}
+                                    </ul>
+                                {{ end }}
+                            </div>
+                        {{ end }}
+                    {{ else }}
+                        {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" $schema "openapi" $.openapi) }}
+                        {{ if $resolved.properties }}
+                            <div class="api-request-body">
                                 <ul class="api-params">
                                     {{ partial "openapi/property-rows.html" (dict
                                         "properties" $resolved.properties
-                                        "required" $resolved.required
+                                        "required" ($resolved.required | default slice)
                                         "openapi" $.openapi
                                         "depth" 0
                                         "maxDepth" 1
                                     ) }}
                                 </ul>
-                            {{ end }}
+                            </div>
                         {{ end }}
-                    {{ else }}
-                        {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" $schema "openapi" $.openapi) }}
-                        {{ if $resolved.properties }}
-                        <ul class="api-params">
-                            {{ partial "openapi/property-rows.html" (dict
-                                "properties" $resolved.properties
-                                "required" ($resolved.required | default slice)
-                                "openapi" $.openapi
-                                "depth" 0
-                                "maxDepth" 1
-                            ) }}
-                        </ul>
                     {{ end }}
                 {{ end }}
             {{ end }}
         {{ end }}
-    {{ end }}
 
         {{/* Request/response examples hidden for now — revisit once example
              quality is validated across the full public spec. */}}

--- a/layouts/partials/openapi/endpoint.html
+++ b/layouts/partials/openapi/endpoint.html
@@ -44,7 +44,10 @@
                 {{ if $schema }}
                     <h4>Request Body</h4>
                     <div class="api-request-body">
-                        {{ template "openapi/response-schema.html" (dict "schema" $schema "openapi" $.openapi) }}
+                        {{/* maxDepth 0: render top-level properties only. Nested $ref fields
+                             render as a link in the type column; users drill into the linked
+                             schema page rather than expanding inline. */}}
+                        {{ template "openapi/response-schema.html" (dict "schema" $schema "openapi" $.openapi "maxDepth" 0) }}
                     </div>
                 {{ end }}
             {{ end }}

--- a/layouts/partials/openapi/property-rows.html
+++ b/layouts/partials/openapi/property-rows.html
@@ -8,7 +8,9 @@
 {{ $required := .required | default slice }}
 {{ $openapi := .openapi }}
 {{ $depth := .depth | default 0 }}
-{{ $maxDepth := .maxDepth | default 2 }}
+{{/* maxDepth is checked with isset so an explicit 0 isn't coerced to the default. */}}
+{{ $maxDepth := 2 }}
+{{ if isset . "maxDepth" }}{{ $maxDepth = .maxDepth }}{{ end }}
 
 {{ $sortedNames := slice }}
 {{ range $propName, $prop := $properties }}

--- a/layouts/partials/openapi/resolve-schema.html
+++ b/layouts/partials/openapi/resolve-schema.html
@@ -58,9 +58,11 @@
 {{ else if isset $schema "$ref" }}
   {{ $refPath := index $schema "$ref" }}
   {{ $refParts := split $refPath "/" }}
-  {{ $schemaName = index $refParts (sub (len $refParts) 1) }}
-  {{ with index $openapi.components.schemas $schemaName }}
-    {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" . "openapi" $openapi "depth" (add $depth 1)) }}
+  {{ $candidateName := index $refParts (sub (len $refParts) 1) }}
+  {{ if isset $openapi.components.schemas $candidateName }}
+    {{ $schemaName = $candidateName }}
+    {{ $schemaDetails := index $openapi.components.schemas $candidateName }}
+    {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" $schemaDetails "openapi" $openapi "depth" (add $depth 1)) }}
     {{ $properties = $resolved.properties }}
     {{ $required = $resolved.required }}
     {{ $description = $resolved.description }}

--- a/layouts/partials/openapi/response-schema.html
+++ b/layouts/partials/openapi/response-schema.html
@@ -1,5 +1,10 @@
 {{ define "openapi/response-schema.html" }}
 {{ if .schema }}
+    {{/* maxDepth defaults to 1 (one level of nested $ref expansion) for responses.
+         Callers can pass 0 to render top-level fields only and let the type-column
+         link be the drill-down (used by Request Body). */}}
+    {{ $maxDepth := 1 }}
+    {{ if isset . "maxDepth" }}{{ $maxDepth = .maxDepth }}{{ end }}
     {{ $resolved := partial "openapi/resolve-schema.html" (dict "schema" .schema "openapi" .openapi) }}
     {{ if $resolved.schemaName }}
         <div class="api-schema-label">Schema: <a href="/docs/reference/cloud-rest-api/schema/{{ $resolved.schemaName | urlize }}/">{{ $resolved.schemaName }}</a></div>
@@ -11,7 +16,7 @@
                 "required" $resolved.required
                 "openapi" .openapi
                 "depth" 0
-                "maxDepth" 1
+                "maxDepth" $maxDepth
             ) }}
         </ul>
     {{ end }}


### PR DESCRIPTION
## Summary

* Wrap each operation's Request Body subtree in a bordered card (`.api-request-body`) that mirrors how `.api-response` already presents response schemas, so body fields are visually nested under the **Request Body** heading instead of sitting flush-left with the section's **Request Parameters** list.
* Request Parameters keep their existing flat layout: path and query parameters aren't fields of an enclosing object, so indentation there would imply false nesting.

## Screenshot 
Request Body info is now nested with left padding so it appears under the `Request Body` heading, like we do for `Response Body`
<img width="736" height="900" alt="Screenshot 2026-05-21 at 11 26 59 AM" src="https://github.com/user-attachments/assets/328f868c-2f02-4414-95dd-333f9d2ebfc6" />

## Problem

On generated OpenAPI docs pages (`/docs/reference/cloud-rest-api/...`), each operation shows three field sections under the endpoint heading: Request Parameters, Request Body, and Responses. All three render fields via the same `property-rows.html` partial. The inconsistency was structural, not in the list rendering:

* **Responses** wrap each status code in `<div class=\"api-response\">`, a bordered, padded card. The schema label and field list live inside, so every response field reads as nested under the Responses heading.
* **Request Body** had no such wrapper. The `<h4>Request Body</h4>` was followed directly by the schema label and `<ul class=\"api-params\">`, all flush-left — at the same margin as the path/query parameters listed above.

Net effect: a body field like `entity` looked like just another peer parameter rather than a member of, say, `CreateXRequest`. Internal feedback flagged exactly this confusion.

## Change

* `layouts/partials/openapi/endpoint.html`: wrap the request body's schema label and property list in `<div class=\"api-request-body\">` for both the `$ref` and inline-schema branches.
* `assets/fingerprinted/css/openapi.css`: add `.api-request-body` styles (same border/padding/radius/background as `.api-response`) plus the matching `.api-params` first/last-child overrides so the field list reads cleanly inside the card.

## Test plan

* [x] Confirm on the Netlify deploy preview that on an OpenAPI operation page (e.g. anything under `/docs/reference/cloud-rest-api/`) the Request Body section now renders as a bordered card, visually nesting its schema fields under the Request Body heading.
* [x] Confirm the Responses section still renders unchanged.
* [x] Confirm the Request Parameters section still renders flush-left and unchanged.
* [x] Spot-check an endpoint whose body is an inline (non-`$ref`) schema and one that uses `$ref` to a component schema to verify both branches.