### PR TITLE
Add .NET ESC SDK to Reference nav

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -351,6 +351,11 @@ reference:
     url: https://pkg.go.dev/github.com/pulumi/esc-sdk/sdk/go
     weight: 10
     identifier: reference-sdks-go-esc
+  - name: .NET ESC SDK ↗
+    parent: reference-sdks
+    url: /docs/reference/pkg/dotnet/esc-sdk/pulumi.esc.sdk/pulumi.esc.sdk.html
+    weight: 11
+    identifier: reference-sdks-dotnet-esc
   - name: CIS
     parent: reference-pre-built-policy-packs
     identifier: reference-pre-built-policy-packs-cis


### PR DESCRIPTION
The Reference > SDKs left nav listed TypeScript, Python, and Go ESC SDKs but was missing the .NET entry. Adds it pointing at the existing DocFX output under `static-prebuilt/docs/reference/pkg/dotnet/esc-sdk/`.