### PR TITLE
fix(claude-workflows): use PULUMI_BOT_TOKEN for checkout so commits trigger downstream workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -120,6 +120,15 @@ jobs:
       checks: write
 
     steps:
+      # ESC runs before checkout so the bot token can authenticate the
+      # checkout — pushes made by claude-code-action later in the workflow
+      # then go out as pulumi-bot rather than github-actions[bot],
+      # which is what lets downstream workflows (build-and-deploy, social
+      # review, etc.) fire on those commits.
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+
       # Check out the PR head, not the base. workflow_run carries the
       # originating commit on the event payload; workflow_dispatch
       # doesn't, so claude-new.yml passes it through as an input.
@@ -128,6 +137,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.head_sha }}
           fetch-depth: 1
 

--- a/.github/workflows/claude-new.yml
+++ b/.github/workflows/claude-new.yml
@@ -42,14 +42,20 @@ jobs:
       id-token: write
       actions: write # Required to dispatch claude-code-review.yml.
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
+      # ESC runs before checkout so the bot token can authenticate the
+      # checkout. claude-new.yml doesn't push today (it just clears the
+      # pinned comment and dispatches claude-code-review.yml), but kept
+      # consistent with the other claude-*.yml workflows in case a future
+      # change adds a push path here.
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          fetch-depth: 1
 
       - name: Check repository write access
         id: check-access

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -71,9 +71,19 @@ jobs:
             echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           fi
 
+      # ESC runs before checkout so the bot token can authenticate the
+      # checkout — pushes made by claude-code-action later in the workflow
+      # then go out as pulumi-bot rather than github-actions[bot],
+      # which is what lets downstream workflows (build-and-deploy, social
+      # review, etc.) fire on those commits.
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           ref: ${{ steps.head.outputs.sha }}
           fetch-depth: 1
 
@@ -83,10 +93,6 @@ jobs:
         uses: jdx/mise-action@v2
         with:
           cache: true
-
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@v1
 
       - name: Check repository write access
         id: check-access

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,14 +42,20 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
+      # ESC runs before checkout so the bot token can authenticate the
+      # checkout — pushes made by claude-code-action later in the workflow
+      # then go out as pulumi-bot rather than github-actions[bot],
+      # which is what lets downstream workflows (build-and-deploy, social
+      # review, etc.) fire on those commits.
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          fetch-depth: 1
 
       - name: Check repository write access
         id: check-access


### PR DESCRIPTION
## Summary

Pushes made by claude-code-action were authenticated as \`github-actions[bot]\` because \`actions/checkout\` uses the default \`GITHUB_TOKEN\` when no \`token:\` is supplied. claude-code-action inherits that auth for \`git push\` regardless of the \`github_token\` input passed under \`with:\` (that input only configures the action's REST client). GitHub's well-known rule then blocks any push by \`GITHUB_TOKEN\` from triggering downstream workflows.

Caught on pulumi/docs#19062 — commit [a63d3c86](https://github.com/pulumi/docs/pull/19062/commits/a63d3c86ac7a2029e90cc3b1b0eef98f1f641618), made in response to an \`@claude #update-review\` comment, came in as \`github-actions[bot]\` / \`claude[bot]\` and the build / deploy / social-review workflows silently skipped it.

## Changes

For each affected workflow, ESC fetch is moved ahead of \`actions/checkout\` so the bot token is available when checkout configures \`.git/config\`. Then the checkout step gets \`token: \${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}\`. After this, any \`git push\` claude-code-action makes goes out as pulumi-bot, which downstream workflows treat as a regular user push.

Applied to all four claude workflows:

- \`.github/workflows/claude.yml\` — ad-hoc \`@claude\` mentions
- \`.github/workflows/claude-update.yml\` — \`@claude #update-review\`
- \`.github/workflows/claude-code-review.yml\` — initial pinned review (no ESC step existed; added one)
- \`.github/workflows/claude-new.yml\` — kept consistent for safety; this workflow doesn't push today (only dispatches claude-code-review.yml via \`gh workflow run\`, which is already authenticated with PULUMI_BOT_TOKEN), but a future change could add a push path

## Test plan

- [ ] Merge, then \`@claude #update-review\` on a test PR
- [ ] Confirm the resulting commit shows pulumi-bot as committer (not github-actions[bot])
- [ ] Confirm Build and deploy, Run Example Code Tests, and Social Media Review all fire on the new commit