### PR TITLE
ci(cli-docs): repoint workflow at moved versions.md, fix other stale paths

### DIFF
--- a/.claude/commands/move-doc/SKILL.md
+++ b/.claude/commands/move-doc/SKILL.md
@@ -475,6 +475,44 @@ Searching for internal references...
 
 **Important**: Always skip `blog/` and `tutorials/` per AGENTS.md. See `move-doc:references:link-updates` for patterns and edge cases.
 
+**Additional check: References in `.github/workflows/` and `scripts/`**
+
+Hugo aliases redirect URLs at request time — they do **not** rewrite filesystem paths or hard-coded URL strings in CI workflows or repository scripts. If automation reads or writes the moved file by its old path (e.g. a `sed -i ./content/...` line in a workflow), the move silently breaks that automation at the next scheduled run.
+
+**Real example**: PR #19137 moved `content/docs/get-started/download-install/versions.md` to `content/docs/install/versions.md`. The Hugo alias kept all user-facing URLs working, but `.github/workflows/pulumi-cli-docs.yml` had `sed -i ./content/docs/get-started/download-install/versions.md` hard-coded, and the next scheduled CLI docs run failed with `sed: can't read ...: No such file or directory`.
+
+Search both the old URL and the old filesystem path:
+
+```bash
+# Combine URL and filesystem-path searches; trim leading ./ from path
+old_path_trimmed="${source_file#./}"
+grep -rn "{old_url}\|${old_path_trimmed}" .github/workflows/ scripts/ 2>/dev/null
+```
+
+**Do not auto-update these matches.** Workflow and script references appear inside shell strings, regex, JS, YAML literals, JSON, etc., where a blind `sed` substitution can corrupt surrounding syntax or the meaning of adjacent code. Surface matches as a manual-review warning instead.
+
+**On matches found**, display:
+
+```
+⚠️  External references that this skill will NOT auto-update:
+
+  .github/workflows/foo.yml:42 — old URL
+  scripts/bar.sh:9 — old filesystem path
+
+Hugo aliases do not redirect filesystem writes or URL constants inside CI.
+Review each match and update by hand if the surrounding code still expects
+the old location. Common offenders:
+
+  - sed -i / cat / cp commands writing to the moved file
+  - Lighthouse / link-checker URL lists
+  - Algolia ranking rules keyed on the old canonical URL
+  - Redirect destinations in scripts/redirects/*.txt
+```
+
+Add a "Manual review: external references" line to the Step 8 summary if any matches were found, listing the file:line locations so the user can act on them in the same PR as the move.
+
+**On no matches**: silently continue — no message needed unless the user has asked for verbose output.
+
 ### Step 8: Summary and Next Steps
 
 **Goal**: Provide comprehensive summary with orphaned menu detection and actionable next steps.
@@ -643,6 +681,7 @@ This skill uses detailed reference documentation:
 3. **Always verify aliases** with repository scripts
 4. **Update links in `docs/` and `product/`** only (skip `blog/` and `tutorials/`)
 5. **Never break existing URLs** - aliases must redirect properly
+6. **Always scan `.github/workflows/` and `scripts/`** for references to the old URL or filesystem path — Hugo aliases do not redirect filesystem writes or URL constants embedded in CI/automation
 
 ## Error Recovery
 

--- a/.claude/commands/move-doc/references/link-updates.md
+++ b/.claude/commands/move-doc/references/link-updates.md
@@ -123,6 +123,35 @@ Patterns to update:
 
 **Rollback**: Use `git restore content/docs/ content/product/` if changes are incorrect
 
