### PR TITLE
content(cicd): rewrite AWS Code Services guide (#19194)

### DIFF
--- a/content/docs/iac/guides/continuous-delivery/_index.md
+++ b/content/docs/iac/guides/continuous-delivery/_index.md
@@ -41,6 +41,14 @@ The most common way to run Pulumi in CI/CD follows a trunk-based development mod
 1. **Merge to the main branch.** The pipeline runs [`pulumi up`](/docs/iac/cli/commands/pulumi_up/) to deploy the change to an environment that receives continuous delivery, such as a shared development or staging environment.
 1. **Promote to production.** Pushing a git tag — or otherwise marking a release — triggers a deployment to production, keeping production updates deliberate and traceable.
 
+## Review infrastructure changes before merging
+
+A preview compares your code against the *current* state of your infrastructure, so a change merged to the main branch can alter what an open pull request would actually do. Require that a branch be up to date with the main branch before it merges, and re-run `pulumi preview` after each update to the branch. Review the refreshed preview carefully: an intervening change to the main branch can invalidate an earlier preview in consequential ways — for example, by adding or removing resources that the original review never showed.
+
+{{% notes type="warning" %}}
+A CI/CD pipeline for infrastructure **must** run a preview on every pull request. Declarative infrastructure as code — whether Pulumi or any other IaC tool — cannot be reviewed from the code change alone: the same code edit can produce very different infrastructure changes depending on the current state of your resources. Reviewers need to see *both* the code diff *and* the proposed infrastructure changes that the preview reports.
+{{% /notes %}}
+
 ## Authentication and configuration with Pulumi Cloud
 
 When your pipeline uses Pulumi Cloud as its backend, it needs only a single [Pulumi access token](/docs/administration/access-identity/access-tokens/) to operate.

--- a/content/docs/iac/guides/continuous-delivery/aws-code-services.md
+++ b/content/docs/iac/guides/continuous-delivery/aws-code-services.md
@@ -1,9 +1,8 @@
 ---
-title_tag: "Using AWS Code Services | CI/CD"
-meta_desc: This page provides an overview of how to use Pulumi with Amazon Code
-           Services CI/CD tools.
+title_tag: "Using AWS Code Services with Pulumi | CI/CD"
+meta_desc: Run Pulumi in AWS CodeBuild and CodePipeline to preview and deploy infrastructure changes through a trunk-based continuous delivery workflow.
 title: AWS Code Services
-h1: Pulumi CI/CD & AWS Code Services
+h1: Using AWS Code Services with Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
@@ -21,54 +20,58 @@ aliases:
 - /docs/iac/packages-and-automation/continuous-delivery/aws-code-services/
 ---
 
-[Amazon Code Services](https://aws.amazon.com/products/developer-tools/) encompasses a variety
-of specific tools for CI/CD, including [CodePipeline](https://aws.amazon.com/codepipeline/),
-[CodeBuild](https://aws.amazon.com/codebuild/), [CodeDeploy](https://aws.amazon.com/codedeploy/),
-and others.
+AWS Code Services are a suite of [developer tools](https://aws.amazon.com/products/developer-tools/) for building and shipping software on AWS. The services most relevant to running Pulumi are [CodeBuild](https://aws.amazon.com/codebuild/), a managed build environment, and [CodePipeline](https://aws.amazon.com/codepipeline/), which models a release process as an ordered set of stages. [CodeDeploy](https://aws.amazon.com/codedeploy/) automates application rollouts onto the infrastructure Pulumi provisions.
 
-To incorporate updating Pulumi stacks into an AWS Code Services-managed CI/CD system, you'll
-want to use CodeBuild. Pulumi needs to execute a built program in order to determine the desired
-state of cloud resources, and CodeBuild provides a compute environment to do just that.
+Pulumi runs in **CodeBuild**: it executes your Pulumi program to compute the desired state of your cloud resources, and CodeBuild supplies the compute environment to do that. **CodePipeline** then invokes CodeBuild as one stage of a larger pipeline, so a Pulumi update can run wherever it fits in your existing release process.
 
-If you are using CodePipeline, you can then create a new pipeline stage which triggers the
-CodeBuild project. Allowing you to update a Pulumi stack wherever it makes sense in your existing
-pipeline.
+## How Pulumi works with AWS Code Services
 
-## Configuring CodeBuild
+To apply infrastructure changes, Pulumi has to run your program with the Pulumi CLI. A CodeBuild project provides that environment: it checks out your source, installs the CLI and your program's dependencies, and runs `pulumi` commands.
 
-To update a Pulumi stack as part of a CodeBuild project, you'll need to add an environment variable
-named `PULUMI_ACCESS_TOKEN`. This is required to authenticate with pulumi.com in order to perform
-an update. You can create a new [Pulumi access token](/docs/pulumi-cloud/accounts#access-tokens) specifically for your CloudBuild project on
-your [Pulumi Account page](https://app.pulumi.com/account/tokens).
+A CodeBuild project can run on its own — triggered directly by a source-repository event — or as a stage inside CodePipeline. In a CodePipeline pipeline, a source stage pulls your repository and a build stage runs the CodeBuild project that invokes Pulumi. You add the build stage wherever an infrastructure update belongs relative to the rest of your pipeline.
 
-Because of the sensitive nature of the access token, it is recommended that the Pulumi access
-token be stored in Amazon's Systems Manager (SSM) Parameter Store. This allows you to keep the value secret, while
-providing auditable access to CodeBuild.
+## Prerequisites
 
-### Service Role
+Before you begin, make sure you have:
 
-When Pulumi runs, it needs credentials in order to make any changes to AWS resources. When
-`pulumi up` is running on the CloudBuild machine, it will default to using the credentials of
-the AWS CodeBuild Service role defined in the CodeBuild project.
+- A [Pulumi Cloud](https://app.pulumi.com/signin) account and organization.
+- An AWS account with permission to create CodeBuild projects and IAM roles.
+- A [Pulumi program](/docs/iac/concepts/projects/) in a Git repository.
+- Familiarity with [CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/welcome.html) and, if you use it, [CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html).
 
-In order for Pulumi to successfully update the stack, the running CodeBuild service role needs to
-have IAM policies sufficient for updating the resources referenced by the Pulumi program.
-This can be done by defining new IAM policies and attaching them to the CloudBuild project's service
-role.
+## Authenticate with Pulumi Cloud
 
-For more information on how to manage the IAM policies used in CodeBuild,
-see [Amazon's documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/setting-up.html#setting-up-service-role).
+When your pipeline uses Pulumi Cloud as its backend, CodeBuild needs a single [Pulumi access token](/docs/administration/access-identity/access-tokens/), supplied through the `PULUMI_ACCESS_TOKEN` environment variable. Prefer an [organization or team token](/docs/administration/access-identity/access-tokens/#creating-an-organization-access-token) over a personal token so the pipeline's identity is not tied to an individual.
 
-## Scripts
+Because the token is a sensitive credential, store it in [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) (as a `SecureString`) or [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html), and reference it from the CodeBuild project rather than hardcoding it. CodeBuild resolves the value at build time and never persists it in the build definition.
 
-With the CloudBuild project created, you then just need to add two files to your repository:
-`buildspec.yml` and `update_pulumi_stack.sh`.
+{{% notes type="warning" %}}
+Do not store the access token in plaintext environment variables or commit it to your repository. Keep it in Parameter Store or Secrets Manager so access is auditable and the value stays encrypted at rest.
+{{% /notes %}}
 
-### buildspec.yml
+## Provide AWS credentials
 
-The following is a minimal `buildspec.yml`, which describes the steps CodeBuild should perform when
-building your project. This includes downloading and installing the Pulumi CLI and then running a
-script specific to building and updating your stack.
+When Pulumi runs, your program also needs AWS credentials to read and modify cloud resources. You can supply them in one of two ways.
+
+### CodeBuild service role
+
+Every CodeBuild project runs as an IAM [service role](https://docs.aws.amazon.com/codebuild/latest/userguide/setting-up.html#setting-up-service-role). When `pulumi up` runs on the build host, the AWS provider uses that role's credentials by default. Attach IAM policies to the service role that grant the permissions your Pulumi program needs to manage its resources.
+
+This is the simplest option, but the service role accumulates every permission any pipeline program requires, and those permissions differ from what developers use on their own machines.
+
+{{% notes type="info" %}}
+The service role only authenticates to AWS. If your Pulumi program uses other providers — another cloud, a SaaS provider, or a Kubernetes cluster — the service role does not supply those credentials, and you must provide them another way, such as through [Pulumi ESC](#pulumi-esc-recommended).
+{{% /notes %}}
+
+### Pulumi ESC (recommended)
+
+[Pulumi ESC](/docs/esc/) (Environments, Secrets, and Configuration) delivers cloud credentials, secrets, and configuration to your Pulumi program from a central environment definition. Configure an ESC environment to broker short-lived AWS credentials through [OpenID Connect (OIDC)](/docs/esc/guides/configuring-oidc/aws/), and your program receives temporary credentials scoped to exactly what it needs.
+
+Because ESC supplies those values the same way whether the consumer is a CodeBuild project or a developer's machine, a single environment definition works in both places — the pipeline only needs its Pulumi access token, and everything else flows from ESC.
+
+## Configure the CodeBuild project
+
+CodeBuild reads build instructions from a `buildspec.yml` file in your repository. The following minimal `buildspec.yml` installs the Pulumi CLI, installs your program's dependencies, and updates a [stack](/docs/iac/concepts/stacks/):
 
 ```yaml
 version: 0.2
@@ -76,35 +79,95 @@ version: 0.2
 phases:
   install:
     commands:
-      # pulumi
       - curl -fsSL https://get.pulumi.com/ | sh
       - export PATH=$PATH:$HOME/.pulumi/bin
+  pre_build:
+    commands:
+      - pulumi install
   build:
     commands:
-      - update_pulumi_stack.sh
+      - pulumi stack select acme/website/production
+      - pulumi up --yes
 ```
 
-### update_pulumi_stack.sh
+[`pulumi install`](/docs/iac/cli/commands/pulumi_install/) installs the program's language dependencies and required plugins, so the same `buildspec.yml` works for a Pulumi program written in any supported language.
 
-`update_pulumi_stack.sh` is the minimal set of steps for updating a Pulumi stack.
+Expose the Pulumi access token to the build by adding an environment variable to the CodeBuild project that pulls from Parameter Store:
 
-It runs `npm` commands to download the dependencies of the Pulumi program, and then builds it.
-And then uses the Pulumi CLI to select the stack and perform the update.
-
-You'll want to modify this script depending on the language used for your program, how it is
-built, etc.
-
-```bash
-echo "Updating Pulumi Stack"
-
-# Download dependencies and build
-npm install
-npm run build
-
-# Update the stack
-pulumi stack select acme/website-production
-pulumi up --yes
+```yaml
+environment:
+  environmentVariables:
+    - name: PULUMI_ACCESS_TOKEN
+      type: PARAMETER_STORE
+      value: /pulumi/access-token
 ```
 
-That's it! With the CloudBuild project configured to update your Pulumi stack on-demand,
-you can now incorporate it into other AWS Code Services products.
+## Build a trunk-based CI/CD workflow
+
+The most common way to run Pulumi in CI/CD follows a [trunk-based development model](/docs/iac/guides/continuous-delivery/#the-trunk-based-development-workflow): work merges into a single main branch, and deployments flow outward from there. CodePipeline's [source triggers](https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-trigger-source-repository-events.html) distinguish pull request, branch, and tag events, so you can map each step of the workflow to its own pipeline or CodeBuild project.
+
+### Preview infrastructure changes in a pull request
+
+When a pull request is opened, run a dry run instead of a deployment. Trigger a CodeBuild project on pull request events and have it run [`pulumi preview`](/docs/iac/cli/commands/pulumi_preview/):
+
+```yaml
+  build:
+    commands:
+      - pulumi stack select acme/website/staging
+      - pulumi preview
+```
+
+`pulumi preview` reports the proposed changes without modifying any resources, giving reviewers a summary of what the merge would do. To let reviewers exercise the change in a live environment, use a [Review Stack](/docs/deployments/deployments/review-stacks/), which provisions an ephemeral stack for the pull request and destroys it when the pull request closes.
+
+### Deploy to staging on merge to the main branch
+
+When a pull request merges, run [`pulumi up`](/docs/iac/cli/commands/pulumi_up/) against an environment that receives continuous delivery, such as a shared development or staging environment. Trigger a CodeBuild project on pushes to the main branch:
+
+```yaml
+  build:
+    commands:
+      - pulumi stack select acme/website/staging
+      - pulumi up --yes
+```
+
+### Promote to production with a git tag
+
+Production updates should be deliberate. Keep production on its own stack and deploy it only when you push a release tag — for example, a moving `production` tag that you advance to a commit already validated in staging:
+
+```yaml
+  build:
+    commands:
+      - pulumi stack select acme/website/production
+      - pulumi up --yes
+```
+
+Configure this CodeBuild project (or CodePipeline source stage) to trigger on git tag events rather than branch pushes. Promotion then becomes a single, traceable Git operation, and production never deploys from an untested commit.
+
+## Manage the pipeline with Pulumi
+
+The CodeBuild projects, CodePipeline pipelines, IAM roles, and Parameter Store entries described above are themselves AWS resources, so you can define them with Pulumi using the [AWS provider](/registry/packages/aws/). Managing the pipeline as code keeps it versioned, reviewable, and reproducible alongside the infrastructure it deploys.
+
+See the AWS provider's [CodeBuild](/registry/packages/aws/api-docs/codebuild/), [CodePipeline](/registry/packages/aws/api-docs/codepipeline/), and [CodeDeploy](/registry/packages/aws/api-docs/codedeploy/) modules in the Pulumi Registry for the available resources and their inputs.
+
+If you operate many pipelines that are similar or identical, package the pattern once instead of copying it. Wrap these resources in a [component](/docs/iac/concepts/components/) so each pipeline becomes a single resource with a small set of inputs, or publish a [template](/docs/iac/guides/building-extending/creating-templates/) so teams can scaffold a new pipeline with `pulumi new`.
+
+## Troubleshooting
+
+**`pulumi: command not found`** — The `install` phase did not add the CLI to `PATH`. Confirm both the `curl` install step and the `export PATH=$PATH:$HOME/.pulumi/bin` line ran.
+
+**Authentication or 401 errors against Pulumi Cloud** — `PULUMI_ACCESS_TOKEN` is missing or empty. Verify the CodeBuild environment variable resolves from Parameter Store and that the token has not expired.
+
+**`AccessDenied` errors from AWS** — The CodeBuild service role lacks the IAM permissions your program needs, or the ESC environment is not brokering credentials. Attach the required policies to the service role, or check the ESC environment configuration.
+
+**Dependency or build failures** — `pulumi install` could not resolve your program's dependencies. Confirm the language runtime your program uses is available in the CodeBuild image you selected.
+
+For more, see the [CI/CD troubleshooting guide](/docs/support/troubleshooting/ci-cd/).
+
+## Next steps
+
+- [Continuous delivery](/docs/iac/guides/continuous-delivery/)
+- [Pulumi ESC](/docs/esc/)
+- [OIDC Issuers](/docs/administration/access-identity/oidc-issuers/)
+- [AWS provider](/registry/packages/aws/)
+- [Component resources](/docs/iac/concepts/components/)
+- [Review Stacks](/docs/deployments/deployments/review-stacks/)


### PR DESCRIPTION
Rewrites the AWS Code Services CI/CD guide as part of the CI/CD docs cleanup epic, following the standard outline established by the Argo CD guide and CI/CD index.

## Changes
- Rewrote `aws-code-services.md`: ESC-based credential guidance, a trunk-based CI/CD workflow (preview on PR → deploy on merge → git-tag promotion), a service-role/AWS-scope note, and a pipeline-as-IaC section linking the AWS provider's CodeBuild, CodePipeline, and CodeDeploy Registry modules.
- Modernized terminology, fixed a stale access-token link, dropped CodeCommit (closed to new customers).
- Added a "Review infrastructure changes before merging" section to the CI/CD index covering preview staleness and why a preview is mandatory for reviewing IaC changes.

Closes #19194. Part of #19190.