### PR TITLE
content(cicd): rewrite the Bitbucket Pipelines guide (#19196)

### DIFF
--- a/content/docs/iac/guides/continuous-delivery/_index.md
+++ b/content/docs/iac/guides/continuous-delivery/_index.md
@@ -51,7 +51,7 @@ A CI/CD pipeline for infrastructure **must** run a preview on every pull request
 
 ## Authentication and configuration with Pulumi Cloud
 
-When your pipeline uses Pulumi Cloud as its backend, it needs only a single [Pulumi access token](/docs/administration/access-identity/access-tokens/) to operate.
+Your pipeline needs a single [Pulumi access token](/docs/administration/access-identity/access-tokens/) to authenticate with Pulumi Cloud.
 
 You can remove even that static secret with [OpenID Connect (OIDC)](/docs/administration/access-identity/oidc-issuers/): the pipeline exchanges the OIDC token issued by your CI/CD system for a short-lived Pulumi access token, so no long-lived credential is stored anywhere.
 

--- a/content/docs/iac/guides/continuous-delivery/aws-code-services.md
+++ b/content/docs/iac/guides/continuous-delivery/aws-code-services.md
@@ -41,7 +41,7 @@ Before you begin, make sure you have:
 
 ## Authenticate with Pulumi Cloud
 
-When your pipeline uses Pulumi Cloud as its backend, CodeBuild needs a single [Pulumi access token](/docs/administration/access-identity/access-tokens/), supplied through the `PULUMI_ACCESS_TOKEN` environment variable. Prefer an [organization or team token](/docs/administration/access-identity/access-tokens/#creating-an-organization-access-token) over a personal token so the pipeline's identity is not tied to an individual.
+CodeBuild authenticates to Pulumi Cloud with a single [Pulumi access token](/docs/administration/access-identity/access-tokens/), supplied through the `PULUMI_ACCESS_TOKEN` environment variable. Prefer an [organization or team token](/docs/administration/access-identity/access-tokens/#creating-an-organization-access-token) over a personal token so the pipeline's identity is not tied to an individual.
 
 Because the token is a sensitive credential, store it in [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) (as a `SecureString`) or [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html), and reference it from the CodeBuild project rather than hardcoding it. CodeBuild resolves the value at build time and never persists it in the build definition.
 
@@ -151,18 +151,6 @@ See the AWS provider's [CodeBuild](/registry/packages/aws/api-docs/codebuild/), 
 
 If you operate many pipelines that are similar or identical, package the pattern once instead of copying it. Wrap these resources in a [component](/docs/iac/concepts/components/) so each pipeline becomes a single resource with a small set of inputs, or publish a [template](/docs/iac/guides/building-extending/creating-templates/) so teams can scaffold a new pipeline with `pulumi new`.
 
-## Troubleshooting
-
-**`pulumi: command not found`** — The `install` phase did not add the CLI to `PATH`. Confirm both the `curl` install step and the `export PATH=$PATH:$HOME/.pulumi/bin` line ran.
-
-**Authentication or 401 errors against Pulumi Cloud** — `PULUMI_ACCESS_TOKEN` is missing or empty. Verify the CodeBuild environment variable resolves from Parameter Store and that the token has not expired.
-
-**`AccessDenied` errors from AWS** — The CodeBuild service role lacks the IAM permissions your program needs, or the ESC environment is not brokering credentials. Attach the required policies to the service role, or check the ESC environment configuration.
-
-**Dependency or build failures** — `pulumi install` could not resolve your program's dependencies. Confirm the language runtime your program uses is available in the CodeBuild image you selected.
-
-For more, see the [CI/CD troubleshooting guide](/docs/support/troubleshooting/ci-cd/).
-
 ## Next steps
 
 - [Continuous delivery](/docs/iac/guides/continuous-delivery/)
@@ -171,3 +159,4 @@ For more, see the [CI/CD troubleshooting guide](/docs/support/troubleshooting/ci
 - [AWS provider](/registry/packages/aws/)
 - [Component resources](/docs/iac/concepts/components/)
 - [Review Stacks](/docs/deployments/deployments/review-stacks/)
+- [CI/CD troubleshooting](/docs/support/troubleshooting/ci-cd/)

--- a/content/docs/iac/guides/continuous-delivery/azure-devops.md
+++ b/content/docs/iac/guides/continuous-delivery/azure-devops.md
@@ -40,7 +40,7 @@ Install the [Pulumi Task Extension](https://marketplace.visualstudio.com/items?i
 
 ## Authenticate with Pulumi Cloud
 
-When your pipeline uses Pulumi Cloud as its backend, it needs only a single [Pulumi access token](/docs/administration/access-identity/access-tokens/) to operate.
+Your pipeline needs a single [Pulumi access token](/docs/administration/access-identity/access-tokens/) to authenticate with Pulumi Cloud.
 
 The task looks for the pipeline variable `pulumi.access.token` and maps it automatically to the `PULUMI_ACCESS_TOKEN` environment variable. Store the token as a [secret pipeline variable](https://learn.microsoft.com/azure/devops/pipelines/process/set-secret-variables) or in a linked [variable group](https://learn.microsoft.com/azure/devops/pipelines/library/variable-groups) so it isn't checked into source control. Prefer an organization or team token over a personal token.
 

--- a/content/docs/iac/guides/continuous-delivery/bitbucket.md
+++ b/content/docs/iac/guides/continuous-delivery/bitbucket.md
@@ -1,102 +1,134 @@
 ---
-title_tag: "Using Bitbucket Pipelines | CI/CD"
-meta_desc: This page details how to use Bitbucket Pipelines to manage deploying staging and production stacks based on commits to specific Git branches.
+title_tag: "Using Bitbucket Pipelines with Pulumi | CI/CD"
+meta_desc: Run Pulumi in Bitbucket Pipelines, authenticate with Pulumi Cloud, and ship infrastructure changes through a trunk-based CI/CD workflow.
 title: Bitbucket Pipelines
-h1: Pulumi CI/CD with Bitbucket Pipelines
+h1: Using Bitbucket Pipelines with Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
-aliases:
-- /docs/iac/using-pulumi/continuous-delivery/bitbucket/
 menu:
     iac:
         name: Bitbucket Pipelines
         parent: iac-using-pulumi-cicd
         weight: 40
+aliases:
+- /docs/reference/cd-bitbucket/
+- /docs/console/continuous-delivery/bitbucket/
+- /docs/guides/continuous-delivery/bitbucket/
+- /docs/guides/continuous-delivery/cd-bitbucket/
+- /docs/using-pulumi/continuous-delivery/cd-bitbucket/
+- /docs/using-pulumi/continuous-delivery/bitbucket/
+- /docs/iac/using-pulumi/continuous-delivery/bitbucket/
+- /docs/iac/packages-and-automation/continuous-delivery/bitbucket/
 ---
 
-[Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/) is a CI/CD service built into Bitbucket Cloud. It allows you to build, test, and deploy your code automatically to your Pulumi staging and production stacks based on commits to specific Git branches.
+[Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/) is the CI/CD service built into Bitbucket Cloud. It runs the pipeline defined in a `bitbucket-pipelines.yml` file at the root of your repository, building and deploying your code on each push, pull request, or tag.
 
-This guide provides examples for integrating Bitbucket Pipelines with a [Pulumi AWS TypeScript project](/docs/iac/get-started/), but the outlined steps can be adapted for other projects in your favorite language.
+Pulumi runs in a pipeline as plain CLI commands, so this guide works with a Pulumi program written in any [supported language](/docs/iac/languages-sdks/) and targeting [any cloud provider](/registry/).
 
 ## Prerequisites
 
-- Sign up for a [Pulumi account](https://app.pulumi.com/signup)
-- Create a [Pulumi Access Token](https://app.pulumi.com/account/tokens)
-- Install the [latest Pulumi CLI](/docs/install/)
-- Create a [Bitbucket account](https://bitbucket.org) with Pipelines enabled
-- Create a [new Bitbucket repository](https://support.atlassian.com/bitbucket-cloud/docs/create-a-git-repository/), and ensure you do not initialize it with a README
+Before you begin, make sure you have:
 
-- Create a [new Pulumi project](/tutorials/pulumi-fundamentals/create-a-pulumi-project/) and [initialize it as a git repository](https://git-scm.com/docs/git-init)
+1. A [Pulumi Cloud](https://app.pulumi.com/signin) account and organization.
+1. A Bitbucket Cloud repository with [Pipelines enabled](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/).
+1. A Pulumi program committed to that repository. If you don't have one yet, follow a [Get started](/docs/iac/get-started/) guide.
 
-## Setting up environment variables
+## Authenticate with Pulumi Cloud
 
-To use Pulumi within Bitbucket Pipelines, there are a few environment variables you'll need to set.
+Your pipeline authenticates to Pulumi Cloud with a single [Pulumi access token](/docs/administration/access-identity/access-tokens/), supplied through the `PULUMI_ACCESS_TOKEN` environment variable. Prefer an [organization or team token](/docs/administration/access-identity/access-tokens/#creating-an-organization-access-token) over a personal token so the pipeline's identity is not tied to an individual.
 
-The first is `PULUMI_ACCESS_TOKEN`, which is required to authenticate with Pulumi in order to
-perform the `preview` or `update`.
-
-Next, you will need to set environment variables specific to your cloud resource provider.
-For example, if your stack is managing resources on AWS, you will need to set `AWS_ACCESS_KEY_ID` and
-`AWS_SECRET_ACCESS_KEY`.
+Add the token as a [repository variable](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/) under **Repository settings > Repository variables**. Name it `PULUMI_ACCESS_TOKEN` and select the **Secured** checkbox so the value is encrypted and masked in build logs. Secured variables are exposed to every step of the pipeline as environment variables.
 
 {{% notes type="info" %}}
-
-Add these variables in Bitbucket to your **Repository settings > Repository variables**, ensuring you click on the **Secured** checkbox, as is a security best practice to mark any sensitive variables as protected in Bitbucket. You can learn more about how to protect environment variables by referencing their [variables and secrets](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/) documentation.
-
+Always mark sensitive values — access tokens, cloud provider keys — as **Secured**. An unsecured variable is stored and printed in plaintext.
 {{% /notes %}}
 
-## Bitbucket pipeline configuration
+[Pulumi ESC](/docs/esc/) (Environments, Secrets, and Configuration) then supplies cloud credentials, secrets, and configuration to your Pulumi program. Because ESC delivers those values the same way whether the consumer is a pipeline or a developer's machine, a single environment definition works in both places — you don't store separate cloud provider keys as repository variables.
 
-In Bitbucket, a CI/CD pipeline is defined in a yaml file labeled `.bitbucket-pipelines.yml`. This file must exist in the root of your repository and defines how Bitbucket Pipelines will build and deploy your Pulumi stack.
+## Authenticate without a stored token using OIDC
 
-Here's an example configuration:
+You can remove the static token entirely. Bitbucket Pipelines can issue a short-lived [OpenID Connect (OIDC)](https://support.atlassian.com/bitbucket-cloud/docs/integrate-pipelines-with-resource-servers-using-oidc/) token for any step that sets `oidc: true`, exposing it as the `BITBUCKET_STEP_OIDC_TOKEN` environment variable.
+
+Register Bitbucket Pipelines as a trusted [OIDC issuer](/docs/administration/access-identity/oidc-issuers/) in Pulumi Cloud, and your pipeline can exchange that OIDC token for a short-lived Pulumi access token at runtime — no long-lived credential is stored as a repository variable.
+
+## The trunk-based development workflow
+
+The most common way to run Pulumi in CI/CD follows a [trunk-based development model](/docs/iac/guides/continuous-delivery/#the-trunk-based-development-workflow): work merges into a single main branch, and deployments flow outward from there.
+
+Bitbucket Pipelines has three pipeline triggers that map directly onto the three stages of this workflow:
+
+- `pull-requests` runs when a pull request is opened or updated — use it to **preview** changes.
+- `branches` runs when commits land on a branch — use it to **deploy to staging** on merge to `main`.
+- `tags` runs when a tag is pushed — use it to **promote to production**.
+
+The `bitbucket-pipelines.yml` below implements all three stages. It assumes a Pulumi program in an `infra/` directory and stacks named `acme/website/staging` and `acme/website/production`:
 
 ```yaml
-# This is an example Bitbucket starter pipeline configuration
-# Use a skeleton to build, test and deploy using manual and parallel steps
-# -----
-# You can specify a custom docker image from Docker Hub as your build environment.
-
-image: atlassian/default-image:4
+# bitbucket-pipelines.yml
+image: pulumi/pulumi:latest
 
 pipelines:
+  # Pull request: preview the proposed changes.
   pull-requests:
     '**':
       - step:
+          name: Preview infrastructure changes
           script:
-            - if [ "${BITBUCKET_PR_DESTINATION_BRANCH}" != "main" ]; then printf 'target branch not main, skipping preview'; exit; fi
-      - step:
-          name: 'Run Pulumi Preview'
-          image: pulumi/pulumi-nodejs:latest
-          script:
-            - npm ci
-            - pulumi login
-            - pulumi stack select $STACK
+            - cd infra
+            - pulumi install
+            - pulumi stack select acme/website/staging
             - pulumi preview
 
+  # Merge to main: deploy to the staging environment.
   branches:
     main:
       - step:
-          name: 'Run Pulumi Up'
-          image: pulumi/pulumi-nodejs:latest
+          name: Deploy to staging
           script:
-            - npm ci
-            - pulumi login
-            - pulumi stack select $STACK
+            - cd infra
+            - pulumi install
+            - pulumi stack select acme/website/staging
             - pulumi up --yes
 
+  # Tag push: promote to production.
+  tags:
+    'release-*':
+      - step:
+          name: Deploy to production
+          script:
+            - cd infra
+            - pulumi install
+            - pulumi stack select acme/website/production
+            - pulumi up --yes
 ```
 
-When working with Pulumi in Bitbucket Pipelines with Pulumi, you will need to specify when certain actions, like previews, are run.
+The `pulumi/pulumi` Docker image includes the Pulumi CLI and every language runtime, so the same pipeline works regardless of the language your program is written in. [`pulumi install`](/docs/iac/cli/commands/pulumi_install/) installs the program's language dependencies and required plugins.
 
-```yaml
-'**':
-  - step:
-      script:
-        - if [ "${BITBUCKET_PR_DESTINATION_BRANCH}" != "main" ]; then printf 'target branch not main, skipping preview'; exit; fi
+`pulumi preview` reports the proposed changes without modifying any resources, giving reviewers a summary of what the merge would do. To let reviewers exercise the change in a live environment, pair the preview step with a [Review Stack](/docs/deployments/deployments/review-stacks/), which provisions an ephemeral stack for the pull request and destroys it when the pull request closes.
+
+To promote a release, push a tag that matches the `release-*` pattern:
+
+```bash
+git tag release-2026-05-20
+git push origin release-2026-05-20
 ```
 
-This step and script ensures that the following Pulumi preview step only runs if the pull request is targeting the main branch. This avoids unnecessary previews for pull requests to other branches.
+Keeping production on its own stack and deploying it only from a tag makes each production update a single, traceable Git operation, and ensures production never deploys from an untested commit.
 
-## Running the pipeline
+## Cloud provider credentials
 
-Once the `.bitbucket-pipelines.yml` is committed, each push or pull request to the main branch of the repository will trigger the pipeline, automating the deployment of your infrastructure. You can monitor the pipeline status in the **Pipelines** tab in Bitbucket.
+Your Pulumi program needs credentials for whichever cloud it manages. Supply them as **Secured** repository variables, or — better — use [Pulumi ESC](/docs/esc/) to broker short-lived cloud credentials so no provider keys are stored as repository variables at all.
+
+## Report results back to Bitbucket
+
+The Pulumi Cloud [Bitbucket version control integration](/docs/integrations/version-control/bitbucket/) posts pull request comments and commit status checks for every deployment, regardless of which CI/CD system triggers the run. Connecting it gives reviewers a summary of resource changes directly on the pull request.
+
+The integration can also replace a hand-written pipeline entirely: with [push-to-deploy](/docs/deployments/deployments/using/triggers/#push-to-deploy) and [review stacks](/docs/deployments/deployments/review-stacks/), Pulumi Cloud runs your updates on Pulumi-hosted infrastructure in response to Bitbucket events, with no `bitbucket-pipelines.yml` to maintain.
+
+## Next steps
+
+- [Continuous delivery](/docs/iac/guides/continuous-delivery/)
+- [Pulumi ESC](/docs/esc/)
+- [OIDC issuers](/docs/administration/access-identity/oidc-issuers/)
+- [Bitbucket version control integration](/docs/integrations/version-control/bitbucket/)
+- [Review Stacks](/docs/deployments/deployments/review-stacks/)
+- [CI/CD troubleshooting](/docs/support/troubleshooting/ci-cd/)


### PR DESCRIPTION
Rewrites the Bitbucket Pipelines CI/CD guide to the standard format established by the Azure DevOps and AWS Code Services guides, as part of the CI/CD docs cleanup epic.

## Changes
- Rewrite `bitbucket.md`: fix the `bitbucket-pipelines.yml` filename (was wrongly `.bitbucket-pipelines.yml`), make examples language- and cloud-agnostic, demonstrate the full trunk-based workflow (preview → staging → tag-promoted production), and add OIDC and Pulumi Cloud version-control integration coverage. Restore the historical alias family.
- De-hedge the "Pulumi Cloud as its backend" auth phrasing across `azure-devops.md`, `aws-code-services.md`, and the CI/CD `_index.md`.
- Drop the redundant Troubleshooting sections from `bitbucket.md` and `aws-code-services.md` in favor of the existing generic CI/CD troubleshooting guide.

Closes #19196