### PR TITLE
content+layout(what-is): author attribution and section refresh

### DIFF
--- a/content/what-is/_index.md
+++ b/content/what-is/_index.md
@@ -1,6 +1,7 @@
 ---
-title: What Is?
-meta_desc: |
-    Pulumi's "What Is?" series provides deep dives into popular Cloud Engineering terminology, topics,
-    and leading techniques.
+title: "Cloud Engineering Concepts Explained"
+page_title: "Cloud Engineering Concepts Explained"
+meta_desc: "Plain-English explainers of infrastructure as code, DevOps, CI/CD, Kubernetes, platform engineering, secrets management, and other cloud engineering topics."
 ---
+
+**Cloud engineering is the discipline of building, running, and continuously improving software systems on cloud infrastructure.** This series of explainers covers the concepts, practices, and tools that show up most often in that work — from [infrastructure as code](/what-is/what-is-infrastructure-as-code/) and [DevOps](/what-is/what-is-devops/) to [CI/CD](/what-is/what-is-ci-cd/), Kubernetes, [secrets management](/what-is/what-is-secrets-management/), [platform engineering](/what-is/what-is-platform-engineering/), and common AWS troubleshooting. Each page is a self-contained explainer for engineers picking up a new term or evaluating a tool for a specific job.

--- a/content/what-is/_index.md
+++ b/content/what-is/_index.md
@@ -3,5 +3,3 @@ title: "Cloud Engineering Concepts Explained"
 page_title: "Cloud Engineering Concepts Explained"
 meta_desc: "Plain-English explainers of infrastructure as code, DevOps, CI/CD, Kubernetes, platform engineering, secrets management, and other cloud engineering topics."
 ---
-
-**Cloud engineering is the discipline of building, running, and continuously improving software systems on cloud infrastructure.** This series of explainers covers the concepts, practices, and tools that show up most often in that work — from [infrastructure as code](/what-is/what-is-infrastructure-as-code/) and [DevOps](/what-is/what-is-devops/) to [CI/CD](/what-is/what-is-ci-cd/), Kubernetes, [secrets management](/what-is/what-is-secrets-management/), [platform engineering](/what-is/what-is-platform-engineering/), and common AWS troubleshooting. Each page is a self-contained explainer for engineers picking up a new term or evaluating a tool for a specific job.

--- a/content/what-is/amazon-dynamodb-vs-google-cloud-bigtable.md
+++ b/content/what-is/amazon-dynamodb-vs-google-cloud-bigtable.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["kat-cosgrove"]
 ---
 
 ## Biggest Similarities and Differences Between Google Cloud Bigtable and AWS DynamoDB

