### PR TITLE
content(cicd): rewrite the Harness guide (#19203)

### DIFF
--- a/content/docs/iac/guides/continuous-delivery/harness.md
+++ b/content/docs/iac/guides/continuous-delivery/harness.md
@@ -1,9 +1,8 @@
 ---
-title_tag: "Using Harness | CI/CD"
-meta_desc: This page details how to use Harness CI/CD to deploy infrastructure with Pulumi
-           and manage Harness resources using the Pulumi Harness provider.
+title_tag: "Using Harness with Pulumi | CI/CD"
+meta_desc: Run Pulumi in Harness CI with standard pipeline steps, authenticate with Pulumi Cloud, and ship infrastructure through a trunk-based CI/CD workflow.
 title: Harness
-h1: Pulumi CI/CD & Harness
+h1: Using Harness with Pulumi
 meta_image: /images/docs/meta-images/docs-meta.png
 aliases:
 - /docs/iac/using-pulumi/continuous-delivery/harness/
@@ -14,97 +13,57 @@ menu:
         weight: 110
 ---
 
-[Harness](https://www.harness.io/) is a modern software delivery platform that provides comprehensive CI/CD, feature flags, cloud cost management, and security testing capabilities. This page shows how to use Harness CI/CD to deploy infrastructure with Pulumi and how to manage Harness platform resources using the Pulumi Harness provider.
+[Harness](https://www.harness.io/) is a software delivery platform whose CI module runs pipelines defined as stages of steps. A pipeline can live in Harness itself or in your Git repository through [Git Experience](https://developer.harness.io/docs/platform/git-experience/git-experience-overview/).
 
-Pulumi doesn't require any particular arrangement of stacks or workflow to work in a continuous integration / continuous deployment system. The steps described here can be altered to fit into any existing deployment setup.
+You run Pulumi in Harness with standard [`Run` steps](https://developer.harness.io/docs/continuous-integration/use-ci/run-step-settings/) that invoke the Pulumi CLI. Because the CLI drives every operation, this works with a Pulumi program written in any [supported language](/docs/iac/languages-sdks/) and targeting [any cloud provider](/registry/) Pulumi supports.
+
+{{< cicd-cloud-note >}}
 
 ## Prerequisites
 
-- An account on [https://app.pulumi.com](https://app.pulumi.com/signup)
-- The latest [Pulumi CLI](/docs/install/)
-- A Harness account and access to Harness CI/CD
-- A git repository connected to your Harness project
-- [Pulumi Harness provider](/registry/packages/harness/) (optional, for managing Harness resources)
+Before you begin, make sure you have:
 
-## Setting Up Harness CI/CD with Pulumi
+1. A [Pulumi Cloud](https://app.pulumi.com/signin) account and organization.
+1. A Harness account with the CI module enabled and a project connected to your Git repository.
+1. A Pulumi program committed to that repository. If you don't have one yet, follow a [Get started](/docs/iac/get-started/) guide.
 
-### Authentication and Secrets Management
+## Authenticate with Pulumi Cloud
 
-Authentication for both Pulumi and your cloud provider can be managed in several ways. We recommend using [Pulumi ESC (Environments, Secrets, and Configuration)](/docs/esc/) as your primary secrets management solution, as it provides centralized, secure configuration management that works seamlessly across different CI/CD platforms.
+When your pipeline uses Pulumi Cloud as its backend, it needs only a single [Pulumi access token](/docs/administration/access-identity/access-tokens/) to operate. Add the token as a Harness [secret](https://developer.harness.io/docs/platform/secrets/add-use-text-secrets/) and reference it from a step's environment variables — the examples below read it from a secret named `pulumi_access_token` into `PULUMI_ACCESS_TOKEN`. Prefer an [organization or team token](/docs/administration/access-identity/access-tokens/#creating-an-organization-access-token) over a personal token so the pipeline's identity isn't tied to an individual.
 
-#### Option 1: Using Pulumi ESC (Recommended)
+[Pulumi ESC](/docs/esc/) (Environments, Secrets, and Configuration) then supplies cloud credentials, secrets, and configuration to your Pulumi program. Because ESC delivers those values the same way whether the consumer is a Harness pipeline or a developer's machine, a single environment definition works in both places — you don't store separate cloud provider keys as Harness secrets.
 
-With Pulumi ESC, you can centralize all your secrets and configuration in one place:
+To remove the static token entirely, Harness can act as an OIDC issuer, and Pulumi Cloud can register any third-party issuer as a trusted [OIDC Issuer](/docs/administration/access-identity/oidc-issuers/). A pipeline then exchanges a short-lived OIDC token for a Pulumi access token at runtime instead of storing one. See [OIDC Issuers](/docs/administration/access-identity/oidc-issuers/) for the Pulumi Cloud side of the setup, and the Harness documentation for issuing OIDC tokens from a pipeline.
 
-1. **Create a Pulumi ESC environment** with your secrets:
+## Build a trunk-based CI/CD workflow
 
-```yaml
-# esc-environment.yaml
-values:
-  pulumiConfig:
-    pulumi:access-token:
-      fn::secret: "your-pulumi-access-token"
-  aws:
-    AWS_ACCESS_KEY_ID:
-      fn::secret: "your-aws-access-key"
-    AWS_SECRET_ACCESS_KEY:
-      fn::secret: "your-aws-secret-key"
-    AWS_REGION: "us-east-1"
-  environmentVariables:
-    PULUMI_ACCESS_TOKEN: ${pulumiConfig.pulumi:access-token}
-    AWS_ACCESS_KEY_ID: ${aws.AWS_ACCESS_KEY_ID}
-    AWS_SECRET_ACCESS_KEY: ${aws.AWS_SECRET_ACCESS_KEY}
-    AWS_REGION: ${aws.AWS_REGION}
-```
+The most common way to run Pulumi in CI/CD follows a [trunk-based development model](/docs/iac/guides/continuous-delivery/#the-trunk-based-development-workflow): work merges into a single main branch, and deployments flow outward from there.
 
-1. **Configure your Harness pipeline** to use ESC:
+The pipeline below maps each stage of that model to its own CI stage, gated by a `when` condition on the [build type](https://developer.harness.io/docs/continuous-integration/use-ci/codebase-configuration/built-in-cie-codebase-variables-reference/):
 
-```yaml
-- step:
-    type: Run
-    name: Load Pulumi ESC Environment
-    identifier: load_esc_env
-    spec:
-      shell: Bash
-      command: |
-        # Install and use ESC CLI to inject environment variables
-        curl -fsSL https://get.pulumi.com/esc/install.sh | sh
-        export PATH=$PATH:$HOME/.pulumi/bin
-        # Open ESC environment and export variables
-        eval "$(esc open your-org/your-environment --format shell)"
+1. **Open a pull request.** The `preview` stage runs on pull requests and reports the proposed changes with `pulumi preview`.
+1. **Merge to the main branch.** The `deploy-staging` stage runs on pushes to `main` and deploys the change to a staging environment with `pulumi up`.
+1. **Promote to production.** Pushing a `release-*` tag runs the `deploy-production` stage, which deploys to production.
 
-        # These variables are now available for subsequent steps
-        echo "Environment loaded successfully"
-    envVariables:
-      PULUMI_ACCESS_TOKEN: <+secrets.getValue("PULUMI_ACCESS_TOKEN")>
-```
-
-#### Option 2: Using Harness Secrets
-
-If you prefer to manage secrets directly in Harness, navigate to your project's **Secrets** section and add:
-
-1. **`PULUMI_ACCESS_TOKEN`** - [Create a Pulumi access token](/docs/pulumi-cloud/accounts#access-tokens)
-2. **Cloud provider credentials**:
-   - AWS: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
-   - Azure: `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID`, `ARM_SUBSCRIPTION_ID`
-   - Google Cloud: `GOOGLE_CREDENTIALS`
-
-### Pipeline Configuration
-
-Create a `.harness/` directory in your repository with your pipeline configuration. Here's an example pipeline that runs `pulumi preview` on pull requests and `pulumi up` on commits to the main branch:
+Each `Run` step uses the official [`pulumi/pulumi`](https://hub.docker.com/r/pulumi/pulumi) container image, which bundles the Pulumi CLI and every language runtime, so the same step works regardless of your program's language. Pin the image to a specific version, as the examples do, so builds stay reproducible. The examples assume a Pulumi program in an `infra/` directory and stacks named `acme/website/staging` and `acme/website/production`:
 
 ```yaml
 pipeline:
-  name: Pulumi Infrastructure
-  identifier: pulumi_infrastructure
-  projectIdentifier: your_project_id
-  orgIdentifier: your_org_id
-  tags: {}
+  name: Pulumi
+  identifier: pulumi
+  projectIdentifier: my_project
+  orgIdentifier: default
+  properties:
+    ci:
+      codebase:
+        connectorRef: my_git_connector
+        repoName: website
+        build: <+input>
   stages:
+    # Pull request: preview the proposed changes.
     - stage:
-        name: Preview Infrastructure
-        identifier: preview_infrastructure
-        description: Preview infrastructure changes on pull requests
+        name: Preview
+        identifier: preview
         type: CI
         spec:
           cloneCodebase: true
@@ -118,58 +77,25 @@ pipeline:
             steps:
               - step:
                   type: Run
-                  name: Install Dependencies
-                  identifier: install_dependencies
-                  spec:
-                    shell: Bash
-                    command: |
-                      # Install Pulumi CLI
-                      curl -fsSL https://get.pulumi.com | sh
-                      export PATH=$PATH:$HOME/.pulumi/bin
-                      # Install language-specific dependencies
-                      case "<+pipeline.variables.language>" in
-                        "typescript"|"javascript")
-                          npm install
-                          ;;
-                        "python")
-                          pip install -r requirements.txt
-                          ;;
-                        "go")
-                          go mod download
-                          ;;
-                        "csharp")
-                          dotnet restore
-                          ;;
-                      esac
-              - step:
-                  type: Run
-                  name: Pulumi Preview
+                  name: Pulumi preview
                   identifier: pulumi_preview
                   spec:
                     shell: Bash
-                    command: |
-                      export PATH=$PATH:$HOME/.pulumi/bin
-                      cd <+pipeline.variables.workingDirectory>
-
-                      # Login to Pulumi
-                      pulumi login
-
-                      # Select the stack
-                      pulumi stack select <+pipeline.variables.stackName>
-                      # Run preview
-                      pulumi preview
+                    image: pulumi/pulumi:3.242.0
                     envVariables:
-                      PULUMI_ACCESS_TOKEN: <+secrets.getValue("PULUMI_ACCESS_TOKEN")>
-                      AWS_ACCESS_KEY_ID: <+secrets.getValue("AWS_ACCESS_KEY_ID")>
-                      AWS_SECRET_ACCESS_KEY: <+secrets.getValue("AWS_SECRET_ACCESS_KEY")>
-                      AWS_REGION: <+secrets.getValue("AWS_REGION")>
+                      PULUMI_ACCESS_TOKEN: <+secrets.getValue("pulumi_access_token")>
+                    command: |-
+                      pulumi login
+                      pulumi install --cwd infra/
+                      pulumi preview --cwd infra/ --stack acme/website/staging
         when:
           pipelineStatus: Success
-          condition: <+trigger.event> == "PR"
+          condition: <+codebase.build.type> == "PR"
+
+    # Merge to main: deploy to the staging environment.
     - stage:
-        name: Deploy Infrastructure
-        identifier: deploy_infrastructure
-        description: Deploy infrastructure changes on main branch
+        name: Deploy staging
+        identifier: deploy_staging
         type: CI
         spec:
           cloneCodebase: true
@@ -183,553 +109,105 @@ pipeline:
             steps:
               - step:
                   type: Run
-                  name: Install Dependencies
-                  identifier: install_dependencies_deploy
+                  name: Pulumi up
+                  identifier: pulumi_up_staging
                   spec:
                     shell: Bash
-                    command: |
-                      # Install Pulumi CLI
-                      curl -fsSL https://get.pulumi.com | sh
-                      export PATH=$PATH:$HOME/.pulumi/bin
-                      # Install language-specific dependencies
-                      case "<+pipeline.variables.language>" in
-                        "typescript"|"javascript")
-                          npm install
-                          ;;
-                        "python")
-                          pip install -r requirements.txt
-                          ;;
-                        "go")
-                          go mod download
-                          ;;
-                        "csharp")
-                          dotnet restore
-                          ;;
-                      esac
-              - step:
-                  type: HarnessApproval
-                  name: Infrastructure Approval
-                  identifier: infra_approval
-                  spec:
-                    message: Please review the infrastructure changes before deployment
-                    includePipelineExecutionHistory: true
-                    approvers:
-                      userGroups:
-                        - account.Infrastructure_Team
-                  timeout: 1d
-                  when:
-                    stageStatus: Success
-                    condition: <+pipeline.variables.requireApproval> == "true"
-              - step:
-                  type: Run
-                  name: Pulumi Up
-                  identifier: pulumi_up
-                  spec:
-                    shell: Bash
-                    command: |
-                      export PATH=$PATH:$HOME/.pulumi/bin
-                      cd <+pipeline.variables.workingDirectory>
-                      # Login to Pulumi
-                      pulumi login
-
-                      # Select the stack
-                      pulumi stack select <+pipeline.variables.stackName>
-
-                      # Deploy infrastructure
-                      pulumi up --yes
+                    image: pulumi/pulumi:3.242.0
                     envVariables:
-                      PULUMI_ACCESS_TOKEN: <+secrets.getValue("PULUMI_ACCESS_TOKEN")>
-                      AWS_ACCESS_KEY_ID: <+secrets.getValue("AWS_ACCESS_KEY_ID")>
-                      AWS_SECRET_ACCESS_KEY: <+secrets.getValue("AWS_SECRET_ACCESS_KEY")>
-                      AWS_REGION: <+secrets.getValue("AWS_REGION")>
+                      PULUMI_ACCESS_TOKEN: <+secrets.getValue("pulumi_access_token")>
+                    command: |-
+                      pulumi login
+                      pulumi install --cwd infra/
+                      pulumi up --yes --cwd infra/ --stack acme/website/staging
         when:
           pipelineStatus: Success
-          condition: <+trigger.sourceBranch> == "main"
-  variables:
-    - name: stackName
-      type: String
-      description: The Pulumi stack to deploy
-      value: "dev"
-    - name: workingDirectory
-      type: String
-      description: Directory containing Pulumi project
-      value: "infra"
-    - name: language
-      type: String
-      description: Programming language (typescript, python, go, csharp)
-      value: "typescript"
-    - name: requireApproval
-      type: String
-      description: Whether to require approval for deployments
-      value: "true"
-```
+          condition: <+codebase.build.type> == "branch" && <+codebase.branch> == "main"
 
-## Use Cases
-
-### Use Case 1: Infrastructure as Code for Application Platforms
-
-You can use Harness to deploy applications while leveraging Pulumi to manage the underlying infrastructure. This creates a powerful combination where:
-
-1. **Pulumi manages infrastructure**: Virtual machines, networking, databases, and Kubernetes clusters
-2. **Harness manages applications**: Deployments, feature flags, and application lifecycle
-3. **Integration through stack outputs**: Pulumi stack outputs provide connection details to Harness deployments
-
-Example workflow:
-
-```bash
-# Infrastructure pipeline (Pulumi)
-pulumi up --stack production-infra
-
-# Get infrastructure outputs
-CLUSTER_ENDPOINT=$(pulumi stack output clusterEndpoint)
-DATABASE_CONNECTION=$(pulumi stack output databaseConnectionString)
-
-# Pass to application deployment (Harness)
-harness deploy --cluster $CLUSTER_ENDPOINT --database $DATABASE_CONNECTION
-```
-
-### Use Case 2: Managing Harness Platform Configuration with Pulumi
-
-Use the [Pulumi Harness provider](/registry/packages/harness/) to manage your Harness platform configuration as code:
-
-{{< chooser language "typescript,python,go,csharp" >}}
-
-{{% choosable language typescript %}}
-
-```typescript
-import * as harness from "@pulumi/harness";
-
-// Create a project
-const project = new harness.platform.Project("myProject", {
-    identifier: "my_project",
-    name: "My Project",
-    orgId: "default",
-    color: "#0063F7",
-    modules: ["CI", "CD", "CV"],
-});
-
-// Create an environment
-const environment = new harness.platform.Environment("production", {
-    identifier: "production",
-    name: "Production",
-    orgId: "default",
-    projectId: project.identifier,
-    tags: ["env:production"],
-    type: "Production",
-});
-
-// Create a service
-const service = new harness.platform.Service("webApp", {
-    identifier: "web_app",
-    name: "Web Application",
-    orgId: "default",
-    projectId: project.identifier,
-});
-
-// Create a connector for your cloud provider
-const awsConnector = new harness.platform.ConnectorAwsSecret("awsConnector", {
-    identifier: "aws_connector",
-    name: "AWS Connector",
-    orgId: "default",
-    projectId: project.identifier,
-    secretManagerRef: "account.harnessSecretManager",
-    region: "us-east-1",
-    delegateSelectors: ["harness-delegate"],
-});
-```
-
-{{% /choosable %}}
-{{% choosable language python %}}
-
-```python
-import pulumi_harness as harness
-
-# Create a project
-project = harness.platform.Project("my-project",
-    identifier="my_project",
-    name="My Project",
-    org_id="default",
-    color="#0063F7",
-    modules=["CI", "CD", "CV"]
-)
-
-# Create an environment
-environment = harness.platform.Environment("production",
-    identifier="production",
-    name="Production",
-    org_id="default",
-    project_id=project.identifier,
-    tags=["env:production"],
-    type="Production"
-)
-
-# Create a service
-service = harness.platform.Service("web-app",
-    identifier="web_app",
-    name="Web Application",
-    org_id="default",
-    project_id=project.identifier
-)
-
-# Create a connector for your cloud provider
-aws_connector = harness.platform.ConnectorAwsSecret("aws-connector",
-    identifier="aws_connector",
-    name="AWS Connector",
-    org_id="default",
-    project_id=project.identifier,
-    secret_manager_ref="account.harnessSecretManager",
-    region="us-east-1",
-    delegate_selectors=["harness-delegate"]
-)
-```
-
-{{% /choosable %}}
-{{% choosable language go %}}
-
-```go
-package main
-
-import (
-    "github.com/pulumi/pulumi-harness/sdk/go/harness/platform"
-    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-)
-
-func main() {
-    pulumi.Run(func(ctx *pulumi.Context) error {
-        // Create a project
-        project, err := platform.NewProject(ctx, "myProject", &platform.ProjectArgs{
-            Identifier: pulumi.String("my_project"),
-            Name:       pulumi.String("My Project"),
-            OrgId:      pulumi.String("default"),
-            Color:      pulumi.String("#0063F7"),
-            Modules:    pulumi.StringArray{pulumi.String("CI"), pulumi.String("CD"), pulumi.String("CV")},
-        })
-        if err != nil {
-            return err
-        }
-
-        // Create an environment
-        _, err = platform.NewEnvironment(ctx, "production", &platform.EnvironmentArgs{
-            Identifier: pulumi.String("production"),
-            Name:       pulumi.String("Production"),
-            OrgId:      pulumi.String("default"),
-            ProjectId:  project.Identifier,
-            Tags:       pulumi.StringArray{pulumi.String("env:production")},
-            Type:       pulumi.String("Production"),
-        })
-        if err != nil {
-            return err
-        }
-
-        // Create a service
-        _, err = platform.NewService(ctx, "webApp", &platform.ServiceArgs{
-            Identifier: pulumi.String("web_app"),
-            Name:       pulumi.String("Web Application"),
-            OrgId:      pulumi.String("default"),
-            ProjectId:  project.Identifier,
-        })
-        if err != nil {
-            return err
-        }
-
-        return nil
-    })
-}
-```
-
-{{% /choosable %}}
-{{% choosable language csharp %}}
-
-```csharp
-using Pulumi;
-using Pulumi.Harness.Platform;
-
-class Program
-{
-    static Task<int> Main() => Deployment.RunAsync(() => {
-        // Create a project
-        var project = new Project("myProject", new ProjectArgs
-        {
-            Identifier = "my_project",
-            Name = "My Project",
-            OrgId = "default",
-            Color = "#0063F7",
-            Modules = new[] { "CI", "CD", "CV" }
-        });
-
-        // Create an environment
-        var environment = new Environment("production", new EnvironmentArgs
-        {
-            Identifier = "production",
-            Name = "Production",
-            OrgId = "default",
-            ProjectId = project.Identifier,
-            Tags = new[] { "env:production" },
-            Type = "Production"
-        });
-
-        // Create a service
-        var service = new Service("webApp", new ServiceArgs
-        {
-            Identifier = "web_app",
-            Name = "Web Application",
-            OrgId = "default",
-            ProjectId = project.Identifier
-        });
-
-        return new Dictionary<string, object?>
-        {
-            ["projectId"] = project.Identifier,
-            ["environmentId"] = environment.Identifier,
-            ["serviceId"] = service.Identifier
-        };
-    });
-}
-```
-
-{{% /choosable %}}
-
-{{< /chooser >}}
-
-### Use Case 3: Internal Developer Platform (IDP) Integration
-
-If you're using Harness as part of an Internal Developer Platform, Pulumi can be integrated to provision infrastructure that applications depend on. This is particularly valuable when:
-
-1. **Self-service infrastructure**: Developers can trigger infrastructure provisioning through Harness workflows
-2. **Template-driven deployments**: Use Pulumi templates that developers can customize through Harness parameters
-3. **Environment standardization**: Ensure consistent infrastructure across different teams and projects
-
-Example IDP integration:
-
-```yaml
-# Template pipeline for infrastructure provisioning
-pipeline:
-  name: IDP Infrastructure Template
-  identifier: idp_infra_template
-  templateInputs:
-    - name: applicationName
-      type: String
-      description: Name of the application
-    - name: environment
-      type: String
-      description: Target environment (dev/staging/prod)
-      allowedValues:
-        - dev
-        - staging
-        - prod
-    - name: instanceSize
-      type: String
-      description: Instance size for the application
-      allowedValues:
-        - small
-        - medium
-        - large
-  stages:
+    # Release tag: promote to production.
     - stage:
-        name: Provision Infrastructure
+        name: Deploy production
+        identifier: deploy_production
         type: CI
         spec:
+          cloneCodebase: true
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
           execution:
             steps:
               - step:
-                  name: Generate Infrastructure
                   type: Run
+                  name: Pulumi up
+                  identifier: pulumi_up_production
                   spec:
-                    command: |
-                      # Use Pulumi template with dynamic configuration
-                      pulumi new aws-typescript --name <+pipeline.variables.applicationName>
-
-                      # Configure based on template inputs
-                      pulumi config set aws:region us-east-1
-                      pulumi config set instanceSize <+pipeline.variables.instanceSize>
-                      pulumi config set environment <+pipeline.variables.environment>
-
-                      # Deploy infrastructure
-                      pulumi up --yes
+                    shell: Bash
+                    image: pulumi/pulumi:3.242.0
+                    envVariables:
+                      PULUMI_ACCESS_TOKEN: <+secrets.getValue("pulumi_access_token")>
+                    command: |-
+                      pulumi login
+                      pulumi install --cwd infra/
+                      pulumi up --yes --cwd infra/ --stack acme/website/production
+        when:
+          pipelineStatus: Success
+          condition: <+codebase.build.type> == "tag" && <+codebase.tag>.startsWith("release-")
 ```
 
-## Advanced Configuration
+`pulumi install` installs the program's language dependencies and required plugins, and `pulumi up --yes` applies changes non-interactively, with no confirmation prompt.
 
-### Environment-Specific Infrastructure Management
+To run this pipeline automatically, add two Harness [triggers](https://developer.harness.io/docs/platform/triggers/triggering-pipelines/) on your repository: a **pull request** trigger and a **push** trigger. The push trigger fires for both branch pushes and tag pushes; the per-stage `when` conditions then route each event to the correct stage. To promote a release, push a tag that matches the `release-*` pattern:
 
-Pulumi excels at managing different environments with varying infrastructure needs. You can structure your infrastructure to handle the unique requirements of development, staging, and production environments:
-
-#### Development Environment
-
-- **Smaller resource allocations**: Use smaller instance sizes and fewer replicas
-- **Relaxed security**: Allow broader access for debugging and testing
-- **Cost optimization**: Use spot instances or scaled-down services
-- **Rapid iteration**: Enable features like auto-scaling and blue-green deployments
-
-```typescript
-const config = new pulumi.Config();
-const environment = config.require("environment");
-
-const instanceType = environment === "dev" ? "t3.micro" :
-                    environment === "staging" ? "t3.small" : "t3.large";
-
-const cluster = new aws.ecs.Cluster("app-cluster", {
-    capacityProviders: environment === "dev" ? ["FARGATE_SPOT"] : ["FARGATE"],
-});
+```bash
+git tag release-2026-05-20
+git push origin release-2026-05-20
 ```
 
-#### Staging Environment
+Keeping production on its own stack and deploying it only from a tag makes each production update a single, traceable Git operation, and ensures production never deploys from an untested commit. To require human sign-off before a production deployment, add a [`HarnessApproval` step](https://developer.harness.io/docs/platform/approvals/adding-harness-approval-stages/) ahead of the `pulumi up` step in the `Deploy production` stage.
 
-- **Production-like configuration**: Mirror production settings for accurate testing
-- **Data isolation**: Use production-sized databases with test data
-- **Security testing**: Enable security scanning and compliance checks
-- **Performance testing**: Scale to handle load testing scenarios
+For an optional ephemeral environment on each pull request, pair the `preview` stage with a [Review Stack](/docs/deployments/deployments/review-stacks/), which provisions and tears down a per-pull-request environment automatically.
 
-#### Production Environment
+{{% notes type="info" %}}
+If you already maintain Pulumi workflows for GitHub Actions, Harness CI can run them directly: its [GitHub Action step](https://developer.harness.io/docs/continuous-integration/use-ci/use-drone-plugins/ci-github-action-step/) executes a published action such as [`pulumi/actions`](https://github.com/pulumi/actions) as a pipeline step.
+{{% /notes %}}
 
-- **High availability**: Multi-zone deployments with redundancy
-- **Enhanced security**: Strict network policies and encryption
-- **Monitoring and alerting**: Comprehensive observability stack
-- **Backup and disaster recovery**: Automated backup procedures
+## Speed up builds with caching
 
-### Approval Gates and Workflow Integration
+A clean CI worker starts with an empty plugin cache, so Pulumi re-downloads its provider plugins on every run. Cache the Pulumi plugin directory (`~/.pulumi/plugins`) to avoid that.
 
-Harness approval gates work particularly well with Pulumi workflows. You can implement different approval strategies:
-
-#### Infrastructure Change Approvals
-
-Use approval gates specifically for infrastructure changes that require review:
+On Harness Cloud, enable [Cache Intelligence](https://developer.harness.io/docs/continuous-integration/use-ci/caching-ci-data/cache-intelligence/) on the stage and add the plugin directory to its cached paths:
 
 ```yaml
-- step:
-    type: HarnessApproval
-    name: Infrastructure Security Review
-    identifier: security_review
-    spec:
-      message: "Infrastructure changes detected. Please review security implications."
-      includePipelineExecutionHistory: true
-      approvers:
-        userGroups:
-          - account.Security_Team
-          - account.Infrastructure_Team
-      approverInputs:
-        - name: securityApproved
-          type: String
-          allowedValues:
-            - approved
-            - rejected
-    timeout: 2d
-    when:
-      stageStatus: Success
-      condition: <+pipeline.variables.hasInfraChanges> == "true"
+spec:
+  cloneCodebase: true
+  caching:
+    enabled: true
+    paths:
+      - "~/.pulumi/plugins"
 ```
 
-#### Environment-Specific Approvals
+On self-managed build infrastructure, use the [`Save Cache`/`Restore Cache` steps](https://developer.harness.io/docs/continuous-integration/use-ci/caching-ci-data/saving-cache/) to store the same directory in an S3 or GCS bucket.
 
-Different environments can have different approval requirements:
+The most deterministic option is to bake the plugins into a custom builder image: derive it from `pulumi/pulumi`, `pulumi plugin install` the providers your program uses, and reference that image from the `Run` step instead of `pulumi/pulumi`. See the [plugins documentation](/docs/iac/concepts/plugins/) for details.
 
-```yaml
-- step:
-    type: HarnessApproval
-    name: Production Deployment Approval
-    identifier: prod_approval
-    spec:
-      message: "Production infrastructure deployment requires approval"
-      approvers:
-        userGroups:
-          - account.Production_Approvers
-        minimumCount: 2
-    when:
-      stageStatus: Success
-      condition: <+pipeline.variables.environment> == "production"
-```
+## Report results on pull requests
 
-#### Application Deployment Gates
+When the `preview` stage runs `pulumi preview` on a pull request, you'll usually want the proposed changes summarized on the pull request itself rather than buried in the pipeline logs.
 
-Coordinate infrastructure and application deployments with sequential approval gates:
+Pulumi offers native [version control integrations](/docs/integrations/version-control/) for popular version control systems. Independently of which CI/CD system runs Pulumi, a version control integration lets Pulumi Cloud post infrastructure-change summaries as pull request comments and status checks, and link each stack update back to the commit and pull request that produced it. See the [Version Control](/docs/integrations/version-control/) page for the current list of supported systems.
 
-```yaml
-stages:
-  - stage:
-      name: Infrastructure Deployment
-      # Pulumi infrastructure deployment
-  - stage:
-      name: Infrastructure Validation
-      type: Approval
-      spec:
-        approvers:
-          userGroups:
-            - account.Infrastructure_Team
-  - stage:
-      name: Application Deployment
-      # Harness application deployment
-      dependsOn:
-        - Infrastructure Validation
-```
+## Managing Harness with Pulumi
 
-### Multi-Stack Deployments
+You can manage Harness itself — projects, environments, services, connectors, and pipelines — as code with the [Pulumi Harness provider](/registry/packages/harness/) in the Pulumi Registry. This lets you define the Harness resources this guide describes as part of a Pulumi program, in any supported language.
 
-For complex environments with multiple stacks, you can configure your Harness pipeline to deploy multiple stacks in sequence:
+## Additional resources
 
-```yaml
-- step:
-    type: Run
-    name: Deploy Infrastructure Stack
-    identifier: deploy_infra
-    spec:
-      shell: Bash
-      command: |
-        pulumi stack select infrastructure
-        pulumi up --yes
-
-- step:
-    type: Run
-    name: Deploy Application Stack
-    identifier: deploy_app
-    spec:
-      shell: Bash
-      command: |
-        pulumi stack select application
-        pulumi up --yes
-    when:
-      stageStatus: Success
-```
-
-## Best Practices
-
-Following these best practices will help ensure reliable, secure, and maintainable infrastructure deployments with Harness and Pulumi:
-
-- **Use Secrets Management**: Prefer Pulumi ESC for centralized secrets management, with Harness secrets as a secondary option for platform-specific needs.
-
-- **Environment Configuration**: Use different Pulumi stacks and ESC environments for each deployment target (dev/staging/production).
-
-- **Resource Tagging**: Tag your infrastructure resources with environment and ownership information for better cost management and organization.
-
-- **Pipeline Validation**: Always run `pulumi preview` before `pulumi up` to review changes.
-
-- **Approval Gates**: Implement appropriate approval gates based on environment criticality and change scope.
-
-- **Rollback Strategy**: Implement proper rollback mechanisms using Pulumi's stack history:
-
-   ```bash
-   # Rollback to previous deployment
-   pulumi stack history
-   pulumi stack export --version <previous-version> > previous-state.json
-   pulumi stack import previous-state.json
-   ```
-
-- **IDP Integration**: When using Harness as an IDP, provide templates and self-service capabilities that abstract infrastructure complexity from developers.
-
-## Troubleshooting
-
-When integrating Harness with Pulumi, you may encounter some common issues. Here are solutions to the most frequently encountered problems:
-
-- **Authentication Failures**: Ensure all required secrets are properly configured in Harness or Pulumi ESC.
-- **Stack Not Found**: Verify stack names and ensure stacks exist in Pulumi Cloud.
-- **Resource Conflicts**: Use `pulumi refresh` to sync state with actual cloud resources.
-- **Pipeline Timeouts**: Increase timeout values for long-running infrastructure deployments.
-
-For additional troubleshooting, see our [CI/CD troubleshooting guide](/docs/iac/using-pulumi/continuous-delivery/troubleshooting-guide).
-
-## Next Steps
-
-- Explore the [Pulumi Harness provider documentation](/registry/packages/harness/)
-- Learn about [Pulumi ESC](/docs/esc/) for advanced secrets and configuration management
-- Check out [Pulumi Deployments](/docs/deployments/deployments/) for additional CI/CD capabilities
-- Review [Harness CI/CD documentation](https://docs.harness.io/category/zgffarnh1m-ci-category) for platform-specific features
-- Explore [Harness IDP documentation](https://developer.harness.io/docs/internal-developer-portal) for internal developer platform capabilities
+- [Continuous delivery](/docs/iac/guides/continuous-delivery/) — overview of running Pulumi in CI/CD.
+- [Pulumi ESC](/docs/esc/) — deliver credentials, secrets, and configuration to pipelines and developers consistently.
+- [OIDC Issuers](/docs/administration/access-identity/oidc-issuers/) — exchange a CI/CD system's OIDC token for a short-lived Pulumi access token.
+- [Version Control](/docs/integrations/version-control/) — post infrastructure-change summaries on pull requests.
+- [Review Stacks](/docs/deployments/deployments/review-stacks/) — ephemeral per-pull-request environments.
+- [CI/CD troubleshooting](/docs/support/troubleshooting/ci-cd/) — fixes for common failures when running Pulumi in CI/CD.

--- a/content/docs/iac/guides/continuous-delivery/harness.md
+++ b/content/docs/iac/guides/continuous-delivery/harness.md
@@ -189,13 +189,13 @@ spec:
       - "~/.pulumi/plugins"
 ```
 
-On self-managed build infrastructure, use the [`Save Cache`/`Restore Cache` steps](https://developer.harness.io/docs/continuous-integration/use-ci/caching-ci-data/saving-cache/) to store the same directory in an S3 or GCS bucket.
+On self-managed build infrastructure, use the [`Save Cache`/`Restore Cache` steps](https://developer.harness.io/docs/category/share-and-cache-ci-data) to store the same directory in an [S3](https://developer.harness.io/docs/continuous-integration/use-ci/caching-ci-data/saving-cache/) or [GCS](https://developer.harness.io/docs/continuous-integration/use-ci/caching-ci-data/save-cache-in-gcs/) bucket.
 
 The most deterministic option is to bake the plugins into a custom builder image: derive it from `pulumi/pulumi`, `pulumi plugin install` the providers your program uses, and reference that image from the `Run` step instead of `pulumi/pulumi`. See the [plugins documentation](/docs/iac/concepts/plugins/) for details.
 
 ## Report results on pull requests
 
-When the `preview` stage runs `pulumi preview` on a pull request, you'll usually want the proposed changes summarized on the pull request itself rather than buried in the pipeline logs.
+When the `preview` stage runs `pulumi preview` on a pull request, you'll want the proposed changes summarized on the pull request itself rather than buried in the pipeline logs.
 
 Pulumi offers native [version control integrations](/docs/integrations/version-control/) for popular version control systems. Independently of which CI/CD system runs Pulumi, a version control integration lets Pulumi Cloud post infrastructure-change summaries as pull request comments and status checks, and link each stack update back to the commit and pull request that produced it. See the [Version Control](/docs/integrations/version-control/) page for the current list of supported systems.
 


### PR DESCRIPTION
Conforms the Harness CI/CD guide to the epic #19190 standard outline, already applied to the GitHub Actions and CircleCI guides.

## Changes

- Focused intro, shared `{{< cicd-cloud-note >}}` backend note, and a single `## Authenticate with Pulumi Cloud` section (static token + ESC; brief OIDC pointer).
- A trunk-based CI/CD workflow as the centerpiece — one Harness pipeline with PR preview / staging-on-main / production-on-`release-*`-tag.
- Plugin caching, PR reporting via Pulumi's version control integrations, a short Harness-provider section, and a standardized `## Additional resources` section.
- Removes marketing prose, speculative use cases, generic best practices, and the per-page troubleshooting section (-634 lines).

Part of #19190. Fixes #19203.