### PR TITLE
releases: flatten frontmatter and tighten responsive type

### DIFF
--- a/content/releases/agentic-infrastructure-era.md
+++ b/content/releases/agentic-infrastructure-era.md
@@ -1,21 +1,23 @@
 ---
-title: Building for the agentic infrastructure era
+title: Building for agentic infrastructure
 date: 2026-05-19
 meta_desc: As agents take on more of the work of cloud infrastructure, they need tools that meet them where they are. Here's a closer look at what we've just shipped.
 meta_image: /images/releases/may-2026/meta.png
+label: May 2026 release
+short_description: As agents take on more of the work of infrastructure, they need tools that meet them where they are.
+feature_image: /images/releases/may-2026/release-hero-right-light.svg
+feature_image_alt: Agent surfaces — Claude Code, OpenCode, Codex, and Pulumi Neo — around the Pulumi mark
 
 hero:
-  overline: May 2026 release
   breadcrumb_label: May 2026
   heading: Building for agentic infrastructure
   description: |
     As agents take on more of the work of infrastructure, they need tools that meet them where they are.
     This month, we've got new commands, providers, integrations, and more that help humans and agents do
     infrastructure better.
-  feature_image_centered: /images/releases/may-2026/release-hero-bottom-dark.svg
-  feature_image_split: /images/releases/may-2026/release-hero-right-light.svg
-  feature_image_alt: Agent surfaces — Claude Code, OpenCode, Codex, and Pulumi Neo — around the Pulumi mark
-  feature_image_max_width: 430
+  hero_image: /images/releases/may-2026/release-hero-bottom-dark.svg
+  hero_image_alt: Agent surfaces — Claude Code, OpenCode, Codex, and Pulumi Neo — around the Pulumi mark
+  hero_image_max_width: 430
 
 intro:
   quote: |
@@ -83,6 +85,7 @@ sections:
         description: |
           The new `pulumi neo` command brings Neo out of Pulumi Cloud and into your terminal, so you can do
           agentic infrastructure anywhere you can run Pulumi.
+        link: /blog/pulumi-neo-cli/
 
       - variant: image-top
         image: /images/releases/may-2026/release-neo-github-slack.svg
@@ -99,6 +102,7 @@ sections:
         description: |
           A new integration catalog lets you configure connectors for a growing library of complementary
           services including Atlassian, Datadog, Honeycomb, Linear, PagerDuty, and Supabase.
+        link: /blog/neo-integrations/
 
       - variant: text
         icon: calendar-check

--- a/layouts/partials/releases/blog-list.html
+++ b/layouts/partials/releases/blog-list.html
@@ -6,14 +6,6 @@
     date on the right, separated by a bottom border (no border on the
     last row). The entire row is the link.
 
-    Figma tokens (208:904):
-      - Container card: white bg, gray-200 border, rounded-lg
-      - Overline: mono / 14px / tracking-wider / uppercase / service-black
-      - Title (heading-3): 24px / font-semibold / leading-1.1 / tracking-tighter / service-black
-      - Avatar: 36px circle, stacked with -ml-3 overlap when multiple
-      - Date (overline-small): mono / 12px / tracking-wider / uppercase / service-black
-      - Row height: 50px
-
     Parameters:
     - anchor:   Optional section ID for TOC link targets.
     - title:    Overline text. Defaults to "More from the blog".
@@ -26,7 +18,7 @@
 {{ $posts := .posts }}
 
 <section{{ with $anchor }} id="{{ . }}"{{ end }} class="card bg-white p-8 md:p-10 scroll-mt-28">
-    <p class="font-mono text-sm tracking-wider uppercase text-service-black m-0 mb-6">{{ $title }}</p>
+    <p class="font-mono text-xs md:text-sm tracking-wider uppercase text-service-black m-0 mb-6">{{ $title }}</p>
     <ul class="list-none p-0 m-0 flex flex-col">
         {{ range $posts }}
             {{ $post := site.GetPage . }}
@@ -35,7 +27,7 @@
                 <a class="grid grid-cols-1 md:grid-cols-2 items-center justify-between gap-2 md:gap-6 min-h-[50px] py-4 no-underline hover:no-underline text-service-black hover:text-violet-primary transition-colors"
                    href="{{ $post.RelPermalink }}">
                     <span class="text-2xl font-display font-semibold tracking-tighter leading-[1.1]">{{ $post.Title }}</span>
