### PR TITLE
Add skip_auto_merge flag and no-changes guard to doc-gen workflows

### DIFF
--- a/.github/workflows/customer-managed-workflow-agent-cli.yml
+++ b/.github/workflows/customer-managed-workflow-agent-cli.yml
@@ -11,6 +11,15 @@ on:
   repository_dispatch:
     types:
       - customer-managed-workflow-agent
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "customer-managed-workflow-agent version (e.g. v0.1.0)"
+        required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 jobs:
   pull-request:
     runs-on: ubuntu-latest
@@ -24,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
       - name: set the customer-managed-workflow-agent version
         run: |
-          echo "CMWA_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+          echo "CMWA_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
       - name: pull-request
         id: create-pr
         uses: repo-sync/pull-request@v2
@@ -36,7 +45,7 @@ jobs:
           pr_label: "automation/customer-managed-workflow-agent-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
@@ -50,7 +59,7 @@ jobs:
         uses: pulumi/esc-action@v1
       - name: set the customer-managed-workflow-agent version
         run: |
-          echo "CMWA_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+          echo "CMWA_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
       - name: checkout docs repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -11,10 +11,20 @@ on:
   repository_dispatch:
     types:
       - esc-cli
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "esc version (e.g. v0.13.1)"
+        required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 jobs:
   pull-request:
     runs-on: ubuntu-latest
     needs: build-esc-cli-docs
+    if: needs.build-esc-cli-docs.outputs.has_changes == 'true'
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -23,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
       - name: set the esc version
         run: |
-          echo "ESC_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+          echo "ESC_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
       - name: pull-request
         id: create-pr
         uses: repo-sync/pull-request@v2
@@ -35,19 +45,21 @@ jobs:
           pr_label: "automation/esc-cli-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
   build-esc-cli-docs:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
       - name: set the esc version
         run: |
-          echo "ESC_VERSION=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+          echo "ESC_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
       - name: checkout docs repo
         uses: actions/checkout@v6
         with:
@@ -57,7 +69,7 @@ jobs:
         with:
           repository: pulumi/esc
           path: esc
