### PR TITLE
content(what-is): expand the Internal Developer Platform explainer

### DIFF
--- a/content/what-is/what-is-an-internal-developer-platform.md
+++ b/content/what-is/what-is-an-internal-developer-platform.md
@@ -1,137 +1,204 @@
 ---
 title: What is an Internal Developer Platform (IDP)?
 allow_long_title: true
-meta_desc: |
-    Understand what an Internal Developer Platform (IDP) is, its benefits, key components, and how it streamlines development workflows.
+meta_desc: "An Internal Developer Platform (IDP) is a self-service layer over an organization's infrastructure. Learn what's in one, why it matters, and how to build."
 meta_image: /images/what-is/what-is-an-internal-developer-platform-meta.png
 type: what-is
 page_title: What is an Internal Developer Platform (IDP)?
 authors: ["sarah-hughes"]
 ---
 
-An Internal Developer Platform (IDP) is a layer that sits on top of your organization's infrastructure and tools, providing a standardized, self-service experience for developers. It abstracts away the complexity of underlying infrastructure, allowing developers to provision and manage the resources they need without having to understand all the underlying details.
+**An Internal Developer Platform (IDP) is a self-service layer built on top of an organization's infrastructure, CI/CD, and operational tooling that lets application developers provision environments, ship code, and run services without needing to operate the underlying systems.** It abstracts the cloud, container, secrets, and policy stack behind a paved-road interface — a portal, a CLI, an API, or all three — so that the routine path from idea to production is fast, consistent, and safe.
+
+An IDP is the *product* that a [platform engineering](/what-is/what-is-platform-engineering/) team builds. The point isn't to hide the cloud from developers; it's to make the right thing the easy thing. Developers self-serve from a curated catalog of vetted templates and components, and the platform team encodes the organization's standards (security, compliance, cost, reliability) into the platform itself.
 
 {{< youtube "is83TV8nrTg?rel=0" >}}
 
-## What is an Internal Developer Platform?
+In this article, we'll cover the key questions about Internal Developer Platforms:
 
-An Internal Developer Platform is a set of tools, services, and processes that platform engineering teams build to enable application developers to self-serve infrastructure and deploy applications. Organizations can build IDPs internally or adopt flexible solutions like [Pulumi IDP](/product/internal-developer-platforms/) to enable self-service infrastructure efficiently.
+* Why do organizations build IDPs?
+* What is inside an Internal Developer Platform?
+* How is an IDP different from platform engineering and a PaaS?
+* How do you build an Internal Developer Platform?
+* What are the benefits of an IDP?
+* What are the common pitfalls and anti-patterns?
+* What tools are used to build IDPs?
+* Frequently asked questions about IDPs
 
-IDPs consolidate infrastructure components, deployment pipelines, environments, and monitoring tools into a unified, developer-centric interface. The goal is to increase developer productivity and satisfaction by providing them with the tools they need while ensuring infrastructure best practices, security, and compliance.
+## Why do organizations build IDPs?
 
-At its core, an IDP implements "golden paths" - predefined, optimized workflows for developers to follow when building, testing, and deploying applications. One of those paths incorporates organizational standards and best practices, making it easy for developers to do the right thing without requiring expert knowledge of infrastructure.
+A few pressures consistently push engineering organizations toward an internal platform.
 
-Pulumi's approach to [building Internal Developer Platforms](/blog/announcing-pulumi-idp) focuses on combining flexibility for platform teams with simplicity for application developers, creating a seamless experience that accelerates software delivery.
+### Cognitive load on product teams has gotten unmanageable
 
-## Key components of an Internal Developer Platform
+A modern application touches dozens of cloud services, a container runtime, a CI/CD system, a secrets store, observability, identity, policy, and cost controls. Expecting every product team to be expert in all of those (and to keep up as the stack changes) is no longer realistic. An IDP moves that expertise into the platform.
 
-An IDP may include these core components:
+### Patterns are repeated everywhere
 
