### PR TITLE
content(what-is): rewrite the InvalidAccessKeyId page

### DIFF
--- a/content/what-is/resolve-list-buckets-invalid-access-key-id.md
+++ b/content/what-is/resolve-list-buckets-invalid-access-key-id.md
@@ -1,70 +1,115 @@
 ---
 title: An error occurred (InvalidAccessKeyId) when calling the ListBuckets operation
 allow_long_title: true
-meta_desc: |
-     Use Pulumi ESC and dynamic credentials to run commands like aws ListBuckets in a more secure and seamless way.
+meta_desc: "The InvalidAccessKeyId error from aws s3 ls means the access key isn't recognized by AWS. The key has been deleted, deactivated, or mistyped."
 meta_image: /images/what-is/resolve-list-buckets-invalid-access-key-id-meta.png
 type: what-is
 page_title: An error occurred (InvalidAccessKeyId) when calling the ListBuckets operation
 authors: ["torian-crane"]
 ---
 
-The error message "An error occurred (InvalidAccessKeyId) when calling the ListBuckets operation" in AWS (Amazon Web Services) indicates that the provided AWS Access Key Id does not exist in their records. AWS Access Key IDs are used by AWS to authenticate and authorize access to various AWS services and resources. When you attempt an AWS CLI operation with an invalid or nonexistent Access Key ID, this error arises, as AWS cannot validate the provided identifier.
+**The `InvalidAccessKeyId` error from `aws s3 ls` means the AWS access key ID in the request does not exist in AWS's records.** The key has been deleted, deactivated, never created, or — most commonly — there's a typo or whitespace in the `AWS_ACCESS_KEY_ID` value the SDK picked up. Confirm the key with `aws iam list-access-keys`, re-export a valid one, or switch to a profile or role that produces fresh credentials.
 
-[Pulumi ESC (Environments, Secrets, and Configurations)](/docs/pulumi-cloud/esc/) offers a solution to the challenges of managing credentials and can make errors like this a thing of the past. By enabling the [management of dynamic credentials from AWS using OIDC](/blog/esc-env-run-aws/), Pulumi ESC simplifies and secures your AWS CLI operations. This approach eliminates the need for manually providing credentials and is a more secure solution than the use of long-term credentials, which can often present a security risk. Pulumi ESC also enables you to focus on your tasks without the interruption of credential-related errors, providing a more efficient flow for your AWS operations and tasks.
+In this article, we'll cover:
 
-## Using Pulumi ESC for dynamic credentials with AWS
+* What the `InvalidAccessKeyId` error means
+* What causes it
+* How to fix it in four steps
+* How to prevent it from happening again
+* Common variations and related errors
+* How Pulumi ESC eliminates manual access key management
+* Frequently asked questions
 
