### PR TITLE
Fix broken canonical_url on IaC Best Practices series posts

### DIFF
--- a/content/blog/iac-best-practices-applying-stack-references/index.md
+++ b/content/blog/iac-best-practices-applying-stack-references/index.md
@@ -1,6 +1,5 @@
 ---
 title: "IaC Best Practices: Applying Stack References"
-canonical_url: https://www.pulumi.com/blog/understanding-code-organization-stacks/
 date: 2023-03-31
 updated: 2025-03-04
 meta_desc: Learn how to apply Pulumi stack references to share data across projects. Improve modularity and maintainability with best practices for stack dependencies.

--- a/content/blog/iac-best-practices-enabling-developer-stacks-git-branches/index.md
+++ b/content/blog/iac-best-practices-enabling-developer-stacks-git-branches/index.md
@@ -1,6 +1,5 @@
 ---
 title: "IaC Best Practices: Enabling Developer Stacks & Git Branches"
-canonical_url: https://www.pulumi.com/blog/understanding-code-organization-stacks/
 date: 2023-03-10
 updated: 2025-03-04
 meta_desc: See how to enable team collaboration with Pulumi stacks and Git workflows. Learn best practices for managing feature branches and development environments.

--- a/content/blog/iac-best-practices-implementing-rbac-and-security/index.md
+++ b/content/blog/iac-best-practices-implementing-rbac-and-security/index.md
@@ -1,6 +1,5 @@
 ---
 title: "IaC Best Practices: Implementing RBAC and Security"
-canonical_url: https://www.pulumi.com/blog/understanding-code-organization-stacks/
 date: 2023-05-23
 updated: 2025-03-04
 meta_desc: Discover best practices for securing Pulumi stacks with role-based access control (RBAC). Learn how to manage permissions and enforce least privilege.

--- a/content/blog/iac-best-practices-structuring-pulumi-projects/index.md
+++ b/content/blog/iac-best-practices-structuring-pulumi-projects/index.md
@@ -1,6 +1,5 @@
 ---
 title: "IaC Best Practices: Structuring Pulumi Projects"
-canonical_url: https://www.pulumi.com/blog/understanding-code-organization-stacks/
 date: 2023-03-17
 updated: 2025-03-04
 meta_desc: See how you can structures Pulumi projects as your infrastructure grows. Learn best practices for managing complexity and scaling teams.

--- a/content/blog/iac-best-practices-summarizing-key-learnings/index.md
+++ b/content/blog/iac-best-practices-summarizing-key-learnings/index.md
@@ -1,6 +1,5 @@
 ---
 title: "IaC Best Practices: Summarizing Key Learnings"
-canonical_url: https://www.pulumi.com/blog/understanding-code-organization-stacks/
 date: 2024-04-08
 updated: 2025-03-04
 draft: false

--- a/content/blog/iac-best-practices-understanding-code-organization-stacks/index.md
+++ b/content/blog/iac-best-practices-understanding-code-organization-stacks/index.md
@@ -17,6 +17,7 @@ tags:
 series: iac-best-practices
 aliases:
     - /blog/iac-recommended-practices-code-organization-and-stacks/
+    - /blog/understanding-code-organization-stacks/
 ---
 
 This is the first in a series of blog posts that explores how a fictional company---Zephyr Archaeotech Emporium---uses Pulumi to manage their online retail store. This post explores a couple of common questions that users ask when working with Pulumi; specifically, where should I store my Pulumi code? And how do I support multiple environments with Pulumi? This post will provide some guidance and [Infrastructure as Code](/what-is/what-is-infrastructure-as-code/) best practices around these topics, using Zephyr and their online store as the use case.<!--more-->

--- a/content/blog/iac-best-practices-using-automation-api/index.md
+++ b/content/blog/iac-best-practices-using-automation-api/index.md
@@ -1,6 +1,5 @@
 ---
 title: "IaC Best Practices: Using Automation API"
-canonical_url: https://www.pulumi.com/blog/understanding-code-organization-stacks/
 date: 2023-07-26
 updated: 2025-03-04
 meta_desc: Review key learnings from the IaC best practices series. Recap insights on structuring Pulumi projects, security, automation, and scaling infrastructure.


### PR DESCRIPTION
## Summary

Six posts in the IaC Best Practices series declared `canonical_url: https://www.pulumi.com/blog/understanding-code-organization-stacks/` in their frontmatter. That URL **has never been a published slug in this repo** — the series intro post lives at `/blog/iac-best-practices-understanding-code-organization-stacks/` (prior slug: `/blog/iac-recommended-practices-code-organization-and-stacks/`, still preserved as an alias).

The bare slug was introduced in #15269 ("Expanding Series functionality") along with the rest of the series infrastructure, but it pointed at a page that didn't exist then and still doesn't. Pointing `canonical_url` at a 404 tells search engines the real version of these six pages lives at a URL that doesn't resolve — actively harmful for SEO and very likely a contributor to the high-traffic 404 we're seeing on `/blog/understanding-code-organization-stacks/`.

## The fix

- **Remove** the broken `canonical_url:` line from the six sibling posts in the series. With it gone, Hugo emits each post's own URL as canonical, which is the correct behavior — each post is its own canonical page.
- **Add** `/blog/understanding-code-organization-stacks/` to the `aliases:` list on the series intro post (`iac-best-practices-understanding-code-organization-stacks/index.md`) so external links and search traffic to the bare slug resolve to the real intro post instead of 404ing.

Posts touched (canonical_url removed):
- `iac-best-practices-applying-stack-references`
- `iac-best-practices-enabling-developer-stacks-git-branches`
- `iac-best-practices-implementing-rbac-and-security`
- `iac-best-practices-structuring-pulumi-projects`
- `iac-best-practices-summarizing-key-learnings`
- `iac-best-practices-using-automation-api`

Post touched (alias added):
- `iac-best-practices-understanding-code-organization-stacks`

## Why not just point `canonical_url` at the real intro post?

Setting all six siblings to canonical to the intro post would tell Google "these six other posts are duplicates of the intro" — which they aren't. Each one is a distinct article. The right behavior is no `canonical_url` override (Hugo's default = self-canonical).

## Test plan

- [ ] `make build` succeeds locally.
- [ ] After deploy, hitting `https://www.pulumi.com/blog/understanding-code-organization-stacks/` returns a 301 to the real intro post (instead of 404).
- [ ] View source on any of the six edited series posts and confirm `<link rel="canonical">` now points at that post's own URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)