### PR TITLE
Revise and relocate the Pulumi IaC architecture guide (#18671)

### DIFF
--- a/content/docs/iac/concepts/_index.md
+++ b/content/docs/iac/concepts/_index.md
@@ -77,7 +77,7 @@ Finally, the server's resulting IP address and DNS name are exported as stack ou
 
 ### Core concepts
 
-- [Pulumi Architecture](/docs/iac/concepts/how-pulumi-works) — Learn more about how Pulumi works under the hood.
+- [How Pulumi IaC Works](/docs/iac/guides/basics/how-pulumi-works/) — Learn how the language host, deployment engine, and resource providers work together under the hood.
 - [Pulumi Cloud](/docs/iac/concepts/pulumi-cloud/) — Learn how Pulumi Cloud relates to the open source tool and what it offers for teams.
 - [Projects](/docs/iac/concepts/projects) — Learn how Pulumi projects are organized and configured.
 - [Stacks](/docs/iac/concepts/stacks) — Learn how to create and deploy stacks.

--- a/content/docs/iac/concepts/plugins.md
+++ b/content/docs/iac/concepts/plugins.md
@@ -35,7 +35,7 @@ When you first run `pulumi preview` or `pulumi up`, the Pulumi CLI will install 
 
 ### Language plugins
 
-Language plugins (also known as language hosts) host programs written in specific languages, enabling the Pulumi engine to execute your Pulumi code without understanding language-specific details. As described in [How Pulumi works](/docs/iac/concepts/how-pulumi-works/#language-hosts), language plugins consist of:
+Language plugins (also known as language hosts) host programs written in specific languages, enabling the Pulumi engine to execute your Pulumi code without understanding language-specific details. As described in [How Pulumi works](/docs/iac/guides/basics/how-pulumi-works/#language-hosts), language plugins consist of:
 
 1. A language executor binary named `pulumi-language-<language-name>`, which Pulumi uses to launch the runtime for your program's language (e.g., Node.js or Python). This binary is distributed with the Pulumi CLI.
 1. For all languages except YAML, a language SDK that prepares your program for execution and observes resource registrations.
@@ -206,4 +206,4 @@ requiredPulumiVersion: ">=3.100.0"
 ## Related topics
 
 - [Providers](/docs/iac/concepts/providers/) - Learn more about resource plugins (providers)
-- [How Pulumi works](/docs/iac/concepts/how-pulumi-works/) - Understand how plugins fit into Pulumi's architecture
+- [How Pulumi works](/docs/iac/guides/basics/how-pulumi-works/) - Understand how plugins fit into Pulumi's architecture

--- a/content/docs/iac/concepts/providers/_index.md
+++ b/content/docs/iac/concepts/providers/_index.md
@@ -21,7 +21,7 @@ aliases:
 
 A resource provider handles communications with a cloud or SaaS service to create, read, update, and delete the resources you define in your Pulumi programs.
 
-Providers are composed of two parts: an executable, which makes the actual call to the cloud provider's API, and an SDK, which allows you to consume the provider in the language of your Pulumi program. When you run your Pulumi program, Pulumi passes your code to a language host such as Node.js, waits to be notified of resource registrations, assembles a model of your desired state, and calls on the provider executable to produce that state. The resource provider translates those requests into API calls to the cloud service.
+Providers are composed of two parts: an executable, which makes the actual call to the cloud provider's API, and an SDK, which allows you to consume the provider in the language of your Pulumi program. When you run your Pulumi program, Pulumi passes your code to a language host such as Node.js, waits to be notified of resource registrations, assembles a model of your desired state, and calls on the provider executable to produce that state. The resource provider translates those requests into API calls to the cloud service. To see how providers fit into the larger picture, see [How Pulumi IaC works](/docs/iac/guides/basics/how-pulumi-works/).
 
 {{% notes type="info" %}}
 Providers are a specific type of [plugin](/docs/iac/concepts/plugins/) called a resource plugin. For more information about plugins and how they work in Pulumi, see the [plugins concept page](/docs/iac/concepts/plugins/).

--- a/content/docs/iac/concepts/state-and-backends.md
+++ b/content/docs/iac/concepts/state-and-backends.md
@@ -125,7 +125,7 @@ $ pulumi login https://pulumi.acmecorp.com
 
 Everything works the same as with the standard Pulumi Cloud, except that Pulumi will target your private instance instead of the shared one hosted at `app.pulumi.com`.
 
-To learn how the Pulumi Cloud backend is designed—including why it never needs your cloud credentials—see [Pulumi Cloud architecture](/docs/iac/concepts/how-pulumi-works/#pulumi-cloud-architecture). If you are interested in hosting your own instance, see [Self-Hosted Pulumi Cloud](/docs/pulumi-cloud/self-hosted/).
+To learn how the Pulumi Cloud backend is designed—including why it never needs your cloud credentials—see [Pulumi Cloud architecture](/docs/iac/guides/basics/how-pulumi-works/#pulumi-cloud-architecture). If you are interested in hosting your own instance, see [Self-Hosted Pulumi Cloud](/docs/pulumi-cloud/self-hosted/).
 
 ## Using a DIY backend
 

--- a/content/docs/iac/guides/basics/_index.md
+++ b/content/docs/iac/guides/basics/_index.md
@@ -20,6 +20,10 @@ These fundamentals apply across all cloud providers and help you build maintaina
 
 ## Guides
 
+**[How Pulumi IaC works](/docs/iac/guides/basics/how-pulumi-works/)** - Go under the hood to see how the language host, deployment engine, and resource providers work together when you run `pulumi up`.
+
+**[Pulumi Cloud vs. OSS](/docs/iac/guides/basics/pulumi-cloud-vs-oss/)** - Compare open source Pulumi with Pulumi Cloud across state backends, access management, secrets and configuration, policy enforcement, and workflows.
+
 **[Organizing projects & stacks](/docs/iac/guides/basics/organizing-projects-stacks/)** - Learn how to structure your infrastructure code into projects and stacks. Understand when to split infrastructure into multiple projects versus using a single project with multiple stacks.
 
 **[Least privilege security](/docs/iac/guides/basics/iac-least-privileges/)** - Implement security best practices by granting only the minimum permissions needed for infrastructure operations. Learn how to configure cloud provider credentials with appropriate access controls.
@@ -27,7 +31,5 @@ These fundamentals apply across all cloud providers and help you build maintaina
 **[Update plans](/docs/iac/guides/basics/update-plans/)** - Preview and review infrastructure changes before applying them. Update plans help you catch unintended modifications and coordinate changes across teams.
 
 **[Targeted updates](/docs/iac/guides/basics/targeted-updates/)** - Limit which resources Pulumi operates on with `--target`, `--exclude`, and `--target-replace`. Learn the trade-offs of partial operations and when to use them.
-
-**[Pulumi Cloud vs. OSS](/docs/iac/guides/basics/pulumi-cloud-vs-oss/)** - Compare open source Pulumi with Pulumi Cloud across state backends, access management, secrets and configuration, policy enforcement, and workflows.
 
 **[Using a DIY backend](/docs/iac/guides/basics/using-a-diy-backend/)** - Configure a self-managed state backend with AWS S3, Azure Blob Storage, Google Cloud Storage, PostgreSQL, or the local filesystem.

--- a/content/docs/iac/guides/basics/how-pulumi-works.md
+++ b/content/docs/iac/guides/basics/how-pulumi-works.md
@@ -1,16 +1,14 @@
 ---
-title_tag: Pulumi Architecture
-meta_desc: "An in-depth look at Pulumi's internal architecture: the language host, deployment engine, and resource providers, and how they interact when you run pulumi up."
-title: Pulumi Architecture
-h1: Pulumi Architecture
+title_tag: "How Pulumi IaC Works | Pulumi Guides"
+meta_desc: "How Pulumi IaC works internally: the language host, deployment engine, and resource providers, and how they interact when you run pulumi up."
+title: How Pulumi IaC Works
+h1: How Pulumi IaC Works
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
-        name: Pulumi Architecture
+        name: How Pulumi IaC Works
         weight: 10
-        parent: iac-concepts
-    concepts:
-        weight: 1
+        parent: iac-guides-basics
 aliases:
     - /docs/reference/how/
     - /docs/tour/basics-programs/
@@ -20,39 +18,12 @@ aliases:
     - /docs/tour/programs-stacks/
     - /docs/intro/concepts/how-pulumi-works/
     - /docs/concepts/how-pulumi-works/
+    - /docs/iac/concepts/how-pulumi-works/
 ---
 
-{{< notes >}}
-Most Pulumi users don't need to understand these internals. The key concept is that Pulumi uses a **declarative model**: you describe the desired state of your infrastructure in code, and Pulumi figures out what changes to make. This page covers advanced architecture details useful for troubleshooting or deeper understanding.
-{{< /notes >}}
+This page describes how Pulumi Infrastructure as Code (IaC) turns a program into deployed cloud resources.
 
-Pulumi's three main components work together when you run `pulumi up`: a _language host_, a _deployment engine_, and [resource providers](/docs/iac/concepts/providers/). The following diagram illustrates how they interact:
-
-<img src="/images/docs/reference/engine-block-diagram.png" alt="Pulumi IaC system architecture, the Pulumi engine and providers" width="600">
-
-## Language hosts
-
-The _language host_ is responsible for running a Pulumi program and setting up an environment where it can register resources with the _deployment engine_. Language hosts are implemented via [plugins](/docs/iac/concepts/plugins/) (specifically, language plugins). The language host consists of two different pieces:
-
-1. A language executor, which is a binary named `pulumi-language-<language-name>`, that Pulumi uses to launch the runtime for the language your program is written in (e.g. Node or Python). This binary is distributed with the Pulumi CLI.
-2. A language SDK is responsible for preparing your program to be executed and observing its execution in order to detect resource registrations. When a resource is _registered_ (via `new Resource()` in JavaScript or `Resource(...)` in Python), the language SDK communicates the registration request back to the _deployment engine_. The language SDK is distributed as a regular package, just like any other code that might depend on your program. For example, the Node SDK is contained in the [`@pulumi/pulumi`](https://www.npmjs.com/package/@pulumi/pulumi) package available on npm, and the Python SDK is contained in the [`pulumi`](https://pypi.org/project/pulumi/) package available on PyPI.
-
-## Deployment engine
-
-The _deployment engine_ is responsible for computing the set of operations needed to drive the current state of your infrastructure into the desired state expressed by your program. When a _resource registration_ is received from the language host, the engine consults the existing [state](/docs/iac/concepts/state-and-backends/) to determine if that resource has been created before. If it has not, the engine uses a _resource provider_ to create it. If it already exists, the engine works with the resource provider to determine what, if anything, has changed by comparing the old state of the resource with the new desired state of the resource as expressed by the program. If there are changes, the engine determines if it can _update_ the resource in place or if it must _replace_ it by _creating_ a new version and _deleting_ the old version. The decision depends on what properties of the resource are changing and the type of the resource itself. When the language host communicates to the engine that it has completed the execution of the Pulumi program, the engine looks for any existing resources that it did not see a new resource registration and schedules these resources for deletion.
-
-The deployment engine is embedded in the `pulumi` CLI itself.
-
-## Resource providers
-
-A resource provider is made up of two different pieces:
-
-1. A _resource plugin_ is the binary used by the deployment engine to manage a resource. These plugins are stored in the _plugin cache_ (located in `~/.pulumi/plugins`) and can be managed using the [`pulumi plugin`](/docs/iac/cli/commands/pulumi_plugin) set of commands.
-2. An _SDK_ which provides bindings for each type of resource the provider can manage.
-
-Like the language runtime itself, the SDKs are available as regular packages. For example, there is a [`@pulumi/aws`](https://www.npmjs.com/package/@pulumi/aws) package for Node available on npm and a [`pulumi_aws`](https://pypi.org/project/pulumi-aws) package for Python available on PyPI.  When these packages are added to your project, they run [`pulumi plugin install`](/docs/iac/cli/commands/pulumi_plugin_install) behind the scenes to download the resource plugin from Pulumi.com.
-
-## Putting it all together
+## Running a Pulumi program
 
 Let's walk through a simple example. Suppose we have the following Pulumi program, which creates two S3 buckets:
 
@@ -163,15 +134,23 @@ In this case, since the last deployed state has no resources, the engine determi
 
 As the engine was creating the `media-bucket` bucket, the language host continued to execute the Pulumi program. This caused another resource registration to be generated (for `content-bucket`). Since there is no dependency between these two buckets, the engine is able to process that request in parallel with the creation of `media-bucket`.
 
-After both operations have completed, the language host exits as the program has finished running. Then the engine and resource providers shutdown. The state for mystack now looks like the following:
+After both operations have completed, the language host exits as the program has finished running. Then the engine and resource providers shut down. The `pulumi up` output reports the resources that were created:
 
 ```
-stack mystack
-   - aws.s3.Bucket "media-bucket653a4"
-   - aws.s3.Bucket "content-bucket125ce"
+Updating (mystack)
+
+     Type                      Name                Status
+ +   pulumi:pulumi:Stack       my-project-mystack  created (6s)
+ +   ├─ aws:s3/bucket:Bucket   media-bucket        created (2s)
+ +   └─ aws:s3/bucket:Bucket   content-bucket      created (2s)
+
+Resources:
+    + 3 created
+
+Duration: 7s
 ```
 
-Note the extra suffixes on the end of these bucket names. This is due to a process called [auto-naming](/docs/concepts/resources/names/#autonaming), which Pulumi uses by default in order to allow you to deploy multiple copies of your infrastructure without creating name collisions for resources. This behavior can be disabled if desired.
+The names shown above—`media-bucket` and `content-bucket`—are the _logical names_ you gave the resources in your program. By default, Pulumi appends a random suffix to each resource's _physical name_ in AWS (for example, `media-bucket-653a4f2`). This is due to a process called [auto-naming](/docs/iac/concepts/resources/names/#autonaming), which Pulumi uses by default in order to allow you to deploy multiple copies of your infrastructure without creating name collisions for resources. This behavior can be disabled if desired.
 
 Now, let's make a change to one of resources and run `pulumi up` again.  Since Pulumi operates on a desired state model, it will use the last deployed state to compute the minimal set of changes needed to update your deployed infrastructure. For example, imagine that we wanted to add tags to the S3 `media-bucket`.  We change our program to express this new desired state:
 
@@ -458,15 +437,178 @@ When a resource property changes in a way that cannot be updated in place, Pulum
 1. Creating the new resource with the updated configuration (create-replacement)
 1. Deleting the old resource after the new one is ready (delete-replaced)
 
-By default, Pulumi creates the replacement before deleting the original to minimize downtime. You can change this behavior with the [deleteBeforeReplace](/docs/concepts/resources#deletebeforereplace) option.
+By default, Pulumi creates the replacement before deleting the original to minimize downtime. You can change this behavior with the [deleteBeforeReplace](/docs/iac/concepts/resources/options/deletebeforereplace/) option.
 
 ## Creation and deletion order
 
-Pulumi executes resource operations in parallel whenever possible, but understands that some resources may have dependencies on other resources. If an [output](/docs/concepts/inputs-outputs/) of one resource is provided as an input to another, the engine records the dependency between these two resources as part of the state and uses these when scheduling operations. This list can also be augmented by using the [dependsOn](/docs/concepts/resources#dependson) resource option.
+Pulumi executes resource operations in parallel whenever possible, but understands that some resources may have dependencies on other resources. If an [output](/docs/iac/concepts/inputs-outputs/) of one resource is provided as an input to another, the engine records the dependency between these two resources as part of the state and uses these when scheduling operations. This list can also be augmented by using the [dependsOn](/docs/iac/concepts/resources/options/dependson/) resource option.
 
-By default, if a resource must be replaced, Pulumi will attempt to create a new copy of the resource before destroying the old one. This is helpful because it allows updates to infrastructure to happen without downtime. This behavior can be controlled by the [deleteBeforeReplace](/docs/concepts/resources#deletebeforereplace) option. If you have disabled [auto-naming](/docs/concepts/resources/names/#autonaming) using configuration or by providing a specific name for a resource, it will be treated as if it was marked as `deleteBeforeReplace` automatically (otherwise the create operation for the new version would fail since the name is in use).
+By default, if a resource must be replaced, Pulumi will attempt to create a new copy of the resource before destroying the old one. This is helpful because it allows updates to infrastructure to happen without downtime. This behavior can be controlled by the [deleteBeforeReplace](/docs/iac/concepts/resources/options/deletebeforereplace/) option. If you have disabled [auto-naming](/docs/iac/concepts/resources/names/#autonaming) using configuration or by providing a specific name for a resource, it will be treated as if it was marked as `deleteBeforeReplace` automatically (otherwise the create operation for the new version would fail since the name is in use).
 
-## Pulumi Cloud architecture
+## Architecture
+
+Three main components work together when you run `pulumi up`: a _language host_, a _deployment engine_, and [resource providers](/docs/iac/concepts/providers/). The following diagram illustrates how they interact. Because each language has its own language host and program entrypoint, select your language to see the corresponding diagram:
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+
+{{% choosable language typescript %}}
+
+```mermaid
+flowchart LR
+    subgraph host["Node language host"]
+        program["index.ts"]
+    end
+    state[("Last deployed<br/>state")]
+    engine["Pulumi CLI &<br/>deployment engine"]
+    subgraph providers["Resource providers"]
+        aws["AWS"]
+        azure["Azure"]
+        k8s["Kubernetes"]
+    end
+    program -->|"new aws.s3.Bucket()"| engine
+    engine <-->|"read / write"| state
+    engine -->|"create, update, delete"| aws
+    engine -->|"create, update, delete"| azure
+    engine -->|"create, update, delete"| k8s
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```mermaid
+flowchart LR
+    subgraph host["Python language host"]
+        program["__main__.py"]
+    end
+    state[("Last deployed<br/>state")]
+    engine["Pulumi CLI &<br/>deployment engine"]
+    subgraph providers["Resource providers"]
+        aws["AWS"]
+        azure["Azure"]
+        k8s["Kubernetes"]
+    end
+    program -->|"s3.Bucket()"| engine
+    engine <-->|"read / write"| state
+    engine -->|"create, update, delete"| aws
+    engine -->|"create, update, delete"| azure
+    engine -->|"create, update, delete"| k8s
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```mermaid
+flowchart LR
+    subgraph host["Go language host"]
+        program["main.go"]
+    end
+    state[("Last deployed<br/>state")]
+    engine["Pulumi CLI &<br/>deployment engine"]
+    subgraph providers["Resource providers"]
+        aws["AWS"]
+        azure["Azure"]
+        k8s["Kubernetes"]
+    end
+    program -->|"s3.NewBucket()"| engine
+    engine <-->|"read / write"| state
+    engine -->|"create, update, delete"| aws
+    engine -->|"create, update, delete"| azure
+    engine -->|"create, update, delete"| k8s
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```mermaid
+flowchart LR
+    subgraph host[".NET language host"]
+        program["Program.cs"]
+    end
+    state[("Last deployed<br/>state")]
+    engine["Pulumi CLI &<br/>deployment engine"]
+    subgraph providers["Resource providers"]
+        aws["AWS"]
+        azure["Azure"]
+        k8s["Kubernetes"]
+    end
+    program -->|"new Aws.S3.Bucket()"| engine
+    engine <-->|"read / write"| state
+    engine -->|"create, update, delete"| aws
+    engine -->|"create, update, delete"| azure
+    engine -->|"create, update, delete"| k8s
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+```mermaid
+flowchart LR
+    subgraph host["JVM language host"]
+        program["App.java"]
+    end
+    state[("Last deployed<br/>state")]
+    engine["Pulumi CLI &<br/>deployment engine"]
+    subgraph providers["Resource providers"]
+        aws["AWS"]
+        azure["Azure"]
+        k8s["Kubernetes"]
+    end
+    program -->|"new Bucket()"| engine
+    engine <-->|"read / write"| state
+    engine -->|"create, update, delete"| aws
+    engine -->|"create, update, delete"| azure
+    engine -->|"create, update, delete"| k8s
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```mermaid
+flowchart LR
+    subgraph host["YAML language host"]
+        program["Pulumi.yaml"]
+    end
+    state[("Last deployed<br/>state")]
+    engine["Pulumi CLI &<br/>deployment engine"]
+    subgraph providers["Resource providers"]
+        aws["AWS"]
+        azure["Azure"]
+        k8s["Kubernetes"]
+    end
+    program -->|"aws:s3:Bucket"| engine
+    engine <-->|"read / write"| state
+    engine -->|"create, update, delete"| aws
+    engine -->|"create, update, delete"| azure
+    engine -->|"create, update, delete"| k8s
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+### Language hosts
+
+The _language host_ is responsible for running a Pulumi program and setting up an environment where it can register resources with the _deployment engine_. Language hosts are implemented via [plugins](/docs/iac/concepts/plugins/) (specifically, language plugins). The language host consists of two different pieces:
+
+1. A language executor, which is a binary named `pulumi-language-<language-name>`, that Pulumi uses to launch the runtime for the language your program is written in (e.g. Node or Python). This binary is distributed with the Pulumi CLI.
+2. A language SDK is responsible for preparing your program to be executed and observing its execution in order to detect resource registrations. When a resource is _registered_—by constructing a resource object in your program—the language SDK communicates the registration request back to the _deployment engine_. The language SDK is distributed as a regular package, just like any other code that might depend on your program. For example, the TypeScript and JavaScript SDK is contained in the [`@pulumi/pulumi`](https://www.npmjs.com/package/@pulumi/pulumi) package available on npm, and the Python SDK is contained in the [`pulumi`](https://pypi.org/project/pulumi/) package available on PyPI.
+
+### Deployment engine
+
+The _deployment engine_ is responsible for computing the set of operations needed to drive the current state of your infrastructure into the desired state expressed by your program. When a _resource registration_ is received from the language host, the engine consults the existing [state](/docs/iac/concepts/state-and-backends/) to determine if that resource has been created before. If it has not, the engine uses a _resource provider_ to create it. If it already exists, the engine works with the resource provider to determine what, if anything, has changed by comparing the old state of the resource with the new desired state of the resource as expressed by the program. If there are changes, the engine determines if it can _update_ the resource in place or if it must _replace_ it by _creating_ a new version and _deleting_ the old version. The decision depends on what properties of the resource are changing and the type of the resource itself. When the language host communicates to the engine that it has completed the execution of the Pulumi program, the engine looks for any existing resources that it did not see a new resource registration and schedules these resources for deletion.
+
+The deployment engine is embedded in the `pulumi` CLI itself.
+
+### Resource providers
+
+A resource provider is made up of two different pieces:
+
+1. A _resource plugin_ is the binary used by the deployment engine to manage a resource. These plugins are stored in the _plugin cache_ (located in `~/.pulumi/plugins`) and can be managed using the [`pulumi plugin`](/docs/iac/cli/commands/pulumi_plugin) set of commands.
+2. An _SDK_ which provides bindings for each type of resource the provider can manage.
+
+Like the language runtime itself, the SDKs are available as regular packages. For example, there is a [`@pulumi/aws`](https://www.npmjs.com/package/@pulumi/aws) package for Node available on npm and a [`pulumi_aws`](https://pypi.org/project/pulumi-aws) package for Python available on PyPI.  When these packages are added to your project, they run [`pulumi plugin install`](/docs/iac/cli/commands/pulumi_plugin_install) behind the scenes to download the resource plugin from Pulumi.com.
+
+### Pulumi Cloud architecture
 
 The components described above—the language host, deployment engine, and resource providers—all run on the client, wherever the Pulumi CLI runs. When you use the default [Pulumi Cloud backend](/docs/iac/concepts/state-and-backends/) to store state, the CLI also coordinates with Pulumi Cloud.
 

--- a/content/docs/iac/guides/basics/pulumi-cloud-vs-oss.md
+++ b/content/docs/iac/guides/basics/pulumi-cloud-vs-oss.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Pulumi Cloud vs. OSS
         parent: iac-guides-basics
-        weight: 70
+        weight: 20
 aliases:
   - /docs/deployments/get-started/what-is-it/
   - /docs/pulumi-cloud/get-started/what-is-it/

--- a/content/docs/iac/languages-sdks/javascript/_index.md
+++ b/content/docs/iac/languages-sdks/javascript/_index.md
@@ -191,7 +191,7 @@ Writing a Pulumi program in Node.js involves declaring infrastructure resources 
 The Pulumi SDK provides constructs for working with key Pulumi concepts. For more information, see:
 
 - [Pulumi Concepts](/docs/iac/concepts/)
-- [How Pulumi Works](/docs/iac/concepts/how-pulumi-works/)
+- [How Pulumi Works](/docs/iac/guides/basics/how-pulumi-works/)
 
 ## Program execution
 

--- a/content/docs/iac/languages-sdks/python/_index.md
+++ b/content/docs/iac/languages-sdks/python/_index.md
@@ -42,7 +42,7 @@ The Pulumi programming model includes a core concept of `Input` and `Output` val
 In Python, inputs that are objects, that is inputs that group multiple values together, can be represented either as classes or as dictionary literals. The types for the argument classes have the suffix `Args`, whereas the types for the dictionaries have the suffix `ArgsDict`. Both types take the same arguments, but the dictionary types are often more concise.
 
 {{% notes type="info" %}}
-The types with the suffix `ArgsDict` for dictionary literals were introduced in July 2024. You can still use dictionary literals with [providers](/docs/concepts/how-pulumi-works/#resource-providers) that have not been updated yet with this change, but you will not benefit from the type checking that the new types provide.
+The types with the suffix `ArgsDict` for dictionary literals were introduced in July 2024. You can still use dictionary literals with [providers](/docs/iac/guides/basics/how-pulumi-works/#resource-providers) that have not been updated yet with this change, but you will not benefit from the type checking that the new types provide.
 {{% /notes %}}
 
 This example shows two ways to create an `ecr.Repository` resource in Python, once using a dictionary literal and once using a class:

--- a/content/docs/support/debugging/debugger-attachment.md
+++ b/content/docs/support/debugging/debugger-attachment.md
@@ -19,7 +19,7 @@ aliases:
 
 Because Pulumi uses general purpose programming languages to provision cloud resources, you can take advantage of native debugging tools to troubleshoot your infrastructure definitions.
 
-Note that you can't directly F5-launch your Pulumi program from your IDE. Instead, you run the Pulumi CLI that will launch your program via its language runtime in a separate process, and then you attach to that process from your IDE. See [How Pulumi works](/docs/concepts/how-pulumi-works/) to learn more about Pulumi execution mode.
+Note that you can't directly F5-launch your Pulumi program from your IDE. Instead, you run the Pulumi CLI that will launch your program via its language runtime in a separate process, and then you attach to that process from your IDE. See [How Pulumi works](/docs/iac/guides/basics/how-pulumi-works/) to learn more about Pulumi execution mode.
 
 ## Debugging with Visual Studio Code and Pulumi extension
 

--- a/content/docs/support/pulumi-cloud-faq.md
+++ b/content/docs/support/pulumi-cloud-faq.md
@@ -33,7 +33,7 @@ The Pulumi Cloud supports the following browsers:
 
 ### How does Pulumi depend on the Pulumi Cloud?
 
-Pulumi uses the Pulumi Cloud to store information about the current state of your application, which is used during updates, previews, and destroys as the source of truth for the current state of your cloud resources. We refer to this state as the "checkpoint" for your application. In addition, the Pulumi Cloud ensures that for a given stack, only a single update is running at once (so, if you and someone else are collaborating on a stack together, it ensures that you both don't update the same stack at the same time.) Once your stack has been deployed, it has no dependency on the Pulumi Cloud. To learn more about how the Pulumi engine uses pulumi.com, see [How Pulumi Works](/docs/concepts/how-pulumi-works/).
+Pulumi uses the Pulumi Cloud to store information about the current state of your application, which is used during updates, previews, and destroys as the source of truth for the current state of your cloud resources. We refer to this state as the "checkpoint" for your application. In addition, the Pulumi Cloud ensures that for a given stack, only a single update is running at once (so, if you and someone else are collaborating on a stack together, it ensures that you both don't update the same stack at the same time.) Once your stack has been deployed, it has no dependency on the Pulumi Cloud. To learn more about how the Pulumi engine uses pulumi.com, see [How Pulumi Works](/docs/iac/guides/basics/how-pulumi-works/).
 
 ### What happens if app.pulumi.com is down?
 

--- a/content/docs/support/troubleshooting/ci-cd.md
+++ b/content/docs/support/troubleshooting/ci-cd.md
@@ -138,7 +138,7 @@ package(s) from the private feed are accessible or you can use a [pre-built bina
 
 * You might be caching the library dependencies but not the Pulumi plugins. Some services offer dependency caching by capturing a specific folder and restoring
 that folder when your pipeline executes. However, note that Pulumi dependencies have a post-install step that also pulls-down
-a [plugin](/docs/concepts/how-pulumi-works#resource-providers) binary from our CDN. So be sure to cache the plugins path as well.
+a [plugin](/docs/iac/guides/basics/how-pulumi-works#resource-providers) binary from our CDN. So be sure to cache the plugins path as well.
 
   If in doubt about problems encountered during execution, clear out all caches and restore dependencies from scratch.
 

--- a/content/docs/support/troubleshooting/common-issues/connection-issues.md
+++ b/content/docs/support/troubleshooting/common-issues/connection-issues.md
@@ -33,4 +33,4 @@ Resources:
 $
 ```
 
-If you have a system-wide proxy server running on your machine, it may be misconfigured. The [Pulumi architecture](/docs/concepts/how-pulumi-works/) has three different components, running as separate processes that talk to each other using a bidirectional gRPC protocol on IP address `127.0.0.1`. Your proxy server should be configured **NOT** to proxy these local network connections. Add both `127.0.0.1` and `localhost` to the exclusion list of your proxy server.
+If you have a system-wide proxy server running on your machine, it may be misconfigured. The [Pulumi architecture](/docs/iac/guides/basics/how-pulumi-works/) has three different components, running as separate processes that talk to each other using a bidirectional gRPC protocol on IP address `127.0.0.1`. Your proxy server should be configured **NOT** to proxy these local network connections. Add both `127.0.0.1` and `localhost` to the exclusion list of your proxy server.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -359,13 +359,44 @@
         // Initialize mermaid with manual control to preserve source before rendering
         mermaid.initialize({ startOnLoad: false });
 
-        // Preserve original mermaid source, then render
         document.addEventListener('DOMContentLoaded', () => {
-            document.querySelectorAll('pre.mermaid').forEach(pre => {
+            const diagrams = document.querySelectorAll('pre.mermaid');
+
+            // Preserve original mermaid source before rendering replaces it.
+            diagrams.forEach(pre => {
                 pre.setAttribute('data-mermaid-source', pre.textContent.trim());
             });
-            // Render mermaid diagrams after preserving source
-            mermaid.run();
+
+            // Render a single diagram, skipping ones already rendered. Diagrams
+            // inside a chooser start hidden (display:none) and cannot be measured,
+            // so they are rendered lazily once they become visible.
+            const render = pre => {
+                if (pre.dataset.processed === 'true') return;
+                mermaid.run({ nodes: [pre] }).catch(err => {
+                    console.error('Mermaid render error:', err);
+                });
+            };
+
+            const isHidden = el => el.offsetParent === null;
+
+            // Render everything that is visible now.
+            diagrams.forEach(pre => {
+                if (!isHidden(pre)) render(pre);
+            });
+
+            // Render hidden diagrams when a chooser reveals them.
+            const hidden = [...diagrams].filter(isHidden);
+            if (hidden.length) {
+                const observer = new IntersectionObserver(entries => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            render(entry.target);
+                            observer.unobserve(entry.target);
+                        }
+                    });
+                });
+                hidden.forEach(pre => observer.observe(pre));
+            }
         });
     </script>
     {{ end }}


### PR DESCRIPTION
Implements the changes requested in #18671 for the Pulumi Architecture page.

## Changes
- Moved `how-pulumi-works` from `concepts/` to `guides/basics/` (aliases added; inbound links updated)
- Reframed around Pulumi IaC; retitled "How Pulumi IaC Works"
- Replaced the static PNG with per-language Mermaid diagrams
- Refreshed the outdated `pulumi up` output sample
- Reordered so running a program comes before the architecture breakdown
- `head.html`: lazily render Mermaid diagrams inside choosers so they render correctly per language

Fixes #18671