### PR TITLE
content(what-is): expand the Kubernetes Secrets explainer

### DIFF
--- a/content/what-is/what-are-kubernetes-secrets.md
+++ b/content/what-is/what-are-kubernetes-secrets.md
@@ -1,272 +1,210 @@
 ---
 title: What are Kubernetes Secrets?
-meta_desc: |
-     Learn about Kubernetes Secrets and how to manage sensitive information securely in your Kubernetes clusters.
-
+meta_desc: "Kubernetes Secrets are objects for storing sensitive data like passwords, tokens, and keys. Learn types, base64 vs encryption, and integration patterns."
 meta_image: /images/what-is/what-are-kubernetes-secrets-meta.png
 type: what-is
 page_title: "What are Kubernetes Secrets?"
-
 authors: ["diana-esteves"]
 ---
 
-Kubernetes, or K8s, is an open-source container orchestration platform designed to automate the deployment, scaling, and management of containerized applications.
+**Kubernetes Secrets are built-in API objects that store small amounts of sensitive data (passwords, API tokens, TLS keys, container registry credentials) and inject them into pods as environment variables, mounted files, or `imagePullSecrets` references.** A Secret is a namespaced resource stored in the cluster's `etcd` datastore and consumed by workloads through the Kubernetes API.
 
-## What are Kubernetes Secrets?
+The most common point of confusion: by default, Secret values in `etcd` are **base64-encoded, not encrypted**. Base64 is reversible by anyone who can read the data, so a Secret is only as protected as the cluster's `etcd` access controls and any [encryption-at-rest configuration](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) you enable. Production clusters layer additional protection on top: an external KMS provider for encryption at rest, RBAC to limit which workloads can read which Secrets, and often an external store (HashiCorp Vault, AWS Secrets Manager, [Pulumi ESC](/product/esc/)) brokered into the cluster through the [External Secrets Operator](https://external-secrets.io/) or the [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/).
 
-Kubernetes Secrets, or [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) for short, are a built-in Kubernetes solution to manage the lifecycle of secrets, which are sensitive data such as passwords, API keys, and tokens. These secrets are consumed by containerized applications directly, to prevent the exposure of sensitive data in code, Docker images, or configuration files.
+In this article, we'll cover the key questions about Kubernetes Secrets:
 
-## Why use Kubernetes Secrets?
+* What is a Kubernetes Secret used for?
+* How are Kubernetes Secrets stored?
+* What types of Kubernetes Secrets are there?
+* How do pods consume Secrets?
+* What are the limitations of Kubernetes Secrets?
+* How do Secrets compare to ConfigMaps?
+* How do external secret stores integrate with Kubernetes?
+* How does Pulumi manage Kubernetes Secrets?
+* Frequently asked questions about Kubernetes Secrets
 
-Manual secrets management is prone to introducing errors and poses high-lift operational challenges. At the same time,  the absence of a dedicated secret management solution means carrying a higher risk of accidental data leaks or unauthorized access to private information. One should never use ConfigMaps to hold secrets. Kubernetes Secrets come into play by providing an integrated mechanism for the secure storage and distribution of sensitive data to pods.
+## What is a Kubernetes Secret used for?
 
-Kubernetes Secrets are fundamental to the cloud-native stack. It provides a secure and standardized means to manage sensitive information like credentials, tokens, or API keys within our cloud apps so these don't have to be passed around in plain text.
+A Secret holds the credentials and keys a workload needs at runtime without baking them into a container image, a Git repository, or a pod spec in plain text. Typical uses:
 
-### Key features
+* Database connection strings and passwords.
+* API tokens for third-party services.
+* TLS certificates and private keys for ingress controllers.
+* Docker registry credentials so a pod can pull a private image.
+* Service account tokens that pods present to the Kubernetes API.
 
-Securing sensitive data in Kubernetes Secrets is essential for various reasons:
+Anything more sensitive than a feature flag or a log level belongs in a Secret rather than a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/).
 
-- **Managed lifecycle:** Secrets can be created, updated, and removed without restarting containers, ensuring seamless management.
-- **Easy integration:** Applications can access secrets as environment variables or mounted files.
-- **Dynamic updates:** Secrets can be updated without redeploying your applications.
-- **Role-based access control (RBAC):** You can control who can access and modify secrets.
-- **Enable auditing** When required for compliance.
+## How are Kubernetes Secrets stored?
 
