### PR TITLE
Classify resource options by custom vs. component resource

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,12 @@ The left nav is data-driven from `data/docs_menu_sections.yml`, which is consume
 
 ---
 
+## Resource options
+
+The reference pages under `content/docs/iac/concepts/resources/options/` show a classification callout (custom resource / component resource / both, plus per-SDK enforcement) rendered by the `resource-option-scope` shortcode. The classification data — and the summary table on that section's `_index.md` — is generated from `data/resource_options.yaml`, which is the single source of truth. **When you add a new resource option, you must add an entry to `data/resource_options.yaml` and place the `{{< resource-option-scope "<name>" >}}` shortcode on the new page.** That file's header comment is the authoritative step-by-step checklist; the build fails if a page references an option missing from the data file.
+
+---
+
 ## Workflow Skills
 
 Before starting any documentation task, check `.claude/commands/` for a relevant skill — there are well-structured skills covering common tasks like creating docs, reviewing PRs (see `.claude/commands/docs-review/SKILL.md`), moving files, and more. To see a full inventory, run `.claude/commands/docs-tools/scripts/scrape-metadata.py`.

--- a/content/docs/iac/concepts/resources/options/_index.md
+++ b/content/docs/iac/concepts/resources/options/_index.md
@@ -17,59 +17,13 @@ aliases:
 
 All Pulumi IaC resources support a common set of options that allow you to customize how your resources are managed. Resource options allow you to do things like protect resources from being deleted, express more fine-grained control to the order in which resources are changed, or apply custom code that will allow you to change the properties of your resources.
 
-Resource constructors accept the following resource options:
+Resource constructors accept the following resource options. Each option's reference page describes its behavior in depth and how the Pulumi SDKs enforce which resource types it applies to.
 
