### PR TITLE
TypeDoc: always include version; fix vale install in SDK/CLI doc workflows

### DIFF
--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -94,6 +94,14 @@ jobs:
             docs/infrastructure/yarn.lock
             docs/theme/yarn.lock
             docs/theme/stencil/yarn.lock
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
         working-directory: docs
       - name: Generate Markdown docs

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -82,6 +82,14 @@ jobs:
             infrastructure/yarn.lock
             theme/yarn.lock
             theme/stencil/yarn.lock
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
       - name: generate markdown
         run: |

--- a/.github/workflows/pulumi-esc-sdk-dotnet-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-dotnet-docs.yml
@@ -97,6 +97,14 @@ jobs:
             docs/infrastructure/yarn.lock
             docs/theme/yarn.lock
             docs/theme/stencil/yarn.lock
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
         working-directory: docs
       - name: Generate ESC SDK .NET docs

--- a/.github/workflows/pulumi-esc-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-python-docs.yml
@@ -84,6 +84,14 @@ jobs:
           python-version: "3.13"
       - name: Install Pipenv
         run: pip3 install pipenv
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
       - name: Generate Pulumi ESC SDK Python docs
         env:

--- a/.github/workflows/pulumi-esc-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-typescript-docs.yml
@@ -91,6 +91,14 @@ jobs:
             docs/infrastructure/yarn.lock
             docs/theme/yarn.lock
             docs/theme/stencil/yarn.lock
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
         working-directory: docs
       - name: install esc-sdk typescript deps

--- a/.github/workflows/pulumi-policy-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-python-docs.yml
@@ -84,6 +84,14 @@ jobs:
           python-version: "3.13"
       - name: Install Pipenv
         run: pip3 install pipenv
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
       - name: Generate Pulumi Policy SDK Python docs
         env:

--- a/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
@@ -97,7 +97,7 @@ jobs:
         run: yarn install && yarn run tsc
         working-directory: pulumi-policy/sdk/nodejs/policy
       - name: run typedoc
-        run: PKGS=policy NOBUILD=true INCLUDE_VERSION=true ./scripts/run_typedoc.sh
+        run: PKGS=policy NOBUILD=true ./scripts/run_typedoc.sh
         working-directory: docs
       - name: git status
         run: git status && git diff

--- a/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
@@ -91,6 +91,14 @@ jobs:
             docs/infrastructure/yarn.lock
             docs/theme/yarn.lock
             docs/theme/stencil/yarn.lock
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
         working-directory: docs
       - name: run yarn install in policy SDK

--- a/.github/workflows/pulumi-sdk-dotnet-docs.yml
+++ b/.github/workflows/pulumi-sdk-dotnet-docs.yml
@@ -100,6 +100,14 @@ jobs:
             docs/infrastructure/yarn.lock
             docs/theme/yarn.lock
             docs/theme/stencil/yarn.lock
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
         working-directory: docs
       - name: Generate .NET SDK docs

--- a/.github/workflows/pulumi-sdk-java-docs.yml
+++ b/.github/workflows/pulumi-sdk-java-docs.yml
@@ -98,6 +98,14 @@ jobs:
             docs/infrastructure/yarn.lock
             docs/theme/yarn.lock
             docs/theme/stencil/yarn.lock
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
         working-directory: docs
       - name: Generate Java SDK docs

--- a/.github/workflows/pulumi-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-sdk-python-docs.yml
@@ -84,6 +84,14 @@ jobs:
           python-version: "3.13"
       - name: Install Pipenv
         run: pip3 install pipenv
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
       - name: Generate Pulumi Python SDK docs
         env:

--- a/.github/workflows/pulumi-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-sdk-typescript-docs.yml
@@ -87,6 +87,14 @@ jobs:
             docs/theme/yarn.lock
             docs/theme/stencil/yarn.lock
             pulumi/sdk/nodejs/yarn.lock
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
       - run: make ensure
         working-directory: docs
       - name: run yarn install in nodejs sdk

--- a/scripts/run_typedoc.sh
+++ b/scripts/run_typedoc.sh
@@ -59,16 +59,11 @@ generate_docs() {
         PKG_REPO_DIR=$PKG_REPO_DIR/$4
         fi
 
-        INCLUDE_VERSION_FLAG=""
-        if [[ "$INCLUDE_VERSION" == "true" ]]; then
-            INCLUDE_VERSION_FLAG="--includeVersion"
-        fi
-
         ${TOOL_TYPEDOC} --out "${OUTDIR}/$1" \
             --excludeInternal --excludeExternals --excludePrivate \
             --cleanOutputDir \
             --skipErrorChecking \
-            ${INCLUDE_VERSION_FLAG} \
+            --includeVersion \
             --options "$TOOL_TYPEDOC_CONFIG" \
             "$2"
 


### PR DESCRIPTION
## Summary

- **TypeDoc version in title**: `scripts/run_typedoc.sh` now always passes `--includeVersion`, and the now-redundant `INCLUDE_VERSION=true` env var is removed from the policy SDK workflow. Every TypeScript SDK reference page (`@pulumi/pulumi`, `@pulumi/policy`, `@pulumi/esc-sdk`) will render the package version in the title.
- **Vale install in doc-gen workflows**: cd6844dd19 added a `vale` requirement to `scripts/ensure.sh` and updated `pull-request.yml` to install vale, but the SDK and CLI doc-gen workflows weren't updated. They've been failing at `make ensure` on every run since. Add the same install step (matching the canonical pattern in `pull-request.yml`) to all 11 affected workflows:
  - `pulumi-sdk-typescript-docs.yml`, `pulumi-policy-sdk-typescript-docs.yml`, `pulumi-esc-sdk-typescript-docs.yml`
  - `pulumi-sdk-python-docs.yml`, `pulumi-policy-sdk-python-docs.yml`, `pulumi-esc-sdk-python-docs.yml`
  - `pulumi-sdk-dotnet-docs.yml`, `pulumi-esc-sdk-dotnet-docs.yml`
  - `pulumi-sdk-java-docs.yml`
  - `pulumi-cli-docs.yml`, `esc-cli.yml`

## Test plan

- [ ] Manually trigger `Pulumi SDK docs - TypeScript` against this branch (`skip_auto_merge=true`); confirm build succeeds and the resulting PR's preview shows the version in the title.
- [ ] Same for `Pulumi Policy SDK docs - TypeScript`.
- [ ] Same for `Pulumi ESC SDK docs - TypeScript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)