-## Kubernetes Secrets best practices
+A Secret lives in `etcd`, the cluster's distributed key-value store. The path from a `kubectl create secret` command to the application that reads the value runs through several layers, each of which can be hardened separately.
 
-- **Use Namespacing:** Organize your secrets within namespaces to control access and limit exposure.
-- **[Encrypt Sensitive Data](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/):** Ensure that secrets are encrypted at rest and in transit. Secret resources stored within etcd need to be encrypted at rest as this is not the default.
-- **[Implement Access Control](https://kubernetes.io/docs/reference/access-authn-authz/authorization/):** Leverage Kubernetes RBAC to restrict access to secrets.
-- **Regularly Rotate Secrets:** Periodically update your secrets to enhance security.
+| Layer | Default behavior | Production hardening |
+|---|---|---|
+| API submission | TLS to the API server | Same; ensure API server cert is rotated |
+| Storage in etcd | **Base64-encoded only** | Enable [encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) with an external KMS (AWS KMS, GCP KMS, Azure Key Vault, HashiCorp Vault) |
+| Access from the API | RBAC on the `secrets` resource | Default-deny RBAC; grant `get` on specific Secret names; audit-log all `secrets` reads |
+| Delivery to pods | Mounted from `tmpfs` (in-memory), not written to disk | Same; avoid passing Secrets as command-line args |
+| In the pod | Readable by any process in the container | Use distroless images; drop unnecessary capabilities |
 
-For more details visit the [Kubernetes Secrets security checklist](https://kubernetes.io/docs/concepts/security/security-checklist/#secrets ) and the [Kubernetes Good Practices guidelines](https://kubernetes.io/docs/concepts/security/secrets-good-practices/)
+The single most important hardening step is enabling encryption at rest with a KMS provider. Without it, anyone who can read `etcd` (an admin, a backup, a compromised control-plane node) can read every Secret in the cluster.
 
-## Using Kubernetes Secrets
+## What types of Kubernetes Secrets are there?
 
-One crucial aspect of securing applications is managing sensitive data. We will delve into the use of Kubernetes Secrets by following the lifecycle of database credentials. In particular, you'll learn how to perform the basic CRUD (Create, Read, Update, Delete) operations against a Secret.
+Secrets carry a `type` field that signals to the API server and to controllers how the data should be interpreted. The built-in types:
 
-### Prerequisites
+| Type | Purpose |
+|---|---|
+| `Opaque` | Arbitrary user-defined key/value data. The default and most common type. |
+| `kubernetes.io/service-account-token` | Token issued for a ServiceAccount; created automatically (or via TokenRequest) and mounted into pods. |
+| `kubernetes.io/dockercfg` | Legacy `~/.dockercfg` registry credentials. |
+| `kubernetes.io/dockerconfigjson` | Modern `~/.docker/config.json` registry credentials. Referenced by `imagePullSecrets`. |
+| `kubernetes.io/basic-auth` | Username and password for basic auth. |
+| `kubernetes.io/ssh-auth` | SSH private key. |
+| `kubernetes.io/tls` | TLS certificate and key. Consumed by ingress controllers and webhook configurations. |
+| `bootstrap.kubernetes.io/token` | Bootstrap tokens used to join new nodes to the cluster. |
 
-To use Kubernetes Secrets, a Kubernetes Cluster, and the [kubectl](https://kubernetes.io/docs/reference/kubectl/) CLI are required.
+Custom types are allowed (any string with a domain prefix), but the built-ins cover almost every real use case.
 
-Consider using [minikube](https://minikube.sigs.k8s.io/docs/start/) as a starting option to getting a local Kubernetes Cluster installed. Alternatively, you can use [Pulumi](https://www.pulumi.com/kubernetes/) to deploy a Kubernetes Cluster in [Azure](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/aks/), [GCP](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/gke/), or [AWS](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/eks/).
+## How do pods consume Secrets?
 
-Let's look at a practical example of how to create, read, update, and delete a Kubernetes Secret via the `kubectl` CLI.
+A workload reads a Secret in one of three ways:
 
-### Creating a Kubernetes Secret
+1. **Environment variables.** Inject specific keys with `env.valueFrom.secretKeyRef`, or load all keys at once with `envFrom.secretRef`. Simple, but the values appear in process environment listings and may leak into logs.
+1. **Mounted files.** Project the Secret into a volume; each key becomes a file under the mount path (for example, `/etc/secrets/db-password`). Preferred for TLS certs and anything an application reads from disk. The mount is backed by `tmpfs`, so the data never hits the node's disk.
+1. **`imagePullSecrets`.** A pod-level reference that tells the kubelet which registry credentials to use when pulling images. Only used for `dockerconfigjson` Secrets.
 
-1. Define a new secret resource called `shhhhhh` that contains a user and a password. These are saved in the `dbcreds.yaml` file.
+File mounts are generally safer than env vars: less likely to be logged, easier to rotate without a restart (the kubelet updates the mounted files on a sync interval), and easier to scope through file permissions.
 
-    ```bash
-    $ cat <<EOF > dbcreds.yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-        name: shhhhhh
-    type: Opaque
-    data:
-        username: cm9vdA==
-        password: cm9vdA==
-    EOF
-    ```
+## What are the limitations of Kubernetes Secrets?
 
-    The keys in the `data` section are encoded in base64. Given this is a basic example, we use 'root' for the credentials. This can be confirmed by running `echo "cm9vdA==" | base64 -d` which outputs
-  `root`
+Secrets cover the common case but have well-known gaps that drive teams to external solutions.
 
-2. Apply the new resource definition:
+* **Base64 is not encryption.** Without encryption at rest configured, anyone with `etcd` access reads every Secret.
+* **No built-in versioning.** A Secret has one current value. Rolling back means re-creating it from a backup or external source.
+* **No native rotation.** Kubernetes won't rotate a database password or expire an API token. Rotation has to come from an operator, an external store, or a manual process.
+* **Namespace-scoped only.** No first-class way to share a Secret across namespaces without copying it (or using a third-party operator).
+* **Limited audit detail.** Audit logs show that a Secret was read, but most clusters don't enable that audit level by default.
+* **1 MiB size limit per Secret.** Fine for credentials, too small for large keys or files.
+* **Cluster-bound.** Multi-cluster fleets need an external source of truth and a sync mechanism.
 
-    ```bash
-    $ kubectl apply -f dbcreds.yaml
-    ```
+These gaps don't make Secrets unusable; they explain why most teams pair them with an external store.
 
-3. Verify the contents:
+## How do Secrets compare to ConfigMaps?
 
-    ```bash
-    $ kubectl describe secrets shhhhhh  
-    ```
+Both objects look similar (key/value data, namespaced, mounted as files or env vars), but they're not interchangeable.
 
-### Reading a Kubernetes Secret
+| Aspect | Secret | ConfigMap |
+|---|---|---|
+| Intended for | Sensitive data | Non-sensitive configuration |
+| Default storage | Base64-encoded in etcd | Plain text in etcd |
+| Encryption at rest | Supported via KMS provider | Supported via KMS provider |
+| Size limit | 1 MiB | 1 MiB |
+| Mounted via | `tmpfs` (in-memory) | Regular file (in-memory in practice via the kubelet) |
+| Visibility | Hidden from `kubectl describe` by default | Shown in `kubectl describe` |
 
-1. Run the following `kubectl` command along with the name of the secret.
+Use Secrets for credentials, tokens, and keys. Use ConfigMaps for log levels, feature flags, application URLs, and other non-sensitive settings. Mixing the two (putting secrets in ConfigMaps to "make them easier to read") defeats the small but real protections Secrets provide.
 
-    ```bash
-    $ kubectl get secret shhhhhh
-    # NAME      TYPE     DATA   AGE
-    # shhhhhh   Opaque   2      2m
-    ```
+## How do external secret stores integrate with Kubernetes?
 
-2. To read a specific value within the secret, use `jsonpath` to specify the key.
+For anything beyond a small cluster, the operating pattern is to keep the source of truth outside the cluster and project values in as native Kubernetes Secrets. Two patterns dominate.
 
-    ```bash
-    $ kubectl get secret shhhhhh -o jsonpath="{.data.user}" | base64 -d
-    # root
-    $ kubectl get secret shhhhhh -o jsonpath="{.data.password}" | base64 -d
-    # root
-    ```
+### External Secrets Operator (ESO)
 
-    Recall that the values are stored as base64 thus we have to decode them to read the actual value. Hence the `base64 -d`.
+[ESO](https://external-secrets.io/) is a controller that watches `ExternalSecret` resources and synchronizes values from an external store (AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, Azure Key Vault, [Pulumi ESC](/product/esc/), and many others) into native Kubernetes Secrets. Applications keep reading regular Secrets; ESO handles fetching, rotation, and reconciliation.
 
-### Updating a Kubernetes Secret
+### Secrets Store CSI Driver
 
-In this example, we update the password of our secret so that it's a tad harder and does not match the username.
+The [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/) mounts secrets directly from an external store as files in a pod, without creating a Kubernetes Secret object at all (or, optionally, by syncing one for env-var consumption). Useful when you want secrets to live exclusively in the external store and never touch `etcd`.
 
-1. Determine the base64 encoding of the new password.
-
-    ```bash
-    echo "r00t123" | base64
-    # cjAwdDEyMwo=
-    ```
-
-2. Open the editor to modify the secret.
-
-    ```bash
-    $ kubectl edit secrets shhhhhh
-    ```
-
-3. Replace the `data.password` with the new base64-encoded value from Step 1.
-
-4. View the changes.
-
-    ```bash
-    kubectl get secret shhhhhh -o jsonpath="{.data.password}" | base64 -d
-    # r00t123
-    ```
-
-### Deleting a Kubernetes Secret
-
-1. Run the following `kubectl` command along with the name of the secret.
-
-    ```bash
-    $ kubectl delete secret shhhhhh
-    # secret "shhhhhh" deleted
-    ```
-
-### A real-world example with database credentials
-
-When managing database credentials, you can use Kubernetes Secrets to securely define, store, and deploy the necessary credentials to your pods. This ensures that your application has secure access to the database, without exposing the credentials in your codebase.
-
-Let's explore a real-world example that demonstrates the use of Kubernetes Secrets management.
-
-In the below example, we have MongoDB in the backend provisioned via helm. It was configured by mounting a secret volume containing user credential(s). We then create a pod that mounts the same secret to test the connection to the backend.
-
-1. Define a new secret resource.
-
-    ```bash
-    $ cat <<EOF > demo-dbcreds.yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-        name: demo-dbcreds
-    type: Opaque
-    stringData:
-        mongodb-root-password: 'r00t'
-        mongodb-passwords: ''
-    EOF
-    ```
-
-2. Apply the new resource definition.
-
-    ```bash
-    $ kubectl apply -f demo-dbcreds.yaml  --namespace mongodb
-    ```
-
-3. Use the [MongoDB Bitnami helm chart](https://artifacthub.io/packages/helm/bitnami/mongodb) to deploy MongoDB.
-
-    ```bash
-    $ helm install backend \
-       --set auth.username=root,auth.database=admin,architecture=standalone,persistence.enabled=false,auth.existingSecret=demo-dbcreds \
-       oci://registry-1.docker.io/bitnamicharts/mongodb --namespace mongodb
-    ```
-
-    Note: This deployment is for demo purposes only.
-    In the command above, the parameter `auth.existingSecret` has a reference to the previously created Secret, `demo-dbcreds`.
-
-4. Confirm the secrets reference in the MongoDB pod.
-
-    ```bash
-    $ kubectl describe pod backend-mongodb-776ff496b7-hmlrq --namespace mongodb
-    # ...
-    # other output not shown
-   # Environment:
-   #   BITNAMI_DEBUG:                    false
-   #   MONGODB_EXTRA_USERNAMES:          root
-   #   MONGODB_EXTRA_DATABASES:          admin
-   #   MONGODB_EXTRA_PASSWORDS:          <set to the key 'mongodb-passwords' in secret 'demo-dbcreds'>  Optional: false
-   #   MONGODB_ROOT_USER:                root
-   #   MONGODB_ROOT_PASSWORD:            <set to the key 'mongodb-root-password' in secret 'demo-dbcreds'>  Optional: false
-    # ...
-    ```
-
-5. Create a pod to test connectivity. Note this pod will have the `demo-dbcreds` secret mounted.
-
-    ```bash
-    $ cat <<EOF > mongo-conn-test.yaml
-    apiVersion: v1
-    kind: Pod
-    metadata:
-     name: mongo-conn-test
-    spec:
-     containers:
-     - name: mongo-conn-test
-       image: mongo:latest
-       command: ["/bin/sh", "-c"]
-       args:
-         - |
-           echo "Waiting for MongoDB to be ready..."
-           until mongosh --host=backend-mongodb.mongodb.svc.cluster.local -u root -p \$(cat /mnt/secrets/mongodb-root-password) --authenticationDatabase admin --eval "db.stats()" > /dev/null 2>&1; do
-             sleep 5
-           done
-           echo "Connected to MongoDB!"
-       volumeMounts:
-       - name: secret-volume
-         mountPath: "/mnt/secrets"
-     volumes:
-     - name: secret-volume
-       secret:
-         secretName: demo-dbcreds
-    EOF
-    ```
-
-    Update your host if using a different resource name or namespace. This example uses `backend-mongodb.mongodb.svc.cluster.local`.
-
-6. Create the pod.
-
-    ```bash
-    $ kubectl apply -f mongo-conn-test.yaml   --namespace mongodb
-    ```
-
-7. Verify connectivity via the logs.
-
-    ```bash
-    $ kubectl logs mongo-conn-test --namespace mongodb
-    # Waiting for MongoDB to be ready...
-    # Connected to MongoDB!
-    ```
-
-8. Delete the test pod.
-
-    ```bash
-    $ kubectl delete pod mongo-conn-test  --namespace mongodb
-    ```
-
-### Challenges and considerations
-
-While Kubernetes Secrets provide a way to store and manage sensitive information, such as passwords, API keys, and tokens, there are some challenges and considerations associated with their use. Here are some common challenges:
-
-- **Base64 encoding:** Kubernetes Secrets are often base64-encoded, but this is **not** encryption; it's just encoding. Anyone with access to the cluster can easily decode the values. Hence, the recommended best practice is to enable encryption in transit and at rest.
-- **Access controls complexity:** Access control to secrets is limited to namespace level. If you need to share secrets across namespaces or have more granular access control, you might need to implement additional solutions or consider external secret management tools.
-- **Limited versioning:** Kubernetes Secrets don't have built-in support for versioning. If you need to manage different versions of a secret, you may need to implement a naming convention or use an external tool for versioned secret management.
-- **No Audit trail:** Kubernetes doesn't provide a built-in audit trail for changes to Secrets. This lack of visibility can make it challenging to track who accessed or modified a secret and when. External auditing tools or additional configurations may be necessary.
-- **Difficulty in key rotation:** Kubernetes Secrets do not provide a built-in mechanism for key rotation. If you need to regularly rotate keys or secrets, you'll need to implement a custom solution or use an external tool.
-- **Limited secret types:** Kubernetes Secrets are primarily designed for simple key-value pairs. If you need to manage more complex data structures or different types of secrets, you may need to consider external solutions or custom resources.
-- **Difficulty in synchronizing with external systems:** If you have secrets managed outside of Kubernetes (e.g., in a password manager or a different secret store), synchronizing them with Kubernetes Secrets might require custom scripts or external tools.
-
-To address these challenges, you may consider using external secret management tools like [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets), or other solutions that provide enhanced security features and more flexible secret management capabilities.
-
-### Conclusion
-
-Kubernetes secrets are crucial to many applications and we must have a solution to the lifecycle of these. Kubernetes Secrets is the native way to manage secrets. By following best practices and using Kubernetes secrets, you can ensure the security of your applications and sensitive data.
-
-Now that you're equipped with the knowledge of Kubernetes Secrets, take your cloud infrastructure management to the next level with Pulumi Advanced Secrets Management. Discover how to efficiently manage sensitive data and secrets in your cloud applications. Dive into Pulumi's [Secrets Management guide](/blog/managing-secrets-with-pulumi/) for in-depth information on encrypting specific values for added security and ensuring that these values never appear in plain text in your state file​.
-
-Our [community on Slack](https://slack.pulumi.com/) is always open for discussions, questions, and sharing experiences. Join us there and become part of our growing community of cloud professionals!
+| Pattern | What lands in etcd | Best for |
+|---|---|---|
+| **External Secrets Operator** | A normal Kubernetes Secret, materialized from the external source | Existing apps that read native Secrets; broad provider support |
+| **Secrets Store CSI Driver** | Nothing (or an optionally-synced Secret) | Pods that read secrets from disk; minimizing data in etcd |
+| **Vault Agent sidecar** | Nothing | Workloads with dynamic short-lived credentials |
+
+Either approach lets teams centralize rotation, audit, and access control in one place and treat Kubernetes Secrets as a delivery mechanism rather than the system of record.
+
+## How does Pulumi manage Kubernetes Secrets?
+
+[Pulumi's Kubernetes provider](/registry/packages/kubernetes/) exposes `Secret` as a first-class resource. The same Pulumi program that provisions a cluster can declare its Secrets, populate them from [Pulumi ESC](/product/esc/), and roll them forward through the same review and CI pipeline as the rest of your infrastructure.
+
+```typescript
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+const dbPassword = config.requireSecret("dbPassword");
+
+const dbCreds = new k8s.core.v1.Secret("db-creds", {
+    metadata: { name: "db-creds", namespace: "app" },
+    type: "Opaque",
+    stringData: {
+        username: "app",
+        password: dbPassword,
+    },
+});
+```
+
+A few things happen for free here:
+
+* `config.requireSecret` pulls the value from [Pulumi ESC](/product/esc/) or a stack-level encrypted config. No plaintext credentials in the program, the state file, or Git.
+* The Secret resource is reconciled like any other Kubernetes object: drift is detected, deletes are tracked, and rollouts can be coordinated with the deployments that consume the Secret.
+* For external stores, Pulumi's [External Secrets](/registry/packages/kubernetes/) and provider packages let you create `ExternalSecret`, `SecretStore`, and `ClusterSecretStore` resources in code alongside the apps that depend on them.
+
+[Get started with Pulumi for Kubernetes](/docs/iac/clouds/kubernetes/) to manage clusters, Secrets, and external-secret integrations in TypeScript, Python, Go, C#, Java, or YAML.
+
+## Frequently asked questions about Kubernetes Secrets
+
+### Are Kubernetes Secrets encrypted?
+
+By default, no. Secret values are base64-encoded in `etcd` (reversible, not encrypted). Encryption at rest requires explicitly configuring an `EncryptionConfiguration` on the API server, typically backed by a KMS provider (AWS KMS, GCP KMS, Azure Key Vault, HashiCorp Vault). Most managed Kubernetes services (EKS, GKE, AKS) make this a one-flag setting.
+
+### Is base64 the same as encryption?
+
+No. Base64 is an encoding that converts binary data to a printable ASCII string. It is fully reversible without a key (`echo "cm9vdA==" | base64 -d` returns `root`). Anyone with read access to `etcd` or the API can decode any Secret.
+
+### Who can read Kubernetes Secrets?
+
+Any identity with `get` or `list` permission on the `secrets` resource in the relevant namespace. By default that includes cluster admins, the workloads that mount the Secret via a ServiceAccount, and any RBAC binding that grants those verbs. Audit logging and least-privilege RBAC are the standard controls.
+
+### How do I rotate a Kubernetes Secret?
+
+Kubernetes itself won't rotate values for you. Options: rotate the upstream credential (database password, API key) and update the Secret manually; let an operator like the External Secrets Operator pull the new value from an external store on a schedule; or use short-lived dynamic credentials (Vault, IRSA, Workload Identity) that the workload requests on demand.
+
+### What is the size limit for a Kubernetes Secret?
+
+1 MiB per Secret. The total etcd object size cap (~1.5 MiB) and the way Secrets are streamed to nodes make larger payloads impractical. Store large blobs (full certificate bundles, large keyfiles) in object storage and put only the reference in a Secret.
+
+### Can I share a Secret across namespaces?
+
+Not natively. A Secret is scoped to one namespace. Common workarounds: copy the Secret into each namespace with a controller (Reflector, Kubed); use an `ExternalSecret` per namespace pointing at the same external source; or run the consuming workload in the namespace where the Secret lives.
+
+### How are Secrets exposed to pods at runtime?
+
+As environment variables, as files in a `tmpfs` volume, or as `imagePullSecrets` references on the pod spec. File mounts are usually preferred: they're easier to rotate without a pod restart (the kubelet refreshes the mount on a sync interval, default 60 seconds) and harder to leak into logs.
+
+### What is the difference between a Secret and an ExternalSecret?
+
+A `Secret` is a native Kubernetes object that holds data in `etcd`. An `ExternalSecret` is a custom resource defined by the [External Secrets Operator](https://external-secrets.io/) that declares "fetch this value from an external store and project it as a Secret." Pods still consume a regular `Secret`; ESO is the controller that keeps it in sync.
+
+### Should I commit Kubernetes Secret manifests to Git?
+
+Not in plaintext. Either reference an external store ([Pulumi ESC](/product/esc/), AWS Secrets Manager, Vault) at apply time, encrypt the manifest with a tool like SOPS or sealed-secrets, or pull the values from a CI-time secret store. Committing base64 to Git is committing plaintext.
+
+### Does Pulumi store Kubernetes Secrets in state?
+
+Values pulled through `config.requireSecret` or [Pulumi ESC](/product/esc/) are encrypted in the Pulumi state file using your stack's encryption key (Pulumi-managed, KMS, or a passphrase). `kubectl`-style plaintext does not appear in state. See [secrets in Pulumi](/docs/iac/concepts/secrets/) for the full model.
+
+## Learn more
+
+Pulumi puts Kubernetes Secrets into the same review-and-CI workflow as the rest of your cluster: values come from [Pulumi ESC](/product/esc/), manifests are declared in TypeScript, Python, Go, C#, Java, or YAML, and every change is a reviewable pull request. [Get started today](/docs/get-started/).
+
+Related reading:
+
+* [What is Secrets Management?](/what-is/what-is-secrets-management/)
+* [What is HashiCorp Vault?](/what-is/what-is-hashicorp-vault/)
+* [What is AWS Secrets Manager?](/what-is/what-is-aws-secrets-manager/)
+* [What is Azure Key Vault?](/what-is/what-is-azure-key-vault/)
+* [What is Google Cloud Secret Manager?](/what-is/what-is-google-cloud-secret-manager/)
+* [What are Docker Secrets?](/what-is/what-are-docker-secrets/)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/what-are-kubernetes-secrets.md` for SEO and AEO. The old page led with a generic Kubernetes overview, then walked through a `kubectl` CRUD tutorial that didn't carry much information per line. The new version is structured around the questions an engineer or architect actually asks about Secrets: how they're stored, what types exist, how pods consume them, where they fall short, and how external stores extend them.

## What changed

- **Opening definition** — bolded one-sentence definition (API object, namespaced, lives in etcd, projected to pods three ways), followed by the crucial caveat that base64 is not encryption and a short tour of the production-hardening pattern (KMS, RBAC, ESO, CSI Driver).
- **Storage table** — five-layer breakdown (API submission, etcd, API access, pod delivery, in-pod) with default behavior vs. production hardening.
- **Types table** — `Opaque`, `service-account-token`, `dockercfg`, `dockerconfigjson`, `basic-auth`, `ssh-auth`, `tls`, `bootstrap.kubernetes.io/token`.
- **Consumption modes** — env vars vs. `tmpfs` file mounts vs. `imagePullSecrets`, with the tradeoffs.
- **Limitations** — base64 caveat, no versioning, no native rotation, namespace scope, audit gaps, 1 MiB size cap, cluster-bound.
- **Secret vs. ConfigMap table** — clears up the most common confusion.
- **External store patterns** — External Secrets Operator, Secrets Store CSI Driver, Vault Agent sidecar, with a comparison table on what lands in etcd.
- **Pulumi section** — TypeScript example using `config.requireSecret` and a short rundown of how Pulumi handles drift, deletes, and external-store integration.
- **FAQ** — ten doubt-removers (encryption, base64, who can read, rotation, size limit, cross-namespace sharing, runtime exposure, ExternalSecret vs Secret, committing manifests to Git, Pulumi state).
- **Cross-links** — secrets management, HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Cloud Secret Manager, Docker Secrets, Pulumi ESC.

## Test plan

- [ ] `make serve`; visit `/what-is/what-are-kubernetes-secrets/` and confirm tables and code block render correctly
- [ ] Spot-check cross-links (`/what-is/what-is-secrets-management/`, `/product/esc/`, `/docs/iac/clouds/kubernetes/`)
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)