### PR TITLE
content(what-is): expand the cloud autoscaling explainer

### DIFF
--- a/content/what-is/what-is-cloud-infrastructure-autoscaling.md
+++ b/content/what-is/what-is-cloud-infrastructure-autoscaling.md
@@ -48,7 +48,7 @@ In this article, we'll cover the key questions about cloud infrastructure autosc
 
 Three pressures explain why autoscaling is now table stakes for any production workload:
 
-* **Cost.** Fixed capacity sized for peak load wastes money the rest of the time. Autoscaling keeps the fleet sized to actual demand and shrinks the over-provisioning bill, which routinely runs 30–50% of compute spend on legacy environments.
+* **Cost.** Fixed capacity sized for peak load wastes money the rest of the time. Autoscaling keeps the fleet sized to actual demand and shrinks the over-provisioning bill, which industry estimates routinely put at 30–50% of cloud compute spend.
 * **Reliability.** When traffic spikes, the gap between adding capacity in minutes and adding it in days is the gap between absorbing a launch and serving 5xx errors. Autoscaling closes the gap.
 * **Operations.** Without autoscaling, someone has to be on call to watch dashboards and run scale-up scripts. With it, that human is replaced by a policy that runs in seconds. The on-call rotation gets to spend its time on the things automation can't handle.
 
@@ -65,7 +65,7 @@ Two ways to add capacity to a workload, with very different operational characte
 | Cost shape | Often nonlinear: a 2× instance can cost more than 2× | Roughly linear: 2× instances ≈ 2× cost |
 | Common autoscaler | Less common; usually a manual or scheduled action | The dominant pattern for autoscaling |
 
-In practice, "autoscaling" almost always means horizontal autoscaling. Vertical scaling decisions tend to be manual or change-managed because they involve a restart and a sizing analysis. A few services (RDS, Aurora Serverless, Azure SQL serverless) support automatic vertical scaling for databases.
+In practice, "autoscaling" almost always means horizontal autoscaling. Vertical scaling decisions tend to be manual or change-managed because they involve a restart and a sizing analysis. A few managed serverless databases (Aurora Serverless v2, Azure SQL Database serverless) automatically scale compute capacity up and down with load. Standard RDS only autoscales storage; instance-class changes there are a manual operation.
 
 ## What types of autoscaling are there?
 
@@ -158,7 +158,7 @@ A model that forecasts future load using historical data and scales out in advan
 
 ### Can I autoscale stateful workloads?
 
-Read replicas and stateless components of stateful systems can autoscale. Primary database instances usually cannot, because adding or removing a primary requires explicit failover logic. The newer serverless database tier (Aurora Serverless v2, DynamoDB on-demand, Azure SQL serverless, Spanner autoscaler) provides autoscaled state by handling the failover and resharding inside the managed service.
+Read replicas and stateless components of stateful systems can autoscale. Primary database instances usually cannot, because adding or removing a primary requires explicit failover logic. The newer serverless database tier (Aurora Serverless v2, DynamoDB on-demand, Azure SQL serverless, Spanner autoscaler) provides autoscaled state by handling the underlying scaling operations — failover, resharding, or compute resizing depending on the service — inside the managed service.
 
 ### What's the relationship between HPA, VPA, and Cluster Autoscaler?
 

--- a/content/what-is/what-is-cloud-infrastructure-autoscaling.md
+++ b/content/what-is/what-is-cloud-infrastructure-autoscaling.md
@@ -1,7 +1,6 @@
 ---
 title: What Is Cloud Infrastructure Autoscaling?
-meta_desc: |
-    Autoscaling is a service offered by the cloud provider that will increase or decrease the number of servers, based on need.
+meta_desc: "Autoscaling adds and removes cloud capacity automatically. Learn horizontal vs vertical, reactive vs predictive, the major cloud services, and common pitfalls."
 
 type: what-is
 page_title: Autoscaling 101
@@ -30,44 +29,161 @@ customer_logos:
 authors: ["zack-chase"]
 ---
 
