### PR TITLE
content(what-is): expand the Python for DevOps explainer

### DIFF
--- a/content/what-is/python-for-devops.md
+++ b/content/what-is/python-for-devops.md
@@ -1,7 +1,6 @@
 ---
 title: Python for DevOps
-meta_desc: |
-     Learn Python for DevOps with Pulumi’s Cloud Engineering Platform to deliver modern cloud applications faster and speed innovation.
+meta_desc: "Python is the lingua franca of DevOps and MLOps automation. Learn where Python fits in IaC, CI/CD, observability, and machine-learning operations."
 
 type: what-is
 page_title: "Python for DevOps"
@@ -30,39 +29,174 @@ customer_logos:
 authors: ["zack-chase"]
 ---
 
-[Python](/why-is-python-so-popular/) is a popular, approachable programming language. It’s easy both to write your own Python code and to understand the code other people have written. Python is open source and the Python community has developed a large number of tools, libraries, frameworks and support groups. Even though Python is a great language for people just learning to program, it’s not a toy. Thanks to its well-designed syntax, modularity, support, and ecosystem, it’s easy to scale up from simple projects to complex ones. It is common to use Python for DevOps to tackle everything from web scraping to machine learning to managing infrastructure in the cloud.
+**Python is the most common general-purpose language for DevOps work: writing automation scripts, defining infrastructure as code, building CI/CD glue, instrumenting observability, and running the data and machine-learning pipelines that increasingly sit alongside traditional services.** Its readable syntax, deep standard library, and large ecosystem of vendor SDKs make it the path of least resistance whenever a DevOps team needs to wire two systems together or replace a manual task with a script.
 
-## Python for DevOps and Infrastructure Automation
+Python's role in DevOps grew naturally from its role in sysadmin scripting and scientific computing. The same language that powers `boto3`, `kubernetes` client libraries, Ansible modules, and Jupyter notebooks now also powers full [infrastructure as code](/what-is/what-is-infrastructure-as-code/) programs, MLOps pipelines, and FinOps tooling. For a team that's already using [Python](/why-is-python-so-popular/) for application code or data work, choosing it for DevOps reduces the number of languages the organization has to maintain.
 
-One of the primary uses of Python is to automate tasks that are being done manually. Automation is a core tenet of DevOps, so you’ll find that many DevOps practitioners use [Python to run automated scripts](/blog/automation-api-python/) for a variety of tasks such as triggering the CI/CD pipeline on specific events, configuring cloud infrastructure. In fact, you can do almost anything in DevOps using the Python programming language. A few other common examples of using Python for DevOps are creating automation tools to check on servers, creating tools to gather application statistics, and creating tools to check on network devices.
+In this article, we'll cover the key questions about Python for DevOps:
 
-## Python for MLOps
+* Why is Python so popular for DevOps?
+* Where do DevOps engineers actually use Python?
+* How is Python used for infrastructure as code?
+* How is Python used for MLOps?
+* What does the Python DevOps toolchain look like?
+* What are best practices for Python in DevOps?
+* How does Pulumi support Python?
+* Frequently asked questions about Python for DevOps
 
-Along with automation, Python has proven to be very popular with data scientists. The reasons we’ve already mentioned for Python’s general popularity apply here, of course. Another reason is the development of a process that has many similarities with DevOps. That process is called MLOps and, as you can guess from the name, it’s a process that applies DevOps practices, such as continuous delivery, to machine learning models.
+## Why is Python so popular for DevOps?
 
-DevOps practitioners aim to efficiently write, deploy and run enterprise applications. They break down silos between software developers and IT operations teams. DevOps emphasizes collaboration and communication among team members.
+A handful of properties keep Python at the top of DevOps language surveys year after year:
 
