### PR TITLE
content(what-is): rewrite the SignatureDoesNotMatch page

### DIFF
--- a/content/what-is/resolve-list-buckets-signature-does-not-match.md
+++ b/content/what-is/resolve-list-buckets-signature-does-not-match.md
@@ -1,70 +1,108 @@
 ---
 title: An error occurred (SignatureDoesNotMatch) when calling the ListBuckets operation
 allow_long_title: true
-meta_desc: |
-     Use Pulumi ESC and dynamic credentials to run commands like aws ListBuckets in a more secure and seamless way.
+meta_desc: "The SignatureDoesNotMatch error from aws s3 ls means the request signature doesn't match. Most often a wrong AWS secret key or skewed system clock."
 meta_image: /images/what-is/resolve-list-buckets-signature-does-not-match-meta.png
 type: what-is
 page_title: An error occurred (SignatureDoesNotMatch) when calling the ListBuckets operation
 authors: ["torian-crane"]
 ---
 
-The error message "An error occurred (SignatureDoesNotMatch) when calling the ListBuckets operation" in AWS (Amazon Web Services) indicates that there's a mismatch between the request signature calculated by AWS and the signature you provided. AWS relies on two key components for authentication: the AWS Access Key ID and the AWS Secret Access Key. The Secret Access Key is used for securely signing requests to AWS services. When you encounter this error, it typically signifies that the provided AWS Secret Access Key is incorrect or has been used with an inappropriate signing method.
+**The `SignatureDoesNotMatch` error from `aws s3 ls` means the signature your client computed for the request does not match the signature AWS expected.** It almost always comes from one of three things: a wrong `AWS_SECRET_ACCESS_KEY` (typo, trailing whitespace, or truncated paste), a system clock that has drifted by more than 5 minutes, or a proxy/middlebox modifying the request after it was signed. Re-copy the secret, run an NTP sync, and disable any HTTP-rewriting proxy in front of S3.
 
-[Pulumi ESC (Environments, Secrets, and Configurations)](/docs/pulumi-cloud/esc/) offers a solution to the challenges of managing credentials and can make errors like this a thing of the past. By enabling the [management of dynamic credentials from AWS using OIDC](/blog/esc-env-run-aws/), Pulumi ESC simplifies and secures your AWS CLI operations. This approach eliminates the need for manually providing credentials and is a more secure solution than the use of long-term credentials, which can often present a security risk. Pulumi ESC also enables you to focus on your tasks without the interruption of credential-related errors, providing a more efficient flow for your AWS operations and tasks.
+In this article, we'll cover:
 
-## Using Pulumi ESC for dynamic credentials with AWS
+* What the `SignatureDoesNotMatch` error means
+* What causes it
+* How to fix it in four steps
+* How to prevent it from happening again
+* Common variations and related errors
+* How Pulumi ESC eliminates manual secret handling
+* Frequently asked questions
 
