### PR TITLE
content(what-is): expand the infrastructure as code explainer

### DIFF
--- a/content/what-is/what-is-infrastructure-as-code.md
+++ b/content/what-is/what-is-infrastructure-as-code.md
@@ -1,7 +1,6 @@
 ---
 title: "What is Infrastructure as Code (IaC)?"
-meta_desc: |
-    Infrastructure as code (IaC) provisions cloud infrastructure with code instead of consoles. Learn how IaC works, declarative vs. imperative, and top tools.
+meta_desc: "Infrastructure as code (IaC) provisions cloud resources from machine-readable files. Learn how IaC works, declarative vs. imperative, top tools, and benefits."
 meta_image: /images/what-is/what-is-infrastructure-as-code-meta.png
 type: what-is
 page_title: "What is Infrastructure as Code (IaC)?"
@@ -10,9 +9,9 @@ aliases:
 authors: ["zack-chase"]
 ---
 
-**Infrastructure as code (IaC) is the practice of provisioning and managing computing infrastructure with machine-readable configuration files instead of clicking through a console or running one-off scripts.** You write code that describes the infrastructure you want, check it into Git, and let an IaC engine make the real world match what you've declared.
+**Infrastructure as code (IaC) is the practice of provisioning and managing computing infrastructure with machine-readable configuration files instead of clicking through a console or running one-off scripts.** You write code that describes the infrastructure you want, check it into Git, and let an IaC engine reconcile the real world with what you've declared.
 
-The idea is to treat infrastructure the way software engineers already treat application code. Version control, code review, testing, and CI/CD all become available to whoever is provisioning a VPC or a Kubernetes cluster. Modern platforms like [Pulumi](/) take it a step further by letting you write that code in TypeScript, Python, Go, C#, Java, or YAML rather than a custom configuration language.
+IaC brings infrastructure into the same workflow that software engineers already use for application code: version control, code review, testing, and CI/CD. Modern platforms like [Pulumi](/) take it a step further by letting you write that code in TypeScript, JavaScript, Python, Go, C#, Java, or YAML rather than a custom configuration language.
 
 In this article, we'll cover the key questions about infrastructure as code:
 
@@ -23,38 +22,33 @@ In this article, we'll cover the key questions about infrastructure as code:
 * What benefits does infrastructure as code provide?
 * What are common use cases for infrastructure as code?
 * What are the most popular infrastructure as code tools?
-* How do you get started with infrastructure as code?
+* How do I get started with infrastructure as code?
 * Frequently asked questions about IaC
-
-Let's start with why infrastructure as code matters.
 
 ## Why is infrastructure as code important?
 
-IaC is important because of three significant trends, all of them happening at the same time.
+IaC is important because of three trends, all of them happening at the same time.
 
 ### The transition to the cloud
 
-One trend, of course, is the ongoing transition to the cloud. More and more companies are shifting workloads from on-premises infrastructure to cloud environments.
+The first is the ongoing transition from on-premises infrastructure to the cloud. The term "cloud" is broader than it first sounds — it includes:
 
-It's worth mentioning the scope of this transition. The term "cloud environments" is more far-reaching than many may realize. Hyperscaler clouds like AWS or Microsoft Azure may be the first to come to mind, but there is so much more to cloud infrastructure:
+* Hyperscaler clouds such as AWS, Microsoft Azure, and Google Cloud
+* Regional clouds such as Alibaba Cloud or OVHcloud
+* Specialized providers (DigitalOcean, Linode, Civo, etc.)
+* Private cloud running in on-premises data centers (VMware vSphere, OpenStack, Nutanix)
+* SaaS infrastructure companies such as Cloudflare, Snowflake, Confluent, Datadog, and New Relic
+* Other cloud-managed assets like Auth0, GitHub, or GitLab
 
-* Regional clouds, like Alibaba Cloud
-* Specialized cloud providers
-* Private cloud technologies running in on-premises data centers, such as VMware vSphere
-* Modern SaaS infrastructure companies such as Cloudflare, Snowflake, Confluent, Datadog, New Relic, and many others
-* Other cloud-based assets like Auth0, GitLab, or GitHub
-
-All these cloud environments can be provisioned or managed via APIs, and, as a result, can be managed with infrastructure as code tools.
+All of these are managed through APIs, which is what makes them addressable by IaC tools.
 
 ### Cloud modernization
 