-MLOps is similar. Along with the [data scientists who curate datasets](/blog/data-science-in-the-cloud/), build AI models and analyze them, there are also ML engineers who complete the deployment setup and, along with the data scientists, monitor the models. MLOps means doing whatever is necessary to make the whole ML build-deploy-monitor lifecycle as smooth and as safe as possible.
+* **Readability.** Python's syntax is forgiving and close to pseudocode, so on-call engineers can read and edit each other's scripts without weeks of ramp-up. That matters more for ops tooling than for application code, because the same script may be touched by SREs, security engineers, data engineers, and product engineers.
+* **A library for everything.** PyPI has wrappers around every major cloud API, every messaging system, every monitoring vendor, and every IaC and configuration tool. Most DevOps tasks reduce to glue code on top of existing libraries.
+* **The data and ML overlap.** Pandas, NumPy, scikit-learn, PyTorch, and TensorFlow live in the same language. As MLOps pipelines mature, the DevOps team that already knows Python can ship them without picking up a second language.
+* **First-class IaC support.** Modern IaC tools, including Pulumi, support Python natively. The same engineers who wrote the deploy scripts can write the platform itself.
+* **Cloud and Kubernetes SDKs.** Every major provider ships an official Python SDK: `boto3` (AWS), `google-cloud-*` (Google Cloud), `azure-sdk-for-python` (Azure), the Kubernetes Python client. The first thing a DevOps engineer reaches for is usually one of these.
 
-Python is an ideal language for MLOps because it’s popular not just with data scientists but with engineers who deal with cloud infrastructure. A common language means that scientists and engineers can work together to get the best results.
+## Where do DevOps engineers actually use Python?
 
-## Benefits of Using Python for DevOps
+DevOps work has gotten broad enough that a single chart of "what Python is for" tends to leave things out. A reasonable taxonomy:
 
-We’ve talked about how well-suited Python is for MLOps but, of course, it’s been very popular with DevOps engineers for years. The IEEE Spectrum's sixth annual interactive ranking of the top programming languages puts Python firmly on top. This popularity is driven in no small part by the vast number of specialized libraries available for it, which makes Python suitable for all sorts of applications. For example, in the domain of artificial intelligence, the Keras library is a top choice among deep-learning developers. Keras provides an interface to the TensorFlow, CNTK, and Theano deep-learning frameworks and tool kits.
+| Area | What Python does |
+|---|---|
+| **Infrastructure as code** | Define cloud resources as a Python program with Pulumi; describe Ansible modules and roles; write CDK programs that synthesize CloudFormation |
+| **Configuration management** | Ansible playbooks (YAML) plus custom modules in Python; SaltStack |
+| **CI/CD glue** | Build steps, deployment scripts, release-engineering tooling that runs in GitHub Actions, GitLab CI, Jenkins, Buildkite |
+| **Cloud automation** | One-off and scheduled scripts using `boto3`/`google-cloud`/`azure-sdk` for housekeeping, audits, and remediation |
+| **Observability and alerting** | Custom collectors, Datadog/New Relic/Prometheus exporters, OpenTelemetry instrumentation, log shippers |
+| **ChatOps and runbooks** | Slack/Teams bots, on-call automation, incident response scripts |
+| **Security and compliance** | IAM analyzers, secret scanners, custom Open Policy Agent / CrossGuard policies, vulnerability scanning glue |
+| **MLOps** | Training pipelines, model serving, feature stores, experiment tracking (MLflow, Weights & Biases) |
+| **FinOps** | Cost-tagging audits, budget reports, anomaly detection on cloud spend |
 
-Python is also known for its easy-to-remember and direct syntax, which makes it easy for the developer to build fast. Python is a great language for scripting, deployment automation, and web development. This makes it one of the most suitable languages for DevOps. Whether you’re in web development, want to work in data science, or simply want to enhance the backend of an existing app, Python is the language to use.
+What's common across the list: Python is rarely the only language, but it's almost always one of the languages.
 
-## Choose the Right Platform to Learn Python for DevOps
+## How is Python used for infrastructure as code?
 
