### PR TITLE
Move update plans page from Guides to Concepts

### DIFF
--- a/content/docs/iac/concepts/update-plans.md
+++ b/content/docs/iac/concepts/update-plans.md
@@ -2,24 +2,24 @@
 title_tag: "Update Plans | Pulumi Concepts"
 meta_desc: Learn about Pulumi update plans and how they can be used.
 title: Update plans
-h1: Update  plans
+h1: Update plans
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
         name: Update plans
-        parent: iac-guides-basics
-        weight: 60
+        parent: iac-concepts
+        weight: 80
     concepts:
         weight: 11
 aliases:
 - /docs/iac/guides/update-plans/
+- /docs/iac/guides/basics/update-plans/
 - /updateplans/
 - /docs/intro/concepts/plans/
 - /docs/intro/concepts/update-plans/
 - /docs/intro/vs/
 - /docs/concepts/plans/
 - /docs/concepts/update-plans/
-- /docs/iac/concepts/update-plans/
 ---
 
 The result of previews can be saved to an _update plan_, this can then be used during a later update to

--- a/content/docs/iac/guides/basics/_index.md
+++ b/content/docs/iac/guides/basics/_index.md
@@ -24,8 +24,6 @@ These fundamentals apply across all cloud providers and help you build maintaina
 
 **[Least privilege security](/docs/iac/guides/basics/iac-least-privileges/)** - Implement security best practices by granting only the minimum permissions needed for infrastructure operations. Learn how to configure cloud provider credentials with appropriate access controls.
 
-**[Update plans](/docs/iac/guides/basics/update-plans/)** - Preview and review infrastructure changes before applying them. Update plans help you catch unintended modifications and coordinate changes across teams.
-
 **[Pulumi Cloud vs. OSS](/docs/iac/guides/basics/pulumi-cloud-vs-oss/)** - Compare open source Pulumi with Pulumi Cloud across state backends, access management, secrets and configuration, policy enforcement, and workflows.
 
 **[Using a DIY backend](/docs/iac/guides/basics/using-a-diy-backend/)** - Configure a self-managed state backend with AWS S3, Azure Blob Storage, Google Cloud Storage, PostgreSQL, or the local filesystem.


### PR DESCRIPTION
Fixes #19016

## Summary

The `update-plans` page explains the concept of update plans rather than being a how-to guide, so it has been moved from `content/docs/iac/guides/basics/` to `content/docs/iac/concepts/`.

- Renamed file preserves git history (98% similarity, detected as rename).
- Re-parented under `iac-concepts` with weight `80`.
- Aliases updated so the old guides path continues to redirect to the new location.
- Removed entry from `guides/basics/_index.md` listing.
- Fixed a pre-existing double-space in the `h1` while there.

## Test plan

- [ ] `make build` succeeds
- [ ] `make lint` passes
- [ ] `/docs/iac/concepts/update-plans/` renders and appears in the Concepts nav
- [ ] `/docs/iac/guides/basics/update-plans/` redirects via the alias

Generated with [Claude Code](https://claude.ai/code)