### PR TITLE
Use `typeToken` placeholder for registry docs endpoint

### DIFF
--- a/content/blog/better-cli-interactions-for-agents-and-humans/index.md
+++ b/content/blog/better-cli-interactions-for-agents-and-humans/index.md
@@ -228,14 +228,14 @@ The Random provider is available as a package in all Pulumi languages:
 
 Even compared to JSON (which is itself a significant improvement over HTML), Markdown is a much more token-efficient format for agents to work with:
 
-| Package      | Endpoint                  | JSON     | Markdown | Tokens saved |
-| ------------ | ------------------------- | -------- | -------- | ------------ |
-| random       | `/readme`                 | 10.68 KB | 6.04 KB  | 43%          |
-| aws          | `/readme`                 | 4.22 KB  | 2.54 KB  | 40%          |
-| aws          | `/nav?depth=full`         | 204 KB   | 170 KB   | 17%          |
-| aws          | `/docs/{resource token}`  | 15.24 KB | 11.28 KB | 26%          |
-| azure-native | `/docs/{resource token}`  | 48.13 KB | 30.37 KB | 37%          |
-| aws          | `/docs/{function token}`  | 2.40 KB  | 1.46 KB  | 39%          |
+| Package      | Endpoint                      | JSON     | Markdown | Tokens saved |
+| ------------ | ----------------------------- | -------- | -------- | ------------ |
+| random       | `/readme`                     | 10.68 KB | 6.04 KB  | 43%          |
+| aws          | `/readme`                     | 4.22 KB  | 2.54 KB  | 40%          |
+| aws          | `/nav?depth=full`             | 204 KB   | 170 KB   | 17%          |
+| aws          | `/docs/{resource type token}` | 15.24 KB | 11.28 KB | 26%          |
+| azure-native | `/docs/{resource type token}` | 48.13 KB | 30.37 KB | 37%          |
+| aws          | `/docs/{function type token}` | 2.40 KB  | 1.46 KB  | 39%          |
 
 Learn more about our Registry endpoints in the [REST API docs](/docs/reference/cloud-rest-api/registry-preview/). (Or just ask your agent!)
 

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -35,10 +35,10 @@ If you are an AI agent or programmatic consumer, start with these endpoints. Eac
       /api/registry/packages/{source}/{publisher}/{name}/versions/{version}/readme
       /api/registry/packages/{source}/{publisher}/{name}/versions/{version}/installation
       /api/registry/packages/{source}/{publisher}/{name}/versions/{version}/nav
-      /api/registry/packages/{source}/{publisher}/{name}/versions/{version}/docs/{token}
+      /api/registry/packages/{source}/{publisher}/{name}/versions/{version}/docs/{typeToken}
       /api/registry/packages/{source}/{publisher}/{name}/versions/{version}/examples
 
-  Common parameters: `?lang=typescript|python|go|csharp|java|yaml`, `?os=linux|macos|windows`, `?depth=summary|full` and `?q=<term>` on `nav`, `?limit=` (max 100) on `examples`. For prose: `--output=markdown` (CLI) or `Accept: text/markdown` (HTTP). Tokens for `docs/{token}` are percent-encoded; discover them via `nav?depth=full`.
+  Common parameters: `?lang=typescript|python|go|csharp|java|yaml`, `?os=linux|macos|windows`, `?depth=summary|full` and `?q=<term>` on `nav`, `?limit=` (max 100) on `examples`. For prose: `--output=markdown` (CLI) or `Accept: text/markdown` (HTTP). Type tokens for `docs/{typeToken}` are URL-encoded — use `encodeURIComponent` (or equivalent), e.g. `random:index/RandomPassword` becomes `random%3Aindex%2FRandomPassword`. Discover them via `nav?depth=full`.
 
 - **Full docs index (JSON)** — hierarchical sitemap of every documentation page with titles and nesting.
 


### PR DESCRIPTION
## Summary

The registry docs endpoint path parameter has been renamed from `token` to `typeToken` in the Pulumi Cloud public API. Update the agent-facing `llms.txt` URL template and the matching `Endpoint` column cells in the agent-CLI blog post table to match.

The `data/openapi-spec.json` snapshot will refresh automatically the next time `scripts/fetch-openapi-spec.sh` runs against the deployed API.

Service-side rename: https://github.com/pulumi/pulumi-service/pull/43530.

## Test plan

- Visual review of the updated `llms.txt` URL template and the blog table cell labels