### PR TITLE
content(what-is): expand the secrets management explainer

### DIFF
--- a/content/what-is/what-is-secrets-management.md
+++ b/content/what-is/what-is-secrets-management.md
@@ -1,437 +1,232 @@
 ---
 title: What is Secrets Management?
-meta_desc: |
-    Understand secrets management, the importance of secrets management, and how secrets management relates to infrastructure as code and configuration management
+meta_desc: "Secrets management is the practice of securely storing, distributing, rotating, and auditing credentials. Learn the patterns, tools, and how Pulumi ESC fits."
 meta_image: /images/what-is/what-is-secrets-management-meta.png
 type: what-is
 page_title: "What is Secrets Management?"
 authors: ["scott-lowe"]
 ---
 
-Secrets management refers to the **secure storage, distribution, and protection of sensitive information**, also known as "secrets." Secret creation is a vital process for securely generating and managing credentials within a secrets management framework. These secrets can include passwords, privileged accounts, API keys, cryptographic keys, and other confidential data crucial for the functioning of applications, systems, and networks. The goal of secrets management is to prevent unauthorized access, reduce the risk of data breaches, and ensure the confidentiality of sensitive information.
+**Secrets management is the practice of securely storing, distributing, rotating, and auditing the credentials (passwords, API keys, certificates, tokens, and encryption keys) that applications and infrastructure need to operate.** Done well, it keeps those credentials out of source code, CI logs, and developer laptops, and brokers them to the systems that actually need them through a single audited interface.
 
-In today’s interconnected world, the security of sensitive information is of the utmost importance. Security breaches—sometimes occurring due to a failure to keep sensitive information secure—can have significant repercussions for a company, its customers, and its reputation. This is why secrets management is such an important part of every company’s information technology (IT) toolset. Implementing secrets management is crucial for addressing security challenges in dynamic environments, such as those that auto-scale.
+The discipline exists because every non-trivial system needs credentials to do its job, and every leaked credential is a breach waiting to happen. Modern teams centralize secrets in a dedicated vault (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Google Cloud Secret Manager), pull them at runtime instead of baking them into images or config files, rotate them on a schedule, and log every read. [Pulumi ESC](/product/esc/) sits one layer above those vaults, composing environments and brokering secrets to Pulumi programs, CI jobs, and applications from whichever vault each team already uses.
 
-## Why is Secrets Management important?
+In this article, we'll cover the key questions about secrets management:
 
-Secrets management is a critical aspect of cybersecurity, serving as a foundational practice for safeguarding sensitive information within any organization. Properly managing secrets—such as API keys, passwords, certificates, and other confidential data—ensures they are stored, accessed, and used securely. Here’s why secrets management is essential:
+* Why does secrets management matter?
+* What counts as a secret?
+* What are the biggest risks of poor secrets management?
+* What does a secrets management workflow look like?
+* What are the leading secrets management tools?
+* How do the major vault tools compare?
+* What are secrets management best practices?
+* How does secrets management work in CI/CD?
+* How does secrets management support compliance?
+* How does Pulumi ESC fit into secrets management?
+* Frequently asked questions about secrets management
 
-### Protecting Sensitive Data from Unauthorized Access
+## Why does secrets management matter?
 
-Secrets are often the gateway to accessing sensitive systems and data. With robust secrets management, these keys can avoid falling into the wrong hands, leading to unauthorized access, data theft, or system compromise. By enforcing strong secrets management, organizations can ensure that sensitive information remains protected, reducing the risk of exposure.
+Credentials are the single most common target in modern breaches. Verizon's annual *Data Breach Investigations Report* has consistently found stolen credentials in the top three initial-access vectors, and GitGuardian's *State of Secrets Sprawl* reports continue to find millions of new secrets leaked into public repositories every year. Three forces make this an engineering-leadership concern, not a back-office one.
 
-### Maintaining Compliance with Security Regulations
+### Credentials are everywhere
 
-Many industries are governed by strict regulations that require the protection of sensitive data. Effective secrets management helps organizations comply with these regulations, such as GDPR, HIPAA, or PCI DSS, by ensuring that access to sensitive data is tightly controlled and monitored. Compliance not only avoids legal penalties but also builds trust with customers and partners.
+A typical cloud-native app pulls dozens of secrets at runtime: database passwords, cloud IAM keys, API tokens for third-party services, TLS private keys, signing keys, OIDC client secrets, encryption keys. Multiply that by every environment (dev, staging, prod, per-tenant) and every team, and the number quickly reaches the thousands.
 
-### Simplifying the Process of Rotating and Updating Secrets
+### A single leak can compromise everything
 
-Secrets, like passwords, need to be regularly rotated to maintain security. A well-implemented secrets management system simplifies this process by automating the rotation, updating, and revocation of secrets. This reduces the risk of human error and ensures that outdated or compromised secrets are replaced promptly, minimizing potential vulnerabilities.
+Most secrets are gates to something larger: a cloud account, a customer database, a deploy pipeline. Attackers who acquire one credential typically pivot to others. Long-lived, broadly-scoped credentials make that pivot trivial.
 
-#### Secret Management Tools
+### Regulators and customers now ask
 
-Secret management tools play a crucial role in automating the rotation and management of secrets. These tools mitigate risks associated with manual sharing and provide centralized management of critical information like passwords and encryption keys, ultimately safeguarding against data breaches and reputational damage.
+SOC 2, ISO 27001, HIPAA, PCI DSS, and FedRAMP all require demonstrable controls over how secrets are stored, accessed, rotated, and audited. Enterprise procurement teams now routinely ask SaaS vendors to describe their secrets management program before signing.
 
-#### Enabling Secure Collaboration Among Team Members
+## What counts as a secret?
 
-In modern, collaborative environments, team members often need to share access to sensitive resources. Secrets management allows for the secure sharing of secrets, ensuring that only authorized personnel can access them. This facilitates secure collaboration without exposing sensitive information to unnecessary risk.
+A secret is any value that an attacker could use to impersonate, decrypt, or escalate. The common categories:
 
-#### Preventing Data Breaches and Potential Financial Losses
+* **Passwords and service-account credentials.** Database logins, admin accounts, machine-to-machine credentials.
+* **API keys and tokens.** Long-lived API keys for third-party SaaS, OAuth refresh tokens, PATs.
+* **Cloud provider credentials.** AWS access keys, Azure service principal secrets, GCP service account keys.
+* **SSH keys.** Private keys used to access servers or sign Git commits.
+* **TLS and code-signing certificates.** Private keys for serving HTTPS or signing release artifacts.
+* **Encryption keys.** Symmetric keys for application-layer encryption, KMS data keys, customer-managed keys (CMEK).
+* **Database connection strings.** Frequently embed both endpoint and credential in a single string.
+* **OIDC client secrets and webhook signing secrets.** Used in federation and inbound API verification.
 
-Data breaches are costly, both in terms of financial impact and reputational damage. Poor secrets management can lead to breaches where attackers exploit improperly stored or shared secrets. By implementing a robust secrets management strategy, organizations can significantly reduce the risk of breaches, protecting themselves from the financial and operational fallout that often follows.
+Configuration values that look like secrets (e.g. internal hostnames) usually aren't — but they're often stored in the same system because the access-control and rotation needs overlap.
 
-#### Implementing Strong Security Practices as Part of a Comprehensive Security Policy
+## What are the biggest risks of poor secrets management?
 
-Secrets management is a key component of a broader security strategy. It reinforces the organization’s commitment to cybersecurity by embedding strong practices into daily operations. This protects individual secrets and strengthens the overall security posture, making the organization more resilient against various cyber threats.
+The recurring incident patterns:
 
-## What are some common types of secrets?
+1. **Secrets committed to source control.** A developer pastes an API key into a config file, commits, and pushes. Even after rewriting Git history, the key is considered compromised. GitGuardian's research consistently finds millions of secrets newly exposed in public repos each year.
+1. **Plaintext secrets in CI logs.** A misconfigured pipeline echoes a token into a build log that's retained, indexed, and visible to anyone with repo access.
+1. **Long-lived, broad-scope credentials.** A single AWS access key with `*` permissions that's been valid for years. When it leaks, the blast radius is the entire account.
+1. **Shared credentials.** "The production database password" used by ten services and two dozen engineers. Rotation becomes a coordinated outage; revocation gets put off.
+1. **No audit trail.** No one can answer "who read this secret last Tuesday?" Compliance frameworks and incident response both fail at that question.
+1. **No rotation.** Credentials that were created in 2019 and have never been changed. Each year of age increases the probability of compromise.
+1. **Insecure distribution.** Secrets shared over Slack, email, or unencrypted config files because there's no better path.
 
-Secrets are sensitive information used to authenticate, authorize, and secure access to systems and data. In modern IT environments, these secrets are integral to maintaining the security and integrity of applications, services, and infrastructure. Here’s a breakdown of some common types of secrets:
+A serious secrets program addresses all seven.
 