-          ref: ${{ github.event.client_payload.ref }}
+          ref: ${{ env.ESC_VERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
@@ -97,14 +109,21 @@ jobs:
         run: git status && git diff
         working-directory: docs
       - name: commit changes
+        id: commit
         run: |
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b esc/${{ github.run_id }}-${{ github.run_number }}
           git add static/
           git add content/
-          git commit -m "Regenerating docs for esc@${{ env.ESC_VERSION }}"
-          git push origin esc/${{ github.run_id }}-${{ github.run_number }}
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "Regenerating docs for esc@${{ env.ESC_VERSION }}"
+            git push origin esc/${{ github.run_id }}-${{ github.run_number }}
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
         working-directory: docs
     strategy:
       matrix:

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -12,10 +12,20 @@ on:
   repository_dispatch:
     types:
       - pulumi-cli-dev-version
+  workflow_dispatch:
+    inputs:
+      dev_version:
+        description: "Pulumi CLI dev version (e.g. 3.240.0-alpha.xa906d66)"
+        required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 jobs:
   pull-request:
     runs-on: ubuntu-latest
     needs: update-latest-dev-version
+    if: needs.update-latest-dev-version.outputs.has_changes == 'true'
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -28,17 +38,19 @@ jobs:
         with:
           source_branch: "pulumi/${{ github.run_id }}-${{ github.run_number }}"
           destination_branch: "master"
-          pr_title: "Regen dev version pulumi@${{ github.event.client_payload.dev_version}}"
+          pr_title: "Regen dev version pulumi@${{ github.event.inputs.dev_version || github.event.client_payload.dev_version }}"
           pr_body: "Automated PR"
           pr_label: "automation/pulumi-cli-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
   update-latest-dev-version:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -47,17 +59,24 @@ jobs:
         uses: actions/checkout@v6
       - name: Update latest version
         run: |
-          echo -n "${{ github.event.client_payload.dev_version }}" > ./static/latest-dev-version
+          echo -n "${{ github.event.inputs.dev_version || github.event.client_payload.dev_version }}" > ./static/latest-dev-version
       - name: git status
         run: git status && git diff
       - name: commit changes
+        id: commit
         run: |
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b pulumi/${{ github.run_id }}-${{ github.run_number }}
           git add static/latest-dev-version
-          git commit -m "Updating latest pulumi dev version@${{ github.event.client_payload.dev_version }}"
-          git push origin pulumi/${{ github.run_id }}-${{ github.run_number }}
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "Updating latest pulumi dev version@${{ github.event.inputs.dev_version || github.event.client_payload.dev_version }}"
+            git push origin pulumi/${{ github.run_id }}-${{ github.run_number }}
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
   notify:
     if: failure()
     name: Send slack notification

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -13,11 +13,16 @@ on:
       version:
         description: "Pulumi CLI version (e.g. 3.150.0, without leading 'v')"
         required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 
 jobs:
   pull-request:
     runs-on: ubuntu-latest
     needs: build-pulumi-cli-docs
+    if: needs.build-pulumi-cli-docs.outputs.has_changes == 'true'
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -41,12 +46,14 @@ jobs:
           pr_label: "automation/pulumi-cli-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
   build-pulumi-cli-docs:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -93,6 +100,7 @@ jobs:
       - name: git status
         run: git status && git diff
       - name: commit changes
+        id: commit
         run: |
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
@@ -100,8 +108,14 @@ jobs:
           git add content/
           git add data/
           git add static/
-          git commit -m "Regenerating CLI docs for Pulumi@${{ env.PULUMI_VERSION}}"
-          git push origin pulumi-cli-docs/${{ github.run_id }}-${{ github.run_number }}
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "Regenerating CLI docs for Pulumi@${{ env.PULUMI_VERSION}}"
+            git push origin pulumi-cli-docs/${{ github.run_id }}-${{ github.run_number }}
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
   notify:
     if: failure()
     name: Send slack notification

--- a/.github/workflows/pulumi-esc-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-python-docs.yml
@@ -13,6 +13,10 @@ on:
       version:
         description: "pulumi_esc_sdk version (e.g. 0.10.0, without leading 'v')"
         required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 
 jobs:
   pull-request:
@@ -42,7 +46,7 @@ jobs:
           pr_label: "automation/pulumi-esc-sdk-python-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/pulumi-policy-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-python-docs.yml
@@ -13,6 +13,10 @@ on:
       version:
         description: "pulumi_policy version (e.g. 1.16.0, without leading 'v')"
         required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 
 jobs:
   pull-request:
@@ -42,7 +46,7 @@ jobs:
           pr_label: "automation/pulumi-policy-sdk-python-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/pulumi-sdk-dotnet-docs.yml
+++ b/.github/workflows/pulumi-sdk-dotnet-docs.yml
@@ -16,11 +16,16 @@ on:
       version:
         description: "pulumi-dotnet version (e.g. 3.0.0, with or without leading 'v')"
         required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 
 jobs:
   pull-request:
     runs-on: ubuntu-latest
     needs: build-pulumi-sdk-dotnet-docs
+    if: needs.build-pulumi-sdk-dotnet-docs.outputs.has_changes == 'true'
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -46,12 +51,14 @@ jobs:
           pr_label: "automation/pulumi-sdk-dotnet-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
   build-pulumi-sdk-dotnet-docs:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -104,13 +111,20 @@ jobs:
         run: git status && git diff
         working-directory: docs
       - name: commit changes
+        id: commit
         run: |
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b pulumi-sdk-dotnet-docs/${{ github.run_id }}-${{ github.run_number }}
           git add static-prebuilt/
-          git commit -m "Regenerating Pulumi SDK .NET docs for pulumi-dotnet@${{ env.DOTNET_SDK_VERSION }}"
-          git push origin pulumi-sdk-dotnet-docs/${{ github.run_id }}-${{ github.run_number }}
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "Regenerating Pulumi SDK .NET docs for pulumi-dotnet@${{ env.DOTNET_SDK_VERSION }}"
+            git push origin pulumi-sdk-dotnet-docs/${{ github.run_id }}-${{ github.run_number }}
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
         working-directory: docs
   notify:
     if: failure()

--- a/.github/workflows/pulumi-sdk-java-docs.yml
+++ b/.github/workflows/pulumi-sdk-java-docs.yml
@@ -16,10 +16,15 @@ on:
       version:
         description: "pulumi-java version (e.g. 0.10.0, with or without leading 'v')"
         required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 jobs:
   pull-request:
     runs-on: ubuntu-latest
     needs: build-pulumi-sdk-java-docs
+    if: needs.build-pulumi-sdk-java-docs.outputs.has_changes == 'true'
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -45,12 +50,14 @@ jobs:
           pr_label: "automation/pulumi-sdk-java-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
   build-pulumi-sdk-java-docs:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
@@ -102,13 +109,20 @@ jobs:
         run: git status && git diff
         working-directory: docs
       - name: commit changes
+        id: commit
         run: |
           git config --local user.email "bot@pulumi.com"
           git config --local user.name "pulumi-bot"
           git checkout -b pulumi-sdk-java-docs/${{ github.run_id }}-${{ github.run_number }}
           git add static-prebuilt/
-          git commit -m "Regenerating Pulumi SDK Java docs for pulumi-java@${{ env.JAVA_SDK_VERSION }}"
-          git push origin pulumi-sdk-java-docs/${{ github.run_id }}-${{ github.run_number }}
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "Regenerating Pulumi SDK Java docs for pulumi-java@${{ env.JAVA_SDK_VERSION }}"
+            git push origin pulumi-sdk-java-docs/${{ github.run_id }}-${{ github.run_number }}
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
         working-directory: docs
   notify:
     if: failure()

--- a/.github/workflows/pulumi-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-sdk-python-docs.yml
@@ -13,6 +13,10 @@ on:
       version:
         description: "Pulumi version (e.g. 3.238.0, without leading 'v')"
         required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 
 jobs:
   pull-request:
@@ -42,7 +46,7 @@ jobs:
           pr_label: "automation/pulumi-sdk-python-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/pulumi-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-sdk-typescript-docs.yml
@@ -13,6 +13,10 @@ on:
       version:
         description: "Pulumi version (e.g. 3.237.0, without leading 'v')"
         required: true
+      skip_auto_merge:
+        description: "Skip enabling auto-merge on the generated PR (for testing)"
+        type: boolean
+        default: false
 
 jobs:
   pull-request:
@@ -42,7 +46,7 @@ jobs:
           pr_label: "automation/pulumi-sdk-typescript-docs,automation/merge"
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pr_created == 'true'
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}


### PR DESCRIPTION
Every SDK/CLI doc-generation workflow now accepts a skip_auto_merge workflow_dispatch input (default false) so a maintainer can produce a PR without auto-merging it during testing. The three workflows that were repository_dispatch-only (esc-cli, pulumi-cli-dev-version, customer-managed-workflow-agent-cli) also gain workflow_dispatch triggers with the same version-resolution fallback already used by the .NET and Java SDK workflows.

Five workflows that previously ran `git commit` unconditionally now follow the canonical has_changes guard pattern used by the other seven, so re-running for an already-published version exits clean instead of failing the commit step. All twelve doc-gen workflows are now consistent.