-* **Self-service infrastructure provisioning**: Enables developers to create and manage the infrastructure resources they need through simplified interfaces or APIs
-* **Application configuration management**: Provides standardized ways to manage application configurations across different environments
-* **Environment management**: Offers consistent ways to manage development, staging, and production environments
-* **Workflow orchestration**: Automates the steps required to build, test, and deploy applications
-* **Observability and monitoring**: Integrates tools for logging, monitoring, and alerting to help developers understand application behavior
-* **Security and compliance guardrails**: Enforces organizational policies and security requirements
-* **Documentation and knowledge sharing**: Centralizes technical documentation and promotes sharing of best practices
+Without a platform, every team reinvents the same things: a Kubernetes namespace with the right defaults, a database with the right backup policy, a CI/CD template with the right gates, a logging stack with the right indexes. Multiplied across many teams, the duplicated work and divergent quality become a serious tax.
 
-## Why are Internal Developer Platforms important?
+### Standards exist on paper but not in code
 
-IDPs have become increasingly important as organizations face several challenges in modern software development:
+Compliance baselines, security policies, and cost rules tend to live in PDFs and wiki pages until someone violates them. An IDP turns those standards into the only path that exists: encryption is on by default because the platform turns it on; secrets come from the central vault because the platform wires them in; cost tags exist because the platform applies them.
 
-### Growing infrastructure complexity
+### Hiring and onboarding don't scale linearly
 
-Cloud-native architectures, microservices, and containerization have increased the complexity of infrastructure management. This complexity often becomes a bottleneck as developers need to wait for infrastructure teams to provision resources or troubleshoot issues.
+A new engineer who has to learn an organization's bespoke combination of cloud, Kubernetes, CI/CD, and policy before they can ship anything is a slow ramp. An IDP collapses the learning curve to "use the portal" for everything routine, freeing the deep ramp for the genuinely novel work.
 
-### Developer productivity gaps
+## What is inside an Internal Developer Platform?
 
-When developers spend time dealing with infrastructure configuration, deployment processes, and operational concerns, they have less time for building features and innovating. This negatively impacts productivity and time-to-market.
+There is no single blueprint, but most production IDPs include some combination of these components.
 
-### Inconsistent development practices
+| Capability | What it does |
+|---|---|
+| **Service catalog and templates** | "Golden paths" for common service shapes — REST API, worker, scheduled job, data pipeline. New services come from templates. |
+| **Self-service infrastructure** | Developers can spin up environments, databases, queues, and clusters from the portal or API without filing a ticket. |
+| **Environment management** | Consistent dev / staging / production environments with promotion workflows. |
+| **CI/CD integration** | Pre-wired pipelines for build, test, scan, deploy. Developers don't author pipelines from scratch. |
+| **Configuration and secrets** | Hierarchical configuration and secrets pulled at runtime from a central store like [Pulumi ESC](/product/esc/) or HashiCorp Vault. |
+| **Security and policy guardrails** | [Policy as code](/docs/insights/policy/) blocks insecure configurations; encryption, IAM, and network defaults are baked into platform components. |
+| **Observability** | Metrics, logs, traces, and SLO-based alerts wired into every service automatically. |
+| **Cost and ownership** | Resources are tagged, attributable, and visible in cost dashboards. |
+| **Documentation and discovery** | Searchable catalog of services, owners, dependencies, and runbooks. |
 
-Without standardized platforms, different teams may adopt different tools and practices, leading to inconsistency, difficulty in knowledge sharing, and increased maintenance costs.
+A useful sanity check: if a developer has to read three wikis and ask in two Slack channels to ship a routine change, the IDP doesn't cover enough of the lifecycle yet.
 
-### Scale and speed requirements
+## How is an IDP different from platform engineering and a PaaS?
 
-As organizations grow, they need to onboard developers quickly and enable them to be productive without extensive training on infrastructure specifics.
+These three terms get used interchangeably in marketing material. They are not the same thing.
 
-## Benefits of implementing an Internal Developer Platform
+| Term | What it is |
+|---|---|
+| **Platform engineering** | The discipline and practice of designing, building, and operating internal platforms. The people and the process. |
+| **Internal Developer Platform (IDP)** | The product that platform engineering builds — the actual portal, CLI, API, templates, and components developers use. |
+| **PaaS (Platform as a Service)** | A vendor-operated platform like Heroku, Vercel, or Google App Engine. Developers consume it; nobody at the customer organization builds or operates it. |
 
