### PR TITLE
Substitute ${VERSION} placeholder in ESC SDK TypeScript docs workflow

### DIFF
--- a/.github/workflows/pulumi-esc-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-typescript-docs.yml
@@ -76,6 +76,16 @@ jobs:
           path: esc-sdk
           ref: v${{ env.ESC_SDK_VERSION }}
           submodules: recursive
+      # The pulumi/esc-sdk repo commits sdk/typescript/package.json with a
+      # literal "version": "${VERSION}" placeholder that its release pipeline
+      # substitutes at npm-publish time. TypeDoc's --includeVersion reads
+      # package.json verbatim, so without this substitution every generated
+      # page title would render "v${VERSION}". Replace the placeholder with
+      # the real release version before running typedoc.
+      - name: substitute version in esc-sdk package.json
+        run: |
+          sed -i "s/\${VERSION}/${ESC_SDK_VERSION}/g" esc-sdk/sdk/typescript/package.json
+          grep '"version"' esc-sdk/sdk/typescript/package.json
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3
         with:

--- a/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
@@ -72,6 +72,12 @@ jobs:
           repository: pulumi/pulumi-policy
           path: pulumi-policy
           ref: v${{ env.POLICY_SDK_VERSION }}
+      # The pulumi/pulumi-policy repo commits sdk/nodejs/policy/package.json
+      # with a literal "version": "${VERSION}" placeholder that its release
+      # pipeline substitutes at npm-publish time. TypeDoc's --includeVersion
+      # reads package.json verbatim, so without this substitution every
+      # generated page title would render "v${VERSION}". Replace the
+      # placeholder with the real release version before running typedoc.
       - name: substitute version in policy SDK package.json
         run: |
           sed -i "s/\${VERSION}/${POLICY_SDK_VERSION}/g" pulumi-policy/sdk/nodejs/policy/package.json


### PR DESCRIPTION
## Summary

- The `pulumi/esc-sdk` repo commits `sdk/typescript/package.json` with a literal `"version": "${VERSION}"` placeholder (substituted at npm-publish time, not at tag time). After #19056 made TypeDoc's `--includeVersion` always-on, that placeholder began rendering literally in every generated page title — e.g. `@pulumi/esc-sdk - v${VERSION}` (visible on PR #19064's preview).
- Add a `sed` step to the ESC SDK TypeScript workflow that substitutes the real version into `package.json` before `typedoc` runs, mirroring the same step the Policy SDK TypeScript workflow already has.
- Add an explanatory comment above the sed step in **both** workflows so future readers understand why this exists and don't delete it.

## Follow-up

After merging, close PR #19064 (its committed `static-prebuilt/` files have `v${VERSION}` baked in) and re-dispatch the **Pulumi ESC SDK docs - TypeScript** workflow with `version: 0.13.1` to regenerate.

## Test plan

- [ ] Re-run the ESC SDK TS workflow with `version: 0.13.1` and `skip_auto_merge: true`
- [ ] On the resulting preview, confirm `<title>` and `<h1>` on `/docs/reference/pkg/nodejs/pulumi/esc-sdk/` read `@pulumi/esc-sdk - v0.13.1`
- [ ] `grep -r '\${VERSION}' static-prebuilt/docs/reference/pkg/nodejs/pulumi/esc-sdk/` returns nothing in the new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)