-- [additionalSecretOutputs](/docs/concepts/options/additionalsecretoutputs/): specify properties that must be encrypted as secrets.
-- [aliases](/docs/concepts/options/aliases/): specify aliases for this resource, so that renaming or refactoring doesn’t replace it.
-- [customTimeouts](/docs/concepts/options/customtimeouts/): override the default retry/timeout behavior for resource provisioning. The default value varies by resource.
-- [deleteBeforeReplace](/docs/concepts/options/deletebeforereplace/): override the default create-before-delete behavior when replacing a resource.
-- [deletedWith](/docs/concepts/options/deletedwith/): If set, the provider's Delete method will not be called for this resource if the specified resource is being deleted as well.
-- [replaceWith](/docs/concepts/options/replacewith/): If set, the resource will be replaced if one of the specified resources is replaced.
-- [dependsOn](/docs/concepts/options/dependson/): specify additional explicit dependencies in addition to the ones in the dependency graph.
-- [envVarMappings](/docs/concepts/options/envvarmappings/): remap environment variables to custom keys for provider authentication.
-- [hideDiffs](/docs/concepts/options/hidediffs/): compact the display of diffs for specified properties in CLI output without affecting update behavior.
-- [hooks](/docs/concepts/options/hooks/): specify a set of resource hooks that will be executed at specific points in the resource lifecycle.
-- [ignoreChanges](/docs/concepts/options/ignorechanges/): declare that changes to certain properties should be ignored during a diff.
-- [import](/docs/concepts/options/import/): bring an existing cloud resource into Pulumi.
-- [parent](/docs/concepts/options/parent/): establish a parent/child relationship between resources.
-- [protect](/docs/concepts/options/protect/): prevent accidental deletion of a resource by marking it as protected.
-- [provider](/docs/concepts/options/provider/): pass an [explicitly configured provider](/docs/concepts/resources/providers/#explicit-provider-configuration), instead of using the default global provider.
-- [providers](/docs/concepts/options/providers/): pass a set of [explicitly configured providers](/docs/concepts/resources/providers/#explicit-provider-configuration). These are used if provider is not given, and are passed to child resources.
-- [replacementTrigger](/docs/concepts/options/replacementtrigger/): forces a replacement operation on a resource whenever a specified trigger value changes.
-- [replaceOnChanges](/docs/concepts/options/replaceonchanges/): declare that changes to certain properties should be treated as forcing a replacement.
-- [retainOnDelete](/docs/concepts/options/retainondelete/): if true the resource will be retained in the backing cloud provider during a Pulumi delete operation.
-- [transformations](/docs/concepts/options/transformations/): dynamically transform a resource's properties on the fly. Prefer `transforms` if possible. `transformations` will be deprecated in the future in favor of `transforms`.
-- [transforms](/docs/concepts/options/transforms/): dynamically transform a resource's properties on the fly.
-- [version](/docs/concepts/options/version/): pass a provider plugin version that should be used when operating on a resource.
+{{< resource-options-table >}}
 
 ## Resource options and component resources
 
-Not all resource options apply to [component resources](/docs/iac/concepts/components/). Component resources are logical groupings that don't have a backing cloud provider, so options that affect provider behavior have no effect on the component itself (though they may affect child resources).
-
-| Resource option | Applies to components? | Notes |
-|----------------|------------------------|-------|
-| [additionalSecretOutputs](/docs/concepts/options/additionalsecretoutputs/) | No | Components don't have provider-managed outputs |
-| [aliases](/docs/concepts/options/aliases/) | Yes | Works for renaming or refactoring components |
-| [customTimeouts](/docs/concepts/options/customtimeouts/) | No | Components don't have provider operations to time out |
-| [deleteBeforeReplace](/docs/concepts/options/deletebeforereplace/) | No | Components are not replaced by providers |
-| [deletedWith](/docs/concepts/options/deletedwith/) | Yes | Controls deletion behavior |
-| [dependsOn](/docs/concepts/options/dependson/) | Yes | Creates explicit dependencies on the component |
-| [envVarMappings](/docs/concepts/options/envvarmappings/) | No | Only applies to provider resources |
-| [hideDiffs](/docs/concepts/options/hidediffs/) | No | Components don't have provider-generated diffs |
-| [hooks](/docs/concepts/options/hooks/) | No | Components don't have provider lifecycle events |
-| [ignoreChanges](/docs/concepts/options/ignorechanges/) | No | Components don't have provider-managed inputs. The component implementation may choose to propagate this to children. |
-| [import](/docs/concepts/options/import/) | No | Components cannot be imported from cloud providers |
-| [parent](/docs/concepts/options/parent/) | Yes | Establishes parent-child relationships |
-| [protect](/docs/concepts/options/protect/) | Yes | Protects the component from deletion |
-| [provider](/docs/concepts/options/provider/) | No | Use `providers` instead for component resources |
-| [providers](/docs/concepts/options/providers/) | Yes | Pass providers to use for child resources |
-| [replacementTrigger](/docs/concepts/options/replacementtrigger/) | Yes | Components can be replaced by triggers |
-| [replaceOnChanges](/docs/concepts/options/replaceonchanges/) | No | Components are not replaced by providers |
-| [replaceWith](/docs/concepts/options/replacewith/) | No | Components are not replaced by providers |
-| [retainOnDelete](/docs/concepts/options/retainondelete/) | No | Components don't have cloud resources to retain |
-| [transformations](/docs/concepts/options/transformations/) | Yes | Transform child resources within the component |
-| [transforms](/docs/concepts/options/transforms/) | Yes | Transform child resources within the component |
-| [version](/docs/concepts/options/version/) | No | Components don't use provider plugins |
+Not all resource options apply to [component resources](/docs/iac/concepts/components/). Component resources are logical groupings that don't have a backing cloud provider, so options that affect provider behavior have no effect on the component itself (though they may affect child resources). The **Applies to** column in the table above shows which options apply to component resources; each option's reference page explains the behavior in detail.
 
 {{% notes type="info" %}}
 When you apply a resource option to a component that doesn't support it, the option is silently ignored. To apply options like `protect` or `ignoreChanges` to the child resources within a component, use the `transforms` option to modify child resources as they're created.

--- a/content/docs/iac/concepts/resources/options/additionalsecretoutputs.md
+++ b/content/docs/iac/concepts/resources/options/additionalsecretoutputs.md
@@ -17,6 +17,8 @@ aliases:
 
 The `additionalSecretOutputs` resource option specifies a list of named output properties that should be treated as [secrets](/docs/concepts/secrets/), which means they will be encrypted. It augments the list of values that Pulumi detects, based on secret inputs to the resource.
 
+{{< resource-option-scope "additionalSecretOutputs" >}}
+
 This example ensures that the password generated for a database resource is an encrypted secret:
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
@@ -80,7 +82,3 @@ resources:
 {{< /chooser >}}
 
 Only top-level resource properties can be designated secret. If sensitive data is nested inside of a property, you must mark the entire top-level output property as secret.
-
-{{% notes type="warning" %}}
-The `additionalSecretOutputs` resource option does not apply to component resources, and will not have the intended effect.
-{{% /notes %}}

--- a/content/docs/iac/concepts/resources/options/aliases.md
+++ b/content/docs/iac/concepts/resources/options/aliases.md
@@ -18,6 +18,8 @@ aliases:
 
 The `aliases` resource option provides a list of aliases for a resource or component resource. If you’re changing the name, type, or parent path of a resource or component resource, you can add the old name to the list of aliases for a resource to ensure that existing resources will be migrated to the new name instead of being deleted and replaced with the new named resource.
 
+{{< resource-option-scope "aliases" >}}
+
 Aliases are frequently used when refactoring Pulumi programs.
 
 For example, imagine we change a database resource’s name from `old-name-for-db` to `new-name-for-db`. By default, when we run `pulumi up`, we see that the old resource is deleted and the new one created. If we annotate that resource with the aliases option, however, the resource is updated in-place. Pulumi identifies resources by their [URN](/docs/iac/concepts/resources/names/#urns), which encodes the resource name, so the alias tells Pulumi to treat the old URN as equivalent to the new one:

--- a/content/docs/iac/concepts/resources/options/customtimeouts.md
+++ b/content/docs/iac/concepts/resources/options/customtimeouts.md
@@ -17,6 +17,8 @@ aliases:
 
 The `customTimeouts` resource option provides a set of custom timeouts for `create`, `update`, and `delete` operations on a resource. These timeouts are specified using a duration string such as "5m" (5 minutes), "40s" (40 seconds), or "12h" (12 hours). Supported duration units are "ns", "us" (or "µs"), "ms", "s", "m", and "h" (nanoseconds, microseconds, milliseconds, seconds, minutes, and hours, respectively).
 
+{{< resource-option-scope "customTimeouts" >}}
+
 For the most part, Pulumi automatically waits for operations to complete and times out appropriately. In some circumstances, such as working around bugs in the infrastructure provider, custom timeouts may be necessary.
 
 This example specifies that the create operation should wait up to 30 minutes to complete before timing out:
@@ -85,10 +87,6 @@ resources:
 {{% /choosable %}}
 
 {{< /chooser >}}
-
-{{% notes type="warning" %}}
-The `customTimeouts` resource option does not apply to component resources, and will not have the intended effect.
-{{% /notes %}}
 
 {{% notes type="warning" %}}
 Not all Pulumi resources support `customTimeouts` as support is dependent upon the particular resource's implementation in a given provider. Most resources will print a warning when `customTimeouts` is not supported, e.g.:

--- a/content/docs/iac/concepts/resources/options/deletebeforereplace.md
+++ b/content/docs/iac/concepts/resources/options/deletebeforereplace.md
@@ -17,6 +17,8 @@ aliases:
 
 A resource may need to be replaced if an immutable property changes. In these cases, cloud providers do not support updating an existing resource so a new instance will be created and the old one deleted. By default, to minimize downtime, Pulumi creates new instances of resources before deleting old ones.
 
+{{< resource-option-scope "deleteBeforeReplace" >}}
+
 Setting the `deleteBeforeReplace` option to true means that Pulumi will delete the existing resource before creating its replacement. This option may be necessary for resources that manage scarce resources or resources that cannot exist side-by-side. However, it's important to note that it can cascade to dependent resources, potentially causing more replacements and downtime. Additionally, eventual consistency in cloud APIs (like AWS) may lead to corrupted dependent resources if deletion hasn't fully propagated before creation begins.
 
 This example deletes a database entirely before its replacement is created:

--- a/content/docs/iac/concepts/resources/options/deletedwith.md
+++ b/content/docs/iac/concepts/resources/options/deletedwith.md
@@ -17,6 +17,8 @@ aliases:
 
 The `deletedWith` resource option allows you to skip resource deletion if another resource is being deleted as well.
 
+{{< resource-option-scope "deletedWith" >}}
+
 Pulumi will normally call the provider's delete action for every resource during a delete operation. Sometimes, this is redundant if another resource is also deleted, such as a parent container resource, and can cause your delete or destroy operations to take longer than needed.
 
 For example, if you are deleting a Kubernetes cluster or Kubernetes namespace, you might want to speed up deletion by skipping delete on any Pulumi managed resources created in that Kubernetes cluster or namespace since they will be deleted implicitly.

--- a/content/docs/iac/concepts/resources/options/dependson.md
+++ b/content/docs/iac/concepts/resources/options/dependson.md
@@ -17,6 +17,8 @@ aliases:
 
 The `dependsOn` resource option creates a list of explicit dependencies between resources.
 
+{{< resource-option-scope "dependsOn" >}}
+
 Pulumi automatically tracks dependencies between resources when you supply an input argument that came from another resource’s output properties. In some cases, however, you may need to explicitly specify additional dependencies that Pulumi doesn’t know about but must still respect. This might happen if a dependency is external to the infrastructure itself—such as an application dependency—or is implied due to an ordering or eventual consistency requirement. The `dependsOn` option ensures that resource creation, update, and deletion operations are executed in the correct order.
 
 This example demonstrates how to make `res2` dependent on `res1`, even if there is no property-level dependency:

--- a/content/docs/iac/concepts/resources/options/envvarmappings.md
+++ b/content/docs/iac/concepts/resources/options/envvarmappings.md
@@ -18,17 +18,13 @@ aliases:
 The `envVarMappings` resource option allows you to remap environment variables that a provider expects to custom environment variable names.
 This is useful when you need to run multiple providers or provider instances that require different values for the same environment variable.
 
+{{< resource-option-scope "envVarMappings" >}}
+
 ## When to use envVarMappings
 
 Use this option when:
 
 - **Running multiple providers targeting different accounts or regions**: For example, two AWS providers targeting different accounts can each use their own environment variable-based credentials without conflicting.
-
-{{% notes type="info" %}}
-The `envVarMappings` resource option only applies to provider resources.
-It cannot be used on regular resources or component resources.
-You must define an explicit provider to use this resource option.
-{{% /notes %}}
 
 ## Example
 

--- a/content/docs/iac/concepts/resources/options/hidediffs.md
+++ b/content/docs/iac/concepts/resources/options/hidediffs.md
@@ -16,6 +16,8 @@ aliases:
 
 The `hideDiffs` resource option specifies a list of property paths whose diff details Pulumi will compact in CLI output. Setting `hideDiffs` does not affect what resources are updated, only how those updates are displayed.
 
+{{< resource-option-scope "hideDiffs" >}}
+
 {{% notes type="info" %}}
 The `hideDiffs` option only affects CLI display output. It does not change resource update behavior, prevent changes from being detected, or modify what gets stored in state.
 {{% /notes %}}

--- a/content/docs/iac/concepts/resources/options/hooks.md
+++ b/content/docs/iac/concepts/resources/options/hooks.md
@@ -17,6 +17,8 @@ aliases:
 
 The `hooks` resource option provides a set of resource hooks linked to a resource. Hooks are used to execute custom logic at specific points in the resource lifecycle, such as before or after creation, update, or deletion.
 
+{{< resource-option-scope "hooks" >}}
+
 {{% notes type="info" %}}
 Resource hooks are supported in TypeScript/JavaScript, Python, Go, and C#/.NET. Java and YAML do not support resource hooks.
 {{% /notes %}}

--- a/content/docs/iac/concepts/resources/options/ignorechanges.md
+++ b/content/docs/iac/concepts/resources/options/ignorechanges.md
@@ -17,12 +17,10 @@ aliases:
 
 The `ignoreChanges` resource option specifies a list of properties that Pulumi will ignore when it updates existing resources. Pulumi ignores a property by using the old value from the state instead of the value provided by the Pulumi program when determining whether an update or replace is needed. Ignored properties will still be used from the program when there is no previous value in the state (most commonly when creating the resource).
 
+{{< resource-option-scope "ignoreChanges" >}}
+
 {{% notes type="info" %}}
 The `ignoreChanges` option only applies to resource inputs, not outputs.
-{{% /notes %}}
-
-{{% notes type="warning" %}}
-The `ignoreChanges` resource option does not automatically apply to inputs to component resources.  If `ignoreChanges` is passed to a component resource, it is up to that component's implementation to decide what if anything it will do.
 {{% /notes %}}
 
 In addition to passing simple property names, nested properties can also be supplied to ignore changes to a more targeted nested part of the resource's inputs. See [property paths](/docs/reference/property-paths/) for examples of legal paths that can be passed to specify nested properties of objects and arrays.

--- a/content/docs/iac/concepts/resources/options/import.md
+++ b/content/docs/iac/concepts/resources/options/import.md
@@ -17,6 +17,8 @@ aliases:
 
 The `import` resource option imports an existing cloud resource so that Pulumi can manage it. Imported resources can have been provisioned by any other method, including manually in the cloud console or with the cloud CLI.
 
+{{< resource-option-scope "import" >}}
+
 To import a resource, first specify the `import` option with the resource’s ID. This ID is the same as would be returned by the id property for any resource created by Pulumi; the ID is resource-specific. Pulumi reads the current state of the resource with the given ID from the cloud provider. Next, you must specify all required arguments to the resource constructor so that it exactly matches the state to import. By doing this, you end up with a Pulumi program that will accurately generate a matching desired state.
 
 This example imports an existing EC2 security group with ID `sg-04aeda9a214730248` and an EC2 instance with ID `i-06a1073de86f4adef`:

--- a/content/docs/iac/concepts/resources/options/parent.md
+++ b/content/docs/iac/concepts/resources/options/parent.md
@@ -22,6 +22,8 @@ The `parent` resource option specifies a parent for a resource, which has the fo
 
 By default, resources are parented to the implicitly created `pulumi:pulumi:Stack` resource which is at the root of all Pulumi stacks. The most common use of explicitly setting the `parent` property is when authoring a [Component Resource](/docs/iac/concepts/components/). Resources that are part of a component should be explicitly parented to the component itself. This ensures that all resources within a component share desirable lifecycle behavior. You can also create multiple levels of nesting within a component to improve the visual display in the CLI.
 
+{{< resource-option-scope "parent" >}}
+
 ## Setting a resource's parent
 
 The following example shows a simple parent/child relationship between two resources:

--- a/content/docs/iac/concepts/resources/options/protect.md
+++ b/content/docs/iac/concepts/resources/options/protect.md
@@ -17,6 +17,8 @@ aliases:
 
 The `protect` resource option marks a resource as protected. A protected resource cannot be deleted directly, and it will be an error to do a Pulumi deployment which tries to delete a protected resource for any reason.
 
+{{< resource-option-scope "protect" >}}
+
 To delete a protected resource, it must first be *unprotected*. There are two ways to unprotect a resource:
 
 * Set `protect: false` and then run `pulumi up`

--- a/content/docs/iac/concepts/resources/options/provider.md
+++ b/content/docs/iac/concepts/resources/options/provider.md
@@ -17,6 +17,8 @@ aliases:
 
 The `provider` resource option sets a provider for the resource. For more information, see [Providers](../providers). The default is to inherit this value from the parent resource, and to use the ambient provider specified by Pulumi configuration for resources without a parent.
 
+{{< resource-option-scope "provider" >}}
+
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language typescript %}}

--- a/content/docs/iac/concepts/resources/options/providers.md
+++ b/content/docs/iac/concepts/resources/options/providers.md
@@ -17,6 +17,8 @@ aliases:
 
 The `providers` resource option is supported only on [component resources](/docs/iac/concepts/components/). It sets a map of providers (keyed by package name) for the component and its child resources — the map flows from the component to every child via parent inheritance. To pass an explicit provider to a single custom resource, use the [`provider`](/docs/iac/concepts/resources/options/provider/) option instead.
 
+{{< resource-option-scope "providers" >}}
+
 When the SDK creates a resource it picks a provider by checking, in order:
 
 1. The explicit `provider` option, if set.

--- a/content/docs/iac/concepts/resources/options/replacementtrigger.md
+++ b/content/docs/iac/concepts/resources/options/replacementtrigger.md
@@ -19,6 +19,8 @@ The `replacementTrigger` resource option forces a replacement operation on a res
 
 For example, you might want to rotate cryptographic keys monthly by using a `YYYY-MM` string as the trigger, or synchronize infrastructure updates with application releases by using a version number. Unlike `replaceOnChanges`, which triggers replacements based on resource property changes, `replacementTrigger` allows you to control replacement timing based on arbitrary values.
 
+{{< resource-option-scope "replacementTrigger" >}}
+
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language typescript %}}

