### PR TITLE
content(what-is): expand the Docker Configs explainer

### DIFF
--- a/content/what-is/what-are-docker-configs.md
+++ b/content/what-is/what-are-docker-configs.md
@@ -1,176 +1,198 @@
 ---
 title: What are Docker Configs?
-meta_desc: |
-     Learn more about what Docker Configs are and how to use them.
-
+meta_desc: "Docker Configs are Swarm-only objects for storing non-sensitive config files and mounting them into services without rebuilding the image. Learn limits, use cases, and Secrets vs. Configs."
 meta_image: /images/what-is/what-are-docker-configs-meta.png
 type: what-is
 page_title: "What are Docker Configs?"
 authors: ["torian-crane"]
 ---
 
-Docker, a leading platform in containerization technology, has revolutionized how applications are developed, shipped, and deployed. An essential facet of this ecosystem is the effective management of configuration data. [Docker Configs](https://docs.docker.com/engine/swarm/configs/) is a feature specially crafted to handle non-sensitive configuration information within Docker environments.
+**Docker Configs are Swarm-only objects for storing non-sensitive configuration files (nginx configs, application properties, JSON/YAML settings, certificate bundles) and mounting them into service containers at a path you choose, without rebuilding the image.** Configs let you keep one generic container image and project environment-specific configuration in at deploy time.
 
-## What are Docker Configs?
+The single most important rule: **Docker Configs are not encrypted at rest.** They're encrypted in transit between Swarm nodes (over mutual TLS) and only delivered to nodes running services that reference them, but the stored value sits in the Raft log in plaintext. For credentials, tokens, TLS keys, and anything else genuinely sensitive, use [Docker Secrets](/what-is/what-are-docker-secrets/) instead. Configs are for the config file next to the credential, not the credential itself.
 
-Docker Configs are a resource in Docker for storing non-sensitive information such as configuration files, separate from a service's image or running containers within [Docker Swarm](https://docs.docker.com/engine/swarm/) environments. This enables keeping Docker images as generic as possible without the need for bind-mounting configuration files into containers or using environment variables. Unlike [Docker Secrets](/what-is/what-are-docker-secrets), Docker Configs are not encrypted at rest and are directly mounted into the container's filesystem.
+In this article, we'll cover the key questions about Docker Configs:
 
-### Key features
+* What is a Docker Config used for?
+* How do Docker Configs and Docker Secrets compare?
+* How do containers consume Docker Configs?
+* What are the limits of Docker Configs?
+* How do you create and use a Docker Config?
+* What are Docker Configs best practices?
+* How does Pulumi manage Docker Configs?
+* Frequently asked questions about Docker Configs
 
-- **Separation of configuration from code**: Docker Configs allow you to store configuration files outside of your Docker images, leading to more generic and reusable images.
-- **Flexibility in management**: Configs can be added, updated, or removed from services dynamically, without the need to rebuild or restart containers.
-- **Secure transmission**: Configs are sent to the swarm manager over a mutual TLS connection and are stored securely.
-- **Easy access within containers**: Configs are automatically mounted into the container's filesystem, making them easily accessible to applications.
-- **Support for various data types**: Configs can store generic strings or binary content, providing flexibility for different types of configuration data.
+## What is a Docker Config used for?
 
-## Creating Docker Configs
+A Docker Config is the right place for any file an application or sidecar needs at startup that isn't sensitive but still varies by environment. Typical contents:
 
-Docker Configs can be created via the Docker CLI. Before creating configs in Docker, you must first make sure you have [Docker installed](https://docs.docker.com/get-docker/). Once you have installed Docker, enable and start the Docker service.
+* `nginx.conf`, `haproxy.cfg`, and other reverse-proxy configurations.
+* Application settings files (`application.properties`, `appsettings.json`, `config.yaml`).
+* Public certificate bundles (CA certs, public keys).
+* Feature-flag manifests and routing rules.
+* Logging or telemetry configuration files.
+
+Configs let you build a single, generic image (`myorg/api:1.2.3`) and project the per-environment configuration in at deploy time. You don't rebuild the image to change the log level; you publish a new Config and update the service.
+
+## How do Docker Configs and Docker Secrets compare?
+
+Configs and [Secrets](/what-is/what-are-docker-secrets/) are sibling features with the same Swarm plumbing but different security guarantees.
+
+| Aspect | Docker Configs | Docker Secrets |
+|---|---|---|
+| Intended for | Non-sensitive config files | Sensitive credentials and keys |
+| Encrypted at rest | **No** (plaintext in Raft log) | Yes (encrypted in Raft log) |
+| Encrypted in transit | Yes (mTLS between nodes) | Yes (mTLS between nodes) |
+| Default mount path | `/<config-name>` at filesystem root | `/run/secrets/<secret-name>` |
+| Storage in container | Regular filesystem mount | `tmpfs` (in-memory only) |
+| Maximum size | 500 KB | 500 KB |
+| Immutable once attached | Yes | Yes |
+| Swarm-only | Yes | Yes |
+
+The "Encrypted at rest" row is the decision driver. Anything sensitive belongs in a Secret. Everything else (config files, public certs, routing rules) belongs in a Config and benefits from being mounted as a real on-disk file rather than tucked into the more restricted `tmpfs` mount Secrets use.
+
+## How do containers consume Docker Configs?
+
+Configs are mounted into a service's containers as files. By default, a Config named `nginx-config` lands at `/nginx-config` inside the container; you can choose a different path with the `target` option:
 
 ```bash
-sudo systemctl enable docker
-sudo systemctl start docker
+docker service create --name web \
+  --config source=nginx-config,target=/etc/nginx/nginx.conf,mode=0444 \
+  nginx:alpine
 ```
 
-You can optionally add your user to the Docker group to provide non-root access.
+Inside the container, applications read the Config like any other file:
 
 ```bash
-sudo usermod -a -G docker ${USER}
+$ cat /etc/nginx/nginx.conf
+# ... nginx configuration ...
 ```
 
-Restart your terminal to apply the changes to the group, then check that Docker has installed correctly.
+Unlike Secrets (which always live in `tmpfs`), Configs are mounted onto the regular container filesystem, which is fine because their contents aren't sensitive.
 
-```bash
-docker --version
-```
+## What are the limits of Docker Configs?
 
-{{< notes type="info" >}}
+Docker Configs share most of the Swarm-feature boundaries that Secrets have, plus a couple specific to non-sensitive data.
 
-The command to start Docker depends on your operating system. The above commands show examples for how to do this on Linux. You can find the commands relevant to your own operating system in the [Docker documentation](https://docs.docker.com/engine/install/).
+* **Swarm-only.** No support outside of Swarm services. Standalone `docker run` and non-Swarm Compose can't consume them.
+* **500 KB maximum size.** Large configuration bundles (multi-megabyte ML model configs, full nginx site directories) don't fit and should be packaged differently.
+* **Not encrypted at rest.** Don't smuggle credentials into a Config to avoid the Secret workflow. Anything genuinely sensitive belongs in a [Docker Secret](/what-is/what-are-docker-secrets/) even if it's mixed in with a larger config file.
+* **Immutable once attached.** A Config attached to a running service can't be edited in place; rotating means create-new-name + service-update + delete-old.
+* **No native versioning.** Docker doesn't track config history. If you need rollback, keep the canonical version in Git and let your IaC pipeline reconcile.
+* **Service-scoped delivery.** A Config is delivered only to nodes running services that reference it. Nodes without a referencing service never receive the value.
 
-{{< /notes >}}
+## How do you create and use a Docker Config?
 
-You will also need to initialize a swarm since Docker Configs are a feature of [Docker Swarm](https://docs.docker.com/engine/swarm/key-concepts/).
-
-```
-$ docker swarm init
-
-Swarm initialized: current node (u26cvq5cro6ro76sv47fs2nr4) is now a manager.
-
-To add a worker to this swarm, run the following command:
-
-    docker swarm join --token SWMTKN-1-5fev6zooqj2vi3n4ffhnkzjx96oiogfziizivyordmf12iv0yo-7bqlgowmz7sy2k932cjkbukpi 172.31.30.90:2377
-
-To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.
-```
-
-### Create a config via the CLI
-
-You can create a config by piping the configuration data into the `docker config create` command.
+Once you've initialized a Swarm (`docker swarm init`), creating and attaching a Config is short:
 
 ```bash
 $ echo "This is my config data" | docker config create my-config -
+j41rg08gmnx1t91l0zjnefosz
 
-ix4v0pm352e7a4idpshbrbrt4
-```
-
-Verify the config is created:
-
-```bash
 $ docker config ls
-
 ID                          NAME        CREATED          UPDATED
 j41rg08gmnx1t91l0zjnefosz   my-config   33 seconds ago   33 seconds ago
-```
 
-Now you will create a [service](https://docs.docker.com/engine/swarm/how-swarm-mode-works/services/). When doing so, you can grant it access to specific configs. Configs are available to the service from the default mount point within the container, which is `/<config-name>`. This means that the config will be available at the root of the container's filesystem with the same name as the config.
+$ docker service create --name web \
+    --config source=my-config,target=/etc/my-app/config.conf \
+    nginx:alpine
 
-```bash
-$ docker service create --name myservice --config src=my-config nginx
-
-hfmhkka4zg6ea2j3sp9tkdd7h
-overall progress: 1 out of 1 tasks
-1/1: running   [==================================================>]
-verify: Service converged
-```
-
-You can also explicitly specify a target location for the config to be stored:
-
-```bash
-docker service create --name myservice --config src=my-config,target=/etc/my-config nginx
-```
-
-Inspect the service to ensure it is running.
-
-```bash
-$ docker service ps myservice
-ID             NAME          IMAGE          NODE                                            DESIRED STATE   CURRENT STATE            ERROR     PORTS
-kf8ysfgiipkb   myservice.1   nginx:latest   ip-172-31-30-90.eu-central-1.compute.internal   Running         Running 35 seconds ago  
-```
-
-### Accessing configs inside a container
-
-Now that you have created a service with a config, you can access the value of this config from within the container.
-
-First, login to the container using the `docker exec` command:
-
-```bash
-docker exec -it <container_id> /bin/bash
-```
-
-Replace `<container_id>` with the ID of the container created in the previous step. You can find this value by running the following command:
-
-```bash
-$ docker ps
-CONTAINER ID   IMAGE          COMMAND                  CREATED         STATUS         PORTS     NAMES
-00a6ae3d1bd5   nginx:latest   "/docker-entrypoint.…"   4 minutes ago   Up 4 minutes   80/tcp    myservice.1.w6i5cct5o9gwmb3ud43c5ienl
-```
-
-Taking the value of the container ID in the output, the full command will look something like this:
-
-```bash
-$ docker exec -it 00a6ae3d1bd5 /bin/bash
-root@00a6ae3d1bd5:/#
-
-```
-
-Once inside the container, you can access the secret like a regular file:
-
-```bash
-root@00a6ae3d1bd5:/# cat /my-config
+$ docker exec -it $(docker ps -qf name=web) cat /etc/my-app/config.conf
 This is my config data
 ```
 
-## Best practices
+In Docker Compose (v3.3+, Swarm mode):
 
-When using Docker Configs, it's important to follow best practices to ensure efficient and secure management of your configuration data:
+```yaml
+services:
+  web:
+    image: nginx:alpine
+    configs:
+      - source: nginx-config
+        target: /etc/nginx/nginx.conf
+        mode: 0444
 
-- **Use for Non-Sensitive Data Only**: Given that Docker Configs are not encrypted at rest, use them only for non-sensitive configuration data. Store any sensitive information like passwords or API keys in Docker Secrets instead.
-- **Naming Conventions and Organization**: Use clear and consistent naming conventions for your configs. This approach helps in quickly identifying the purpose of each config and its associated services.
-- **Avoid Large Config Files**: Since Docker Configs have a size limitation, avoid using them for very large configuration files. Instead, consider splitting large configurations into smaller, more manageable pieces.
-- **Documentation**: Document your configuration management strategy, including how configs are named, structured, and updated. This documentation is invaluable for new team members and for maintaining consistency across your deployments.
+configs:
+  nginx-config:
+    file: ./nginx.conf
+```
 
-By following these best practices, you can maximize the benefits of Docker Configs in managing your application's configuration data effectively and securely.
+For production deployments, prefer `external: true` and create the Config out of band so the value isn't committed alongside the Compose file (the same pattern that's recommended for Secrets).
 
-## Challenges and considerations
+## What are Docker Configs best practices?
 
-Docker Configs, similar to Docker Secrets, provide a useful way to manage configuration data in Docker environments, particularly in Docker Swarm. However, they also come with their own set of challenges and considerations:
+* **Use Configs for non-sensitive data only.** The lack of at-rest encryption is the defining limitation. Anything genuinely sensitive belongs in a [Docker Secret](/what-is/what-are-docker-secrets/).
+* **Choose explicit target paths.** Default mounts at `/<config-name>` are fine for demos but rarely match where applications actually look for configuration. Always set `target` to the canonical path your app expects.
+* **Keep the source of truth in Git.** Configs are deploy artifacts; the canonical version of the file should live in your IaC repo and be checked in.
+* **Treat Configs as immutable.** Roll forward with a new Config name (`nginx-config-v2`) rather than mutating values. Update the service to reference the new Config, then remove the old one once nothing depends on it.
+* **Split large files.** Configs cap at 500 KB. Big bundles (full nginx site directories, large rule sets) should be broken into multiple Configs or shipped as a separate volume.
+* **Watch the diff in PR review.** Because Configs are projected into services exactly as written, the Pulumi/Compose diff is also the production diff. Code review catches misconfigurations before deploy.
 
-- **Limited to Docker Swarm**: Like Docker Secrets, Docker Configs are specifically designed for Docker Swarm. This means they are not natively available for standalone Docker containers or other container orchestrators like Kubernetes. This limitation can be significant for teams not using Docker Swarm.
+## How does Pulumi manage Docker Configs?
 
-- **Not suitable for sensitive data**: Docker Configs are not encrypted at rest, unlike Docker Secrets. This makes them unsuitable for storing sensitive data such as passwords, tokens, or private keys. They should be used only for non-sensitive configuration data.
+The [Pulumi Docker provider](/registry/packages/docker/) treats Configs as first-class resources, so the same program that provisions a Swarm stack can declare its Configs and the services that reference them.
 
-- **Size limitation**: There is a size limit for the contents of Docker Configs (typically around 500 KB). This limitation can be a challenge when dealing with large configuration files.
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as docker from "@pulumi/docker";
+import * as fs from "fs";
 
-- **Immutable once attached to running services**: Once a config is attached to a running service, it cannot be edited. Any changes require creating a new config and updating the service to use this new config, which might cause service disruption.
+const nginxConfig = new docker.Config("nginx-config", {
+    name: "nginx-config",
+    data: Buffer.from(fs.readFileSync("./nginx.conf", "utf8")).toString("base64"),
+});
+```
 
-## Conclusion
+A few benefits of managing Configs this way:
 
-Docker Configs offer a flexible and secure way to manage non-sensitive configuration data in Docker environments. By storing configuration outside of application code, Docker Configs facilitate a more modular and maintainable architecture.
+* The Config and the service that consumes it live in the same Pulumi program; refactoring is straightforward.
+* Rotations are reviewable PRs. Renaming a Config triggers a service update with full preview output.
+* For per-environment values that aren't sensitive but still vary (log levels, region settings, public endpoints), keep them in [Pulumi config](/docs/iac/concepts/config/) and template them into the Config at deploy time. Anything actually sensitive comes from [Pulumi ESC](/product/esc/) and lands in a Docker Secret instead.
 
-Now that you're equipped with the knowledge of Docker Configs, take your cloud infrastructure management to the next level with Pulumi. Explore these key resources to deepen your understanding and enhance your implementation strategies:
+[Get started with Pulumi](/docs/get-started/) to manage Swarm Configs, Secrets, and services as code in TypeScript, Python, Go, C#, Java, or YAML.
 
-- **Advanced configuration management**: Discover how to efficiently manage configuration data in your cloud applications. Dive into Pulumi's [Configuration Management docs](/docs/concepts/config/) for in-depth information on creating and managing configuration across stacks and projects.
-- **Container management solutions**: Learn about deploying containers with ease using Pulumi. Whether you prefer low-management solutions like AWS Fargate and Microsoft ACI for ease of deployment or require complete control with Kubernetes-based solutions, our [Container Management](/templates/container-service/) docs provide comprehensive insights. They cover everything from managing clusters and infrastructure to deploying application containers in various environments.
+## Frequently asked questions about Docker Configs
 
-Our [community on Slack](https://slack.pulumi.com/) is always open for discussions, questions, and sharing experiences. Join us there and become part of our growing community of cloud professionals!
+### Are Docker Configs encrypted?
+
+In transit, yes — Configs travel between Swarm nodes over mutual TLS. At rest, no — they're stored in the Raft log on manager nodes without encryption. That's why Configs are explicitly for non-sensitive data; encrypted-at-rest storage is what [Docker Secrets](/what-is/what-are-docker-secrets/) provide.
+
+### What's the difference between a Docker Config and a Docker Secret?
+
+Same Swarm plumbing, different security guarantees. Both are mounted into containers as files, both are immutable once created, both cap at 500 KB. The differences: Secrets are encrypted at rest and mounted as `tmpfs` (in-memory); Configs are stored plaintext and mounted onto the regular filesystem. Use Configs for config files; use Secrets for credentials.
+
+### Can I use Docker Configs without Docker Swarm?
+
+No. Configs are a Swarm-mode feature. Standalone `docker run` and non-Swarm `docker-compose` can't consume them. For non-Swarm environments, bind-mount the file, bake it into the image, or use the orchestrator's native mechanism (`ConfigMap` in Kubernetes, for example).
+
+### What is the maximum size of a Docker Config?
+
+500 KB. For larger configuration bundles, either split them into multiple Configs (one per logical section) or use a shared volume to hand the data to the container.
+
+### Where is a Docker Config mounted by default?
+
+At the root of the container filesystem, with the Config's name as the filename — for example, a Config named `nginx-config` mounts at `/nginx-config`. Most teams override this with the `target` option to match where the application actually reads its config from (e.g., `/etc/nginx/nginx.conf`).
+
+### How do I update a Docker Config?
+
+You don't, in place. Create a new Config (often suffixed with a version), update the referencing service(s) to use the new Config, then remove the old one once nothing references it. The update is a service redeploy.
+
+### Can I store TLS certificates in a Docker Config?
+
+Public certificates yes; private keys no. The certificate itself isn't sensitive once issued. The private key is, and it belongs in a Docker Secret. A common pattern is to put the cert in a Config and the key in a Secret, then reference both from the same service.
+
+### Should I check Docker Config contents into Git?
+
+Yes — the source file behind a Config is just a config file. Keep the canonical version in your IaC repo and let your deployment pipeline create the Config from it. That gives you version history, code review, and rollback for free, and matches how the rest of your infrastructure is managed.
+
+## Learn more
+
+Pulumi manages Docker Configs and Secrets in the same program as the services that consume them. Configurable content stays in Git; sensitive content stays in [Pulumi ESC](/product/esc/); every change is a reviewable pull request. [Get started today](/docs/get-started/).
+
+Related reading:
+
+* [What are Docker Secrets?](/what-is/what-are-docker-secrets/)
+* [What is Secrets Management?](/what-is/what-is-secrets-management/)
+* [What is Configuration Management?](/what-is/what-is-configuration-management/)
+* [What are Kubernetes Secrets?](/what-is/what-are-kubernetes-secrets/)
+* [What is HashiCorp Vault?](/what-is/what-is-hashicorp-vault/)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/what-are-docker-configs.md` for SEO and AEO. The new page emphasizes the one fact that decides whether you should use Configs at all (no at-rest encryption, use Secrets for sensitive data) and walks through the rest of the lifecycle once that's clear.

## What changed

- **Opening definition** — bolded one-sentence definition (Swarm-only, non-sensitive config files, mounted at a path you choose), followed by the at-rest-encryption caveat and a pointer to Docker Secrets.
- **Use cases** — concrete list (`nginx.conf`, `appsettings.json`, public certs, feature flags, telemetry config).
- **Configs vs. Secrets table** — at-rest encryption, transit encryption, mount path, storage layer, size cap, immutability, Swarm scope.
- **Runtime access** — explicit `--config source=... target=...` example.
- **Limits** — Swarm-only, 500 KB cap, no at-rest encryption, immutable, no versioning, service-scoped.
- **Lifecycle example** — `docker config create`, service attach, Compose `external: true` pattern.
- **Best practices** — non-sensitive only, explicit `target` paths, Git as source of truth, immutable rotation, file splitting, PR review.
- **Pulumi section** — TypeScript example creating a Config from a Git-checked-in file; notes on combining ESC for sensitive values with Configs for non-sensitive ones.
- **FAQ** — eight doubt-removers (encryption, Configs vs. Secrets, non-Swarm usage, size limit, default mount path, rotation, TLS certs vs. keys, checking into Git).
- **Cross-links** — Docker Secrets, secrets management, configuration management, Kubernetes Secrets, HashiCorp Vault.

## Test plan

- [ ] `make serve`; visit `/what-is/what-are-docker-configs/` and confirm tables and code blocks render
- [ ] Spot-check cross-links (`/what-is/what-are-docker-secrets/`, `/what-is/what-is-configuration-management/`)
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)