+## External References (workflows and scripts)
+
+Hugo aliases redirect URLs at request time — they do **not** rewrite filesystem paths or hard-coded URL strings in CI workflows or repository scripts. If automation reads or writes the moved file by its old path, the move silently breaks that automation at the next scheduled run.
+
+### Search
+
+Search both the old URL and the old filesystem path (without the leading `./`):
+
+```bash
+old_path_trimmed="${source_file#./}"
+grep -rn "{old_url}\|${old_path_trimmed}" .github/workflows/ scripts/ 2>/dev/null
+```
+
+### Do not auto-update these matches
+
+Workflow and script references appear inside shell strings, regex, JavaScript, YAML literals, JSON, etc., where blind `sed` substitution can corrupt surrounding syntax or the semantics of adjacent code. Surface matches as a manual-review warning instead and let the user update each one in context.
+
+### Common breakage patterns
+
+- **Hard-coded `sed -i` / `cat` / `cp` writes** to the moved file (e.g. `sed -i ./content/docs/old/path/file.md` in a workflow step)
+- **URL lists in audit scripts** — Lighthouse runners, link-checkers, smoke-test scripts iterating over a hard-coded set of paths
+- **Algolia ranking rules** keyed on the old canonical URL (`page.getObjectID({ href: "/docs/old/..." })`)
+- **Redirect destinations** in `scripts/redirects/*.txt` pointing to the old URL — these create double-redirects rather than breaking, so they're easy to miss
+- **CODEOWNERS** lines targeting the old path for auto-merge or review routing
+
+### Real example
+
+PR #19137 moved `content/docs/get-started/download-install/versions.md` to `content/docs/install/versions.md`. Hugo aliases kept all user URLs working, but `.github/workflows/pulumi-cli-docs.yml` had a `sed -i ./content/docs/get-started/download-install/versions.md` line that wasn't updated. The next scheduled CLI docs run failed with `sed: can't read ...: No such file or directory` — see [run 26097909723](https://github.com/pulumi/docs/actions/runs/26097909723/job/76740530471).
+
 ## Performance Considerations
 
 **Small updates (< 20 files)**: Show preview with context, ask confirmation

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Update version lists
         run: |
           NL=$'\n'
-          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/get-started/download-install/versions.md
+          sed -e "s/<tbody>/<tbody>\\${NL}        {{< changelog-table-row version=\"${{ env.PULUMI_VERSION}}\" date=\"$(date +%Y-%m-%d)\" showChecksum=\"true\" >}}/" -i ./content/docs/install/versions.md
       - name: git status
         run: git status && git diff
       - name: commit changes

--- a/content/docs/install/versions.md
+++ b/content/docs/install/versions.md
@@ -14,6 +14,24 @@ aliases:
 - /docs/get-started/download-install/versions/
 ---
 
+<!--
+  AUTOMATED FILE — DO NOT MOVE OR RENAME WITHOUT UPDATING CI.
+
+  A new changelog-table-row entry is appended to the table body below by
+  the "Update version lists" step in .github/workflows/pulumi-cli-docs.yml
+  every time the Pulumi CLI docs workflow runs. (That step targets the
+  literal opening table-body tag via sed, so don't add another one above
+  the table or the wrong line will get rewritten.)
+
+  If you move or rename this file, you MUST also update the hard-coded
+  path in that workflow (currently `./content/docs/install/versions.md`)
+  — Hugo aliases do not redirect filesystem writes, and the workflow
+  will fail at the `sed -i` step.
+
+  The matching `static/latest-version` file is written by the same
+  workflow's "Update latest version" step.
+-->
+
 The current stable version of Pulumi is **{{< latest-version >}}**.
 
 <table>

--- a/scripts/redirects/general-broken-links-redirects.txt
+++ b/scripts/redirects/general-broken-links-redirects.txt
@@ -17,8 +17,8 @@ docs/pulumi-cloud/developer-portals/new-project-wizard/index.html|/docs/idp/deve
 docs/pulumi-cloud/developer-portals/backstage/index.html|/docs/idp/developer-portals/backstage/
 docs/pulumi-cloud/access-management/scim/azuread/index.html|/docs/administration/access-identity/scim/entra/
 docs/iac/packages-and-automation/crossguard/core-concepts/index.html|/docs/insights/policy/
