### PR TITLE
ci: install Vale in build-and-deploy workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -63,6 +63,15 @@ jobs:
           sudo tar -xz -C /usr/local/bin s5cmd -f /tmp/s5cmd.tar.gz
           rm /tmp/s5cmd.tar.gz
 
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
+
       - name: Install Pulumi CLI
         uses: pulumi/actions@v6
 

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -57,6 +57,15 @@ jobs:
           sudo tar -xz -C /usr/local/bin s5cmd -f /tmp/s5cmd.tar.gz
           rm /tmp/s5cmd.tar.gz
 
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
+
       - name: Install Pulumi CLI
         uses: pulumi/actions@v6
 


### PR DESCRIPTION
## Summary

- `scripts/ensure.sh` now requires Vale 3.14.1 and aborts under `set -o errexit` if the `vale` binary is missing on `PATH`. `pull-request.yml` and `esc-cli.yml` were updated when the requirement landed, but `build-and-deploy.yml` and `testing-build-and-deploy.yml` were missed, so every push to `master` and every scheduled deploy has been failing at `make ci_push` → `make ensure`.
- Adds the same pinned `Install Vale` step to both deploy workflows, in the same position as in `pull-request.yml` (between the s5cmd install and the Pulumi CLI install). Uses curl + SHA256 verification, matching the existing pattern.
- Audited every workflow under `.github/workflows/`. Only these two were broken. `pr-closed.yml` runs `make ci_pull_request_closed`, which does not call `ensure`, so it is unaffected.

## Test plan

- [ ] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"` — passes locally)
- [ ] CI on this PR runs `pull-request.yml`, which already installs Vale — should remain green
- [ ] After merge, watch the next push-to-master run of `Build and deploy` — the `Install Vale` step should pass and `make ci_push` should clear the `check_version "Vale"` gate in `scripts/ensure.sh:32`
- [ ] Next scheduled deploy (6 AM ET / noon PT) should complete successfully