-                    <span class="flex items-center justify-end gap-5 shrink-0">
+                    <span class="flex items-center md:justify-end gap-5 shrink-0">
                         {{ with $post.Params.authors }}
                         <span class="flex items-center">
                             {{ range $i, $authorId := . }}

--- a/layouts/partials/releases/hero-card.html
+++ b/layouts/partials/releases/hero-card.html
@@ -2,44 +2,38 @@
     Releases Hero Card
 
     Dark card used on /releases/[slug] as the page hero. Breadcrumb at the top (linking back
-    to /releases), then heading and description, then a feature image flush
+    to /releases), then heading and description, then a hero image flush
     with the bottom and side edges of the card.
 
-    Figma tokens applied (utility/foreground-muted = gray-300 on dark,
-    brand/violet-accent = violet-500, heading-1 = 48px, paragraph/large = 18px):
-
     Parameters:
-    - breadcrumb_label:        Right-side breadcrumb segment (e.g., "May 2026").
-                               Falls back to `overline` if unset.
-    - overline:                Used as the fallback breadcrumb label.
-    - heading:                 Card heading.
-    - description:             Body copy (markdown).
-    - feature_image_centered:    Image path.
-    - feature_image:             Fallback if feature_image_centered is unset.
-    - feature_image_alt:         Alt text for the feature image.
-    - feature_image_max_width:   Optional max-width (in px) for the image,
-                                 centered horizontally and flush with the
-                                 bottom of the card. Image goes full-width
-                                 when unset.
+    - breadcrumb_label:      Right-side breadcrumb segment (e.g., "May 2026").
+    - heading:               Card heading.
+    - description:           Body copy (markdown).
+    - hero_image:            Image path.
+    - hero_image_alt:        Alt text for the hero image.
+    - hero_image_max_width:  Optional max-width (in px) for the image,
+                             centered horizontally and flush with the
+                             bottom of the card. Image goes full-width
+                             when unset.
 */}}
 
-{{ $breadcrumbLabel := .breadcrumb_label | default .overline }}
+{{ $breadcrumbLabel := .breadcrumb_label }}
 {{ $heading := .heading }}
 {{ $description := .description }}
-{{ $featureImage := .feature_image_centered | default .feature_image }}
-{{ $featureImageAlt := .feature_image_alt | default $heading }}
-{{ $featureImageMaxWidth := .feature_image_max_width }}
+{{ $heroImage := .hero_image }}
+{{ $heroImageAlt := .hero_image_alt | default $heading }}
+{{ $heroImageMaxWidth := .hero_image_max_width }}
 
 {{ $maxWidthAttr := "" }}
-{{ with $featureImageMaxWidth }}
+{{ with $heroImageMaxWidth }}
     {{ $maxWidthAttr = printf ` style="max-width: %vpx;"` . }}
 {{ end }}
 
-{{ $featureImageExists := false }}
-{{ with $featureImage }}
+{{ $heroImageExists := false }}
+{{ with $heroImage }}
     {{ $fpSrc := strings.TrimPrefix "/" . }}
     {{ if resources.Get (printf "fingerprinted/%s" $fpSrc) }}
-        {{ $featureImageExists = true }}
+        {{ $heroImageExists = true }}
     {{ end }}
 {{ end }}
 
@@ -61,16 +55,16 @@
             {{ end }}
         </div>
     </div>
-    {{ if $featureImage }}
+    {{ if $heroImage }}
     <div class="w-full flex justify-center mt-24">
         <div class="w-full"{{ $maxWidthAttr | safeHTMLAttr }}>
-            {{ if $featureImageExists }}
+            {{ if $heroImageExists }}
                 {{ partial "fingerprinted-img.html" (dict
-                    "src" $featureImage
-                    "alt" $featureImageAlt
+                    "src" $heroImage
+                    "alt" $heroImageAlt
                     "class" "w-full h-auto block"
                     "loading" "eager"
-                    "maxWidth" (or $featureImageMaxWidth 1500)
+                    "maxWidth" (or $heroImageMaxWidth 1500)
                     "quality" 95
                 ) }}
             {{ else }}