-Two of the great advantages to infrastructure in the cloud are flexibility and speed. You can quickly adjust your infrastructure to conform to variable conditions, such as the amount of traffic or the number of requests in a queue. In other words, you can scale your infrastructure up or down, depending on what you need at a particular time. Scaling often refers to servers (or instances), in particular.
+**Autoscaling is the practice of automatically adding and removing compute capacity in response to observed load, so an application has just enough resources to meet demand without paying for resources it isn't using.** A scaling policy watches one or more signals (CPU usage, request count, queue depth, custom metrics), compares them to thresholds, and triggers the cloud provider to provision more capacity when load rises or release capacity when load falls.
 
-## Scaling Up or Scaling Out
+Autoscaling is one of the foundational features that distinguishes cloud infrastructure from fixed on-premises capacity. It's available at every layer of a modern stack: VMs, containers, Kubernetes pods, serverless concurrency, managed databases, queue consumers, even global content distribution. Most production cloud applications use autoscaling at multiple layers at once, configured through [infrastructure as code](/what-is/what-is-infrastructure-as-code/) so the policies are reviewable and reproducible across environments.
 
-Scaling up is when you make a server more powerful so it can handle more load. Scaling out means distributing the workload by adding more servers.
+In this article, we'll cover the key questions about cloud infrastructure autoscaling:
 
-To scale up (also called vertical scaling), you might add more CPUs, memory, or network capacity. Scaling up works well for applications that are difficult to distribute. A good example is a relational database. Distributing the database across multiple servers may have unintended consequences, such as changing the data. It might be easier to use a more powerful machine, instead.
+* Why does autoscaling matter?
+* What is the difference between horizontal and vertical scaling?
+* What types of autoscaling are there?
+* What can be autoscaled in the cloud?
+* How do cloud provider autoscaling services compare?
+* What are common patterns and pitfalls?
+* How do you define autoscaling as code?
+* Frequently asked questions about autoscaling
 
-Scaling out (also called horizontal scaling) spreads the workload across multiple servers that work in parallel. Applications that can sit on a single machine, such as websites, are well-suited to scaling out because you don’t need to coordinate tasks between servers. For example, a retail website might have peak periods, such as around the Christmas holiday or when there are sales. During those times, you would want to add more servers to handle the additional traffic so your site stays responsive to customer demand.
+## Why does autoscaling matter?
 
-## What is Autoscaling?
+Three pressures explain why autoscaling is now table stakes for any production workload:
 
-Autoscaling is a service offered by the cloud provider. Once you configure it, that service automatically scales out for you. It increases or decreases the number of servers, based on need. With autoscaling, your workload gets exactly the resources it requires at any given time. You pay only for the server resources you use.
+* **Cost.** Fixed capacity sized for peak load wastes money the rest of the time. Autoscaling keeps the fleet sized to actual demand and shrinks the over-provisioning bill, which routinely runs 30–50% of compute spend on legacy environments.
+* **Reliability.** When traffic spikes, the gap between adding capacity in minutes and adding it in days is the gap between absorbing a launch and serving 5xx errors. Autoscaling closes the gap.
+* **Operations.** Without autoscaling, someone has to be on call to watch dashboards and run scale-up scripts. With it, that human is replaced by a policy that runs in seconds. The on-call rotation gets to spend its time on the things automation can't handle.
 
-Autoscaling is a great feature if your workload is at all volatile. It isn’t practical to have someone manually adjusting the number of servers you need. Instead, use automation to make sure it happens instantly. You set the parameters, either through your cloud provider’s console or, even better, programmatically.
+## What is the difference between horizontal and vertical scaling?
 
-With a properly configured service, your infrastructure manages itself and you can be certain that when your application needs additional resources, those resources will be available. You can also know that, when demand decreases, you won’t be paying for servers you’re not using.
+Two ways to add capacity to a workload, with very different operational characteristics.
 
