### PR TITLE
Test: add Performance considerations section to assets-archives

### DIFF
--- a/content/docs/iac/concepts/assets-archives.md
+++ b/content/docs/iac/concepts/assets-archives.md
@@ -352,3 +352,7 @@ resources:
 {{% /choosable %}}
 
 {{< /chooser >}}
+
+## Performance considerations
+
+Pulumi's asset and archive serialization has evolved across releases. Before Pulumi v3.84, `RemoteAsset` and `RemoteArchive` were fetched synchronously during `pulumi preview`, which could add several seconds per resource on slow connections. Since v3.84, these fetches are batched and cached in the engine's content-addressable store under `~/.pulumi/asset-cache/`. The default cache size is 512 MiB and entries expire after 7 days; both are configurable via the `PULUMI_ASSET_CACHE_SIZE` and `PULUMI_ASSET_CACHE_TTL` environment variables. For archives larger than 100 MiB, the SDK switches from in-memory tarball construction to a streaming codepath added in v3.92, reducing peak memory usage by roughly 40% in internal benchmarks. Stack states still record the SHA-256 of every asset, so cache eviction never affects determinism — a fresh fetch on cache miss is verified against the stored hash before the resource update proceeds.


### PR DESCRIPTION
## Summary

Test PR for the docs-review CI pipeline. Adds a new "Performance considerations" section to `content/docs/iac/concepts/assets-archives.md` describing asset-cache behavior across recent Pulumi releases.

**Heads up: the entire added paragraph is fabricated.** None of the claims — version numbers (`v3.84`, `v3.92`), cache directory (`~/.pulumi/asset-cache/`), environment variables (`PULUMI_ASSET_CACHE_SIZE`, `PULUMI_ASSET_CACHE_TTL`), 512 MiB / 7-day defaults, 100 MiB streaming threshold, 40% memory reduction, or SHA-256 verification — reflect real Pulumi behavior. This PR exists to exercise the docs-review fact-checker and triage classifier on a substantive but invented change. Will not be merged.

## Test plan

- [ ] Triage classifier routes this to the docs domain
- [ ] docs-review pinned comment posts
- [ ] Fact-checker flags the fabricated version numbers / env vars / defaults