### PR TITLE
Consolidate typography into a shared @utility type scale

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ sections:
     badge_text: "AI for infrastructure"
     badge_link: /product/neo/
     title_primary: "Next-level"
-    title_secondary: "infrastructure as code \n for humans and agents."
+    title_secondary: "infrastructure as code \n for humans and agents."
     description: |
       Ship cloud infrastructure at the speed of AI with languages and tools that stay out of your way.
     anchor: hero

--- a/content/product/neo.md
+++ b/content/product/neo.md
@@ -18,7 +18,9 @@ meta_image: /images/product/neo/neo-meta.png
 
 sections:
   - type: hero
-    title: "Meet Neo, your new AI infrastructure agent."
+    title_primary: "AI infrastructure agent."
+    title_secondary: "Meet Neo, your new"
+    title_reversed: true
     description: Neo provisions, governs, and optimizes your cloud infrastructure — with enterprise controls built in.
     image: /images/product/neo/neo-hero.svg
     image_alt: Neo AI infrastructure agent diagram showing Kubernetes cluster upgrade automation

--- a/content/product/secrets-management.md
+++ b/content/product/secrets-management.md
@@ -20,7 +20,7 @@ sections:
     anchor: hero
 
   - type: feature_split
-    heading: One interface for all your secrets and configuration
+    heading: One interface for all your secrets and configuration
     description: |
       **Connect any secrets store and control everything centrally.**
 

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -10,7 +10,7 @@
             <div class="flex flex-col items-center text-center w-full max-w-4xl mx-auto">
                 <h1 class="title mb-6">{{ .Title }}</h1>
                 {{ with .Params.description }}
-                <p class="description mb-10">{{ . | markdownify }}</p>
+                <p class="description mb-10 max-w-2xl">{{ . | markdownify }}</p>
                 {{ end }}
             </div>
         </div>

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -2,7 +2,7 @@
 {{ end }}
 
 {{ define "main" }}
-<div class="font-body container mx-auto mb-16 mt-16 px-6 md:px-8 flex flex-col gap-16 md:gap-20 lg:gap-24 overflow-hidden">
+<div class="font-body container mx-auto mb-16 mt-8 md:mt-16 px-6 md:px-8 flex flex-col gap-16 md:gap-20 lg:gap-24 overflow-hidden">
 
     {{/* Hero */}}
     <section class="template-hero template-hero--centered" id="hero">

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -11,7 +11,7 @@
                 <a href="/case-studies/" class="hero-tag-line no-underline hover:no-underline">Case Study</a>
                 <h1 class="title mb-6">{{ .Title }}</h1>
                 {{ with .Description }}
-                <p class="description mb-10">{{ . | markdownify }}</p>
+                <p class="description mb-10 max-w-2xl">{{ . | markdownify }}</p>
                 {{ end }}
             </div>
         </div>

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -23,8 +23,6 @@
                 {{ else }}
                     <a href="/events/#upcoming">Upcoming</a>
                 {{ end }}
-                <span class="event-breadcrumb-separator">/</span>
-                <span class="event-breadcrumb-current">{{ .Params.title }}</span>
             </nav>
 
             <section class="template-event-single-header">

--- a/layouts/page/demo.html
+++ b/layouts/page/demo.html
@@ -4,16 +4,16 @@
 
     <section>
         <div class="container mx-auto py-12">
-            <div class="flex items-center flex-col md:flex-row">
-                <div class="w-full md:w-1/2 p-6">
-                    <h1 class="text-5xl font-bold mb-6">{{ .Params.overview.title }}</h1>
-                    <ul class="text-xl max-w-xl">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-24 items-center">
+                <div class="p-6">
+                    <h1 class="heading-xl mb-6 max-w-lg">{{ .Params.overview.title }}</h1>
+                    <ul class="body-xl max-w-xl">
                         {{ range $detail := .Params.overview.details }}
                             <li>{{ $detail }}</li>
                         {{ end }}
                     </ul>
 
-                    <div class="flex flex-wrap justify-center items-center mt-12">
+                    <div class="flex flex-wrap justify-center items-center mt-12 max-w-lg">
                         {{ range $logo := .Params.customer_logos.logos }}
                             <div class="w-1/4 p-3">
                                 {{ if $logo.link }}
@@ -28,7 +28,7 @@
                     </div>
                 </div>
 
-                <div class="w-full md:w-1/2 p-6 flex items-center">
+                <div class="p-6 flex items-center">
                     <div class="card mt-10 md:mt-0 p-12 mx-auto">
                         <h4>Request a demo</h4>
                         <pulumi-hubspot-form form-id="{{ .Params.form.form_id }}"></pulumi-hubspot-form>

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -8,8 +8,8 @@
                 "class" "w-[340px] md:w-[450px]") }}
     </div>
     <div class="container mx-auto px-6 pt-16 pb-12 md:pt-24 md:pb-16 text-center">
-        <h1 class="text-4xl md:text-5xl font-semibold tracking-tight">Plans for teams of all&nbsp;sizes</h1>
-        <p class="max-w-xl mx-auto mt-5 text-lg md:text-xl text-gray-secondary">
+        <h1 class="heading-xl tracking-tight">Plans for teams of all&nbsp;sizes</h1>
+        <p class="max-w-xl mx-auto mt-5 body-xl">
             Start for free. Stay free forever for open source and individuals, or scale with advanced editions for your team.
         </p>
     </div>
@@ -169,7 +169,7 @@
                         {{ if eq $item.content "_check" }}
                         {{ partial "icon.html" (dict "name" "phosphor/check" "class" "text-green-primary size-6 inline-block") }}
                         {{ else if eq $item.content "_blank" }}
-                        <span class="text-gray-300"> {{ partial "icon.html" (dict "name" "phosphor/minus" "class" "text-gray-secondary size-6 inline-block") }} </span>
+                        <span class="text-gray-300"> {{ partial "icon.html" (dict "name" "phosphor/minus" "class" "text-gray-primary size-6 inline-block") }} </span>
                         {{ else }}
                         <span>{{ $item.content | markdownify }}</span>
                         {{ with $item.subtext }}

--- a/layouts/partials/blog/sidebar.html
+++ b/layouts/partials/blog/sidebar.html
@@ -8,12 +8,12 @@
     </div>
 
     {{ if eq .Page.Title "Blog" }}
-        <h1 class="no-anchor hidden lg:flex mt-2 mb-6">
-            <a data-track="sidebar" class="text-2xl" href="{{ relref . "/blog" }}">Pulumi Blog</a>
+        <h1 class="no-anchor hidden lg:flex mt-2 mb-6 text-2xl">
+            <a data-track="sidebar" href="{{ relref . "/blog" }}">Pulumi Blog</a>
         </h1>
     {{ else }}
-        <h2 class="no-anchor hidden lg:flex mt-2 mb-6">
-            <a data-track="sidebar" class="text-2xl" href="{{ relref . "/blog" }}">Pulumi Blog</a>
+        <h2 class="no-anchor hidden lg:flex mt-2 mb-6 text-2xl">
+            <a data-track="sidebar" href="{{ relref . "/blog" }}">Pulumi Blog</a>
         </h2>
     {{ end }}
 

--- a/layouts/partials/contact-us.html
+++ b/layouts/partials/contact-us.html
@@ -2,8 +2,7 @@
         <div class="md:max-w-2xl md:mx-auto">
             <div class="w-full ">
                 <div class="card mt-4 mx-auto md:w-full md:mt-0 p-10 bg-white">
-                                            <h1 class="text-5xl my-6">How can we help you?</h1>
-
+                    <h1 class="heading-1 mb-6">How can we help you?</h1>
                     <div class="w-full">
                         <div class="hs-form hs-form-fg-dark font-normal">
                             <pulumi-contact-us-form
@@ -17,7 +16,7 @@
             </div>
 
             <div class="mt-16">
-                <h2 class="text-3xl my-6">Our Address</h2>
+                <h2 class="font-overline my-6">Our Address</h2>
                 <p class="m-0">
                     Pulumi Corporation<br />
                     601 Union St., Suite 1415<br />

--- a/layouts/partials/events/list-section.html
+++ b/layouts/partials/events/list-section.html
@@ -218,5 +218,5 @@
             {{ end }}
         {{ end }}
     </div>
-    <div class="no-results text-center text-body-l mb-8 hidden" style="color: #5b5b5b;">No events match the selected filters.</div>
+    <div class="no-results text-center body-xl mb-8 hidden" style="color: #5b5b5b;">No events match the selected filters.</div>
 </section>

--- a/layouts/partials/events/timing-info-template.html
+++ b/layouts/partials/events/timing-info-template.html
@@ -8,20 +8,20 @@
     - duration: Duration string (e.g., "60 minutes")
 */}}
 
-<div class="template-timing-info flex flex-row flex-wrap gap-3">
-    <div class="timing-info-item flex-1 min-w-0">
+<div class="template-timing-info grid grid-cols-1 sm:grid-cols-3 gap-3">
+    <div class="timing-info-item">
         <div class="timing-info-label">
             {{ partial "icon.html" (dict "name" "calendar" "class" "mr-2") }}Date
         </div>
         <div class="timing-info-value">{{ .datetime | time.Format ":date_medium" }}</div>
     </div>