-[Pulumi ESC](https://www.pulumi.com/product/esc/) is a service that helps to alleviate the burden of managing cloud configuration and secrets by providing a centralized way to handle these critical aspects of cloud development. The `esc run` command of this service in particular helps to resolve concerns around how to:
+## What does this error mean?
 
-- Securely share credentials with teammates in a consistent way.
-- Minimize the risks associated with locally configured, long-lived and highly privileged credentials.
-- Ensure teams can easily and safely run commands like  without requiring deep security expertise.
+AWS authenticates every API call with a [Signature Version 4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html) signature: the client hashes the request (method, host, path, headers, body, and timestamp) using the AWS secret access key. AWS recomputes the same hash on its side; if they don't match, the request is rejected with `SignatureDoesNotMatch`.
 
-## What is the esc run command?
+The error means AWS *recognized your access key* (otherwise you'd get `InvalidAccessKeyId`) but rejected the signature itself. That narrows the cause to either the secret used to compute the signature, the inputs to the signature (most commonly the timestamp), or someone modifying the request in flight.
 
-The [Pulumi documentation for the `esc run` command](/docs/esc/cli/commands/esc_run/) states the following:
+## What causes it?
 
-> This command opens the environment with the given name and runs the given command. If the opened environment contains a top-level ’environmentVariables’ object, each key-value pair in the object is made available to the command as an environment variable.
+| Cause | Symptom | Fix |
+|---|---|---|
+| Wrong or truncated secret key | First key works, second fails identically | Re-copy from IAM console; mind trailing whitespace |
+| Special characters in secret | Secret contains `/`, `+`, or `=` and got shell-escaped | Quote the value: `export AWS_SECRET_ACCESS_KEY='...'` |
+| Clock skew (> 5 minutes) | Works on one machine, fails on another | `sudo sntp -sS time.apple.com` or `w32tm /resync` |
+| Corporate proxy modifying headers | Works at home, fails on VPN | Bypass the proxy for S3 endpoints |
+| Wrong signing region | S3 path-style URL with mismatched region | Use the correct region for the bucket |
+| AWS_SECRET_ACCESS_KEY exported with quotes | Quotes ended up *inside* the value | Re-export without surrounding quotes |
 
-But what does this actually mean? If we use AWS as an example, it means that we can run commands like `aws s3 ls` without the need to configure AWS credentials locally each time. It’s a significant stride towards making your cloud interactions more efficient and less error-prone, and here’s a deeper dive into why:
+## How to fix it
 
-- **Seamless Command Execution** - The `esc run` command lets you execute AWS commands effortlessly, freeing you from the intricacies of managing AWS credentials on your local machine. Simply put, it significantly reduces the overhead of credential setup and maintenance.
+Follow these steps in order. Each one is copy-pasteable.
 
-- **Enhanced Security** - One of the standout features of `esc run` is its commitment to security. By removing the local storage of credentials, it drastically reduces the risk of accidental exposure. Your credentials and secrets are securely managed within the Pulumi environment.
+1. **Check the clock.** AWS rejects any request whose `X-Amz-Date` is more than 5 minutes off server time.
 
-- **Streamlined Collaboration** - Because credentials will be centralized, `esc run` facilitates smoother team collaboration by providing a consistent environment for all team members to run commands with. Everyone can access the same secure environment which reduces the complexities of coordinating credentials and configurations across teams.
+   ```bash
+   date -u
+   # compare to:
+   curl -sI https://s3.amazonaws.com | grep -i ^date
+   ```
 
-## Getting started with esc run
+   If the two values differ by more than 5 minutes, sync NTP (`sudo sntp -sS time.apple.com` on macOS, `sudo timedatectl set-ntp on` on Linux, `w32tm /resync` on Windows).
 
-### Step 1: Install and login to Pulumi ESC
+1. **Verify the secret is exactly what AWS gave you.** Length is the fastest check; AWS secret keys are 40 characters.
 
-To begin, you’ll need to [install Pulumi ESC](/docs/install/esc/). Once the installation is complete, run the `esc login` command and follow the steps to login to the CLI.
+   ```bash
+   echo "Secret length: ${#AWS_SECRET_ACCESS_KEY}"
+   ```
 
-```bash
-$ esc login
-Manage your Pulumi ESC environments by logging in.
-Run `esc --help` for alternative login options.
-Enter your access token from https://app.pulumi.com/account/tokens
-    or hit <ENTER> to log in using your browser                   :
-Logged in to pulumi.com as …
-```
+   If the value isn't 40 characters, re-copy it from the IAM console or from your secrets manager. Special characters (`/`, `+`, `=`) must be inside single quotes when exporting.
 
-### Step 2: Create the OIDC configuration
+1. **Strip out interfering middleware.** If you're behind a corporate proxy or TLS-inspecting firewall, temporarily disable it:
 
-Pulumi ESC offers you the ability to manually set your credentials as secrets in your Pulumi ESC environment files. When it comes to something like OIDC configuration, a more secure and efficient alternative is to leverage yet another great feature of Pulumi ESC: dynamic credentials.
+   ```bash
+   curl --noproxy '*' https://s3.amazonaws.com/
+   ```
 
-This service can dynamically generate credentials on your behalf each time you need to interact with your AWS environments. To do so, follow the steps in the [guide for configuring OIDC between Pulumi and AWS](/docs/esc/environments/configuring-oidc/aws/). Make sure that the IAM role you create has sufficient permissions to perform S3 actions.
+   Any proxy that rewrites headers or query strings will break the signature.
 
-### Step 3: Create a new Pulumi ESC environment
+1. **Verify.**
 
-Once OIDC has been configured between Pulumi and AWS, the next step is to create a new environment in the [Pulumi Cloud](https://app.pulumi.com/signin). Make sure that you have the correct organization selected in the left-hand navigation menu. From there, click the **Environments** link, then click the **Create environment** button. In the following pop-up, provide a name for your environment before clicking the **Create environment** button.
+   ```bash
+   aws sts get-caller-identity
+   aws s3 ls
+   ```
 
-{{< video title="Open environment in Pulumi ESC console" src="https://www.pulumi.com/uploads/esc-create-new-env.mp4" autoplay="true" loop="true" >}}
+   If `get-caller-identity` works but `s3 ls` still fails, the problem is region-specific signing — set `AWS_REGION` to the bucket's home region.
 
-### Step 4: Add the AWS provider integration
+## How to prevent it
 
-Once you’ve created your new environment, you will be presented with a split-pane document view. You’ll want to clear out the default placeholder content in the editor on the left-hand side and replace it with the following code, making sure to replace <your-oidc-iam-role-arn> with the value of your IAM role ARN from the configure OIDC step:
+* **Pull secrets from a manager, not from copy/paste.** AWS Secrets Manager, HashiCorp Vault, and [Pulumi ESC](/product/esc/) all keep the secret out of clipboards and shell histories, eliminating the truncation and whitespace cases.
+* **Keep clocks in sync.** Enable NTP on every machine that talks to AWS. Containers in particular tend to inherit the host clock, which silently breaks signatures when the host drifts.
+* **Avoid TLS-inspecting proxies in front of S3.** If you must use one, exclude S3 hosts from inspection.
+* **Don't use long-lived keys.** OIDC-issued temporary credentials never get copy-pasted, so the whole class of "the secret was wrong" disappears.
+
+## Common variations
+
+The same root cause produces a few closely related messages:
+
+* `The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method.`
+* `An error occurred (SignatureDoesNotMatch) when calling the PutObject operation` — same problem, different operation; usually a content-hash mismatch from middleware re-encoding the body.
+* `RequestTimeTooSkewed` — the related "clock is off by more than 5 minutes" error. Fix the same way (NTP).
+
+## Related errors
+
+* [InvalidAccessKeyId](/what-is/resolve-list-buckets-invalid-access-key-id/) — the access key doesn't exist at all.
+* [InvalidClientTokenId](/what-is/resolve-list-buckets-invalid-client-token-id/) — the session token doesn't match the access key.
+* [ExpiredToken](/what-is/resolve-list-buckets-expired-token/) — the credential is past its lifetime.
+* [Unable to locate credentials](/what-is/resolve-unable-to-locate-credentials/) — the SDK found no credentials at all.
+
+## How Pulumi ESC eliminates manual secret handling
+
+[Pulumi ESC](/product/esc/) (Environments, Secrets, and Configurations) issues short-lived AWS credentials via OIDC. There's no 40-character secret to copy, paste, or accidentally truncate. ESC delivers a coherent triple (access key, secret, session token) into the environment for the lifetime of the command.
+
+Define the environment once:
 
 ```yaml
 values:
@@ -73,7 +111,7 @@ values:
       fn::open::aws-login:
         oidc:
           duration: 1h
-          roleArn: <your-oidc-iam-role-arn>
+          roleArn: arn:aws:iam::123456789012:role/PulumiESCRole
           sessionName: pulumi-environments-session
   environmentVariables:
     AWS_ACCESS_KEY_ID: ${aws.login.accessKeyId}
@@ -81,20 +119,43 @@ values:
     AWS_SESSION_TOKEN: ${aws.login.sessionToken}
 ```
 
-### Step 5: Run the aws CLI command
-
-With your environment set up, you can validate your configuration and verify that the error has been resolved by running the `aws s3 ls` command using `esc run` as shown below, making sure to replace `<your-pulumi-org-name>`, `<your-project-name>`, and `<your-environment-name>` with the names of your own Pulumi organization and environment respectively:
+Then run any AWS command with credentials that won't drift, expire, or get truncated:
 
 ```bash
-esc run <your-pulumi-org-name>/<your-project-name>/<your-environment-name> -i aws s3 ls --query "Buckets[].Name"
+esc run my-org/aws/dev -- aws s3 ls
 ```
 
-## Conclusion
+For Pulumi programs, the AWS provider's [`assumeRole` configuration](/registry/packages/aws/api-docs/provider/) gives you the same OIDC-backed, no-secrets-in-code workflow inside a deployment.
 
-Pulumi ESC makes it easier than ever to tame infrastructure complexity, especially when running commands like `aws s3 ls`. Because Pulumi ESC supports dynamic credentials using OIDC across AWS, Azure, and Google Cloud, you no longer have to worry about credential errors like "SignatureDoesNotMatch" as the service will dynamically generate and refresh them for you. Check out the following links to learn more about Pulumi ESC today.
+## Frequently asked questions
 
-- Follow the [Getting Started](/docs/pulumi-cloud/esc/get-started) guide.
-- Read the [Documentation](/docs/pulumi-cloud/esc) for all the commands and features available.
-- Visit the [Open Source](https://github.com/pulumi/esc) repo for Pulumi ESC.
+### How much clock skew does AWS tolerate?
 
-Feel free to [join our community on Slack](https://slack.pulumi.com/) and let us know what you think!
+Five minutes. AWS rejects any request whose `X-Amz-Date` header differs from server time by more than 5 minutes (the related error is `RequestTimeTooSkewed`). NTP keeps most machines comfortably inside this window.
+
+### Why does my secret work on one machine but not another?
+
+Almost always a copy/paste artifact. Trailing newlines, smart quotes, or the secret being re-typed instead of pasted are the usual suspects. The fact that the same access key works elsewhere confirms it isn't an identity problem.
+
+### Can a proxy actually cause this?
+
+Yes. SigV4 hashes the request headers and body. Any HTTP-aware proxy that adds, removes, or rewrites headers (a corporate `Via` header, a content-rewriting filter) will break the signature. TLS-inspecting firewalls are the most common offender.
+
+### What if I'm using `boto3` or another SDK, not the CLI?
+
+The same error and the same causes. SDKs construct the SigV4 signature locally before sending the request; everything that breaks the CLI's signature also breaks the SDK's.
+
+### Does this error mean my key is compromised?
+
+No. `SignatureDoesNotMatch` is a client-side configuration error. It does not indicate that anyone has tried to use your key fraudulently. If you suspect compromise, audit CloudTrail for `AccessDenied` and unexpected `GetCallerIdentity` calls.
+
+### Does this affect non-S3 calls?
+
+Yes. SigV4 is used for nearly every AWS service. The same `SignatureDoesNotMatch` symptom appears on `aws ec2 describe-instances`, `aws sts get-caller-identity`, and so on, with the same root causes.
+
+## Learn more
+
+* [Pulumi ESC documentation](/docs/pulumi-cloud/esc/)
+* [Configuring OIDC between Pulumi ESC and AWS](/docs/esc/environments/configuring-oidc/aws/)
+* [AWS provider reference](/registry/packages/aws/api-docs/provider/)
+* [AWS Signature Version 4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/resolve-list-buckets-signature-does-not-match.md` for SEO and AEO. The page now leads with a direct, citable answer naming the three most-common causes (wrong secret, clock skew, request-modifying proxy) and the corresponding fixes.

## What changed

- **Opening direct answer** — bold one-paragraph definition explaining SigV4 and the three canonical causes.
- **"In this article, we'll cover"** lead-in for navigability.
- **Causes table** — six common sources of the error, including the often-overlooked shell-quoting trap with `/`/`+`/`=` characters.
- **Numbered fix steps** — clock check, secret-length check, proxy bypass, verification.
- **Prevention section** — secrets manager over copy-paste, NTP everywhere, no TLS-inspecting proxies in front of S3, OIDC over long-lived keys.
- **Common variations** — closely related strings (`RequestTimeTooSkewed`, `PutObject` variant) to capture long-tail search.
- **Related errors cross-links** — sibling resolve-* pages for the credential-error family.
- **Pulumi ESC section** — YAML environment example plus `esc run`; brief reference to `aws:assumeRole` for in-program use.
- **FAQ** — six doubt-removers: clock skew tolerance, machine-specific failures, proxy causation, SDK-vs-CLI behavior, security implications, non-S3 surfaces.
- **Strengthened `meta_desc`** to lead with the direct answer, well under 160 chars.

## Test plan

- [ ] `make serve`; visit `/what-is/resolve-list-buckets-signature-does-not-match/` and confirm the page renders with table, code blocks, and cross-links intact.
- [ ] Spot-check links to sibling resolve-* pages and to `/docs/pulumi-cloud/esc/` and `/docs/esc/environments/configuring-oidc/aws/`.
- [ ] CI lint + pinned review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)