### PR TITLE
Expand prose file scope for Vale and URL validation

### DIFF
--- a/.claude/commands/docs-review/scripts/extract-urls-and-fetch.py
+++ b/.claude/commands/docs-review/scripts/extract-urls-and-fetch.py
@@ -41,7 +41,7 @@ Output schema (flat list, sorted by URL):
       ...
     ]
 
-Empty input (no diff, no PR-changed content/(docs|blog) files, no external
+Empty input (no diff, no PR-changed in-scope prose files, no external
 URLs) produces an empty list (`[]`), never errors. The script does not call
 any APIs except `gh pr diff` and HTTP fetches via urllib.
 
@@ -135,7 +135,7 @@ def fetch_pr_patch(pr: str) -> str:
 
 
 def added_lines_in_content(patch: str) -> list[str]:
-    """Return `+`-prefixed body lines from content/(docs|blog)/**/*.md only.
+    """Return `+`-prefixed body lines from content/(docs|blog|what-is|tutorials|learn)/**/*.md only.
 
     Skips file headers, hunk markers, and removed/context lines. The PR can
     add URLs in any file but we only care about prose files -- code-fence
@@ -148,7 +148,7 @@ def added_lines_in_content(patch: str) -> list[str]:
         m = DIFF_FILE_RE.match(raw)
         if m:
             current_file = m.group(1)
-            in_content = bool(re.match(r"^content/(docs|blog)/.*\.md$", current_file))
+            in_content = bool(re.match(r"^content/(docs|blog|what-is|tutorials|learn)/.*\.md$", current_file))
             continue
         if not in_content or current_file is None:
             continue

--- a/.claude/commands/docs-review/scripts/validate-pinned.py
+++ b/.claude/commands/docs-review/scripts/validate-pinned.py
@@ -250,7 +250,7 @@ class Context:
     # Schema v5: workflow pre-step `extract-urls-and-fetch.py` writes the
     # fetched URLs here. None means the file wasn't present (e.g., local
     # invocation with no PR diff context); empty list means the workflow
-    # ran but the diff had no external URLs in content/(docs|blog)/**/*.md.
+    # ran but the diff had no external URLs in content/(docs|blog|what-is|tutorials|learn)/**/*.md.
     fetched_urls: list[dict] | None = None
     # Schema v5: workflow pre-step `editorial-balance-detect.py` writes
     # Tier 1 stats here (trigger, sections, mean/median/std, outliers).

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -397,11 +397,11 @@ jobs:
           PR: ${{ steps.pr-context.outputs.pr_number }}
         run: |
           CHANGED=$(gh pr diff "$PR" --name-only \
-            | grep -E '^content/(docs|blog)/.*\.md$' || true)
+            | grep -E '^content/(docs|blog|what-is|tutorials|learn)/.*\.md$' || true)
           if [ -z "$CHANGED" ]; then
             echo '{}' > .vale-raw.json
             echo '[]' > .vale-findings.json
-            echo "vale: no docs/blog files changed; skipping"
+            echo "vale: no in-scope prose files changed; skipping"
             exit 0
           fi
           # `||` fallbacks guarantee both files exist even when vale is
@@ -444,10 +444,10 @@ jobs:
           PR: ${{ steps.pr-context.outputs.pr_number }}
         run: |
           CHANGED=$(gh pr diff "$PR" --name-only \
-            | grep -E '^content/(docs|blog)/.*\.md$' || true)
+            | grep -E '^content/(docs|blog|what-is|tutorials|learn)/.*\.md$' || true)
           if [ -z "$CHANGED" ]; then
             echo '[]' > .fetched-urls.json
-            echo "extract-urls: no docs/blog files changed; skipping"
+            echo "extract-urls: no in-scope prose files changed; skipping"
             exit 0
           fi
           python3 .claude/commands/docs-review/scripts/extract-urls-and-fetch.py \

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -222,7 +222,7 @@ jobs:
           VALE_CONCERNS=""
           if [[ "$PROSE_CHECK_NEEDED" == "true" ]]; then
             VALE_FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only \
-              | grep -E '^content/(docs|blog)/.*\.md$' || true)
+              | grep -E '^content/(docs|blog|what-is|tutorials|learn)/.*\.md$' || true)
             if [[ -n "$VALE_FILES" ]]; then
               vale --no-exit --output=JSON $VALE_FILES > .vale-raw.json 2>/dev/null \
                 || echo '{}' > .vale-raw.json

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -230,7 +230,7 @@ jobs:
           printf '%s' "$BODY" > .claude-mention-body.txt
 
       # Run Vale on PR-changed prose files (content/docs, content/blog,