--- a/content/docs/iac/concepts/resources/options/replaceonchanges.md
+++ b/content/docs/iac/concepts/resources/options/replaceonchanges.md
@@ -19,6 +19,8 @@ The `replaceOnChanges` resource option can be used to indicate that changes to c
 
 For example, with Kubernetes `CustomResource` resources, the Kubernetes resource model doesn't know whether or not a specific input property on a specific kind of `CustomResource` requires a replacement, and so assumes that *any* change can be made without replacement.  However, in practice, many specific kinds of `CustomResource` in the Kubernetes ecosystem *do* require replacement when certain input properties are changed.  The Kubernetes provider itself can't know this, but users can use `replaceOnChanges` to ensure that these changes can be made correctly via Pulumi.
 
+{{< resource-option-scope "replaceOnChanges" >}}
+
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language typescript %}}
@@ -120,9 +122,5 @@ The property paths passed to `replaceOnChanges` should always be the "camelCase"
 If there are initialization errors on a resource (because the resource was created but failed to fully initialize correctly on a previous deployment) then the resource will normally be updated on the following Pulumi update, even if there are no other changes to the resource's inputs.  If `*` is specified as a property path for `replaceOnChanges`, then initialization errors will trigger a replacement instead of an update.
 
 The `replaceOnChanges` resource option can be combined with the [`deleteBeforeReplace`](/docs/concepts/options/deletebeforereplace) resource option to trigger a resource to be deleted before it is replaced whenever a given input has changes.