-Whether you’re already an experienced ops practitioner or a data scientist who’s learning about cloud infrastructure, the right platform can help you get the most out of your Python skills for [deploying and managing cloud infrastructure](/blog/programming-the-cloud-with-python/) with DevOps. Look for a platform that:
+Python is one of the four primary languages for IaC tools that support real programming languages (alongside TypeScript, Go, and C#/.NET). With Pulumi, a Python IaC program describes the desired state of cloud infrastructure as ordinary Python classes and functions:
 
-- Lets you use your existing Python skills and development tools to deploy and manage [cloud infrastructure as code](/what-is/what-is-infrastructure-as-code/).
-- Use software development tools such as IDEs like PyCharm, package managers like PyPI, and Python test frameworks.
-- Test and deploy cloud applications and infrastructure together through CI/CD pipelines, with integrations for your existing CI/CD tools
-- Use any cloud provider you choose.
+* **Generated, typed SDKs.** Pulumi's Python providers ship type hints for every cloud resource (AWS, Azure, Google Cloud, Kubernetes, Cloudflare, Datadog, Snowflake, and more). IDEs like PyCharm and VS Code surface the available properties as you type.
+* **Real abstractions.** A reusable VPC pattern becomes a Python class (`MyVpc(...)`), not a folder of templates. Components ship as PyPI packages.
+* **Standard testing tools.** `pytest`, `unittest`, mocks via `unittest.mock`, and Pulumi's own [Python mocks](/docs/iac/using-pulumi/testing/unit/) for cloud responses. IaC tests run alongside application tests in the same CI job.
+* **Standard packaging.** `pip`, `poetry`, `uv`, or Pipenv manage dependencies. Lock files (`requirements.txt`, `poetry.lock`, `uv.lock`) make deploys reproducible.
 
-The right platform means you don’t need to learn domain-specific languages that are tied to a particular cloud provider. It will help you provision and manage your infrastructure and it will provide features such as state management and concurrency management. That’s where tools like Pulumi come in – allowing you to manage infrastructure with languages and constructs you already know.
+Compared to writing infrastructure in HCL or YAML, Python gives you loops, conditionals, classes, type hints, and the ability to share modules through PyPI. Compared to writing infrastructure in TypeScript, the team trades off some compile-time type rigor for the language they're already using. Both options are first-class in Pulumi; the right one depends on what your team writes most of its other code in.
 
-## Pulumi Corporation
+For a deeper look at IaC concepts, see [What is Infrastructure as Code?](/what-is/what-is-infrastructure-as-code/) and [Infrastructure as Code for DevOps](/what-is/infrastructure-as-code-for-devops/).
 
-Pulumi's Cloud Engineering Platform unites infrastructure teams, application developers, and compliance teams around a unified software engineering process for delivering modern cloud applications faster and speeding innovation. Pulumi’s open-source tools help infrastructure teams tame the cloud’s complexity with Universal Infrastructure-as-Code using the world’s most popular programming languages and communities, including Python, Node.js (JavaScript, TypeScript), Go, and .NET (C#, F#, VB). [Get started for free today](/docs/get-started/) or check out our [on-demand workshops](/events#on-demand) and tutorials for getting started with IaC and Python.
+## How is Python used for MLOps?
+
+MLOps is the application of DevOps practices to machine-learning systems: version control for models and training data, CI/CD for retraining pipelines, observability of model behavior in production, and rollback when a model regresses. Python is the dominant language at every layer:
+
+* **Training pipelines.** Frameworks like PyTorch, TensorFlow, JAX, and Hugging Face Transformers are Python-first.
+* **Pipeline orchestration.** Tools like Airflow, Prefect, Dagster, Kubeflow, Metaflow, and ZenML use Python as the orchestration language.
+* **Experiment tracking.** MLflow, Weights & Biases, and Neptune all expose Python-first APIs.
+* **Serving.** FastAPI, BentoML, Seldon Core, KServe, and Triton's Python client all sit in the Python ecosystem.
+* **Feature stores.** Feast, Tecton, and Hopsworks ship Python SDKs.
+
+The practical consequence is that a DevOps team that already knows Python can sit alongside the data and ML teams without translating between languages. The same `pulumi up` that provisions a model serving stack, the same `pytest` that tests the IaC, and the same `boto3` script that audits cost can all live in one Python codebase. See [data science in the cloud](/blog/data-science-in-the-cloud/) for a deeper take on the overlap.
+
+## What does the Python DevOps toolchain look like?
+
+A typical Python toolchain for DevOps work:
+
+| Category | Representative tools |
+|---|---|
+| Package management | pip, [uv](https://github.com/astral-sh/uv), Poetry, Pipenv |
+| Virtual environments | venv, virtualenv, conda |
+| Type checking | mypy, Pyright, pyre |
+| Linting and formatting | Ruff, Flake8, Pylint, Black |
+| Testing | pytest, unittest, hypothesis, tox |
+| CI/CD | GitHub Actions, GitLab CI, CircleCI, Jenkins, Buildkite |
+| Infrastructure as code | [Pulumi](/), Ansible |
+| Cloud SDKs | boto3, google-cloud-* (GCP), azure-sdk-for-python, kubernetes |
+| Orchestration / pipelines | Airflow, Prefect, Dagster, Argo Workflows |
+| ML / MLOps | PyTorch, TensorFlow, scikit-learn, MLflow, Kubeflow, BentoML |
+| Observability | OpenTelemetry Python SDK, Datadog APM, New Relic, Sentry |
+| Secrets | [Pulumi ESC](/product/esc/) Python SDK, HashiCorp Vault client, AWS Secrets Manager |
+
+The toolchain isn't static. Astral's `uv` and `ruff` have displaced a lot of older tools in the last two years; both are dramatic speedups over their predecessors and are now common defaults in new Python projects.
+
+## What are best practices for Python in DevOps?
+
+A few patterns that hold up across team sizes:
+
+* **Use a fast resolver.** `uv` or Poetry, with a checked-in lock file. `requirements.txt` alone doesn't pin transitive dependencies, which causes "works on my machine" failures.
+* **Enable type hints and run a checker.** mypy or Pyright on every PR. Even partial typing pays off because cloud SDKs have complex shapes.
+* **Use Ruff for linting and formatting.** Combines what Flake8 + Black + isort + pyupgrade used to do, runs orders of magnitude faster, and ships with sensible defaults.
+* **Pin Python versions.** Use `pyproject.toml` to declare a supported Python range, and use `.python-version` (or `tool.uv.python`) to pin a specific local version. Production drift between Python versions is a real source of bugs.
+* **Don't hide secrets in `.env` files.** Use [Pulumi ESC](/product/esc/), Vault, or your cloud's secrets manager and pull them at runtime. Commit `.env.example` if you have to, never `.env`.
+* **Test the scripts.** Even short DevOps scripts deserve a pytest run. A test that simulates the `boto3` call with a mock catches the API regressions cloud SDKs introduce.
+* **Containerize CI jobs that depend on system packages.** A Dockerfile beats trying to make a CI image match a developer laptop.
+* **Prefer libraries over invoking subprocesses.** `boto3` over shelling out to `aws`; the `kubernetes` client over `kubectl`. The library calls are easier to test and easier to handle errors from.
+
+## How does Pulumi support Python?
+
+Python is a first-class language for Pulumi, supported on par with TypeScript, Go, .NET, and Java.
+
+* **Typed SDKs for every cloud.** AWS, Azure, Google Cloud, Kubernetes, Cloudflare, Snowflake, Datadog, and 100+ other providers. Generated from each provider's API, including full type hints and docstrings.
+* **`pulumi new python`.** Creates a project with a `Pulumi.yaml`, a virtualenv setup, and a starter program in seconds. See the [Python language guide](/docs/languages-sdks/python/) and [the get-started flow](/docs/get-started/).
+* **Component model.** Reusable [Pulumi components](/docs/iac/concepts/components/) ship as PyPI packages, with full type hints.
+* **Crosswalk for AWS.** Higher-level abstractions for common AWS patterns wrapped in idiomatic Python.
+* **Unit testing with mocks.** Pulumi's [Python test mocks](/docs/iac/using-pulumi/testing/unit/) replace cloud calls with canned responses so pytest runs in milliseconds.
+* **Automation API.** The [automation API](/docs/iac/packages-and-automation/automation-api/) lets you call Pulumi from inside another Python application. Build self-service portals, CLIs, or CI jobs that drive `pulumi up` programmatically.
+* **CrossGuard policies in Python.** Write [policy as code](/docs/insights/policy/) in the same language as your infrastructure.
+* **Pulumi ESC for secrets.** [Pulumi ESC](/product/esc/) pulls secrets at runtime into Python programs, CI jobs, and applications.
+
+[Get started with Pulumi and Python](/docs/get-started/) to provision cloud infrastructure with the language your team is already using.
+
+## Frequently asked questions about Python for DevOps
+
+### Is Python a good language for DevOps?
+
+Yes, for most teams. Its readability, library ecosystem, and overlap with data/ML work make it the default scripting language for ops tasks. Pure performance-sensitive systems work tends to use Go or Rust, but for the broad middle of DevOps automation, Python is the most common choice.
+
+### Should I use Python or Bash for DevOps scripts?
+
+Bash is fine for very short scripts that wrap a few commands. Anything that has to parse JSON, talk to a cloud API, retry on failure, or be tested should be in Python. The transition point comes earlier than most people expect, around the time a Bash script grows past a screen.
+
+### Is Python better than YAML for IaC?
+
+For teams that already write Python, almost always yes. YAML has no real abstractions, no real testing, and no type system. Python has all three. The trade-off is a slightly higher floor for an engineer with no Python background, but most cloud teams have someone who knows Python.
+
+### Should I use Python or TypeScript for Pulumi?
+
+Pick the language your team writes most of its other code in. Both are first-class in Pulumi. Python tends to win when there's overlap with data/ML work; TypeScript tends to win when there's overlap with full-stack web work. The cloud coverage and feature set are equivalent.
+
+### How do you test Python IaC?
+
+Use pytest and Pulumi's [Python test mocks](/docs/iac/using-pulumi/testing/unit/) for unit tests, run a static scanner like Checkov against the rendered output, run [CrossGuard policies](/docs/insights/policy/) in CI, and use the [automation API](/docs/iac/packages-and-automation/automation-api/) to spin up ephemeral stacks for integration tests.
+
+### What's MLOps and how does it relate to DevOps?
+
+MLOps applies DevOps practices (version control, CI/CD, observability, rollback) to machine-learning models and the pipelines that produce them. The two disciplines overlap in tooling but diverge in subject matter: DevOps ships application services; MLOps ships models, datasets, and the training and serving infrastructure around them. Python is dominant in both.
+
+### What Python tools have changed recently?
+
+`uv` (Astral) has displaced `pip` and a lot of `poetry` usage as the fast default package manager. `ruff` (also Astral) has replaced most of the Flake8 / Black / isort stack as a unified, fast linter and formatter. Both are worth adopting in new projects; both can be added to existing projects incrementally.
+
+### How does Python compare to Go for DevOps?
+
+Python is better at glue, scripts, IaC, and ML-adjacent work. Go is better at building self-contained binaries, network services, and cloud-native tools (Kubernetes itself, plus a lot of CNCF tooling, is written in Go). Many DevOps shops use both: Python for scripts and IaC, Go for any custom controllers or operators they ship.
+
+### How do I handle secrets in a Python DevOps program?
+
+Don't put secrets in source. Use [Pulumi ESC](/product/esc/), HashiCorp Vault, AWS Secrets Manager, or Azure Key Vault. Pull secrets at runtime using the vendor's Python SDK or ESC's pull-at-runtime pattern. Treat `.env` files as developer convenience for local work only; never commit them.
+
+### Can I migrate from Ansible to Pulumi?
+
+Yes, and many teams do. Ansible's strength is configuring long-lived servers and one-off remote tasks; Pulumi's strength is provisioning cloud resources and managing them as a versioned, tested codebase. Common migration path: move provisioning to Pulumi first, leave Ansible in place for VM-level configuration that hasn't moved to containers, retire Ansible as more workloads become immutable.
+
+## Learn more
+
+Pulumi treats Python as a first-class IaC language: typed SDKs for every major cloud, components packaged as PyPI modules, pytest with cloud mocks, and the same CI/CD and code review workflow you already use for application Python. [Get started today](/docs/get-started/).
+
+Related reading:
+
+* [What is Infrastructure as Code (IaC)?](/what-is/what-is-infrastructure-as-code/)
+* [What is DevOps?](/what-is/what-is-devops/)
+* [Infrastructure as Code for DevOps](/what-is/infrastructure-as-code-for-devops/)
+* [Infrastructure as Code for Kubernetes](/what-is/infrastructure-as-code-for-kubernetes/)
+* [JavaScript and Infrastructure as Code](/what-is/javascript-and-infrastructure-as-code/)
+* [How to Step Up Cloud Infrastructure Testing](/what-is/how-to-step-up-cloud-infrastructure-testing/)

--- a/content/what-is/python-for-devops.md
+++ b/content/what-is/python-for-devops.md
@@ -26,7 +26,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
-authors: ["zack-chase"]
+authors: ["pablo-seibelt"]
 ---
 
 **Python is the most common general-purpose language for DevOps work: writing automation scripts, defining infrastructure as code, building CI/CD glue, instrumenting observability, and running the data and machine-learning pipelines that increasingly sit alongside traditional services.** Its readable syntax, deep standard library, and large ecosystem of vendor SDKs make it the path of least resistance whenever a DevOps team needs to wire two systems together or replace a manual task with a script.
@@ -49,7 +49,7 @@ In this article, we'll cover the key questions about Python for DevOps:
 A handful of properties keep Python at the top of DevOps language surveys year after year:
 
 * **Readability.** Python's syntax is forgiving and close to pseudocode, so on-call engineers can read and edit each other's scripts without weeks of ramp-up. That matters more for ops tooling than for application code, because the same script may be touched by SREs, security engineers, data engineers, and product engineers.
-* **A library for everything.** PyPI has wrappers around every major cloud API, every messaging system, every monitoring vendor, and every IaC and configuration tool. Most DevOps tasks reduce to glue code on top of existing libraries.
+* **A library for everything.** PyPI has wrappers for almost every major cloud API, messaging system, monitoring vendor, and IaC and configuration tool. Most DevOps tasks reduce to glue code on top of existing libraries.
 * **The data and ML overlap.** Pandas, NumPy, scikit-learn, PyTorch, and TensorFlow live in the same language. As MLOps pipelines mature, the DevOps team that already knows Python can ship them without picking up a second language.
 * **First-class IaC support.** Modern IaC tools, including Pulumi, support Python natively. The same engineers who wrote the deploy scripts can write the platform itself.
 * **Cloud and Kubernetes SDKs.** Every major provider ships an official Python SDK: `boto3` (AWS), `google-cloud-*` (Google Cloud), `azure-sdk-for-python` (Azure), the Kubernetes Python client. The first thing a DevOps engineer reaches for is usually one of these.
@@ -87,7 +87,7 @@ For a deeper look at IaC concepts, see [What is Infrastructure as Code?](/what-i
 
 ## How is Python used for MLOps?
 
-MLOps is the application of DevOps practices to machine-learning systems: version control for models and training data, CI/CD for retraining pipelines, observability of model behavior in production, and rollback when a model regresses. Python is the dominant language at every layer:
+MLOps is the application of DevOps practices to machine-learning systems: version control for models and training data, CI/CD for retraining pipelines, observability of model behavior in production, and rollback when a model regresses. Python is the dominant language across MLOps:
 
 * **Training pipelines.** Frameworks like PyTorch, TensorFlow, JAX, and Hugging Face Transformers are Python-first.
 * **Pipeline orchestration.** Tools like Airflow, Prefect, Dagster, Kubeflow, Metaflow, and ZenML use Python as the orchestration language.
@@ -135,7 +135,7 @@ A few patterns that hold up across team sizes:
 
 Python is a first-class language for Pulumi, supported on par with TypeScript, Go, .NET, and Java.
 
-* **Typed SDKs for every cloud.** AWS, Azure, Google Cloud, Kubernetes, Cloudflare, Snowflake, Datadog, and 100+ other providers. Generated from each provider's API, including full type hints and docstrings.
+* **Typed SDKs for every cloud.** AWS, Azure, Google Cloud, Kubernetes, Cloudflare, Snowflake, Datadog, and hundreds of other providers. Generated from each provider's API, including full type hints and docstrings.
 * **`pulumi new python`.** Creates a project with a `Pulumi.yaml`, a virtualenv setup, and a starter program in seconds. See the [Python language guide](/docs/languages-sdks/python/) and [the get-started flow](/docs/get-started/).
 * **Component model.** Reusable [Pulumi components](/docs/iac/concepts/components/) can be distributed as PyPI packages with full type hints, among other formats.
 * **Crosswalk for AWS.** Higher-level abstractions for common AWS patterns wrapped in idiomatic Python.

--- a/content/what-is/python-for-devops.md
+++ b/content/what-is/python-for-devops.md
@@ -66,7 +66,7 @@ DevOps work has gotten broad enough that a single chart of "what Python is for" 
 | **Cloud automation** | One-off and scheduled scripts using `boto3`/`google-cloud`/`azure-sdk` for housekeeping, audits, and remediation |
 | **Observability and alerting** | Custom collectors, Datadog/New Relic/Prometheus exporters, OpenTelemetry instrumentation, log shippers |
 | **ChatOps and runbooks** | Slack/Teams bots, on-call automation, incident response scripts |
-| **Security and compliance** | IAM analyzers, secret scanners, custom Open Policy Agent / CrossGuard policies, vulnerability scanning glue |
+| **Security and compliance** | IAM analyzers, secret scanners, custom Open Policy Agent / Pulumi policy packs, vulnerability scanning glue |
 | **MLOps** | Training pipelines, model serving, feature stores, experiment tracking (MLflow, Weights & Biases) |
 | **FinOps** | Cost-tagging audits, budget reports, anomaly detection on cloud spend |
 
@@ -141,7 +141,7 @@ Python is a first-class language for Pulumi, supported on par with TypeScript, G
 * **Crosswalk for AWS.** Higher-level abstractions for common AWS patterns wrapped in idiomatic Python.
 * **Unit testing with mocks.** Pulumi's [Python test mocks](/docs/iac/using-pulumi/testing/unit/) replace cloud calls with canned responses so pytest runs in milliseconds.
 * **Automation API.** The [automation API](/docs/iac/packages-and-automation/automation-api/) lets you call Pulumi from inside another Python application. Build self-service portals, CLIs, or CI jobs that drive `pulumi up` programmatically.
-* **CrossGuard policies in Python.** Write [policy as code](/docs/insights/policy/) in the same language as your infrastructure.
+* **Pulumi policies in Python.** Write [policy as code](/docs/insights/policy/) in the same language as your infrastructure.
 * **Pulumi ESC for secrets.** [Pulumi ESC](/product/esc/) pulls secrets at runtime into Python programs, CI jobs, and applications.
 
 [Get started with Pulumi and Python](/docs/get-started/) to provision cloud infrastructure with the language your team is already using.
@@ -166,7 +166,7 @@ Pick the language your team writes most of its other code in. Both are first-cla
 
 ### How do you test Python IaC?
 
-Use pytest and Pulumi's [Python test mocks](/docs/iac/using-pulumi/testing/unit/) for unit tests, run a static scanner like Checkov against the rendered output, run [CrossGuard policies](/docs/insights/policy/) in CI, and use the [automation API](/docs/iac/packages-and-automation/automation-api/) to spin up ephemeral stacks for integration tests.
+Use pytest and Pulumi's [Python test mocks](/docs/iac/using-pulumi/testing/unit/) for unit tests, run a static scanner like Checkov against the rendered output, run [Pulumi policies](/docs/insights/policy/) in CI, and use the [automation API](/docs/iac/packages-and-automation/automation-api/) to spin up ephemeral stacks for integration tests.
 
 ### What's MLOps and how does it relate to DevOps?
 

--- a/content/what-is/python-for-devops.md
+++ b/content/what-is/python-for-devops.md
@@ -74,10 +74,10 @@ What's common across the list: Python is rarely the only language, but it's almo
 
 ## How is Python used for infrastructure as code?
 
-Python is one of the four primary languages for IaC tools that support real programming languages (alongside TypeScript, Go, and C#/.NET). With Pulumi, a Python IaC program describes the desired state of cloud infrastructure as ordinary Python classes and functions:
+Python is one of the primary languages for IaC tools that support real programming languages (alongside TypeScript, Go, .NET, and Java). With Pulumi, a Python IaC program describes the desired state of cloud infrastructure as ordinary Python classes and functions:
 
 * **Generated, typed SDKs.** Pulumi's Python providers ship type hints for every cloud resource (AWS, Azure, Google Cloud, Kubernetes, Cloudflare, Datadog, Snowflake, and more). IDEs like PyCharm and VS Code surface the available properties as you type.
-* **Real abstractions.** A reusable VPC pattern becomes a Python class (`MyVpc(...)`), not a folder of templates. Components ship as PyPI packages.
+* **Real abstractions.** A reusable VPC pattern becomes a Python class (`MyVpc(...)`), not a folder of templates. Components can ship as PyPI packages.
 * **Standard testing tools.** `pytest`, `unittest`, mocks via `unittest.mock`, and Pulumi's own [Python mocks](/docs/iac/using-pulumi/testing/unit/) for cloud responses. IaC tests run alongside application tests in the same CI job.
 * **Standard packaging.** `pip`, `poetry`, `uv`, or Pipenv manage dependencies. Lock files (`requirements.txt`, `poetry.lock`, `uv.lock`) make deploys reproducible.
 
@@ -137,7 +137,7 @@ Python is a first-class language for Pulumi, supported on par with TypeScript, G
 
 * **Typed SDKs for every cloud.** AWS, Azure, Google Cloud, Kubernetes, Cloudflare, Snowflake, Datadog, and 100+ other providers. Generated from each provider's API, including full type hints and docstrings.
 * **`pulumi new python`.** Creates a project with a `Pulumi.yaml`, a virtualenv setup, and a starter program in seconds. See the [Python language guide](/docs/languages-sdks/python/) and [the get-started flow](/docs/get-started/).
-* **Component model.** Reusable [Pulumi components](/docs/iac/concepts/components/) ship as PyPI packages, with full type hints.
+* **Component model.** Reusable [Pulumi components](/docs/iac/concepts/components/) can be distributed as PyPI packages with full type hints, among other formats.
 * **Crosswalk for AWS.** Higher-level abstractions for common AWS patterns wrapped in idiomatic Python.
 * **Unit testing with mocks.** Pulumi's [Python test mocks](/docs/iac/using-pulumi/testing/unit/) replace cloud calls with canned responses so pytest runs in milliseconds.
 * **Automation API.** The [automation API](/docs/iac/packages-and-automation/automation-api/) lets you call Pulumi from inside another Python application. Build self-service portals, CLIs, or CI jobs that drive `pulumi up` programmatically.


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/python-for-devops.md` from a 40-line summary into a deeper reference for teams using Python across IaC, CI/CD, observability, and MLOps.

## What changed

- **Opening definition** — quotable one-paragraph definition followed by a lead-in covering Python's roots in sysadmin scripting and scientific computing and how those flow into DevOps and MLOps work today.
- **Why Python dominates DevOps** — five concrete drivers (readability, library ecosystem, data/ML overlap, native IaC, cloud SDKs).
- **Where DevOps engineers use Python** — nine-row taxonomy table covering IaC, configuration management, CI/CD glue, cloud automation, observability, ChatOps, security/compliance, MLOps, FinOps.
- **Python for IaC section** — typed SDKs, components on PyPI, pytest with cloud mocks, standard packaging (`pip`, `uv`, Poetry).
- **Python for MLOps section** — training pipelines (PyTorch / TensorFlow / JAX), orchestration (Airflow / Prefect / Dagster / Kubeflow), experiment tracking (MLflow / W&B), serving (FastAPI / BentoML / Seldon), feature stores.
- **Toolchain table** — 12 categories covering package management, type checking, linting, testing, CI/CD, IaC, cloud SDKs, orchestration, ML/MLOps, observability, secrets. Modern defaults (`uv`, `ruff`) called out.
- **Eight best practices** — fast resolver + lock files, type hints with mypy/Pyright, Ruff for lint+format, pinned Python versions, secrets hygiene, test the scripts, containerize CI, prefer libraries over subprocesses.
- **Pulumi-Python section** — typed SDKs, awsx, pytest mocks, automation API, CrossGuard in Python, ESC.
- **FAQ** — ten doubt-removers covering Python vs Bash, Python vs YAML for IaC, Python vs TypeScript for Pulumi, MLOps vs DevOps, recent tooling changes (uv, ruff), Python vs Go, secrets, Ansible migration.
- **Learn-more cross-links** — IaC, DevOps, IaC for DevOps, IaC for Kubernetes, JavaScript IaC, infrastructure testing.

## Test plan

- [ ] \`make serve\`; visit \`/what-is/python-for-devops/\` and confirm tables, code spans, and headings render correctly
- [ ] Spot-check cross-links
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)