### PR TITLE
layout(what-is): style the Get started CTA as a real button

### DIFF
--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -91,14 +91,12 @@
 </section>
 
 <section id="get-started" class="container px-6 lg:px-0 mx-auto my-16">
-    <div class="w-full bg-violet-50 card p-6 lg:p-16 lg:pt-24 text-center">
+    <div class="w-full bg-violet-50 card p-8 lg:p-12 text-center">
         <div class="max-w-xl mx-auto">
-                <h2 class="text-gray-900 hidden lg:block px-0 lg:px-16">Get started today</h2>
-                <h4 class="text-gray-900 mt-0 lg:hidden">Get started today</h4>
-                <p class="text-gray-700">Pulumi is open source and free to get started. Deploy your first stack today.</p>
-                <div class="mt-16">
-                    <a class="btn" href="{{ site.Params.cta.primary.href }}" data-role="cta-get-started">{{ site.Params.cta.primary.label }}</a>
-                </div>
+                <h2 class="text-gray-900 hidden lg:block mt-0 mb-4">Get started today</h2>
+                <h4 class="text-gray-900 mt-0 mb-4 lg:hidden">Get started today</h4>
+                <p class="text-gray-700 mb-8">Pulumi is open source and free to get started. Deploy your first stack today.</p>
+                <a class="btn btn-primary btn-xl" href="{{ site.Params.cta.primary.href }}" data-role="cta-get-started">{{ site.Params.cta.primary.label }}</a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary

Fixes the bottom-of-page CTA on every what-is page. It was rendering as plain underlined text instead of the standard Pulumi button.

![before — plain text](https://github.com/user-attachments/assets/placeholder)

## Cause

`layouts/what-is/single.html` set the link's class to just `btn`. The site's button base is composed from three layers:

- `btn` — base utility (display, common reset)
- a variant: `btn-primary`, `btn-outline`, ...
- a size: `btn-xl`, ...

With only `btn`, the link renders as an unstyled anchor.

## Fix

```diff
- <a class="btn" ...>
+ <a class="btn btn-primary btn-xl" ...>
```

Matches how the same CTA is composed on `layouts/page/product.html`, `home-b.html`, `superpowers.html`, and `why-pulumi.html`.

## Test plan

- [ ] `make serve`; visit any what-is page (`/what-is/what-is-devops/`, `/what-is/what-is-cloud-security/`, etc.) and confirm the "Get started today" CTA renders as a violet button instead of plain text
- [ ] Mobile and desktop widths
- [ ] CI lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)