-
-{{% notes type="warning" %}}
-The `replaceOnChanges` resource option does not apply to component resources, and will not have the intended effect.
-{{% /notes %}}
 
 For one-time resource replacements without code changes, see [`pulumi state taint`](/docs/iac/cli/commands/pulumi_state_taint/) and [`pulumi state untaint`](/docs/iac/cli/commands/pulumi_state_untaint/).

--- a/content/docs/iac/concepts/resources/options/replacewith.md
+++ b/content/docs/iac/concepts/resources/options/replacewith.md
@@ -1,7 +1,7 @@
 ---
-title_tag: "replacewith | Resource Options"
-meta_desc: The replacewith resource option allows for explicit replace dependencies to be declared between resources.
-title: "replacewith"
+title_tag: "replaceWith | Resource Options"
+meta_desc: The replaceWith resource option allows for explicit replace dependencies to be declared between resources.
+title: "replaceWith"
 h1: "Resource option: replaceWith"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
@@ -20,6 +20,8 @@ The `replaceWith` resource option allows you to force a replace operation on the
 However, not all relationships are visible to Pulumi: perhaps there are differences in behavior between providers, or your application introduces its own specific relationships, such as two services that depend on one another and thus must always be replaced together.
 
 In these cases, you can use `replaceWith` to make these relationships explicit to the Pulumi engine. In the following example, an explicit dependency is declared: whenever the database is replaced, we must also replace the server.
