### PR TITLE
social: trigger schedule-social after Build and deploy succeeds

### DIFF
--- a/.github/workflows/schedule-social.yml
+++ b/.github/workflows/schedule-social.yml
@@ -1,8 +1,13 @@
 name: Schedule social media posts
 on:
-  push:
-    branches:
-      - master
+  # Fire after Build and deploy finishes on master so posts only go out
+  # after the blog page is actually live. Posting on `push: master` raced
+  # the deploy and produced 404 link cards (especially sticky on Bluesky,
+  # which caches the first fetch of the og:image).
+  workflow_run:
+    workflows: ["Build and deploy"]
+    types: [completed]
+    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -16,7 +21,9 @@ concurrency:
 
 jobs:
   schedule-social:
-    if: github.repository == 'pulumi/docs'
+    if: |
+      github.repository == 'pulumi/docs' &&
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     name: Schedule social media posts
     runs-on: ubuntu-latest
     environment: production
@@ -32,6 +39,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # On workflow_run, pin to the SHA the deploy actually built. Default
+          # ref under workflow_run is master HEAD, which may have moved on.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Summary

Switch `schedule-social.yml` from `push: master` to `workflow_run` on **Build and deploy**, gated on `conclusion == 'success'`.

## Why

Posts were going out on push to master, racing the deploy. Result:

- Link cards 404'd briefly on every platform during the deploy window.
- **Bluesky cached the missing `og:image`** on first fetch, so the card stayed broken on Bluesky even after the page went live — sticky, user-visible regression.

The fix is to delay posting until after the deploy that produces the page has actually finished.

## What changed

- **Trigger**: `push: master` → `workflow_run: ["Build and deploy"]`. `workflow_dispatch` preserved for manual reruns.
- **Job gate**: only run on `workflow_run.conclusion == 'success'` (the `workflow_dispatch` path still runs unconditionally).
- **Checkout ref**: pinned to `github.event.workflow_run.head_sha`. The default ref under `workflow_run` is master HEAD, which can have moved on by the time the deploy finishes — pinning to the built SHA keeps the diff range honest.

## Why no BASE_REF / diff-range rewiring

`social_core` resolves the diff range from the S3-stored `last_sha` against the current `HEAD`. As long as we check out the deployed SHA, the range it computes naturally lines up. No code changes needed in `pulumi/social`.

## Validation plan

`workflow_run` is one of the GHA features where the trigger config is only honored when the workflow file is on the default branch — can't validate the trigger itself from a PR branch. Plan:

1. **Sandbox the trigger wiring** in `adamgordonbell/social-test` first (two minimal workflows mirroring `Build and deploy` → `Schedule social media posts`). Confirm ordering, `head_sha` propagation, and the `conclusion` gate.
2. **Mark this PR ready** once sandbox confirms.
3. **Watch first real merge to master** to confirm the trigger fires and the run picks up the right SHA. S3 idempotency means even an unexpected double-fire won't double-post.

## Follow-ups (separate PR, in `pulumi/social`)

Vendor-side 404 / `og:image` propagation can still bite the manual `workflow_dispatch` and the `--post` paths, and there's CDN lag even after deploy "succeeds." Plan to add a `verify_url_live(url, *, require_og_image=True)` check inside `_process_posts` / `run_post_file` in `social_core.py` (3× retry with backoff, then skip without advancing `last_sha`).

## Test plan

- [ ] Validate `workflow_run` ordering + `head_sha` resolution in `adamgordonbell/social-test`
- [ ] Mark PR ready after sandbox validation
- [ ] Watch first post-merge run on a real master push
- [ ] Confirm S3 state advanced correctly + correct posts shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)