-Organizations that successfully implement IDPs realize several significant benefits:
+The clearest distinction: with a PaaS, the platform is someone else's product. With an IDP, the platform is *your organization's* product, built by your platform engineering team on top of cloud primitives and best-of-breed tools to fit your organization's specific needs. A PaaS is "rent"; an IDP is "build to suit."
 
-* **Increased developer productivity**: Developers spend less time on infrastructure configuration and more time on application development
-* **Faster onboarding**: New team members can become productive more quickly by following established patterns
-* **Standardized workflows**: Consistent approaches to development, testing, and deployment across teams
-* **Improved reliability**: Built-in best practices reduce the likelihood of production issues
-* **Better governance**: Centralized policy enforcement for security and compliance requirements
-* **Reduced cognitive load**: Developers don't need to be experts in every infrastructure technology
-* **Improved collaboration**: Common interfaces facilitate better communication between development and platform teams
+For more on the discipline that produces an IDP, see [what is platform engineering?](/what-is/what-is-platform-engineering/).
 
-## The difference between Platform Engineering and IDPs
+## How do you build an Internal Developer Platform?
 
-While closely related, Platform Engineering and Internal Developer Platforms are not the same:
+There is no single right architecture, but the most consistently successful path is incremental.
 
-* **Platform Engineering** is the discipline and practice of designing, building, and maintaining developer platforms. It involves the people, processes, and cultural aspects of creating developer-centric infrastructure solutions.
-* **Internal Developer Platforms** are the actual products that platform engineering teams build - the technical implementation that developers interact with daily.
+### Start with the painful path
 
-Think of Platform Engineering as the discipline, and the IDP as the product of that discipline.
+Identify the single workflow that consumes the most product-team time today — typically environment provisioning, deploying a new service, or onboarding a new developer. Build the first slice of the platform around that workflow. Resist the temptation to design the "platform of the future" before solving today's problem.
 
-## Common implementation approaches for IDPs
+### Treat the platform as a product
 
-Organizations take different approaches to building Internal Developer Platforms based on their specific needs:
+The platform's users are internal engineers. Apply normal product practice: user research, roadmap, releases, support, telemetry on what's actually used. The teams that succeed run their platform with a product manager and a backlog, not as a side project of an SRE team.
 
-### Custom-built platforms
+### Build on infrastructure as code
 
-Some organizations build their IDPs from scratch, tailoring them specifically to their unique requirements. This approach offers maximum customization but requires significant engineering resources.
+[Infrastructure as code](/what-is/what-is-infrastructure-as-code/) is the substrate. Every platform component (a Kubernetes namespace, a database, a CI/CD pipeline, an observability hookup) is a reusable [Pulumi component](/docs/iac/concepts/components/) that the platform composes on demand. The platform's "Provision a new environment" button is, underneath, a Pulumi program.
 
-### Open source foundations
+### Encode standards as code, not policy documents
 
-Many IDPs build upon open source tools like Kubernetes, Backstage, Argo CD, and Terraform. These provide a foundation that can be extended and customized.
+Policy, security, and cost rules belong in the same pipeline as the code they govern. [Pulumi Policies](/docs/insights/policy/) and Open Policy Agent let you block insecure configurations before they deploy. The platform consumes the same checks, so the paved-road path is also the compliant path.
 
-### Commercial solutions
+### Centralize configuration and secrets
 
-There are also commercial platforms that provide out-of-the-box IDPs with customization options, often requiring less engineering investment but providing less flexibility.
+Secrets in code, in CI logs, or in container images are a frequent breach pattern. The platform should pull secrets at runtime from a central store like [Pulumi ESC](/product/esc/), and developers should never see plaintext credentials in their workflow.
 
-### Hybrid approaches
+### Provide a clear interface
 