+
+{{< resource-option-scope "replaceWith" >}}
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 

--- a/content/docs/iac/concepts/resources/options/retainOnDelete.md
+++ b/content/docs/iac/concepts/resources/options/retainOnDelete.md
@@ -17,6 +17,8 @@ aliases:
 
 The `retainOnDelete` resource option marks a resource to be retained. If this option is set then Pulumi will not call through to the resource provider's `Delete` method when deleting or replacing the resource during `pulumi up` or `pulumi destroy`. As a result, the resource will not be deleted from the backing cloud provider, but will be removed from the Pulumi state.
 
+{{< resource-option-scope "retainOnDelete" >}}
+
 If a retained resource is deleted by Pulumi and you later want to actually delete it from the backing cloud provider you will either need to use your provider's manual interface to find and delete the resource, or import the resource back into Pulumi to unset `retainOnDelete` and delete it again fully.
 
 To actually delete a retained resource, this setting must first be set to `false`.
@@ -82,7 +84,3 @@ resources:
 {{% /choosable %}}
 
 {{< /chooser >}}
-
-{{% notes type="warning" %}}
-The `retainOnDelete` resource option does not apply to component resources, and will not have the intended effect.
-{{% /notes %}}

--- a/content/docs/iac/concepts/resources/options/transformations.md
+++ b/content/docs/iac/concepts/resources/options/transformations.md
@@ -19,6 +19,8 @@ The `transformations` resource option provides a list of transformations to appl
 
 Each transformation is a callback that gets invoked by the Pulumi runtime. It receives the resource type, name, input properties, resource options, and the resource instance object itself. The callback returns a new set of resource input properties and resource options that will be used to construct the resource instead of the original values.
 
+{{< resource-option-scope "transformations" >}}
+
 {{% notes type="warning" %}}
 Note that Transformations will be deprecated in the future in favor of [Transforms](/docs/concepts/options/transforms).
 

