### PR TITLE
content(what-is): expand the GitHub Actions secret explainer

### DIFF
--- a/content/what-is/what-is-a-github-action-secret.md
+++ b/content/what-is/what-is-a-github-action-secret.md
@@ -1,92 +1,209 @@
 ---
 title: What is a GitHub Actions Secret?
-meta_desc: |
-    Learn more about GitHub Actions secrets and how to use them.
-
+meta_desc: "GitHub Actions secrets are encrypted environment variables for CI/CD workflows. Learn scopes (repo, environment, organization), libsodium encryption, and OIDC alternatives."
 meta_image: /images/what-is/what-is-a-github-action-secret-meta.png
 type: what-is
 page_title: "What is a GitHub Actions Secret?"
 authors: ["diana-esteves"]
 ---
 
-[GitHub Actions](https://github.com/features/actions) is an automation feature provided by [GitHub](https://github.com/) that allows you to define workflows to automate various aspects of your software development process directly within your GitHub repository. A prevalent example is automatically running a linter test every time a commit is made against an opened pull request.
+**A GitHub Actions secret is an encrypted variable scoped to a repository, environment, or organization that GitHub injects into workflow runs as an environment variable or step input, with automatic redaction in logs and no exposure to forked pull requests by default.** Secrets let you keep API tokens, deployment credentials, and signing keys out of your workflow YAML while still using them in CI/CD steps.
 
-## What is a GitHub Actions secret?
+Secrets are encrypted using a [libsodium sealed box](https://docs.github.com/en/rest/actions/secrets) before they ever leave your browser or the GitHub REST client, and decrypted only on the runner that's executing a job that references them. Logs are scanned for secret values and automatically redacted, but the protection is real-time text matching — `echo $MY_SECRET | base64` or `set -x` can still expose values in ways the redactor can't reliably catch. For credentials that require fine-grained access or short-lived issuance, modern GitHub Actions workflows often skip stored secrets entirely and use [OIDC federation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) to mint cloud credentials per run.
 
-In GitHub Actions, secrets are encrypted environment variables you can store and use in your workflows. Secrets store sensitive information, such as API keys, access tokens, or passwords, without exposing them to your files.
+In this article, we'll cover the key questions about GitHub Actions secrets:
 
-### Key features
+* What is a GitHub Actions secret used for?
+* What are the secret scopes (repo, environment, organization)?
+* How are GitHub Actions secrets encrypted?
+* How do workflows access secrets?
+* What are the limits of GitHub Actions secrets?
+* What is OIDC and how does it compare to stored secrets?
+* What are best practices for GitHub Actions secrets?
+* How does Pulumi use GitHub Actions secrets?
+* Frequently asked questions about GitHub Actions secrets
 
-Using GitHub Actions secrets provides several key features that enhance the security and flexibility of your workflows:
+## What is a GitHub Actions secret used for?
 
-- **Automatic encryption** - Secrets are always encrypted in transit and at rest.
-- **Limited access** - A workflow will access a referenced secret during execution only. The GitHub UI does not expose secrets, nor are they available to users viewing the repository.
-- **Log redaction** - GitHub Actions automatically redact secrets from most logs and prevent them from being exposed in the workflow run logs.
-- **Dynamic configurations** - By referencing secrets in workflow files, you can easily update sensitive information without modifying the code. This flexibility is beneficial when collaborating with others or managing multiple environments (e.g., development, staging, production).
+A secret is the right place for any sensitive value a workflow needs at runtime. Typical uses:
 
-## Using GitHub Actions secrets
+* Cloud credentials (AWS access keys, Azure service principal secrets, GCP service-account JSON).
+* Container registry tokens for `docker login`.
+* Deployment tokens for hosting platforms (Vercel, Netlify, Cloudflare).
+* Third-party API tokens (Slack, PagerDuty, monitoring tools).
+* Signing keys for code signing, package publishing, or commit signing.
+* Pulumi access tokens for IaC workflows.
 
-This example lists the steps required to configure a GitHub token in one of the most popular GitHub Actions, [super linter](https://github.com/marketplace/actions/super-linter). We can obtain extra details about a given commit's code quality when provided with a GitHub token. This token is sensitive; thus, it will be stored and referenced as a secret within a GitHub [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment).
+For non-sensitive data (build flags, environment names, log levels), use repository, environment, or organization **variables** instead. Variables aren't encrypted but also aren't redacted — they're meant for things that can safely appear in logs.
 
-### Prerequisites
+## What are the secret scopes (repo, environment, organization)?
 
-An existing GitHub personal access token is required to proceed. Navigate to your [GitHub settings](https://github.com/settings/personal-access-tokens/new) to create one.
+GitHub Actions secrets live at three scopes that determine where they can be referenced and which workflows can read them.
 
-### Steps
+| Scope | Where defined | Available to | Best for |
+|---|---|---|---|
+| **Repository** | Repository → Settings → Secrets and variables → Actions | Every workflow in the repository | Single-repo deploys, build tokens |
+| **Environment** | Repository → Settings → Environments → \<env\> | Jobs that `environment:` into that environment, with optional approval gates | Per-stage credentials (dev/staging/prod) |
+| **Organization** | Organization → Settings → Secrets and variables → Actions | Selected (or all) repositories in the org | Shared credentials across many repos |
 
-To use secrets in GitHub Actions, you'd need to follow these steps:
+Environment-scoped secrets are the most powerful tier because they let you require manual approval, wait timers, and deployment-branch policies before a job can read production credentials. A common production pattern: organization-scoped credentials for shared services, environment-scoped secrets for per-stage deploy keys, repository secrets for repo-specific tokens.
 
-1. **Create a new environment**
+## How are GitHub Actions secrets encrypted?
 
-    - Go to your GitHub repository.
-    - Click on the "Settings" tab.
-    - In the left sidebar, click on "Environments".
-    - Click on the "New environment" button.
-    - Provide a name for the environment, e.g., `demo`.
-    - Click on the "Configure environment" button.
+Secrets are encrypted with a [libsodium sealed box](https://doc.libsodium.org/public-key_cryptography/sealed_boxes) before they're transmitted to GitHub. The repository or organization holds a public key; the secret is encrypted with that key client-side; only GitHub holds the corresponding private key to decrypt it on the runner.
 
-2. **Create an environment secret**
+| Stage | Protection |
+|---|---|
+| Submission | Sealed-box encryption (NaCl `crypto_box_seal`) before transit |
+| Storage | Encrypted at rest in GitHub's storage |
+| Delivery to runner | Decrypted only when a job that references the secret runs |
+| In the runner | Available to the running job as an env var or step input |
+| In logs | Automatic redaction of matching values |
+| After job ends | Discarded with the ephemeral runner |
 
-    - In the environment configuration page from Step 1,
-    - Scroll to the "Environment secrets" section.
-    - Click on the "Add secret" button.
-    - Provide a name for the secret and its corresponding value.
-        e.g., Name: `DEMO_GITHUB_TOKEN`
-            Value: `github_pat_123123123`
-    - Click "Add secret" to save it.
+GitHub itself can decrypt your secrets to deliver them to runners, so the trust boundary is GitHub plus your runner. For higher-assurance setups, self-hosted runners or hardware security modules in the cloud provider you're deploying to (via OIDC, see below) can shrink that boundary further.
 
-3. **Use the secret in the workflow**
+## How do workflows access secrets?
 
-    - You can see a reference to the secret using the `secrets.` context in the workflow YAML file (e.g., `.github/workflows/super-linter.yml`)
-    - Ensure the name of the secret matches: `GITHUB_TOKEN: ${{ secrets.DEMO_GITHUB_TOKEN }}`
+Inside a workflow YAML file, secrets are referenced through the `secrets` context:
 
-For more information, visit the GitHub guide [Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: ./deploy.sh
+```
 
-## Best practices
+Notes that catch teams out:
 
-- **Restrict access to secrets** - Follow the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) and avoid granting unnecessary permissions to actions or workflows. Only provide the minimum required access to complete the necessary tasks.
-- **Use environment-specific secrets:** - Consider creating different sets of secrets for different environments (e.g., development, staging, production). This practice helps minimize the impact of a potential compromise and allows for more granular control over which secrets are accessible in different contexts.
-- **Audit workflow runs:** - Regularly review the logs and outputs of your workflow runs to ensure that secrets are not inadvertently exposed. GitHub Actions automatically redacts secrets in most logs, but it's a good practice to review logs for any potential issues.
+* **Secrets aren't passed to forked PRs by default.** Workflows triggered by `pull_request` from a fork get an empty `secrets` context unless you explicitly opt in with `pull_request_target` (which has its own security considerations).
+* **Composite and reusable actions don't inherit secrets automatically.** You have to pass them in as `inputs:` or use `secrets: inherit` when calling a reusable workflow.
+* **`GITHUB_TOKEN` is a special, auto-issued, short-lived secret** scoped to the current repository. Prefer it to a personal access token whenever you can.
 
-## Challenges and considerations
+## What are the limits of GitHub Actions secrets?
 
-Using GitHub Actions secrets provides a secure way to manage sensitive information. Still, there are challenges and considerations to remember:
+Per GitHub's [documentation](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions):
 
-- **Nongranular access scope** - Secrets are repository-wide, and there's no inherent support for limiting secrets to specific workflows or jobs. Exercise caution with repository-wide secrets and explore external solutions for more granular access control.
-- **Unavailability of secrets in Pull Requests** - Secrets are unavailable in workflows triggered by pull requests from forks by default. For workflows involving pull requests, especially from forks, consider alternative solutions or design workflows that don't rely on sensitive information.
-- **Limited default visibility and auditing:** - Limited visibility into when and by whom secrets are accessed during workflow runs. Consider implementing additional logging or external monitoring tools to enhance the visibility and audibility of secret usage in workflows.
+* **64 KB maximum size** per secret. Large credential bundles (full service-account JSON files, multi-line certs) may need to be base64-encoded to fit, or stored externally.
+* **Up to 1,000 secrets** per repository, **100** per environment, and **1,000** per organization.
+* **No native rotation.** GitHub doesn't expire or rotate values for you; you have to update them out of band (or use OIDC to avoid storing them at all).
+* **No fine-grained access within a repo.** Any workflow in the repository can read any repo-scoped secret. Environments are the only way to gate access to a subset.
+* **Limited audit detail.** The audit log records secret-management events (create/update/delete) but not which workflow runs read a given secret.
+* **No first-class versioning.** Updating a secret overwrites the previous value.
 
-Refer to the official [secrets documentation](https://docs.github.com/en/actions/security-guides/encrypted-secrets) for more details on GitHub Actions secrets.
+## What is OIDC and how does it compare to stored secrets?
 
-## Conclusion
+[GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) lets workflows request a short-lived OIDC token that the cloud provider exchanges for temporary credentials. Nothing has to be stored as a secret.
 
-GitHub Actions secrets are encrypted and only exposed to workflow runs. They are not visible in the GitHub UI, and users or other GitHub Actions cannot directly access their values. User precaution is still required to avoid unintentionally exposing secrets in logs. GitHub automatically redacts secrets in most places, but avoid using secrets in unsecured ways in your workflow scripts.
+| Approach | Credential lifetime | Rotation | Surface area |
+|---|---|---|---|
+| **Stored secret** | Until you rotate it (often months) | Manual | Anything that can read the secret |
+| **OIDC + cloud role** | Minutes (provider-controlled) | Automatic per run | Only the specific job's identity |
 
-Now that you know about GitHub Actions secrets, take your cloud infrastructure management to the next level with Pulumi:
+For AWS, Azure, GCP, HashiCorp Vault, [Pulumi ESC](/product/esc/), and most modern cloud providers, OIDC is the recommended path. Workflows assume a role scoped to "GitHub Actions in this repo on this branch" and receive temporary credentials directly. Stored secrets remain useful for SaaS APIs that don't support OIDC.
 
-- **Integrate your [continuous delivery with Pulumi](https://www.pulumi.com/docs/iac/packages-and-automation/continuous-delivery/github-actions/)**: Ship software faster and more safely by combining Pulumi with the other components of your automated infrastructure.
-- **Install the [Pulumi GitHub App](https://www.pulumi.com/docs/iac/packages-and-automation/continuous-delivery/github-app/)**:  Once installed, the Pulumi GitHub app will submit rich, inline comments on any pull request or commit that introduces a change to your Pulumi-managed infrastructure.
-- **Manage sensitive data and secrets with Pulumi**: Dive into Pulumi's [Secrets Management guide](/blog/managing-secrets-with-pulumi/) for in-depth information on encrypting specific values for added security and ensuring that these values never appear in plain text in your state file​.
-- **Use the [GitHub provider for Pulumi](https://www.pulumi.com/registry/packages/github/#github)**: Provision any of the cloud resources available in GitHub.
+## What are best practices for GitHub Actions secrets?
 
-Our [community on Slack](https://slack.pulumi.com/) is always open for discussions, questions, and sharing experiences. Join us there and become part of our growing community of cloud professionals!
+* **Prefer OIDC to stored secrets.** For any cloud that supports it (AWS, Azure, GCP, Vault, [Pulumi ESC](/product/esc/)), federate identity instead of storing long-lived credentials.
+* **Scope secrets to environments, not repos.** Environment secrets unlock deploy gates, branch policies, and approval workflows that repo-scoped secrets don't.
+* **Use the smallest scope that works.** Repo > environment > org isn't a hierarchy of "more powerful" — it's a hierarchy of blast radius. Pick the tightest one.
+* **Use `GITHUB_TOKEN` over PATs.** It's auto-issued, short-lived, and scoped to the current repository.
+* **Don't `echo` secrets.** GitHub's log redactor catches direct prints, but transformations (`echo $SECRET | base64`, `set -x`, logging child process output) can leak values past the redactor. Pass secrets as env vars and let the tools that need them read them directly.
+* **Block secrets in forked PRs.** The default is already to not pass them; resist any workflow design that requires `pull_request_target` with secrets unless you've thought hard about the threat model.
+* **Rotate periodically.** Even with OIDC, anything still stored as a secret should have a documented rotation cadence. Pair this with secret-scanning to catch accidental commits.
+
+## How does Pulumi use GitHub Actions secrets?
+
+Pulumi's [GitHub Actions integration](/docs/iac/packages-and-automation/continuous-delivery/github-actions/) uses secrets for the same things any other CI tool does: a `PULUMI_ACCESS_TOKEN` for talking to the Pulumi Cloud backend, and cloud-provider credentials (or, ideally, OIDC) for the actual `pulumi up`.
+
+A typical workflow with OIDC and [Pulumi ESC](/product/esc/):
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pulumi/auth-actions@v1
+        with:
+          organization: my-org
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+      - uses: pulumi/actions@v6
+        with:
+          command: up
+          stack-name: prod
+```
+
+What this gives you:
+
+* No `PULUMI_ACCESS_TOKEN` stored in GitHub. The OIDC flow exchanges the workflow's identity for a short-lived Pulumi Cloud token.
+* No cloud-provider credentials stored in GitHub. [Pulumi ESC](/product/esc/) brokers AWS/Azure/GCP credentials and rotates them on every run.
+* The `environment: production` gate gives you approval workflows and branch policies on top.
+
+[Get started with Pulumi and GitHub Actions](/docs/iac/packages-and-automation/continuous-delivery/github-actions/) to wire up IaC pipelines in TypeScript, Python, Go, C#, Java, or YAML.
+
+## Frequently asked questions about GitHub Actions secrets
+
+### Are GitHub Actions secrets encrypted?
+
+Yes. Secrets are encrypted with a libsodium sealed box before they're transmitted to GitHub, stored encrypted at rest, and decrypted only on the runner executing a job that references them. The trust boundary is GitHub plus the runner that decrypts the value.
+
+### Where do I add a GitHub Actions secret?
+
+For a repository: **Settings → Secrets and variables → Actions → New repository secret**. For an environment: **Settings → Environments → \<env\> → Add secret**. For an organization (admin-only): **Organization Settings → Secrets and variables → Actions**.
+
+### What is the maximum size of a GitHub Actions secret?
+
+64 KB. For larger payloads (full service-account JSON, multi-line certificates), base64-encode the value before storing it, or store the payload in an external secrets manager and use a smaller secret to authenticate to that store.
+
+### How many secrets can I have?
+
+Up to 1,000 per repository, 100 per environment, and 1,000 per organization. Hitting these limits usually means the secrets should live in a centralized store like [Pulumi ESC](/product/esc/) or [HashiCorp Vault](/what-is/what-is-hashicorp-vault/) instead.
+
+### Can a forked pull request access my secrets?
+
+No, by default. Workflows triggered by `pull_request` from a fork run with an empty `secrets` context. `pull_request_target` does pass secrets but executes against the base branch's workflow definition; use it carefully and never check out forked code before secrets are needed.
+
+### How are secrets redacted from logs?
+
+GitHub scans log output for known secret values and replaces matches with `***`. This works for direct prints (`echo $MY_SECRET`) but not for transformations (`echo $MY_SECRET | base64`, partial outputs, or values written to files that are later cat'd). Treat the redactor as defense-in-depth, not the primary control.
+
+### Should I use OIDC instead of storing secrets?
+
+For any cloud provider that supports it (AWS, Azure, GCP, Vault, [Pulumi ESC](/product/esc/)), yes. OIDC issues short-lived credentials per workflow run, eliminating long-lived stored secrets and dramatically reducing rotation overhead. Stored secrets stay useful for SaaS APIs that don't support OIDC.
+
+### Can I share secrets between repositories?
+
+Yes — use organization-level secrets and select which repositories can access them. Avoid the older pattern of duplicating the same secret into every repo; it's a rotation nightmare.
+
+### Does `GITHUB_TOKEN` count as a secret?
+
+It behaves like one (encrypted, redacted in logs, scoped to the job) but you don't manage it — GitHub issues a fresh `GITHUB_TOKEN` for every workflow run and discards it at the end. Prefer it to a personal access token wherever possible.
+
+### Can I rotate secrets automatically?
+
+Not natively. GitHub doesn't refresh stored values on a schedule. The closest options: rotate the upstream credential and update the secret via the GitHub REST/GraphQL API from another workflow, or skip stored secrets entirely with OIDC.
+
+## Learn more
+
+Pulumi pairs with GitHub Actions through OIDC and [Pulumi ESC](/product/esc/) so cloud credentials never live in your repository. Workflows authenticate by identity, ESC brokers per-run credentials, and the Pulumi GitHub Actions integration handles the rest. [Get started today](/docs/get-started/).
+
+Related reading:
+
+* [What is Secrets Management?](/what-is/what-is-secrets-management/)
+* [What is a CircleCI Secret?](/what-is/what-is-a-circleci-secret/)
+* [What is a Cloudflare Secret?](/what-is/what-is-a-cloudflare-secret/)
+* [What is HashiCorp Vault?](/what-is/what-is-hashicorp-vault/)
+* [What is AWS Secrets Manager?](/what-is/what-is-aws-secrets-manager/)
+* [What is Azure Key Vault?](/what-is/what-is-azure-key-vault/)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/what-is-a-github-action-secret.md` for SEO and AEO. The previous page led with a generic GitHub Actions intro and a single tutorial; the new version covers the three secret scopes, libsodium encryption, OIDC as a stored-secret alternative, and the specific limits engineers ask about (64 KB, 1,000 secrets per repo, no rotation).

## What changed

- **Opening definition** — bolded one-sentence definition (encrypted variable, scoped to repo/environment/org, redacted from logs, withheld from forked PRs), followed by an explicit note on libsodium and OIDC as a modern alternative.
- **Use cases** — concrete list (cloud credentials, registry tokens, deploy tokens, third-party APIs, signing keys, Pulumi access tokens).
- **Scope table** — repository vs. environment vs. organization with where to define, who can read, and best-fit use cases.
- **Encryption table** — six-stage breakdown (submission, storage, delivery, runner, logs, post-job).
- **Workflow access** — YAML example, caveats on forked PRs, composite/reusable workflows, and `GITHUB_TOKEN`.
- **Limits** — 64 KB per secret, 1,000 per repo, 100 per env, 1,000 per org, no native rotation, no fine-grained access within a repo, no versioning.
- **OIDC section** — comparison table (stored secret vs. OIDC + cloud role) and where each fits.
- **Best practices** — prefer OIDC, scope to environments, smallest scope possible, use `GITHUB_TOKEN`, don't `echo` secrets, block forked-PR access, rotate.
- **Pulumi section** — YAML example using `pulumi/auth-actions` and `pulumi/actions` with OIDC and Pulumi ESC.
- **FAQ** — ten doubt-removers (encryption, where to add, size limit, count limits, forked PRs, log redaction limits, OIDC, cross-repo sharing, `GITHUB_TOKEN`, rotation).
- **Cross-links** — secrets management, CircleCI/Cloudflare secrets, HashiCorp Vault, AWS Secrets Manager, Azure Key Vault.

## Test plan

- [ ] `make serve`; visit `/what-is/what-is-a-github-action-secret/` and confirm tables and code blocks render
- [ ] Spot-check cross-links (`/docs/iac/packages-and-automation/continuous-delivery/github-actions/`, `/product/esc/`)
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)