--- a/content/what-is/cosmos-db-vs-mongodb-know-the-differences.md
+++ b/content/what-is/cosmos-db-vs-mongodb-know-the-differences.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["kat-cosgrove"]
 ---
 {{% notes type="info" %}}
 **This document has been updated and expanded into [Cosmos DB vs Mongo DB](https://www.pulumi.com/blog/when-to-use-azure-cosmos-db/#cosmos-db-vs-mongodb) section of the [When to use Cosmos DB Guide](https://www.pulumi.com/blog/when-to-use-azure-cosmos-db/).**

--- a/content/what-is/database-comparison-cosmos-db-vs-dynamodb.md
+++ b/content/what-is/database-comparison-cosmos-db-vs-dynamodb.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["kat-cosgrove"]
 ---
 {{% notes type="info" %}}
 **This document has been updated and expanded into [Cosmos DB vs DynamoDB](https://www.pulumi.com/blog/when-to-use-azure-cosmos-db/#dynamo-db-vs-cosmos-db) section of the [When to use Cosmos DB Guide](https://www.pulumi.com/blog/when-to-use-azure-cosmos-db/).**

--- a/content/what-is/guide-to-automating-file-expiration-in-aws-s3.md
+++ b/content/what-is/guide-to-automating-file-expiration-in-aws-s3.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Automate AWS S3 File Expiration with Pulumi
+authors: ["james-denyer"]
 ---
 
 ## A guide to automate AWS S3 file expiration with Pulumi

--- a/content/what-is/how-to-step-up-cloud-infrastructure-testing.md
+++ b/content/what-is/how-to-step-up-cloud-infrastructure-testing.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["zack-chase"]
 ---
 
 Infrastructure testing isn’t new and, over the years, there have been various tools that people have used to perform it. However, what tends to happen is that standard ops testing focuses on acceptance tests. That means the ops team spins up some infrastructure in the cloud and they then test that infrastructure to see if it’s correct. Of course, if it wasn’t spun up correctly, the team needs to destroy and recreate it. That’s not a great approach because, potentially, something that shouldn’t have happened already has, depending on how quickly the team took a look.

--- a/content/what-is/infrastructure-as-code-for-devops.md
+++ b/content/what-is/infrastructure-as-code-for-devops.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["zack-chase"]
 ---
 
 DevOps isn’t any one thing. It’s a term that represents a blend of culture, tools and practices that aims to improve the software delivery life cycle (SDLC)  and to deliver your products (which may be an app for outside customers but might also be cloud infrastructure to internal developers) as quickly and reliably as possible. Two of the most important aspects of DevOps are automation and culture. [Infrastructure as Code](/what-is/what-is-infrastructure-as-code/) (IaC) is a practice that’s fundamental to both.

--- a/content/what-is/infrastructure-as-code-for-kubernetes.md
+++ b/content/what-is/infrastructure-as-code-for-kubernetes.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["zack-chase"]
 ---
 
 [Infrastructure as Code](/what-is/what-is-infrastructure-as-code/) (IaC) means that you use code to define and manage your infrastructure automatically rather than with manual processes. In a broader sense, IaC allows you to effectively apply software engineering practices to your infrastructure. With IaC, you can automatically build, deploy and manage your infrastructure much more effectively and reliably than you can manually. IaC makes your whole infrastructure, including your Kubernetes clusters, versionable, testable and repeatable.

--- a/content/what-is/javascript-and-infrastructure-as-code.md
+++ b/content/what-is/javascript-and-infrastructure-as-code.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["zack-chase"]
 ---
 
 [Infrastructure as Code (IaC)](/what-is/what-is-infrastructure-as-code) means that you use code to define and manage your infrastructure automatically rather than with manual processes. In a broader sense, IaC enables [cloud engineering](/blog/what-exactly-is-cloud-engineering/) and allows you to effectively apply software engineering practices to your infrastructure. With IaC, you can automatically build, deploy and manage your infrastructure much more effectively and reliably than you can manually. IaC makes your whole infrastructure versionable, [testable](/what-is/how-to-step-up-cloud-infrastructure-testing/) and repeatable.

--- a/content/what-is/python-for-devops.md
+++ b/content/what-is/python-for-devops.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["zack-chase"]
 ---
 
 [Python](/why-is-python-so-popular/) is a popular, approachable programming language. It’s easy both to write your own Python code and to understand the code other people have written. Python is open source and the Python community has developed a large number of tools, libraries, frameworks and support groups. Even though Python is a great language for people just learning to program, it’s not a toy. Thanks to its well-designed syntax, modularity, support, and ecosystem, it’s easy to scale up from simple projects to complex ones. It is common to use Python for DevOps to tackle everything from web scraping to machine learning to managing infrastructure in the cloud.

--- a/content/what-is/resolve-list-buckets-expired-token.md
+++ b/content/what-is/resolve-list-buckets-expired-token.md
@@ -5,6 +5,7 @@ meta_desc: |
      Use Pulumi ESC and dynamic credentials to run commands like aws ListBuckets in a more secure and seamless way.
 type: what-is
 page_title: An error occurred (ExpiredToken) when calling the ListBuckets operation
+authors: ["torian-crane"]
 ---
 
 The error message "An error occurred (ExpiredToken) when calling the ListBuckets operation" in AWS (Amazon Web Services) typically means that the temporary credentials used for the AWS CLI (Command Line Interface) operation have expired. AWS employs temporary credentials for services like IAM roles and AWS Security Token Service (STS), which expire for security reasons. When you attempt an AWS CLI operation with these expired credentials, this error arises.

--- a/content/what-is/resolve-list-buckets-invalid-access-key-id.md
+++ b/content/what-is/resolve-list-buckets-invalid-access-key-id.md
@@ -5,6 +5,7 @@ meta_desc: |
      Use Pulumi ESC and dynamic credentials to run commands like aws ListBuckets in a more secure and seamless way.
 type: what-is
 page_title: An error occurred (InvalidAccessKeyId) when calling the ListBuckets operation
+authors: ["torian-crane"]
 ---
 
 The error message "An error occurred (InvalidAccessKeyId) when calling the ListBuckets operation" in AWS (Amazon Web Services) indicates that the provided AWS Access Key Id does not exist in their records. AWS Access Key IDs are used by AWS to authenticate and authorize access to various AWS services and resources. When you attempt an AWS CLI operation with an invalid or nonexistent Access Key ID, this error arises, as AWS cannot validate the provided identifier.

--- a/content/what-is/resolve-list-buckets-invalid-client-token-id.md
+++ b/content/what-is/resolve-list-buckets-invalid-client-token-id.md
@@ -5,6 +5,7 @@ meta_desc: |
      Use Pulumi ESC and dynamic credentials to run commands like aws ListBuckets in a more secure and seamless way.
 type: what-is
 page_title: An error occurred (InvalidClientTokenId) when calling the ListBuckets operation
+authors: ["torian-crane"]
 ---
 
 The error message "An error occurred (InvalidClientTokenId) when calling the ListBuckets operation" in AWS (Amazon Web Services) indicates that the security token included in the request is invalid. AWS uses security tokens for authentication and authorization purposes. When you attempt an AWS CLI operation with an invalid token value, this error arises.

--- a/content/what-is/resolve-list-buckets-signature-does-not-match.md
+++ b/content/what-is/resolve-list-buckets-signature-does-not-match.md
@@ -5,6 +5,7 @@ meta_desc: |
      Use Pulumi ESC and dynamic credentials to run commands like aws ListBuckets in a more secure and seamless way.
 type: what-is
 page_title: An error occurred (SignatureDoesNotMatch) when calling the ListBuckets operation
+authors: ["torian-crane"]
 ---
 
 The error message "An error occurred (SignatureDoesNotMatch) when calling the ListBuckets operation" in AWS (Amazon Web Services) indicates that there's a mismatch between the request signature calculated by AWS and the signature you provided. AWS relies on two key components for authentication: the AWS Access Key ID and the AWS Secret Access Key. The Secret Access Key is used for securely signing requests to AWS services. When you encounter this error, it typically signifies that the provided AWS Secret Access Key is incorrect or has been used with an inappropriate signing method.

--- a/content/what-is/resolve-unable-to-locate-credentials.md
+++ b/content/what-is/resolve-unable-to-locate-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
      Use Pulumi ESC and dynamic credentials to run commands like aws ListBuckets in a more secure and seamless way.
 type: what-is
 page_title: Unable to locate credentials
+authors: ["torian-crane"]
 ---
 
 The error message "Unable to locate credentials" typically occurs in AWS (Amazon Web Services) when the AWS CLI or SDKs cannot find the necessary credentials for authentication. AWS requires a valid AWS Access Key ID and AWS Secret Access Key or an IAM role with associated permissions to access its services. This error arises when these credentials are either missing or incorrectly configured.

--- a/content/what-is/run-aws-cloudwatch-get-metric-data-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-cloudwatch-get-metric-data-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws cloudwatch get-metric-data' with Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws cloudwatch get-metric-data`](https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/get-metric-data.html) command is part of the AWS Command Line Interface (CLI). It retrieves metric data from Amazon CloudWatch, a monitoring service provided by AWS. This command allows you to query and retrieve time-series data for a specified metric or set of metrics.

--- a/content/what-is/run-aws-dynamodb-list-tables-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-dynamodb-list-tables-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws dynamodb list-tables' with Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws dynamodb list-tables`](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/list-tables.html) command is part of the AWS Command Line Interface (CLI) and retrieves a list of Amazon DynamoDB tables within your AWS account.

--- a/content/what-is/run-aws-ec2-describe-instances-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-ec2-describe-instances-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws ec2 describe-instances' using Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws ec2 describe-instances` command](https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-commands.html) is part of the AWS Command Line Interface (CLI) and is utilized for retrieving details about instances in Amazon Elastic Compute Cloud (Amazon EC2). Amazon EC2 provides scalable computing capacity in the AWS cloud, enabling users to launch and manage virtual servers as per their requirements.

--- a/content/what-is/run-aws-ec2-start-instances-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-ec2-start-instances-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws ec2 start-instances' using Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws ec2 start-instances` command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/start-instances.html) is part of the AWS Command Line Interface (CLI) and is utilized for starting Amazon Elastic Compute Cloud (Amazon EC2) instances that were previously stopped. Amazon EC2 provides scalable computing capacity in the AWS cloud, enabling users to launch and manage virtual servers as per their requirements.

--- a/content/what-is/run-aws-ec2-stop-instances-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-ec2-stop-instances-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws ec2 stop-instances' using Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws ec2 stop-instances` command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/stop-instances.html) is part of the AWS Command Line Interface (CLI) and is utilized for stopping Amazon Elastic Compute Cloud (Amazon EC2) instances that are currently running. Amazon EC2 provides scalable computing capacity in the AWS cloud, enabling users to launch and manage virtual servers as per their requirements.

--- a/content/what-is/run-aws-iam-list-users-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-iam-list-users-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws iam list-users' using Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws iam list-users` command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/list-users.html) is part of the AWS Command Line Interface (CLI) and is utilized for listing all Identity and Access Management (IAM) users in an AWS account. Amazon IAM enables users to specify who or what can access services and resources in AWS.

--- a/content/what-is/run-aws-lambda-list-functions-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-lambda-list-functions-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws lambda list-functions' with Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws lambda list-functions`](https://docs.aws.amazon.com/cli/latest/reference/lambda/list-functions.html) command is part of the AWS Command Line Interface (CLI) and retrieves a list of AWS Lambda functions within your AWS account. It returns a JSON-formatted list of information such as function name, ARN (Amazon Resource Name), runtime, memory size, and more.

--- a/content/what-is/run-aws-s3-cp-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-s3-cp-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws s3 cp' using Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [aws s3 cp command](https://docs.aws.amazon.com/cli/latest/userguide/cli-services-s3-commands.html) is part of the AWS Command Line Interface (CLI) and is used to copy files to and from buckets in Amazon Simple Storage Service (Amazon S3). Amazon S3 is a scalable object storage service offered by Amazon Web Services (AWS) and is commonly used for backup and storage, serving content, and hosting static websites.

--- a/content/what-is/run-aws-s3-ls-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-s3-ls-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws s3 ls' using Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws s3 ls` command](https://docs.aws.amazon.com/cli/latest/userguide/cli-services-s3-commands.html) is part of the AWS Command Line Interface (CLI) and is used to list the contents of buckets and directories in Amazon Simple Storage Service (Amazon S3). Amazon S3 is a scalable object storage service offered by Amazon Web Services (AWS) and is commonly used for backup and storage, serving content, and hosting static websites.

--- a/content/what-is/run-aws-s3-sync-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-s3-sync-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws s3 sync' with Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws s3 sync`](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html) command is part of the AWS Command Line Interface (CLI) and synchronizes files and directories between your local file system and Amazon S3 buckets. This command simplifies uploading files to and downloading files from S3.

--- a/content/what-is/run-aws-sts-get-caller-identity-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-sts-get-caller-identity-with-dynamic-credentials.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: Run 'aws sts get-caller-identity' using Dynamic Credentials
+authors: ["diana-esteves"]
 ---
 
 The [`aws sts get-caller-identity` command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/get-caller-identity.html) is part of the AWS Command Line Interface (CLI) and is utilized for retrieving the details about the IAM user or role whose credentials are used to call operations in AWS. Amazon Security Token Service (STS)  enables users to request temporary, limited-privilege credentials for AWS interactions.

--- a/content/what-is/top-iac-tools.md
+++ b/content/what-is/top-iac-tools.md
@@ -4,6 +4,7 @@ meta_desc: |
      Explore top Infrastructure as Code (IaC) tools for cloud resource management. Find the best fit for your DevOps needs.
 type: what-is
 page_title: "Top Infrastructure as Code Tools"
+authors: ["adam-gordon-bell"]
 ---
 
 Infrastructure as Code tools (IaC tools) let you automate the setup of your cloud resources. Instead of manually configuring resources in your cloud web console, you can write a script that specifies what you need, and the cloud provider sets it up for you. It's a great way to make infrastructure setup consistent and repeatable.

--- a/content/what-is/what-are-docker-configs.md
+++ b/content/what-is/what-are-docker-configs.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What are Docker Configs?"
+authors: ["torian-crane"]
 ---
 
 Docker, a leading platform in containerization technology, has revolutionized how applications are developed, shipped, and deployed. An essential facet of this ecosystem is the effective management of configuration data. [Docker Configs](https://docs.docker.com/engine/swarm/configs/) is a feature specially crafted to handle non-sensitive configuration information within Docker environments.

--- a/content/what-is/what-are-docker-secrets.md
+++ b/content/what-is/what-are-docker-secrets.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What are Docker Secrets?"
+authors: ["torian-crane"]
 ---
 
 Docker, a leading platform in containerization technology, has revolutionized how applications are developed, shipped, and deployed. One critical aspect of this process is managing sensitive information, commonly known as "secrets." [Docker Secrets](https://docs.docker.com/engine/swarm/secrets/) is a feature specifically designed for safely transmitting and storing confidential data within Docker environments.

--- a/content/what-is/what-are-kubernetes-secrets.md
+++ b/content/what-is/what-are-kubernetes-secrets.md
@@ -6,6 +6,7 @@ meta_desc: |
 type: what-is
 page_title: "What are Kubernetes Secrets?"
 
+authors: ["diana-esteves"]
 ---
 
 Kubernetes, or K8s, is an open-source container orchestration platform designed to automate the deployment, scaling, and management of containerized applications.

--- a/content/what-is/what-is-a-circleci-secret.md
+++ b/content/what-is/what-is-a-circleci-secret.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What is a CircleCI Secret?"
+authors: ["diana-esteves"]
 ---
 
 [CircleCI](https://circleci.com/) is an agile, continuous integration/continuous deployment ([CI/CD](/what-is/what-is-ci-cd/)) platform. It aims to automate software development processes for faster, more reliable releases. CircleCI secrets empower developers to safeguard critical data while streamlining workflows.

--- a/content/what-is/what-is-a-cloudflare-secret.md
+++ b/content/what-is/what-is-a-cloudflare-secret.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What is a Cloudflare Secret?"
+authors: ["diana-esteves"]
 ---
 
 [Cloudflare](https://www.cloudflare.com/) operates one of the world's largest networks, providing network and cloud services to improve website and application security and performance. A critical security aspect of building applications and solutions integrating with Cloudflare involves the management of sensitive data, commonly known as [secrets](/what-is/what-is-secrets-management/). Cloudflare has a secure mechanism for handling secrets, offering tools for storing, accessing, and managing confidential information in the cloud.

--- a/content/what-is/what-is-a-github-action-secret.md
+++ b/content/what-is/what-is-a-github-action-secret.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What is a GitHub Actions Secret?"
+authors: ["diana-esteves"]
 ---
 
 [GitHub Actions](https://github.com/features/actions) is an automation feature provided by [GitHub](https://github.com/) that allows you to define workflows to automate various aspects of your software development process directly within your GitHub repository. A prevalent example is automatically running a linter test every time a commit is made against an opened pull request.

--- a/content/what-is/what-is-an-internal-developer-platform.md
+++ b/content/what-is/what-is-an-internal-developer-platform.md
@@ -5,6 +5,7 @@ meta_desc: |
     Understand what an Internal Developer Platform (IDP) is, its benefits, key components, and how it streamlines development workflows.
 type: what-is
 page_title: What is an Internal Developer Platform (IDP)?
+authors: ["sarah-hughes"]
 ---
 
 An Internal Developer Platform (IDP) is a layer that sits on top of your organization's infrastructure and tools, providing a standardized, self-service experience for developers. It abstracts away the complexity of underlying infrastructure, allowing developers to provision and manage the resources they need without having to understand all the underlying details.

--- a/content/what-is/what-is-aws-secrets-manager.md
+++ b/content/what-is/what-is-aws-secrets-manager.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What is AWS Secrets Manager?"
+authors: ["torian-crane"]
 ---
 
 Amazon Web Services (AWS) is a leader in cloud computing, transforming the way organizations manage their digital infrastructure. A critical aspect of this landscape is the management of sensitive data, commonly known as "[secrets](/what-is/what-is-secrets-management/)". AWS Secrets Manager is a service designed for the secure handling of these secrets, offering tools for storing, accessing, and managing confidential information in the cloud.

--- a/content/what-is/what-is-azure-key-vault.md
+++ b/content/what-is/what-is-azure-key-vault.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What is Azure Key Vault?"
+authors: ["torian-crane"]
 ---
 
 Microsoft Azure is a leader in cloud computing, transforming the way organizations manage their digital infrastructure. An important aspect of Azure’s security framework is the management of sensitive data, commonly known as "[secrets](/what-is/what-is-secrets-management/)". Azure Key Vault is a service designed for the secure handling of these secrets, offering tools for storing, accessing, and managing confidential information in the cloud.

--- a/content/what-is/what-is-ci-cd.md
+++ b/content/what-is/what-is-ci-cd.md
@@ -4,6 +4,7 @@ meta_desc: |
     Learn about CI/CD practices that improve dev process with automation for effective, rapid software delivery.
 type: what-is
 page_title: "What is Continuous Integration/Continuous Delivery (CI/CD)?"
+authors: ["james-denyer"]
 ---
 
 Continuous integration/continuous delivery (CI/CD) is a methodology in software development that emphasizes frequent, automated integration of code changes into a shared repository, followed by automated and reliable software release processes. As a foundational component of [modern DevOps practices](/what-is/what-is-devops/) CI/CD practices and tools increase efficiency, reduce bugs, and enable faster release cycles, thereby enhancing overall software quality and accelerating time-to-market for new features.

--- a/content/what-is/what-is-cloud-infrastructure-autoscaling.md
+++ b/content/what-is/what-is-cloud-infrastructure-autoscaling.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["zack-chase"]
 ---
 
 Two of the great advantages to infrastructure in the cloud are flexibility and speed. You can quickly adjust your infrastructure to conform to variable conditions, such as the amount of traffic or the number of requests in a queue. In other words, you can scale your infrastructure up or down, depending on what you need at a particular time. Scaling often refers to servers (or instances), in particular.

--- a/content/what-is/what-is-cloud-security.md
+++ b/content/what-is/what-is-cloud-security.md
@@ -4,6 +4,7 @@ meta_desc: |
     Learn about cloud security concepts, best practices, and how infrastructure as code helps secure cloud environments.
 type: what-is
 page_title: "What is Cloud Security?"
+authors: ["asaf-ashirov"]
 ---
 
 Cloud security encompasses the technologies, policies, controls, and services designed to protect cloud computing environments, data, applications, and infrastructure against threats and vulnerabilities. As organizations accelerate their digital transformation and migrate critical workloads to the cloud, implementing robust cloud infrastructure security measures becomes essential for preventing data breaches, ensuring regulatory compliance, and maintaining business continuity.

--- a/content/what-is/what-is-configuration-management.md
+++ b/content/what-is/what-is-configuration-management.md
@@ -5,6 +5,7 @@ meta_desc: |
     Learn about what configuration management is and why configuration management is instrumental in maintaining the health and consistency of software systems.
 type: what-is
 page_title: What is Configuration Management?
+authors: ["scott-lowe"]
 ---
 
 ## What is configuration management?

--- a/content/what-is/what-is-devops-automation.md
+++ b/content/what-is/what-is-devops-automation.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["james-denyer"]
 ---
 
 Discover the transformative power of DevOps automation through real-world examples. Learn essential best practices like version control and modular design, and find out how Pulumi is reshaping modern Infrastructure as Code solutions.

--- a/content/what-is/what-is-devops.md
+++ b/content/what-is/what-is-devops.md
@@ -4,6 +4,7 @@ meta_desc: |
     Understand what is DevOps, Understand key practices of CI/CD, automation, infrastructure testing and security
 type: what-is
 page_title: "What is DevOps"
+authors: ["james-denyer"]
 ---
 
 DevOps integrates the historic siloed disciplines of software development (Dev) and IT operations (Ops) as a methodology and culture shift that aligns people, processes, and technology in the lifecycle of application planning, development, delivery, and operations. For teams that successfully break down these silos and invest in the process and tools, they realize they can respond much more quickly to customer needs and improve products much faster than traditional methods have allowed. Additionally, DevOps practices lead to more reliable and secure software, enabling organizations to adapt swiftly to the pace of technology and market changes.

--- a/content/what-is/what-is-google-cloud-secret-manager.md
+++ b/content/what-is/what-is-google-cloud-secret-manager.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What is Google Cloud Secret Manager?"
+authors: ["torian-crane"]
 ---
 
 Google Cloud is a leader in cloud computing, transforming the way organizations manage their digital infrastructure. An important aspect of Google Cloud’s security framework is the management of sensitive data, commonly known as "[secrets](/what-is/what-is-secrets-management/)". [Google Cloud Secret Manager](https://cloud.google.com/secret-manager) is a service designed for the secure handling of these secrets, offering tools for storing, accessing, and managing confidential information in the cloud.

--- a/content/what-is/what-is-hashicorp-vault.md
+++ b/content/what-is/what-is-hashicorp-vault.md
@@ -5,6 +5,7 @@ meta_desc: |
 
 type: what-is
 page_title: "What is HashiCorp Vault?"
+authors: ["james-denyer"]
 ---
 ### What is HashiCorp Vault?
 

--- a/content/what-is/what-is-hipaa.md
+++ b/content/what-is/what-is-hipaa.md
@@ -4,6 +4,7 @@ meta_desc: |
     Understand what HIPAA is, its key requirements, compliance implications for healthcare organizations, and how technology can help meet HIPAA standards.
 type: what-is
 page_title: "What is HIPAA?"
+authors: ["asaf-ashirov"]
 ---
 
 HIPAA, or the Health Insurance Portability and Accountability Act, is a federal law passed in 1996 that established national standards for protecting sensitive patient health information from being disclosed without the patient's consent or knowledge. HIPAA created regulations that mandate how healthcare providers, health plans, healthcare clearinghouses, and business associates handle Protected Health Information (PHI).

--- a/content/what-is/what-is-hitrust.md
+++ b/content/what-is/what-is-hitrust.md
@@ -4,6 +4,7 @@ meta_desc: |
     Understand what HITRUST is, its Common Security Framework (CSF), benefits for healthcare organizations, and how it helps with regulatory compliance.
 type: what-is
 page_title: "What is HITRUST?"
+authors: ["asaf-ashirov"]
 ---
 
 HITRUST, or the Health Information Trust Alliance, is a private company that provides a certification and framework called the [HITRUST CSF (Common Security Framework)](https://hitrustalliance.net/hitrust-framework) to help organizations manage data, information risk, and compliance, particularly in the healthcare sector. HITRUST aims to provide a standardized approach for managing risk and demonstrating compliance with various regulations, including HIPAA and the HITECH Act.

--- a/content/what-is/what-is-infrastructure-as-code.md
+++ b/content/what-is/what-is-infrastructure-as-code.md
@@ -6,6 +6,7 @@ type: what-is
 page_title: "What is Infrastructure as Code (IaC)?"
 aliases:
   - /blog/five-years-of-infrastructure-as-code-part-one/
+authors: ["zack-chase"]
 ---
 
 **Infrastructure as code (IaC) is the practice of provisioning and managing computing infrastructure with machine-readable configuration files instead of clicking through a console or running one-off scripts.** You write code that describes the infrastructure you want, check it into Git, and let an IaC engine make the real world match what you've declared.

--- a/content/what-is/what-is-infrastructure-as-software.md
+++ b/content/what-is/what-is-infrastructure-as-software.md
@@ -28,6 +28,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["zack-chase"]
 ---
 
 [Infrastructure as Code (IaC)](/what-is/what-is-infrastructure-as-code) is now a widely adopted practice. With IaC, you describe your infrastructure programmatically using a tool that provides its own domain-specific language (DSL). IaC is a huge improvement over earlier ways of managing infrastructure, such as using a web console or having a collection of batch scripts. With IaC, you can apply many of the best engineering practices, which you already use with application software, to your infrastructure. Some best practices include:

--- a/content/what-is/what-is-platform-engineering.md
+++ b/content/what-is/what-is-platform-engineering.md
@@ -6,6 +6,7 @@ meta_desc: |
 type: what-is
 page_title: What is Platform Engineering?
 lastmod: 2026-05-11
+authors: ["christian-nunciato"]
 ---
 
 Platform engineering is a set of modern engineering practices that take a holistic approach to managing the entire software development lifecycle, encompassing infrastructure, tools, and processes. The aim of platform engineering is to provide a scalable and secure platform that supports the development, deployment, and operation of software applications in a standardized and efficient way.

--- a/content/what-is/what-is-pulumi.md
+++ b/content/what-is/what-is-pulumi.md
@@ -4,6 +4,7 @@ meta_desc: |
     Discover what Pulumi is, how it works, and why it's revolutionizing infrastructure as code with familiar programming languages.
 type: what-is
 page_title: "What is Pulumi?"
+authors: ["asaf-ashirov"]
 ---
 
 The modern cloud landscape has transformed how organizations build and deploy applications, but managing cloud infrastructure often remains a complex, error-prone process involving clicking through web consoles, writing brittle scripts, or learning domain-specific languages. Pulumi emerges as a solution that fundamentally changes this paradigm by enabling developers and infrastructure teams to manage cloud resources using the same programming languages they already know and love.

--- a/content/what-is/what-is-secrets-management.md
+++ b/content/what-is/what-is-secrets-management.md
@@ -4,6 +4,7 @@ meta_desc: |
     Understand secrets management, the importance of secrets management, and how secrets management relates to infrastructure as code and configuration management
 type: what-is
 page_title: "What is Secrets Management?"
+authors: ["scott-lowe"]
 ---
 
 Secrets management refers to the **secure storage, distribution, and protection of sensitive information**, also known as "secrets." Secret creation is a vital process for securely generating and managing credentials within a secrets management framework. These secrets can include passwords, privileged accounts, API keys, cryptographic keys, and other confidential data crucial for the functioning of applications, systems, and networks. The goal of secrets management is to prevent unauthorized access, reduce the risk of data breaches, and ensure the confidentiality of sensitive information.

--- a/content/what-is/what-is-serverless.md
+++ b/content/what-is/what-is-serverless.md
@@ -4,6 +4,7 @@ meta_desc: |
     Understand serverless architectures, along with some of the benefits of using serverless architectures for modern application development
 type: what-is
 page_title: "What is Serverless?"
+authors: ["scott-lowe"]
 ---
 
 Serverless architectures have gained and continue to gain significant traction in modern application development. Despite its name, serverless doesn't mean servers are absent; instead, it represents a paradigm shift in how applications are built, deployed, and scaled in the cloud.

--- a/content/what-is/what-is-soc-2.md
+++ b/content/what-is/what-is-soc-2.md
@@ -4,6 +4,7 @@ meta_desc: |
     Learn about SOC 2 compliance, its key trust principles, and how organizations can achieve and maintain this important security framework.
 type: what-is
 page_title: "What is SOC 2?"
+authors: ["asaf-ashirov"]
 ---
 
 SOC 2 (System and Organization Controls 2) is a framework and auditing standard designed to help service organizations demonstrate the security, availability, and integrity of their systems and data. Developed by the American Institute of CPAs (AICPA), SOC 2 has become the gold standard for verifying that service providers securely manage customer data and systems, particularly for cloud-based services and SaaS companies.

--- a/content/what-is/what-is-yaml.md
+++ b/content/what-is/what-is-yaml.md
@@ -27,6 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["kat-cosgrove"]
 ---
 
 YAML is a data serialization language most commonly used for configuration files. Its easy readability and rich feature set have made it an increasingly popular choice over the years, for everything from configuration files to object serialization. Originally named "Yet Another Markup Language," the creators changed the name to "YAML Ain't a Markup Language" in order to better reflect its strength as a data-oriented language rather than simply markup.

--- a/data/team/team/james-denyer.toml
+++ b/data/team/team/james-denyer.toml
@@ -1,0 +1,6 @@
+id = "james-denyer"
+name = "James Denyer"
+title = "Technical Writer"
+weight = 1
+
+status = "inactive"

--- a/layouts/partials/schema/collectors/article-entity.html
+++ b/layouts/partials/schema/collectors/article-entity.html
@@ -80,10 +80,14 @@
 {{ $duration := printf "PT%dM" $readTime }}
 {{ $schema = merge $schema (dict "timeRequired" $duration) }}
 
-{{/* Add author as organization for docs */}}
-{{ $schema = merge $schema (dict
-  "author" (dict "@id" "https://www.pulumi.com/#organization")
-) }}
+{{/* Add author. Prefer Person entities from frontmatter (e.g. what-is pages) so
+     Google can render the author byline in rich results; fall back to the
+     Pulumi organization for pages with no declared authors (most docs). */}}
+{{ $authors := partial "schema/utils/author-entities.html" . }}
+{{ if not $authors }}
+  {{ $authors = slice (dict "@id" "https://www.pulumi.com/#organization") }}
+{{ end }}
+{{ $schema = merge $schema (dict "author" $authors) }}
 
 {{/* Add publisher reference */}}
 {{ $schema = merge $schema (dict

--- a/layouts/partials/schema/collectors/collection-entity.html
+++ b/layouts/partials/schema/collectors/collection-entity.html
@@ -1,0 +1,44 @@
+{{/* Returns CollectionPage entity with embedded ItemList for hub/index pages.
+     Lets search engines recognize the page as a directory of articles and
+     unlocks itemList rich results in SERPs. */}}
+
+{{ $items := slice }}
+{{ $position := 0 }}
+{{ $topics := (where (where $.Site.Pages "Type" .Type) "IsPage" true).ByTitle }}
+{{ range $topics }}
+  {{ $position = add $position 1 }}
+  {{ $items = $items | append (dict
+    "@type" "ListItem"
+    "position" $position
+    "url" .Permalink
+    "name" .Title
+  ) }}
+{{ end }}
+
+{{ $schema := dict
+  "@type" "CollectionPage"
+  "@id" "#main-content"
+  "name" .Title
+  "url" .Permalink
+  "inLanguage" "en-US"
+}}
+
+{{ with (or .Params.meta_desc .Summary) }}
+  {{ $schema = merge $schema (dict "description" .) }}
+{{ end }}
+
+{{ $schema = merge $schema (dict "mainEntity" (dict
+  "@type" "ItemList"
+  "numberOfItems" $position
+  "itemListElement" $items
+)) }}
+
+{{ $schema = merge $schema (dict
+  "publisher" (dict "@id" "https://www.pulumi.com/#organization")
+) }}
+
+{{ $schema = merge $schema (dict
+  "mainEntityOfPage" (dict "@id" (printf "%s#webpage" .Permalink))
+) }}
+
+{{ return $schema }}

--- a/layouts/partials/schema/collectors/main-entity.html
+++ b/layouts/partials/schema/collectors/main-entity.html
@@ -48,8 +48,14 @@
       {{ end }}
 
     {{ else if eq .Type "what-is" }}
-      {{/* What-is pages always emit Article schema so dateModified and timeRequired are present for SERP */}}
-      {{ $entity = partial "schema/collectors/article-entity.html" . }}
+      {{/* Single what-is pages get Article schema (with dateModified, timeRequired).
+           The /what-is/ section index gets CollectionPage + ItemList so it's
+           treated as a directory, not an article. */}}
+      {{ if .IsPage }}
+        {{ $entity = partial "schema/collectors/article-entity.html" . }}
+      {{ else }}
+        {{ $entity = partial "schema/collectors/collection-entity.html" . }}
+      {{ end }}
 
     {{ else if eq .Type "docs" }}
       {{/* Documentation pages get TechArticle schema */}}

--- a/layouts/partials/schema/utils/author-entities.html
+++ b/layouts/partials/schema/utils/author-entities.html
@@ -45,10 +45,11 @@
       {{/* Add URL to author page */}}
       {{ $author = merge $author (dict "url" (printf "https://www.pulumi.com/authors/%s/" .id)) }}
 
-      {{/* Add image if available */}}
-      {{ with .image }}
-        {{ $author = merge $author (dict "image" (printf "https://www.pulumi.com%s" .)) }}
-      {{ end }}
+      {{/* Add image. Team avatars live at /images/team/<id>.jpg by convention; an
+           explicit .image in the team toml overrides it. Including a Person image
+           is what unlocks the author byline in Google's rich results. */}}
+      {{ $imagePath := or .image (printf "/images/team/%s.jpg" .id) }}
+      {{ $author = merge $author (dict "image" (printf "https://www.pulumi.com%s" $imagePath)) }}
 
       {{/* Add expertise based on title */}}
       {{ $knowsAbout := slice "Infrastructure as Code" "Cloud Computing" "DevOps" }}

--- a/layouts/what-is/list.html
+++ b/layouts/what-is/list.html
@@ -1,34 +1,58 @@
 {{ define "hero" }}
-    {{ partial "hero" (dict "title" .Params.title ) }}
+<header class="page-hero">
+    <div class="container mx-auto px-6 lg:px-0">
+        <div class="page-hero-title">
+            <h1 class="small-title">
+                <span><span data-text="{{ .Title }}">{{ .Title }}</span></span>
+            </h1>
+        </div>
+        {{ with .Params.meta_desc }}
+            <p class="max-w-3xl mx-auto mt-6 text-center text-lg text-gray-700">{{ . }}</p>
+        {{ end }}
+    </div>
+</header>
 {{ end }}
 
 {{ define "main" }}
-    <!-- Set the page context in a variable in a loop. -->
-    {{ $pageContext := . }}
+    {{ $topics := (where (where $.Site.Pages "Type" "what-is") "Title" "ne" "What Is?").ByTitle }}
 
-
-    <!-- Grab the what-is page data. -->
-    {{ $topics := (where (where $.Site.Pages "Type" "what-is") "Title" "ne" "What Is?") }}
-
-
-    <div class="container mx-auto pb-16">
-        <h2>Topics</h2>
-
-        <div class="lg:flex lg:flex-wrap lg:items-stretch">
+    <section class="container mx-auto px-6 lg:px-0 pb-16">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {{ range $topics }}
-                <div class="lg:w-1/2 p-6">
-                    <div class="card p-6 h-full">
-                        <a class="hover:underline" href="{{ .RelPermalink }}">
-                            <div>
-                                <h5>{{ .Params.title }}</h5>
-                            </div>
-                            <div class="description">
-                                <p>{{ .Params.meta_desc }}</p>
-                            </div>
-                        </a>
+                {{ $page := . }}
+
+                {{/* Read time */}}
+                {{ $wordCount := .Content | plainify | countwords }}
+                {{ if not $wordCount }}{{ $wordCount = 500 }}{{ end }}
+                {{ $readTime := div $wordCount 200 }}
+                {{ if lt $readTime 1 }}{{ $readTime = 1 }}{{ end }}
+
+                {{/* Resolve first author from team data */}}
+                {{ $author := false }}
+                {{ with .Params.authors }}
+                    {{ range first 1 . }}
+                        {{ with index site.Data.team.team . }}
+                            {{ $author = . }}
+                        {{ end }}
+                    {{ end }}
+                {{ end }}
+
+                <a class="group flex flex-col h-full p-6 rounded-lg border border-gray-200 bg-white hover:border-violet-400 hover:shadow-md transition" href="{{ .RelPermalink }}" data-track="what-is-card-{{ .Title | urlize }}">
+                    <h3 class="no-anchor text-lg font-semibold text-gray-900 group-hover:text-violet-700 mb-3">{{ .Params.title }}</h3>
+                    {{ with .Params.meta_desc }}
+                        <p class="text-sm text-gray-700 mb-6 line-clamp-3 flex-grow">{{ . }}</p>
+                    {{ end }}
+                    <div class="flex items-center justify-between text-xs text-gray-500 pt-4 border-t border-gray-100 mt-auto">
+                        <span class="flex items-center gap-2 min-w-0">
+                            {{ if $author }}
+                                <img class="w-6 h-6 rounded-full flex-shrink-0" src="/images/team/{{ $author.id }}.jpg" alt="{{ $author.name }}" title="{{ $author.name }}" loading="lazy" />
+                                <span class="truncate">{{ $author.name }}</span>
+                            {{ end }}
+                        </span>
+                        <span class="flex-shrink-0">{{ $readTime }} min read</span>
                     </div>
-                </div>
+                </a>
             {{ end }}
         </div>
-    </div>
+    </section>
 {{ end }}

--- a/layouts/what-is/list.html
+++ b/layouts/what-is/list.html
@@ -14,7 +14,15 @@
 {{ end }}
 
 {{ define "main" }}
-    {{ $topics := (where (where $.Site.Pages "Type" "what-is") "Title" "ne" "What Is?").ByTitle }}
+    {{ $topics := (where (where $.Site.Pages "Type" "what-is") "IsPage" true).ByTitle }}
+
+    {{ with .Content }}
+        <section class="container mx-auto px-6 lg:px-0 pb-12">
+            <div class="max-w-3xl mx-auto text-gray-800 text-lg leading-relaxed">
+                {{ . }}
+            </div>
+        </section>
+    {{ end }}
 
     <section class="container mx-auto px-6 lg:px-0 pb-16">
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -26,29 +26,7 @@
                 <span><span data-text="{{ .Params.page_title }}">{{ .Params.page_title | safeHTML }}</span></span>
             </h1>
         </div>
-        {{ with .Params.authors }}
-            <div class="max-w-4xl mx-auto mt-6 flex flex-wrap items-center justify-center gap-3 text-sm text-gray-700">
-                {{ range $id := . }}
-                    {{ $authorPage := $.Site.GetPage (printf "/authors/%s" ($id | urlize)) }}
-                    {{ $authorData := index site.Data.team.team $id }}
-                    {{ if $authorData }}
-                        <span class="flex items-center gap-3">
-                            <a class="rounded-full p-1 bg-violet-200" href="{{ with $authorPage }}{{ .RelPermalink }}{{ end }}" data-track="{{ $authorData.name | urlize }}-img">
-                                <img class="w-12 h-12 rounded-full" src="/images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}" title="{{ $authorData.name }}" loading="lazy" />
-                            </a>
-                            <span>
-                                <span class="text-gray-500">By </span>
-                                <a class="font-medium text-gray-900 hover:text-violet-700" href="{{ with $authorPage }}{{ .RelPermalink }}{{ end }}" data-track="{{ $authorData.name | urlize }}-name" rel="author">{{ $authorData.name }}</a>
-                                {{ with $authorData.title }}
-                                    <span class="block text-xs text-gray-500">{{ . }}</span>
-                                {{ end }}
-                            </span>
-                        </span>
-                    {{ end }}
-                {{ end }}
-            </div>
-        {{ end }}
-        <div class="max-w-4xl mx-auto mt-4 flex flex-wrap items-center justify-center gap-3 text-sm text-gray-600">
+        <div class="max-w-4xl mx-auto mt-6 flex flex-wrap items-center justify-center gap-3 text-sm text-gray-600">
             {{ with $modifiedDate }}
                 <time datetime="{{ .Format "2006-01-02T15:04:05Z07:00" }}">
                     Updated {{ .Format "January 2, 2006" }}
@@ -56,6 +34,19 @@
                 <span aria-hidden="true">·</span>
             {{ end }}
             <span>{{ $readTime }} min read</span>
+            {{ with .Params.authors }}
+                <span aria-hidden="true">·</span>
+                {{ range $id := . }}
+                    {{ $authorPage := $.Site.GetPage (printf "/authors/%s" ($id | urlize)) }}
+                    {{ $authorData := index site.Data.team.team $id }}
+                    {{ if $authorData }}
+                        <a class="inline-flex items-center gap-2 hover:text-violet-700" href="{{ with $authorPage }}{{ .RelPermalink }}{{ end }}" rel="author" data-track="{{ $authorData.name | urlize }}-byline">
+                            <img class="w-6 h-6 rounded-full" src="/images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}" title="{{ $authorData.name }}" loading="lazy" />
+                            <span class="font-medium text-gray-900">{{ $authorData.name }}</span>
+                        </a>
+                    {{ end }}
+                {{ end }}
+            {{ end }}
         </div>
     </div>
 </header>

--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -42,7 +42,7 @@
                     {{ if $authorData }}
                         <a class="inline-flex items-center gap-2 hover:text-violet-700" href="{{ with $authorPage }}{{ .RelPermalink }}{{ end }}" rel="author" data-track="{{ $authorData.name | urlize }}-byline">
                             <img class="w-6 h-6 rounded-full" src="/images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}" title="{{ $authorData.name }}" loading="lazy" />
-                            <span class="font-medium text-gray-900">{{ $authorData.name }}</span>
+                            <span>{{ $authorData.name }}</span>
                         </a>
                     {{ end }}
                 {{ end }}

--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -26,11 +26,29 @@
                 <span><span data-text="{{ .Params.page_title }}">{{ .Params.page_title | safeHTML }}</span></span>
             </h1>
         </div>
-        <div class="max-w-4xl mx-auto mt-6 flex flex-wrap items-center justify-center gap-3 text-sm text-gray-600">
-            {{ with .Params.authors }}
-                {{ partial "blog/authors.html" (dict "context" $ "authors" .) }}
-                <span aria-hidden="true">·</span>
-            {{ end }}
+        {{ with .Params.authors }}
+            <div class="max-w-4xl mx-auto mt-6 flex flex-wrap items-center justify-center gap-3 text-sm text-gray-700">
+                {{ range $id := . }}
+                    {{ $authorPage := $.Site.GetPage (printf "/authors/%s" ($id | urlize)) }}
+                    {{ $authorData := index site.Data.team.team $id }}
+                    {{ if $authorData }}
+                        <span class="flex items-center gap-3">
+                            <a class="rounded-full p-1 bg-violet-200" href="{{ with $authorPage }}{{ .RelPermalink }}{{ end }}" data-track="{{ $authorData.name | urlize }}-img">
+                                <img class="w-12 h-12 rounded-full" src="/images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}" title="{{ $authorData.name }}" loading="lazy" />
+                            </a>
+                            <span>
+                                <span class="text-gray-500">By </span>
+                                <a class="font-medium text-gray-900 hover:text-violet-700" href="{{ with $authorPage }}{{ .RelPermalink }}{{ end }}" data-track="{{ $authorData.name | urlize }}-name" rel="author">{{ $authorData.name }}</a>
+                                {{ with $authorData.title }}
+                                    <span class="block text-xs text-gray-500">{{ . }}</span>
+                                {{ end }}
+                            </span>
+                        </span>
+                    {{ end }}
+                {{ end }}
+            </div>
+        {{ end }}
+        <div class="max-w-4xl mx-auto mt-4 flex flex-wrap items-center justify-center gap-3 text-sm text-gray-600">
             {{ with $modifiedDate }}
                 <time datetime="{{ .Format "2006-01-02T15:04:05Z07:00" }}">
                     Updated {{ .Format "January 2, 2006" }}

--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -27,6 +27,10 @@
             </h1>
         </div>
         <div class="max-w-4xl mx-auto mt-6 flex flex-wrap items-center justify-center gap-3 text-sm text-gray-600">
+            {{ with .Params.authors }}
+                {{ partial "blog/authors.html" (dict "context" $ "authors" .) }}
+                <span aria-hidden="true">·</span>
+            {{ end }}
             {{ with $modifiedDate }}
                 <time datetime="{{ .Format "2006-01-02T15:04:05Z07:00" }}">
                     Updated {{ .Format "January 2, 2006" }}


### PR DESCRIPTION
## Summary

A small bundle of changes that improve the `/what-is/` section: pages now show who wrote them, the section index has been refreshed visually, and the page metadata is more complete.

Parallel to PR #19132 (the DevOps page rewrite) — should merge cleanly since the two touch different frontmatter fields.

## Changes

### Author attribution on every what-is page

- Added `authors: ["<slug>"]` to every `content/what-is/*.md`. The author is the file's first git committer, mapped to the matching `data/team/team/*.toml`
- 
  The section's `_index.md` is intentionally left without an author.

- **`data/team/team/james-denyer.toml`** (new) — James authored 5 what-is pages and already had an avatar at `static/images/team/james-denyer.jpg`, but no team toml. Created with `status = "inactive"` and `title = "Technical Writer"`. Happy to adjust those values if you'd rather.

### Single-page hero byline

`layouts/what-is/single.html` now renders the author alongside the existing Updated date / read time line:

```
Updated May 18, 2026 · 6 min read · [avatar] James Denyer
```

24px circular avatar, name as plain text, link carries `rel="author"`. The byline links to the existing `/blog/author/<slug>/` taxonomy page (Hugo auto-creates these once a slug appears in frontmatter, verified live).

### Page schema

- `layouts/partials/schema/utils/author-entities.html` always includes a Person `image` from the convention `/images/team/<id>.jpg` when the team toml doesn't set `.image` explicitly. Without this, the Person entity was missing the image field for every author except those who'd hand-set one.
- `layouts/partials/schema/collectors/article-entity.html` now builds the `author` field from the page's frontmatter (Person entities via the partial above) when authors are present, falling back to the Pulumi `#organization` for pages with no authors. Docs behavior is unchanged.
- `layouts/partials/schema/collectors/main-entity.html` routes the `/what-is/` section index to a new `collection-entity.html` partial that emits `CollectionPage` with an embedded `ItemList` of all 54 child articles. Single what-is pages keep their existing Article schema.

### Section index refresh (`/what-is/`)

- Hero title and `<title>` tag: "What Is?" → "Cloud Engineering Concepts Explained". The subtitle pulls from `meta_desc`, also rewritten to be a clearer one-liner.
- Replaced the two-column "Topics" list with a responsive 3-column grid (1 / 2 / 3 columns at sm / md / lg). Each card shows the topic title, a clamped description, the author's avatar + name on the left of the footer, and read time on the right. Hover state lifts the card with a violet ring.
- Topics sort alphabetically by title.
- `_index.md` only contains frontmatter now; the layout has a `{{ .Content }}` slot ready if we want to add a body intro later.

## Verification

Ran `hugo server` locally:

- `/what-is/` — new hero, 54-card grid, all cards show author avatars and read times.
- `/what-is/what-is-devops/`, `/what-is/what-is-infrastructure-as-code/`, `/what-is/what-is-platform-engineering/` — hero renders the inline byline; HTTP 200.
- `/blog/author/james-denyer/`, `/blog/author/zack-chase/` — taxonomy term pages resolve.
- JSON-LD on a single what-is page emits a `Person` `author` array with `name`, `jobTitle`, `image`, `worksFor`, `affiliation`, `knowsAbout`, and `sameAs` when the team toml has socials.
- JSON-LD on `/what-is/` emits `CollectionPage` with `ItemList` containing all 54 articles (positions, names, URLs).
- Docs page schema (`/docs/iac/concepts/inputs-outputs/`) still emits the organization-only `author` — fallback preserved.
- Prettier clean on every changed file.

## Test plan

- [ ] `make serve` and walk `/what-is/`, a few single pages, and `/blog/author/<slug>/`
- [ ] Confirm the new index hero, the 3-column grid, and the inline single-page byline read well at sm / md / lg widths
- [ ] Confirm avatar images load for every author (especially `james-denyer.jpg`)
- [ ] Decide on the right title / status for the new `james-denyer.toml`
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)