### PR TITLE
lint(prose): flag deprecated &quot;CrossGuard&quot; → &quot;Pulumi Policies&quot;

### DIFF
--- a/styles/Pulumi/Substitutions.yml
+++ b/styles/Pulumi/Substitutions.yml
@@ -11,3 +11,5 @@ swap:
   '\bcross-language package\b': Pulumi package
   '\bsingle-language package\b': native language package
   '\blanguage-native package\b': native language package
+  '\bPulumi CrossGuard\b': Pulumi Policies
+  '\bCrossGuard\b': Pulumi Policies


### PR DESCRIPTION
## Summary

Adds two swap entries to the `Pulumi.Substitutions` Vale rule so stale references to the former product name surface as lint errors with an auto-suggested replacement:

- `Pulumi CrossGuard` → `Pulumi Policies`
- `CrossGuard` → `Pulumi Policies`

The longer pattern is listed first so Vale matches it before the bare term. `ignorecase: true` is already set at the rule level, so all casings are covered without additional entries.

No `CrossGuard` references currently exist under `content/` — this is a forward-looking guardrail for new content (blog posts, customer stories, docs updates).

## Test plan

- [ ] CI prose lint passes on the existing tree (no new findings).
- [ ] Locally, dropping `CrossGuard` or `Pulumi CrossGuard` into any markdown file produces a `Pulumi.Substitutions` error suggesting `Pulumi Policies`.

https://claude.ai/code/session_01ByuPoKXrTS3jQKQSf5s5JM

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByuPoKXrTS3jQKQSf5s5JM)_