### PR TITLE
Skip claude-triage on fork PRs

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -21,8 +21,16 @@ jobs:
     # their own labeling pipelines (label-dependabot.yml) and don't
     # carry secrets. `ready_for_review` always has `draft: false`, so
     # the draft guard is a no-op for that event.
+    #
+    # Also skip fork PRs: `pull_request` from a fork runs without secrets
+    # (ANTHROPIC_API_KEY is empty) and with a read-only GITHUB_TOKEN, and
+    # the downstream write-access check would reject the external author
+    # anyway. Letting the workflow start just to no-op every step burns
+    # Actions minutes and leaves a misleading green workflow_run that
+    # claude-code-review.yml then has to filter out.
     if: >-
       !github.event.pull_request.draft
+      && github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.user.login != 'pulumi-bot'
       && github.event.pull_request.user.login != 'dependabot[bot]'
 


### PR DESCRIPTION
## Summary

- Skip the `claude-triage` workflow on fork PRs by gating the job on `head.repo.full_name == github.repository`.
- Fork `pull_request` events run without `ANTHROPIC_API_KEY` and with a read-only `GITHUB_TOKEN`, and the existing write-access check would reject any external author anyway — so the whole job is already a guaranteed no-op for fork PRs.
- Today it still runs to completion, burning Actions minutes and emitting a misleading green `workflow_run` that `claude-code-review.yml` has to filter out via its own access gate. Gating at the job level keeps `Actions` cleaner.

No functional change for same-repo PRs: drafts, `pulumi-bot`, and `dependabot[bot]` are still excluded; the new clause only adds a fork filter.

## Test plan

- [ ] Open a same-repo PR and confirm `Pre-merge Review (triage)` still fires on `opened` (non-draft) and on `ready_for_review`.
- [ ] Open a draft PR and confirm triage does not run (existing behavior).
- [ ] On a fork PR (if/when one lands), confirm the triage workflow shows as "Skipped" rather than running and no-op'ing.
- [ ] Confirm `claude-code-review.yml`'s `workflow_run` chain still fires correctly on same-repo PRs after triage completes.