-    <div class="timing-info-item flex-1 min-w-0">
+    <div class="timing-info-item">
         <div class="timing-info-label">
             {{ partial "icon.html" (dict "name" "clock" "class" "mr-2") }}Time
         </div>
         <div class="timing-info-value"><pulumi-datetime date="{{ .datetime }}" timeonly></pulumi-datetime></div>
     </div>
-    <div class="timing-info-item flex-1 min-w-0">
+    <div class="timing-info-item">
         <div class="timing-info-label">
             {{ partial "icon.html" (dict "name" "hourglass" "class" "mr-2") }}Duration
         </div>

--- a/layouts/partials/footer/cta.html
+++ b/layouts/partials/footer/cta.html
@@ -4,7 +4,7 @@
 {{ end }}
 <section class="bg-violet-background text-gray-950"{{ with $cta.anchor }} id="{{ . }}"{{ end }}>
     <div class="container mx-auto flex flex-col md:flex-row items-center justify-center gap-5 md:gap-12 px-4 py-7 text-center md:text-left">
-        <h2 class="text-2xl md:text-3xl font-semibold tracking-tight leading-tight">{{ $cta.heading }}</h2>
+        <h2 class="text-2xl md:text-3xl font-semibold tracking-tight leading-tight mb-0">{{ $cta.heading }}</h2>
         <div class="flex gap-2.5 items-center shrink-0">
             {{ range $cta.buttons }}
                 {{ $class := "btn btn-primary btn-xl" }}

--- a/layouts/partials/template-page-content.html
+++ b/layouts/partials/template-page-content.html
@@ -29,7 +29,7 @@
     {{ partial "template-page-content.html" . }}
 */}}
 
-<div class="font-body container mx-auto mb-16 mt-16 px-6 md:px-8 flex flex-col gap-16 md:gap-20 lg:gap-24 overflow-hidden">
+<div class="font-body container mx-auto mb-16 mt-8 md:mt-16 px-6 md:px-8 flex flex-col gap-16 md:gap-20 lg:gap-24 overflow-hidden">
 {{ range .Params.sections }}
   {{ partial (printf "template-partials/template-%s.html" (replace .type "_" "-")) . }}
 {{ end }}

--- a/layouts/partials/template-partials/template-card-grid.html
+++ b/layouts/partials/template-partials/template-card-grid.html
@@ -29,7 +29,7 @@
 
 <section class="template-section-card-grid flex flex-col gap-8"{{ if $anchor }} id="{{ $anchor }}"{{ end }}>
     {{ if or $title $description }}
-    <div class="{{ if eq $align "center" }}text-center max-w-4xl mx-auto{{ else }}text-left{{ end }}">
+    <div class="{{ if eq $align "center" }}sm:text-center max-w-4xl mx-auto{{ else }}text-left{{ end }}">
         {{ if $title }}
         <h2 class="section-header-title m-0 mb-4">{{ $title }}</h2>
         {{ end }}

--- a/layouts/partials/template-partials/template-card-grid.html
+++ b/layouts/partials/template-partials/template-card-grid.html
@@ -43,7 +43,7 @@
         {{ range $largeCards }}
         <div class="card p-8 flex flex-col items-start overflow-hidden">
 
-            <div class="flex flex-col gap-4 mb-4">
+            <div class="flex flex-col mb-4">
                 <h3 class="template-feature-card-title">{{ .title }}</h3>
                 <div class="template-feature-card-description">{{ .description | markdownify }}</div>
             </div>
@@ -81,7 +81,7 @@
                     {{ partial "icon.html" (dict "name" .icon "weight" "duotone") }}
                 </div>
                 {{ end }}
-                <div class="flex flex-col gap-4 mb-4">
+                <div class="flex flex-col mb-4">
                     <h3 class="template-feature-card-title">{{ .title }}</h3>
                     <div class="template-feature-card-description">{{ .description | markdownify }}</div>
                 </div>

--- a/layouts/partials/template-partials/template-case-study-grid.html
+++ b/layouts/partials/template-partials/template-case-study-grid.html
@@ -33,7 +33,7 @@
 
 <section class="template-case-study-grid flex flex-col gap-8"{{ if $anchor }} id="{{ $anchor }}"{{ end }}>
     {{ if or $title $description }}
-    <div class="{{ if eq $align "center" }}text-center max-w-4xl mx-auto{{ else }}text-left{{ end }}">
+    <div class="{{ if eq $align "center" }}sm:text-center max-w-4xl mx-auto{{ else }}text-left{{ end }}">
         {{ if $title }}
         <h2 class="section-header-title m-0 mb-4">{{ $title }}</h2>
         {{ end }}

--- a/layouts/partials/template-partials/template-feature-split.html
+++ b/layouts/partials/template-partials/template-feature-split.html
@@ -33,7 +33,7 @@ Example: [{"icon": "code", "title": "Use real code", "description": "..."}, ...]
     <h2 class="product-two-column-heading mb-8">{{ $heading | markdownify }}</h2>
     {{ end }}
     {{ else }}
-    <div class="flex flex-col xl:flex-row gap-8 md:gap-10 xl:gap-20 items-start">
+    <div class="flex flex-col xl:flex-row gap-2 md:gap-10 xl:gap-20 items-start">
         <div class="xl:w-2/5 flex-shrink-0">
             {{ if $heading }}
             <h2 class="product-two-column-heading">{{ $heading | markdownify }}</h2>

--- a/layouts/partials/template-partials/template-hero.html
+++ b/layouts/partials/template-partials/template-hero.html
@@ -104,7 +104,7 @@
     <div class="flex flex-col xl:flex-row items-center justify-between gap-12">
         <div class="xl:w-1/2 flex flex-col items-start">
             {{ if or $badgeText $badgeHighlightText }}
