### PR TITLE
content(what-is): rewrite the ExpiredToken page

### DIFF
--- a/content/what-is/resolve-list-buckets-expired-token.md
+++ b/content/what-is/resolve-list-buckets-expired-token.md
@@ -1,70 +1,105 @@
 ---
 title: An error occurred (ExpiredToken) when calling the ListBuckets operation
 allow_long_title: true
-meta_desc: |
-     Use Pulumi ESC and dynamic credentials to run commands like aws ListBuckets in a more secure and seamless way.
+meta_desc: "The ExpiredToken error from aws s3 ls means your temporary AWS credentials expired. Refresh them with aws sso login or by re-assuming the role."
 meta_image: /images/what-is/resolve-list-buckets-expired-token-meta.png
 type: what-is
 page_title: An error occurred (ExpiredToken) when calling the ListBuckets operation
 authors: ["torian-crane"]
 ---
 
-The error message "An error occurred (ExpiredToken) when calling the ListBuckets operation" in AWS (Amazon Web Services) typically means that the temporary credentials used for the AWS CLI (Command Line Interface) operation have expired. AWS employs temporary credentials for services like IAM roles and AWS Security Token Service (STS), which expire for security reasons. When you attempt an AWS CLI operation with these expired credentials, this error arises.
+**The `ExpiredToken` error from `aws s3 ls` means your temporary AWS credentials have expired and need to be refreshed.** STS session tokens are short-lived (default 1 hour, max 12 hours for `assume-role`, up to 12 hours by default and 90 days when extended for IAM Identity Center sessions). When they expire, every AWS API call returns this error until you obtain fresh credentials by re-authenticating with `aws sso login`, calling `aws sts assume-role` again, or letting your credential helper rotate them.
 
-[Pulumi ESC (Environments, Secrets, and Configurations)](/docs/pulumi-cloud/esc/) offers a solution to the challenges of managing temporary credentials and can make errors like this a thing of the past. By enabling the [management of dynamic credentials from AWS using OIDC](/blog/esc-env-run-aws/), Pulumi ESC simplifies and secures your AWS CLI operations. This approach eliminates the need for manual refreshing of temporary credentials and is a more secure solution than the use of long-term credentials, which can often present a security risk. Pulumi ESC also enables you to focus on your tasks without the interruption of credential-related errors, providing a more efficient flow for your AWS operations and tasks.
+In this article, we'll cover:
 
-## Using Pulumi ESC for dynamic credentials with AWS
+* What the `ExpiredToken` error means
+* What causes it
+* How to fix it in three steps
+* How to prevent it from happening again
+* Common variations and related errors
+* How Pulumi ESC eliminates manual credential refresh
+* Frequently asked questions
 