-* **Passwords:** Passwords are one of the most basic forms of secrets used for authenticating users to systems, applications, and databases. Despite their simplicity, passwords are a critical security component, and poor password management can lead to unauthorized access and breaches. Strong, unique passwords that are regularly rotated are essential for protecting accounts and systems.
-* **API Keys:** API keys are used to authenticate and authorize applications or users when accessing APIs. They act as a digital passport, allowing systems to communicate securely. However, if not properly managed, API keys can be exposed, leading to unauthorized access to APIs and the sensitive data they handle. Protecting and rotating API keys is crucial to maintaining secure API interactions.
-* **Database Connection Strings:** Database connection strings are used to establish connections between applications and databases. They typically contain sensitive information such as database names, usernames, and passwords. If exposed, they can provide attackers with direct access to an organization’s data, making it essential to store them securely and restrict access.
-* **SSH Keys:** SSH (Secure Shell) keys are cryptographic keys used to authenticate users and systems when accessing servers remotely. Unlike passwords, SSH keys provide a more secure and automated way of accessing systems. However, poor management of SSH keys—such as not rotating them or leaving them unprotected—can lead to unauthorized access and potential compromises of critical infrastructure.
-* **SSL/TLS Certificates:** SSL (Secure Sockets Layer) and TLS (Transport Layer Security) certificates are used to encrypt data in transit between clients and servers, ensuring secure communication over networks. These certificates also authenticate the identity of websites or services. Managing SSL/TLS certificates involves ensuring they are renewed before expiration and protecting the private keys associated with them to prevent man-in-the-middle attacks.
-* **Encryption Keys:** Encryption keys are used to encrypt and decrypt data, ensuring that sensitive information remains confidential both at rest and in transit. They are fundamental to maintaining data security, but they must be managed carefully. If encryption keys are lost or compromised, the data they protect becomes vulnerable or inaccessible.
-* **OAuth Tokens:** OAuth tokens are used in the OAuth protocol to authorize access to resources on behalf of a user or application. These tokens are often short-lived and are essential for enabling secure, delegated access to services without sharing passwords. Protecting OAuth tokens from exposure is crucial, as they can be used to gain unauthorized access to user accounts and data.
-* **Cloud Service Credentials:** Cloud service credentials are used to authenticate and authorize access to cloud resources, such as AWS IAM credentials, Azure service principals, or Google Cloud service accounts. These credentials can grant significant access to cloud environments, making them a prime target for attackers. Securing cloud service credentials and limiting their scope is vital for protecting cloud infrastructure.
-* **Private Certificates:** Private certificates, along with their corresponding private keys, are used in various cryptographic processes, such as signing code, securing communications, and authenticating devices or users. These certificates must be handled with care, as exposure of the private key can lead to a compromise of the security mechanisms they support.
+## What does a secrets management workflow look like?
 
-## What are the risks of poor secrets management?
+A mature secrets workflow has the same shape regardless of which vault you use.
 
-Poor secrets management can have severe and far-reaching consequences for an organization. Secrets, such as passwords, API keys, and encryption keys, are critical to maintaining the security and integrity of IT systems. When these secrets are not properly managed, it can expose an organization to a variety of risks. Here’s a closer look at the key risks associated with poor secrets management:
+```mermaid
+flowchart LR
+    Create[Create secret] --> Store[Store encrypted]
+    Store --> Access[Grant least-privilege access]
+    Access --> Consume[Apps pull at runtime]
+    Consume --> Rotate[Rotate on schedule]
+    Rotate --> Audit[Audit every read]
+    Audit --> Revoke[Revoke on incident]
+    Revoke --> Create
+```
 
-### Data Breaches
+The seven stages:
 
-One of the most significant risks of poor secrets management is the potential for data breaches. When secrets are improperly stored, shared, or managed, they can be easily exposed to malicious actors. This can lead to unauthorized access to sensitive data, resulting in data breaches that can compromise customer information, intellectual property, and other critical assets. Data breaches often have long-lasting impacts, including the loss of customer trust and substantial financial costs. When each application, cloud provider, or organizational unit has its own security model, it results in a lack of visibility and control, leading to secret sprawl and increased risks.
+1. **Create.** Generate a strong, unique credential. Prefer dynamic, short-lived credentials over static ones.
+1. **Store.** Encrypt at rest using a KMS- or HSM-backed key. Never store in plain text.
+1. **Grant access.** Use identity-based, least-privilege access control (RBAC or ABAC). Prefer workload identity over long-lived API keys.
+1. **Consume.** Applications and Pulumi programs fetch secrets at runtime from the vault — not from environment files baked into images.
+1. **Rotate.** Replace credentials on a regular schedule (or on demand after suspicion of compromise). Automate so rotation doesn't require a maintenance window.
+1. **Audit.** Log every read with identity, timestamp, and source IP. Ship logs to a SIEM.
+1. **Revoke.** When a credential is compromised or an employee leaves, the vault is the single place to cut access.
 
-### Unauthorized Access to Systems and Data
+## What are the leading secrets management tools?
 
-Secrets are often the keys to accessing systems, applications, and data. If secrets like passwords, API keys, or SSH keys are not adequately protected, they can be stolen or misused, granting attackers unauthorized access to critical systems. This unauthorized access can lead to data theft, system manipulation, or even complete system takeovers, putting the entire organization at risk.
+The market has consolidated around five categories of tool. Most organizations use more than one.
 
-### Compliance Violations and Potential Fines
+* **[HashiCorp Vault](/what-is/what-is-hashicorp-vault/).** Open source and enterprise editions. Strongest dynamic-secrets story (database credentials, cloud IAM, PKI generated on demand and short-lived). Common in multi-cloud and hybrid environments.
+* **[AWS Secrets Manager](/what-is/what-is-aws-secrets-manager/).** KMS-backed, with built-in Lambda-driven rotation for RDS, Redshift, and DocumentDB. The default in AWS-centric organizations.
+* **[Azure Key Vault](/what-is/what-is-azure-key-vault/).** Managed HSM and Standard tiers. Tight integration with Microsoft Entra ID and Managed Identity. The default in Azure-centric organizations.
+* **[Google Cloud Secret Manager](/what-is/what-is-google-cloud-secret-manager/).** IAM-based access, automatic or user-managed replication, CMEK support. The default in Google Cloud-centric organizations.
+* **[Pulumi ESC](/product/esc/).** Environments, Secrets, and Configuration. Composes secrets and config across vaults and providers, brokers dynamic OIDC credentials, and exposes a single interface to applications, CI, and Pulumi programs. Sits *above* the cloud-native vaults rather than replacing them.
 
-Many industries are subject to stringent regulations that mandate the protection of sensitive information. Poor secrets management can lead to non-compliance with regulations such as GDPR, HIPAA, or PCI DSS, exposing the organization to legal penalties and fines. Regulatory violations not only have financial implications but can also lead to increased scrutiny from regulatory bodies and a loss of business opportunities.
+Kubernetes ships with built-in [Kubernetes Secrets](/what-is/what-are-kubernetes-secrets/), and Docker has [Docker Secrets](/what-is/what-are-docker-secrets/) for Swarm. Both are useful primitives but neither is a substitute for a real vault. See how [different secrets managers compare](/docs/esc/vs).
 
-### Reputational Damage
+## How do the major vault tools compare?
 
-The exposure of secrets and subsequent security incidents can cause significant reputational damage. Customers, partners, and stakeholders expect organizations to handle their data with the utmost care. A breach resulting from poor secrets management can erode trust and damage the organization’s reputation, leading to customer attrition, loss of business, and negative media coverage. Rebuilding trust after a security incident is often a long and difficult process.
+| Capability | HashiCorp Vault | AWS Secrets Manager | Azure Key Vault | Google Cloud Secret Manager |
+|---|---|---|---|---|
+| Deployment model | Self-hosted or HCP managed | Fully managed (AWS) | Fully managed (Azure) | Fully managed (GCP) |
+| Dynamic secrets | Yes (databases, cloud IAM, PKI, SSH) | Limited (Lambda rotation) | Limited (via Functions) | No (manual rotation) |
+| Built-in rotation | Yes | Yes (RDS, Redshift, DocumentDB, others via Lambda) | Yes (certificates; secrets via Functions) | Not built-in |
+| HSM-backed keys | Vault Enterprise / HCP | KMS Custom Key Stores | Managed HSM (Premium) | Cloud HSM via CMEK |
+| Multi-region replication | Performance and DR replicas | Multi-Region replication | Geo-redundant pairs | Automatic or user-managed |
+| Primary auth model | Tokens, AppRole, cloud IAM, OIDC, K8s, more | AWS IAM | Microsoft Entra ID + RBAC | Google Cloud IAM |
+| Pricing model | OSS free; Enterprise per-cluster; HCP per-hour | Per secret/month + API calls | Per operation; HSM per key | Per active secret version + access ops |
 
