### PR TITLE
content(ai): fix nonexistent "Pulumi Neo GitHub App" reference

### DIFF
--- a/content/docs/ai/integrations/github/_index.md
+++ b/content/docs/ai/integrations/github/_index.md
@@ -20,9 +20,9 @@ Neo sees the diff, the stacks linked to the repository, and their current state.
 
 ## Setting up the integration
 
-### 1. Install the Pulumi Neo GitHub App
+### 1. Install the Pulumi GitHub App
 
-A GitHub organization admin installs the **Pulumi Neo GitHub App** on the organization or user account that owns the repositories you want Neo to access.
+A GitHub organization admin installs the [Pulumi GitHub App](/docs/integrations/version-control/github-app/) on the organization or user account that owns the repositories you want Neo to access.
 
 ### 2. Link your Pulumi user to GitHub
 


### PR DESCRIPTION
## Summary

- The Neo GitHub integration page told readers to install a "Pulumi Neo GitHub App" that doesn't exist. The Neo `@pulumi-neo` mention support runs through the single [Pulumi GitHub App](/docs/integrations/version-control/github-app/).
- Renames the install step heading and links the canonical app docs.
- Verified `@pulumi-neo` is the correct GitHub handle (live user account; ~570 mentions across `org:pulumi`). Slack `@Neo` vs `@neo` casing left untouched pending team confirmation — flagged on the issue.

Fixes #19236

## Test plan

- [ ] `make lint` passes
- [ ] `make serve` and confirm `/docs/ai/integrations/github/` renders with the new heading and a working link to `/docs/integrations/version-control/github-app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)