-            <a href="{{ $badgeLink }}" class="font-overline flex-wrap inline-flex items-center gap-1 border border-violet-300 rounded-full py-3 px-5 mb-4 no-underline hover:border-violet-500 transition-colors">
+            <a href="{{ $badgeLink }}" class="font-overline flex-wrap inline-flex items-center gap-1 border border-violet-300 rounded-full py-3 px-5 no-underline hover:border-violet-500 transition-colors">
                 <span class="text-violet-primary whitespace-nowrap">{{ $badgeHighlightText }}</span>
                 <span class="text-gray-900 whitespace-nowrap">{{ $badgeText }} <span class="text-gray-500">{{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}</span></span>
             </a>
@@ -115,7 +115,7 @@
             </div>
             {{ end }}
             {{ if or $titlePrimary $title }}
-            <h1 class="product-hero-heading text-left mb-6">
+            <h1 class="product-hero-heading text-left">
                 {{ if and $titlePrimary $titleSecondary }}
                 {{ if $titleReversed }}
                 <span class="product-hero-title-secondary">{{ $titleSecondary }}</span>
@@ -202,7 +202,7 @@
     <div class="flex flex-col items-center gap-12">
         <div class="flex flex-col items-center text-center w-full max-w-4xl mx-auto">
             {{ if or $titlePrimary $title }}
-            <h1 class="product-hero-heading mb-6">
+            <h1 class="product-hero-heading">
                 {{ if and $titlePrimary $titleSecondary }}
                 {{ if $titleReversed }}
                 <span class="product-hero-title-secondary">{{ $titleSecondary }}</span>

--- a/layouts/partials/template-partials/template-hero.html
+++ b/layouts/partials/template-partials/template-hero.html
@@ -104,9 +104,9 @@
     <div class="flex flex-col xl:flex-row items-center justify-between gap-12">
         <div class="xl:w-1/2 flex flex-col items-start">
             {{ if or $badgeText $badgeHighlightText }}
-            <a href="{{ $badgeLink }}" class="font-mono flex-wrap text-sm tracking-wider uppercase inline-flex items-center gap-1 border border-violet-200 rounded-full py-3 px-5 mb-4 no-underline hover:border-violet-400 transition-colors">
+            <a href="{{ $badgeLink }}" class="font-overline flex-wrap inline-flex items-center gap-1 border border-violet-300 rounded-full py-3 px-5 mb-4 no-underline hover:border-violet-500 transition-colors">
                 <span class="text-violet-primary whitespace-nowrap">{{ $badgeHighlightText }}</span>
-                <span class="text-gray-900 whitespace-nowrap">{{ $badgeText }} <span class="text-gray-800">&rsaquo;</span></span>
+                <span class="text-gray-900 whitespace-nowrap">{{ $badgeText }} <span class="text-gray-500">{{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}</span></span>
             </a>
             {{ end }}
             {{ if $tagLine }}

--- a/layouts/partials/template-partials/template-mini-cards.html
+++ b/layouts/partials/template-partials/template-mini-cards.html
@@ -31,7 +31,7 @@
 {{ if eq $cols 2 }}{{ $colsClass = "md:grid-cols-2" }}{{ end }}
 {{ if eq $cols 4 }}{{ $colsClass = "md:grid-cols-2 lg:grid-cols-4" }}{{ end }}
 
-<div class="product-two-column-cards grid grid-cols-1 {{ $colsClass }} gap-12 md:gap-16 lg:gap-36 mt-12 md:mt-16 {{ $lgTopClass }} w-full">
+<div class="product-two-column-cards grid grid-cols-1 {{ $colsClass }} gap-8 md:gap-16 lg:gap-36 mt-12 md:mt-16 {{ $lgTopClass }} w-full">
     {{ range $cards }}
     <div class="product-feature-mini-card">
         {{ if .image }}

--- a/layouts/partials/template-partials/template-section-header.html
+++ b/layouts/partials/template-partials/template-section-header.html
@@ -39,7 +39,7 @@
 {{ $cards := .cards }}
 {{ $cardsCols := .cards_cols | default 3 }}
 {{ $align := .align | default "center" }}
-{{ $alignClasses := "text-center max-w-4xl mx-auto" }}
+{{ $alignClasses := "sm:text-center max-w-4xl mx-auto" }}
 {{ if eq $align "left" }}{{ $alignClasses = "text-left" }}{{ end }}
 {{ $ctaAlignClass := "text-center" }}
 {{ if eq $align "left" }}{{ $ctaAlignClass = "text-left" }}{{ end }}

--- a/layouts/partials/template-partials/template-three-column.html
+++ b/layouts/partials/template-partials/template-three-column.html
@@ -40,7 +40,7 @@ Note: icon should be a Phosphor icon name (e.g., "shield", "rocket")
     </div>
     {{ end }}
 
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-12 md:gap-16 lg:gap-36 {{ if or $tagLine $title $subtitle }}mt-12 md:mt-12 lg:mt-20{{ end }}">
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 md:gap-16 lg:gap-36 {{ if or $tagLine $title $subtitle }}mt-12 md:mt-12 lg:mt-20{{ end }}">
         {{ range $columns }}
         <div class="three-column-item text-left flex flex-col justify-start">
             {{ if and .icon (eq $iconLayout "above") }}
@@ -49,7 +49,7 @@ Note: icon should be a Phosphor icon name (e.g., "shield", "rocket")
             </div>
             {{ end }}
             {{ if .title }}
-            <h4 class="three-column-item-title {{ if eq $iconLayout "above" }}template-feature-card-title{{ end }} mb-3
+            <h4 class="three-column-item-title {{ if eq $iconLayout "above" }}template-feature-card-title{{ end }}
                 {{ if and .icon (ne $iconLayout "above" ) }}flex items-center{{ end }}">
                 {{ if and .icon (ne $iconLayout "above") }}
                 {{ partial "icon.html" (dict "name" .icon "weight" "duotone" "class" "mr-3") }}

--- a/layouts/product/superintelligence-infrastructure.html
+++ b/layouts/product/superintelligence-infrastructure.html
@@ -4,7 +4,7 @@
     <section id="overview" class="max-w-5xl mx-auto text-center my-12 px-6">
         {{ with .Params.overview }}
             <div class="md:px-0">
-                <h1 class="font-display font-semibold">{{ .title }}</h1>
+                <h1 class="heading-xl">{{ .title }}</h1>
                 <p class="text-center text-2xl w-full lg:w-3/4 mx-auto">{{ .description | markdownify }}</p>
                 <div class="mt-8 flex flex-col md:flex-row justify-center gap-4 mb-12">
                     {{ partial "cta-get-started" (dict) }}
@@ -20,7 +20,7 @@
     <section id="stats" class="text-center pt-12 pb-6 my-12 relative">
         <div class="container mx-auto">
             <div class="mx-6 lg:mx-2 rounded-xl">
-                <h2 class="font-display font-semibold">{{ .Params.stats.title }}</h2>
+                <h2 class="heading-1">{{ .Params.stats.title }}</h2>
 
                 <div class="flex flex-col lg:flex-row justify-left items-stretch mt-8 lg:mt-16 relative pb-8">
                     {{ range $section := .Params.stats.sections}}
@@ -37,7 +37,7 @@
 
     <section id="what-it-is" class="text-center pt-12 pb-6 my-12 relative">
         <div class="container mx-auto">
-            <h2 class="text-center mb-4 font-display font-semibold">{{ .Params.features.title }}</h2>
+            <h2 class="text-center mb-4 heading-1">{{ .Params.features.title }}</h2>
             <p class="text-center text-2xl w-full lg:w-3/4 mx-auto mb-4">{{ .Params.features.description | markdownify }}</p>
             <div class="p-0.5 rounded-lg mx-4" style="background: #5a30c5;">
                 <div class="rounded-lg bg-white flex flex-wrap mx-auto p-4 justify-center">
@@ -60,7 +60,7 @@
 
     <section id="capabilities" class="text-center p-12 pb-6 my-12 relative">
         {{ with .Params.capabilities }}
-            <h2 class="font-display font-semibold">{{ .title }}</h2>
+            <h2 class="heading-1">{{ .title }}</h2>
             <p class="text-center w-full lg:w-3/4 mx-auto text-2xl">{{ .description | markdownify }}</p>
             <div class="flex justify-center">{{ partial "fingerprinted-img.html" (dict "src" "/images/product/ml-engineer.png" "alt" "ML engineer" "maxWidth" 1200 "style" "max-height: 1200px; width:auto") }}</div>
         {{ end }}
@@ -70,7 +70,7 @@
     <section id="casestudy" class="text-center p-12 pb-6 my-12 relative">
         <div class="container mx-auto">
             {{ with .Params.casestudy }}
-            <h2 class="font-display font-semibold">{{ .title }}</h2>
+            <h2 class="heading-1">{{ .title }}</h2>
             <p class="text-center text-2xl w-full lg:w-3/4 mx-auto">{{ .supabase.title | markdownify }}</p>
 
             <div>
@@ -109,7 +109,7 @@
     <section ic="enablement" class="text-center p-12 pb-6 mt-12 mb-6 relative">
         <div class="container mx-auto">
             {{ with .Params.enablement }}
-                <h2 class="font-display font-semibold"> {{ .title }}</h2>
+                <h2 class="heading-1"> {{ .title }}</h2>
                 <div class="flex flex-col xl:flex-row gap-24 my-12">
                     <div class="w-full xl:w-1/2 text-left mt-8 xl:mt-20">
                         <h4 class="text-left">{{ .description | markdownify }}</h4>
@@ -127,7 +127,7 @@
 
     <section id="building-blocks" class="text-center pt-0 pb-6 my-6 mb-12 relative">
         <div class="container mx-auto">
-            <h2 class="font-display font-semibold">{{ .Params.building_blocks.title }}</h2>
+            <h2 class="heading-1">{{ .Params.building_blocks.title }}</h2>
             <div class="flex flex-wrap justify-content items-stretch text-left my-8">
                 {{ range $block := .Params.building_blocks.items }}
                 {{ if not $block.graphic }}
@@ -149,7 +149,7 @@
 
     <section id="learn" class="text-center pt-12 pb-6 my-12 relative">
         <div class="container mx-auto">
-            <h2 class="font-display font-semibold">{{ .Params.learn.title }}</h2>
+            <h2 class="heading-1">{{ .Params.learn.title }}</h2>
             <div class="flex flex-wrap justify-content items-stretch my-4">
                 {{ range $index, $item := .Params.learn.items }}
                 <div class="w-full p-3">

--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -14,8 +14,8 @@
 {{ end }}
 <header class="page-hero text-left">
     <div class="container mx-auto px-6 lg:px-0 flex flex-col items-start">
-        <nav aria-label="Breadcrumb" class="max-w-4xl mx-auto mb-6 font-overline">
-            <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-600">
+        <nav aria-label="Breadcrumb" class="max-w-4xl mx-auto mb-6">
+            <ol class="flex flex-wrap items-center gap-2 font-overline text-gray-600">
                 <li><a class="hover:text-violet-700" href="/what-is/">What Is</a></li>
                 <li aria-hidden="true" class="text-gray-400">/</li>
                 <li aria-current="page" class="text-gray-900 font-medium">{{ .Params.page_title | safeHTML }}</li>

--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -12,9 +12,9 @@
 {{ else if and .GitInfo .GitInfo.AuthorDate }}
     {{ $modifiedDate = .GitInfo.AuthorDate }}
 {{ end }}
-<header class="page-hero">
-    <div class="container mx-auto px-6 lg:px-0">
-        <nav aria-label="Breadcrumb" class="max-w-4xl mx-auto mb-6">
+<header class="page-hero text-left">
+    <div class="container mx-auto px-6 lg:px-0 flex flex-col items-start">
+        <nav aria-label="Breadcrumb" class="max-w-4xl mx-auto mb-6 font-overline">
             <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-600">
                 <li><a class="hover:text-violet-700" href="/what-is/">What Is</a></li>
                 <li aria-hidden="true" class="text-gray-400">/</li>
@@ -22,7 +22,7 @@
             </ol>
         </nav>
         <div class="page-hero-title">
-            <h1 class="small-title">
+            <h1>
                 <span><span data-text="{{ .Params.page_title }}">{{ .Params.page_title | safeHTML }}</span></span>
             </h1>
         </div>

--- a/layouts/whitepapers/list.html
+++ b/layouts/whitepapers/list.html
@@ -10,7 +10,7 @@
             <div class="flex flex-col items-center text-center w-full max-w-4xl mx-auto">
                 <h1 class="title mb-6">{{ .Title }}</h1>
                 {{ with .Params.description }}
-                <p class="description mb-10">{{ . | markdownify }}</p>
+                <p class="description mb-10 max-w-2xl">{{ . | markdownify }}</p>
                 {{ end }}
             </div>
         </div>

--- a/layouts/whitepapers/list.html
+++ b/layouts/whitepapers/list.html
@@ -2,7 +2,7 @@
 {{ end }}
 
 {{ define "main" }}
-<div class="font-body container mx-auto mb-16 mt-16 px-6 md:px-8 flex flex-col gap-16 md:gap-20 lg:gap-24 overflow-hidden">
+<div class="font-body container mx-auto mb-16 mt-8 md:mt-16 px-6 md:px-8 flex flex-col gap-16 md:gap-20 lg:gap-24 overflow-hidden">
 
     {{/* Hero */}}
     <section class="template-hero template-hero--centered" id="hero">

--- a/layouts/whitepapers/single.html
+++ b/layouts/whitepapers/single.html
@@ -11,7 +11,7 @@
                 <a href="/whitepapers/" class="hero-tag-line no-underline hover:no-underline">Whitepaper</a>
                 <h1 class="title mb-6">{{ .Title }}</h1>
                 {{ with .Description }}
-                <p class="description mb-10">{{ . | markdownify }}</p>
+                <p class="description mb-10 max-w-2xl">{{ . | markdownify }}</p>
                 {{ end }}
             </div>
         </div>

--- a/theme/src/scss/_base-shared.scss
+++ b/theme/src/scss/_base-shared.scss
@@ -61,19 +61,19 @@ h6 {
 }
 
 h1 {
-    @apply text-2xl md:text-3xl lg:text-4xl;
+    @apply text-3xl md:text-4xl;
 }
 h2 {
-    @apply text-xl md:text-2xl lg:text-3xl;
+    @apply text-2xl md:text-3xl;
 }
 h3 {
-    @apply text-lg md:text-xl lg:text-2xl;
+    @apply text-xl md:text-2xl;
 }
 h4 {
-    @apply text-base md:text-lg lg:text-xl;
+    @apply text-lg md:text-xl;
 }
 h5 {
-    @apply text-sm md:text-base lg:text-lg;
+    @apply text-base md:text-lg;
 }
 h6 {
     @apply text-sm md:text-base;

--- a/theme/src/scss/_base-shared.scss
+++ b/theme/src/scss/_base-shared.scss
@@ -1,0 +1,84 @@
+// Shared @layer base rules for both the docs bundle (main.scss) and the
+// marketing bundle (_marketing.scss). Each bundle ships its own Tailwind
+// preflight, so anything that needs to defeat the second preflight to load
+// (headings, border-color, custom-element display) belongs here.
+// Keep this file consumable from inside an `@layer base { ... }` block.
+
+// Tailwind v2 preflight set default border-color to gray-200. v4 defaults to
+// currentColor, which makes `.border` dividers render too dark. Restore the old default.
+*,
+::before,
+::after {
+    border-color: var(--color-gray-200);
+}
+
+// Custom elements default to display: inline in browsers. Tailwind v4 preflight
+// does not reset them to block, so we do it here for all Pulumi web components.
+pulumi-chooser,
+pulumi-choosable,
+pulumi-tabs,
+pulumi-tab-panel,
+pulumi-install,
+pulumi-banner,
+pulumi-examples,
+pulumi-convert,
+pulumi-tooltip,
+pulumi-audio,
+pulumi-slot-machine,
+pulumi-tertiary-nav,
+pulumi-greenhouse-jobs-list,
+pulumi-resource-links,
+pulumi-filter-select,
+pulumi-user-toggle,
+pulumi-hubspot-form {
+    display: block;
+}
+
+// Heading + paragraph element defaults. The `.heading-1`–`.heading-6`,
+// `.heading-xl`, `.body-*`, and `.font-overline` class versions live in
+// `_utilities-shared.scss` as @utility blocks so they can be composed via @apply.
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    @apply font-display text-service-black mb-2;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        // Don't apply top margin when one's being specified.
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
+h1 {
+    @apply text-2xl md:text-3xl lg:text-4xl;
+}
+h2 {
+    @apply text-xl md:text-2xl lg:text-3xl;
+}
+h3 {
+    @apply text-lg md:text-xl lg:text-2xl;
+}
+h4 {
+    @apply text-base md:text-lg lg:text-xl;
+}
+h5 {
+    @apply text-sm md:text-base lg:text-lg;
+}
+h6 {
+    @apply text-sm md:text-base;
+}
+
+p {
+    @apply leading-normal my-4 text-service-black;
+}

--- a/theme/src/scss/_hero.scss
+++ b/theme/src/scss/_hero.scss
@@ -76,34 +76,13 @@
 }
 
 .page-hero {
-    @apply relative w-full py-10 mb-10 border-b border-gray-300;
+    @apply relative w-full py-10 mb-10 border-b border-gray-200;
 
     .page-hero-title {
         @apply text-black w-full flex flex-col items-center justify-center pointer-events-none;
 
-        h1 {
+        h1, h2, h3 {
             @apply text-center max-w-4xl;
-            font-weight: 600;
-            @include screen-lg {
-                font-size: 3.75rem;
-                line-height: 1.1em;
-            }
-        }
-
-        h2 {
-            @apply text-center max-w-4xl;
-            @include screen-lg {
-                font-size: 3rem;
-                line-height: 1.1em;
-            }
-        }
-
-        h3 {
-            @apply text-center max-w-4xl;
-            @include screen-lg {
-                font-size: 2.5rem;
-                line-height: 1.1em;
-            }
         }
     }
 }

--- a/theme/src/scss/_marketing.scss
+++ b/theme/src/scss/_marketing.scss
@@ -10,81 +10,16 @@
 
 @import "mixins";
 
+@import "utilities-shared";
+
 @layer base {
-    // Restore global heading defaults after Tailwind preflight resets font-size/weight to inherit.
-    h1, h2, h3, h4, h5, h6 {
-        font-weight: 600;
-        letter-spacing: -0.05em;
-        line-height: 1.1em;
-    }
-
-    // Tailwind v2 preflight set default border-color to gray-200. v4 defaults to
-    // currentColor, which makes `.border` dividers render too dark. Restore the old default.
-    *,
-    ::before,
-    ::after {
-        border-color: var(--color-gray-200);
-    }
-
-    // Custom elements default to display: inline in browsers. Tailwind v4 preflight
-    // does not reset them to block, so we do it here for all Pulumi web components.
-    pulumi-chooser,
-    pulumi-choosable,
-    pulumi-tabs,
-    pulumi-tab-panel,
-    pulumi-install,
-    pulumi-banner,
-    pulumi-examples,
-    pulumi-convert,
-    pulumi-tooltip,
-    pulumi-audio,
-    pulumi-slot-machine,
-    pulumi-tertiary-nav,
-    pulumi-greenhouse-jobs-list,
-    pulumi-resource-links,
-    pulumi-filter-select,
-    pulumi-user-toggle,
-    pulumi-hubspot-form {
-        display: block;
-    }
+    @import "base-shared";
 }
 
 // v4 layer placement: custom styles must be in @layer so Tailwind utilities can override them.
 @layer components {
     body {
         @apply overflow-x-hidden;
-
-        h1 {
-            @apply text-5xl;
-        }
-        h2 {
-            @apply text-4xl;
-        }
-        h3 {
-            @apply text-3xl;
-        }
-        h4 {
-            @apply text-2xl;
-        }
-        h5 {
-            @apply text-xl;
-        }
-        h6 {
-            @apply text-base;
-        }
-
-        h1,
-        h2,
-        h3,
-        h4,
-        h5,
-        h6 {
-            line-height: 1.1em !important;
-        }
-
-        p {
-            @apply text-service-black;
-        }
 
         .large-container {
             width: 100%;
@@ -116,31 +51,6 @@
 
             &:focus {
                 @apply bg-violet-400;
-            }
-        }
-
-        @include screen-md {
-            h1 {
-                @apply text-7xl;
-
-                &.small-title {
-                    @apply text-5xl;
-                }
-            }
-            h2 {
-                @apply text-5xl;
-            }
-            h3 {
-                @apply text-4xl;
-            }
-            h4 {
-                @apply text-3xl;
-            }
-            h5 {
-                @apply text-2xl;
-            }
-            h6 {
-                @apply text-lg;
             }
         }
     }

--- a/theme/src/scss/_templates.scss
+++ b/theme/src/scss/_templates.scss
@@ -14,11 +14,11 @@
 
 
 @mixin product-hero-heading {
-    @apply text-black text-center not-italic heading-xl;
+    @apply text-black text-center not-italic heading-xl mb-4;
 }
 
 @mixin section-description {
-    @apply font-normal leading-normal body-xl;
+    @apply font-normal leading-normal body-xl mt-0;
 }
 
 @mixin section-subheader-bold {
@@ -274,7 +274,7 @@
     }
 
     .three-column-item-description {
-        @apply body-base;
+        @apply body-base mt-0;
     }
 }
 

--- a/theme/src/scss/_templates.scss
+++ b/theme/src/scss/_templates.scss
@@ -2,78 +2,60 @@
 // Styles for reusable template partials (template-hero, template-logo-banner, etc.)
 
 @mixin page-header {
-    @apply font-semibold text-black font-body text-heading-m;
-    line-height: 1.375;
-    letter-spacing: -2px;
+    @apply text-black heading-1;
 }
 
 @mixin section-header {
-    @apply font-semibold text-black font-body text-heading-s;
-    line-height: 55px;
-    letter-spacing: -2px;
+    @apply heading-1;
     strong {
-        @apply text-violet-primary font-semibold;
+        @apply text-violet-primary;
     }
 }
 
-@mixin section-header-small {
-    @apply font-semibold text-black font-body text-heading-s;
-    line-height: 55px;
-    letter-spacing: -2px;
-}
-
-@mixin section-header-extra-small {
-    @apply font-semibold leading-extra-tight text-black font-body text-heading-2xs;
-}
-
-@mixin section-header-extra-extra-small {
-    @apply font-semibold leading-extra-tight text-black font-body text-heading-2xsSmall;
-}
 
 @mixin product-hero-heading {
-    @apply text-black text-center not-italic font-semibold text-heading-l;
-    font-family: Inter, sans-serif;
-    letter-spacing: -3.2px;
-    line-height: 1.1 !important;
+    @apply text-black text-center not-italic heading-xl;
 }
 
 @mixin section-description {
-    @apply font-normal leading-normal font-body text-body-l;
-    color: #2f3032;
+    @apply font-normal leading-normal body-xl;
 }
 
 @mixin section-subheader-bold {
-    @apply font-semibold leading-normal text-black font-body text-body-xl;
+    @apply font-semibold leading-normal text-black body-2xl;
 }
 
 @mixin section-hint {
-    @apply font-semibold leading-normal font-body text-body-l;
-    color: #1e1e1e;
+    @apply font-semibold leading-normal body-xl;
 }
 
 @mixin section-hint-accent {
-    font-family: "Monaspace Neon Var", monospace;
-    font-weight: 400;
-    font-size: 14px;
-    line-height: 1.5;
-    letter-spacing: 0.7px;
-    text-transform: uppercase;
-    color: #404041;
+    @apply font-overline text-gray-primary;
 }
 
-@mixin section-hint-small {
-    @include section-hint-accent();
+@mixin edge-fade {
+    &::before,
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 40px;
+        z-index: 10;
+        pointer-events: none;
+    }
+
+    &::before {
+        left: 0;
+        background: linear-gradient(to right, white, transparent);
+    }
+
+    &::after {
+        right: 0;
+        background: linear-gradient(to left, white, transparent);
+    }
 }
 
-@mixin section-body-medium {
-    @apply font-normal leading-normal font-body text-body-m;
-    color: #2f3032;
-}
-
-@mixin section-body-small {
-    @apply font-normal leading-normal font-body text-body-s;
-    color: #2f3032;
-}
 
 // Offset anchored sections within event pages to account for the fixed nav.
 .event-page-content section[id] {
@@ -90,8 +72,7 @@
     }
 
     .hero-event-details {
-        @apply flex flex-wrap items-center font-semibold leading-normal font-body text-body-m;
-        color: #5b5b5b;
+        @apply flex flex-wrap items-center font-semibold leading-normal body-lg text-gray-primary;
     }
 
     .hero-date-and-location {
@@ -114,7 +95,6 @@
 
     .title {
         @include page-header();
-        line-height: 110% !important;
     }
 
     .description {
@@ -124,34 +104,50 @@
     // Centered variant for non-event, non-product pages (e.g. whitepapers)
     &--centered {
         .title {
-            @include page-header();
-            @apply text-center text-heading-s leading-tight tracking-tight;
-
-            @include screen-sm {
-                @apply text-heading-m;
-            }
-            @include screen-md {
-                @apply text-heading-l;
-            }
+            @apply text-black heading-xl text-center leading-tight tracking-tight;
         }
 
         .description {
             @include section-description();
-            @apply text-body-xl;
+            @apply text-center;
         }
+    }
+
+    // Product page widgets
+    .product-hero-heading {
+        @include product-hero-heading();
+    }
+
+    .product-hero-title-primary {
+        @apply block text-violet-primary;
+    }
+
+    .product-hero-title-secondary {
+        @apply block text-black;
+    }
+
+    .product-hero-title {
+        @include product-hero-heading();
+    }
+
+    .product-hero-description {
+        @include section-description();
+        @apply max-w-xl;
+    }
+
+    .product-hero-visual {
+        @apply w-full;
     }
 }
 
 .template-logo-banner {
     .logo-banner-text {
-        @include section-hint-small();
+        @include section-hint-accent();
     }
 
     .logo-container {
         img {
-            height: 54px;
-            max-height: 54px;
-            @apply w-auto;
+            @apply w-auto h-[54px] max-h-[54px];
         }
     }
 
@@ -165,16 +161,10 @@
         }
 
         .logo-container {
-            width: 150px;
-            height: 150px;
-            border: 1px solid var(--color-violet-300);
-            border-radius: 10px;
+            @apply w-[150px] h-[150px] border border-violet-300 rounded-[10px];
 
             img {
-                height: auto;
-                max-height: 107px;
-                max-width: 130px;
-                @apply w-auto;
+                @apply w-auto h-auto max-h-[107px] max-w-[130px];
             }
         }
     }
@@ -194,7 +184,7 @@
     }
 
     .feature-title {
-        @include section-header-extra-extra-small();
+        @apply heading-4;
         @apply flex flex-row items-center;
 
         i {
@@ -203,7 +193,7 @@
     }
 
     .feature-description {
-        @include section-body-medium();
+        @apply body-lg;
     }
 
     .features-content {
@@ -232,27 +222,27 @@
     }
 
     .card-title {
-        @include section-header-extra-small();
+        @apply heading-3;
     }
 
     .card-subheader {
-        @include section-header-extra-extra-small();
-        color: #5b5b5b;
+        @apply heading-4;
+        @apply text-gray-primary;
     }
 
     .card-description {
-        @include section-body-medium();
+        @apply body-lg;
     }
 }
 
 .template-promo-banner {
     .promo-banner-title {
-        @include section-header-extra-small();
+        @apply heading-3;
         @apply text-white;
     }
 
     .promo-banner-description {
-        @include section-body-medium();
+        @apply body-lg;
         @apply text-white;
     }
 
@@ -272,10 +262,7 @@
     }
 
     .three-column-item-title {
-        font-family: Inter, sans-serif;
-        letter-spacing: -1.4px;
-        line-height: 38.5px;
-        @apply text-black font-semibold text-heading-xs;
+        @apply text-black font-semibold heading-3;
 
         i {
             @apply flex-shrink-0;
@@ -287,13 +274,13 @@
     }
 
     .three-column-item-description {
-        @include section-body-small();
+        @apply body-base;
     }
 }
 
 // Shared feature card (icon above title + description) — used by template-feature-split and template-three-column (icon_layout: above)
 .template-feature-card-icon {
-    @apply text-violet-primary mb-3 text-body-xl;
+    @apply text-violet-primary mb-3 body-2xl;
 
     svg {
         width:32px;
@@ -303,17 +290,14 @@
 }
 
 .template-feature-card-title {
-    @apply font-body text-black font-semibold mt-0! mb-3 text-heading-xs;
-    line-height: 38.5px;
-    letter-spacing: -1.4px;
+    @apply text-black font-semibold mt-0! mb-3 heading-3;
 }
 
 .template-feature-card-description {
-    @include section-body-small();
+    @apply body-base;
 
     ul {
-        @apply list-disc pl-5 mt-2;
-        color: var(--color-gray-700);
+        @apply list-disc pl-5 mt-2 text-gray-700;
 
         li {
             @apply mb-1;
@@ -322,10 +306,7 @@
 }
 
 .template-testimonial {
-    @apply font-body bg-violet-50;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    @apply font-body bg-violet-50 bg-cover bg-center bg-no-repeat;
 
     &.template-testimonial-bg-1 {
         background-image: url('/images/template-testimonial-bg-1.svg');
@@ -336,17 +317,12 @@
     }
 
     .template-testimonial-logo img {
-        height: 48px;
-        width: auto;
-        @apply grayscale brightness-0;
+        @apply grayscale brightness-0 h-12 w-auto;
     }
 }
 
 .template-feature-callout {
-    @apply font-body bg-violet-50;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    @apply font-body bg-violet-50 bg-cover bg-center bg-no-repeat;
 
     &.template-feature-callout-bg-1 {
         background-image: url('/images/template-testimonial-bg-1.svg');
@@ -357,13 +333,7 @@
     }
 
     .feature-callout-tag-line {
-        font-family: "Monaspace Neon Var", monospace;
-        font-weight: 400;
-        font-size: 14px;
-        line-height: 1.5;
-        letter-spacing: 0.7px;
-        text-transform: uppercase;
-        color: #404041;
+        @include section-hint-accent();
     }
 
     .feature-callout-title {
@@ -377,7 +347,6 @@
 
     .feature-callout-description {
         @include section-description();
-        @apply text-body-s text-black;
 
         a {
             @apply text-inherit no-underline;
@@ -396,16 +365,15 @@
 
     .location-details {
         @include section-subheader-bold();
-        color: #404041;
+        @apply text-gray-800;
     }
 
     .location-description {
-        @include section-body-medium();
-        color: #757576;
+        @apply body-lg text-gray-primary;
     }
 
     iframe {
-        border-radius: 1rem;
+        @apply rounded-2xl;
     }
 }
 
@@ -437,7 +405,7 @@
 // Shared content styles for sidebar-nav pages (whitepapers, case studies, etc.)
 .template-sidebar-content {
     h2 {
-        @apply font-body font-semibold text-heading-xs leading-extra-tight scroll-mt-22;
+        @apply font-semibold heading-2 leading-extra-tight scroll-mt-22;
 
         @include screen-lg {
             @apply scroll-mt-28;
@@ -445,7 +413,7 @@
     }
 
     h3 {
-        @apply font-body font-semibold text-heading-2xs leading-tight scroll-mt-22;
+        @apply font-semibold heading-3 leading-tight scroll-mt-22;
 
         @include screen-lg {
             @apply scroll-mt-28;
@@ -453,7 +421,7 @@
     }
 
     h4, h5, h6 {
-        @apply font-body font-semibold text-body-xl leading-tight scroll-mt-22;
+        @apply font-semibold body-2xl leading-tight scroll-mt-22;
 
         @include screen-lg {
             @apply scroll-mt-28;
@@ -484,7 +452,7 @@
     }
 
     .case-study-hero-stat {
-        @apply font-body font-bold text-black mb-2 text-heading-xs leading-relaxed;
+        @apply font-bold text-black heading-3 leading-relaxed;
     }
 
     .case-study-hero-headline {
@@ -511,65 +479,14 @@
 }
 
 
-// Product page widgets
-.template-hero {
-    .product-hero-heading {
-        @include product-hero-heading();
-        @apply text-heading-s;
-        @include screen-sm {
-            @apply text-heading-m;
-        }
-        @include screen-md {
-            @apply text-heading-l;
-        }
-    }
-
-    .product-hero-title-primary {
-        @apply block;
-        color: var(--color-violet-primary);
-    }
-
-    .product-hero-title-secondary {
-        @apply block text-black;
-    }
-
-    .product-hero-title {
-        @include product-hero-heading();
-        @apply text-heading-s;
-        @include screen-sm {
-            @apply text-heading-m;
-        }
-        @include screen-md {
-            @apply text-heading-l;
-        }
-    }
-
-    .product-hero-description {
-        @include section-description();
-        @apply text-body-xl;
-    }
-
-    .product-hero-visual {
-        @apply w-full;
-
-    }
-}
-
 .template-section-header {
 
     .section-header-image-above-img {
-        @apply w-auto h-auto;
-        max-width: 350px;
+        @apply w-auto h-auto max-w-[350px];
     }
 
     .section-header-tag-line {
-        font-family: "Monaspace Neon Var", monospace;
-        font-weight: 400;
-        font-size: 14px;
-        line-height: 1.5;
-        letter-spacing: 0.7px;
-        text-transform: uppercase;
-        color: #404041;
+        @include section-hint-accent();
         @apply text-center;
     }
 
@@ -583,7 +500,7 @@
 
     .section-header-description {
         @include section-description();
-        @apply text-body-s max-w-xl mx-auto;
+        @apply max-w-xl mx-auto;
 
         a {
             @apply text-inherit no-underline;
@@ -625,7 +542,7 @@
     }
 
     .section-header-split-tag {
-        @include section-hint-small();
+        @include section-hint-accent();
         @apply m-0;
     }
 
@@ -635,9 +552,7 @@
     }
 
     .section-header-split-description {
-        color: #2f3032;
-        font-family: Inter, sans-serif;
-        @apply text-left font-body text-body-s font-normal leading-normal;
+        @include section-description();
 
         p {
             @apply m-0;
@@ -649,35 +564,33 @@
     }
 
     pulumi-chooser > ul li.active {
+        @apply border-violet-primary;
         border-image-source: none;
-        border-color: var(--color-violet-primary);
     }
 
 }
 
 .template-section-header-with-image {
     .section-header-split-content {
-        flex: 1 1 0%;
+        @apply flex-1;
     }
-
 }
 
 .template-counter-cards {
     .counter-card-number {
         @include page-header();
-        @apply mb-2 font-semibold;
-        color: #1b1b1b;
+        @apply text-black;
     }
 
     .counter-card-label {
-        @include section-body-medium();
+        @apply body-lg;
         @apply m-0;
     }
 }
 
 .template-icon-grid {
     .icon-grid-tag-line {
-        @include section-hint-small();
+        @include section-hint-accent();
         @apply m-0;
     }
 
@@ -687,7 +600,7 @@
 
     .icon-grid-title {
         @include section-header();
-        margin: 0 !important;
+        @apply m-0!;
     }
 
     .icon-grid-description {
@@ -698,9 +611,7 @@
 // Event list and card styles
 .template-event-list {
     .event-list-month-header {
-        @include section-header-extra-small();
-        @apply m-0;
-        color: #404041;
+        @apply heading-3 m-0 text-gray-800;
     }
 
     .event-card-grid {
@@ -709,12 +620,10 @@
 }
 
 .template-event-card {
-    border: 0.5px solid #CECECE;
-    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    @apply border border-gray-300 transition;
 
     &:hover {
-        border-color: #999;
-        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+        @apply border-gray-accent;
     }
 
     a {
@@ -722,152 +631,112 @@
     }
 
     .event-card-type {
-        @apply font-semibold font-body text-body-s uppercase;
-        color: var(--color-violet-primary);
+        @apply font-semibold font-body uppercase text-violet-primary text-[0.7rem];
         letter-spacing: 0.5px;
-        font-size: 0.7rem;
     }
 
     .event-card-location {
-        @apply font-body text-body-s;
-        color: #757576;
-        font-size: 0.8rem;
+        @apply font-body text-gray-primary text-[0.8rem];
     }
 
     .event-card-title {
-        @include section-header-extra-extra-small();
-        @apply m-0 leading-snug;
-        transition: color 0.15s ease;
+        @apply heading-4 m-0 leading-snug transition-colors;
     }
 
     &:hover .event-card-title {
-        color: var(--color-violet-primary);
+        @apply text-violet-primary;
     }
 
     .event-card-date {
-        @apply flex flex-col items-center justify-center rounded-lg overflow-hidden flex-shrink-0;
-        width: 56px;
-        height: 56px;
-        border: 0.5px solid #CECECE;
+        @apply flex flex-col items-center justify-center rounded-lg overflow-hidden flex-shrink-0 w-14 h-14 border border-gray-300;
     }
 
     .event-card-date-day {
-        @apply text-center font-semibold text-gray-900 font-body;
-        font-size: 1.25rem;
-        line-height: 1.4;
+        @apply text-center font-semibold text-gray-900 font-body text-xl;
     }
 
     .event-card-date-month {
-        @apply text-center font-body font-semibold;
-        font-size: 0.65rem;
-        letter-spacing: 0.5px;
-        color: #757576;
+        @apply text-center font-body font-semibold text-gray-primary text-[0.65rem];
     }
 
     .event-card-description {
-        @include section-body-medium();
-        @apply m-0 text-body-s line-clamp-3;
+        @apply m-0 body-base line-clamp-3;
     }
 
     .event-card-tag {
-        @apply inline-block font-body text-gray-700 rounded-md;
-        font-size: 0.7rem;
-        padding: 2px 8px;
-        background-color: #FAF9FD;
-        border: 0.5px solid #D7CDEA;
+        @apply inline-block font-body text-gray-700 rounded-md text-[0.7rem] py-0.5 px-2 bg-violet-50 border border-violet-200;
     }
 
     .event-card-cta {
-        @apply font-semibold font-body whitespace-nowrap flex-shrink-0;
-        color: var(--color-violet-primary);
-        font-size: 0.875rem;
+        @apply font-semibold font-body whitespace-nowrap flex-shrink-0 text-violet-primary text-sm;
 
         i {
-            transition: transform 0.15s ease;
+            @apply transition-transform;
         }
     }
 
     &:hover .event-card-cta i {
-        transform: translateX(3px);
+        @apply translate-x-[3px];
     }
 }
 
 // Single event page styles
 .event-breadcrumb {
-    @apply font-body;
-    font-size: 0.85rem;
+    @apply font-overline;
 
     a {
-        @apply font-semibold no-underline;
-        color: var(--color-violet-primary);
+        @apply no-underline text-violet-primary;
     }
 
     .event-breadcrumb-separator {
-        @apply mx-2;
-        color: var(--color-gray-400);
-    }
-
-    .event-breadcrumb-current {
-        color: var(--color-gray-600);
+        @apply mx-2 text-gray-400;
     }
 }
 
 .template-event-single-header {
     .event-single-title {
         @include page-header();
-        @apply m-0 mb-2;
+        @apply mb-4;
     }
 
     .event-single-type {
-        @apply font-semibold font-body uppercase;
-        color: var(--color-violet-primary);
-        font-size: 0.8rem;
-        letter-spacing: 0.5px;
+        @apply font-overline text-violet-primary;
     }
 
     .event-single-date-separator {
-        color: #CECECE;
+        @apply text-gray-300;
     }
 
     .event-single-date {
-        @apply font-body;
-        color: #757576;
-        font-size: 0.8rem;
+        @apply font-overline text-gray-primary;
     }
 }
 
 .template-timing-info {
     .timing-info-item {
-        @apply rounded-lg p-4;
-        border: 0.5px solid #CECECE;
+        @apply rounded-lg p-4 border border-gray-300;
     }
 
     .timing-info-label {
-        @apply font-body font-semibold text-body-s pb-2 mb-2 border-b uppercase tracking-wide;
-        color: #757576;
-        border-color: #E8E8E8;
-        font-size: 0.75rem;
+        @apply font-overline-sm pb-2 mb-2 border-b text-gray-primary border-gray-200;
     }
 
     .timing-info-value {
-        @apply font-body font-semibold text-body-s text-gray-900;
+        @apply font-semibold body-base text-gray-primary;
     }
 }
 
 .event-summary-cloud-notice {
-    @apply font-body text-body-s rounded-xl p-4 mb-6 text-gray-700;
-    background-color: var(--color-violet-50);
-    border: 0.5px solid var(--color-violet-primary);
+    @apply body-base rounded-xl p-4 mb-6 text-gray-700 bg-violet-50 border border-violet-primary;
 
     a {
-        color: var(--color-violet-primary);
-        @apply font-semibold;
+        @apply font-semibold text-violet-primary;
     }
 }
 
 .template-event-summary {
     .event-summary-description {
-        @include section-body-small();
+        @apply body-base;
 
         p:first-child {
             @apply mt-0;
@@ -881,69 +750,63 @@
 
 .event-summary-learn {
     .event-summary-learn-title {
-        @apply font-body font-semibold text-body-m text-gray-900 mb-4;
+        @apply font-semibold body-lg mb-4;
     }
 
     .event-summary-learn-list {
         @apply list-none p-0 m-0 flex flex-col gap-3;
 
         li {
-            @apply flex items-start font-body text-body-s m-0;
-            color: #5b5b5b;
+            @apply flex items-start body-base m-0;
 
-            i {
-                color: var(--color-violet-primary);
-                @apply mt-0.5 flex-shrink-0;
+            svg {
+                @apply mt-0.5 flex-shrink-0 text-violet-primary;
             }
         }
     }
 }
 
 .event-single-registration {
-    border: 0.5px solid #CECECE;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    @apply border border-gray-300;
 
     .event-single-registration-title {
-        @include section-header-extra-small();
-        @apply mb-4;
+        @apply heading-3 mb-4;
     }
 }
 
 .template-event-speakers {
-    @apply bg-white;
-    border: 0.5px solid #CECECE;
+    @apply bg-white border border-gray-300;
 
     .event-speakers-label {
-        @apply font-body font-semibold text-body-m text-gray-900;
+        @apply font-semibold body-lg text-gray-primary;
     }
 
     .event-speaker-photo {
-        @apply rounded-full object-cover;
-        width: 48px;
-        height: 48px;
+        @apply rounded-full object-cover w-12 h-12;
     }
 
     .event-speaker-name {
-        @apply font-body font-semibold text-body-s text-gray-900;
+        @apply font-semibold body-base text-gray-primary;
     }
 
     .event-speaker-role {
-        @apply font-body font-normal text-body-s;
-        color: #757576;
+        @apply font-normal body-base text-gray-primary;
     }
 }
 
 .template-feature-split {
     .product-two-column-heading {
-        @include section-header();
+        @apply heading-1;
+        strong {
+            @apply text-violet-primary;
+        }
     }
 
     .product-two-column-description {
         @include section-description();
-        @apply text-body-xl;
 
         p:first-of-type {
-            @apply text-black font-semibold mt-0;
+            @apply font-semibold mt-0;
         }
 
         p+p {
@@ -960,27 +823,7 @@
 .template-social-carousel {
     .template-social-carousel-rows {
         @apply overflow-hidden pb-8 relative;
-
-        &::before,
-        &::after {
-            content: '';
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            width: 40px;
-            z-index: 10;
-            pointer-events: none;
-        }
-
-        &::before {
-            left: 0;
-            background: linear-gradient(to right, white, transparent);
-        }
-
-        &::after {
-            right: 0;
-            background: linear-gradient(to left, white, transparent);
-        }
+        @include edge-fade;
     }
 
     .template-social-carousel-header {
@@ -997,12 +840,10 @@
 
     .social-carousel-card {
         @extend .card;
-        @apply p-4 md:p-8 flex flex-col gap-4;
-        min-height: 320px;
-        width: 100%;
+        @apply p-4 md:p-8 flex flex-col gap-4 w-full min-h-[320px];
 
         p {
-            @apply text-gray-900 text-left leading-relaxed m-0 line-clamp-5;
+            @apply text-gray-primary text-left leading-relaxed m-0 line-clamp-5;
         }
 
         .social-carousel-card-author {
@@ -1027,39 +868,17 @@
 
     .case-study-cards-description {
         @include section-description();
-        @apply text-body-xl;
 
         p { @apply mt-0; }
     }
 
     .case-study-swiper-wrapper {
         @apply relative;
-
-        &::before,
-        &::after {
-            content: '';
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            width: 40px;
-            z-index: 10;
-            pointer-events: none;
-        }
-
-        &::before {
-            left: 0;
-            background: linear-gradient(to right, white, transparent);
-        }
-
-        &::after {
-            right: 0;
-            background: linear-gradient(to left, white, transparent);
-        }
+        @include edge-fade;
     }
 
     pulumi-swiper .swiper-slide {
-        @apply items-stretch;
-        height: 50vh;
+        @apply items-stretch h-[50vh];
     }
 
     .case-study-card {
@@ -1072,8 +891,7 @@
         }
 
         &--full {
-            @apply p-8 justify-between;
-            min-height: 50vh;
+            @apply p-8 justify-between min-h-[50vh];
         }
     }
 }

--- a/theme/src/scss/_utilities-shared.scss
+++ b/theme/src/scss/_utilities-shared.scss
@@ -5,8 +5,25 @@
 // @utility must live at the top level of the stylesheet — do not nest this
 // import inside `@layer base { ... }`.
 
+@utility heading-xl {
+    @apply font-display mb-2 text-4xl md:text-5xl;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
 @utility heading-1 {
-    @apply font-display mb-2 text-2xl md:text-3xl lg:text-4xl;
+    @apply font-display mb-2 text-3xl md:text-4xl;
     font-weight: 600;
     letter-spacing: -0.05em;
     line-height: 1.1em;
@@ -23,7 +40,7 @@
 }
 
 @utility heading-2 {
-    @apply font-display mb-2 text-xl md:text-2xl lg:text-3xl;
+    @apply font-display mb-2 text-2xl md:text-3xl;
     font-weight: 600;
     letter-spacing: -0.05em;
     line-height: 1.1em;
@@ -40,7 +57,7 @@
 }
 
 @utility heading-3 {
-    @apply font-display mb-2 text-lg md:text-xl lg:text-2xl;
+    @apply font-display mb-2 text-xl md:text-2xl;
     font-weight: 600;
     letter-spacing: -0.05em;
     line-height: 1.1em;
@@ -57,7 +74,7 @@
 }
 
 @utility heading-4 {
-    @apply font-display mb-2 text-base md:text-lg lg:text-xl;
+    @apply font-display mb-2 text-lg md:text-xl;
     font-weight: 600;
     letter-spacing: -0.05em;
     line-height: 1.1em;
@@ -74,7 +91,7 @@
 }
 
 @utility heading-5 {
-    @apply font-display mb-2 text-sm md:text-base lg:text-lg;
+    @apply font-display mb-2 text-base md:text-lg;
     font-weight: 600;
     letter-spacing: -0.05em;
     line-height: 1.1em;
@@ -107,23 +124,6 @@
     }
 }
 
-@utility heading-xl {
-    @apply font-display mb-2 text-3xl md:text-4xl lg:text-5xl;
-    font-weight: 600;
-    letter-spacing: -0.05em;
-    line-height: 1.1em;
-
-    &:not(:first-child) {
-        &:not([class*="mt-"]):not([class*="m-"]) {
-            @apply mt-8;
-        }
-    }
-
-    code {
-        letter-spacing: normal;
-    }
-}
-
 @utility body-sm {
     @apply font-body text-xs md:text-sm;
 }
@@ -137,11 +137,11 @@
 }
 
 @utility body-xl {
-    @apply font-body text-base md:text-lg lg:text-xl;
+    @apply font-body text-lg md:text-xl;
 }
 
 @utility body-2xl {
-    @apply font-body text-xl md:text-2xl lg:text-3xl;
+    @apply font-body text-xl md:text-2xl;
 }
 
 @utility font-overline {

--- a/theme/src/scss/_utilities-shared.scss
+++ b/theme/src/scss/_utilities-shared.scss
@@ -1,0 +1,153 @@
+// Shared utility classes for both the docs bundle (main.scss) and the
+// marketing bundle (_marketing.scss). Declared with `@utility` so they can be
+// composed via `@apply` from anywhere in either bundle.
+//
+// @utility must live at the top level of the stylesheet — do not nest this
+// import inside `@layer base { ... }`.
+
+@utility heading-1 {
+    @apply font-display mb-2 text-2xl md:text-3xl lg:text-4xl;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
+@utility heading-2 {
+    @apply font-display mb-2 text-xl md:text-2xl lg:text-3xl;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
+@utility heading-3 {
+    @apply font-display mb-2 text-lg md:text-xl lg:text-2xl;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
+@utility heading-4 {
+    @apply font-display mb-2 text-base md:text-lg lg:text-xl;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
+@utility heading-5 {
+    @apply font-display mb-2 text-sm md:text-base lg:text-lg;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
+@utility heading-6 {
+    @apply font-display mb-2 text-sm md:text-base;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
+@utility heading-xl {
+    @apply font-display mb-2 text-3xl md:text-4xl lg:text-5xl;
+    font-weight: 600;
+    letter-spacing: -0.05em;
+    line-height: 1.1em;
+
+    &:not(:first-child) {
+        &:not([class*="mt-"]):not([class*="m-"]) {
+            @apply mt-8;
+        }
+    }
+
+    code {
+        letter-spacing: normal;
+    }
+}
+
+@utility body-sm {
+    @apply font-body text-xs md:text-sm;
+}
+
+@utility body-base {
+    @apply font-body text-sm md:text-base;
+}
+
+@utility body-lg {
+    @apply font-body text-base md:text-lg;
+}
+
+@utility body-xl {
+    @apply font-body text-base md:text-lg lg:text-xl;
+}
+
+@utility body-2xl {
+    @apply font-body text-xl md:text-2xl lg:text-3xl;
+}
+
+@utility font-overline {
+    @apply font-mono text-xs md:text-sm uppercase tracking-wider;
+}
+
+@utility font-overline-sm {
+    @apply font-mono text-xs uppercase tracking-wider;
+}

--- a/theme/src/scss/docs/_docs-main.scss
+++ b/theme/src/scss/docs/_docs-main.scss
@@ -1,11 +1,6 @@
 .docs-list-main .docs-main-content,
 body.section-registry {
     h1 {
-        font-family: Inter;
-        line-height: 1.1em;
-        font-weight: 600;
-        font-size: 30px;
-        color: var(--color-gray-950);
         margin: 16px 0;
     }
 
@@ -15,8 +10,6 @@ body.section-registry {
 
     section.docs-content {
         h1, h2, h3, h4, h5, h6 {
-            font-family: Inter;
-            line-height: 1.1em;
             scroll-margin-top: 60px;
         }
 
@@ -37,41 +30,7 @@ body.section-registry {
         }
 
         h1 {
-            font-weight: 600;
-            font-size: 30px;
-            color: var(--color-gray-950);
             margin: 16px 0;
-        }
-
-        h2 {
-            font-weight: 600;
-            font-size: 24px;
-            color: var(--color-gray-950);
-        }
-
-        h3 {
-            font-weight: 600;
-            font-size: 21px;
-            color: var(--color-gray-950);
-        }
-
-        h4 {
-            font-weight: 600;
-            font-size: 18px;
-            color: var(--color-gray-700);
-        }
-
-        h5 {
-            font-weight: 600;
-            font-size: 18px;
-            color: var(--color-gray-950);
-        }
-
-        h6 {
-            font-weight: 600;
-            font-size: 16px;
-            color: var(--color-gray-700);
-
         }
 
         p {

--- a/theme/src/scss/main.scss
+++ b/theme/src/scss/main.scss
@@ -17,19 +17,7 @@
 $sitenav-height: 90px;
 $sitenav-offset: calc($sitenav-height + 16px);
 
-// Typography token utilities (font sizes from design system).
-@utility text-heading-2xl { font-size: 80px; }
-@utility text-heading-xl { font-size: 72px; }
-@utility text-heading-l { font-size: 64px; }
-@utility text-heading-m { font-size: 48px; }
-@utility text-heading-s { font-size: 40px; }
-@utility text-heading-xs { font-size: 28px; }
-@utility text-heading-2xs { font-size: 24px; }
-@utility text-heading-2xsSmall { font-size: 20px; }
-@utility text-body-xl { font-size: 24px; }
-@utility text-body-l { font-size: 20px; }
-@utility text-body-m { font-size: 18px; }
-@utility text-body-s { font-size: 16px; }
+@import "utilities-shared";
 
 // v4 layer placement: base styles go in @layer base so Tailwind utilities can override them.
 // Component styles go in @layer components for the same reason.
@@ -38,86 +26,7 @@ $sitenav-offset: calc($sitenav-height + 16px);
 // but loses to unlayered CSS. So we must layer our custom styles.
 
 @layer base {
-    // Tailwind v2 preflight set default border-color to gray-200. v4 defaults to
-    // currentColor, which makes `.border` dividers render too dark. Restore the old default.
-    *,
-    ::before,
-    ::after {
-        border-color: var(--color-gray-200);
-    }
-
-    // Custom elements default to display: inline in browsers. Tailwind v4 preflight
-    // does not reset them to block, so we do it here for all Pulumi web components.
-    pulumi-chooser,
-    pulumi-choosable,
-    pulumi-tabs,
-    pulumi-tab-panel,
-    pulumi-install,
-    pulumi-banner,
-    pulumi-examples,
-    pulumi-convert,
-    pulumi-tooltip,
-    pulumi-audio,
-    pulumi-slot-machine,
-    pulumi-tertiary-nav,
-    pulumi-greenhouse-jobs-list,
-    pulumi-resource-links,
-    pulumi-filter-select,
-    pulumi-user-toggle,
-    pulumi-hubspot-form {
-        display: block;
-    }
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        @apply font-display text-service-black mb-2;
-        font-weight: 600;
-        letter-spacing: -0.05em;
-        line-height: 1.1em;
-
-        &:not(:first-child) {
-            // Don't apply top margin when one's being specified.
-            &:not([class*="mt-"]):not([class*="m-"]) {
-                @apply mt-8;
-            }
-        }
-
-        code {
-            letter-spacing: normal;
-        }
-    }
-
-    h1 {
-        @apply text-4xl;
-    }
-
-    h2 {
-        font-size: 32px;
-    }
-
-    h3 {
-        @apply text-2xl;
-    }
-
-    h4 {
-        @apply text-xl;
-    }
-
-    h5 {
-        @apply text-lg;
-    }
-
-    h6 {
-        @apply text-sm;
-    }
-
-    p {
-        @apply leading-normal my-4;
-    }
+    @import "base-shared";
 
     body {
         @apply font-body text-service-black;
@@ -155,9 +64,10 @@ $sitenav-offset: calc($sitenav-height + 16px);
                 }
             }
 
-            strong {
-                @apply font-semibold;
-            }
+        }
+
+        strong {
+            @apply font-semibold;
         }
 
         ul,


### PR DESCRIPTION
Reworks global marketing typography to be slightly smaller and use one consistent typographic scale with more responsive breakpoints. Also refactors `_templates.scss` to use the new styles as well as general cleanup. The docs typographic scale wasn't touched but could be modified to use this scale as well if desired.

The new classes aren't applied everywhere and some pages will still have manual Tailwind font sizes applied that we'll need to fix as we come across them. But any raw headings, etc. will get the styles. 

Includes some other miscellaneous updates and tweaks in files I was touching.

Resolves: #19139

---

**Generated description of changes:**

## Summary

- Extracts the base-element and utility CSS shared by the docs (`main.scss`) and marketing (`_marketing.scss`) bundles into two new partials — `theme/src/scss/_base-shared.scss` and `theme/src/scss/_utilities-shared.scss` — so both bundles ship the same preflight overrides, custom-element resets, heading defaults, and a single canonical type scale.
- Replaces the legacy `text-heading-*` / `text-body-*` font-size tokens with composable Tailwind v4 `@utility` blocks: `heading-1`–`heading-6`, `heading-xl`, `body-sm`–`body-2xl`, `font-overline`, and `font-overline-sm`. Each utility bundles size, weight, family, letter-spacing, and line-height so templates no longer hand-wire those properties.
- Refactors `_templates.scss` onto the new utilities, drops the now-redundant `section-header-*`, `section-body-*`, and `section-hint-small` mixins, adds a shared `@mixin edge-fade` to dedupe the carousel/swiper gradient masks, and migrates raw CSS values (hex colors, px sizes, inline `border: 0.5px solid …`) over to design-token utilities (`text-gray-primary`, `border-gray-300`, `bg-violet-50`, `rounded-2xl`, etc.).
- Updates marketing layouts that were depending on the old bundle-local heading rules (`layouts/product/superintelligence-infrastructure.html`, `layouts/page/pricing.html`, `layouts/page/demo.html`, `layouts/partials/contact-us.html`, `layouts/whitepapers/*`, `layouts/case-studies/*`, `layouts/what-is/single.html`, and the template partials) to use `heading-xl` / `heading-1` / `body-xl` / `font-overline` explicitly.
- Tidies a handful of related details surfaced during the migration: page-hero border softened to `gray-200`, hero `h1/h2/h3` collapsed to a single rule, demo page switched from `flex` to a 2-col grid, badge separator swapped for a phosphor caret, event breadcrumb trimmed, neo and homepage hero titles converted to the split-title (primary/secondary) form.

## Test plan

- [ ] `make lint` passes
- [ ] `make build` produces no Tailwind / Sass errors
- [ ] Visual diff homepage, `/product/neo`, `/product/secrets-management`, `/product/superintelligence-infrastructure`, `/pricing`, `/demo`, `/contact-us`, `/what-is/<page>`, `/case-studies` (list + single), `/whitepapers` (list + single)
- [ ] Visual diff a marketing template page exercising hero, logo banner, three-column, card grid, mini cards, promo banner, feature split, feature callout, testimonial, section header (centered + split), counter cards, icon grid, social carousel, case study cards
- [ ] Visual diff `/events` list and a single event page (breadcrumb, timing-info grid on mobile + desktop, speakers card, learn list, registration card, cloud-notice callout)
- [ ] Confirm docs pages still render headings/body at the expected sizes (no regressions from the shared base)
- [ ] Confirm h1/h2/h3 sizes on `.page-hero` across breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)