-[Pulumi ESC](https://www.pulumi.com/product/esc/) is a service that helps to alleviate the burden of managing cloud configuration and secrets by providing a centralized way to handle these critical aspects of cloud development. The `esc run` command of this service in particular helps to resolve concerns around how to:
+## What does this error mean?
 
-- Securely share credentials with teammates in a consistent way.
-- Minimize the risks associated with locally configured, long-lived and highly privileged credentials.
-- Ensure teams can easily and safely run commands like  without requiring deep security expertise.
+`InvalidAccessKeyId` is an AWS authentication error returned when the access key ID in a request does not match any access key registered in AWS. AWS access keys are 20-character identifiers, typically starting with `AKIA` (for IAM users) or `ASIA` (for temporary STS sessions). When AWS receives a signed request, it looks the access key ID up in its account database; if the lookup fails, the API call is rejected with this error before any S3-specific authorization is checked.
 
-## What is the esc run command?
+The error means AWS couldn't find the key at all. That's different from `SignatureDoesNotMatch` (the key exists but the secret is wrong) or `ExpiredToken` (the temporary credential is past its lifetime).
 
-The [Pulumi documentation for the `esc run` command](https://www.pulumi.com/docs/esc/cli/commands/esc_run/) states the following:
+## What causes it?
 
-> This command opens the environment with the given name and runs the given command. If the opened environment contains a top-level ’environmentVariables’ object, each key-value pair in the object is made available to the command as an environment variable.
+| Cause | Symptom | Fix |
+|---|---|---|
+| Key was deleted | Worked yesterday; nothing changed locally | Create a new key or switch profile |
+| Key was deactivated | `aws iam list-access-keys` shows `Status: Inactive` | Reactivate or rotate the key |
+| Typo or whitespace in env var | Key looks right but `echo $AWS_ACCESS_KEY_ID \| wc -c` is not 21 | Re-export the key cleanly |
+| Wrong account | Key exists, but in a different AWS account than the resource | Switch to a profile in the correct account |
+| Stale `~/.aws/credentials` | A `default` profile still holds a key from months ago | Update or remove the profile |
+| `ASIA…` key used without its session token | Temporary key works only with the matching `AWS_SESSION_TOKEN` | Export all three values together |
 
-But what does this actually mean? If we use AWS as an example, it means that we can run commands like `aws s3 ls` without the need to configure AWS credentials locally each time. It’s a significant stride towards making your cloud interactions more efficient and less error-prone, and here’s a deeper dive into why:
+## How to fix it
 
-- **Seamless Command Execution** - The `esc run` command lets you execute AWS commands effortlessly, freeing you from the intricacies of managing AWS credentials on your local machine. Simply put, it significantly reduces the overhead of credential setup and maintenance.
+Follow these steps in order. Each one is copy-pasteable.
 
-- **Enhanced Security** - One of the standout features of `esc run` is its commitment to security. By removing the local storage of credentials, it drastically reduces the risk of accidental exposure. Your credentials and secrets are securely managed within the Pulumi environment.
+1. **See what the SDK is actually using.** The credential chain is the first thing to check, because the value you think is set may not be the one the SDK picked up.
 
-- **Streamlined Collaboration** - Because credentials will be centralized, `esc run` facilitates smoother team collaboration by providing a consistent environment for all team members to run commands with. Everyone can access the same secure environment which reduces the complexities of coordinating credentials and configurations across teams.
+   ```bash
+   aws configure list
+   echo "AWS_ACCESS_KEY_ID length: ${#AWS_ACCESS_KEY_ID}"
+   ```
 
-## Getting started with esc run
+   A valid access key ID is 20 characters. Anything else points at a copy/paste issue.
 
-### Step 1: Install and login to Pulumi ESC
+1. **Confirm the key exists in AWS.** If you have working credentials for the same user (for example via the console or another profile):
 
-To begin, you’ll need to [install Pulumi ESC](/docs/install/esc/). Once the installation is complete, run the `esc login` command and follow the steps to login to the CLI.
+   ```bash
+   aws iam list-access-keys --user-name <your-user>
+   ```
 
-```bash
-$ esc login
-Manage your Pulumi ESC environments by logging in.
-Run `esc --help` for alternative login options.
-Enter your access token from https://app.pulumi.com/account/tokens
-    or hit <ENTER> to log in using your browser                   :
-Logged in to pulumi.com as …
-```
+   Compare the `AccessKeyId` values and `Status` (`Active` or `Inactive`) with what you have locally.
 
-### Step 2: Create the OIDC configuration
+1. **Rotate or re-export.** If the key is missing or inactive, create a new one and rotate. If you're using SSO or `assume-role`, log in again to refresh:
 
-Pulumi ESC offers you the ability to manually set your credentials as secrets in your Pulumi ESC environment files. When it comes to something like OIDC configuration, a more secure and efficient alternative is to leverage yet another great feature of Pulumi ESC: dynamic credentials.
+   ```bash
+   aws sso login --profile my-profile
+   ```
 
-This service can dynamically generate credentials on your behalf each time you need to interact with your AWS environments. To do so, follow the steps in the [guide for configuring OIDC between Pulumi and AWS](/docs/esc/environments/configuring-oidc/aws/). Make sure that the IAM role you create has sufficient permissions to perform S3 actions.
+   For temporary credentials, make sure all three values are exported together:
 
-### Step 3: Create a new Pulumi ESC environment
+   ```bash
+   export AWS_ACCESS_KEY_ID=ASIA...
+   export AWS_SECRET_ACCESS_KEY=...
+   export AWS_SESSION_TOKEN=...
+   ```
 
-Once OIDC has been configured between Pulumi and AWS, the next step is to create a new environment in the [Pulumi Cloud](https://app.pulumi.com/signin). Make sure that you have the correct organization selected in the left-hand navigation menu. From there, click the **Environments** link, then click the **Create environment** button. In the following pop-up, provide a name for your environment before clicking the **Create environment** button.
+1. **Verify.**
 
-{{< video title="Open environment in Pulumi ESC console" src="https://www.pulumi.com/uploads/esc-create-new-env.mp4" autoplay="true" loop="true" >}}
+   ```bash
+   aws sts get-caller-identity
+   aws s3 ls
+   ```
 
-### Step 4: Add the AWS provider integration
+   `get-caller-identity` succeeds as soon as authentication works, so it's the cleanest signal that the key is recognized.
 
-Once you’ve created your new environment, you will be presented with a split-pane document view. You’ll want to clear out the default placeholder content in the editor on the left-hand side and replace it with the following code, making sure to replace <your-oidc-iam-role-arn> with the value of your IAM role ARN from the configure OIDC step:
+## How to prevent it
+
+* **Stop using long-lived access keys for humans.** Use [IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/) (SSO) so humans get short-lived `ASIA…` credentials that are never typed or pasted.
+* **Use named profiles, not the `default`.** Mistakes happen when a stale `default` profile silently shadows your intent. Explicit `--profile` flags or `AWS_PROFILE` make the active identity obvious.
+* **Avoid keys in CI.** GitHub Actions, GitLab, and CircleCI all support OIDC into AWS; that removes long-lived keys from the runner entirely.
+* **Rotate on a schedule, not on incident.** AWS recommends rotating IAM user access keys every 90 days. Combined with key-age alerts, this prevents most "the key was deleted and nobody told me" cases.
+
+## Common variations
+
+The same root cause produces a few closely related messages:
+
+* `The AWS Access Key Id you provided does not exist in our records.`
+* `An error occurred (InvalidAccessKeyId) when calling the GetCallerIdentity operation` — same problem, surfaced earlier in the chain.
+* `InvalidAccessKeyId: The AWS Access Key Id needs a subscription for the service` — almost always the wrong AWS partition (commercial vs GovCloud vs China).
+
+The fix is always the same: prove the access key actually exists in the account you're talking to.
+
+## Related errors
+
+* [SignatureDoesNotMatch](/what-is/resolve-list-buckets-signature-does-not-match/) — the key exists, but the secret is wrong.
+* [InvalidClientTokenId](/what-is/resolve-list-buckets-invalid-client-token-id/) — the *session token* doesn't match the access key.
+* [ExpiredToken](/what-is/resolve-list-buckets-expired-token/) — the credential is valid but past its lifetime.
+* [Unable to locate credentials](/what-is/resolve-unable-to-locate-credentials/) — the SDK found no credentials at all.
+
+## How Pulumi ESC eliminates manual access key management
+
+[Pulumi ESC](/product/esc/) (Environments, Secrets, and Configurations) replaces hand-managed access keys with short-lived, OIDC-issued credentials. There's nothing to rotate, nothing to paste into `~/.aws/credentials`, and no `AKIA…` key to leak.
+
+Define the environment once:
 
 ```yaml
 values:
@@ -73,7 +118,7 @@ values:
       fn::open::aws-login:
         oidc:
           duration: 1h
-          roleArn: <your-oidc-iam-role-arn>
+          roleArn: arn:aws:iam::123456789012:role/PulumiESCRole
           sessionName: pulumi-environments-session
   environmentVariables:
     AWS_ACCESS_KEY_ID: ${aws.login.accessKeyId}
@@ -81,20 +126,43 @@ values:
     AWS_SESSION_TOKEN: ${aws.login.sessionToken}
 ```
 
-### Step 5: Run the aws CLI command
-
-With your environment set up, you can validate your configuration and verify that the error has been resolved by running the `aws s3 ls` command using `esc run` as shown below, making sure to replace `<your-pulumi-org-name>`, `<your-project-name>`, and `<your-environment-name>` with the names of your own Pulumi organization and environment respectively:
+Then run any AWS command with credentials that are always recognized by AWS:
 
 ```bash
-esc run <your-pulumi-org-name>/<your-project-name>/<your-environment-name> -i aws s3 ls --query "Buckets[].Name"
+esc run my-org/aws/dev -- aws s3 ls
 ```
 
-## Conclusion
+For Pulumi programs that need to operate across accounts, the AWS provider's [`assumeRole` configuration](/registry/packages/aws/api-docs/provider/) does the same thing inside a deployment — no static keys live in code or CI.
 
-Pulumi ESC makes it easier than ever to tame infrastructure complexity, especially when running commands like `aws s3 ls`. Because Pulumi ESC supports dynamic credentials using OIDC across AWS, Azure, and Google Cloud, you no longer have to worry about credential errors like "InvalidAccessKeyId" as the service will dynamically generate and refresh them for you. Check out the following links to learn more about Pulumi ESC today.
+## Frequently asked questions
 
-- Follow the [Getting Started](/docs/pulumi-cloud/esc/get-started) guide.
-- Read the [Documentation](/docs/pulumi-cloud/esc) for all the commands and features available.
-- Visit the [Open Source](https://github.com/pulumi/esc) repo for Pulumi ESC.
+### How do I check whether my access key still exists?
 
-Feel free to [join our community on Slack](https://slack.pulumi.com/) and let us know what you think!
+Use `aws iam list-access-keys --user-name <your-user>`. It returns every key associated with that IAM user along with its status. If your key isn't in the list, it has been deleted.
+
+### What's the difference between `AKIA` and `ASIA` keys?
+
+`AKIA…` keys belong to IAM users and are long-lived; `ASIA…` keys are temporary, issued by STS for an `assume-role`, SSO, or federated session. `ASIA…` keys must always be paired with the matching `AWS_SESSION_TOKEN`. Using one without the other produces this error or `InvalidClientTokenId`.
+
+### Could this be a region problem?
+
+Generally no. `InvalidAccessKeyId` is about identity, not region. The most common region-adjacent variant is the GovCloud/commercial mix-up: a commercial-region key cannot authenticate against `aws-us-gov` endpoints, and the API returns this error.
+
+### Does this happen with EC2 instance roles?
+
+Rarely, and usually as a side effect of a stale local profile. If `AWS_PROFILE` or `AWS_ACCESS_KEY_ID` is set in the shell, the SDK uses those instead of the instance metadata role. Unset them and the instance role takes over.
+
+### Why do I get this after a key rotation?
+
+Because the old key was deleted while a long-running process or terminal was still holding it. Restart the process and re-export the new key. CI pipelines often hit this when only the secrets manager was updated but not the deployed runner.
+
+### Can I tell from the error message which account the key was supposed to be in?
+
+No. AWS deliberately does not echo the access key back in the response, and it does not say which account was queried. Use `aws sts get-caller-identity` once you have working credentials to confirm the account ID.
+
+## Learn more
+
+* [Pulumi ESC documentation](/docs/pulumi-cloud/esc/)
+* [Configuring OIDC between Pulumi ESC and AWS](/docs/esc/environments/configuring-oidc/aws/)
+* [AWS provider reference](/registry/packages/aws/api-docs/provider/)
+* [AWS IAM access key best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/resolve-list-buckets-invalid-access-key-id.md` for SEO and AEO. The page now leads with a direct, citable answer that explains the error precisely (the key isn't in AWS's records) and walks through the diagnostic steps a real engineer takes.

## What changed

- **Opening direct answer** — bold one-paragraph definition, with the canonical fix path (`aws iam list-access-keys`).
- **"In this article, we'll cover"** lead-in for navigability.
- **Causes table** — six common sources mapped to symptom and fix, including `AKIA` vs `ASIA` key confusion and GovCloud partition mismatch.
- **Numbered fix steps** — inspect SDK chain, confirm key exists, rotate or re-export, verify with `aws sts get-caller-identity`.
- **Prevention section** — SSO over long-lived keys, named profiles, OIDC in CI, 90-day rotation.
- **Common variations** — closely related error strings collected so the page can rank for the long-tail forms.
- **Related errors cross-links** — sibling resolve-* pages for the credential-error family.
- **Pulumi ESC section** — YAML environment example plus `esc run`; brief reference to `aws:assumeRole` for in-program use.
- **FAQ** — six doubt-removers: key existence checks, `AKIA` vs `ASIA`, region/partition mistakes, EC2 instance role interplay, key rotation timing, account-ID disclosure.
- **Strengthened `meta_desc`** to lead with the direct answer, well under 160 chars.

## Test plan

- [ ] `make serve`; visit `/what-is/resolve-list-buckets-invalid-access-key-id/` and confirm the page renders with table, code blocks, and cross-links intact.
- [ ] Spot-check links to sibling resolve-* pages and to `/docs/pulumi-cloud/esc/` and `/docs/esc/environments/configuring-oidc/aws/`.
- [ ] CI lint + pinned review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)