-### Financial Losses
+For a deeper breakdown of vendor differences and how Pulumi ESC sits above them, see the [ESC comparison docs](/docs/esc/vs).
 
-The financial impact of poor secrets management can be substantial. Beyond regulatory fines, organizations may face costs related to incident response, legal fees, customer notification, and remediation efforts. Additionally, the loss of business due to reputational damage can further exacerbate financial losses. In severe cases, the financial burden can threaten the viability of the organization.
+## What are secrets management best practices?
 
-### Inability to Revoke or Rotate Compromised Credentials
+A short list that holds up across every vault:
 
-#### Quick Revocability of Secrets
+* **Never commit secrets to source control.** Use a pre-commit hook (gitleaks, trufflehog) and GitHub's push-protection feature to enforce it.
+* **Centralize in a dedicated vault.** Pick one cloud-native vault per cloud, and use [Pulumi ESC](/product/esc/) to compose them if you span more than one.
+* **Pull at runtime, don't bake at build.** Container images and IaC artifacts should never contain plaintext secrets.
+* **Prefer short-lived, dynamic credentials.** Use OIDC federation to issue short-lived cloud credentials to CI jobs instead of long-lived access keys.
+* **Enforce least privilege.** Each app, pipeline, or service identity gets only the secrets it needs.
+* **Rotate on a schedule.** Automate rotation; don't rely on humans remembering.
+* **Audit every read.** Ship vault audit logs to a SIEM and alert on unusual patterns.
+* **Separate environments.** Dev, staging, and production secrets live in different vaults or different paths with different ACLs.
+* **Plan for break-glass.** A documented, audited process for emergency access when the normal path fails.
+* **Encrypt in transit and at rest.** TLS for every API call to the vault; KMS- or HSM-backed encryption for storage.
 
-Effective secrets management includes the ability to quickly revoke or rotate credentials in the event of a compromise. Poor secrets management practices, such as hard-coding credentials in code or using manual processes for rotation, can delay the response to a security incident. This delay increases the window of opportunity for attackers to exploit compromised credentials, potentially leading to more extensive damage.
+## How does secrets management work in CI/CD?
 
-#### Challenges and Importance of Managing Secrets to Prevent Unauthorized Access and Breaches
+CI/CD pipelines are the single most common place secrets get exposed, because they need real production credentials to do their job. The modern pattern:
 
-Managing secrets effectively is a complex but essential task. Poor secrets management practices create challenges in ensuring that secrets are stored securely, rotated regularly, and accessed only by authorized users. Without a robust secrets management strategy, organizations are at a higher risk of unauthorized access and breaches. Implementing strong secrets management practices is critical to maintaining the security of systems and data, preventing unauthorized access, and protecting the organization from the wide-ranging impacts of security incidents.
+1. **The pipeline authenticates with workload identity, not a long-lived key.** GitHub Actions, GitLab CI, and CircleCI all support OIDC federation: the pipeline presents a short-lived JWT to AWS, Azure, or GCP, and gets back a short-lived cloud credential. No static cloud keys live in the CI system.
+1. **The pipeline pulls secrets from the vault at runtime.** Not from CI-level secret stores when avoidable. The vault is the single source of truth.
+1. **Secrets are masked in logs.** Most CI systems auto-mask values that came from their secret store, but values fetched at runtime have to be explicitly registered for masking.
+1. **The pipeline uses ephemeral credentials wherever possible.** Database credentials generated on-demand by Vault, cloud credentials federated through OIDC, signing tokens scoped to a single deployment.
 
-## Implementation Best Practices
+[Pulumi ESC](/product/esc/) directly addresses this: a pipeline opens a Pulumi ESC environment, which dynamically generates cloud credentials via OIDC and exports the relevant secrets as environment variables — no long-lived keys to manage.
 
-### How should secrets be stored?
+## How does secrets management support compliance?
 
-Storing secrets securely is a fundamental aspect of protecting sensitive information and ensuring the overall security of an organization’s IT environment. Secrets, such as passwords, API keys, and encryption keys, must be stored in a way that prevents unauthorized access and reduces the risk of exposure. Here’s how secrets should be stored to ensure maximum security:
+Almost every compliance framework includes secrets-relevant controls.
 
-#### Encrypted at Rest
+| Framework | Secrets-relevant requirement |
+|---|---|
+| SOC 2 (Trust Services Criteria) | Logical access controls, encryption of sensitive information, audit logging |
+| ISO/IEC 27001 (Annex A) | Access control (A.9), cryptography (A.10), operational security (A.12) |
+| HIPAA Security Rule | Access controls (164.312(a)), audit controls (164.312(b)), transmission security (164.312(e)) |
+| PCI DSS 4.0 | Requirement 3 (protect stored data), 8 (identify and authenticate users) |
+| FedRAMP / NIST 800-53 | AC-2, AC-3, AC-6, AU-2, AU-3, IA-2, IA-5, SC-12, SC-13 |
 
-One of the most important practices for storing secrets is ensuring they are encrypted at rest. Encryption protects secrets by converting them into a format that is unreadable without the proper decryption key. This ensures that even if the storage medium is compromised, the secrets remain inaccessible without the corresponding encryption key. Using strong encryption algorithms and regularly updating encryption methods are essential practices for keeping secrets secure.
+A real secrets management program produces the artifacts auditors want: who can read what, who did read what, when secrets were last rotated, and where the encryption keys live. See [What is SOC 2?](/what-is/what-is-soc-2/) for how that maps to the most common SaaS-vendor attestation.
 
-#### In a Dedicated Secrets Management System or Vault
+## How does Pulumi ESC fit into secrets management?
 
-Secrets should be stored in a dedicated secrets management system or vault designed specifically for this purpose. These systems provide secure storage, management, and access control for secrets. They often include features such as automated rotation, auditing, and fine-grained access controls. Examples include HashiCorp Vault, AWS Secrets Manager, and Azure Key Vault. Using a specialized secrets management solution reduces the risk of mismanagement and ensures that best practices are consistently applied.
+Pulumi ESC (Environments, Secrets, and Configuration) is a layer that sits *above* your existing vaults and pulls them together into composable, hierarchical environments. It doesn't replace HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, or Google Cloud Secret Manager — it brokers access to them.
 
-#### Separate from Source Code Repositories
+Concrete patterns:
 
-Storing secrets in source code repositories is a common but dangerous practice. Source code repositories are often accessed by multiple users and systems, increasing the risk that secrets could be exposed. Instead, secrets should be stored separately from the source code, ideally in a secure secrets management system. This separation ensures that even if the source code is compromised, the secrets remain protected.
+* **Compose secrets across vaults.** A single Pulumi ESC environment can pull database credentials from HashiCorp Vault, cloud IAM credentials from AWS via OIDC, an API key from Azure Key Vault, and a CMEK reference from GCP Secret Manager.
+* **Generate dynamic cloud credentials.** ESC mints short-lived AWS, Azure, or GCP credentials via OIDC at the moment they're needed, with no long-lived keys in any system.
+* **Hierarchical environments.** Compose a `production-base` environment, then layer `production-us-east` on top of it. Changes to base flow through.
+* **Single consumption interface.** Pulumi programs, CI jobs, application runtimes, and the `esc` CLI all see the same audited interface, regardless of which vault each secret actually lives in.
+* **End-to-end audit.** Every read of an ESC environment is logged with identity, timestamp, and which downstream provider was called.
 
-#### With Access Restricted to Authorized Personnel Only
+Pulumi ESC works hand-in-hand with [Pulumi IaC](/docs/iac/) but also stands alone — many teams use it purely as a secrets broker, with no Pulumi-managed infrastructure at all. See the [ESC documentation](/docs/pulumi-cloud/esc/) for setup and provider catalog.
 
-Access to secrets should be tightly controlled and restricted to authorized personnel only. This means implementing role-based access controls (RBAC) and ensuring that only those who absolutely need access to certain secrets have it. By minimizing the number of people and systems that can access secrets, organizations can reduce the risk of accidental or malicious exposure. Regularly reviewing and auditing access permissions is also critical to maintaining security.
+## Frequently asked questions about secrets management
 
-#### With Strict Access Controls to Secure Sensitive Data
+### What is secrets management in simple terms?
 
-In addition to restricting access to authorized personnel, strict access controls should be implemented to secure sensitive data. This includes using multi-factor authentication (MFA) for accessing secrets, enforcing strong password policies, and monitoring access logs for any suspicious activity. Access controls should also be dynamic, meaning they can be quickly updated or revoked in response to changing security requirements or in the event of a suspected compromise.
+The discipline of keeping the passwords, keys, and tokens that systems need to run somewhere safer than a config file, and giving them out only to the right identity at the right time, with a record of every access.
 
