### PR TITLE
content(cicd): rewrite the Buildkite guide

### DIFF
--- a/content/docs/iac/guides/continuous-delivery/buildkite.md
+++ b/content/docs/iac/guides/continuous-delivery/buildkite.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Using Buildkite | CI/CD"
-meta_desc: This page details how to use Buildkite pipelines to deploy infrastructure implemented using Pulumi.
+title_tag: "Using Buildkite with Pulumi | CI/CD"
+meta_desc: Run Pulumi in a Buildkite pipeline with the official Pulumi plugin, and ship infrastructure through a trunk-based CI/CD workflow.
 title: Buildkite
-h1: Pulumi CI/CD with Buildkite
+h1: Using Buildkite with Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 aliases:
 - /docs/iac/using-pulumi/continuous-delivery/buildkite/
@@ -13,151 +13,158 @@ menu:
         weight: 50
 ---
 
-[Buildkite](https://buildkite.com/) is a continuous integration and delivery platform designed to scale with your projects. This guide shows you how to install, configure, and run Pulumi in a Buildkite pipeline.
+[Buildkite](https://buildkite.com/) is a CI/CD platform that runs pipelines on agents you host or on Buildkite-hosted agents. You run Pulumi in a Buildkite pipeline with the [`pulumi` plugin](https://buildkite.com/resources/plugins/buildkite-plugins/pulumi-buildkite-plugin/), an official Buildkite plugin that installs and configures the Pulumi CLI for a step.
+
+Because the plugin runs CLI commands, it works with a Pulumi program written in any [supported language](/docs/iac/languages-sdks/), and with [any cloud provider](/registry/) Pulumi supports.
+
+{{% notes type="info" %}}
+This guide assumes [Pulumi Cloud](/docs/pulumi-cloud/) as your backend. Pulumi Cloud isn't required to run Pulumi in CI/CD — Pulumi also supports [self-managed backends](/docs/iac/concepts/state-and-backends/) — but the access token, OIDC, and ESC features described here are specific to Pulumi Cloud.
+{{% /notes %}}
 
 ## Prerequisites
 
-- Sign up for a [Pulumi account](https://app.pulumi.com/signup)
-- Create a [Pulumi Access Token](https://app.pulumi.com/account/tokens)
-  - Save this token as a [pipeline secret](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets)
-named `PULUMI_ACCESS_TOKEN`.
-- Install the [latest Pulumi CLI](/docs/install/), so you can run the project locally as a test
-- Create a new GitHub [repository](https://github.com/new)
-- Create a [new Pulumi project](/tutorials/pulumi-fundamentals/create-a-pulumi-project/) and [initialize it as a git repository](https://git-scm.com/docs/git-init)
-- Obtain credentials for the cloud provider your Pulumi project will use and store them as pipeline secrets similar to the Pulumi access token from the previous step.
-  - Some cloud providers support OIDC token exchange. See [OIDC in Buildkite Pipelines](https://buildkite.com/docs/pipelines/security/oidc).
-- A Buildkite cluster and agent. Follow the [Getting Started](https://buildkite.com/docs/pipelines/getting-started) guide to complete setup.
+Before you begin, make sure you have:
 
-## Install and Configure Pulumi
+1. A [Pulumi Cloud](https://app.pulumi.com/signin) account and organization.
+1. A Buildkite account with a [cluster and agent](https://buildkite.com/docs/pipelines/getting-started).
+1. A Git repository connected to a Buildkite pipeline.
+1. A Pulumi program. If you don't have one yet, follow a [Get started](/docs/iac/get-started/) guide.
 
-Pipeline steps can be defined in Buildkite directly or stored in a YAML file in your
-source repo. Defining steps in a YAML file will give you access to more configuration
-options than the web interface.
+## Install and configure Pulumi
 
-1. In your source repository, create the `.buildkite` folder in the root. The Buildkite agent will look for a pipeline
-configuration file [in a few places](https://buildkite.com/docs/agent/v3/cli-pipeline#uploading-pipelines-description). You may also choose one of the other locations to store your config.
-1. Create a new file called `pipeline.yml` and paste the following pipeline configuration into the file.
+A Buildkite pipeline's steps can be defined in the web interface or, more commonly, in a `pipeline.yml` file committed to your repository. The Buildkite agent looks for this file in [a few locations](https://buildkite.com/docs/agent/v3/cli-pipeline#uploading-pipelines-description); `.buildkite/pipeline.yml` in the repository root is the conventional choice.
 
-**Note**: The pipeline assumes you are using the Node.js Pulumi SDK for your cloud infrastructure
-but you can, of course, use any of the languages supported by Pulumi.
+Add the `pulumi` plugin to any step that runs a Pulumi command. The plugin installs the CLI before the step's commands run:
 
 ```yaml
-env:
-  PULUMI_STACK: dev
-
+# .buildkite/pipeline.yml
 steps:
   - label: ":pulumi: Preview"
     commands:
-      - npm install
-      - pulumi preview -s $PULUMI_STACK | tee preview
-      - printf '```\n%b\n```\n' "$(cat preview)" | buildkite-agent annotate --style "info"
+      - cd infra && npm install
+      - pulumi preview --stack acme/website/dev
     plugins:
-      - secrets:
-          variables:
-            # Map the PULUMI_ACCESS_TOKEN secret to an env var of the same name.
-            # If you are using OIDC, this won't be needed.
-            PULUMI_ACCESS_TOKEN: PULUMI_ACCESS_TOKEN
-            #
-            # NOTE: Don't forget to map cloud provider credentials as env vars
-            # also unless you are using OIDC with the cloud provider too.
-            # AWS_ACCESS_KEY_ID: AWS_ACCESS_KEY_ID
-            # AWS_SECRET_ACCESS_KEY: AWS_SECRET_ACCESS_KEY
-
       - pulumi#v1.0.0:
-        # Optional: The specific version to install
-        # if you don't want to use the latest
-        # available version.
-        #
-        # version: 3.183.0
-        #
-        # Optional: Use self-managed backend URL instead of (default) Pulumi Cloud.
-        # backend-url: s3://bucket_name/project_name/stack_name
-        #
-        # Optional: Use OIDC auth with Pulumi Cloud.
-        # use-oidc: true
-        # audience: urn:pulumi:org:{INDIVIDUAL_OR_ORG_LOGIN_NAME}
-        # pulumi-token-type: urn:pulumi:token-type:access_token:personal
-        # pulumi-token-scope: "user:{USER_LOGIN}"
+          # Pin a specific CLI version. Optional; defaults to the latest release.
+          version: 3.143.0
 ```
 
-Use of the `pulumi` [plugin](https://buildkite.com/resources/plugins/buildkite-plugins/pulumi-buildkite-plugin/) is optional.
-However, if you are using OIDC auth with Pulumi, you might consider using the plugin since it handles the OIDC token exchange
-with Pulumi Cloud.
-
-Another option to consider is to use one of Pulumi's official container [images](https://github.com/pulumi/pulumi-docker-containers) for the language
-you're using. Pulumi container images have the Pulumi CLI pre-installed along with the language runtime needed to run your programs.
-The following example shows how you can use one of those images (or even a custom one.)
+As an alternative to the plugin, you can run your step inside one of Pulumi's official [container images](https://github.com/pulumi/pulumi-docker-containers), which ship the Pulumi CLI and a language runtime preinstalled. Use the [`docker` plugin](https://buildkite.com/resources/plugins/buildkite-plugins/docker-buildkite-plugin/) to select the image for your language:
 
 ```yaml
-env:
-  PULUMI_STACK: dev
-
-steps:
-  - label: ":pulumi: Preview"
-    commands:
-      - npm install
-      - pulumi preview -s $PULUMI_STACK | tee preview
-      - printf '```\n%b\n```\n' "$(cat preview)" | buildkite-agent annotate --style "info"
     plugins:
-      - secrets:
-          variables:
-            # Map the PULUMI_ACCESS_TOKEN secret to an env var of the same name.
-            # If you are using OIDC, this won't be needed.
-            PULUMI_ACCESS_TOKEN: PULUMI_ACCESS_TOKEN
-            #
-            # NOTE: Don't forget to map cloud provider credentials as env vars
-            # also unless you are using OIDC with the cloud provider too.
-            # AWS_ACCESS_KEY_ID: AWS_ACCESS_KEY_ID
-            # AWS_SECRET_ACCESS_KEY: AWS_SECRET_ACCESS_KEY
-
       - docker#v5.9.0:
-          image: "pulumi/pulumi-nodejs"
+          image: pulumi/pulumi-nodejs
           mount-buildkite-agent: true
           environment:
             - PULUMI_ACCESS_TOKEN
-            #
-            # NOTE: Don't forget to map cloud provider credentials as env vars
-            # also unless you are using OIDC with the cloud provider too.
-            # - AWS_ACCESS_KEY_ID
-            # - AWS_SECRET_ACCESS_KEY
 ```
 
-Create a pull request trigger by editing the [GitHub settings](https://buildkite.com/docs/pipelines/source-control/github#running-builds-on-pull-requests) in the pipeline.
-See Buildkite docs on [source control](https://buildkite.com/docs/pipelines/source-control) for other VCS.
+## Authenticate with Pulumi Cloud
 
-Similarly, create a pipeline config YAML that runs `pulumi up` when a commit is pushed to your default branch.
+When your pipeline uses Pulumi Cloud as its backend, it needs only a single [Pulumi access token](/docs/administration/access-identity/access-tokens/) to operate.
+
+Store the token as a [Buildkite secret](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets) so it isn't committed to source control, and use the [`secrets` plugin](https://buildkite.com/resources/plugins/buildkite-plugins/secrets-buildkite-plugin/) to map it to the `PULUMI_ACCESS_TOKEN` environment variable:
 
 ```yaml
-env:
-  PULUMI_STACK: xxx
-
-steps:
-  - label: ":pulumi: Up"
-    commands:
-      - npm install
-      - pulumi up -s $PULUMI_STACK
     plugins:
-      # Use pulumi plugin or the Docker plugin to ensure Pulumi is installed.
-      ...
+      - secrets#v1.0.0:
+          variables:
+            PULUMI_ACCESS_TOKEN: PULUMI_ACCESS_TOKEN
+      - pulumi#v1.0.0: ~
 ```
 
-## Next Steps
+Prefer an organization or team token over a personal token.
 
-This guide covered a simple way of running Pulumi in a Buildkite pipeline.
-As your Pulumi project grows and you add more stacks to a project, you
-can make the stack name dynamic (the `PULUMI_STACK` env var in the examples
-above) and run a pipeline for a specific stack based on a branch.
+You can remove even that static secret with [OpenID Connect (OIDC)](/docs/administration/access-identity/oidc-issuers/). Register Buildkite as an OIDC issuer in Pulumi Cloud, then enable OIDC on the plugin — it exchanges the [OIDC token Buildkite issues for the job](https://buildkite.com/docs/pipelines/security/oidc) for a short-lived Pulumi access token, so no long-lived credential is stored:
 
-### Dynamic Pipelines
+```yaml
+    plugins:
+      - pulumi#v1.0.0:
+          use-oidc: true
+          audience: "urn:pulumi:org:ACME_ORG"
+```
 
-Buildkite allows you to create [dynamic pipelines](https://buildkite.com/docs/pipelines/configure/dynamic-pipelines).
-Similar to Pulumi, Buildkite, too, allows you to use a [programming language](https://buildkite.com/docs/pipelines/configure/dynamic-pipelines/sdk)
-to generate pipeline configurations dynamically at build time.
+[Pulumi ESC](/docs/esc/) (Environments, Secrets, and Configuration) then supplies cloud credentials, secrets, and configuration to your Pulumi program. Because ESC delivers those values the same way whether the consumer is a pipeline or a developer's machine, a single environment definition works in both places — you don't store separate cloud provider keys in the pipeline.
 
-### Cache Volumes
+## The trunk-based development workflow
 
-[Cache volumes](https://buildkite.com/docs/pipelines/hosted-agents/cache-volumes) are
-external volumes attached to hosted agent instances. They can be used to cache Pulumi
-plugins that get installed in `$HOME/.pulumi/plugins`, as well as any language-specific
-packages, i.e. `node_modules` etc. Pulumi plugin binary versions are 1:1 with the
-versions of the Pulumi packages that use them.
+The most common way to run Pulumi in Buildkite follows a trunk-based development model, where work merges into a single main branch and deployments flow outward from there:
+
+1. **Open a pull request.** The pipeline runs `pulumi preview` and surfaces the proposed changes for review.
+1. **Merge to the main branch.** The pipeline runs `pulumi up` to deploy the change to an environment that receives continuous delivery, such as a shared development or staging environment.
+1. **Promote to production.** Pushing a git tag triggers a deployment to production, keeping production updates deliberate and traceable.
+
+The pipeline below implements all three stages with conditional steps. It assumes a Pulumi program in an `infra/` directory and stacks named `acme/website/staging` and `acme/website/production`.
+
+```yaml
+# .buildkite/pipeline.yml
+steps:
+  # Pull request: preview the proposed changes and post them as a build annotation.
+  - label: ":pulumi: Preview"
+    if: build.pull_request.id != null
+    commands:
+      - cd infra && npm install
+      - pulumi preview --stack acme/website/staging 2>&1 | tee preview.txt
+      - printf '```\n%s\n```\n' "$(cat preview.txt)" | buildkite-agent annotate --style info
+    plugins:
+      - secrets#v1.0.0:
+          variables:
+            PULUMI_ACCESS_TOKEN: PULUMI_ACCESS_TOKEN
+      - pulumi#v1.0.0: ~
+
+  # Merge to the main branch: deploy to the staging environment.
+  - label: ":pulumi: Deploy to staging"
+    if: build.branch == "main" && build.pull_request.id == null
+    commands:
+      - cd infra && npm install
+      - pulumi up --yes --stack acme/website/staging
+    plugins:
+      - secrets#v1.0.0:
+          variables:
+            PULUMI_ACCESS_TOKEN: PULUMI_ACCESS_TOKEN
+      - pulumi#v1.0.0: ~
+
+  # Tag push: promote to production.
+  - label: ":pulumi: Deploy to production"
+    if: build.tag != null
+    commands:
+      - cd infra && npm install
+      - pulumi up --yes --stack acme/website/production
+    plugins:
+      - secrets#v1.0.0:
+          variables:
+            PULUMI_ACCESS_TOKEN: PULUMI_ACCESS_TOKEN
+      - pulumi#v1.0.0: ~
+```
+
+To promote a release, push a tag:
+
+```bash
+git tag release-2026-05-20
+git push origin release-2026-05-20
+```
+
+Buildkite decides *when* to start a build — on pull requests, branch pushes, and tags — through your pipeline's [source control settings](https://buildkite.com/docs/pipelines/source-control), not the pipeline file. Enable pull request and tag builds there; the `if` expressions above then select which steps run for each build.
+
+For an optional ephemeral environment on each pull request, pair the preview step with a [Review Stack](/docs/deployments/deployments/review-stacks/), which provisions and tears down a per-PR environment automatically.
+
+{{% notes type="info" %}}
+The Pulumi CLI automatically detects when it runs inside Buildkite and records the build and commit metadata. Each update in Pulumi Cloud then links back to the build and pull request that triggered it — no extra configuration required.
+{{% /notes %}}
+
+## Buildkite features worth knowing
+
+- **Dynamic pipelines.** Buildkite can generate pipeline steps at build time with [dynamic pipelines](https://buildkite.com/docs/pipelines/configure/dynamic-pipelines). This is useful when you want to fan out a step per Pulumi stack or project rather than hard-coding each one.
+- **Cache volumes.** On hosted agents, [cache volumes](https://buildkite.com/docs/pipelines/hosted-agents/cache-volumes) persist directories across builds. Caching `~/.pulumi/plugins` and your language packages (`node_modules`, and so on) speeds up runs. Pulumi plugin versions are tied 1:1 to the Pulumi package versions that use them, so the cache stays correct as long as those packages are unchanged.
+
+## Managing Buildkite with Pulumi
+
+You can also manage Buildkite itself — pipelines, teams, and agent tokens — as code with the community-maintained [Pulumiverse Buildkite provider](/registry/packages/buildkite/) in the Pulumi Registry.
+
+## See also
+
+- [Continuous delivery](/docs/iac/guides/continuous-delivery/) — overview of running Pulumi in CI/CD.
+- [Pulumi ESC](/docs/esc/) — deliver credentials, secrets, and configuration to pipelines and developers consistently.
+- [OIDC issuers](/docs/administration/access-identity/oidc-issuers/) — exchange a CI/CD system's OIDC token for a short-lived Pulumi access token.
+- [Review Stacks](/docs/deployments/deployments/review-stacks/) — ephemeral environments created automatically for each pull request.


### PR DESCRIPTION
Restructures the Buildkite CI/CD guide against the standard outline from the CI/CD docs cleanup epic (#19190), following the merged Azure DevOps restructure (#19287).

## Changes
- Reframes the page as a workflow-first guide leading with the official `pulumi` Buildkite plugin.
- Adds an "Authenticate with Pulumi Cloud" section (ESC value-add + OIDC issuers to eliminate the static access token).
- Adds a trunk-based workflow with a worked `.buildkite/pipeline.yml`: PR → preview, merge to main → up, git tag → production.
- Notes that Pulumi Cloud is assumed but not required as the backend.
- Documents the community Pulumiverse Buildkite provider.
- Replaces the bare Note with the `notes` shortcode; removes marketing speak and the branch-per-stack guidance.

Closes #19197

🤖 Generated with [Claude Code](https://claude.com/claude-code)