-The second trend is cloud modernization. At first glance this may seem redundant with the first trend, which is the ongoing transition to the cloud. However, after organizations transition to the cloud, they tend to look for opportunities to maximize the value they get from their cloud environment. This frequently involves adopting technologies such as serverless, containers and Kubernetes. In some cases, cloud modernization involves using managed services to offload some of the heavy lifting to the cloud provider. In other cases, cloud modernization means more use of ephemeral, stateless workloads that exist only for a short while, and then need to be decommissioned. When applied correctly, all these approaches enable teams to deliver value more quickly. These technologies and services generally require a more granular management of infrastructure. Stitching together all the primitives that the cloud provider offers into solutions that serve the business is a great fit for IaC.
+The second trend is what most organizations do *after* they've moved to the cloud. They start adopting serverless, containers and Kubernetes, managed services, and ephemeral workloads in order to extract more value from the cloud and ship faster. Those modern architectures require fine-grained management of many small infrastructure primitives stitched together — exactly the workload IaC is built for.
 
 ### Frequent infrastructure changes
 
-Finally, the rate of change for a company's infrastructure is increasing. Part of this increase in the rate of change is due to cloud adoption and cloud modernization. There is a third reason, though: organizations are finding that they can move faster if they take advantage of the fundamental elasticity of the cloud.
-
-For teams managing tens or hundreds of cloud resources that change once every few months, managing infrastructure using scripts or via interactive means (such as using a UI or a CLI) might still be possible. More commonly, teams are finding themselves managing thousands or tens of thousands of resources that change daily or even hourly. Embracing automation via infrastructure as code is the only way to take control of that kind of complexity.
+The third trend is the increasing rate of change. Teams that managed tens of resources changing every few months could get by with scripts and consoles. Teams now routinely manage thousands or tens of thousands of resources that change daily or hourly. At that scale, manual processes don't work; IaC is the only practical way to keep the system consistent.
 
 ## How did infrastructure as code evolve?
 
@@ -64,25 +58,25 @@ Infrastructure as code didn't emerge all at once. It's the latest step in a long
 
 Most teams have moved through some or all of the following stages of automation as their infrastructure footprint has grown:
 
-1. **Manual point-and-click in a UI console.** Quick to start with and useful for exploration, but completely manual: every recovery, scale-up, or environment clone repeats the same painful sequence of clicks.
-1. **CLI commands or direct API calls.** Each UI step can be translated into a CLI invocation or HTTP request. Procedures become easier to document, but they remain step-based and brittle.
-1. **Shell scripts.** Capturing those commands in a script is a real jump in repeatability: scripts can be checked into version control. The downside is fragility: a failure halfway through a script often leaves infrastructure in an unknown state, and every upgrade path has to be reasoned about by hand.
-1. **SDK-driven code.** Using a cloud provider's SDK in a general-purpose language adds first-class error handling, logging, and debugging. It still suffers from the same partial-failure and combinatorial-upgrade problems as scripting.
-1. **Infrastructure as code.** Instead of describing the steps required to reach a desired state, you declare the state itself, and an engine figures out how to get there. The engine understands resource lifetime, computes a plan, and reconciles the real world with the declared state, recovering from partial failures along the way.
+1. **Manual point-and-click in a UI console.** Quick to start with, but every recovery, scale-up, or environment clone repeats the same painful sequence of clicks.
+1. **CLI commands or direct API calls.** Each UI step can be translated into a CLI invocation or HTTP request. Procedures become easier to document but remain step-based and brittle.
+1. **Shell scripts.** Capturing those commands in a script is a real jump in repeatability. The downside is fragility: a failure halfway through a script often leaves infrastructure in an unknown state.
+1. **SDK-driven code.** Using a cloud provider's SDK in a general-purpose language adds error handling, logging, and debugging, but the partial-failure and combinatorial-upgrade problems remain.
+1. **Infrastructure as code.** Instead of describing the steps required to reach a desired state, you declare the state itself, and an engine figures out how to get there.
 
-This last step is what makes IaC qualitatively different from the approaches that came before it. Earlier tools described _how_ to change infrastructure; IaC tools describe _what_ the infrastructure should look like and let a deterministic engine handle the rest.
+That last step is qualitatively different from everything before. Earlier tools described *how* to change infrastructure; IaC tools describe *what* the infrastructure should look like and let a deterministic engine handle the rest.
 
 ### From pets to cattle
 
