### PR TITLE
Document Pulumi Deployments runner hardware and OS

### DIFF
--- a/content/docs/deployments/deployments/runs/_index.md
+++ b/content/docs/deployments/deployments/runs/_index.md
@@ -15,3 +15,17 @@ Every Pulumi Deployment runs in a container image on a workflow runner. Two sett
 
 - The [image](/docs/deployments/deployments/runs/images/): a Pulumi-managed Linux image by default, or a custom image when your project needs extra tools.
 - The [runner](/docs/deployments/deployments/runs/customer-managed-agents/): Pulumi-hosted by default, or customer-managed when you need to run on your own infrastructure.
+
+## Hardware and operating system
+
+When a deployment runs on a Pulumi-hosted workflow runner, it executes inside a Linux container with the following resources:
+
+| Resource | Allocation |
+|---|---|
+| vCPU | 2 |
+| Memory | 8 GB |
+| Disk | A 32 GB volume, with roughly half available for your program's working files after the executor image and dependency caches |
+
+With the default executor image, the container's operating system is Debian, regardless of the operating system of the host it runs on. If you supply a [custom executor image](/docs/deployments/deployments/runs/images/), the operating system is whatever that image is built on. If a deployment depends on a specific OS, package manager, or system library, match it to the image you use.
+
+These specifications apply to Pulumi-hosted workflow runners. [Customer-managed workflow runners](/docs/deployments/deployments/runs/customer-managed-agents/) run on infrastructure you provision, so their hardware and operating system are whatever you configure.

--- a/content/docs/deployments/deployments/runs/images.md
+++ b/content/docs/deployments/deployments/runs/images.md
@@ -17,7 +17,7 @@ Pulumi Cloud runs your Pulumi program inside a container image called the *deplo
 
 ## The default executor image
 
-By default, every deployment runs in [`pulumi/pulumi`](https://hub.docker.com/r/pulumi/pulumi), a Linux image that includes:
+By default, every deployment runs in [`pulumi/pulumi`](https://hub.docker.com/r/pulumi/pulumi), a Debian-based Linux image that includes:
 
 - The `pulumi` CLI on `$PATH`
 - [LTS versions](https://github.com/pulumi/pulumi-docker-containers/blob/main/README.md#version-policy) of all supported language runtimes: Node.js, Python, Go, .NET, and Java


### PR DESCRIPTION
Documents the hardware and operating system of the environment Pulumi Deployments runs in, addressing customer confusion between the EC2 host OS and the container OS.

## Changes
- Add a "Hardware and operating system" section to the Runs page: 2 vCPU, 8 GB RAM, 32 GB volume, and the Debian container OS (scoped to the default executor image)
- Note that the default `pulumi/pulumi` executor image is Debian-based

Fixes #11603