### PR TITLE
content(what-is): rewrite the aws s3 cp with dynamic credentials guide

### DIFF
--- a/content/what-is/run-aws-s3-cp-with-dynamic-credentials.md
+++ b/content/what-is/run-aws-s3-cp-with-dynamic-credentials.md
@@ -1,72 +1,77 @@
 ---
 title: Run 'aws s3 cp' using Dynamic Credentials
-meta_desc: |
-     Learn more about using dynamic credentials in Pulumi ESC to run commands like aws s3 cp in a more secure and seamless way.
-
+meta_desc: Run aws s3 cp with short-lived, OIDC-issued credentials from Pulumi ESC. No static AWS keys, scoped by IAM role, fully auditable in CloudTrail.
 meta_image: /images/what-is/run-aws-s3-cp-with-dynamic-credentials-meta.png
 type: what-is
 page_title: Run 'aws s3 cp' using Dynamic Credentials
 authors: ["diana-esteves"]
 ---
 
-The [aws s3 cp command](https://docs.aws.amazon.com/cli/latest/userguide/cli-services-s3-commands.html) is part of the AWS Command Line Interface (CLI) and is used to copy files to and from buckets in Amazon Simple Storage Service (Amazon S3). Amazon S3 is a scalable object storage service offered by Amazon Web Services (AWS) and is commonly used for backup and storage, serving content, and hosting static websites.
+**This guide shows how to run `aws s3 cp` using short-lived AWS credentials brokered by [Pulumi ESC](/product/esc/) over OIDC, instead of long-lived `AKIA...` keys in `~/.aws/credentials`.** Pulumi ESC exchanges a Pulumi-issued OIDC token for an AWS STS session, scoped to a specific IAM role, expiring automatically. `aws s3 cp` copies a single object or local file to or from S3, automatically using multipart upload for files larger than 8 MB. The IAM permissions you grant the role determine which directions of copy are allowed.
 
-Copying files to and from S3 buckets is a common use case and operation performed on your terminal via the AWS Command Line Interface (CLI). This task requires careful handling of your AWS credentials, which can be a point of vulnerability if not managed correctly. Traditionally, there are two types of credentials used: temporary credentials, which are safer but require manual refreshing, and long-term credentials, which carry a higher security risk.
+In this article, we'll cover:
 
-With [Pulumi ESC (Environments, Secrets, and Configurations)](/docs/pulumi-cloud/esc/) you have an easier and more secure option. Pulumi ESC can help you [manage dynamic credentials from AWS using OIDC](/blog/esc-env-run-aws/), to make all your AWS CLI commands run seamlessly so you never have to worry about invalid credentials, or run the risk of manual copy and paste security risks.
+* Why dynamic credentials beat static IAM keys
+* The IAM permissions `aws s3 cp` needs (upload, download, copy between buckets)
+* Prerequisites for this guide
+* Step-by-step ESC setup with the `aws-login` provider
+* Running `aws s3 cp` in both directions and across buckets
+* Multipart upload, verification, and common errors
+* Frequently asked questions
 
-## Using Pulumi ESC for dynamic credentials with AWS
+## Why dynamic credentials beat static IAM keys
 
-[Pulumi ESC](https://www.pulumi.com/product/esc/) is a service that helps to alleviate the burden of managing cloud configuration and secrets by providing a centralized way to handle these critical aspects of cloud development. The `esc run` command of this service in particular helps to resolve concerns around how to:
+Static IAM access keys persist in `~/.aws/credentials`, leak easily into git or shell history, and carry every permission attached to the user. Dynamic credentials reverse all of that:
 
-- Securely share credentials with teammates in a consistent way.
-- Minimize the risks associated with locally configured, long-lived and highly privileged credentials.
-- Ensure teams can easily and safely run commands like aws s3 cp without requiring deep security expertise.
+* **No long-lived secrets on disk.** Pulumi ESC issues fresh `AccessKeyId`, `SecretAccessKey`, and `SessionToken` values on every `esc run`. Nothing persists locally.
+* **Scoped by IAM role.** The IAM role's trust and permission policies define exactly which buckets and which actions the session can perform.
+* **Time-bound.** Sessions expire after the ESC environment's `duration` (1 hour by default). A leaked token is useless almost immediately.
+* **Auditable.** CloudTrail records each S3 operation under the assumed-role ARN with the `sessionName` you configured.
+* **Centrally rotated.** Update the IAM role or session duration in one ESC environment and every developer and CI job that consumes it picks up the change.
 
-## What is the esc run command?
+## What `aws s3 cp` does (and the IAM you need)
 
-The [Pulumi documentation for the `esc run` command](/docs/esc/cli/commands/esc_run/) states the following:
+`aws s3 cp` is the AWS CLI's S3 copy primitive. It supports three directional patterns:
 
-> This command opens the environment with the given name and runs the given command. If the opened environment contains a top-level ’environmentVariables’ object, each key-value pair in the object is made available to the command as an environment variable.
+| Direction | Example | Min IAM permissions |
+|---|---|---|
+| Local → S3 (upload) | `aws s3 cp ./file.txt s3://bucket/key` | `s3:PutObject` on the destination |
+| S3 → Local (download) | `aws s3 cp s3://bucket/key ./file.txt` | `s3:GetObject` on the source |
+| S3 → S3 (copy) | `aws s3 cp s3://src/a s3://dst/a` | `s3:GetObject` on source, `s3:PutObject` on destination |
+| Recursive (directory) | `aws s3 cp ./dir s3://bucket/prefix/ --recursive` | Above + `s3:ListBucket` |
 
-But what does this actually mean? If we use AWS as an example, it means that we can run commands like `aws s3 cp` without the need to configure AWS credentials locally each time. It’s a significant stride towards making your cloud interactions more efficient and less error-prone, and here’s a deeper dive into why:
+Grant the role only the actions the script needs. For production, scope by bucket ARN and prefer per-prefix `Resource` ARNs over `arn:aws:s3:::*`.
 
-- **Seamless Command Execution** - The `esc run` command lets you execute AWS commands effortlessly, freeing you from the intricacies of managing AWS credentials on your local machine. Simply put, it significantly reduces the overhead of credential setup and maintenance.
+## Prerequisites
 
-- **Enhanced Security** - One of the standout features of `esc run` is its commitment to security. By removing the local storage of credentials, it drastically reduces the risk of accidental exposure. Your credentials and secrets are securely managed within the Pulumi environment.
+* An AWS account where you can create or update IAM roles
+* The [Pulumi CLI](/docs/install/) and [Pulumi ESC CLI](/docs/install/esc/) installed
+* A [Pulumi Cloud account](https://app.pulumi.com/signup) and access to an organization
+* The [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed locally
+* An IAM role with OIDC trust configured for Pulumi (see [Configuring OIDC between Pulumi and AWS](/docs/esc/environments/configuring-oidc/aws/)), with the S3 permissions from the table above attached
+* An existing S3 bucket you can read from or write to
 
-- **Streamlined Collaboration** - Because credentials will be centralized, `esc run` facilitates smoother team collaboration by providing a consistent environment for all team members to run commands with. Everyone can access the same secure environment which reduces the complexities of coordinating credentials and configurations across teams.
+## Step-by-step setup
 
-## Getting started with esc run
-
-### Step 1: Install and login to Pulumi ESC
-
-To begin, you’ll need to [install Pulumi ESC](/docs/install/esc/). Once the installation is complete, run the `esc login` command and follow the steps to login to the CLI.
+### 1. Log in to Pulumi ESC
 
 ```bash
-$ esc login
-Manage your Pulumi ESC environments by logging in.
-Run `esc --help` for alternative login options.
-Enter your access token from https://app.pulumi.com/account/tokens
-    or hit <ENTER> to log in using your browser                   :
-Logged in to pulumi.com as …
+esc login
 ```
 
-### Step 2: Create the OIDC configuration
+Follow the browser prompt or paste an access token from <https://app.pulumi.com/account/tokens>.
 
-Pulumi ESC offers you the ability to manually set your credentials as secrets in your Pulumi ESC environment files. When it comes to something like OIDC configuration, a more secure and efficient alternative is to leverage yet another great feature of Pulumi ESC: dynamic credentials.
+### 2. Configure OIDC between Pulumi and AWS
 
-This service can dynamically generate credentials on your behalf each time you need to interact with your AWS environments. To do so, follow the steps in the [guide for configuring OIDC between Pulumi and AWS](/docs/esc/environments/configuring-oidc/aws/). Make sure that the IAM role you create has sufficient permissions to perform S3 actions.
+Follow the [Pulumi OIDC + AWS guide](/docs/esc/environments/configuring-oidc/aws/) to create an IAM role whose trust policy accepts a JWT from `api.pulumi.com/oidc`. Attach a policy granting the S3 permissions you need. Note the role ARN.
 
-### Step 3: Create a new Pulumi ESC environment
+### 3. Create a new Pulumi ESC environment
 
-Once OIDC has been configured between Pulumi and AWS, the next step is to create a new environment in the [Pulumi Cloud](https://app.pulumi.com/signin). Make sure that you have the correct organization selected in the left-hand navigation menu. From there, click the **Environments** link, then click the **Create environment** button. In the following pop-up, provide a name for your environment before clicking the **Create environment** button.
+In [Pulumi Cloud](https://app.pulumi.com/), open your organization, click **Environments**, then **Create environment**. Name it something like `aws-prod-env`.
 
-{{< video title="Open environment in Pulumi ESC console" src="https://www.pulumi.com/uploads/esc-create-new-env.mp4" autoplay="true" loop="true" >}}
+### 4. Add the `aws-login` provider to the environment
 
-### Step 4: Add the AWS provider integration
-
-Once you’ve created your new environment, you will be presented with a split-pane document view. You’ll want to clear out the default placeholder content in the editor on the left-hand side and replace it with the following code, making sure to replace <your-oidc-iam-role-arn> with the value of your IAM role ARN from the configure OIDC step:
+Paste the following YAML, replacing `<your-oidc-iam-role-arn>`:
 
 ```yaml
 values:
@@ -83,65 +88,123 @@ values:
     AWS_SESSION_TOKEN: ${aws.login.sessionToken}
 ```
 
-### Step 5: [Optional] Create a new S3 bucket
+The `fn::open::aws-login` function exchanges the Pulumi-issued OIDC token for AWS STS credentials. The `environmentVariables` block exposes them to any subprocess `esc run` starts.
 
-The `aws s3 cp` command can be used to copy files to, from, and between S3 buckets. If you do not already have an S3 bucket in your environment, you will need to create one in order to validate your configuration.
-
-First check that your local environment does not have any AWS credentials configured by running the `aws configure list` command as shown below:
+### 5. Confirm there are no static credentials on disk
 
 ```bash
-$ aws configure list
-      Name                    Value             Type    Location
-      ----                    -----             ----    --------
-   profile                <not set>             None    None
-access_key                <not set>             None    None
-secret_key                <not set>             None    None
-    region                <not set>             None    None
+aws configure list
 ```
 
-You can then use the following command to create the bucket, making sure to replace the following values as described:
+You should see `<not set>` for `access_key` and `secret_key`. This guarantees the next step uses ESC-issued credentials.
 
-- `<your-bucket-name>` with a [globally unique name](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) for your bucket
-- `<your-aws-region>` with your desired AWS region
-- `<your-pulumi-org-name>` with the name of your own Pulumi organization
-- `<your-project-name>` with the name of your project
-- `<your-environment-name>` with the name of your environment
+## Run `aws s3 cp`
+
+### Upload a local file to S3
 
 ```bash
-esc run <your-pulumi-org-name>/<your-project-name>/<your-environment-name> -i aws s3api create-bucket --bucket <your-bucket-name> --region <your-aws-region>
+echo "hello pulumi" > test.txt
+esc run <your-org>/<your-project>/<your-env> -- \
+    aws s3 cp test.txt s3://<your-bucket>/test.txt
 ```
 
-### Step 6: Create a sample file
-
-In your local environment, create an empty file named `test.txt`.
+Expected output:
 
 ```bash
-# example CLI command for a Linux environment
-$ touch test.txt
+upload: ./test.txt to s3://your-bucket/test.txt
 ```
 
-In the next step, you will use the `aws s3 cp` command to copy this file into your S3 bucket.
-
-### Step 7: Run the aws s3 cp command
-
-To copy the local file to your S3 bucket, run the command using `esc run` as shown below, making sure to replace `<your-pulumi-org-name>`, `<your-project-name>`, and `<your-environment-name>` with the names of your own Pulumi organization and environment respectively:
+### Download an object from S3
 
 ```bash
-esc run <your-pulumi-org-name>/<your-project-name>/<your-environment-name> -i aws s3 cp test.txt s3://<your-bucket-name>/copied-file.txt
+esc run <your-org>/<your-project>/<your-env> -- \
+    aws s3 cp s3://<your-bucket>/test.txt downloaded.txt
 ```
 
-Then validate that your file was successfully uploaded by running the following command, making sure to replace the value of `<your-bucket-name>` with the name of your S3 bucket:
+### Copy between two S3 buckets
 
 ```bash
-esc run <your-pulumi-org-name>/<your-project-name>/<your-environment-name> -i aws s3api list-objects-v2 --bucket <your-bucket-name>
+esc run <your-org>/<your-project>/<your-env> -- \
+    aws s3 cp s3://source-bucket/key s3://dest-bucket/key
 ```
 
-## Conclusion
+S3-to-S3 copies happen server-side in the same region; the bytes do not transit your laptop.
 
-Pulumi ESC makes it easier than ever to tame infrastructure complexity, especially when running commands like `aws s3 cp`. Pulumi ESC supports dynamic credentials using OIDC across AWS, Azure, and Google Cloud. Check out the following links to learn more about Pulumi ESC today.
+### Recursive copy of a directory
 
-- Follow the [Getting Started](/docs/pulumi-cloud/esc/get-started) guide.
-- Read the [Documentation](/docs/pulumi-cloud/esc) for all the commands and features available.
-- Visit the [Open Source](https://github.com/pulumi/esc) repo for Pulumi ESC.
+```bash
+esc run <your-org>/<your-project>/<your-env> -- \
+    aws s3 cp ./build s3://<your-bucket>/site/ --recursive
+```
 
-Feel free to [join our community on Slack](https://slack.pulumi.com/) and let us know what you think!
+Use `--exclude` and `--include` filters for fine-grained control.
+
+## Multipart upload for large files
+
+For files larger than 8 MB (configurable via `aws configure set s3.multipart_threshold`), the AWS CLI automatically uploads in parts. Two things to know:
+
+* **Session duration must outlast the upload.** A 1 GB upload over a slow network can outrun a 1-hour ESC `duration`. Either raise `duration` in the ESC environment (up to the IAM role's `MaxSessionDuration`) or pre-stage uploads with the [`s3:AbortMultipartUpload`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/abort-mpu.html) permission so failed uploads can be retried.
+* **Partial uploads accumulate cost.** Multipart uploads that never complete leave orphaned parts charged at the storage rate. Set a lifecycle rule on the bucket to clean up incomplete multipart uploads after N days.
+
+## Verify the upload
+
+```bash
+esc run <your-org>/<your-project>/<your-env> -- \
+    aws s3 ls s3://<your-bucket>/
+```
+
+In CloudTrail the event appears as `PutObject` or `CopyObject` with `userIdentity.type=AssumedRole` and an `arn` containing `assumed-role/<your-role>/pulumi-environments-session` — confirmation the session came from ESC.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `AccessDenied` on `PutObject` | IAM role missing `s3:PutObject` on the bucket/prefix | Add the action to the role's policy, scoped to the destination ARN |
+| `AccessDenied` on `GetObject` | IAM role missing `s3:GetObject` for the source object | Add the action, or use `s3:GetObject*` if dealing with versioned objects |
+| `KMS.AccessDenied` | Bucket uses SSE-KMS and role can't decrypt | Grant `kms:Decrypt` (download) or `kms:GenerateDataKey` (upload) on the bucket's KMS key |
+| `InvalidClientTokenId` | Stale local `AWS_*` env vars overriding ESC | Run `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN` and retry |
+| `ExpiredToken` (mid-upload) | Multipart upload outlived ESC `duration` | Raise `duration` in the ESC environment, or split the upload |
+| `RequestTimeout` on large files | Slow network plus default multipart threshold | Tune `s3.multipart_chunksize`, or use `aws s3 cp` with `--storage-class STANDARD_IA` and retry |
+| `NoSuchBucket` | Wrong bucket name or region | Confirm with `aws s3 ls`; add `--region` if the bucket is non-default |
+
+## Frequently asked questions
+
+### Does `aws s3 cp` work for S3-to-S3 copies across accounts?
+
+Yes, but the source bucket policy must allow `s3:GetObject` to the role's ARN, and the destination policy must allow `s3:PutObject` plus `s3:PutObjectAcl` if you want the destination account to own the object. Cross-account copies always require explicit policy on both sides.
+
+### How long are ESC-issued credentials valid?
+
+By default 1 hour, set by the `duration` field in the ESC environment YAML. The maximum is bounded by the IAM role's `MaxSessionDuration` attribute. For long uploads, raise both.
+
+### Can I use server-side encryption (SSE-KMS) with this setup?
+
+Yes. Add the relevant `kms:Decrypt` (for downloads) and `kms:GenerateDataKey` (for uploads) actions to the IAM role and ensure the role's principal is allowed in the KMS key policy.
+
+### Why is my upload slower than the AWS console suggests?
+
+The default multipart chunk size is 8 MB and parallelism is 10. For high-bandwidth links tune `aws configure set default.s3.multipart_chunksize 64MB` and `default.s3.max_concurrent_requests 20`. These settings apply to the AWS CLI invoked under `esc run`.
+
+### Does this work in CI?
+
+Yes — this is the recommended pattern. Replace `AWS_*` secrets in your CI configuration with a single `esc run` invocation. The Pulumi GitHub Action and GitLab integration both support OIDC-issued credentials.
+
+### How do I confirm the credentials really came from ESC?
+
+Run `aws sts get-caller-identity` inside the same `esc run`. The returned `Arn` should start with `assumed-role/<your-role>/pulumi-environments-session`. See [Run `aws sts get-caller-identity` with dynamic credentials](/what-is/run-aws-sts-get-caller-identity-with-dynamic-credentials/).
+
+### Should I use `aws s3 cp` or `aws s3 sync` for many files?
+
+Use `cp --recursive` for one-time copies and `aws s3 sync` for repeated synchronization where only changed files need to move. `sync` uses size and modification time to decide what to transfer; `cp --recursive` re-uploads everything. See [Run `aws s3 sync` with dynamic credentials](/what-is/run-aws-s3-sync-with-dynamic-credentials/).
+
+## Learn more
+
+* [Pulumi ESC product page](/product/esc/)
+* [Configuring OIDC between Pulumi and AWS](/docs/esc/environments/configuring-oidc/aws/)
+* [Run `aws s3 ls` with dynamic credentials](/what-is/run-aws-s3-ls-with-dynamic-credentials/)
+* [Run `aws s3 sync` with dynamic credentials](/what-is/run-aws-s3-sync-with-dynamic-credentials/)
+* [Run `aws sts get-caller-identity` with dynamic credentials](/what-is/run-aws-sts-get-caller-identity-with-dynamic-credentials/)
+* [Resolve `Unable to locate credentials`](/what-is/resolve-unable-to-locate-credentials/)
+* [Resolve `ExpiredToken`](/what-is/resolve-list-buckets-expired-token/)
+
+[Join our community on Slack](https://slack.pulumi.com/) to discuss further, and let us know what you build.


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/run-aws-s3-cp-with-dynamic-credentials.md` for SEO and AEO. The new version is ~210 tight lines explicitly covering all three directions of `aws s3 cp` (upload, download, S3-to-S3) plus the multipart-upload gotchas that bite users with long sessions.

## What changed

- **Quotable opening** — bolded one-paragraph framing of what the guide does, why dynamic credentials beat static, and the 8 MB multipart-upload threshold.
- **"In this article, we'll cover" bullet list** for skim/extract.
- **Why dynamic credentials beat static** — five bullets covering no-disk secrets, role scoping, expiration, CloudTrail audit, central rotation.
- **Direction/IAM table** — local-to-S3, S3-to-local, S3-to-S3, and recursive, each with the minimum IAM permissions. Encourages bucket/prefix-scoped policies.
- **Prerequisites** — Pulumi CLI/ESC, Pulumi Cloud account, AWS CLI v2, OIDC-trusted IAM role, an existing bucket.
- **Numbered step-by-step setup (5 steps)** — login, OIDC config, create environment, paste the `aws-login` YAML, confirm empty `aws configure list`.
- **Four run sub-sections** — upload, download, S3-to-S3 copy, recursive — each with copy-pasteable commands and expected output.
- **Multipart upload section** calling out session duration gotchas, lifecycle rules for orphaned parts, and `s3:AbortMultipartUpload`.
- **Verification** showing CloudTrail's `userIdentity.type=AssumedRole` payload.
- **Common errors table** — `AccessDenied` (PutObject/GetObject), `KMS.AccessDenied`, `InvalidClientTokenId`, `ExpiredToken` mid-upload, `RequestTimeout`, `NoSuchBucket`.
- **FAQ (7 doubt-removers)** — cross-account copy policy, credential lifetime, SSE-KMS, tuning multipart chunk size, CI usage, source verification, `cp` vs `sync`.
- **Cross-links** to `/product/esc/`, OIDC config docs, sibling run-aws pages, resolve-* error pages.
- Tightened `meta_desc` to lead with the value prop (under 160 chars).

## Test plan

- [ ] `make serve`; visit `/what-is/run-aws-s3-cp-with-dynamic-credentials/` and confirm both tables, code blocks, and headings render correctly
- [ ] Spot-check cross-links (`/product/esc/`, OIDC docs, sibling run-aws pages, resolve-* pages)
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)