--- a/content/docs/iac/concepts/resources/options/transforms.md
+++ b/content/docs/iac/concepts/resources/options/transforms.md
@@ -19,6 +19,8 @@ The `transforms` resource option provides a list of transforms to apply to a res
 
 Each transform is a callback that gets invoked by the Pulumi engine. It receives the resource type, name, input properties, and resource options. The callback returns a new set of resource input properties and resource options that will be used to construct the resource instead of the original values.
 
+{{< resource-option-scope "transforms" >}}
+
 ## VPC example
 
 This example looks for all VPC and Subnet resources inside of a component’s child hierarchy and adds an option to ignore any changes for tags properties (perhaps because we manage all VPC and Subnet tags outside of Pulumi):

--- a/content/docs/iac/concepts/resources/options/version.md
+++ b/content/docs/iac/concepts/resources/options/version.md
@@ -17,6 +17,8 @@ aliases:
 
 The `version` resource option specifies a provider version to use when operating on a resource. This version overrides the version information inferred from the current package. This option was built to be used directly by the Pulumi SDK. `version` should not be used directly during normal operations.
 
+{{< resource-option-scope "version" >}}
+
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language typescript %}}

--- a/data/resource_options.yaml
+++ b/data/resource_options.yaml
@@ -1,0 +1,204 @@
+# Classification of Pulumi resource options for the
+# content/docs/iac/concepts/resources/options/ reference pages.
+#
+# This file is the single source of truth consumed by:
+#   - the `resource-option-scope` shortcode (the per-page classification
+#     callout: layouts/shortcodes/resource-option-scope.html, which builds its
+#     text via layouts/partials/resource-option-scope-body.html)
+#   - the `resource-options-table` shortcode (the options table in
+#     options/_index.md: layouts/shortcodes/resource-options-table.html)
+#
+# -----------------------------------------------------------------------------
+# ADDING A NEW RESOURCE OPTION
+# -----------------------------------------------------------------------------
+# When you add a new resource option, keep this system in sync:
+#
+#   1. Create the reference page at
+#      content/docs/iac/concepts/resources/options/<name>.md (lowercase file
+#      name; camelCase `title` in frontmatter, like the existing pages).
+#   2. Add an entry to THIS file, keyed by the camelCase option name, filling
+#      in every field documented below. Verify `applies_to` and `typed_on`
+#      against the SDK source (see "Determining typed_on" below).
+#   3. In the new page, add the callout immediately after the opening
+#      descriptive paragraph:  {{< resource-option-scope "<name>" >}}
+#      The argument MUST exactly match the key you added in step 2.
+#   4. Nothing else to update: the options table in options/_index.md is
+#      generated from this file, so it picks up the new option automatically.
+#   5. Run `make build`. The `resource-option-scope` shortcode fails the build
+#      if its argument has no matching key here, so a forgotten entry can't
+#      ship silently.
+#
+# Determining `typed_on` (where the strongly typed SDKs declare the option):
+#   - TypeScript: sdk/nodejs/resource.ts                in pulumi/pulumi
+#   - C#:         sdk/Pulumi/Resources/*Options.cs       in pulumi/pulumi-dotnet
+#   - Java:       .../com/pulumi/resources/*Options.java in pulumi/pulumi-java
+#   An option declared on `CustomResourceOptions` is `typed_on: custom-options`;
+#   one on `ComponentResourceOptions` is `component-options`; one on the base
+#   `ResourceOptions` type is `base`. Python and Go expose a single options
+#   type and never enforce this distinction, so they need no per-SDK lookup.
+#
+# Fields per option:
+#   description      One-line, sentence-case summary rendered in the
+#                    options/_index.md table.
+#   applies_to       custom | component | both | provider
+#                    Whether the option has a meaningful effect on custom
+#                    resources, component resources, both, or only on
+#                    explicitly configured provider resources.
+#   typed_on         base | custom-options | component-options
+#                    Where the option is declared in the strongly typed SDKs
+#                    (TypeScript, C#, Java). Options on `CustomResourceOptions`
+#                    or `ComponentResourceOptions` are compile-time enforced;
+#                    options on the base `ResourceOptions` type are not.
+#   components_note  Short note on component behavior, used in the per-page
+#                    callout reasoning.
+#   note             Optional extra sentence appended to the per-page callout
+#                    for behavior that needs more explanation.
+
+additionalSecretOutputs:
+  description: Specify output properties that must be encrypted as secrets.
+  applies_to: custom
+  typed_on: custom-options
+  components_note: Components don't have provider-managed outputs.
+
+aliases:
+  description: Specify aliases so that renaming or refactoring doesn't replace a resource.
+  applies_to: both
+  typed_on: base
+  components_note: Works for renaming or refactoring components.
+
+customTimeouts:
+  description: Override the default retry/timeout behavior for resource provisioning.
+  applies_to: custom
+  typed_on: base
+  components_note: Components don't have provider operations to time out.
+
+deleteBeforeReplace:
+  description: Delete the existing resource before creating its replacement.
+  applies_to: custom
+  typed_on: custom-options
+  components_note: A provider doesn't replace component resources.
+
+deletedWith:
+  description: Skip this resource's delete when the named resource is also being deleted.
+  applies_to: both
+  typed_on: base
+  components_note: Controls deletion behavior for the component.
+
+dependsOn:
+  description: Specify explicit dependencies in addition to those in the dependency graph.
+  applies_to: both
+  typed_on: base
+  components_note: Creates explicit dependencies on the component.
+
+envVarMappings:
+  description: Remap environment variables to custom keys for provider authentication.
+  applies_to: provider
+  typed_on: base
+  components_note: Affects only explicitly configured provider resources.
+  note: >-
+    In the C# SDK, `envVarMappings` is defined on `CustomResourceOptions`, so
+    passing it to a component resource is a compile-time error; in the other
+    SDKs it is on the base resource-options type and is silently ignored at
+    runtime when used on a resource that doesn't support it.
+
+hideDiffs:
+  description: Compact the display of diffs for specified properties in CLI output.
+  applies_to: custom
+  typed_on: base
+  components_note: Components don't have provider-generated diffs.
+
+hooks:
+  description: Run custom logic at specific points in the resource lifecycle.
+  applies_to: custom
+  typed_on: base
+  components_note: Components don't have provider lifecycle events.
+
+ignoreChanges:
+  description: Ignore changes to specified properties during a diff.
+  applies_to: custom
+  typed_on: base
+  components_note: >-
+    Components don't have provider-managed inputs; a component's implementation
+    may choose to propagate this to its children.
+  note: >-
+    `ignoreChanges` is not applied automatically to a component resource's
+    inputs. If you pass it to a component, that component's implementation
+    decides whether and how to honor it.
+
+import:
+  description: Bring an existing cloud resource under Pulumi management.
+  applies_to: custom
+  typed_on: custom-options
+  components_note: Components can't be imported from a cloud provider.
+
+parent:
+  description: Establish a parent/child relationship between resources.
+  applies_to: both
+  typed_on: base
+  components_note: Establishes parent-child relationships.
+
+protect:
+  description: Prevent accidental deletion by marking the resource as protected.
+  applies_to: both
+  typed_on: base
+  components_note: Protects the component from deletion.
+
+provider:
+  description: Pass an explicitly configured provider instead of the default.
+  applies_to: custom
+  typed_on: base
+  components_note: Use `providers` instead to configure a component's child resources.
+
+providers:
+  description: Pass explicitly configured providers for a component's child resources.
+  applies_to: component
+  typed_on: component-options
+  components_note: Passes providers used by the component's child resources.
+
+replacementTrigger:
+  description: Force a replacement whenever a specified trigger value changes.
+  applies_to: both
+  typed_on: base
+  components_note: A component is replaced when the trigger value changes.
+
+replaceOnChanges:
+  description: Treat changes to specified properties as forcing a replacement.
+  applies_to: custom
+  typed_on: base
+  components_note: A provider doesn't replace component resources.
+
+replaceWith:
+  description: Replace this resource whenever one of the named resources is replaced.
+  applies_to: custom
+  typed_on: base
+  components_note: A provider doesn't replace component resources.
+
+retainOnDelete:
+  description: Retain the resource in the cloud provider when Pulumi deletes it.
+  applies_to: custom
+  typed_on: base
+  components_note: Components don't have cloud resources to retain.
+
+transformations:
+  description: Dynamically transform a resource's properties (prefer `transforms`).
+  applies_to: both
+  typed_on: base
+  components_note: Transforms the component's child resources.
+  note: >-
+    When applied to a component resource, `transformations` runs against the
+    component's child resources rather than the component itself.
+
+transforms:
+  description: Dynamically transform a resource's properties on the fly.
+  applies_to: both
+  typed_on: base
+  components_note: Transforms the component's child resources.
+  note: >-
+    When applied to a component resource, `transforms` runs against the
+    component's child resources rather than the component itself.
+
+version:
+  description: Pin the provider plugin version used when operating on a resource.
+  applies_to: custom
+  typed_on: base
+  components_note: Components don't use provider plugins.

