### PR TITLE
Update CrossGuard references to Pulumi Policies

### DIFF
--- a/content/what-is/what-is-cloud-infrastructure-autoscaling.md
+++ b/content/what-is/what-is-cloud-infrastructure-autoscaling.md
@@ -27,7 +27,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
-authors: ["zack-chase"]
+authors: ["cam-soper"]
 ---
 
 **Autoscaling is the practice of automatically adding and removing compute capacity in response to observed load, so an application has just enough resources to meet demand without paying for resources it isn't using.** A scaling policy watches one or more signals (CPU usage, request count, queue depth, custom metrics), compares them to thresholds, and triggers the cloud provider to provision more capacity when load rises or release capacity when load falls.
@@ -131,7 +131,7 @@ With Pulumi:
 * **GCP Managed Instance Groups and autoscalers** are defined through [`@pulumi/gcp`](https://www.pulumi.com/registry/packages/gcp/) with the same dependency model as the underlying VMs.
 * **Azure VM Scale Sets** are defined through [`@pulumi/azure-native`](https://www.pulumi.com/registry/packages/azure-native/).
 * **Kubernetes HPAs, VPAs, KEDA scaled objects, and Cluster Autoscaler / Karpenter configurations** are defined through [`@pulumi/kubernetes`](https://www.pulumi.com/registry/packages/kubernetes/) alongside the workloads they scale. See [Infrastructure as Code for Kubernetes](/what-is/infrastructure-as-code-for-kubernetes/).
-* **Policy as code for scaling guardrails.** [Pulumi CrossGuard](/docs/insights/policy/) policies can enforce "every production ASG must have a non-zero max," "no ASG without scale-in protection in stateful tiers," "production database autoscaling must have an upper bound."
+* **Policy as code for scaling guardrails.** [Pulumi Policies](/docs/insights/policy/) can enforce "every production ASG must have a non-zero max," "no ASG without scale-in protection in stateful tiers," "production database autoscaling must have an upper bound."
 
 [Get started with Pulumi](/docs/get-started/) to define autoscaling policies alongside the rest of your cloud infrastructure in TypeScript, Python, Go, C#, Java, or YAML.
 
@@ -171,7 +171,7 @@ Kubernetes Event-Driven Autoscaler. It extends HPA to scale on external metrics 
 
 ### How does autoscaling interact with cost management?
 
-Autoscaling generally reduces cost compared to fixed peak provisioning, but it can also surprise teams when an upper bound is missing. Pair autoscaling with budget alerts in your cloud account and CrossGuard policies in your IaC that enforce a maximum on every ASG / MIG / scale set / HPA.
+Autoscaling generally reduces cost compared to fixed peak provisioning, but it can also surprise teams when an upper bound is missing. Pair autoscaling with budget alerts in your cloud account and [Pulumi Policies](/docs/insights/policy/) in your IaC that enforce a maximum on every ASG / MIG / scale set / HPA.
 
 ### How does autoscaling affect SLOs?
 

--- a/content/what-is/what-is-devops.md
+++ b/content/what-is/what-is-devops.md
@@ -106,7 +106,7 @@ These are the concrete engineering practices that turn the CALMS pillars into da
 * **[Configuration management](/what-is/what-is-configuration-management/) and secrets.** Keep environment-specific configuration and secrets out of code, and manage them centrally with auditing, rotation, and least-privilege access. [Pulumi ESC](/product/esc/) provides hierarchical configuration and dynamic secrets across environments.
 * **Automated testing.** Beyond unit tests, DevOps teams run integration tests, [infrastructure tests](/docs/iac/guides/testing/), security tests (SAST, DAST, dependency scanning), and load tests in CI so regressions are caught before deploy.
 * **Microservices and containers.** Splitting applications into independently deployable services, packaged in containers and orchestrated by Kubernetes, frees teams from waiting on each other. The tradeoff is needing strong automation to manage the resulting complexity.
-* **Policy as code.** Encode security, compliance, and cost rules as code that runs against every change. Pulumi [CrossGuard](/docs/insights/policy/) policies can be written in the same language as your infrastructure and enforced in CI.
+* **Policy as code.** Encode security, compliance, and cost rules as code that runs against every change. [Pulumi Policies](/docs/insights/policy/) can be written in the same language as your infrastructure and enforced in CI.
 * **Observability.** Metrics, structured logs, distributed traces, and SLOs make production behavior legible. When something breaks, you can see what changed and roll it back instead of guessing.
 * **Continuous feedback.** User analytics, error budgets, and incident reviews flow back into planning so the next iteration is shaped by what actually happened in production.
 
@@ -147,7 +147,7 @@ There is no single "DevOps tool." A real DevOps toolchain stitches together a to
 | Configuration management | Ansible, Chef, Puppet, SaltStack |
 | Containers and orchestration | Docker, Podman, Kubernetes, Amazon ECS |
 | Secrets and config | [Pulumi ESC](/product/esc/), HashiCorp Vault, AWS Secrets Manager, Azure Key Vault |
-| Policy as code | [Pulumi CrossGuard](/docs/insights/policy/), Open Policy Agent (OPA), HashiCorp Sentinel |
+| Policy as code | [Pulumi Policies](/docs/insights/policy/), Open Policy Agent (OPA), HashiCorp Sentinel |
 | Observability | Prometheus, Grafana, Datadog, New Relic, Honeycomb, OpenTelemetry |
 | Incident management | PagerDuty, Opsgenie, FireHydrant, Rootly |
 | Collaboration / ChatOps | Slack, Microsoft Teams, GitHub Discussions |


### PR DESCRIPTION
### Proposed changes

Updates documentation references from "Pulumi CrossGuard" to "Pulumi Policies" across two content files:

- **what-is-cloud-infrastructure-autoscaling.md**: Updates 2 references to CrossGuard in the Pulumi section and cost management discussion
- **what-is-devops.md**: Updates 2 references to CrossGuard in the policy as code section and DevOps toolchain table

Also updates the author attribution for the autoscaling article from "zack-chase" to "cam-soper".

These changes reflect the product naming update from CrossGuard to Pulumi Policies while maintaining all existing links and context.

https://claude.ai/code/session_018i6G5f7SLFcWAmHnaPj1Sq