-### What are some best practices for secrets management?
+### What is the difference between secrets management and key management?
 
-Effective secrets management is critical for maintaining the security and integrity of an organization’s IT environment. Implementing best practices for managing secrets helps to protect sensitive data, prevent unauthorized access, and ensure compliance with security regulations. Here’s a detailed look at the best practices for secrets management:
+Key management (e.g. AWS KMS, Azure Key Vault keys, Google Cloud KMS) is about cryptographic keys used for encryption and signing. Secrets management covers the broader category of credentials. The two overlap because secrets managers usually rely on key managers under the hood — the master key that encrypts the secrets is itself a key managed by a KMS.
 
-#### Use a Dedicated Secrets Management Tool
+### What is a dynamic secret?
 
-A dedicated secrets management tool or vault is essential for securely storing, managing, and accessing secrets. These tools provide specialized features such as automated rotation, access control, auditing, and encryption, which are not available with general-purpose storage solutions. By using a dedicated tool like HashiCorp Vault, AWS Secrets Manager, or Azure Key Vault, organizations can ensure that secrets are managed securely and efficiently.
+A credential generated on demand for a specific consumer, with a short lifetime and automatic revocation. HashiCorp Vault generates dynamic database credentials, cloud IAM credentials, and PKI certificates. The point is to remove long-lived static credentials from the system entirely.
 
-#### Implement the Principle of Least Privilege
+### How often should secrets be rotated?
 
-The principle of least privilege dictates that users and systems should have only the minimum level of access necessary to perform their functions. This principle should be applied to secrets management by restricting access to secrets to only those who absolutely need it. Implementing least privilege reduces the attack surface and limits the potential impact of a security breach.
+It depends on the credential. Best practice ranges from continuous rotation (dynamic credentials, valid for minutes or hours) to 30–90 days for service-account passwords and API keys, to annual for TLS certificates (or whatever the issuer enforces). Rotation should always happen on confirmed or suspected compromise, regardless of schedule.
 
-#### Regularly Rotate Secrets
+### How does Pulumi ESC integrate with HashiCorp Vault and the cloud vaults?
 
-Regularly rotating secrets, such as passwords, API keys, and encryption keys, is a critical practice for maintaining security. Secret rotation reduces the risk of long-term exposure and ensures that even if a secret is compromised, it will soon be replaced with a new, secure one. Automated rotation through a secrets management tool can streamline this process and minimize the risk of human error.
+ESC ships first-party providers for HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, and Google Cloud Secret Manager. You point an ESC environment at one or more of those vaults; ESC fetches secrets on demand, applies access policy, logs the read, and exposes the result to whatever's consuming the environment (a Pulumi program, a CI job, an application). See the [ESC providers list](/docs/pulumi-cloud/esc/providers/).
 
-#### Use Strong Encryption for Stored Secrets
+### Can I use secrets management without using Pulumi for infrastructure?
 
-All stored secrets should be encrypted using strong encryption algorithms. Encryption ensures that even if a storage medium is compromised, the secrets remain protected and unreadable without the decryption key. It is important to use up-to-date encryption standards and to regularly review and update encryption methods to guard against emerging threats.
+Yes. Pulumi ESC is useful on its own as a centralized secrets and configuration broker. Many teams use it to drive CI jobs, Kubernetes workloads, and applications without using Pulumi IaC at all.
 
-#### Implement Multi-Factor Authentication for Access to Secrets
+### What's the difference between AWS Secrets Manager and AWS Systems Manager Parameter Store?
 
-Multi-factor authentication (MFA) adds an additional layer of security when accessing secrets by requiring users to provide multiple forms of identification. This significantly reduces the risk of unauthorized access, even if a password or other credential is compromised. Implementing MFA for accessing secrets is a key component of a robust security strategy.
+Both store values. Secrets Manager adds automatic rotation, cross-region replication, and (slightly) higher per-secret cost; it's the right home for genuine secrets. Parameter Store is cheaper and a better fit for general configuration values, including SecureString parameters when occasional encrypted storage is all you need.
 
-#### Audit and Monitor Access to Secrets
+### Should I use environment variables for secrets?
 
-Regular auditing and monitoring of access to secrets are essential for detecting and responding to unauthorized access or suspicious activity. Logs should be maintained for all access events, and these logs should be regularly reviewed to identify potential security issues. Automated alerts can be set up to notify security teams of any anomalies or unauthorized access attempts. Additionally, logging secrets usage is crucial for comprehensive tracking of all secret-related activities, ensuring that standardized logging formats are used for effective monitoring.
+For local development, sometimes. For production, only as the transport mechanism into a process — and only if the process exits without writing the variables to logs. Environment variables are visible to anyone who can `inspect` the container or read `/proc`, so they're a delivery channel, not a storage layer.
 
-#### Use Version Control for Secrets Management Policies
+### Are Kubernetes Secrets actually secure?
 
-Version control should be applied to secrets management policies to ensure that any changes are tracked, reviewed, and auditable. This helps in maintaining a clear history of changes, understanding the context of updates, and reverting to previous configurations if necessary. Using version control also supports compliance and auditability.
+Out of the box, they're base64-encoded, not encrypted, and stored in etcd. They become real secrets once you enable encryption at rest with a KMS provider (AWS KMS, Azure Key Vault, Google Cloud KMS) and lock down RBAC. Many teams use external-secrets-operator or similar tooling to populate Kubernetes Secrets from a real vault.
 
-#### Centralize and Standardize Secrets Management Solutions
+### How do I migrate from an existing secrets manager to Pulumi ESC?
 
-Centralizing secrets management in a single, standardized solution across the organization simplifies management and ensures consistent security practices. A centralized approach reduces the risk of secrets being scattered across various systems and repositories, making it easier to enforce security policies and respond to incidents.
+ESC's import providers let you read existing secrets from HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, or Google Cloud Secret Manager without copying them. You can adopt ESC incrementally by pointing it at the vaults you already have, then layer additional environments and rotation policies on top. See the [ESC providers catalog](/docs/pulumi-cloud/esc/providers/).
 
-#### Automate Secrets Management Processes Where Possible
+## Learn more
 
-Automation reduces the risk of human error, improves efficiency, and ensures consistency in managing secrets. Automated processes can handle tasks such as secret rotation, expiration, access control updates, and auditing. Automation tools can also integrate with CI/CD pipelines to secure secrets throughout the software development lifecycle.
+Pulumi helps engineering teams put secrets management on a defensible footing: every credential lives in a vault, every read goes through an audited interface, and dynamic credentials replace long-lived keys wherever possible. [Get started with Pulumi ESC](/docs/pulumi-cloud/esc/) to compose secrets across HashiCorp Vault, AWS, Azure, and GCP from a single environment definition.
 
-#### Implement Proper Access Controls
+Related reading:
 