--- a/layouts/partials/resource-option-scope-body.html
+++ b/layouts/partials/resource-option-scope-body.html
@@ -1,0 +1,25 @@
+{{- /*
+  Builds the Markdown body for the resource-option classification callout.
+  Expects a dict: { "name": <camelCase option name>, "data": <entry from
+  data/resource_options.yaml> }. Returns a Markdown string.
+*/ -}}
+{{- $name := .name -}}
+{{- $data := .data -}}
+{{- $applies := $data.applies_to -}}
+{{- $typed := $data.typed_on -}}
+{{- $text := "" -}}
+{{- if eq $applies "both" -}}
+  {{- $text = printf "**Applies to custom and component resources.** The `%s` resource option applies to both [custom resources](/docs/iac/concepts/resources/) and [component resources](/docs/iac/concepts/components/). It is defined on the base resource-options type in every Pulumi SDK." $name -}}
+{{- else if eq $applies "component" -}}
+  {{- $text = printf "**Applies to component resources only.** The `%s` resource option applies only to [component resources](/docs/iac/concepts/components/). In the TypeScript, C#, and Java SDKs it is defined on `ComponentResourceOptions`, so passing it to a custom resource is a compile-time error. The Python and Go SDKs expose a single resource-options type, so the option is accepted at compile time and silently ignored at runtime if the resource doesn't support it." $name -}}
+{{- else if eq $applies "provider" -}}
+  {{- $text = printf "**Applies to provider resources only.** The `%s` resource option affects only explicitly configured [provider resources](/docs/iac/concepts/providers/). It has no effect on ordinary custom resources or on component resources." $name -}}
+{{- else if eq $typed "custom-options" -}}
+  {{- $text = printf "**Applies to custom resources only.** The `%s` resource option applies only to custom resources. In the TypeScript, C#, and Java SDKs it is defined on `CustomResourceOptions`, so passing it to a [component resource](/docs/iac/concepts/components/) is a compile-time error. The Python and Go SDKs expose a single resource-options type, so the option is accepted at compile time and silently ignored at runtime when applied to a component resource." $name -}}
+{{- else -}}
+  {{- $text = printf "**Applies to custom resources only.** The `%s` resource option has no effect on [component resources](/docs/iac/concepts/components/). It is defined on the base resource-options type in every Pulumi SDK, so no SDK rejects it at compile time — passing it to a component resource is silently ignored at runtime." $name -}}
+{{- end -}}
+{{- with $data.note -}}
+  {{- $text = printf "%s %s" $text (. | chomp) -}}
+{{- end -}}
+{{- $text -}}