-Two parallel shifts changed the kind of infrastructure that IaC needed to manage. The first was the move from mutable to immutable infrastructure, popularly described as the move ["from pets to cattle"](https://www.engineyard.com/blog/pets-vs-cattle/). In the early cloud era, each server was special: it was patched in place, mourned when it failed, and treated like a pet. Today, most infrastructure is managed as fleets of interchangeable resources that are replaced rather than upgraded, with cluster managers and serverless control planes handling scaling, fault tolerance, and traffic routing automatically.
+In the early cloud era, each server was special: patched in place, mourned when it failed, and treated like a pet. Today, most infrastructure is managed as fleets of interchangeable resources that are replaced rather than upgraded, with cluster managers and serverless control planes handling scaling, fault tolerance, and traffic routing automatically. This is the well-known shift ["from pets to cattle"](https://www.engineyard.com/blog/pets-vs-cattle/), and it changed the kind of infrastructure IaC needed to manage.
 
 ### From configuration to provisioning
 
-The second shift was a change in what IaC tools were _for_. Early tools such as CFEngine, Puppet, Chef, Ansible, and SaltStack were built for the "two VMs and a database" world, where the central problem was configuring and patching long-lived servers after they had been created (often manually). Modern provisioning-oriented tools like [Pulumi](/) target a wider range of cloud resources (containers, serverless functions, managed databases, queues, networks, and identity) and treat the creation, update, and replacement of those resources as the primary workflow. Configuration-style work still happens, but mostly inside immutable images and container builds rather than against running servers.
+The second shift was what IaC was *for*. Earlier tools like CFEngine, Puppet, Chef, Ansible, and SaltStack targeted the "two VMs and a database" world, where the central problem was configuring and patching long-lived servers. Modern provisioning-oriented tools like [Pulumi](/) target a wider range of cloud resources (containers, serverless functions, managed databases, queues, networks, identity) and treat the creation, update, and replacement of those resources as the primary workflow.
 
 ### From a couple of VMs to thousands of resources
 
-Older "infrastructure" was static and slow-moving: an N-tier app on a couple of VMs and a database, with new capacity requested through a ticket and delivered weeks later. Modern systems routinely span dozens or hundreds of cloud resources (microservices, clusters, registries, networks, security policies, secrets, load balancers, serverless functions, queues, data stores, hosted AI/ML services) across many environments. That growth in moving pieces is what makes infrastructure as code essential rather than optional: at this scale, no team can manage the cloud safely by clicking through a console.
+Older infrastructure was static and slow-moving. Modern systems routinely span dozens or hundreds of cloud resources (microservices, clusters, networks, security policies, secrets, load balancers, serverless functions, queues, data stores, hosted AI/ML services) across many environments. That growth in moving pieces is what makes IaC essential rather than optional.
 
 ## Declarative vs. imperative infrastructure as code
 
@@ -100,29 +94,32 @@ Most IaC tools fall into one of two camps: declarative or imperative.
 | Best for | Cloud resource lifecycle management | One-off automation, glue scripts |
 | Examples | Pulumi, Terraform, CloudFormation, Bicep | Bash, cloud SDKs, Ansible playbooks |
 
-Declarative is the more common style for cloud infrastructure because the lifecycle is messy. Changes happen constantly, deployments fail halfway through, multiple teams update the same resources, and drift creeps in. Solving those problems imperatively means writing a lot of bookkeeping code that the tool ought to handle for you. Pulumi is declarative under the hood but lets you write the declarations in a real programming language, so loops, conditionals, abstractions, and unit tests are all available without giving up the deterministic deployment engine. For a side-by-side, see [how Pulumi compares to other IaC tools](/docs/iac/comparisons/).
+Declarative is the more common style for cloud infrastructure because the lifecycle is messy. Changes happen constantly, deployments fail halfway through, multiple teams update the same resources, and drift creeps in. Solving those problems imperatively means writing a lot of bookkeeping code that the tool ought to handle for you. Pulumi is declarative under the hood but lets you write the declarations in a real programming language, so loops, conditionals, abstractions, and unit tests are all available without giving up the deterministic deployment engine.
 
 ## What are the key elements of infrastructure as code?
 
-The key elements of infrastructure as code are the same key elements you'd find in the majority of software engineering environments. These include:
+A real IaC practice depends on a few moving parts working together:
 
-1. **An infrastructure as code mechanism:** For all practical purposes, in order to do infrastructure as code you need a tool or engine that is responsible for translating the IaC instructions into something the cloud provider APIs understand and can use. Infrastructure as code tools may be provided by and limited to a single cloud provider (AWS CloudFormation is one example), or may support multiple cloud providers. Tools may be limited to supporting YAML or JSON; may require the use of a specialized and proprietary domain-specific language (DSL); or may support the use of general purpose programming languages such as TypeScript/JavaScript, C#, Go, Python, and Java.
-1. **Version control:** When infrastructure is described as code, it can be checked into source control, versioned and code-reviewed using existing software engineering practices. Version control systems, like [GitHub](https://github.com/), [GitLab](https://about.gitlab.com/), or [BitBucket](https://bitbucket.org/), enable you to see _what_ changes were made, _when_ the changes were made, and _who_ made the changes.
-1. **Tests:** As any critical system grows in complexity, people can start to feel nervous about making changes. With infrastructure as code, teams can write tests for their infrastructure to ensure its correctness. They can encode policies so that all provisioned infrastructure and its configurations [are compliant](/docs/iac/guides/testing/property-testing/). Once they're tested, infrastructure components can be reusable pieces of code that capture best practices and that can be shared across teams. No more reinventing the wheel.
-1. **CI/CD pipelines:** Assuming the infrastructure as code tool supports the functionality (most do), changes to infrastructure---found in changes to the code that defines the infrastructure---can be deployed using existing CI/CD tools, much in the same way CI/CD pipelines automatically build and deploy other forms of software.
+1. **An IaC engine.** A tool that translates IaC programs into cloud-API calls, computes plans, and reconciles state. Some are limited to a single cloud (AWS CloudFormation) and a fixed language (YAML or JSON); others, like [Pulumi](/), support multi-cloud and multiple general-purpose programming languages.
+1. **Version control.** When infrastructure lives in code, every change is reviewable: who changed what, when, and why. Systems like GitHub, GitLab, or Bitbucket let you treat infrastructure changes with the same discipline as application changes.
+1. **Tests.** As critical systems grow, untested changes get scary. With IaC you can write [unit, integration, and property tests](/docs/iac/guides/testing/) for your infrastructure and encode policies that block non-compliant changes.
+1. **CI/CD pipelines.** Changes to IaC code can flow through the same CI/CD systems that build and deploy application code, with previews, gating tests, and automated rollback.
+1. **Policy as code.** Security, compliance, and cost rules expressed as code that runs against every change. [Pulumi Policies](/docs/insights/policy/) blocks non-compliant configurations in CI before they reach production.
+1. **Secrets and configuration.** Centrally managed, encrypted secrets and environment-specific configuration. [Pulumi ESC](/product/esc/) gives every application, CI job, and IaC program a single audited interface to pull from.
 
 ## What benefits does infrastructure as code provide?
 
-Infrastructure as code tames the complexity of cloud infrastructure because it uses the same software engineering principles, approaches, and tools that have enabled other software-based systems to scale up. Here are some of the benefits infrastructure as code provides.
+IaC tames the complexity of cloud infrastructure by applying the same software-engineering principles that already work for application code:
 
-* **Repeatability and consistency**: Infrastructure that is defined via IaC can be deployed in a highly repeatable fashion. Do you need a development environment that is a high fidelity copy of the production environment? Or do you need to ensure that infrastructure is deployed the same across multiple regions? This is easily accomplished with infrastructure as code.
-* **Accountability**: Changes to the infrastructure can be easily tracked via the use of version control with your infrastructure as code files.
-* **Improved productivity**: Most developers have an integrated development environment (IDE) that they use all the time. When infrastructure is code, you can take advantage of all the features that an IDE offers, such as autocompletion and the ability to look up methods and their parameters.
-* **Better alignment among teams**: Infrastructure as code enables infrastructure teams and software development teams to adopt DevOps principles and work together more closely. When infrastructure is code and is integrated into your company's software lifecycle, there's a common language and a common set of practices that stakeholders already understand. That common understanding fosters cross-team collaboration, which is fundamental to DevOps.
+* **Repeatability and consistency.** Stand up identical development, staging, and production environments from the same code, varying only configuration and sizing. Multi-region deployments become a loop, not a copy-paste exercise.
+* **Accountability.** Every change is a commit. Version control answers "who changed what" without forensic effort.
+* **Improved productivity.** When infrastructure is code, you get autocompletion, refactoring, jump-to-definition, and other IDE features. With Pulumi, you also get the full ecosystem of your chosen language: package managers, testing frameworks, linters, and existing libraries.
+* **Faster recovery.** Re-provision an entire environment in another region or account from versioned code instead of rebuilding by hand.
+* **Better cross-team alignment.** [DevOps](/what-is/what-is-devops/) and [platform engineering](/what-is/what-is-platform-engineering/) both rely on IaC as a common substrate. When infrastructure speaks the same language as the app, the teams responsible for them collaborate more naturally.
 
 ## What are common use cases for infrastructure as code?
 
-IaC shows up across a lot of cloud workflows, but a few patterns account for most of the adoption:
+IaC shows up across a lot of cloud workflows, but a few patterns account for most adoption:
 
 1. **Provisioning cloud environments.** Stand up identical development, staging, and production environments from the same code, varying only config values and sizing. A fresh AWS or Azure account can go from empty to fully provisioned in minutes.
 1. **Multi-cloud and hybrid setups.** Manage AWS, Azure, Google Cloud, on-premises VMware, and SaaS providers like Cloudflare, Snowflake, or Datadog through one workflow instead of juggling separate consoles.
@@ -131,77 +128,75 @@ IaC shows up across a lot of cloud workflows, but a few patterns account for mos
 1. **Disaster recovery.** Re-provision a complete environment in a different region or account from versioned code, rather than rebuilding individual resources by hand.
 1. **Policy and compliance.** Encode security, cost, and architectural rules as [policy as code](/docs/insights/policy/) and have every deployment checked against them automatically.
 1. **Platform engineering.** Platform teams package vetted infrastructure patterns as reusable [components](/docs/iac/concepts/components/) that product teams consume through a standard interface.
-1. **Ephemeral environments.** Spin up short-lived environments for pull request previews, load tests, or customer demos, then tear them down when you're done.
+1. **Ephemeral environments.** Spin up short-lived environments for pull-request previews, load tests, or customer demos, then tear them down when you're done.
 
 ## What are the most popular infrastructure as code tools?
 
-The IaC tooling landscape has grown a lot since CFEngine kicked off the category back in 1993. The tools you're most likely to encounter today:
+The IaC tooling landscape has grown a lot since CFEngine kicked off the category back in 1993. The tools you're most likely to encounter today fall into a few clear categories.
 
-* **[Pulumi](/)** is declarative IaC written in general-purpose programming languages: TypeScript, Python, Go, C#, Java, or YAML. It supports [200+ cloud and SaaS providers](/registry/), including AWS, Azure, Google Cloud, Kubernetes, Cloudflare, Snowflake, and Datadog.
-* **Terraform** is HashiCorp's tool. It uses the HashiCorp Configuration Language (HCL) and moved to a source-available BUSL license in 2023.
-* **OpenTofu** is an open-source fork of Terraform under the Linux Foundation, started in response to that license change.
-* **AWS CloudFormation** is AWS's native IaC service. It's declarative, written in YAML or JSON, and is focused on AWS resources.
-* **AWS CDK** sits on top of CloudFormation and lets you generate templates from TypeScript, Python, Java, C#, or Go.
-* **Azure Resource Manager (ARM) and Bicep** are Azure's native equivalents. Bicep is the modern DSL that compiles down to ARM JSON.
-* **Google Cloud Deployment Manager** is Google Cloud's native option, using YAML and Python templates.
-* **Ansible** started life as a configuration management tool and is often used procedurally to manage long-lived servers. It's owned by Red Hat.
-* **Chef and Puppet** are earlier-generation configuration management tools focused on the state of running servers.
+| Tool | Language | Cloud coverage | License | Notes |
+|---|---|---|---|---|
+| **[Pulumi](/)** | TypeScript, JavaScript, Python, Go, C#, Java, YAML | 200+ providers, multi-cloud and SaaS | Apache 2.0 | Real programming languages on a declarative engine. |
+| **Terraform** | HCL | Large multi-cloud ecosystem | BUSL 1.1 (source-available since 2023) | The category's incumbent. |
+| **OpenTofu** | HCL | Same provider ecosystem as Terraform | MPL 2.0 | Linux Foundation-hosted fork of Terraform. |
+| **AWS CloudFormation** | YAML, JSON | AWS only | AWS-managed | Native AWS, no multi-cloud. |
+| **AWS CDK** | TypeScript, Python, Java, C#, Go | AWS (compiles to CloudFormation) | Apache 2.0 | Generates CloudFormation templates from code. |
+| **Azure ARM / Bicep** | JSON / Bicep DSL | Azure only | Microsoft-managed | Bicep is the modern DSL that compiles to ARM JSON. |
+| **Google Cloud Deployment Manager** | YAML, Python templates | Google Cloud only | Google-managed | Google Cloud's native option. |
+| **Ansible** | YAML | Cross-platform (config-management oriented) | GPLv3 | Often used procedurally; Red Hat-owned. |
+| **Chef, Puppet** | Ruby DSLs | Server configuration | Various | Earlier-generation configuration management. |
 
-To see how Pulumi compares head-to-head, take a look at [Pulumi vs. Terraform](/docs/iac/comparisons/terraform/), [Pulumi vs. CloudFormation](/docs/iac/comparisons/cloudformation/), or the full [comparisons index](/docs/iac/comparisons/).
+To see how Pulumi compares head-to-head, see [Pulumi vs. Terraform](/docs/iac/concepts/vs/terraform/), [Pulumi vs. CloudFormation](/docs/iac/concepts/vs/cloudformation/), [Pulumi vs. CDK](/docs/iac/concepts/vs/cloud-template-transpilers/), or the full [comparisons index](/docs/iac/concepts/vs/).
 
 ## How do I get started with infrastructure as code?
 
-Bringing IaC into a startup or a company with many greenfield applications may not be difficult. For most companies, however, it's not so straightforward. Many companies, both large and small, have a lot of infrastructure that was created by "pointing and clicking" in the console of a cloud provider. Perhaps, over time, someone wrote a run book or created a wiki that describes how to use a cloud provider's console to perform some common task. Maybe even there are Bash or PowerShell scripts, used to manage infrastructure, that are floating around that only one or two people know about (and possibly aren't even being maintained!). What do you do if that's your situation?
-
-Here are steps you can take to get started adopting infrastructure as code.
+Most teams aren't starting from a blank slate. They have legacy services, hand-built environments, half-automated pipelines, and a backlog of incidents. Adopting IaC doesn't have to be a big-bang reorg — it works best as an incremental shift.
 
 ### Define "good"
 
-The first step, even before you begin to [evaluate tools and approaches](/blog/configuring-your-dev-environment/), is to define what "good" looks like to your company. Achieving that ideal doesn't depend on which technology you use. It depends on understanding your company's requirements and what assumptions will remain true regardless of the tools you use. For many companies those assumptions are:
+Before evaluating tools, define what good infrastructure management looks like for your organization. Most teams converge on a similar set of assumptions:
 
 * The amount of infrastructure is going to be high.
 * The number of interconnections between managed services will be high.
-* The rate of change should be high, in order to take maximum advantage of what your cloud provider(s) offer.
+* The rate of change should be high, to take maximum advantage of the cloud's elasticity.
 * The number of people who have access to your cloud's capabilities should grow.
 * Infrastructure code should be integrated into your continuous delivery system.
 
-A team made up of all the stakeholders is one way to define what your company wants to achieve with its cloud infrastructure.
+Get stakeholders from infrastructure, security, and application teams in a room to agree on these before picking a tool.
 
 ### Import existing infrastructure
 
-You probably already have a lot of existing infrastructure. Make sure you can [import that existing infrastructure](/docs/iac/adopting-pulumi/) into your new world. For example, you might have a production database that you want to manage as infrastructure as code. Your tool should let you reliably manage state changes, let you make changes without any downtime, let you test and version those changes, preview the changes, and get pull requests.
+You probably already have a lot of cloud resources that were created by clicking around or running scripts. The right IaC tool should let you [import existing infrastructure](/docs/iac/adopting-pulumi/) without tearing it down and rebuilding. Pulumi's [`pulumi import`](/docs/iac/adopting-pulumi/import/) can pull in individual resources, or import many resources at once from a JSON manifest.
 
 ### Integrate with existing engineering practices
 
-Assuming your infrastructure code is integrated with your continuous delivery pipeline, you can start instituting the same best practices you use with your application software. For example, to understand your infrastructure's correctness, [you'll need tests](/docs/iac/guides/testing/). Some tests should run before delivering the infrastructure to ensure that the program is logically correct and that it provisions the infrastructure correctly. Other tests should run when you deploy your infrastructure to ensure that the deployment was successful.
+Once your IaC code is in a Git repository, hook it into the same CI/CD system that runs your application tests. Add [infrastructure tests](/docs/iac/guides/testing/), policy checks, and a preview step so reviewers see exactly what's about to change.
 
 ### Think about policies and security
 
-Next, you'll want to enforce policy for the entire organization. That way, you'll have a standard that applies to everyone who builds infrastructure. [Those policies should run against everything anyone does](/blog/benefits-of-policy-as-code/).
-
-It's important to plan policies and security because one of the goals of infrastructure as code is to empower the development teams and give them as much flexibility as possible. Without planning, you may find that you'll create an interface that's so restrictive, teams find ways to go around the platforms. It's a balancing act that requires input from everyone.
+Layer in [policy as code](/docs/insights/policy/) so security and compliance rules are enforced automatically rather than reviewed manually. Aim for guardrails that are the default path, not gates that developers route around.
 
 ### Start small
 
-Any time you make a significant change in technology, you want to do it incrementally. You might start with a new service so you don't disrupt existing ones. Once you've figured out what successful patterns look like, go back and figure out how to transform some existing infrastructure. Pick a project where you'll start seeing value early and then iterate.
+Pick a single service or value stream, move it to IaC, measure the impact, and use what you learn as the template for the next one. A working slice of IaC for one team beats a half-finished platform across the whole org.
 
 ## Frequently asked questions about infrastructure as code
 
 ### What is infrastructure as code in simple terms?
 
-It's the practice of describing your cloud setup, such as servers, networks, databases, and security policies, in files that a tool can read and apply. You check those files into version control, and the tool keeps your real infrastructure in sync with what's described.
+It's the practice of describing your cloud setup — servers, networks, databases, IAM policies, secrets — in files that a tool can read and apply. You check those files into version control, and the tool keeps your real infrastructure in sync with what's described.
 
 ### What is the difference between infrastructure as code and configuration management?
 
-IaC provisions and manages the lifecycle of cloud resources themselves: a VM, a Kubernetes cluster, a load balancer. Configuration management tools like Chef, Puppet, and Ansible were originally about configuring software *inside* servers that already existed. As more workloads have moved into immutable images and containers, most of that configuration work has shifted into the image build, leaving IaC as the primary discipline for runtime infrastructure.
+IaC provisions and manages the lifecycle of cloud resources themselves: a VM, a Kubernetes cluster, a load balancer. [Configuration management](/what-is/what-is-configuration-management/) tools like Chef, Puppet, and Ansible were originally about configuring software *inside* servers that already existed. As more workloads have moved into immutable images and containers, most of that configuration work has shifted into the image build, leaving IaC as the primary discipline for runtime infrastructure.
 
 ### Is infrastructure as code the same as DevOps?
 
-No. DevOps is a broader culture and set of practices for delivering software; IaC is one of the technical practices that makes DevOps work. What IaC contributes specifically is bringing infrastructure into the same pull-request, code-review, and CI/CD workflows that developers already use for application code.
+No. [DevOps](/what-is/what-is-devops/) is a broader culture and set of practices for delivering software; IaC is one of the technical practices that makes DevOps work. IaC specifically brings infrastructure into the same pull-request, code-review, and CI/CD workflows that developers already use for application code.
 
 ### What languages are used for infrastructure as code?
 
-Most tools have their own. Terraform and OpenTofu use HCL, CloudFormation uses YAML or JSON, and Bicep is a DSL for Azure. Pulumi is the outlier in supporting general-purpose languages: TypeScript, Python, Go, C#, Java, or YAML.
+Most tools have their own. Terraform and OpenTofu use HCL, CloudFormation uses YAML or JSON, and Bicep is a DSL for Azure. Pulumi is the outlier in supporting general-purpose languages: TypeScript, JavaScript, Python, Go, C#, Java, or YAML.
 
 ### Which infrastructure as code tool should I use?
 
@@ -215,18 +210,34 @@ Yes. Every major IaC tool supports importing resources that already exist, so yo
 
 No. IaC works against anything with an API, which includes public cloud (AWS, Azure, Google Cloud), private cloud (VMware vSphere, OpenStack), Kubernetes, and SaaS platforms like Cloudflare, Snowflake, Datadog, or GitHub.
 
+### How does IaC handle secrets?
+
+Good IaC tools encrypt secrets in state and let you pull them at runtime from a centralized store rather than embedding them in code or CI variables. Pulumi encrypts secrets in state with a key you control and integrates with [Pulumi ESC](/product/esc/) for cross-environment secret and configuration management.
+
+### Is infrastructure as code mature enough for production?
+
+Yes, and has been for years. Hyperscalers, financial-services firms, governments, and the largest SaaS platforms run their production cloud footprints on IaC tools. The category that started with CFEngine in the early 1990s is now the default way to manage cloud infrastructure at any meaningful scale.
+
+### How does IaC relate to GitOps?
+
+GitOps is an operational pattern in which Git is the source of truth for declared state and a controller continuously reconciles the cluster or cloud with that state. IaC is what produces those declarations in the first place. The two are complementary: most GitOps workflows are reconciling resources that IaC programs originally defined.
+
 ## Another look at infrastructure as code
 
-Pulumi's YouTube series, A Quick Bite of Cloud Engineering, tackled the topic of infrastructure as code (IaC) in this video. Have a look!
+Pulumi's YouTube series, A Quick Bite of Cloud Engineering, tackled the topic of infrastructure as code (IaC) in this video. Have a look.
 
 {{< youtube "WhWf48kcEXU?rel=0" >}}
 
 ## Learn more
 
-Pulumi offers a truly modern approach to infrastructure as code. With Pulumi, you can create, deploy, and manage infrastructure on any cloud using the programming languages and tools you already know. [Get started today](/docs/get-started/).
+Pulumi offers a modern approach to IaC that lets you create, deploy, and manage infrastructure on any cloud using the programming languages and tools you already know. [Get started today](/docs/iac/get-started/).
 
-There are many other practices related to infrastructure as code, read more:
+Related reading:
 
-* [What is Secrets Management?](/what-is/what-is-secrets-management)
-* [What is Platform Engineering?](/what-is/what-is-platform-engineering)
-* [What is Infrastructure as Software?](/what-is/what-is-infrastructure-as-software)
+* [What is Pulumi?](/what-is/what-is-pulumi/)
+* [What is DevOps?](/what-is/what-is-devops/)
+* [What is Platform Engineering?](/what-is/what-is-platform-engineering/)
+* [What is CI/CD?](/what-is/what-is-ci-cd/)
+* [What is Configuration Management?](/what-is/what-is-configuration-management/)
+* [What is Secrets Management?](/what-is/what-is-secrets-management/)
+* [What is Infrastructure as Software?](/what-is/what-is-infrastructure-as-software/)


### PR DESCRIPTION
## Summary

Rewrites \`content/what-is/what-is-infrastructure-as-code.md\` for SEO and AEO. Tightens the existing explainer, replaces the prose-only \"popular tools\" list with a structured comparison table, adds a deeper FAQ, and modernizes the opening definition and cross-links.

## What changed

- **Opening definition** — bolded, quotable one-paragraph definition kept up front, with a tighter context paragraph below.
- **Strengthened meta_desc** — now a quotable one-liner under 160 chars.
- **Why IaC matters** — three forces (cloud transition, modernization, rate of change) restructured as scannable H3s with concrete examples.
- **How IaC evolved** — five-step automation maturity list, plus three narrative shifts (pets to cattle, configuration to provisioning, scale).
- **Declarative vs. imperative table** — kept intact; trimmed surrounding prose.
- **Key elements** — six numbered elements (engine, version control, tests, CI/CD, policy as code, secrets/config) with cross-links to \`/docs/iac/guides/testing/\`, \`/docs/insights/policy/\`, and \`/product/esc/\`.
- **Benefits** — focused on five concrete benefits, each tied to a specific engineering practice.
- **Common use cases** — eight numbered patterns covering provisioning, multi-cloud, Kubernetes, CI/CD, DR, policy/compliance, platform engineering, ephemeral envs.
- **Tools table** — replaces the bullet list with a 9-row table covering language, cloud coverage, license, and notes for Pulumi, Terraform, OpenTofu, CloudFormation, CDK, ARM/Bicep, Deployment Manager, Ansible, Chef/Puppet.
- **Getting started** — five-step adoption path: define good, import, integrate with CI/CD, policies, start small.
- **FAQ** — 10 doubt-removers including new ones on GitOps, secrets handling, and production maturity.
- **Cross-links** — Pulumi, DevOps, platform engineering, CI/CD, configuration management, secrets management, infrastructure as software.

## Test plan

- [ ] \`make serve\`; visit \`/what-is/what-is-infrastructure-as-code/\` and confirm both tables, the YouTube embed, and headings render
- [ ] Spot-check cross-links (\`/what-is/what-is-pulumi/\`, \`/what-is/what-is-devops/\`, \`/docs/iac/concepts/vs/terraform/\`, \`/docs/iac/adopting-pulumi/import/\`)
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)