### PR TITLE
fix(claude-code-review): add environment: production so ESC OIDC auth succeeds

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -107,6 +107,12 @@ jobs:
       cancel-in-progress: true
 
     runs-on: ubuntu-latest
+    # Required for pulumi/esc-action's OIDC trust policy, which gates on
+    # the GitHub environment claim. Without this, the ESC step returns
+    # an empty PULUMI_BOT_TOKEN and the checkout below fails with an
+    # empty `token:` value. Matches claude.yml / claude-update.yml /
+    # claude-new.yml, which all declare the same environment.
+    environment: production
     # A review that genuinely hangs (one observed stall ran ~18 min with no
     # output before being cancelled) would otherwise sit on the runner for
     # GitHub's 6-hour default. 25 min is comfortably above the slowest real


### PR DESCRIPTION
## Summary

Every run of `Pre-merge Review (main)` since commit 5909082 has failed at the same step: **`claude-review` job, step #3, "Checkout repository"**. Confirmed on runs #2780, #2774, #2770, #2764, #2756 (all `workflow_run` / `workflow_dispatch` events).

That commit added a `PULUMI_BOT_TOKEN`-authenticated checkout backed by `pulumi/esc-action`:

```yaml
- name: Fetch secrets from ESC
  id: esc-secrets
  uses: pulumi/esc-action@v1

- name: Checkout repository
  uses: actions/checkout@v6
  with:
    token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
    ...
```

…but didn't add `environment: production` to the `claude-review` job. The ESC action's OIDC trust policy gates on the GitHub environment claim, so the OIDC sub never matches, the action returns an empty `PULUMI_BOT_TOKEN` output, and `actions/checkout` fails because it was handed an empty `token:` value.

The three sibling workflows that use the identical ESC → checkout pattern — `claude.yml`, `claude-update.yml`, `claude-new.yml` — all already declare `environment: production` at the job level, which is why they kept working. This PR brings `claude-code-review.yml`'s `claude-review` job in line with them.

The `mark-stale` job in the same workflow is unaffected (no ESC, no checkout) and remains unchanged.
