### PR TITLE
Document how to view and redeliver webhook deliveries

### DIFF
--- a/content/docs/deployments/webhooks.md
+++ b/content/docs/deployments/webhooks.md
@@ -459,6 +459,72 @@ func computeSignature(payload []byte, secret string) string {
 
 {{< /chooser >}}
 
+## Webhook deliveries
+
+Pulumi Cloud records the recent deliveries for each webhook so you can confirm that events
+were received and troubleshoot any that failed. Each delivery records the event kind, when
+it was sent, and the HTTP response status returned by the payload URL.
+
+### Viewing recent deliveries
+
+1. Navigate to the webhook you want to inspect:
+   1. For an organization webhook, navigate to **Settings** > **Integrations** > **Webhooks**.
+   1. For a stack webhook, navigate to the stack, then **Settings** > **Webhooks**.
+1. Select the webhook to open its page.
+1. Review the list of recent deliveries. Each entry shows the event kind, when it was
+   sent, and the HTTP response status returned by your endpoint.
+1. Expand a delivery to inspect the full request payload, the request headers, and the
+   response. Failed deliveries are the ones whose endpoint returned a non-`2xx` HTTP
+   status (or did not respond at all).
+
+The `Pulumi-Webhook-ID` header on each request — described in [Headers](#headers) —
+uniquely identifies the delivery, which is useful when correlating a delivery with logs
+on your receiving service.
+
+### Redelivering a failed webhook
+
+If a delivery failed because your endpoint was unavailable, returned an error, or
+processed the event incorrectly, you can redeliver the same event from the Pulumi Cloud
+UI.
+
+1. Open the webhook and locate the delivery you want to resend, as described in
+   [Viewing recent deliveries](#viewing-recent-deliveries).
+1. Expand the delivery to view its request and response.
+1. Select the redelivery control next to the **Response**.
+
+Redelivery resends the original payload unchanged. Webhooks do not guarantee event
+order, so a redelivered event may arrive after later events.
+
+### Redelivering from the CLI
+
+Stack webhook deliveries can also be inspected and redelivered with the Pulumi CLI. Both
+commands identify a webhook by its ID, which appears in the `ID` column of
+`pulumi stack webhook list`.
+
+List the recent deliveries for a webhook. Each row's `ID` column is the event ID, and the
+`STATUS` column is the HTTP status returned by your endpoint:
+
+```bash
+pulumi stack webhook delivery list <webhook-id>
+```
+
+Then redeliver a specific event by passing the webhook ID and the event ID:
+
+```bash
+pulumi stack webhook delivery redeliver <webhook-id> <event-id>
+```
+
+See the CLI reference for
+[`pulumi stack webhook delivery list`](/docs/iac/cli/commands/pulumi_stack_webhook_delivery_list/)
+and
+[`pulumi stack webhook delivery redeliver`](/docs/iac/cli/commands/pulumi_stack_webhook_delivery_redeliver/).
+
+{{% notes "info" %}}
+The `pulumi stack webhook delivery` commands are experimental, available in recent
+releases of the Pulumi CLI, and currently apply to stack webhooks only. Redeliver
+organization and environment webhooks from the Pulumi Cloud UI.
+{{% /notes %}}
+
 ## Additional Resources
 
 * [Managing Github Webhooks with Pulumi](/blog/managing-github-webhooks-with-pulumi/)

--- a/content/docs/deployments/webhooks.md
+++ b/content/docs/deployments/webhooks.md
@@ -520,9 +520,12 @@ and
 [`pulumi stack webhook delivery redeliver`](/docs/iac/cli/commands/pulumi_stack_webhook_delivery_redeliver/).
 
 {{% notes "info" %}}
-The `pulumi stack webhook delivery` commands are experimental, available in recent
-releases of the Pulumi CLI, and currently apply to stack webhooks only. Redeliver
-organization and environment webhooks from the Pulumi Cloud UI.
+The `pulumi stack webhook delivery` commands are experimental and available in recent
+releases of the Pulumi CLI. Listing recent deliveries is also available for organization
+webhooks (`pulumi org webhook delivery list`) and environment webhooks
+(`pulumi env webhook delivery list`, or `esc env webhook delivery list`), but
+redelivery is currently a stack-only CLI affordance — redeliver organization and
+environment webhooks from the Pulumi Cloud UI.
 {{% /notes %}}
 
 ## Additional Resources

--- a/content/docs/esc/environments/webhooks.md
+++ b/content/docs/esc/environments/webhooks.md
@@ -411,6 +411,17 @@ func computeSignature(payload []byte, secret string) string {
 
 {{< /chooser >}}
 
+## Webhook deliveries
+
+Pulumi Cloud records the recent deliveries for each webhook so you can confirm that events
+were received and troubleshoot any that failed. Environment and organization webhook
+deliveries can be viewed and redelivered from the webhook's page in the Pulumi Cloud UI.
+For step-by-step instructions, see [Webhook deliveries](/docs/deployments/webhooks/#webhook-deliveries)
+on the Pulumi Cloud Webhooks page.
+
+The experimental `pulumi stack webhook delivery` CLI commands apply to stack webhooks
+only, so ESC environment and organization webhooks must be redelivered from the UI.
+
 ## Additional Resources
 
 - [Managing Github Webhooks with Pulumi](/blog/managing-github-webhooks-with-pulumi/)


### PR DESCRIPTION
Adds a "Webhook deliveries" section to the Pulumi Cloud Webhooks page covering how to inspect delivery history and redeliver failed events, via the UI and the CLI. The ESC Webhooks page links to the canonical section. Fixes #12289.

## Changes
- New "Webhook deliveries" section: viewing recent deliveries, redelivering a failed webhook in the UI, and redelivering from the CLI
- ESC Webhooks page: pointer to the canonical section

CLI commands (`pulumi stack webhook delivery list` / `redeliver`) were verified live against Pulumi CLI v3.242.0.