-[Pulumi ESC](https://www.pulumi.com/product/esc/) is a service that helps to alleviate the burden of managing cloud configuration and secrets by providing a centralized way to handle these critical aspects of cloud development. The `esc run` command of this service in particular helps to resolve concerns around how to:
+## What does this error mean?
 
-- Securely share credentials with teammates in a consistent way.
-- Minimize the risks associated with locally configured, long-lived and highly privileged credentials.
-- Ensure teams can easily and safely run commands like without requiring deep security expertise.
+`ExpiredToken` is an AWS Security Token Service (STS) response code. It is returned by any AWS service (S3, EC2, IAM, and so on) when a request is signed with temporary credentials whose lifetime has passed. The credentials themselves are still well-formed, but AWS has marked them as no longer valid. Until you replace them with fresh ones, every signed request fails the same way.
 
-## What is the ESC run command?
+The error is specific to *temporary* credentials. It does not appear for long-lived IAM user access keys, because those have no expiration. If you see `ExpiredToken`, you are using credentials issued through SSO, `assume-role`, an EKS pod identity, EC2 instance metadata, or some other STS-backed source.
 
-The [Pulumi documentation for the `esc run` command](/docs/esc/cli/commands/esc_run/) states the following:
+## What causes it?
 
-> This command opens the environment with the given name and runs the given command. If the opened environment contains a top-level ’environmentVariables’ object, each key-value pair in the object is made available to the command as an environment variable.
+| Cause | Symptom | Fix |
+|---|---|---|
+| SSO session lapsed | `aws sso login` was hours ago; `~/.aws/sso/cache/*.json` is stale | `aws sso login --profile <name>` |
+| `assume-role` token aged out | Helper script set `AWS_SESSION_TOKEN` more than an hour ago | Re-run `aws sts assume-role` and re-export |
+| EC2 or EKS role-cache lag | Process cached creds beyond their TTL | Restart the process or clear the SDK's credential cache |
+| Identity broker (Okta, Vault) token expired | Browser flow times out | Re-authenticate through the broker |
+| Laptop slept, clock drifted | Token isn't actually expired but appears so to AWS | Sync time (`sntp -sS time.apple.com` or `w32tm /resync`) and retry |
 
-But what does this actually mean? If we use AWS as an example, it means that we can run commands like `aws s3 ls` without the need to configure AWS credentials locally each time. It’s a significant stride towards making your cloud interactions more efficient and less error-prone, and here’s a deeper dive into why:
+## How to fix it
 
-- **Seamless Command Execution** - The `esc run` command lets you execute AWS commands effortlessly, freeing you from the intricacies of managing AWS credentials on your local machine. Simply put, it significantly reduces the overhead of credential setup and maintenance.
+Follow these steps in order. Each one is copy-pasteable.
 
-- **Enhanced Security** - One of the standout features of `esc run` is its commitment to security. By removing the local storage of credentials, it drastically reduces the risk of accidental exposure. Your credentials and secrets are securely managed within the Pulumi environment.
+1. **Identify how you got the credentials.** Check the SDK chain by running `aws configure list`. The `Source` column tells you whether they came from environment variables, an SSO profile, an EC2 instance role, or a config file.
 
-- **Streamlined Collaboration** - Because credentials will be centralized, `esc run` facilitates smoother team collaboration by providing a consistent environment for all team members to run commands with. Everyone can access the same secure environment which reduces the complexities of coordinating credentials and configurations across teams.
+   ```bash
+   aws configure list
+   ```
 
-## Getting started with ESC run
+1. **Re-authenticate at the source.** If the profile uses SSO, refresh the SSO session:
 
-### Step 1: Install and login to Pulumi ESC
+   ```bash
+   aws sso login --profile my-profile
+   ```
 
-To begin, you’ll need to [install Pulumi ESC](/docs/install/esc/). Once the installation is complete, run the `esc login` command and follow the steps to login to the CLI.
+   If the profile uses `assume-role` directly, re-assume:
 
-```bash
-$ esc login
-Manage your Pulumi ESC environments by logging in.
-Run `esc --help` for alternative login options.
-Enter your access token from https://app.pulumi.com/account/tokens
-    or hit <ENTER> to log in using your browser                   :
-Logged in to pulumi.com as …
-```
+   ```bash
+   aws sts assume-role \
+     --role-arn arn:aws:iam::123456789012:role/MyRole \
+     --role-session-name my-session
+   ```
 
-### Step 2: Create the OIDC configuration
+   Export the returned `AccessKeyId`, `SecretAccessKey`, and `SessionToken` as the three `AWS_*` environment variables.
 
-Pulumi ESC offers you the ability to manually set your credentials as secrets in your Pulumi ESC environment files. When it comes to something like OIDC configuration, a more secure and efficient alternative is to leverage yet another great feature of Pulumi ESC: dynamic credentials.
+1. **Verify the refresh worked.**
 
-This service can dynamically generate credentials on your behalf each time you need to interact with your AWS environments. To do so, follow the steps in the [guide for configuring OIDC between Pulumi and AWS](/docs/esc/environments/configuring-oidc/aws/). Make sure that the IAM role you create has sufficient permissions to perform S3 actions.
+   ```bash
+   aws sts get-caller-identity
+   aws s3 ls
+   ```
 
-### Step 3: Create a new Pulumi ESC environment
+   `get-caller-identity` is a cheap call that does not require permissions beyond authentication, which makes it the right smoke test before running real workloads.
 
-Once OIDC has been configured between Pulumi and AWS, the next step is to create a new environment in the [Pulumi Cloud](https://app.pulumi.com/signin). Make sure that you have the correct organization selected in the left-hand navigation menu. From there, click the **Environments** link, then click the **Create environment** button. In the following pop-up, provide a name for your environment before clicking the **Create environment** button.
+## How to prevent it
 
-{{< video title="Open environment in Pulumi ESC console" src="https://www.pulumi.com/uploads/esc-create-new-env.mp4" autoplay="true" loop="true" >}}
+* **Use credential helpers, not raw exports.** `aws sso login`, `aws-vault`, and `granted` all refresh tokens transparently. Manually exporting `AWS_*` variables in a shell is the fastest way to end up holding stale credentials.
+* **Increase the session duration where appropriate.** For `assume-role`, set `--duration-seconds` up to the role's `MaxSessionDuration` (max 43200 seconds, or 12 hours). For SSO, raise the permission set's session duration in IAM Identity Center.
+* **Stop using long-lived access keys to work around the error.** It "fixes" the symptom by trading expiration for a much larger blast radius if the keys leak.
+* **Move CI/CD off static credentials.** GitHub Actions, GitLab, and other modern runners support OIDC into AWS, which mints short-lived credentials per job and refreshes them automatically.
 
-### Step 4: Add the AWS provider integration
+## Common variations
 
-Once you’ve created your new environment, you will be presented with a split-pane document view. You’ll want to clear out the default placeholder content in the editor on the left-hand side and replace it with the following code, making sure to replace <your-oidc-iam-role-arn> with the value of your IAM role ARN from the configure OIDC step:
+The same root cause produces several closely related messages:
+
+* `An error occurred (ExpiredToken) when calling the ListBuckets operation: The provided token has expired.`
+* `An error occurred (ExpiredTokenException) when calling the AssumeRole operation` — your STS *caller* credentials expired, not the target role.
+* `Token has expired and refresh failed` — boto3 or another SDK could not auto-refresh because the source credentials are also expired.
+
+The fix is the same in every case: refresh at the original source of the temporary credentials.
+
+## Related errors
+
+* [InvalidClientTokenId](/what-is/resolve-list-buckets-invalid-client-token-id/) — usually a mismatched session token, not an expired one.
+* [InvalidAccessKeyId](/what-is/resolve-list-buckets-invalid-access-key-id/) — the access key does not exist, often a stale rotation.
+* [SignatureDoesNotMatch](/what-is/resolve-list-buckets-signature-does-not-match/) — typically a wrong secret key or clock skew.
+* [Unable to locate credentials](/what-is/resolve-unable-to-locate-credentials/) — the SDK found no credentials at all.
+
+## How Pulumi ESC eliminates manual credential refresh
+
+[Pulumi ESC](/product/esc/) (Environments, Secrets, and Configurations) brokers short-lived AWS credentials via OIDC. Instead of running `aws sso login` and hoping the cached token is still valid, you wrap your command in `esc run`. ESC mints a fresh STS session every time, so `ExpiredToken` cannot occur.
+
+Define the environment once:
 
 ```yaml
 values:
@@ -73,7 +108,7 @@ values:
       fn::open::aws-login:
         oidc:
           duration: 1h
-          roleArn: <your-oidc-iam-role-arn>
+          roleArn: arn:aws:iam::123456789012:role/PulumiESCRole
           sessionName: pulumi-environments-session
   environmentVariables:
     AWS_ACCESS_KEY_ID: ${aws.login.accessKeyId}
@@ -81,20 +116,43 @@ values:
     AWS_SESSION_TOKEN: ${aws.login.sessionToken}
 ```
 
-### Step 5: Run the AWS CLI command
-
-With your environment set up, you can validate your configuration and verify that the error has been resolved by running the `aws s3 ls` command using `esc run` as shown below, making sure to replace `<your-pulumi-org-name>`, `<your-project-name>`, and `<your-environment-name>` with the names of your own Pulumi organization and environment respectively:
+Then run any AWS command with always-fresh credentials:
 
 ```bash
-esc run <your-pulumi-org-name>/<your-project-name>/<your-environment-name> -i aws s3 ls --query "Buckets[].Name"
+esc run my-org/aws/dev -- aws s3 ls
 ```
 
-## Conclusion
+For Pulumi programs themselves, the equivalent provider configuration uses the AWS provider's [`assumeRole` block](/registry/packages/aws/api-docs/provider/), which the provider refreshes automatically during long-running deployments.
 
-Pulumi ESC makes it easier than ever to tame infrastructure complexity, especially when running commands like `aws s3 ls`. Because Pulumi ESC supports dynamic credentials using OIDC across AWS, Azure, and Google Cloud, you no longer have to worry about credential errors like "ExpiredToken" as the service will dynamically generate and refresh them for you. Check out the following links to learn more about Pulumi ESC today.
+## Frequently asked questions
 
-- Follow the [Getting Started](/docs/pulumi-cloud/esc/get-started) guide.
-- Read the [Documentation](/docs/pulumi-cloud/esc) for all the commands and features available.
-- Visit the [Open Source](https://github.com/pulumi/esc) repo for Pulumi ESC.
+### How long do AWS temporary credentials last?
 
-Feel free to [join our community on Slack](https://slack.pulumi.com/) and let us know what you think!
+By default, `assume-role` credentials last 1 hour with a maximum of 12 hours (`MaxSessionDuration` on the role). IAM Identity Center (SSO) sessions can run up to 12 hours by default and can be extended further by an administrator. EC2 instance role credentials refresh automatically.
+
+### Does this error affect IAM users with long-lived access keys?
+
+No. IAM user access keys do not expire on their own. If you see `ExpiredToken` with what you believe is a long-lived key, it almost always means a session token (`AWS_SESSION_TOKEN`) was also exported and is now stale. Unset `AWS_SESSION_TOKEN` and retry.
+
+### Can I extend a single STS session beyond 12 hours?
+
+Not for `assume-role`. The hard maximum is 12 hours, even with `MaxSessionDuration` raised. For longer-running workloads, refresh the credentials on a timer rather than trying to hold one session open.
+
+### Why does my SDK still see the old token after I refreshed?
+
+Most SDKs cache credentials in memory. If a long-running process started with expired credentials, it will keep using them until restarted or until the credential provider chain is reset. Restart the process, or have it call the credential refresh API explicitly.
+
+### Does this only happen with S3?
+
+No. `ExpiredToken` is returned by any AWS service that authenticates a request — EC2, IAM, Lambda, DynamoDB, and so on. `aws s3 ls` happens to be the most common command people run to test credentials, which is why the error is most visible there.
+
+### Will `aws configure` fix this?
+
+No. `aws configure` writes static profile values to `~/.aws/credentials`. It does not refresh STS sessions. Use `aws sso login` (for SSO), re-export credentials from `assume-role`, or use a helper such as `aws-vault` or Pulumi ESC.
+
+## Learn more
+
+* [Pulumi ESC documentation](/docs/pulumi-cloud/esc/)
+* [Configuring OIDC between Pulumi ESC and AWS](/docs/esc/environments/configuring-oidc/aws/)
+* [AWS provider reference](/registry/packages/aws/api-docs/provider/)
+* [AWS STS `AssumeRole` API reference](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/resolve-list-buckets-expired-token.md` for SEO and AEO. The page now leads with a direct answer that names the error and the most-likely cause and fix, then walks through diagnosis, remediation, and prevention with copy-pasteable shell commands.

## What changed

- **Opening direct answer** — bold one-paragraph definition that explains `ExpiredToken` is an STS session expiration with the canonical fix (`aws sso login` / `assume-role`).
- **"In this article, we'll cover"** lead-in list for navigability.
- **Causes table** — five common sources of the error mapped to symptom and fix.
- **Numbered fix steps** — identify credential source, re-authenticate, verify with `aws sts get-caller-identity`.
- **Prevention section** — helpers over raw exports, session duration tuning, OIDC for CI/CD.
- **Common variations** — closely related error strings collected so the page can rank for the long-tail forms.
- **Related errors cross-links** — sibling resolve-* pages for the credential-error family.
- **Pulumi ESC section** — concrete YAML environment plus `esc run` invocation; brief reference to `aws:assumeRole` for in-program use.
- **FAQ** — six doubt-removers: token lifetimes, IAM-user behavior, 12-hour cap, SDK caching, non-S3 coverage, why `aws configure` is the wrong fix.
- **Strengthened `meta_desc`** to lead with the direct answer, well under 160 chars.

## Test plan

- [ ] `make serve`; visit `/what-is/resolve-list-buckets-expired-token/` and confirm the page renders with table, code blocks, and cross-links intact.
- [ ] Spot-check links to sibling resolve-* pages and to `/docs/pulumi-cloud/esc/` and `/docs/esc/environments/configuring-oidc/aws/`.
- [ ] CI lint + pinned review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)