-docs/pulumi-cloud/access-management/oidc/index.html|/docs/administration/access-identity/oidc-client/
-docs/pulumi-cloud/access-management/oidc/client/index.html|/docs/administration/access-identity/oidc-client/
+docs/pulumi-cloud/access-management/oidc/index.html|/docs/administration/access-identity/oidc-issuers/
+docs/pulumi-cloud/access-management/oidc/client/index.html|/docs/administration/access-identity/oidc-issuers/
 docs/administration/self-hosting/pulumi-cloud/index.html|/docs/administration/self-hosting/
 docs/esc/environments/structure/index.html|/docs/esc/environments/syntax/
 docs/reference/cloud-rest-api/cloud-rest-api/index.html|/docs/reference/cloud-rest-api/

--- a/scripts/run-lighthouse-pr.sh
+++ b/scripts/run-lighthouse-pr.sh
@@ -6,7 +6,7 @@ source ./scripts/common.sh
 
 # Pages to audit.
 page_names=("Homepage" "Install Pulumi" "AWS Get Started")
-page_paths=("/" "/docs/get-started/download-install/" "/docs/iac/get-started/aws/")
+page_paths=("/" "/docs/install/" "/docs/iac/get-started/aws/")
 
 # Read preview URL from the metadata file created by sync-and-test-bucket.sh.
 metadata_file="$(origin_bucket_metadata_filepath)"

--- a/scripts/search/settings.js
+++ b/scripts/search/settings.js
@@ -174,7 +174,7 @@ module.exports = {
                         {
                             position: 0,
                             objectIDs: [
-                                page.getObjectID({ href: "/docs/iac/clouds/aws/guides/" }),
+                                page.getObjectID({ href: "/docs/iac/guides/clouds/aws/" }),
                             ],
                         },
                     ],
@@ -199,7 +199,7 @@ module.exports = {
                         {
                             position: 0,
                             objectIDs: [
-                                page.getObjectID({ href: "/docs/iac/clouds/aws/guides/" }),
+                                page.getObjectID({ href: "/docs/iac/guides/clouds/aws/" }),
                                 page.getObjectID({ href: "/registry/packages/awsx/" }),
                                 page.getObjectID({ href: "/registry/packages/aws-apigateway/" }),
                                 page.getObjectID({ href: "/registry/packages/eks/" }),


### PR DESCRIPTION
## Summary

- Fix the `Pulumi CLI docs` workflow's `Update version lists` step, which has been failing since PR #19137 moved `versions.md` from `content/docs/get-started/download-install/` to `content/docs/install/`. The workflow's `sed -i` target was hard-coded to the old path — Hugo aliases redirect URLs, not filesystem writes — see [run 26097909723](https://github.com/pulumi/docs/actions/runs/26097909723/job/76740530471).
- Annotate `versions.md` with an HTML comment so a future move/rename of the file triggers a corresponding workflow update (and notes the sibling `static/latest-version` write).
- Sweep up a few other stale paths from prior moves found while auditing:
  - `scripts/run-lighthouse-pr.sh`: PR Lighthouse audit now targets `/docs/install/` directly instead of taking a 301 hop through the old URL.
  - `scripts/search/settings.js`: Algolia "awsx" promote rule now references the post-#18584 canonical URL (`/docs/iac/guides/clouds/aws/`). The previous URL was silently no-op'ing.
  - `scripts/redirects/general-broken-links-redirects.txt`: two OIDC entries now resolve to `oidc-issuers/` (renamed in #18910) instead of double-hopping through `oidc-client/`.

## Test plan

- [ ] Re-run the failing `Pulumi CLI docs` workflow via `workflow_dispatch` with the current `PULUMI_VERSION` (e.g. `3.241.0`) and `skip_auto_merge: true`; confirm it gets past the `Update version lists` step and opens a `Regenerating CLI docs for Pulumi@<version>` PR.
- [ ] `grep -n '<tbody>' content/docs/install/versions.md` returns exactly one match — the table-body anchor `sed` rewrites — so the new HTML comment doesn't get clobbered.
- [ ] `make build` still succeeds (HTML comment is inert; aliases unchanged).
- [ ] Spot-check the next PR's Lighthouse comment to confirm the "Install Pulumi" row scores the install page directly (no redirect hop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)