### PR TITLE
fix(claude-code-review): restore id-token: write permission

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -112,19 +112,25 @@ jobs:
     # GitHub's 6-hour default. 25 min is comfortably above the slowest real
     # reviews (blog reviews run 9-12+ min).
     timeout-minutes: 25
-    # No `id-token: write` and no `environment: production` — this job
-    # never pushes commits (allowed_tools below excludes git push / commit
-    # / add and gh pr edit), so it doesn't need a PULUMI_BOT_TOKEN-
-    # authenticated checkout. The pinned-review upsert downstream runs
-    # against GITHUB_TOKEN, same as every other gh API call in this job.
+    # No `environment: production` — this job never pushes commits
+    # (allowed_tools below excludes git push / commit / add and gh pr
+    # edit), so it doesn't need a PULUMI_BOT_TOKEN-authenticated
+    # checkout. The pinned-review upsert downstream runs against
+    # GITHUB_TOKEN, same as every other gh API call in this job.
     # claude.yml / claude-update.yml / claude-social-review.yml still use
     # ESC because their claude-code-action invocations push fix commits
     # that need to be authored as pulumi-bot so downstream workflows
     # (build-and-deploy, social review, etc.) re-fire.
+    # `id-token: write` IS still required — anthropics/claude-code-action@v1
+    # requests an OIDC token of its own (independent of ESC). Without
+    # this permission the action errors at startup with "Could not fetch
+    # an OIDC token. Did you remember to add 'id-token: write' to your
+    # workflow permissions?".
     permissions:
       contents: read
       pull-requests: write
       issues: read
+      id-token: write
       checks: write
 
     steps:


### PR DESCRIPTION
## Summary

Restore `id-token: write` on the `claude-review` job in `claude-code-review.yml`. Follows up on #19094, which dropped the permission along with the ESC step.

## Why

`anthropics/claude-code-action@v1` requests an OIDC token of its own — independent of the ESC step we removed in #19094. Without `id-token: write`, the action errors at startup before any review work happens:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

Observed live on the `claude-review` job of [run #2788](https://github.com/pulumi/docs/actions/runs/25999819609) for test PR #19095, which failed at 1m 38s. The triage chain ran fine; the failure is isolated to the action's OIDC fetch.

I removed the permission in #19094 on the assumption that ESC's OIDC trust policy was its only consumer. That was wrong — the action uses OIDC for its own auth flow regardless of whether ESC is in the picture.

## What stays out

`environment: production` stays removed. ESC was its only consumer, and the action's OIDC request does not gate on environment claims (or it would fail the same way for every workflow_run-triggered run, which it doesn't on other repos).

## Test plan

- [ ] Merge this PR.
- [ ] Open a fresh non-trivial PR (or close+reopen #19095) and confirm the pinned review posts successfully.
- [ ] Confirm `claude.yml` / `claude-update.yml` / `claude-social-review.yml` are unaffected (they already declare `id-token: write` and have separate ESC config).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Hy7dthHg3vimdwEmkEiDT)_