### PR TITLE
Add .NET ESC SDK link to Reference -> SDKs

### DIFF
--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -92,6 +92,11 @@ sections:
     description: API reference for automating Pulumi ESC from Go.
     link: https://pkg.go.dev/github.com/pulumi/esc-sdk/sdk/go
 
+  - image: /logos/tech/dotnet.svg
+    heading: .NET ESC SDK ↗
+    description: API reference for automating Pulumi ESC from .NET.
+    link: /docs/reference/pkg/dotnet/esc-sdk/pulumi.esc.sdk/pulumi.esc.sdk.html
+
 - type: button-cards
   heading: APIs & Configuration
   cards:


### PR DESCRIPTION
Surfaces the generated docfx site for pulumi/esc-sdk's C# SDK under the **ESC SDKs** card group on `/docs/reference/`, matching the TypeScript/Python/Go siblings.

The underlying script fix and regenerated docs landed via #19025; this PR just adds the discovery link.

## Test plan
- [x] `make serve` builds with no errors
- [x] Card renders under "ESC SDKs" with href `/docs/reference/pkg/dotnet/esc-sdk/pulumi.esc.sdk/pulumi.esc.sdk.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)