### PR TITLE
Test: add Performance considerations section to assets-archives docs

### DIFF
--- a/content/docs/iac/concepts/assets-archives.md
+++ b/content/docs/iac/concepts/assets-archives.md
@@ -361,12 +361,6 @@ Before Pulumi v3.84, `RemoteAsset` and `RemoteArchive` were fetched synchronousl
 v3.84, these fetches are batched and cached in the engine's content-addressable store
 under `~/.pulumi/asset-cache/`.
 
-For archives larger than 100 MiB, the SDK switches from in-memory tarball construction to
-a streaming codepath added in v3.92, reducing peak memory usage by roughly 40% in internal
-benchmarks. Stack states still record the SHA-256 of every asset, so cache eviction never
-affects determinism — a fresh fetch on cache miss is verified against the stored hash
-before the resource update proceeds.
-
 ### Cache configuration
 
 The cache is enabled by default and stores up to 512 MiB of asset content, with entries
@@ -379,8 +373,7 @@ expiring after 7 days. Both limits are configurable via environment variables:
 | `PULUMI_ASSET_CACHE_DIR`   | `~/.pulumi/asset-cache/` | Directory used for the cache.                              |
 
 To disable caching entirely — useful in CI where the runner is ephemeral — set
-`PULUMI_ASSET_CACHE_SIZE=0`. To purge the cache manually, run `pulumi cache clear
---type=assets`.
+`PULUMI_ASSET_CACHE_SIZE=0`.
 
 ### Programmatic prefetching
 

--- a/content/docs/iac/concepts/assets-archives.md
+++ b/content/docs/iac/concepts/assets-archives.md
@@ -352,3 +352,55 @@ resources:
 {{% /choosable %}}
 
 {{< /chooser >}}
+
+## Performance considerations
+
+Pulumi's asset and archive serialization has evolved substantially across recent releases.
+Before Pulumi v3.84, `RemoteAsset` and `RemoteArchive` were fetched synchronously during
+`pulumi preview`, which could add several seconds per resource on slow connections. Since
+v3.84, these fetches are batched and cached in the engine's content-addressable store
+under `~/.pulumi/asset-cache/`.
+
+For archives larger than 100 MiB, the SDK switches from in-memory tarball construction to
+a streaming codepath added in v3.92, reducing peak memory usage by roughly 40% in internal
+benchmarks. Stack states still record the SHA-256 of every asset, so cache eviction never
+affects determinism — a fresh fetch on cache miss is verified against the stored hash
+before the resource update proceeds.
+
+### Cache configuration
+
+The cache is enabled by default and stores up to 512 MiB of asset content, with entries
+expiring after 7 days. Both limits are configurable via environment variables:
+
+| Variable                   | Default                  | Description                                                |
+|----------------------------|--------------------------|------------------------------------------------------------|
+| `PULUMI_ASSET_CACHE_SIZE`  | `512MiB`                 | Maximum total cache size. Accepts `MiB` or `GiB` suffixes. |
+| `PULUMI_ASSET_CACHE_TTL`   | `168h`                   | Time-to-live for cache entries. Accepts Go duration syntax.|
+| `PULUMI_ASSET_CACHE_DIR`   | `~/.pulumi/asset-cache/` | Directory used for the cache.                              |
+
+To disable caching entirely — useful in CI where the runner is ephemeral — set
+`PULUMI_ASSET_CACHE_SIZE=0`. To purge the cache manually, run `pulumi cache clear
+--type=assets`.
+
+### Programmatic prefetching
+
+For pipelines that publish many archives, you can prefetch content into the cache during
+your program's startup phase to avoid serial fetches during the update:
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+const urls = [
+    "https://example.com/lambda-runtime.zip",
+    "https://example.com/lambda-deps.zip",
+];
+
+await pulumi.asset.prefetchAll(urls, {
+    concurrency: 8,
+    verifyChecksums: true,
+});
+```
+
+The `prefetchAll` helper was introduced in v3.95 and respects the same cache settings as
+`RemoteAsset`. Each URL is fetched once per cache TTL window; subsequent calls return
+immediately from the in-process cache.


### PR DESCRIPTION
## Summary

Second test PR for the docs-review CI pipeline. Adds a multi-paragraph "Performance considerations" section (~52 line diff) to `content/docs/iac/concepts/assets-archives.md`, with two subsections, a configuration table, and a TypeScript code example.

This supersedes #19052, which got classified `review:trivial` because the prior change was a single long markdown line (4 diff lines total). This one is chunky enough to clear the trivial gate.

**Heads up: the entire added section is fabricated.** None of the following reflect real Pulumi behavior — they exist to give the fact-checker, code-examples specialist, and prose-pattern reviewer something to chew on:

- Version-introduction claims (`v3.84`, `v3.92`, `v3.95`)
- Cache directory `~/.pulumi/asset-cache/`
- Environment variables `PULUMI_ASSET_CACHE_SIZE`, `PULUMI_ASSET_CACHE_TTL`, `PULUMI_ASSET_CACHE_DIR`
- CLI subcommand `pulumi cache clear --type=assets`
- Default thresholds (512 MiB, 7-day TTL, 100 MiB streaming threshold, 40% memory reduction)
- TypeScript API `pulumi.asset.prefetchAll(...)` with `concurrency` / `verifyChecksums` options
- SHA-256 stack-state recording for assets

Will not be merged.

## Test plan

- [ ] Triage classifies as non-trivial and routes to the docs domain
- [ ] docs-review pinned comment posts with a full review (not just prose flagging)
- [ ] Fact-checker flags the fabricated version numbers, env vars, defaults, and CLI subcommand
- [ ] Code-examples specialist flags `pulumi.asset.prefetchAll` as a non-existent API