-Access controls are essential for restricting who can view, use, or modify secrets. Implementing role-based access control (RBAC) ensures that only authorized users and systems have access to the secrets they need. Access controls should be regularly reviewed and adjusted to reflect changes in roles or responsibilities within the organization.
-
-#### Use Transport Layer Security (TLS) for All Communications
-
-All communications involving the transmission of secrets should be secured using Transport Layer Security (TLS). TLS ensures that data in transit is encrypted and protected from eavesdropping or tampering. This is particularly important for API calls, inter-service communications, and any remote access to secrets.
-
-#### Have Robust Backup, Restore, and Break-Glass Procedures
-
-It is essential to have robust backup and restore procedures in place to protect against data loss and ensure continuity in case of a failure. Break-glass procedures should also be established for emergency access to secrets during critical incidents, ensuring that key personnel can access necessary credentials without compromising security.
-
-#### Use Automation Tools to Reduce Human Error and Improve the Efficiency of Credential Management
-
-Automation tools can streamline credential management by automating repetitive tasks, enforcing security policies, and reducing the likelihood of human error. These tools can handle tasks such as generating strong passwords, rotating credentials, and securely distributing secrets to applications and services.
-
-### How can we securely share secrets within a team?
-
-Securely [sharing secrets](/tutorials/building-with-pulumi/secrets/) within a team is crucial for maintaining the integrity and security of sensitive information. Secrets, such as passwords, API keys, and encryption keys, need to be shared in a manner that minimizes the risk of exposure while ensuring that only authorized team members have access. Here are the best practices and methods for securely sharing secrets within a team:
-
-#### Using a Centralized Secrets Management System with Role-Based Access Control
-
-A centralized secrets management system, such as HashiCorp Vault, AWS Secrets Manager, or Azure Key Vault, is essential for securely sharing secrets within a team. These systems offer role-based access control (RBAC), allowing you to define and enforce which team members can access specific secrets based on their roles and responsibilities. By centralizing secrets management, you reduce the risk of secrets being scattered across different systems or exposed through insecure methods. RBAC ensures that only authorized personnel can access the secrets they need, limiting the potential for unauthorized access.
-
-#### Implementing a Secure Secrets Distribution Mechanism
-
-Secure secrets distribution mechanisms ensure that secrets are delivered to team members or systems in a controlled and secure manner. This can involve using secure APIs, encrypted communication channels, or secure storage mechanisms that integrate with the centralized secrets management system. By automating the distribution of secrets through secure channels, you reduce the risk of human error and ensure that secrets are always transmitted securely. Additionally, integrating secrets distribution with CI/CD pipelines ensures that secrets are securely delivered to applications and services during the development and deployment processes.
-
-#### Avoiding Sharing Secrets Through Insecure Channels Like Email or Chat
-
-One of the most critical practices for securely sharing secrets is to avoid using insecure channels such as email, chat, or shared documents. These channels are prone to interception, accidental sharing, or unauthorized access, making them unsuitable for transmitting sensitive information. Instead, secrets should be shared using secure, encrypted methods, such as those provided by a dedicated secrets management system. Additionally, policies should be put in place to educate team members about the risks of using insecure channels and to enforce the use of secure alternatives.
-
-#### Using Temporary, One-Time Secrets for Initial Access
-
-When providing initial access to systems or services, it is a best practice to use temporary, one-time secrets. These secrets are valid for a short period or a single use, reducing the risk of long-term exposure if they are compromised. One-time secrets can be generated dynamically by the secrets management system and securely delivered to the intended recipient. Once used, these secrets are automatically revoked, ensuring that they cannot be reused or exploited by unauthorized individuals. This approach is particularly useful for onboarding new team members or granting temporary access to external collaborators.
-
-#### Utilizing a Centralized Secrets Management Solution for Consistent Policy Enforcement and Governance Across Various Cloud Platforms
-
-As organizations increasingly rely on multiple cloud platforms, such as AWS, Azure, and Google Cloud Platform (GCP), maintaining consistent security practices across these environments becomes challenging. A centralized secrets management solution that integrates with all relevant cloud platforms allows for consistent policy enforcement and governance. This ensures that secrets are managed uniformly across the organization, regardless of the cloud environment. By using a centralized solution, you can enforce security policies, such as secret rotation, access controls, and auditing, across all platforms, reducing the risk of misconfiguration or inconsistent security practices.
-
-### How should secrets be handled in memory?
-
-Handling secrets securely in memory is a critical aspect of protecting sensitive information during runtime. Improper management of secrets in memory can lead to exposure through various attack vectors, such as memory dumps, buffer overflows, or debugging tools. Here’s how secrets should be handled in memory to minimize these risks:
-
-* **Minimize the Time Window Where a Secret Is in Plaintext in Memory:** The shorter the duration a secret remains in plaintext in memory, the lower the risk of it being exposed. Developers should aim to keep secrets in memory only for as long as they are actively needed. After their use, secrets should be promptly cleared from memory to reduce the risk of them being accessed by unauthorized processes or during a memory dump.
-* **Use Primitive Types Like Byte Arrays or Char Arrays Instead of Immutable Structures Like Strings:** When working with secrets in memory, it is advisable to use mutable data structures like byte arrays or char arrays rather than immutable structures like Strings (in languages such as Java or C#). Immutable objects, like Strings, are more difficult to clear from memory because they persist until the garbage collector removes them. In contrast, mutable structures allow developers to manually overwrite the data (e.g., by setting each element to zero) once the secret is no longer needed, providing better control over memory management.
-* **Zero Out Memory After a Secret Has Been Used:** Once a secret is no longer required, it should be immediately overwritten (or "zeroed out") in memory to prevent it from lingering in a recoverable state. This involves replacing the secret’s data with zeros or another value before releasing the memory back to the system. This practice reduces the likelihood of the secret being extracted from memory by malicious actors or through forensic analysis.
-* **Consider Using Hardware or OS Features to Encrypt the Entire Memory Space of the Process Handling the Secret:** For highly sensitive applications, consider leveraging hardware or operating system (OS) features that encrypt the entire memory space of the process handling the secret. Technologies like Intel SGX (Software Guard Extensions) or AMD SEV (Secure Encrypted Virtualization) provide hardware-based encryption for memory, protecting the data even if the system is compromised. Additionally, some operating systems offer process-level memory encryption, which can provide an extra layer of security for applications handling sensitive data.
-
-### What are some common mistakes in secrets management?
-
-Effective secrets management is crucial for maintaining the security and integrity of an organization’s systems and data. However, several common mistakes can undermine these efforts, leading to potential security vulnerabilities and breaches. Here are some of the most prevalent mistakes in secrets management:
-
-#### Storing Secrets in Version Control Systems
-
-One of the most significant and common mistakes is storing secrets, such as API keys, passwords, or encryption keys, directly in version control systems (VCS) like Git. Even if a repository is private, it can still be accessed by multiple people or systems, increasing the risk of exposure. If secrets are committed to version control, they become part of the code history and can be retrieved by anyone with access to the repository. This practice can lead to accidental exposure and should be avoided by using secure alternatives like environment variables or secrets management tools.
-
-#### Using Weak or Default Passwords
-
-Using weak or default passwords for accessing secrets or critical systems is another common mistake. Weak passwords are easier for attackers to guess or crack, and default passwords, which are often well-known or documented, present a significant security risk if not changed immediately. Secrets should always be strong, unique, and managed according to best practices, such as using a password manager or secrets management tool to generate and store complex passwords.
-
-#### Failing to Rotate Secrets Regularly
-
-Regularly rotating secrets, such as passwords, API keys, and encryption keys, is essential for reducing the risk of long-term exposure. Failing to rotate secrets regularly can lead to situations where a compromised secret remains in use for extended periods, increasing the potential for unauthorized access. Automation tools and secrets management systems can help ensure that secrets are rotated on a consistent schedule, reducing the risk of exposure.
-
-#### Oversharing Secrets Across Environments
-
-Oversharing secrets across different environments, such as development, staging, and production, is a common mistake that increases the risk of accidental exposure. Each environment should have its own set of secrets, and access should be restricted to only those who need it. Sharing the same secrets across multiple environments can lead to cross-environment contamination, where a compromise in one environment affects others. Segregating secrets by environment is critical for maintaining security boundaries.
-
-#### Neglecting to Revoke Access When Team Members Leave
-
-When team members leave an organization or change roles, their access to secrets should be promptly revoked. Failing to do so can leave critical systems and data vulnerable to unauthorized access, either intentionally or unintentionally. Automated access management tools can help ensure that access is revoked immediately when a team member’s status changes, reducing the risk of lingering access.
-
-#### Using the Same Secrets Across Multiple Services or Applications
-
-Reusing the same secrets across multiple services or applications is a risky practice that can lead to widespread compromise if a single secret is exposed. If an attacker gains access to one service, they may be able to use the same secret to access others, amplifying the damage. Each service or application should have its own unique secrets, and secrets should be rotated regularly to minimize the risk of cross-service compromise.
-
-## Tools and Technologies
-
-### What are some popular secrets management tools?
-
-Several tools and platforms are designed specifically to facilitate secrets management. Let’s explore a few notable ones.
-
-* **[HashiCorp Vault](/what-is/what-is-hashicorp-vault)**: HashiCorp Vault is a popular tool that provides a centralized platform for managing and controlling access to secrets. It supports dynamic secret generation, encryption as a service, and comprehensive access policies.
-* **[AWS Secrets Manager](/what-is/what-is-aws-secrets-manager)**: As part of the Amazon Web Services (AWS) ecosystem, AWS Secrets Manager is a fully managed service designed to protect and manage sensitive information used by applications.
-* **[Azure Key Vault](/what-is/what-is-azure-key-vault)**: Microsoft’s Azure Key Vault is a cloud service that safeguards cryptographic keys, secrets, and certificates used by cloud applications and services.
-* **[Google Cloud Secret Manager](/what-is/what-is-google-cloud-secret-manager)**: Google Cloud’s Secret Manager offers a secure storage system for API keys, passwords, certificates, and other sensitive data.
-* **[Pulumi ESC](/product/esc)**: Pulumi’s Environments, Secrets, and Configuration (ESC) product offers a platform for storing and controlling access to secrets. Pulumi ESC can also dynamically obtain credentials via OIDC providers and manage configuration information as well as secrets.
-
-A well-integrated secrets management solution is crucial for usability and centralization, ensuring consistent policy enforcement and governance across various cloud environments.
-
-Additionally, both Kubernetes and Docker offer limited, built-in secrets management functionality in the form of [Kubernetes Secrets](/what-is/what-are-kubernetes-secrets/) and [Docker Secrets](/what-is/what-are-docker-secrets/), respectively. See how [different secrets managers compare](/docs/esc/vs) to each other.
-
-### How do secrets management tools integrate with CI/CD pipelines?
-
-Integrating secrets management tools with Continuous Integration/Continuous Deployment ([CI/CD](/what-is/what-is-ci-cd/)) pipelines is essential for securely managing and deploying sensitive information throughout the software development lifecycle. This integration ensures that secrets, such as API keys, credentials, and encryption keys, are securely handled during build, test, and deployment stages without exposing them to unnecessary risk. Here’s how secrets management tools integrate with CI/CD pipelines:
-
-#### Providing API Access to Retrieve Secrets During Build and Deployment Processes
-
-Secrets management tools often offer API access, allowing CI/CD pipelines to retrieve secrets dynamically during the build and deployment processes. By using APIs, the pipeline can securely fetch the required secrets, such as database connection strings, API keys, or credentials, directly from the secrets management system at runtime. This eliminates the need to hard-code secrets in the pipeline configuration or store them in less secure locations, such as environment variables or configuration files. API-based access ensures that secrets are retrieved securely and only when needed, minimizing their exposure and reducing the risk of compromise.
-
-#### Offering Plugins or Extensions for Popular CI/CD Tools
-
-Many secrets management tools provide plugins or extensions specifically designed for popular CI/CD tools like Jenkins, GitLab CI/CD, CircleCI, and GitHub Actions. These plugins enable seamless integration between the CI/CD pipeline and the secrets management system, making it easier to securely manage secrets throughout the development and deployment processes. These integrations often include features such as automatic secrets retrieval, secure storage of secrets within the pipeline, and the ability to inject secrets into the build or deployment environment securely. By leveraging these plugins, development teams can enhance the security of their CI/CD pipelines without adding complexity to the workflow.
-
-#### Supporting Dynamic Secrets Generation for Ephemeral Environments
-
-In CI/CD pipelines, ephemeral environments—such as temporary testing or staging environments—are commonly used for running tests, building code, or deploying applications. Secrets management tools can support the generation of dynamic secrets specifically for these ephemeral environments. Dynamic secrets are temporary and have a limited lifespan, ensuring that they expire shortly after use or when the ephemeral environment is destroyed. This approach enhances security by ensuring that secrets are not reused and are only valid for the duration of the task, reducing the risk of exposure or unauthorized access in transient environments.
-
-#### Enabling Automated Secret Rotation as Part of the Deployment Process
-
-Secrets management tools can be integrated into CI/CD pipelines to enable automated secret rotation as part of the deployment process. Automated rotation ensures that secrets, such as passwords, API keys, or tokens, are regularly updated and replaced with new ones, minimizing the risk of long-term exposure or compromise. The CI/CD pipeline can trigger the rotation process, retrieving the new secrets and updating them across all relevant systems and applications automatically. This integration reduces the burden on development and operations teams by automating a critical security task, ensuring that secrets remain secure throughout the software development lifecycle.
-
-## Cloud Providers and Secrets Management
-
-### What centralized secrets management solution do major cloud providers offer?
-
-Major cloud providers offer specialized secrets management solutions designed to securely store, manage, and access sensitive information such as API keys, passwords, and encryption keys. These solutions are fully integrated with their respective cloud ecosystems, providing seamless management of secrets across various cloud services and applications. Here’s a look at the centralized secrets management solutions offered by the leading cloud providers:
-
-* **Amazon Web Services (AWS): AWS Secrets Manager and Systems Manager Parameter Store**
-    * **AWS Secrets Manager:** [AWS Secrets Manager](/what-is/what-is-aws-secrets-manager/) is a fully managed service that helps you protect access to your applications, services, and IT resources without the upfront investment and ongoing maintenance costs associated with operating your own infrastructure. It allows you to easily rotate, manage, and retrieve database credentials, API keys, and other secrets throughout their lifecycle. AWS Secrets Manager also integrates with AWS Identity and Access Management (IAM) to enforce fine-grained access controls and auditing.
-    * **AWS Systems Manager Parameter Store:** AWS Systems Manager Parameter Store is another AWS service that provides a secure and scalable solution for managing configuration data and secrets. While it can store both plain text and encrypted data, it is particularly useful for managing secrets in less critical or less complex scenarios. Parameter Store integrates with other AWS services, making it easy to retrieve parameters and secrets in a controlled and secure manner.
-* **Google Cloud Platform (GCP): GCP Secret Manager:** [Google Cloud Secret Manager](/what-is/what-is-google-cloud-secret-manager) is a centralized service for storing, managing, and accessing secrets securely in Google Cloud. It is designed to be highly available, with automatic replication across regions and support for multiple versions of secrets. Secret Manager integrates with Google Cloud's Identity and Access Management (IAM) for fine-grained access control, ensuring that secrets are only accessible by authorized users and services. It also supports automatic rotation of secrets, making it easier to manage the lifecycle of sensitive data.
-* **Microsoft Azure: Azure Key Vault:** [Azure Key Vault](/what-is/what-is-azure-key-vault) is a cloud service for securely storing and managing secrets, keys, and certificates. It is designed to help you safeguard cryptographic keys and secrets used by cloud applications and services. Azure Key Vault provides a unified interface for managing secrets and integrates with Azure's identity and access management services, allowing you to enforce access policies and audit usage. It also supports seamless integration with Azure services, making it easy to use Key Vault secrets in your applications and workloads.
-
-### What is envelope encryption in cloud-based secrets management?
-
-Envelope encryption is a widely adopted practice in data security that provides an extra layer of protection by using multiple levels of encryption. This method is particularly useful in cloud environments where sensitive data needs to be securely managed. Here’s how envelope encryption works:
-
-* **A Data Key Encrypts the Secret:** The first step in envelope encryption involves the use of a data key, which is typically a symmetric encryption key, to encrypt the actual secret (e.g., a password, API key, or sensitive data). The data key is specifically generated for the purpose of encrypting that secret, ensuring that the secret is not stored in plain text.
-* **A Master Key Encrypts the Data Key:** After the secret has been encrypted with the data key, the data key itself is encrypted using a master key. The master key is often managed by a cloud provider’s key management service (KMS), such as AWS Key Management Service (KMS), Google Cloud Key Management (KMS), or Azure Key Vault. This additional encryption of the data key ensures that even if the data key were to be exposed, it would still be protected by the master key encryption.
-* **This Provides an Additional Layer of Security and Control Over Encryption:** Envelope encryption enhances security by creating a layered approach to encryption. By separating the encryption of the secret and the encryption of the data key, envelope encryption allows for more granular control over encryption keys and their management. This method also simplifies key rotation processes, as only the master key needs to be rotated regularly, while the data keys can remain unchanged. Furthermore, by leveraging a cloud provider's managed key service for the master key, organizations can ensure that their keys are stored securely and are managed according to best practices, reducing the risk of key compromise.
-
-### How can secrets be injected into containers?
-
-Injecting secrets into containers is a critical aspect of container security, ensuring that sensitive information such as API keys, passwords, and certificates is securely passed to the containerized applications. Here are the primary methods for injecting secrets into containers:
-
-#### Mounted Volumes (File-Based)
-
-One of the most secure and commonly used methods for injecting secrets into containers is by mounting a volume that contains secret files. In this approach, secrets are stored in files within a secure location outside of the container, such as a dedicated secrets management system (e.g., Kubernetes Secrets, AWS Secrets Manager). These files are then mounted into the container as a volume at runtime, making the secrets accessible to the application without being hardcoded or exposed in the environment. The file-based method is secure because it keeps secrets out of the container image and allows for tight control over who can access the mounted volumes.
-
-#### Fetching from a Secret Store (In-Memory)
-
-Another secure method is for the containerized application to fetch secrets directly from a secrets management store at runtime. This approach involves the application calling an API to retrieve the secrets, which are then stored in-memory within the application. Since the secrets are fetched at runtime and not stored on disk, they are less likely to be exposed if the container is compromised. This method is particularly useful in environments where secrets need to be dynamically retrieved or rotated. However, it requires the application to have the necessary logic to interact with the secret store securely.
-
-#### Environment Variables (Least Recommended)
-
-While environment variables are a simple and straightforward method for injecting secrets into containers, they are generally the least secure option and are often discouraged for sensitive information. Environment variables can be easily exposed through container introspection commands (e.g., docker inspect, kubectl describe), logs, or error messages. However, in scenarios where simplicity is necessary and security risks are lower, environment variables can be used with caution. When using environment variables, it's important to restrict access to the container and avoid logging or displaying environment variables in any output.
-
-Secrets can be securely injected into containers using mounted volumes, fetching from a secret store, or environment variables. Mounted volumes and fetching from a secret store are the preferred methods due to their enhanced security, while environment variables should be used with caution and only when other methods are not feasible. Properly managing and injecting secrets is crucial for maintaining the security and integrity of containerized applications.
-
-## Security, Monitoring, and Compliance
-
-### How can we detect potential secret exposure?
-
-To detect potential secret exposure:
-
-* Implement monitoring and alerting systems for unusual access patterns
-* Use secret scanning tools in your CI/CD pipeline and code repositories
-* Have an incident response plan in place for potential breaches
-* Regularly audit and review access logs
-* Implement automated secret rotation upon suspected exposure
-
-### What should be included in a secrets management audit?
-
-Detecting potential secret exposure is a critical aspect of maintaining the security of an organization’s sensitive information. Early detection allows for prompt response and mitigation, reducing the risk of significant damage. Here are key strategies to detect potential secret exposure:
-
-#### Implement Monitoring and Alerting Systems for Unusual Access Patterns
-
-Continuous monitoring of access patterns is essential for detecting potential secret exposure. Implement systems that can monitor the access and usage of secrets in real-time. These systems should be configured to detect unusual or anomalous behavior, such as unexpected access times, access from unfamiliar IP addresses, or repeated access attempts. When unusual activity is detected, automated alerts should be triggered to notify the security team for immediate investigation.
-
-#### Use Secret Scanning Tools in Your CI/CD Pipeline and Code Repositories
-
-Secret scanning tools are designed to automatically search for hardcoded secrets, such as API keys, passwords, and tokens, within your code repositories and CI/CD pipelines. These tools can detect and flag potential exposures during code commits, pull requests, and build processes. Integrating secret scanning tools into your development workflow ensures that secrets are identified and remediated before they reach production environments. Examples of such tools include GitGuardian, TruffleHog, and AWS CodeGuru.
-
-#### Have an Incident Response Plan in Place for Potential Breaches
-
-An incident response plan is crucial for handling potential secret exposures effectively. This plan should outline the steps to take when a secret is suspected of being exposed, including containment, eradication, recovery, and communication strategies. Having a well-defined incident response plan ensures that the organization can respond swiftly to mitigate the impact of the exposure and prevent further damage.
-
-#### Regularly Audit and Review Access Logs
-
-Regular audits and reviews of access logs are important for identifying potential secret exposure. By analyzing access logs, you can detect patterns that may indicate unauthorized access to secrets. These audits should be conducted periodically to ensure that any suspicious activity is identified and investigated promptly. Reviewing access logs also helps ensure compliance with security policies and regulatory requirements.
-
-#### Implement Automated Secret Rotation Upon Suspected Exposure
-
-If a secret is suspected of being exposed, one of the most effective immediate responses is to rotate the secret automatically. Automated secret rotation involves generating a new secret and updating all dependent systems and applications to use the new secret. This process can be triggered by monitoring systems when suspicious activity is detected or by a manual response from the security team. Automated rotation helps contain the potential impact of the exposure by ensuring that the compromised secret is no longer valid.
-
-### How does secrets management relate to compliance requirements?
-
-Proper secrets management is essential for meeting a variety of compliance requirements, particularly those that pertain to the security and privacy of sensitive data. Regulatory frameworks across industries often mandate strict controls over how sensitive information is stored, accessed, and managed. Here’s how secrets management directly supports compliance:
-
-#### Ensuring Secure Storage and Transmission of Sensitive Data
-
-Compliance regulations like GDPR, HIPAA, and PCI DSS require organizations to protect sensitive data both at rest and in transit. Secrets management tools and practices help ensure that sensitive information, such as passwords, API keys, and encryption keys, is securely stored using strong encryption methods. Additionally, secure transmission protocols, like TLS, ensure that secrets are protected from interception during communication between systems. Proper secrets management practices ensure that organizations meet these regulatory requirements for data protection.
-
-#### Providing Audit Trails for Access to Secrets
-
-Many compliance frameworks require organizations to maintain detailed logs of access to sensitive data, including who accessed it, when, and why. Secrets management tools often include auditing and logging capabilities that track access to secrets in real-time. These audit trails are crucial for demonstrating compliance during security assessments or regulatory audits, providing clear evidence that sensitive data is being accessed and managed according to policy.
-
-#### Enabling Granular Access Controls
-
-Compliance requirements frequently emphasize the principle of least privilege, ensuring that only authorized individuals have access to sensitive data. Secrets management solutions support granular access controls, allowing organizations to enforce fine-grained permissions based on roles, responsibilities, and need-to-know criteria. This capability helps organizations meet compliance mandates that require strict access controls to protect sensitive information from unauthorized access.
-
-#### Supporting Regular Rotation of Credentials
-
-Regular rotation of credentials is a common requirement in compliance frameworks to reduce the risk of long-term exposure of sensitive data. Secrets management systems automate the rotation of secrets, such as passwords, API keys, and encryption keys, ensuring that they are regularly updated and replaced. This practice not only enhances security but also ensures compliance with regulations that require periodic credential changes to mitigate the risk of compromise.
-
-#### Facilitating Secure Key Management Practices
-
-Compliance standards often require robust key management practices to ensure the secure generation, storage, and rotation of encryption keys. Secrets management solutions typically include integrated key management features that adhere to best practices for key handling. By using these tools, organizations can ensure that their encryption keys are managed securely and in accordance with regulatory requirements, reducing the risk of data breaches and non-compliance.
-
-## Development and CI/CD Considerations
-
-Handling [secrets securely in code](/docs/iac/concepts/secrets/#using-configuration-and-secrets-in-code) is critical to maintaining the security of applications and protecting sensitive information from unauthorized access. Developers must follow [best practices](/tutorials/building-with-pulumi/secrets/) to ensure that secrets such as API keys, passwords, and encryption keys are properly managed and not exposed inadvertently. Here’s how developers should handle secrets in their code:
-
-### Never Hardcode Secrets in Source Code
-
-Hardcoding secrets directly in source code is a significant security risk. Source code repositories are often accessed by multiple people and systems, increasing the likelihood of secrets being exposed. Additionally, if the code is shared or made public, any hardcoded secrets become immediately accessible to anyone with access to the code. To prevent this, developers should store secrets separately from the code, using secure storage solutions such as environment variables or secrets management tools.
-
-### Use Environment Variables or Dedicated Secrets Management Libraries
-
-Environment variables are a common method for [managing secrets](https://developers.cloudflare.com/pulumi/tutorial/manage-secrets/) in a more secure manner. By storing secrets in environment variables, developers can keep them out of the source code, reducing the risk of exposure. However, care must be taken to ensure that environment variables are managed securely and are not inadvertently exposed. Alternatively, developers can use dedicated secrets management libraries or tools, such as AWS Secrets Manager, Azure Key Vault, or HashiCorp Vault, which provide more advanced features for securely storing, accessing, and rotating secrets.
-
-### Avoid Logging Secrets or Including Them in Error Messages
-
-Logging secrets or including them in error messages is another common pitfall that can lead to inadvertent exposure. Logs are often stored in various locations, accessed by different teams, and sometimes even shared externally. If secrets are logged, they can be easily exposed to unauthorized individuals. Developers should ensure that logging mechanisms and error messages do not include sensitive information, and instead, use anonymized or obfuscated data for troubleshooting purposes.
-
-### Use Secure Methods to Inject Secrets into Applications at Runtime
-
-Secrets should be injected into applications at runtime using secure methods. This can be done through environment variables, secure configuration files, or integration with secrets management tools that provide secure APIs for retrieving secrets. By injecting secrets at runtime, developers can ensure that secrets are only accessible when the application is running, reducing the risk of them being exposed during development, testing, or deployment stages. It also allows for easier rotation and management of secrets without requiring changes to the application code.
-
-### Implement Secret Obfuscation Techniques When Necessary
-
-In some cases, additional security measures may be needed to protect secrets from being exposed, even if they are stored securely. Secret obfuscation techniques, such as encoding, encryption, or tokenization, can add an extra layer of protection, making it more difficult for attackers to decipher secrets if they are inadvertently exposed. However, obfuscation should not be relied upon as the sole method of protection and should be used in conjunction with other best practices for handling secrets securely.
-
-## What considerations are important for secrets management in CI/CD pipelines?
-
-Managing secrets securely in CI/CD pipelines is essential for protecting sensitive information and ensuring the integrity of the software development lifecycle. CI/CD pipelines often have access to critical systems and data, making them a prime target for attackers. To mitigate risks and maintain security, several key considerations should be taken into account when handling secrets in CI/CD environments:
-
-### Treat CI/CD Tooling as a Production Environment and Secure It Accordingly
-
-CI/CD pipelines should be treated with the same level of security as any production environment. This means implementing robust security controls to protect the pipeline itself, including secure configurations, regular security audits, and the use of security tools to detect and mitigate potential vulnerabilities. Ensuring that the CI/CD tooling is secured helps to prevent unauthorized access to the pipeline and the secrets it manages, reducing the risk of compromise.
-
-### Implement Least-Privilege Access for Developers
-
-Applying the principle of least privilege to CI/CD pipelines is crucial for minimizing the risk of unauthorized access to secrets. Developers and other users of the pipeline should only have access to the secrets and resources they need to perform their specific tasks. This can be achieved through role-based access controls (RBAC) and fine-grained permissions within the CI/CD tools. Limiting access helps to reduce the attack surface and prevents accidental or malicious misuse of secrets.
-
-### Ensure Pipeline Output Doesn’t Leak Secrets
-
-One of the most critical security concerns in CI/CD pipelines is the potential leakage of secrets through pipeline output, such as logs or error messages. It’s essential to carefully manage what is logged during the pipeline's execution to ensure that secrets, such as API keys, tokens, or credentials, are not inadvertently exposed. Developers should sanitize logs, use secure logging practices, and implement mechanisms to detect and prevent secret leakage in pipeline outputs.
-
-### Use Proper Authentication, Authorization, and Accounting (AAA)
-
-Securing CI/CD pipelines requires implementing strong authentication, authorization, and accounting (AAA) mechanisms. Authentication ensures that only authorized users can access the pipeline, while authorization controls what actions those users can perform. Accounting, or auditing, involves tracking and logging all access and actions within the pipeline to maintain a record for security reviews and compliance purposes. Properly implemented AAA ensures that the pipeline is secure and that any suspicious activities can be quickly identified and addressed.
-
-### Have a Clear Process for Creating and Reviewing Pipelines
-
-Establishing a clear and standardized process for creating and reviewing CI/CD pipelines is essential for maintaining security and consistency. This process should include security checks and reviews at various stages of pipeline creation, such as code reviews, security scans, and compliance checks. Additionally, pipelines should be regularly reviewed and updated to address new security risks, incorporate best practices, and ensure they adhere to organizational security policies.
-
-### Consider Using Short-Lived, Dynamic Secrets for Pipeline Operations
-
-Using short-lived, dynamic secrets is a best practice for securing CI/CD pipelines. These secrets are generated for a specific operation or session and expire shortly after use, reducing the risk of long-term exposure. Dynamic secrets can be integrated into the pipeline using secrets management tools that support automated secret generation and rotation. By using short-lived secrets, the pipeline can securely manage sensitive information while minimizing the risk of compromise if a secret is exposed.
-
-## Future Trends
-
-### What are some emerging trends in secrets management?
-
-As security challenges evolve, so too do the approaches and [technologies](/product/secrets-management/) surrounding secrets management. Here are some of the key emerging trends in this area:
-
-* **Increased Adoption of Zero-Trust Security Models:** The zero-trust security model is gaining momentum across industries, emphasizing the principle of "never trust, always verify." In the context of secrets management, this model advocates for continuous verification of access requests, ensuring that only authenticated and authorized users can access secrets. The adoption of zero-trust models requires robust secrets management solutions that integrate seamlessly with identity management and authentication systems, ensuring that secrets are protected at every level of access.
-* **Integration of AI and Machine Learning for Anomaly Detection:** Artificial intelligence (AI) and machine learning (ML) are being increasingly integrated into secrets management solutions to enhance security through automated anomaly detection. By analyzing access patterns and behaviors, AI and ML can identify potential threats, such as unauthorized access attempts or unusual secret usage, in real time. This proactive approach enables organizations to respond to security incidents more quickly, reducing the risk of breaches and improving overall security posture.
-* **Shift Towards Cloud-Native Secrets Management Solutions:** As organizations continue to migrate to the cloud, there is a growing trend towards cloud-native secrets management solutions. These tools are designed to operate seamlessly within cloud environments, offering scalable and flexible secrets management that can be easily integrated with other cloud services. Cloud-native secrets management [solutions](/blog/pulumi-in-a-cloud-native-world/) often include features like automated secret rotation, dynamic secrets generation, and integration with cloud-based identity and access management (IAM) systems, making them ideal for modern, cloud-first organizations.
-* **Enhanced Focus on Secrets Management for Containerized and Serverless Environments:** With the increasing adoption of containerization and serverless architectures, there is a heightened focus on secrets management tailored to these environments. Managing secrets in containerized and serverless environments presents unique challenges, such as securing ephemeral environments and ensuring that secrets are not exposed during rapid scaling or deployment. Emerging solutions are addressing these challenges by offering dynamic secrets management, secure secret injection at runtime, and seamless integration with container orchestration platforms like Kubernetes.
-* **Adoption of Dynamic Secrets and Just-In-Time Access Provisioning:** Dynamic secrets and just-in-time (JIT) access provisioning are becoming more popular as organizations seek to minimize the risk of long-term secret exposure. Dynamic secrets are generated on-demand and have a limited lifespan, reducing the risk of them being compromised. JIT access provisioning further enhances security by granting temporary access to secrets only when needed, and automatically revoking access afterward. These approaches help organizations minimize their attack surface and ensure that secrets are only accessible when absolutely necessary.
-* **Implementation of Quantum-Resistant Encryption for Long-Term Secrets Protection:** As quantum computing technology advances, there is growing concern about the potential for quantum computers to break current encryption algorithms. To mitigate this risk, some organizations are exploring quantum-resistant encryption methods for protecting long-term secrets. These encryption techniques are designed to withstand attacks from quantum computers, ensuring that secrets remain secure well into the future. The implementation of quantum-resistant encryption is still in its early stages, but it is expected to become increasingly important as quantum computing capabilities develop.
-
-Staying ahead of emerging trends in secrets management is crucial for organizations to maintain robust security practices. By adopting zero-trust models, leveraging AI and ML for anomaly detection, embracing cloud-native solutions, focusing on containerized and serverless environments, implementing dynamic secrets and JIT provisioning, and exploring quantum-resistant encryption, organizations can enhance their secrets management strategies and better protect their sensitive information in an ever-evolving threat landscape.
+* [What is HashiCorp Vault?](/what-is/what-is-hashicorp-vault/)
+* [What is AWS Secrets Manager?](/what-is/what-is-aws-secrets-manager/)
+* [What is Azure Key Vault?](/what-is/what-is-azure-key-vault/)
+* [What is Google Cloud Secret Manager?](/what-is/what-is-google-cloud-secret-manager/)
+* [What is Cloud Security?](/what-is/what-is-cloud-security/)
+* [What is SOC 2?](/what-is/what-is-soc-2/)
+* [What are Kubernetes Secrets?](/what-is/what-are-kubernetes-secrets/)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/what-is-secrets-management.md` from a long, somewhat repetitive overview into a tighter SEO and AEO reference page that an engineering team can actually use. The pillar page for the secrets-management vault family; it cross-links to the four vendor-specific vault explainers (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager) and to Pulumi ESC.

## What changed

- **Opening definition** — quotable one-paragraph definition followed by a short follow-up that positions Pulumi ESC as the brokering layer above the cloud-native vaults.
- **Why it matters** — credentials are the most common breach vector, scale of secret sprawl, regulator and customer pressure.
- **What counts as a secret** — a complete taxonomy from passwords through OIDC client secrets and webhook signing keys.
- **Risk patterns** — seven recurring incident patterns (committed secrets, CI log leaks, long-lived broad-scope creds, shared creds, no audit trail, no rotation, insecure distribution).
- **Mermaid workflow diagram** — create -> store -> grant -> consume -> rotate -> audit -> revoke loop with a seven-stage explainer.
- **Tools section + comparison table** — HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, Pulumi ESC; comparison columns cover deployment model, dynamic secrets, rotation, HSM, replication, auth, pricing.
- **Best practices** — ten-item checklist that holds up across every vault.
- **CI/CD section** — OIDC federation, runtime pulls, log masking, ephemeral credentials, and how Pulumi ESC orchestrates these.
- **Compliance mapping table** — SOC 2, ISO 27001, HIPAA, PCI DSS, FedRAMP / NIST 800-53 with the specific clauses each calls out.
- **Pulumi ESC section** — composes vaults, mints dynamic OIDC creds, hierarchical environments, single audit interface.
- **FAQ** — ten doubt-removers: rotation cadence, dynamic vs static, ESC vs vault, Parameter Store vs Secrets Manager, env vars, K8s Secrets reality, migration to ESC.
- **Cross-links** — all four vendor vault pages, cloud security, SOC 2, Kubernetes Secrets.

## Test plan

- [ ] `make serve`; visit `/what-is/what-is-secrets-management/` and confirm tables, Mermaid diagram, and headings render correctly
- [ ] Spot-check cross-links: `/what-is/what-is-hashicorp-vault/`, `/what-is/what-is-aws-secrets-manager/`, `/what-is/what-is-azure-key-vault/`, `/what-is/what-is-google-cloud-secret-manager/`, `/product/esc/`, `/docs/pulumi-cloud/esc/`
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)