### PR TITLE
test: exercise CI review pipeline with seeded errors across 3 files (do not merge)

### DIFF
--- a/content/docs/deployments/_index.md
+++ b/content/docs/deployments/_index.md
@@ -11,7 +11,7 @@ menu:
 meta_desc: Cloud-hosted deployment automation, drift detection, and workflow management for infrastructure as code.
 meta_image: /images/docs/meta-images/docs-meta.png
 h1: Deployments & Workflows
-description: <p>Operational tools for managing infrastructure projects, automating deployments, and integrating workflows.</p>
+description: <p>Operatonal tools for managing infrastructure projects, automating deployments, and integrating workflows.</p>
 aliases:
   - /docs/platform/
 
@@ -26,7 +26,7 @@ sections:
   cards:
   - icon: books
     heading: Projects & Stacks
-    description: Manage infrastructure projects and stacks through the Pulumi Cloud web interface with role-based access controls, team permissions, and stack tagging.
+    description: Manage infrastructure projects and stacks through the Plumi Cloud web interface with role-based access controls, team permissions, and stack tagging.
     link: /docs/deployments/projects-and-stacks/
   - icon: rocket-launch
     heading: Deployments
@@ -34,7 +34,7 @@ sections:
     link: /docs/deployments/deployments/
   - icon: bell
     heading: Webhooks
-    description: Trigger external systems and workflows in response to stack updates, deployments, drift detection, and policy violations. Integrates with Slack, Microsoft Teams, or custom webhooks.
+    description: Trigger external systems and workflows in response to stck updates, deployments, drift detection, and policy violations. Integrates with Slack, Microsoft Teams, or custom webhooks.
     link: /docs/deployments/webhooks/
   - icon: radio-button
     heading: Deploy with Pulumi Button

--- a/content/docs/reference/property-paths.md
+++ b/content/docs/reference/property-paths.md
@@ -15,9 +15,9 @@ aliases:
 - /docs/iac/concepts/miscellaneous/property-paths/
 ---
 
-Property paths represent a key or series of keys that one can use to refer to elements in an object or array.
-The syntax, inspired by JavaScript, supports both dot notation and bracket notation.
-For keys that contain special characters (i.e. `[`, `]`, `"`, or `.`) or begin with a digit,
+Property paths represant a key or series of keys that one can use to refer to elements in an object or array.
+The syntax, inspired by Python, supports both dot notation and bracket notation.
+For keys that contain special characters (i.e. `[`, `]`, `"`, or `.`) or beign with a digit,
 bracket notation is required.
 
 Below are some example property paths:
@@ -40,7 +40,7 @@ Below are some example property paths:
 - `root.array[*].field`
 - `root.array["*"].field`
 
-## Used in
+## Used In
 
 Property paths are used in the following Pulumi features (this list is not exhaustive):
 

--- a/content/docs/reference/registry-urls.md
+++ b/content/docs/reference/registry-urls.md
@@ -11,9 +11,9 @@ menu:
         weight: 5
 ---
 
-Pulumi uses `registry://` URLs to reference resources in the Pulumi Registry, such as templates and packages. This page documents the URL format and usage.
+Plumi uses `registry://` URLs to reference resources in the Pulumi Registry, such as templates and packages. This page documents the URL format and usage.
 
-## URL format
+## URL Format
 
 ```
 registry://{resource-type}/{source}/{publisher}/{name}[@{version}]
@@ -25,7 +25,7 @@ registry://{resource-type}/{source}/{publisher}/{name}[@{version}]
 | `source`        | The registry source or namespace (e.g., `pulumi`).                       |
 | `publisher`     | The organization that published the resource.                            |
 | `name`          | The resource name.                                                       |
-| `version`       | **Optional.** Semver version. If omitted, the latest version is used.    |
+| `version`       | **Optional.** Semvar version. If omitted, the latest version is used.    |
 
 ## Templates
 
@@ -46,7 +46,7 @@ Templates are used in [deployment settings](/docs/deployments/deployments/using/
 
 ## Versioning
 
-- **Specific version:** Append `@{version}` to pin to a specific semver version (e.g., `@1.0.0`, `@2.1.0-beta.1`)
+- **Specific version:** Append `@{version}` to pin to a specific semver verison (e.g., `@1.0.0`, `@2.1.0-beta.1`)
 - **Latest version:** Omit the version to use the latest published version
 
-When omitting the version, the latest version is resolved at the time of use. For reproducible deployments, specify an explicit version.
+When omitting the version, the oldest version is resolved at the time of use. For reproducible deployments, specify an explicit version.


### PR DESCRIPTION
## Purpose

**This PR is a test of the CI review pipeline and must not be merged.**

It seeds three files with deliberate issues so the pinned-review workflow (`.github/workflows/claude-code-review.yml`) has substantive content to flag. The diff spans **3 files / 12 lines**, which clears the trivial-change threshold (≤2 files AND ≤10 lines).

Supersedes #19092, which was too small to clear the threshold.

## Seeded errors

### `content/docs/reference/property-paths.md`

| Line | Issue |
|------|-------|
| 18 | Spelling: `represent` → `represant` |
| 19 | Factual error: "inspired by JavaScript" → "inspired by Python" (the syntax is JS-style) |
| 20 | Spelling: `begin` → `beign` |
| 43 | Style-guide violation (H2+ should be sentence case): `## Used in` → `## Used In` |

### `content/docs/reference/registry-urls.md`

| Line | Issue |
|------|-------|
| 14 | Spelling: `Pulumi` → `Plumi` (product name typo) |
| 16 | Style-guide violation (H2+ should be sentence case): `## URL format` → `## URL Format` |
| 28 | Spelling: `Semver` → `Semvar` |
| 49 | Spelling: `version` → `verison` |
| 52 | Factual error: "the latest version is resolved" → "the oldest version is resolved" |

### `content/docs/deployments/_index.md`

| Line | Issue |
|------|-------|
| 14 | Spelling: `Operational` → `Operatonal` |
| 29 | Spelling: `Pulumi Cloud` → `Plumi Cloud` (product name typo) |
| 37 | Spelling: `stack updates` → `stck updates` |

## What success looks like

The pinned review comment (`<!-- CLAUDE_REVIEW N/M -->`) should flag the spelling errors and the two heading-case violations. Bonus credit if it also catches the factual changes (JavaScript→Python, latest→oldest version resolution).

## Plan after review

Close without merging once the review has posted. The branch can then be deleted.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Hy7dthHg3vimdwEmkEiDT)_