--- a/layouts/partials/releases/intro-toc-row.html
+++ b/layouts/partials/releases/intro-toc-row.html
@@ -1,13 +1,6 @@
 {{/*
     Releases Intro + TOC Row
 
-    Figma tokens applied:
-      - Quote (heading-2): 30px / font-semibold / leading-1.1 / tracking-tighter / service-black
-      - Attribution (body regular): 16px / service-black / leading-6
-      - TOC overline: mono 14px / tracking-wider / service-black
-      - TOC ".01" number: mono 14px / tracking-wider / violet-primary
-      - TOC label (heading-3): 24px / font-semibold / leading-1.1 / tracking-tighter / service-black
-
     Parameters:
     - intro:        Map with .quote (markdown), .attribution (markdown), and optional .link.
     - toc_heading:  Heading text for the TOC card. Defaults to "What we're shipping".
@@ -44,7 +37,7 @@
     {{/* TOC card */}}
     {{ with $sections }}
     <aside class="card bg-white p-8 lg:p-10 self-start h-full">
-        <p class="font-mono text-sm tracking-wider uppercase text-service-black m-0 mb-6">{{ $tocHeading }}</p>
+        <p class="font-mono text-xs md:text-sm tracking-wider uppercase text-service-black m-0 mb-6">{{ $tocHeading }}</p>
         <ul class="list-none p-0 m-0 flex flex-col gap-4">
             {{ range $i, $section := . }}
             <li class="m-0 flex items-baseline gap-4">

--- a/layouts/partials/releases/release-item.html
+++ b/layouts/partials/releases/release-item.html
@@ -9,8 +9,7 @@
     - overline:                Small uppercase eyebrow text (e.g., "May 2026 release").
     - heading:                 Card heading.
     - description:             Body copy (markdown).
-    - feature_image_split:     Image path.
-    - feature_image:           Fallback if feature_image_split is unset.
+    - feature_image:           Image path.
     - feature_image_alt:       Alt text for the feature image.
     - link:                    Optional URL — turns the card into an anchor with
                                a violet hover treatment.
@@ -19,7 +18,7 @@
 {{ $overline := .overline }}
 {{ $heading := .heading }}
 {{ $description := .description }}
-{{ $featureImage := .feature_image_split | default .feature_image }}
+{{ $featureImage := .feature_image }}
 {{ $featureImageAlt := .feature_image_alt | default $heading }}
 {{ $link := .link }}
 

--- a/layouts/releases/list.html
+++ b/layouts/releases/list.html
@@ -12,12 +12,11 @@
         {{ $items := where (where .Site.Pages "Type" "releases") "Kind" "eq" "page" }}
         {{ range sort $items ".Params.date" "desc" }}
         {{ partial "releases/release-item.html" (dict
-            "overline" .Params.hero.overline
-            "heading" .Params.hero.heading
-            "description" .Params.hero.description
-            "feature_image_split" .Params.hero.feature_image_split
-            "feature_image" .Params.hero.feature_image
-            "feature_image_alt" .Params.hero.feature_image_alt
+            "overline" .Params.label
+            "heading" .Params.title
+            "description" .Params.short_description
+            "feature_image" .Params.feature_image
+            "feature_image_alt" .Params.feature_image_alt
             "link" .RelPermalink
         ) }}
         {{ end }}


### PR DESCRIPTION
Just some quick reorganization in the frontmatter, adding a short description for the listing page as well. Fixes the blog list on mobile and also added in a couple of the new Neo blogs as links up in the cards.

---
**Generated description of changes:**

Refactor the releases page partials and frontmatter:

- Rename hero `feature_image_centered` / `feature_image_split` to `hero_image` / `feature_image` for clarity.
- Lift `label`, `short_description`, `feature_image`, and `feature_image_alt` to top-level frontmatter so `layouts/releases/list.html` can read them directly instead of reaching into `hero:`.
- Add `hero_image_alt` under `hero:` so the dark hero image keeps its descriptive alt text after the rename.
- Bump the mono overline on the TOC and "More from the blog" cards from `text-sm` to `text-xs md:text-sm` and let the blog-list date column left-align on mobile.
- Drop the Figma-token doc comments from the partials now that the tokens are settled.