-Most successful IDPs take a hybrid approach, combining commercial tools, open source components, and custom integrations to create a cohesive developer experience.
+Most IDPs expose two interfaces: a web portal for discovery, requests, and visibility (often built on [Backstage](https://backstage.io/) or [Pulumi IDP](/product/internal-developer-platforms/)), and a CLI or API for the actual work. Both should feel obvious; if developers need training to use the platform, the platform has lost.
 
-## Key considerations when building an IDP
+### Measure adoption and satisfaction
 
-When building an Internal Developer Platform, platform teams should consider:
+Track the percentage of services going through the paved road, lead time for a new environment, and qualitative developer satisfaction (typically with NPS-style surveys). Adoption is the leading indicator of value; satisfaction is the leading indicator of churn.
 
-* **Developer experience**: The platform should be intuitive and provide clear value to developers
-* **Balancing flexibility and standardization**: Too rigid, and developers will find workarounds; too flexible, and you lose the benefits of standardization
-* **Integration with existing tools**: The platform should work with the tools developers already use and love
-* **Incremental implementation**: Start small with focused capabilities and expand based on feedback
-* **Clear documentation**: Comprehensive documentation is essential for platform adoption
-* **Support model**: Define how developers will get help when they encounter issues
-* **Feedback loops**: Establish mechanisms to collect and respond to developer feedback
+## What are the benefits of an IDP?
 
-## Dispelling common myths about IDPs
+Organizations that successfully roll out an IDP see compounding gains:
 
-Several myths persist about Internal Developer Platforms that can create confusion:
+* **Faster delivery.** New services bootstrap in minutes instead of weeks. Routine changes ship without ticket queues.
+* **Faster onboarding.** New engineers ship a real change in days, not months.
+* **Consistent practice.** Every service ships with the same observability, the same security defaults, the same on-call wiring.
+* **Stronger compliance posture.** Standards are enforced in code, so the paved road is the audit trail.
+* **Lower cognitive load.** Product teams stop having to be experts in Kubernetes, IAM, networking, and CI/CD just to ship a feature.
+* **Better leverage for platform teams.** A small platform team can multiply hundreds of product engineers.
 
-### Myth: IDPs eliminate the need for infrastructure teams
+## What are the common pitfalls and anti-patterns?
 
-Even with the best IDP, you still need infrastructure specialists who understand how to architect, manage, scale, troubleshoot, and optimize the underlying systems. What changes is how these specialists work - focusing more on platform development and less on manual, repetitive tasks.
+A few patterns reliably cause IDP programs to stall:
 
-### Myth: Implementing an IDP will dramatically increase staffing costs
+* **Building everything before delivering anything.** Big-bang platform launches consistently underperform an iterative paved-road approach.
+* **Treating the platform as infrastructure, not as a product.** Without a PM and a feedback loop, the platform drifts away from what developers actually need.
+* **Over-abstraction.** Hiding the cloud completely from developers backfires the first time they need to debug a real production issue. The platform should be a paved road, not a closed system.
+* **Mandate without value.** If the platform's only selling point is "you have to use it," teams will route around it. Adoption has to be pulled, not pushed.
+* **Stopping at the portal.** A portal that submits tickets is not a self-service platform. The portal has to invoke automation that actually does the work.
+* **Ignoring exit paths.** The platform should make routine work easy *and* leave the underlying primitives accessible for the genuinely novel cases. A platform with no escape hatch eventually loses the senior engineers.
 
-A well-designed IDP allows the same individuals to accomplish more by leveraging a shared platform. While some initial investment may be needed, IDPs increase efficiency over time by automating repetitive tasks, reducing bottlenecks, and streamlining workflows.
+## What tools are used to build IDPs?
 
-### Myth: Adopting an IDP will quickly solve all your problems
+A real IDP is a stack, not a single product. Most teams use a mix.
 
-Change takes time, and there's no one-size-fits-all solution. The most successful approach is to start with a minimal viable platform (MVP) focused on a subset of users, create fast feedback loops, and iteratively improve based on actual usage.
+| Layer | Representative tools |
+|---|---|
+| Platform portal | [Pulumi IDP](/product/internal-developer-platforms/), Backstage, Port, Cortex |
+| Infrastructure as code | [Pulumi](/), Terraform, OpenTofu, AWS CDK |
+| Container orchestration | Kubernetes, Amazon ECS, GKE Autopilot |
+| CI/CD | GitHub Actions, GitLab CI, Argo CD, Buildkite |
+| Configuration and secrets | [Pulumi ESC](/product/esc/), HashiCorp Vault, AWS Secrets Manager |
+| Policy as code | [Pulumi Policies](/docs/insights/policy/), Open Policy Agent, Kyverno |
+| Observability | Prometheus, Grafana, Datadog, OpenTelemetry |
+| Service mesh / identity | Istio, Linkerd, SPIFFE, workload identity |
 
-### Myth: You should apply IDP practices to every application
+The choice of each tool matters less than the fact that they're stitched together into one paved-road experience.
 
-Focus first on applications where developers are overwhelmed by infrastructure complexities or where operations teams face constant friction. Start with smaller, less-demanding services rather than your most critical systems to build confidence in the platform.
+## Frequently asked questions about IDPs
 
-## Conclusion
+### What is an Internal Developer Platform in simple terms?
 
-Internal Developer Platforms represent a significant evolution in how organizations approach infrastructure and developer experience. By abstracting complexity and providing standardized, self-service capabilities, IDPs enable developers to be more productive while ensuring that organizational standards for security, reliability, and compliance are maintained.
+It's the in-house "easy button" that lets developers do all the routine cloud, infrastructure, and deployment work themselves through a curated portal or API, instead of filing tickets to a central team. The platform team builds and operates it; everyone else uses it.
 
-As cloud infrastructure continues to grow in complexity, IDPs will become increasingly important for organizations that want to maintain developer velocity and satisfaction while managing costs and risks.
+### What is the difference between an IDP and platform engineering?
 
-Pulumi provides a comprehensive foundation for building Internal Developer Platforms that scale with your organization's needs. [Request a demo](/request-a-demo) to learn how Pulumi can help you build an IDP, or [get started with Pulumi](/docs/get-started) today.
+Platform engineering is the *discipline* — the people, practices, and culture of building developer-facing platforms. The IDP is the *product* of that discipline. You don't have one without the other, but they're not the same thing.
+
+### Do you need an IDP if you have a small team?
+
+Not on day one. A small team can succeed with a few good templates, a shared CI/CD pipeline, and a curated set of [Pulumi components](/docs/iac/concepts/components/). The IDP investment pays back once the number of product teams exceeds what a central group can support directly — typically somewhere in the dozens of engineers.
+
+### Will an IDP replace our infrastructure or operations teams?
+
+No. It changes what they spend their time on. Infrastructure and operations specialists are still needed to architect, scale, troubleshoot, and evolve the underlying systems, but they shift from doing repetitive provisioning work to building and operating the platform that does it.
+
+### How long does it take to build an IDP?
+
+The first useful slice ships in weeks (a templated new-service workflow, a single paved-road CI/CD pipeline). A platform that covers most of an org's services is measured in quarters and years. Treat it as an ongoing investment, not a project with an end date.
+
+### Is Backstage an IDP?
+
+Backstage is a developer portal — a UI layer. It's a common front-end for an IDP, but the platform itself is the combination of Backstage (or Port, Cortex, or [Pulumi IDP](/product/internal-developer-platforms/)) plus the automation, IaC, policy, secrets, and CI/CD that actually do the work.
+
+### Can an IDP work in a regulated industry?
+
+Yes — and arguably it's where IDPs pay off most. Compliance frameworks like SOC 2, HIPAA, and FedRAMP are easier to evidence when standards are enforced in code through [policy as code](/docs/insights/policy/), and when every change leaves a Git audit trail.
+
+### How does an IDP work with multiple clouds?
+
+Cleanly, if it's built on a multi-cloud-capable layer like [Pulumi](/). The platform abstracts cloud-specific differences behind shared components ("a database," "a queue," "a Kubernetes namespace"), and the underlying [infrastructure as code](/what-is/what-is-infrastructure-as-code/) provisions the right primitive on AWS, Azure, GCP, or on-prem.
+
+### How is an IDP different from GitOps?
+
+GitOps is a workflow pattern — desired state in Git, controllers reconcile the live system. An IDP is the broader self-service surface. Many IDPs use GitOps under the hood for deployment, but the IDP also covers things GitOps doesn't (templated service creation, environment provisioning, ticketless onboarding, cost attribution).
+
+### Does Pulumi help build an IDP?
+
+Yes. [Pulumi IDP](/product/internal-developer-platforms/) provides templates, components, and a control plane built on Pulumi's infrastructure-as-code engine, so platform teams can offer self-service infrastructure in TypeScript, Python, Go, C#, Java, or YAML without building everything from scratch. See [announcing Pulumi IDP](/blog/announcing-pulumi-idp/) for the design intent.
+
+## Learn more
+
+Pulumi gives platform engineering teams the building blocks for an Internal Developer Platform: [infrastructure as code](/what-is/what-is-infrastructure-as-code/) in real languages, reusable [components](/docs/iac/concepts/components/), [policy as code](/docs/insights/policy/), [configuration and secrets](/product/esc/), and a control plane that ties them together. [Get started with Pulumi](/docs/get-started/) or [request a demo](/request-a-demo/) of Pulumi IDP.
+
+Related reading:
+
+* [What is Platform Engineering?](/what-is/what-is-platform-engineering/)
+* [What is Infrastructure as Code (IaC)?](/what-is/what-is-infrastructure-as-code/)
+* [What is DevOps?](/what-is/what-is-devops/)
+* [What is DevOps Automation?](/what-is/what-is-devops-automation/)
+* [What is Configuration Management?](/what-is/what-is-configuration-management/)
+* [Announcing Pulumi IDP](/blog/announcing-pulumi-idp/)


### PR DESCRIPTION
## Summary

Rewrites `content/what-is/what-is-an-internal-developer-platform.md` for AEO and SEO. Reorganizes the page around the canonical IDP questions, clarifies the relationship between IDPs and platform engineering / PaaS, and surfaces the practical build path.

## What changed

- **Opening definition** — quotable one-sentence definition followed by a short lead-in clarifying that an IDP is the *product* a platform engineering team builds.
- **Why organizations build IDPs** — cognitive load, repeated patterns, standards on paper vs. in code, onboarding scale.
- **What is inside an IDP** — 9-row table covering catalog, self-service infra, environments, CI/CD, config/secrets, policy, observability, cost, docs.
- **IDP vs. platform engineering vs. PaaS** — explicit table to settle the terminology confusion (the discipline, the product, the rented platform).
- **How to build one** — six-step incremental path: painful path → product mindset → IaC substrate → policy as code → centralized secrets → portal/CLI → measure adoption.
- **Benefits** — delivery speed, onboarding, consistency, compliance, cognitive load, leverage.
- **Pitfalls and anti-patterns** — big-bang launches, treating it as infra not product, over-abstraction, mandate without value, portal-as-ticket-form, no escape hatch.
- **Tooling table** — 8 layers (portal, IaC, orchestration, CI/CD, config/secrets, policy, observability, identity).
- **FAQ** — 10 doubt-removers: simple definition, vs. platform engineering, small-team applicability, replacing infra teams, time to build, Backstage status, regulated industries, multi-cloud, vs. GitOps, Pulumi IDP fit.
- **Cross-links** — Platform engineering, IaC, DevOps, DevOps automation, configuration management, Pulumi IDP announcement blog.

Preserves the existing YouTube embed and `allow_long_title` frontmatter.

## Test plan

- [ ] `make serve`; visit `/what-is/what-is-an-internal-developer-platform/` and confirm rendering (incl. YouTube embed)
- [ ] Spot-check cross-links (`/what-is/what-is-platform-engineering/`, `/product/internal-developer-platforms/`, `/blog/announcing-pulumi-idp/`, `/docs/insights/policy/`, `/product/esc/`)
- [ ] CI lint + pinned review

🤖 Generated with [Claude Code](https://claude.com/claude-code)