### PR TITLE
Clean stale generated command pages before CLI doc regens

### DIFF
--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -107,6 +107,11 @@ jobs:
           rm /tmp/vale.tar.gz
       - run: make ensure
         working-directory: docs
+      - name: Clean stale generated command pages
+        run: |
+          find ./content/docs/esc/cli/commands -type f \
+            ! -name '_index.md' ! -name 'README.txt' -delete
+        working-directory: docs
       - name: Generate Markdown docs
         run: |
           esc gen-docs ./content/docs/esc/cli/commands

--- a/.github/workflows/esc-cli.yml
+++ b/.github/workflows/esc-cli.yml
@@ -110,7 +110,10 @@ jobs:
       - name: Clean stale generated command pages
         run: |
           find ./content/docs/esc/cli/commands -type f \
-            ! -name '_index.md' ! -name 'README.txt' -delete
+            ! -name '_index.md' ! -name 'README.txt' -print0 \
+          | while IFS= read -r -d '' f; do
+              grep -aq '^redirect_to:' "$f" || rm -- "$f"
+            done
         working-directory: docs
       - name: Generate Markdown docs
         run: |

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -94,7 +94,10 @@ jobs:
       - name: clean stale generated command pages
         run: |
           find ./content/docs/iac/cli/commands -type f \
-            ! -name '_index.md' ! -name 'README.txt' -delete
+            ! -name '_index.md' ! -name 'README.txt' -print0 \
+          | while IFS= read -r -d '' f; do
+              grep -aq '^redirect_to:' "$f" || rm -- "$f"
+            done
       - name: generate markdown
         run: |
           PULUMI_EXPERIMENTAL=true pulumi gen-markdown ./content/docs/iac/cli/commands

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -91,6 +91,10 @@ jobs:
           sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
           rm /tmp/vale.tar.gz
       - run: make ensure
+      - name: clean stale generated command pages
+        run: |
+          find ./content/docs/iac/cli/commands -type f \
+            ! -name '_index.md' ! -name 'README.txt' -delete
       - name: generate markdown
         run: |
           PULUMI_EXPERIMENTAL=true pulumi gen-markdown ./content/docs/iac/cli/commands


### PR DESCRIPTION
## Summary

- The Cobra-based generators (`pulumi gen-markdown`, `esc gen-docs`) only write files for currently-existing commands; they never delete pages for commands renamed or removed upstream. Both CLI doc workflows ran the generator against a populated directory, so orphan pages accumulated across upstream renames (most recently the `pulumi cloud api` → `pulumi api` rename that required manual cleanup in #19101).
- Adds a step before each generator that deletes every file in the commands directory except the two hand-maintained ones (`_index.md`, `README.txt`), so regens always write into an empty slate. The existing `git add content/` + commit logic in each workflow then naturally picks up both new and removed pages.
- Applies to both `pulumi-cli-docs.yml` (IAC CLI) and `esc-cli.yml` (ESC CLI).

## Test plan

- [ ] After merge, manually re-run `Pulumi CLI docs` workflow with the current Pulumi version and verify the generated PR has no orphan pages and bumps `static/latest-version` / version stamp.
- [ ] After merge, manually re-run `Pulumi ESC CLI docs` workflow with the current ESC version and verify the same for ESC, bumping `static/esc/latest-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)