--- a/layouts/shortcodes/resource-option-scope.html
+++ b/layouts/shortcodes/resource-option-scope.html
@@ -1,0 +1,22 @@
+{{- /*
+  Renders a callout stating whether a resource option applies to custom
+  resources, component resources, or both, and how each SDK enforces it.
+  Usage: {{< resource-option-scope "providers" >}}
+  Data:  data/resource_options.yaml
+*/ -}}
+{{- $key := .Get 0 -}}
+{{- $data := index site.Data.resource_options $key -}}
+{{- if not $data -}}
+  {{- errorf "resource-option-scope: unknown resource option %q (in %s)" $key .Page.File.Path -}}
+{{- end -}}
+{{- $body := partial "resource-option-scope-body.html" (dict "name" $key "data" $data) -}}
+{{- $noteType := cond (eq $data.applies_to "both") "info" "warning" -}}
+<div class="note note-{{ $noteType }}">
+    <div class="icon-and-line">
+        {{ partial "icon.html" (dict "name" $noteType "weight" "fill") }}
+        <div class="line"></div>
+    </div>
+    <div class="content">
+        {{- $body | markdownify -}}
+    </div>
+</div>

--- a/layouts/shortcodes/resource-option-scope.markdown.md
+++ b/layouts/shortcodes/resource-option-scope.markdown.md
@@ -1,0 +1,5 @@
+{{- $key := .Get 0 -}}
+{{- $data := index site.Data.resource_options $key -}}
+{{- $body := partial "resource-option-scope-body.html" (dict "name" $key "data" $data) -}}
+
+> {{ $body }}

--- a/layouts/shortcodes/resource-options-table.html
+++ b/layouts/shortcodes/resource-options-table.html
@@ -1,0 +1,18 @@
+{{- /*
+  Renders the table of resource options — name, description, and which
+  resources each applies to — driven by data/resource_options.yaml.
+  Usage: {{< resource-options-table >}}
+*/ -}}
+{{- $labels := dict
+  "both" "Custom and component"
+  "component" "Component only"
+  "custom" "Custom only"
+  "provider" "Provider only" -}}
+{{- $rows := slice -}}
+{{- range $name, $d := site.Data.resource_options -}}
+  {{- $link := printf "[%s](/docs/iac/concepts/resources/options/%s/)" $name (lower $name) -}}
+  {{- $applies := index $labels $d.applies_to -}}
+  {{- $rows = $rows | append (printf "| %s | %s | %s |" $link (chomp $d.description) $applies) -}}
+{{- end -}}
+{{- $table := printf "| Resource option | Description | Applies to |\n|---|---|---|\n%s\n" (delimit $rows "\n") -}}
+{{ $table | markdownify }}

--- a/layouts/shortcodes/resource-options-table.markdown.md
+++ b/layouts/shortcodes/resource-options-table.markdown.md
@@ -1,0 +1,10 @@
+{{- $labels := dict
+  "both" "Custom and component"
+  "component" "Component only"
+  "custom" "Custom only"
+  "provider" "Provider only" -}}
+| Resource option | Description | Applies to |
+|---|---|---|
+{{ range $name, $d := site.Data.resource_options -}}
+| [{{ $name }}](/docs/iac/concepts/resources/options/{{ lower $name }}/) | {{ chomp $d.description }} | {{ index $labels $d.applies_to }} |
+{{ end -}}


### PR DESCRIPTION
Documents which resource types each resource option applies to

Every resource-option reference page now shows a callout stating whether the option applies to custom resources, component resources, or both — plus how each SDK (TypeScript, Python, Go, C#, Java) enforces it (compile error vs. silent no-op). SDK type placements were verified against the pulumi/pulumi, pulumi-dotnet, and pulumi-java SDK source.

## Changes
- New `data/resource_options.yaml` — single source of truth for the classification, with a contributor checklist for adding new options
- New `resource-option-scope` and `resource-options-table` shortcodes
- All 22 option pages get a consistent classification callout (6 ad-hoc inconsistent notes removed)
- `options/_index.md` intro list replaced by a data-driven table
- `AGENTS.md` documents the workflow for keeping it in sync

Resolves #18602.