-## Who Provides Autoscaling?
+| Aspect | Vertical scaling (scaling up) | Horizontal scaling (scaling out) |
+|---|---|---|
+| What changes | A single instance gets bigger (more CPU, memory, network) | More instances are added |
+| Workloads that suit it | Stateful systems that are hard to distribute (RDBMS primaries, legacy monoliths) | Stateless services, web tiers, queue workers |
+| Time to apply | Often requires a restart | New instances boot in parallel; no impact to existing ones |
+| Upper limit | The largest instance type the cloud offers | Effectively unlimited (within quota) |
+| Cost shape | Often nonlinear: a 2× instance can cost more than 2× | Roughly linear: 2× instances ≈ 2× cost |
+| Common autoscaler | Less common; usually a manual or scheduled action | The dominant pattern for autoscaling |
 
-Autoscaling is a standard service offered by most cloud providers, although they each call it something different. For example:
+In practice, "autoscaling" almost always means horizontal autoscaling. Vertical scaling decisions tend to be manual or change-managed because they involve a restart and a sizing analysis. A few services (RDS, Aurora Serverless, Azure SQL serverless) support automatic vertical scaling for databases.
 
-- AWS provides Auto Scaling groups.
-- Google Cloud provides Managed Instance Groups (MIGs).
-- Microsoft has a service called Autoscale.
+## What types of autoscaling are there?
 
-### AWS Auto Scaling
+Three trigger styles cover most use cases, often combined in the same policy.
 
-AWS Auto Scaling monitors your applications and automatically adjusts capacity to maintain steady, predictable performance. You can build scaling plans for resources including Amazon EC2 instances and Spot Fleets, Amazon ECS tasks, Amazon DynamoDB tables and indexes, and Amazon Aurora Replicas. The service provides recommendations to help you optimize performance, costs, or some balance between them.
+* **Reactive autoscaling.** Add capacity when a metric exceeds a threshold; remove it when the metric drops below another. The simplest and most common pattern. Works well for predictable, smooth load and for workloads that can absorb a short delay while new capacity boots.
+* **Scheduled autoscaling.** Pre-warm capacity at known busy times (market open, business hours, a marketing campaign) and shrink at known quiet times. Cheaper than over-provisioning permanently, faster than reactive scaling, but requires that you know the schedule.
+* **Predictive autoscaling.** A model forecasts load using historical data and scales out before the spike arrives. AWS, Google Cloud, and Azure all offer predictive options on top of their reactive autoscalers. Useful for workloads with daily or weekly periodicity where reactive alone responds too slowly.
 
-### Google Cloud
+Most production setups combine reactive scaling for steady-state demand with either scheduled or predictive scaling for known patterns.
 
-MIGs (where an instance group is a collection of VM instances that you can manage as a single entity) allow you to automatically add or delete VM instances from a MIG, based on increases or decreases in load. You define an autoscaling policy and the autoscaler performs automatic scaling based on the measured load and the options you configured. The service also offers predictive autoscaling, where the autoscaler forecasts future load based on historical data and scales out a MIG in advance.
+## What can be autoscaled in the cloud?
 
-### Azure Autoscale
+Almost every cloud primitive that runs compute has an autoscaler attached to it.
 
-Autoscale is a built-in feature of Cloud Services, Mobile Services, Virtual Machine Scale Sets, and Websites. Autoscale can scale your service by a variety of criteria or you can define your own custom metrics. You can set a schedule so that you anticipate known spikes in demand. You can also set alerts based on metrics, such as CPU status or response time and create alerts for events, including when autoscale itself is triggered.
+| Layer | Examples |
+|---|---|
+| Virtual machines | AWS Auto Scaling Groups, GCP Managed Instance Groups, Azure VM Scale Sets |
+| Containers | ECS Service Auto Scaling, Fargate task scaling, Cloud Run instance scaling |
+| Kubernetes pods | Horizontal Pod Autoscaler (HPA), Vertical Pod Autoscaler (VPA), KEDA for event-driven scaling |
+| Kubernetes nodes | Cluster Autoscaler, Karpenter (on AWS), GKE node-pool autoscaling, AKS Cluster Autoscaler |
+| Serverless functions | Concurrency-based scaling (Lambda, Cloud Functions, Azure Functions) |
+| Databases | Aurora Serverless, DynamoDB on-demand and provisioned with autoscaling, Azure Cosmos DB autoscale RU, Spanner autoscaler |
+| Caches and queues | DynamoDB autoscaled streams, SQS queue-based scaling for consumers, ElastiCache shard scaling |
+| Load balancers | Most managed load balancers scale automatically without a knob |
+| CDN / edge | Effectively infinite; capacity is the network |
 
