### PR TITLE
Add targeted updates guide (#10021)

### DIFF
--- a/content/docs/iac/concepts/stash.md
+++ b/content/docs/iac/concepts/stash.md
@@ -337,7 +337,7 @@ When viewing stashed secret values, their plaintext content will not be shown by
 
 To update the value stored in a `Stash` you need to replace it. There are a few ways to do this.
 
-1. Using the `--target-replace` argument to `up` to tell the engine to replace it.
+1. Using the [`--target-replace`](/docs/iac/guides/basics/targeted-updates/#replacing-a-single-resource) argument to `up` to tell the engine to replace it.
 1. Using `pulumi state taint` to mark the resource to be replaced on the next deployment.
 1. Using the `TriggerReplacement` resource option to trigger the resource to replace on a change of value.
 

--- a/content/docs/iac/guides/basics/_index.md
+++ b/content/docs/iac/guides/basics/_index.md
@@ -26,6 +26,8 @@ These fundamentals apply across all cloud providers and help you build maintaina
 
 **[Update plans](/docs/iac/guides/basics/update-plans/)** - Preview and review infrastructure changes before applying them. Update plans help you catch unintended modifications and coordinate changes across teams.
 
+**[Targeted updates](/docs/iac/guides/basics/targeted-updates/)** - Limit which resources Pulumi operates on with `--target`, `--exclude`, and `--target-replace`. Learn the trade-offs of partial operations and when to use them.
+
 **[Pulumi Cloud vs. OSS](/docs/iac/guides/basics/pulumi-cloud-vs-oss/)** - Compare open source Pulumi with Pulumi Cloud across state backends, access management, secrets and configuration, policy enforcement, and workflows.
 
 **[Using a DIY backend](/docs/iac/guides/basics/using-a-diy-backend/)** - Configure a self-managed state backend with AWS S3, Azure Blob Storage, Google Cloud Storage, PostgreSQL, or the local filesystem.

--- a/content/docs/iac/guides/basics/targeted-updates.md
+++ b/content/docs/iac/guides/basics/targeted-updates.md
@@ -1,0 +1,176 @@
+---
+title_tag: "Targeted updates | Pulumi Guides"
+meta_desc: Learn how to use --target, --exclude, and --target-replace to limit which resources Pulumi operates on, and what trade-offs each approach involves.
+title: Targeted updates
+h1: Targeted updates
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Targeted updates
+        parent: iac-guides-basics
+        weight: 65
+---
+
+By default, `pulumi up`, `pulumi preview`, `pulumi refresh`, and `pulumi destroy` operate on the entire stack. The Pulumi engine compares the program's desired state to the stack's current state and reconciles every resource in one pass. This is the recommended workflow because it keeps the program and the deployed infrastructure in sync.
+
+Sometimes you need finer control. You might want to deploy one new resource without touching anything else, force the replacement of a single resource, or run a wide update while skipping a resource that's in a maintenance window. Targeted update flags let you narrow the set of resources an operation touches.
+
+{{% notes type="warning" %}}
+Targeted operations are an escape hatch. Because the engine reconciles only a subset of the stack, the deployed infrastructure can drift from what the program describes. Use targeted operations for one-off interventions and return to whole-stack operations as soon as you can.
+{{% /notes %}}
+
+## The flags at a glance
+
+| Flag | Available on | What it does |
+| - | - | - |
+| `--target` | `up`, `preview`, `refresh`, `destroy` | Restricts the operation to only the resources whose URNs match. |
+| `--target-dependents` | `up`, `preview`, `refresh`, `destroy` | Also includes resources that depend on a targeted resource. |
+| `--target-replace` | `up`, `preview` | Shorthand for `--target <URN> --replace <URN>`. Restricts the operation to the named resource and forces its replacement. |
+| `--exclude` | `up`, `preview`, `refresh`, `destroy` | Operates on the whole stack except the resources whose URNs match. |
+| `--exclude-dependents` | `up`, `preview`, `refresh` | Also excludes resources that depend on an excluded resource. |
+| `--replace` | `up`, `preview` | Forces replacement of the named resources, but does not restrict the operation to them. The rest of the stack is still reconciled. |
+
+All flags that accept a URN can be passed multiple times.
+
+## Specifying resources
+
+Targeted flags accept resource URNs. A URN identifies one resource uniquely and looks like this:
+
+```text
+urn:pulumi:dev::my-project::aws:s3/bucket:Bucket::my-bucket
+```
+
+The segments are: stack name, project name, resource type, and resource name. To list the URNs in a stack, run:
+
+```bash
+pulumi stack --show-urns
+```
+
+### Wildcards
+
+Both `--target` and `--exclude` accept wildcards in URN patterns:
+
+- `*` matches any characters within a single URN segment (it does not cross `:` separators).
+- `**` matches any characters across segments.
+
+Quote wildcard patterns so your shell doesn't expand them. A few examples:
+
+```bash
+# Match every resource whose name is "my-bucket", in any project or stack.
+pulumi up --target 'urn:pulumi:**::**::**::my-bucket'
+
+# Match every S3 bucket in the stack.
+pulumi up --target 'urn:pulumi:dev::my-project::aws:s3/bucket:Bucket::*'
+
+# Exclude every resource under the "drafts" component.
+pulumi up --exclude 'urn:pulumi:**::**::**::drafts' --exclude-dependents
+```
+
+URNs without wildcards must match a resource's URN character-for-character. Short resource names alone are not accepted.
+
+## How targeting interacts with the dependency graph
+
+By default, `--target` operates only on the resources whose URNs you list. Resources that depend on a targeted resource — or that a targeted resource depends on — are left in their existing state.
+
+When a targeted resource needs an input from a non-targeted resource (for example, the ID of a VPC it lives in), the engine uses the value stored in the stack's state from the last update. This means your targeted update sees the *recorded* state of the wider stack, not what the program would produce if it ran end-to-end.
+
+`--target-dependents` opts you into pulling dependent resources into the operation. For example, if you target a VPC and pass `--target-dependents`, every subnet, security group, and instance whose declaration depends on the VPC is also included.
+
+`pulumi destroy` treats dependents more strictly than the other commands. If a targeted resource has dependents and you don't pass `--target-dependents`, the operation fails: deleting the resource would leave the stack in an inconsistent state. Pass `--target-dependents` to destroy the resource and its dependents together.
+
+## When to use `--target` vs. `--exclude`
+
+Use `--target` when you want to operate on a *small* number of resources and leave the rest of the stack alone. Use `--exclude` when you want to operate on *most* of the stack but skip a few resources.
+
+For example, deploying a single new resource is straightforward with `--target`:
+
+```bash
+pulumi up --target 'urn:pulumi:dev::my-project::aws:s3/bucket:Bucket::new-bucket'
+```
+
+But updating a stack with a hundred resources while skipping a single database under maintenance is much cleaner with `--exclude`:
+
+```bash
+pulumi up --exclude 'urn:pulumi:dev::my-project::aws:rds/instance:Instance::primary-db'
+```
+
+If you instead used `--target` for that update, you would have to enumerate every resource you wanted to include.
+
+## Replacing a single resource
+
+`--target-replace` is shorthand for `--target <URN> --replace <URN>`. It restricts the update to the named resource and forces Pulumi to delete and recreate it rather than updating it in place. Use it when you need to force a recreation of one resource without rolling the rest of the stack forward:
+
+```bash
+pulumi up --target-replace 'urn:pulumi:dev::my-project::aws:ec2/instance:Instance::web-server'
+```
+
+This is different from `--replace`, which forces replacement of the named resource but still reconciles the rest of the stack at the same time.
+
+## Per-command behavior
+
+The flags work the same way across `up`, `preview`, `refresh`, and `destroy`, with a few differences worth knowing:
+
+- **`pulumi preview`** is the safest way to experiment with targeting. It shows you what an `up` with the same flags would change, without applying anything. Preview a targeted update before running it.
+- **`pulumi refresh`** with `--target` updates the state of only the listed resources from the cloud provider. This is useful when you suspect drift in one resource and don't want to wait for a full-stack refresh.
+- **`pulumi destroy`** with `--target` requires `--target-dependents` whenever the targeted resource has dependents in the stack. Without it, destroy aborts rather than leave dangling references in state.
+
+## Limitations and trade-offs
+
+Targeted operations are useful, but they introduce risks that whole-stack operations don't have:
+
+- **Drift between code and infrastructure.** A targeted update applies only what its flags allow. Changes elsewhere in your program are deferred until the next full update. If the deferred changes are forgotten, the deployed stack will not match what the program describes.
+- **Stale inputs.** When a targeted resource references a non-targeted resource, the engine uses the value in state from the last full update. If the non-targeted resource has changed in a way that the program now describes differently, the targeted resource may end up with stale input values.
+- **Skipped dependents.** Without `--target-dependents`, a downstream resource keeps its old configuration even when an upstream resource changes. The next full update will surface those deferred changes.
+- **Interaction with `--refresh`.** Passing `--refresh` alongside `--target` only refreshes the targeted resources before the update. Other resources are not refreshed, even if their state is stale.
+- **Interaction with update plans.** A plan generated from a targeted preview only describes operations on the targeted resources. Applying that plan to a full `pulumi up` will fail because the plan and the program's full goal state will not match. Generate plans from full-stack previews when you intend to apply them to full-stack updates. See [Update plans](/docs/iac/guides/basics/update-plans/) for more.
+
+If you find yourself reaching for targeted operations regularly, consider splitting the stack into smaller stacks instead. Smaller stacks give you the same locality without the drift risk — whole-stack operations on a smaller stack are safer than targeted operations on a large one. See [Organizing projects and stacks](/docs/iac/guides/basics/organizing-projects-stacks/) for guidance.
+
+## Examples
+
+### Deploy a single new resource
+
+You've added one new bucket to a large program and want to deploy only it:
+
+```bash
+pulumi up --target 'urn:pulumi:dev::my-project::aws:s3/bucket:Bucket::reports'
+```
+
+Pulumi will create the bucket and leave the rest of the stack untouched.
+
+### Destroy a component and everything under it
+
+A component groups a feature's resources together. To tear the whole feature down in one command, target the component and pass `--target-dependents`:
+
+```bash
+pulumi destroy \
+  --target 'urn:pulumi:dev::my-project::myorg:feature:Drafts::drafts' \
+  --target-dependents
+```
+
+Every child of the `drafts` component is destroyed alongside the component itself.
+
+### Skip a stateful resource during a wide update
+
+You're rolling out application changes across a stack but the primary database is in a maintenance window. Exclude it from the update:
+
+```bash
+pulumi up \
+  --exclude 'urn:pulumi:dev::my-project::aws:rds/instance:Instance::primary-db'
+```
+
+Every other resource is reconciled. Run the same update without `--exclude` once the maintenance window closes to bring the database back in sync with the program.
+
+### Force recreation of one resource
+
+A configuration value is baked into a resource at creation time and an in-place update won't pick it up. Force the resource to be replaced without disturbing anything else:
+
+```bash
+pulumi up --target-replace 'urn:pulumi:dev::my-project::aws:ec2/instance:Instance::web-server'
+```
+
+## See also
+
+- [`pulumi up`](/docs/iac/cli/commands/pulumi_up/), [`pulumi preview`](/docs/iac/cli/commands/pulumi_preview/), [`pulumi refresh`](/docs/iac/cli/commands/pulumi_refresh/), and [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy/) command references.
+- [Update plans](/docs/iac/guides/basics/update-plans/) for constraining an update to a pre-approved set of operations.
+- [Organizing projects and stacks](/docs/iac/guides/basics/organizing-projects-stacks/) for splitting infrastructure when targeted operations become routine.

--- a/content/docs/support/troubleshooting/_index.md
+++ b/content/docs/support/troubleshooting/_index.md
@@ -45,8 +45,13 @@ sections:
     link: /docs/support/troubleshooting/editing-state-files/
     description: Safe techniques for modifying Pulumi state files when necessary.
 
+  - icon: target
+    heading: Targeted Updates
+    link: /docs/iac/guides/basics/targeted-updates/
+    description: Limit operations to specific resources with --target and --exclude when a stuck or misbehaving resource is blocking a wider update.
+
   - icon: wrench
-    heading: Using dev builds
+    heading: Using Dev Builds
     link: /docs/support/troubleshooting/using-dev-builds/
     description: Install pre-release builds to access bug fixes that haven't shipped in a stable release yet.
 

--- a/content/docs/support/troubleshooting/editing-state-files.md
+++ b/content/docs/support/troubleshooting/editing-state-files.md
@@ -39,14 +39,7 @@ Before manually editing your state file, consider these troubleshooting steps:
 These steps don’t always resolve the issue in every case, but they often help and are worth trying before manually editing your state file.
 
 {{% notes type="info" %}}
-If your Pulumi issue is causing a serious outage for your workload(s), and Pulumi CLI operations are taking too long, consider the `--target` option, which allows you to limit the refresh operation only to the resources you specify. (The flag can be specified more than once.)
-
-The following commands support the `--target` option:
-
-- `pulumi refresh`
-- `pulumi preview`
-- `pulumi up`
-- `pulumi destroy`
+If your Pulumi issue is causing a serious outage for your workload(s), and Pulumi CLI operations are taking too long, consider the [`--target` option](/docs/iac/guides/basics/targeted-updates/), which allows you to limit the operation to only the resources you specify. The flag is supported on `pulumi refresh`, `pulumi preview`, `pulumi up`, and `pulumi destroy`, and can be specified more than once.
 {{% /notes %}}
 
 ## How to edit your state file safely


### PR DESCRIPTION
Adds a guide explaining `--target`, `--target-dependents`, `--target-replace`, `--exclude`, and `--exclude-dependents` in one place, addressing the gap identified in #10021.

## Changes
- New page: `content/docs/iac/guides/basics/targeted-updates.md`
- Cross-links: `stash.md` (`--target-replace` mention), `editing-state-files.md` (`--target` callout), `troubleshooting/_index.md` (new card)
- Menu entry under `iac-guides-basics` (weight 65, between Update plans and Pulumi Cloud vs. OSS)

Fixes #10021