### PR TITLE
Document include/exclude behavior for deployment path filters

### DIFF
--- a/content/docs/deployments/deployments/using/settings.md
+++ b/content/docs/deployments/deployments/using/settings.md
@@ -38,13 +38,51 @@ Pulumi recommends against a stack defining its own Deployment Settings (that is,
 
 ## Path Filtering
 
-When using a [VCS integration](/docs/integrations/version-control/) and push-to-deploy, you may want to filter deployment events to only target file changes in specific directories. You can easily do this using path filtering, so a deployment is only triggered if there is a change in files that match the path filters. This is especially useful for monorepos where you may have multiple Pulumi programs within the same repository.
-
-Path filters are relative to the repository root, and should reference a file by name or a directory must reference files by name relative to the repository or directories via glob patterns such as `/**` to include all changes within a directory.
+When using a [VCS integration](/docs/integrations/version-control/) and push-to-deploy, you may want a deployment to trigger only when a push changes files you care about. You can do this with path filters. This is especially useful for monorepos, where a single repository holds multiple Pulumi programs and you want each stack to deploy only when its own files change.
 
 ![Pulumi UI - Path Filters](../../ui-path-filters.png)
 
-As with any other deployment setting, the path filters may be set via the Pulumi Console, using the REST API or defined in code using the Pulumi Cloud provider.
+### Writing filters
+
+Each filter is a glob pattern matched against the full path of every file changed by a push, relative to the repository root. A pattern must match the *entire* path:
+
+- `infrastructure/Pulumi.dev.yaml` matches only that one file.
+- `infrastructure/**` matches every file anywhere under the `infrastructure/` directory.
+
+A filter is an **include filter** by default. Prefix it with `!` to make it an **exclude filter**:
+
+- `infrastructure/**` — include changes under `infrastructure/`.
+- `!infrastructure/docs/**` — exclude changes under `infrastructure/docs/`.
+
+### How filters are evaluated
+
+A push triggers a deployment when **at least one changed file matches the filters**. An individual file matches when both of these are true:
+
+1. It matches at least one include filter (or no include filters are configured), and
+1. It does not match any exclude filter.
+
+A few consequences worth knowing:
+
+- **No filters:** every push triggers a deployment.
+- **Only exclude filters:** every file is included unless an exclude filter matches it.
+- **Exclude always wins.** If a file matches an exclude filter, it is excluded even when it also matches an include filter. The order in which you list filters does not matter.
+
+{{% notes type="warning" %}}
+Path filters do **not** behave like a `.gitignore` file. In `.gitignore`, a later negated pattern can re-include a path that an earlier pattern excluded. Pulumi path filters have no equivalent: once a file matches an exclude filter, no include filter can bring it back.
+
+For example, given these filters:
+
+```
+!foo/**
+foo/bar/**
+```
+
+a change to `foo/bar/main.ts` does **not** trigger a deployment — it matches the `!foo/**` exclude filter, and the `foo/bar/**` include filter cannot override that. To deploy on changes under `foo/bar/` while ignoring the rest of `foo/`, exclude only the specific subdirectories you want to skip (for example `!foo/baz/**`) rather than excluding all of `foo/`.
+{{% /notes %}}
+
+### Setting path filters
+
+As with any other deployment setting, path filters may be set via the Pulumi Console, using the REST API, or defined in code using the Pulumi Cloud provider.
 
 ## Deployment Runner Pools
 


### PR DESCRIPTION
Fills a documentation gap in the deployments [path filtering](https://www.pulumi.com/docs/deployments/deployments/using/settings/#path-filtering) section. The docs never explained the `!` exclude-filter syntax or how include and exclude filters interact.

## Changes

- Document that a `!` prefix makes a filter an **exclude** filter.
- Explain the evaluation rule: a push deploys when at least one changed file matches an include filter (or no include filters are set) **and** matches no exclude filter. Exclude always wins; filter order is irrelevant.
- Add a warning callout clarifying that path filters do **not** behave like a `.gitignore` file — once a file matches an exclude filter, no later include filter can re-enable it (with a worked `!foo/**` + `foo/bar/**` example).
- Fix a garbled sentence in the original glob-pattern description.

The documented behavior was verified against the deployments path-filter evaluation logic and its test coverage.