-## Learn More
+A real production setup typically autoscales at several layers at once: the Kubernetes HPA scales pods, the Cluster Autoscaler scales the nodes those pods need, and the database tier (often Aurora Serverless or DynamoDB on-demand) scales independently.
 
-Ready to learn more? With Pulumi, you can create and manage infrastructure with the languages and tools you already know. To help you implement autoscaling on AWS, check out [Pulumi AWSx](/docs/iac/clouds/aws/guides/), which enables easy definition of Auto Scaling Groups (ASGs) to configure scaling of EC2 instances. You can [get started](/docs/get-started/) for free today.
+## How do cloud provider autoscaling services compare?
+
+The three major clouds each ship multiple autoscaling services for different primitives.
+
+| Cloud | VM autoscaling | Container / K8s autoscaling | Serverless concurrency |
+|---|---|---|---|
+| **AWS** | Auto Scaling Groups; AWS Auto Scaling spans EC2, ECS, DynamoDB, Aurora, Spot Fleet | ECS Service Auto Scaling; HPA and Cluster Autoscaler on EKS; Karpenter | Lambda concurrency (reserved, provisioned, on-demand) |
+| **Google Cloud** | Managed Instance Groups (MIGs) with reactive, scheduled, and predictive autoscaling | HPA, VPA, and Cluster Autoscaler on GKE; node-pool autoscaling | Cloud Run instance scaling; Cloud Functions concurrency |
+| **Azure** | VM Scale Sets with Autoscale | AKS Cluster Autoscaler; HPA; KEDA integration | Azure Functions premium/consumption plans, Container Apps scaling |
+
+Most teams pick the autoscaler that matches their compute primitive rather than the cloud provider as a whole. Autoscaling decisions are typically a single layer's concern, not an enterprise-wide one.
+
+## What are common patterns and pitfalls?
+
+A handful of patterns hold up well across providers:
+
+* **Pair the application autoscaler with the node autoscaler.** Scaling pods without scaling nodes just stalls when the cluster runs out of room. Scaling nodes without scaling pods leaves room a workload won't use. HPA + Cluster Autoscaler (or Karpenter) is the canonical pairing on Kubernetes.
+* **Set sane minimum and maximum bounds.** A runaway autoscaler with no upper bound can blow a monthly budget in hours. A minimum below your steady-state floor produces cold-start latency on every quiet period.
+* **Mind cold starts.** Booting a VM, pulling a container image, JIT-compiling a runtime, and warming caches all take time. Reactive scaling that responds in 5 minutes is too slow for a 30-second traffic burst. Predictive or scheduled scaling, or pre-warmed concurrency, fills the gap.
+* **Pick scaling metrics that lead, not lag.** CPU works for compute-bound workloads but lags for I/O-bound ones. Queue depth, request rate, or custom application metrics (like time-in-queue) often produce smoother scaling decisions.
+* **Make scale-in safe.** Terminating an instance mid-request causes failed responses. Configure connection draining, lifecycle hooks, and `terminationGracePeriodSeconds` (on Kubernetes) to let in-flight work finish before instances go away.
+* **Don't autoscale stateful primaries.** Read replicas can autoscale. Primary database instances generally cannot without explicit failover logic. Use a managed serverless database (Aurora Serverless, DynamoDB, Spanner) for state that has to scale with load.
+* **Test scaling on the way down too.** Most teams test scale-out; failures often happen on scale-in (a popular service holds onto state, a queue worker shuts down before draining, an LB removes a healthy backend prematurely).
+* **Cap the rate of change.** Scaling 10× in 30 seconds can stress shared dependencies (databases, caches, third-party APIs) more than the original traffic spike did. Step scaling and cooldown periods smooth the changes.
+
+## How do you define autoscaling as code?
+
+Autoscaling policies are infrastructure: they need to be reviewed, versioned, and identical across environments. The right place to define them is in [infrastructure as code](/what-is/what-is-infrastructure-as-code/) alongside the workloads they govern.
+
+With Pulumi:
+
+* **AWS Auto Scaling Groups** are first-class resources in the [`@pulumi/aws`](https://www.pulumi.com/registry/packages/aws/) package. The higher-level [`@pulumi/awsx`](https://github.com/pulumi/pulumi-awsx) Crosswalk package wraps ECS service scaling, ASG defaults, and ALB target tracking in a smaller API.
+* **GCP Managed Instance Groups and autoscalers** are defined through [`@pulumi/gcp`](https://www.pulumi.com/registry/packages/gcp/) with the same dependency model as the underlying VMs.
+* **Azure VM Scale Sets** are defined through [`@pulumi/azure-native`](https://www.pulumi.com/registry/packages/azure-native/).
+* **Kubernetes HPAs, VPAs, KEDA scaled objects, and Cluster Autoscaler / Karpenter configurations** are defined through [`@pulumi/kubernetes`](https://www.pulumi.com/registry/packages/kubernetes/) alongside the workloads they scale. See [Infrastructure as Code for Kubernetes](/what-is/infrastructure-as-code-for-kubernetes/).
+* **Policy as code for scaling guardrails.** [Pulumi CrossGuard](/docs/insights/policy/) policies can enforce "every production ASG must have a non-zero max," "no ASG without scale-in protection in stateful tiers," "production database autoscaling must have an upper bound."
+
+[Get started with Pulumi](/docs/get-started/) to define autoscaling policies alongside the rest of your cloud infrastructure in TypeScript, Python, Go, C#, Java, or YAML.
+
+## Frequently asked questions about autoscaling
+
+### What's the difference between scaling, autoscaling, and elastic scaling?
+
+"Scaling" is the act of changing capacity. "Autoscaling" is scaling driven by a policy without human intervention. "Elastic" is the marketing term cloud providers use for a workload that can scale up and down automatically; in practice it means "autoscaled" plus "billed only for what you use."
+
+### Should I scale up or scale out?
+
+Scale out by default for any stateless service: it's cheaper, more reliable, and easier to automate. Reserve scale-up for stateful systems (primary databases, in-memory caches with affinity, single-node tools) where horizontal scaling adds prohibitive complexity.
+
+### How do I avoid paying for capacity I'm not using?
+
+Set a low minimum, an appropriate maximum, and use reactive autoscaling with a metric that tracks demand (CPU, queue depth, custom). For serverless workloads, on-demand pricing usually wins unless you have very predictable steady-state load, in which case reserved capacity is cheaper.
+
+### How fast does autoscaling react?
+
+Depends on the primitive. Lambda and Cloud Run scale in seconds. Container schedulers (ECS, HPA + Cluster Autoscaler) scale in tens of seconds to a few minutes. Adding a new EC2 instance and waiting for it to be healthy in an ASG typically takes 2–5 minutes. For faster reaction, use predictive or scheduled scaling to pre-warm capacity.
+
+### What is predictive autoscaling?
+
+A model that forecasts future load using historical data and scales out in advance of the predicted spike. AWS Auto Scaling, Google Cloud MIGs, and Azure Autoscale all offer it. It's most useful for workloads with daily or weekly periodicity, like a consumer app whose traffic peaks at the same time every evening.
+
+### Can I autoscale stateful workloads?
+
+Read replicas and stateless components of stateful systems can autoscale. Primary database instances usually cannot, because adding or removing a primary requires explicit failover logic. The newer serverless database tier (Aurora Serverless v2, DynamoDB on-demand, Azure SQL serverless, Spanner autoscaler) provides autoscaled state by handling the failover and resharding inside the managed service.
+
+### What's the relationship between HPA, VPA, and Cluster Autoscaler?
+
+In Kubernetes: HPA (Horizontal Pod Autoscaler) changes the number of pod replicas. VPA (Vertical Pod Autoscaler) changes the CPU and memory requests of pods. Cluster Autoscaler (or Karpenter) changes the number of underlying nodes. HPA + Cluster Autoscaler is the standard pairing; VPA is often used for resource-request recommendations rather than continuous resizing.
+
+### What's KEDA?
+
+Kubernetes Event-Driven Autoscaler. It extends HPA to scale on external metrics like queue length, Kafka consumer lag, or HTTP request rate, beyond what the built-in HPA can reach. Commonly used for queue workers, event processors, and background jobs.
+
+### How does autoscaling interact with cost management?
+
+Autoscaling generally reduces cost compared to fixed peak provisioning, but it can also surprise teams when an upper bound is missing. Pair autoscaling with budget alerts in your cloud account and CrossGuard policies in your IaC that enforce a maximum on every ASG / MIG / scale set / HPA.
+
+### How does autoscaling affect SLOs?
+
+Used well, it improves availability by absorbing load. Used poorly (no cold-start mitigation, slow reactive scaling, primary database can't keep up), it can degrade latency right when traffic spikes. SLO dashboards should track latency during scaling events specifically, not just steady state.
+
+## Learn more
+
+Pulumi puts autoscaling policies in the same code that creates the resources they govern: an ASG, an HPA, a Cloud Run service, a DynamoDB table, and the policies that bound them. Reviewers see the full picture in one diff; auditors see a single source of truth. [Get started today](/docs/get-started/).
+
+Related reading:
+
+* [What is Infrastructure as Code (IaC)?](/what-is/what-is-infrastructure-as-code/)
+* [What is DevOps?](/what-is/what-is-devops/)
+* [Infrastructure as Code for Kubernetes](/what-is/infrastructure-as-code-for-kubernetes/)
+* [What is Serverless?](/what-is/what-is-serverless/)
+* [What is Configuration Management?](/what-is/what-is-configuration-management/)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/what-is-cloud-infrastructure-autoscaling.md` from a brief overview into a deeper reference covering autoscaling across every cloud primitive that supports it.

## What changed

- **Opening definition** — quotable one-paragraph definition of autoscaling followed by a lead-in placing it across every layer of a cloud stack (VMs, containers, K8s, serverless, databases).
- **Why it matters** — three drivers (cost, reliability, operations).
- **Horizontal vs. vertical comparison table** — what changes, suitable workloads, time to apply, upper limit, cost shape.
- **Three trigger types** — reactive, scheduled, predictive, with when each fits.
- **'What can be autoscaled' table** — VMs, containers, Kubernetes pods and nodes (HPA / VPA / Cluster Autoscaler / Karpenter), serverless concurrency, databases, queues, load balancers, CDN.
- **Cloud provider services table** — AWS, GCP, Azure across VM, container/K8s, serverless.
- **Eight patterns and pitfalls** — pair pod and node autoscaling, set bounds, cold starts, leading metrics, safe scale-in, stateful workloads, rate-of-change caps, test scale-in not just scale-out.
- **Autoscaling as code section** — `@pulumi/aws`, `@pulumi/awsx`, `@pulumi/gcp`, `@pulumi/azure-native`, `@pulumi/kubernetes`, and CrossGuard guardrails for bounds.
- **FAQ** — ten doubt-removers covering terminology, scale up vs out, cost control, reaction time, predictive scaling, stateful workloads, HPA/VPA/Cluster Autoscaler relationship, KEDA, cost management, SLO impact.
- **Learn-more cross-links** — IaC, DevOps, IaC for Kubernetes, serverless, configuration management.

## Test plan

- [ ] \`make serve\`; visit \`/what-is/what-is-cloud-infrastructure-autoscaling/\` and confirm both tables and headings render correctly
- [ ] Spot-check cross-links
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)