-      # content/what-is, content/tutorials, content/learn) so the
+      # content/what-is, content/tutorials) so the
       # refreshed review reflects style nits in the current commit.
       # Skipped on issue mentions and when no in-scope prose files were
       # touched. The `||` fallbacks ensure both files exist even when
@@ -246,7 +246,7 @@ jobs:
           PR: ${{ steps.pr-context.outputs.pr_number }}
         run: |
           CHANGED=$(gh pr diff "$PR" --name-only \
-            | grep -E '^content/(docs|blog|what-is|tutorials|learn)/.*\.md$' || true)
+            | grep -E '^content/(docs|blog|what-is|tutorials)/.*\.md$' || true)
           if [ -z "$CHANGED" ]; then
             echo '{}' > .vale-raw.json
             echo '[]' > .vale-findings.json

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -246,7 +246,7 @@ jobs:
           PR: ${{ steps.pr-context.outputs.pr_number }}
         run: |
           CHANGED=$(gh pr diff "$PR" --name-only \
-            | grep -E '^content/(docs|blog|what-is|tutorials)/.*\.md$' || true)
+            | grep -E '^content/(docs|blog|what-is|tutorials|learn)/.*\.md$' || true)
           if [ -z "$CHANGED" ]; then
             echo '{}' > .vale-raw.json
             echo '[]' > .vale-findings.json

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -229,9 +229,10 @@ jobs:
           esac
           printf '%s' "$BODY" > .claude-mention-body.txt
 
-      # Run Vale on PR-changed files in content/docs and content/blog so
-      # the refreshed review reflects style nits in the current commit.
-      # Skipped on issue mentions and when no docs/blog files were
+      # Run Vale on PR-changed prose files (content/docs, content/blog,
+      # content/what-is, content/tutorials, content/learn) so the
+      # refreshed review reflects style nits in the current commit.
+      # Skipped on issue mentions and when no in-scope prose files were
       # touched. The `||` fallbacks ensure both files exist even when
       # vale is missing or the filter crashes (mirrors claude-triage.yml).
       - name: Run Vale on PR-changed prose
@@ -245,11 +246,11 @@ jobs:
           PR: ${{ steps.pr-context.outputs.pr_number }}
         run: |
           CHANGED=$(gh pr diff "$PR" --name-only \
-            | grep -E '^content/(docs|blog)/.*\.md$' || true)
+            | grep -E '^content/(docs|blog|what-is|tutorials|learn)/.*\.md$' || true)
           if [ -z "$CHANGED" ]; then
             echo '{}' > .vale-raw.json
             echo '[]' > .vale-findings.json
-            echo "vale: no docs/blog files changed; skipping"
+            echo "vale: no in-scope prose files changed; skipping"
             exit 0
           fi
           vale --no-exit --output=JSON $CHANGED > .vale-raw.json 2>/dev/null \


### PR DESCRIPTION
### Proposed changes

Extends the Vale linting and URL validation workflows to cover additional prose content directories beyond `content/docs` and `content/blog`. The changes add support for:
- `content/what-is`
- `content/tutorials`
- `content/learn`

This ensures consistent style checking and link validation across all prose content in the repository.

**Files modified:**
- `.github/workflows/claude-update.yml` - Updated Vale prose file filtering and skip messages
- `.github/workflows/claude-code-review.yml` - Updated Vale and URL extraction filtering
- `.github/workflows/claude-triage.yml` - Updated Vale file filtering
- `.claude/commands/docs-review/scripts/extract-urls-and-fetch.py` - Updated documentation and regex patterns
- `.claude/commands/docs-review/scripts/validate-pinned.py` - Updated documentation

All changes are consistent regex pattern updates (`^content/(docs|blog)/` → `^content/(docs|blog|what-is|tutorials|learn)/`) and corresponding documentation updates to reflect "in-scope prose files" instead of just "docs/blog files".

### Test Plan

No testing needed. The changes are straightforward regex pattern expansions in workflow filters and documentation updates. Existing CI workflows will validate the syntax, and the expanded patterns will be exercised on the next PR that modifies files in the newly-included directories.

https://claude.ai/code/session_01KAPbBaLgeuNWmLwU4ARASQ