### PR TITLE
Add Pulumi Cloud IaC concepts page

### DIFF
--- a/content/docs/iac/concepts/_index.md
+++ b/content/docs/iac/concepts/_index.md
@@ -28,7 +28,7 @@ If this is your first time using Pulumi, you likely want to begin with [the Gett
 
 Pulumi is an [infrastructure as code](/what-is/what-is-infrastructure-as-code/) platform that allows you to use familiar programming languages and tools to build, deploy, and manage cloud infrastructure.
 
-Pulumi is free, [open source](https://github.com/pulumi/pulumi), and optionally pairs with [Pulumi Cloud](/docs/iac/guides/basics/pulumi-cloud-vs-oss/) to make managing infrastructure secure, reliable, and hassle-free.
+Pulumi is free, [open source](https://github.com/pulumi/pulumi), and optionally pairs with [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/) to make managing infrastructure secure, reliable, and hassle-free.
 
 ## Supported languages and SDKs
 
@@ -51,7 +51,7 @@ The Pulumi platform comprises several components:
 
 - **Software development kit (SDK)**: Pulumi Software Development Kit (SDK) provides bindings for each type of resource that the provider can manage. This provides the necessary tools and libraries for defining and managing cloud resources on any cloud and with any provider.
 
-- **Command-Line interface (CLI)**: Pulumi is controlled primarily using the command line interface [(CLI)](https://www.pulumi.com/docs/cli/). It works in conjunction with [Pulumi Cloud](/docs/iac/guides/basics/pulumi-cloud-vs-oss/) to deploy changes to your cloud apps and infrastructure. It keeps a history of who updated what in your team and when. This CLI has been designed for great inner loop productivity, in addition to continuous integration and delivery scenarios.
+- **Command-Line interface (CLI)**: Pulumi is controlled primarily using the command line interface [(CLI)](https://www.pulumi.com/docs/cli/). It works in conjunction with [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/) to deploy changes to your cloud apps and infrastructure. It keeps a history of who updated what in your team and when. This CLI has been designed for great inner loop productivity, in addition to continuous integration and delivery scenarios.
 
 - **Deployment engine** The deployment engine is responsible for computing the set of operations needed to drive the current state of your infrastructure into the desired state expressed by your program.
 
@@ -78,7 +78,7 @@ Finally, the server's resulting IP address and DNS name are exported as stack ou
 ### Core concepts
 
 - [Pulumi Architecture](/docs/iac/concepts/how-pulumi-works) — Learn more about how Pulumi works under the hood.
-- [Pulumi Cloud](/docs/iac/guides/basics/pulumi-cloud-vs-oss/) — Learn how Pulumi Cloud relates to the open source tool and what it offers for teams.
+- [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/) — Learn how Pulumi Cloud relates to the open source tool and what it offers for teams.
 - [Projects](/docs/iac/concepts/projects) — Learn how Pulumi projects are organized and configured.
 - [Stacks](/docs/iac/concepts/stacks) — Learn how to create and deploy stacks.
 - [Resources](/docs/iac/concepts/resources) — Learn more about how to use and manage resources in your programs.

--- a/content/docs/iac/concepts/pulumi-cloud.md
+++ b/content/docs/iac/concepts/pulumi-cloud.md
@@ -1,0 +1,31 @@
+---
+title_tag: "Pulumi Cloud | Pulumi Concepts"
+meta_desc: Pulumi Cloud is Pulumi's default state backend and adds access control, secrets, policy enforcement, and drift detection for teams operating at scale.
+title: Pulumi Cloud
+h1: Pulumi Cloud
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Pulumi Cloud
+        parent: iac-concepts
+        weight: 5
+aliases:
+    - /docs/iac/concepts/pulumi-cloud/
+---
+
+Pulumi Cloud is the default [state backend](/docs/iac/concepts/state-and-backends/) for the Pulumi CLI. It is also a managed platform that adds the capabilities teams need to operate Pulumi at scale: access control, reusable configuration and secrets, policy enforcement, cloud resource inventory, scheduled drift detection, managed deployments, and an AI agent. Using Pulumi Cloud is optional—Pulumi works with a do-it-yourself backend such as AWS S3, Azure Blob Storage, Google Cloud Storage, a PostgreSQL database, or the local filesystem—but Pulumi Cloud is the default because it removes the work of running, securing, and scaling a backend yourself.
+
+On top of state, Pulumi Cloud adds:
+
+- **[Role-based access control](/docs/administration/organizations-teams/teams/)** with SAML/SSO integration and fine-grained [access tokens](/docs/administration/access-identity/access-tokens/) for automation.
+- **Reusable configuration and secrets** via [Pulumi ESC](/docs/esc/), so environments can be defined once and consumed across stacks.
+- **[Policy as code](/docs/insights/policy/)** enforcement applied centrally to every update, with pre-built policy packs for common security, compliance, and cost rules.
+- **[Cloud resource inventory](/docs/insights/)** that discovers resources across your cloud accounts—including resources not managed by Pulumi.
+- **Scheduled [drift detection](/docs/deployments/deployments/drift/)** that alerts you or remediates automatically when deployed infrastructure diverges from its declared state.
+- **Managed [deployments](/docs/deployments/deployments/)** that run Pulumi operations remotely—for example, in response to Git pushes—and emit [webhooks](/docs/deployments/webhooks/) for event-driven workflows.
+- **[Pulumi Neo](/docs/ai/)**, an AI agent that helps debug deployments, write infrastructure as code, and answer questions about your environment.
+- **Ephemeral environments** such as Review Stacks and TTL Stacks.
+
+Pulumi Cloud is available as a hosted SaaS and as a [self-hosted](/docs/pulumi-cloud/self-hosted/) edition you can run in your own environment.
+
+For a detailed, capability-by-capability comparison of Pulumi Cloud and open source Pulumi—including which features are available with each option and what operational concerns each one entails—see [Pulumi Cloud vs. OSS](/docs/iac/guides/basics/pulumi-cloud-vs-oss/).

--- a/content/docs/iac/concepts/pulumi-cloud.md
+++ b/content/docs/iac/concepts/pulumi-cloud.md
@@ -13,19 +13,19 @@ aliases:
     - /docs/iac/concepts/pulumi-cloud/
 ---
 
-Pulumi Cloud is the default [state backend](/docs/iac/concepts/state-and-backends/) for the Pulumi CLI. It is also a managed platform that adds the capabilities teams need to operate Pulumi at scale: access control, reusable configuration and secrets, policy enforcement, cloud resource inventory, scheduled drift detection, managed deployments, and an AI agent. Using Pulumi Cloud is optional—Pulumi works with a do-it-yourself backend such as AWS S3, Azure Blob Storage, Google Cloud Storage, a PostgreSQL database, or the local filesystem—but Pulumi Cloud is the default because it removes the work of running, securing, and scaling a backend yourself.
+Pulumi Cloud is the default [state backend](/docs/iac/concepts/state-and-backends/) for the Pulumi CLI. It is also a managed platform that adds the capabilities teams need to operate Pulumi at scale: access control, reusable configuration and secrets, policy enforcement, cloud resource inventory, scheduled drift detection, managed deployments, and an AI agent. Using Pulumi Cloud is optional; Pulumi also works with a [self-managed (DIY) backend](/docs/iac/guides/basics/using-a-diy-backend/). Pulumi Cloud is the default because it removes the work of running, securing, and scaling a backend yourself.
 
 On top of state, Pulumi Cloud adds:
 
 - **[Role-based access control](/docs/administration/organizations-teams/teams/)** with SAML/SSO integration and fine-grained [access tokens](/docs/administration/access-identity/access-tokens/) for automation.
 - **Reusable configuration and secrets** via [Pulumi ESC](/docs/esc/), so environments can be defined once and consumed across stacks.
 - **[Policy as code](/docs/insights/policy/)** enforcement applied centrally to every update, with pre-built policy packs for common security, compliance, and cost rules.
-- **[Cloud resource inventory](/docs/insights/)** that discovers resources across your cloud accounts—including resources not managed by Pulumi.
+- **[Cloud resource inventory](/docs/insights/)** that discovers resources across your cloud accounts, including resources not managed by Pulumi.
 - **Scheduled [drift detection](/docs/deployments/deployments/drift/)** that alerts you or remediates automatically when deployed infrastructure diverges from its declared state.
-- **Managed [deployments](/docs/deployments/deployments/)** that run Pulumi operations remotely—for example, in response to Git pushes—and emit [webhooks](/docs/deployments/webhooks/) for event-driven workflows.
+- **Managed [deployments](/docs/deployments/deployments/)** that run Pulumi operations remotely, for example in response to Git pushes, and emit [webhooks](/docs/deployments/webhooks/) for event-driven workflows.
 - **[Pulumi Neo](/docs/ai/)**, an AI agent that helps debug deployments, write infrastructure as code, and answer questions about your environment.
 - **Ephemeral environments** such as Review Stacks and TTL Stacks.
 
-Pulumi Cloud is available as a hosted SaaS and as a [self-hosted](/docs/pulumi-cloud/self-hosted/) edition you can run in your own environment.
+Pulumi Cloud is available as a hosted SaaS and as a [self-hosted](/docs/pulumi-cloud/self-hosted/) edition you can run in your own environment. The Individual tier is free. [Sign up for a Pulumi account](https://app.pulumi.com/signup) to get started.
 
-For a detailed, capability-by-capability comparison of Pulumi Cloud and open source Pulumi—including which features are available with each option and what operational concerns each one entails—see [Pulumi Cloud vs. OSS](/docs/iac/guides/basics/pulumi-cloud-vs-oss/).
+For a detailed, capability-by-capability comparison of Pulumi Cloud and open source Pulumi, including which features are available with each option and what operational concerns each one entails, see [Pulumi Cloud vs. OSS](/docs/iac/guides/basics/pulumi-cloud-vs-oss/).

--- a/content/docs/iac/get-started/aws/deploy-stack.md
+++ b/content/docs/iac/get-started/aws/deploy-stack.md
@@ -129,7 +129,7 @@ $ aws s3 ls ("s3://" + (pulumi stack output bucket_name))
 
 ### View your update on Pulumi Cloud
 
-If you are logged into [Pulumi Cloud](/docs/pulumi-cloud), you'll see "View Live" hyperlinks in the CLI output during your update. These go to [a page](https://app.pulumi.com/signin) with detailed information about your stack including resources, configuration, a full history of updates, and more. Navigate to it to review the details of your update:
+If you are logged into [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/), you'll see "View Live" hyperlinks in the CLI output during your update. These go to [a page](https://app.pulumi.com/signin) with detailed information about your stack including resources, configuration, a full history of updates, and more. Navigate to it to review the details of your update:
 
 <a href="/images/getting-started/console-update.png" target="_blank">
     <img src="/images/getting-started/console-update.png" alt="A stack update with console output, as shown in the Pulumi Service" />

--- a/content/docs/iac/get-started/azure/deploy-stack.md
+++ b/content/docs/iac/get-started/azure/deploy-stack.md
@@ -101,7 +101,7 @@ Running that command will print out the storage account's name.
 
 ### View your update on Pulumi Cloud
 
-If you are logged into [Pulumi Cloud](/docs/pulumi-cloud), you'll see "View Live" hyperlinks in the CLI output during your update. These go to [a page](https://app.pulumi.com/signin) with detailed information about your stack including resources, configuration, a full history of updates, and more. Navigate to it to review the details of your update:
+If you are logged into [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/), you'll see "View Live" hyperlinks in the CLI output during your update. These go to [a page](https://app.pulumi.com/signin) with detailed information about your stack including resources, configuration, a full history of updates, and more. Navigate to it to review the details of your update:
 
 <a href="/images/getting-started/console-update.png" target="_blank">
     <img src="/images/getting-started/console-update.png" alt="A stack update with console output, as shown in the Pulumi Service" />

--- a/content/docs/iac/get-started/gcp/deploy-stack.md
+++ b/content/docs/iac/get-started/gcp/deploy-stack.md
@@ -132,7 +132,7 @@ Running that command will print out the name of your bucket.
 
 ### View your update on Pulumi Cloud
 
-If you are logged into [Pulumi Cloud](/docs/pulumi-cloud), you'll see "View Live" hyperlinks in the CLI output during your update. These go to [a page](https://app.pulumi.com/signin) with detailed information about your stack including resources, configuration, a full history of updates, and more. Navigate to it to review the details of your update:
+If you are logged into [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/), you'll see "View Live" hyperlinks in the CLI output during your update. These go to [a page](https://app.pulumi.com/signin) with detailed information about your stack including resources, configuration, a full history of updates, and more. Navigate to it to review the details of your update:
 
 <a href="/images/getting-started/console-update.png" target="_blank">
     <img src="/images/getting-started/console-update.png" alt="A stack update with console output, as shown in the Pulumi Service" />

--- a/content/docs/iac/get-started/kubernetes/deploy-stack.md
+++ b/content/docs/iac/get-started/kubernetes/deploy-stack.md
@@ -93,7 +93,7 @@ step to set up your Kubernetes cluster and kubectl.
 
 ### View your update on Pulumi Cloud
 
-If you are logged into [Pulumi Cloud](/docs/pulumi-cloud), you'll see "View Live" hyperlinks in the CLI output during your update. These go to [a page](https://app.pulumi.com/signin) with detailed information about your stack including resources, configuration, a full history of updates, and more. Navigate to it to review the details of your update:
+If you are logged into [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/), you'll see "View Live" hyperlinks in the CLI output during your update. These go to [a page](https://app.pulumi.com/signin) with detailed information about your stack including resources, configuration, a full history of updates, and more. Navigate to it to review the details of your update:
 
 <a href="/images/getting-started/console-update.png" target="_blank">
     <img src="/images/getting-started/console-update.png" alt="A stack update with console output, as shown in the Pulumi Service" />

--- a/content/docs/iac/guides/basics/pulumi-cloud-vs-oss.md
+++ b/content/docs/iac/guides/basics/pulumi-cloud-vs-oss.md
@@ -10,7 +10,6 @@ menu:
         parent: iac-guides-basics
         weight: 70
 aliases:
-  - /docs/iac/concepts/pulumi-cloud/
   - /docs/deployments/get-started/what-is-it/
   - /docs/pulumi-cloud/get-started/what-is-it/
 ---


### PR DESCRIPTION
Adds a brief IaC concepts page that frames Pulumi Cloud as the default state backend plus the platform features that enable Pulumi at scale, with a pointer to the comparison guide for details.

## Changes

- Created `content/docs/iac/concepts/pulumi-cloud.md` at weight 5 (first in the Concepts sub-nav, above Pulumi Architecture).
- Moved the `/docs/iac/concepts/pulumi-cloud/` alias off `pulumi-cloud-vs-oss.md` so the new page owns that URL. The 6 IaC comparison pages that already link to that URL now resolve directly to the new page.
- Rewired 7 generic "what is Pulumi Cloud" intro links across `content/docs/iac/` (concepts index + 4 get-started deploy-stack pages) to point at the new concepts page.

Fixes #19122