### PR TITLE
chore(claude-code-review): drop ESC, run review on GITHUB_TOKEN

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -107,34 +107,27 @@ jobs:
       cancel-in-progress: true
 
     runs-on: ubuntu-latest
-    # Required for pulumi/esc-action's OIDC trust policy, which gates on
-    # the GitHub environment claim. Without this, the ESC step returns
-    # an empty PULUMI_BOT_TOKEN and the checkout below fails with an
-    # empty `token:` value. Matches claude.yml / claude-update.yml /
-    # claude-new.yml, which all declare the same environment.
-    environment: production
     # A review that genuinely hangs (one observed stall ran ~18 min with no
     # output before being cancelled) would otherwise sit on the runner for
     # GitHub's 6-hour default. 25 min is comfortably above the slowest real
     # reviews (blog reviews run 9-12+ min).
     timeout-minutes: 25
+    # No `id-token: write` and no `environment: production` — this job
+    # never pushes commits (allowed_tools below excludes git push / commit
+    # / add and gh pr edit), so it doesn't need a PULUMI_BOT_TOKEN-
+    # authenticated checkout. The pinned-review upsert downstream runs
+    # against GITHUB_TOKEN, same as every other gh API call in this job.
+    # claude.yml / claude-update.yml / claude-social-review.yml still use
+    # ESC because their claude-code-action invocations push fix commits
+    # that need to be authored as pulumi-bot so downstream workflows
+    # (build-and-deploy, social review, etc.) re-fire.
     permissions:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
       checks: write
 
     steps:
-      # ESC runs before checkout so the bot token can authenticate the
-      # checkout — pushes made by claude-code-action later in the workflow
-      # then go out as pulumi-bot rather than github-actions[bot],
-      # which is what lets downstream workflows (build-and-deploy, social
-      # review, etc.) fire on those commits.
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@v1
-
       # Check out the PR head, not the base. workflow_run carries the
       # originating commit on the event payload; workflow_dispatch
       # doesn't, so claude-new.yml passes it through as an input.
@@ -143,7 +136,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.head_sha }}
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

Strip the `pulumi/esc-action@v1` step and supporting config (`environment: production`, `id-token: write`) from the `claude-review` job in `claude-code-review.yml`. Let `actions/checkout` use the default `GITHUB_TOKEN`.

## Why

The `claude-review` job posts a pinned review comment but **never pushes commits**:

- `allowed_tools` for `claude-code-action` deliberately excludes `git push` / `git commit` / `git add` and `gh pr edit` (line 828) — only read-only git Bash perms are granted.
- `Write` / `Edit` are scoped to `.review-draft.md` in the runner workspace, a temp file that's never committed back.
- The pinned-review comment is posted by a separate downstream step using `secrets.GITHUB_TOKEN` (16 occurrences in this file vs. 1 for `PULUMI_BOT_TOKEN`).
- Unlike `claude.yml` and `claude-update.yml`, no `github_token: PULUMI_BOT_TOKEN` input is passed to `claude-code-action` itself.

The `PULUMI_BOT_TOKEN`-authenticated checkout was added by analogy to the workflows that *do* push fix commits — but the rationale (so downstream workflows re-fire on bot-authored pushes) doesn't apply here.

Removing ESC also removes the OIDC failure mode that bit #19093: `workflow_run`-triggered runs from non-default branches present different OIDC claims than the trust policy was tuned for, so the ESC step returned an empty `PULUMI_BOT_TOKEN` and `actions/checkout` failed with `Input required and not supplied: token`. Adding `environment: production` in #19091 was an incomplete fix for the same underlying claim mismatch.

## Cross-workflow comparison

| Workflow | Pushes? | Needs ESC? | After this PR |
|---|---|---|---|
| `claude-triage.yml` | No | No | unchanged (already on `GITHUB_TOKEN`) |
| `claude-code-review.yml` | **No** | **No** | **ESC removed (this PR)** |
| `claude.yml` | Yes | Yes | unchanged |
| `claude-update.yml` | Yes | Yes | unchanged |
| `claude-social-review.yml` | Yes | Yes | unchanged |
| `claude-new.yml` | Dispatches review | Yes (different reason — dispatch actor must be User, not Bot, for `claude-code-action@v1`) | unchanged |

## Test plan

- [ ] Open a non-trivial PR (>2 files, >10 lines of content changes) and confirm the pinned review posts successfully under `GITHUB_TOKEN`.
- [ ] Trigger a refresh via `@claude #new-review` to confirm the `workflow_dispatch` path also works under the simplified config.
- [ ] Confirm the `mark-stale` job on `pull_request: synchronize` is unaffected (it already only used `GITHUB_TOKEN`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Hy7dthHg3vimdwEmkEiDT)_