### PR TITLE
content(onboarding): use relative links and fix style-guide violations

### DIFF
--- a/content/docs/administration/onboarding-guide/choose-subscription.md
+++ b/content/docs/administration/onboarding-guide/choose-subscription.md
@@ -19,14 +19,14 @@ Setting up your Pulumi Cloud account will lay the foundation for onboarding your
 Your subscription tier determines the level of support, training, and features available to your team.
 
 {{%notes type="info"%}}
-Pulumi’s community has grown to hundreds of thousands of practitioners worldwide. Check out the [Pulumi Community](https://www.pulumi.com/community/) to connect!
+Pulumi’s community has grown to hundreds of thousands of practitioners worldwide. Check out the [Pulumi Community](/community/) to connect!
 {{%/notes%}}
 
 ### Individual and Team tiers
 
 Perfect for smaller teams or getting started. Access community support through GitHub [Discussions](https://github.com/pulumi/pulumi/discussions) and [Issues](https://github.com/pulumi/pulumi/issues), [Community Slack](https://slack.pulumi.com), and free workshops.
 
-You can also make use of the [Pulumi Neo](https://www.pulumi.com/product/neo/), detailed documentation in the [Pulumi Registry](https://www.pulumi.com/registry/), and the [examples repo](https://github.com/pulumi/examples) to help you get started.
+You can also make use of the [Pulumi Neo](/product/neo/), detailed documentation in the [Pulumi Registry](/registry/), and the [examples repo](https://github.com/pulumi/examples) to help you get started.
 
 ### Enterprise and Business Critical tiers
 
@@ -40,11 +40,11 @@ Designed for larger organizations with mission-critical workloads. These tiers i
 Access your support through the [support portal](https://support.pulumi.com/hc/en-us) if you're on a premium plan.
 
 {{% notes type="info" %}}
-Learn more about the differences between our subscription tiers [here](https://www.pulumi.com/pricing/)
+Learn more about the differences between [our subscription tiers](/pricing/).
 {{% /notes %}}
 
 {{% notes type="info" %}}
-For hands-on engineering support, consider Pulumi Professional Services. Our team can help design and implement best practices, build custom providers and components, migrate existing infrastructure, and more. We offer standard packages and custom solutions. [Learn more about Professional Services](https://www.pulumi.com/proserv/).
+For hands-on engineering support, consider Pulumi Professional Services. Our team can help design and implement best practices, build custom providers and components, migrate existing infrastructure, and more. We offer standard packages and custom solutions. [Learn more about Professional Services](/proserv/).
 {{% /notes %}}
 
 ## Choose your deployment model
@@ -53,7 +53,7 @@ Pulumi Cloud offers two deployment options, each designed for different organiza
 
 ### SaaS (Recommended for most organizations)
 
-Choose Pulumi Cloud SaaS if you want the simplest setup with enterprise-grade reliability built in. You get high availability, disaster recovery, and geo-replication out of the box, plus security and compliance features detailed in the [Pulumi Cloud Security Whitepaper](https://www.pulumi.com/security/pulumi-cloud-security-whitepaper). Simply sign up at [pulumi.com](http://pulumi.com) to get started.
+Choose Pulumi Cloud SaaS if you want the simplest setup with enterprise-grade reliability built in. You get high availability, disaster recovery, and geo-replication out of the box, plus security and compliance features detailed in the [Pulumi Cloud Security Whitepaper](/security/pulumi-cloud-security-whitepaper). Sign up at [pulumi.com](/) to get started.
 
 ### Self-hosted (For regulated or air-gapped environments)
 
@@ -61,11 +61,11 @@ Choose Pulumi Cloud SaaS if you want the simplest setup with enterprise-grade re
 Self-hosted Pulumi Cloud is only available for Business Critical customers.
 {{% /notes %}}
 
-Choose [self-hosted Pulumi Cloud](https://www.pulumi.com/product/self-hosted/) if you need complete control over your hosting environment. This is ideal for air-gapped environments or customers who require an isolated version of the Pulumi platform. You can deploy anywhere: on-premises, in your cloud account, or any infrastructure you control.
+Choose [self-hosted Pulumi Cloud](/product/self-hosted/) if you need complete control over your hosting environment. This is ideal for air-gapped environments or customers who require an isolated version of the Pulumi platform. You can deploy anywhere: on-premises, in your cloud account, or any infrastructure you control.
 
 {{% notes type="info" %}}
 
-To get started with self-hosted Pulumi Cloud, follow the guides to set up your [state backend](https://www.pulumi.com/docs/iac/concepts/state-and-backends/#logging-into-the-aws-s3-backend) and [self-hosting infrastructure](https://www.pulumi.com/docs/administration/self-hosting/)
+To get started with self-hosted Pulumi Cloud, follow the guides to set up your [state backend](/docs/iac/concepts/state-and-backends/#logging-into-the-aws-s3-backend) and [self-hosting infrastructure](/docs/administration/self-hosting/)
 
 {{% /notes %}}
 
@@ -79,10 +79,10 @@ Pay monthly with a credit card. This option provides flexibility and is ideal fo
 
 ### Annual commitment pricing
 
-Pay upfront with invoicing to access significant cost savings through commitment pricing. This option works well for organizations with predictable usage and established procurement processes. [Contact us](https://www.pulumi.com/contact/) to explore commitment pricing options.
+Pay upfront with invoicing to access significant cost savings through commitment pricing. This option works well for organizations with predictable usage and established procurement processes. [Contact us](/contact/) to explore commitment pricing options.
 
 {{% notes type="info" %}}
-Both billing options include detailed usage insights through the Billing & usage page in your organization settings. Track IaC resources, deployment minutes, ESC secrets, and download usage history. Only organization administrators and designated [billing administrators](https://www.pulumi.com/docs/pulumi-cloud/access-management/billing-managers/) can access these pages. You'll also receive monthly usage reports via email.
+Both billing options include detailed usage insights through the Billing & usage page in your organization settings. Track IaC resources, deployment minutes, ESC secrets, and download usage history. Only organization administrators and designated [billing administrators](/docs/administration/organizations-teams/billing-managers/) can access these pages. You'll also receive monthly usage reports via email.
 {{% /notes %}}
 
 ## Getting started with your chosen model
@@ -95,10 +95,10 @@ If you are using a self-hosted installation of the Pulumi platform, the URLs use
 
 ### Create your account
 
-Sign up using your email address and password, or connect with your GitHub, GitLab, or Atlassian identity at [app.pulumi.com/signup](https://app.pulumi.com/signup). After signup, you can configure SAML/SSO for team onboarding. Learn more about [account management](https://www.pulumi.com/docs/administration/organizations-teams/teams/).
+Sign up using your email address and password, or connect with your GitHub, GitLab, or Atlassian identity at [app.pulumi.com/signup](https://app.pulumi.com/signup). After signup, you can configure SAML/SSO for team onboarding. Learn more about [account management](/docs/administration/organizations-teams/teams/).
 
 ### Explore the console
 
-Access the Pulumi Cloud console through the "Sign In" link at [pulumi.com](https://pulumi.com) or go directly to [app.pulumi.com](https://app.pulumi.com/signin). The dashboard provides useful content and links, while the left navigation gives you access to stacks, resources, and settings. Use the search function to find specific resources, and click the sparkle icon to access Pulumi Neo, your AI agent.
+Access the Pulumi Cloud console through the "Sign In" link at [pulumi.com](/) or go directly to [app.pulumi.com](https://app.pulumi.com/signin). The dashboard provides useful content and links, while the left navigation gives you access to stacks, resources, and settings. Use the search function to find specific resources, and select the sparkle icon to access Pulumi Neo, your AI agent.
 
 {{< get-started-stepper >}}

--- a/content/docs/administration/onboarding-guide/choose-subscription.md
+++ b/content/docs/administration/onboarding-guide/choose-subscription.md
@@ -65,7 +65,7 @@ Choose [self-hosted Pulumi Cloud](/product/self-hosted/) if you need complete co
 
 {{% notes type="info" %}}
 
-To get started with self-hosted Pulumi Cloud, follow the guides to set up your [state backend](/docs/iac/concepts/state-and-backends/#logging-into-the-aws-s3-backend) and [self-hosting infrastructure](/docs/administration/self-hosting/)
+To get started with self-hosted Pulumi Cloud, follow the [self-hosting infrastructure](/docs/administration/self-hosting/) guide. Because Pulumi Cloud isn't yet available to store state during the initial bootstrap process, you'll need a [DIY backend](/docs/iac/guides/basics/using-a-diy-backend/) to manage state for the deployment that stands up the platform.
 
 {{% /notes %}}
 

--- a/content/docs/administration/onboarding-guide/migrating-to-pulumi.md
+++ b/content/docs/administration/onboarding-guide/migrating-to-pulumi.md
@@ -15,13 +15,13 @@ Successfully migrating to Pulumi requires strategic decisions about your migrati
 
 ## Migrating existing infrastructure
 
-If you have existing cloud infrastructure to bring into Pulumi IaC, you have several strategies available.
+If you have existing cloud infrastructure to bring into Pulumi IaC, you have multiple strategies available.
 
 ### Choose your migration approach
 
-**Start fresh:** Simply throw away existing infrastructure and begin anew. This ensures you can adopt all best practices from the outset without technical debt. This option isn't always practical for business-critical services.
+**Start fresh:** Throw away existing infrastructure and begin anew. This ensures you can adopt all best practices from the outset without technical debt. This option isn't always practical for business-critical services.
 
-**Import existing infrastructure:** Pulumi has tools to import any cloud infrastructure regardless of how it was created — even manually through cloud consoles. The [Visual Import](https://www.pulumi.com/docs/insights/import/) feature is the recommended approach for importing resources. However, Pulumi also offers tailored migration tools for Terraform, AWS CloudFormation/CDK, Azure ARM, and Kubernetes YAML. These tools generate Pulumi IaC code in your chosen language and actively place existing resource management under Pulumi IaC, swapping out management without disrupting resources for zero downtime.
+**Import existing infrastructure:** Pulumi has tools to import any cloud infrastructure — including resources created manually through cloud consoles. The [Visual Import](/docs/insights/discovery/visual-import/) feature is the recommended approach for importing resources. However, Pulumi also offers tailored migration tools for Terraform, AWS CloudFormation/CDK, Azure ARM, and Kubernetes YAML. These tools generate Pulumi IaC code in your chosen language and actively place existing resource management under Pulumi IaC, swapping out management without disrupting resources for zero downtime.
 
 **Coexist and migrate incrementally:** Pulumi supports coexisting with existing ecosystems. You can deploy Helm charts as-is or consume Terraform workspace outputs. This enables incremental migration over time when the value is right.
 
@@ -29,7 +29,7 @@ If you have existing cloud infrastructure to bring into Pulumi IaC, you have sev
 
 {{% notes type="info" %}}
 
-Learn more at the [Pulumi Migration Hub](https://www.pulumi.com/docs/iac/adopting-pulumi/migrating-to-pulumi/) or [detailed migration tooling documentation](https://www.pulumi.com/docs/iac/adopting-pulumi/).
+Learn more at the [Pulumi Migration Hub](/docs/iac/guides/migration/) or [detailed migration tooling documentation](/docs/iac/guides/migration/).
 
 {{%/notes%}}
 
@@ -51,7 +51,7 @@ These workloads should be automated with CI/CD pipelines and use as many best pr
 
 ### Stay focused on impact
 
-**Take a "workload-first" strategy:** Rather than creating dozens of abstractly-useful components, inform specific component requirements from real-world applications emerging from your beachhead win.
+**Take a "workload-first" strategy:** Rather than creating dozens of abstractly useful components, inform specific component requirements from real-world applications emerging from your beachhead win.
 
 **Resist the redesign temptation:** Don't conflate redesigning projects with new cloud architectures and platform migration. This adds risk. Get workloads onto Pulumi first, then refactor and redesign in place.
 
@@ -60,13 +60,13 @@ These workloads should be automated with CI/CD pipelines and use as many best pr
 An internal cloud platform is a product requiring superb developer experiences. While self-service is the primary goal, it's a journey. Start by:
 
 - Getting your platform well-architected
-- Documenting components and templates. You can use [Pulumi Cloud IDP](https://www.pulumi.com/product/internal-developer-platforms/) to provide user visibility and access to your templates and components.
+- Documenting components and templates. You can use [Pulumi Cloud IDP](/product/internal-developer-platforms/) to provide user visibility and access to your templates and components.
 - Instituting an internal open source strategy for collaboration
 - Building comprehensive platform capabilities over time
 
 ### Don't defer security
 
-Use this moment of change to build security into your platform from day one. Implement Pulumi IaC's Policy as Code features and short-lived cloud credentials with [Pulumi ESC and OIDC](https://www.pulumi.com/docs/esc/integrations/dynamic-login-credentials/). Teams that build up technical debt in this area face costly implications later.
+Use this moment of change to build security into your platform from day one. Implement Pulumi IaC's Policy as Code features and short-lived cloud credentials with [Pulumi ESC and OIDC](/docs/esc/integrations/dynamic-login-credentials/). Teams that build up technical debt in this area face costly implications later.
 
 ### Measure your success
 

--- a/content/docs/administration/onboarding-guide/migrating-to-pulumi.md
+++ b/content/docs/administration/onboarding-guide/migrating-to-pulumi.md
@@ -29,7 +29,7 @@ If you have existing cloud infrastructure to bring into Pulumi IaC, you have mul
 
 {{% notes type="info" %}}
 
-Learn more at the [Pulumi Migration Hub](/docs/iac/guides/migration/) or [detailed migration tooling documentation](/docs/iac/guides/migration/).
+Learn more in the [migration guide](/docs/iac/guides/migration/).
 
 {{%/notes%}}
 

--- a/content/docs/administration/onboarding-guide/setting-up-for-success.md
+++ b/content/docs/administration/onboarding-guide/setting-up-for-success.md
@@ -15,25 +15,25 @@ Before creating projects and shipping to the cloud, make key decisions that will
 
 ## Secure your infrastructure from day one
 
-Security is a team effort that's best established from the outset. Pulumi Cloud makes it easy to adopt security best practices during team onboarding.
+Security is a team effort that's best established from the outset. Pulumi Cloud helps your team adopt security best practices during onboarding.
 
 ### Choose your compliance approach
 
-Modern enterprises face rigorous compliance requirements. Pulumi Cloud is SOC 2 Type II certified and AWS-reviewed for compliance best practices. The infrastructure hosting Pulumi Cloud aligns with IT security standards including SOC 1/SSAE 16/ISAE 3402, SOC 2, SOC 3, FISMA, FedRAMP, DOD SRG Levels 2 and 4, PCI DSS Level 1, EU Model Clauses, ISO 9001/27001/27017/27018, ITAR, IRAP, FIPS 140-2, MLPS Level 3, and MTCS. Learn more at [Pulumi Security](https://www.pulumi.com/security/).
+Modern enterprises face rigorous compliance requirements. Pulumi Cloud is SOC 2 Type II certified and AWS-reviewed for compliance best practices. The infrastructure hosting Pulumi Cloud aligns with IT security standards including SOC 1/SSAE 16/ISAE 3402, SOC 2, SOC 3, FISMA, FedRAMP, DOD SRG Levels 2 and 4, PCI DSS Level 1, EU Model Clauses, ISO 9001/27001/27017/27018, ITAR, IRAP, FIPS 140-2, MLPS Level 3, and MTCS. Learn more at [Pulumi Security](/security/).
 
-Use Pulumi's Policy as Code engine, [Pulumi Policies](https://www.pulumi.com/docs/insights/policy/), to enforce compliant infrastructure practices. Pulumi Policies includes hundreds of out-of-the-box policies for AWS, Azure, Google Cloud, and Kubernetes, spanning CIS, HITRUST, NIST, and PCI DSS. You can also write custom policies for your specific industry or enterprise requirements.
+Use Pulumi's Policy as Code engine, [Pulumi Policies](/docs/insights/policy/), to enforce compliant infrastructure practices. Pulumi Policies includes hundreds of out-of-the-box policies for AWS, Azure, Google Cloud, and Kubernetes, spanning CIS, HITRUST, NIST, and PCI DSS. You can also write custom policies for your specific industry or enterprise requirements.
 
-Pulumi Policies identifies issues in existing cloud infrastructure and prevents new problems from being introduced. Configure it at various warning and error levels, and apply it flexibly across projects—for example, GDPR rules might only apply to infrastructure in European regions. Pulumi Policies also features automatic remediations.
+Pulumi Policies identifies issues in existing cloud infrastructure and prevents new problems from being introduced. Configure it at warning or error levels, and apply it flexibly across projects—for example, GDPR rules might only apply to infrastructure in European regions. Pulumi Policies also features automatic remediations.
 
 Pulumi Cloud maintains an audit log of every activity and who performed it for complete visibility.
 
 ### Select your cloud authentication method
 
-Pulumi supports hundreds of cloud providers, though most organizations use AWS, Azure, Google Cloud, and Kubernetes. Other supported providers include SaaS infrastructure products like Cloudflare, DataDog, MongoDB, and Snowflake, plus on-premises technologies like VMware vSphere. Find the complete list in the [Pulumi Registry](https://pulumi.com/registry), your one-stop shop for provider documentation and configuration guidance.
+Pulumi supports hundreds of cloud providers, though most organizations use AWS, Azure, Google Cloud, and Kubernetes. Other supported providers include SaaS infrastructure products like Cloudflare, DataDog, MongoDB, and Snowflake, plus on-premises technologies like VMware vSphere. Find the complete list in the [Pulumi Registry](/registry/), your one-stop shop for provider documentation and configuration guidance.
 
-**Recommended approach:** Use Pulumi ESC's OpenID Connect (OIDC) support for [dynamic, short-lived credentials](https://www.pulumi.com/docs/esc/integrations/dynamic-login-credentials/). This is the most secure method and should be preferred for supported providers.
+**Recommended approach:** Use Pulumi ESC's OpenID Connect (OIDC) support for [dynamic, short-lived credentials](/docs/esc/integrations/dynamic-login-credentials/). This is the most secure method and should be preferred for supported providers.
 
-**Alternative approach:** If your chosen cloud lacks Pulumi ESC OIDC support, consult the registry documentation. Each provider has an "Install & config" section with authentication guidance. See [AWS Installation & Configuration](https://www.pulumi.com/docs/esc/integrations/dynamic-login-credentials/) as an example. Pulumi uses native tools and techniques for authentication, keeping it consistent with your existing usage patterns.
+**Alternative approach:** If your chosen cloud lacks Pulumi ESC OIDC support, consult the registry documentation. Each provider has an "Install & config" section with authentication guidance. See [AWS Installation & Configuration](/docs/esc/integrations/dynamic-login-credentials/) as an example. Pulumi uses native tools and techniques for authentication, keeping it consistent with your existing usage patterns.
 
 ## Test your infrastructure code
 
@@ -43,17 +43,17 @@ Infrastructure as code is code and should be tested. This yields more predictabl
 
 Implement a three-tier testing approach:
 
-**Unit tests** test targeted functionality without deploying actual cloud infrastructure. These are part of your inner development loop and run quickly. Pulumi makes it easy to mock cloud capabilities for this testing.
+**Unit tests** test targeted functionality without deploying actual cloud infrastructure. These are part of your inner development loop and run quickly. Pulumi provides built-in mocking of cloud capabilities for these tests.
 
 **Policy as Code** acts as a form of testing that blocks deployments failing to meet predetermined policies. This was covered in your security decisions above.
 
-**Integration tests** coordinate with actual Pulumi deployments to verify that real infrastructure is provisioned to specification.
+**Integration tests** run real deployments with Pulumi to verify that infrastructure is provisioned to specification.
 
 ### Consider advanced testing techniques
 
 Build sophisticated test strategies on this foundation. Options include fuzz testing to verify your infrastructure configurations react correctly to varying inputs, or chaos testing that destroys infrastructure components to test system responses.
 
-Also consider using linters and static analysis tools to enforce industry standards and your team's coding guidelines. See the [Testing Pulumi programs guide](https://www.pulumi.com/docs/iac/guides/testing/) for more details.
+Also consider using linters and static analysis tools to enforce industry standards and your team's coding guidelines. See the [Testing Pulumi programs guide](/docs/iac/guides/testing/) for more details.
 
 ## Share and reuse code effectively
 
@@ -61,11 +61,11 @@ Pulumi projects, stacks, and environments help reduce "sprawl"—the copy-and-pa
 
 ### Choose your abstraction level
 
-**[Components](https://www.pulumi.com/docs/iac/concepts/components/)** are IaC resources you define to abstract and encapsulate one or more other resources. For example, an AWS Virtual Private Cloud (VPC) might consist of dozens of resources: public and private subnets, Internet and NAT Gateways, the VPC itself, and more. Rather than coding the VPC definition in every project—potentially hundreds or thousands of lines of code—use a component. The Pulumi AWSX package offers a VPC component out of the box, but you can create your own by subclassing the component resource base class.
+**[Components](/docs/iac/concepts/components/)** are IaC resources you define to abstract and encapsulate one or more other resources. For example, an AWS Virtual Private Cloud (VPC) might consist of dozens of resources: public and private subnets, internet gateways, NAT gateways, the VPC itself, and more. Rather than coding the VPC definition in every project—potentially hundreds or thousands of lines of code—use a component. The Pulumi AWSX package offers a VPC component out of the box, but you can create your own by subclassing the component resource base class.
 
 Components provide all the benefits of native language packages: storage in package managers, versioning, secure dependencies, and more.
 
-**[Templates](https://www.pulumi.com/docs/idp/concepts/organization-templates/)** are blueprints that scaffold entirely new projects. While components encapsulate cloud resource usage patterns, templates provide standard starting points for complete projects with many resources. [Pulumi offers templates](https://www.pulumi.com/templates/) for common architectures and patterns, but you can create your own. You can also register your organization's templates in the Pulumi Cloud New Project Wizard for easy access.
+**[Templates](/docs/idp/concepts/organization-templates/)** are blueprints that scaffold entirely new projects. While components encapsulate cloud resource usage patterns, templates provide standard starting points for complete projects with many resources. [Pulumi offers templates](/templates/) for common architectures and patterns, but you can create your own. You can also register your organization's templates in the Pulumi Cloud New Project Wizard for convenient access.
 
 ### Make the decision
 

--- a/content/docs/administration/onboarding-guide/ways-of-working.md
+++ b/content/docs/administration/onboarding-guide/ways-of-working.md
@@ -21,7 +21,7 @@ Pulumi's project model is intentionally flexible to support many different archi
 
 Both Pulumi IaC and Pulumi ESC have a notion of **project**—an abstract concept defining a collection of related configurations. Pulumi IaC projects have any number of **stacks** (instances of that project), while Pulumi ESC projects have **environments** (groups of related secrets and configuration).
 
-Think of an IaC project like a Git repository and a stack like a Git branch. Just as teams structure Git repos differently—some prefer monolithic repos while others prefer smaller, single-purpose repos—you can structure Pulumi projects in various ways.
+Think of an IaC project like a Git repository and a stack like a Git branch. Teams structure Git repos differently—some prefer monolithic repos while others prefer smaller, single-purpose repos—and you can structure Pulumi projects with the same flexibility.
 
 ### Choosing your project architecture
 
@@ -47,13 +47,13 @@ Each IaC project has its own set of stacks, so you may want ESC environments rep
 
 {{% notes type="info" %}}
 
-Learn more about [organizing projects and stacks](https://www.pulumi.com/docs/using-pulumi/organizing-projects-stacks/) here.
+Learn more about [organizing projects and stacks](/docs/iac/guides/basics/organizing-projects-stacks/) here.
 
 {{%/notes%}}
 
 ### Deciding on a language strategy
 
-Pulumi's polyglot nature supports the top programming languages: Python, Go, Node.js languages (JavaScript, TypeScript), .NET languages (C#, F#), JVM languages (Java, Groovy, Scala, Clojure), and YAML for simple use cases. [Learn more about language support](https://www.pulumi.com/docs/languages-sdks/).
+Pulumi's polyglot nature supports the top programming languages: Python, Go, Node.js languages (JavaScript, TypeScript), .NET languages (C#, F#), JVM languages (Java, Groovy, Scala, Clojure), and YAML for declarative use cases. [Learn more about language support](/docs/iac/languages-sdks/).
 
 You have two main options:
 
@@ -61,7 +61,7 @@ You have two main options:
 This approach makes it easier to standardize on tools, patterns, and practices, and to train your team. Choose the language your team already uses to leverage existing standards.
 
 **Multi-language (common in large organizations)**
-While offering flexibility, this approach risks fragmentation between teams using different languages. Pulumi addresses this through consistent experiences across languages in Pulumi Cloud and Pulumi Policies, plus [Pulumi Packages](https://www.pulumi.com/docs/iac/guides/packages/) that let you author packages in one language and consume them in another.
+While offering flexibility, this approach risks fragmentation between teams using different languages. Pulumi addresses this through consistent experiences across languages in Pulumi Cloud and Pulumi Policies, plus [Pulumi Packages](/docs/iac/concepts/packages/) that let you author packages in one language and consume them in another.
 
 ## Organizing people for collaboration
 
@@ -75,26 +75,26 @@ Organizations and their capabilities are a paid feature of Pulumi Cloud. Creatin
 
 ### Creating teams
 
-Teams are groups of individual users that typically reflect your company's structure or working groups. By organizing members into teams, you can control which projects, stacks, and environments they can access, and with what permissions, through role-based access control (RBAC). Teams and roles change frequently, so Pulumi Cloud makes it easy to reconfigure teams or automatically sync with your identity provider. [Learn more about teams](https://www.pulumi.com/docs/administration/organizations-teams/teams/).
+Teams are groups of individual users that typically reflect your company's structure or working groups. By organizing members into teams, you can control which projects, stacks, and environments they can access, and with what permissions, through role-based access control (RBAC). Teams and roles change frequently, so Pulumi Cloud lets you reconfigure teams or automatically sync with your identity provider. [Learn more about teams](/docs/administration/organizations-teams/teams/).
 
 ### Configuring Single Sign-On (SSO)
 
-Many organizations prefer to use Single Sign-On (SSO) with identity providers like Microsoft Entra ID, Google Workspace, Okta, or any SAML 2.0 compliant provider. If you have SSO with System for Cross-domain Identity Management (SCIM) enabled, onboarding and offboarding happen automatically. Otherwise, you can continue using email, GitHub, GitLab, or Atlassian identity. [Learn about configuring SSO](https://www.pulumi.com/docs/administration/access-identity/saml/).
+Many organizations prefer to use Single Sign-On (SSO) with identity providers like Microsoft Entra ID, Google Workspace, Okta, or any SAML 2.0 compliant provider. If you have SSO with System for Cross-domain Identity Management (SCIM) enabled, your team is onboarded and offboarded automatically. Otherwise, you can continue using email, GitHub, GitLab, or Atlassian identity. [Learn about configuring SSO](/docs/administration/access-identity/saml/).
 
-Once you've completed the setup steps, you're ready to invite your team. Refer to [Inviting members to an organization](https://www.pulumi.com/docs/administration/organizations-teams/organizations/#inviting-members-to-an-organization) for detailed instructions.
+Once you've completed the setup steps, you're ready to invite your team. Refer to [Inviting members to an organization](/docs/administration/organizations-teams/organizations/#inviting-members-to-an-organization) for detailed instructions.
 
 ### Creating productive developer experiences
 
-It's common to give developers their own stacks for development and testing. Pulumi's projects and stacks model makes this easy and leads to fast, productive experiences.
+It's common to give developers their own stacks for development and testing. Pulumi's projects and stacks model is built for this and leads to fast, productive experiences.
 
 **Developer stack patterns:**
 
 - **Individual developer stacks**: Each developer gets their own complete environment
 - **Shared infrastructure**: Developers share costly resources like databases while having their own application instances
-- **[Review stacks](https://www.pulumi.com/docs/deployments/deployments/review-stacks/)**: Short-lived stacks for each pull request that are automatically torn down
-- **[TTL stacks](https://www.pulumi.com/docs/deployments/deployments/ttl/)**: Automatically destroyed after a specified timeframe to prevent cloud waste
+- **[Review stacks](/docs/deployments/deployments/review-stacks/)**: Short-lived stacks for each pull request that are automatically torn down
+- **[TTL stacks](/docs/deployments/deployments/ttl/)**: Automatically destroyed after a specified timeframe to prevent cloud waste
 
-Use [stack references](https://www.pulumi.com/blog/iac-recommended-practices-using-stack-references/) to factor out shared infrastructure and create flexible project architectures.
+Use [stack references](/blog/iac-best-practices-applying-stack-references/) to factor out shared infrastructure and create flexible project architectures.
 
 ### Enabling developer self-service
 
@@ -104,16 +104,16 @@ Platform engineering teams often want to enable application and backend develope
 Developers interface with Pulumi directly, typically using separate teams with different RBAC settings. Use components, templates, and policies to enforce guardrails while providing simpler starting points.
 
 **2. YAML interface**
-Developers check in YAML files to a Git repository and let CI/CD handle the rest. Write components, templates, and policies with simple interfaces conducive to YAML usage. [Learn more about Pulumi YAML](https://www.pulumi.com/docs/languages-sdks/yaml/).
+Developers check in YAML files to a Git repository and let CI/CD handle the rest. Write components, templates, and policies with interfaces conducive to YAML usage. [Learn more about Pulumi YAML](/docs/iac/languages-sdks/yaml/).
 
 **3. UI-based experience**
-Developers log into a portal and click buttons to provision infrastructure. Options include:
+Developers log into a portal and provision infrastructure through a graphical interface. Options include:
 
-- [Pulumi IDP](https://www.pulumi.com/docs/idp/)
-- [Pulumi's Backstage plugin](https://www.pulumi.com/blog/pulumi-backstage-plugin/)
-- Custom portals powered by [Pulumi's Automation API](https://www.pulumi.com/docs/using-pulumi/automation-api/)
+- [Pulumi IDP](/docs/idp/)
+- [Pulumi's Backstage plugin](/blog/pulumi-backstage-plugin/)
+- Custom portals powered by [Pulumi's Automation API](/docs/iac/automation-api/)
 
-[Learn more about building developer portals](https://www.pulumi.com/docs/idp/concepts/).
+[Learn more about building developer portals](/docs/idp/concepts/).
 
 ## Working together on deployments
 
@@ -125,24 +125,24 @@ While most teams start by running the Pulumi CLI manually, you'll eventually wan
 
 **CI/CD platform options:**
 
-- **[Pulumi Deployments](https://www.pulumi.com/docs/deployments/deployments/)** (recommended): Purpose-built for IaC deployments and integrated into Pulumi Cloud
-- **[Pulumi Kubernetes Operator](https://www.pulumi.com/docs/integrations/clouds/kubernetes/pulumi-kubernetes-operator/)**: Trigger deployments from within Kubernetes clusters
-- **Existing CI/CD solutions**: GitHub Actions, GitLab CI, Octopus Deploy, and [many others](https://www.pulumi.com/docs/using-pulumi/continuous-delivery/)
+- **[Pulumi Deployments](/docs/deployments/deployments/)** (recommended): Purpose-built for IaC deployments and integrated into Pulumi Cloud
+- **[Pulumi Kubernetes Operator](/docs/integrations/clouds/kubernetes/pulumi-kubernetes-operator/)**: Trigger deployments from within Kubernetes clusters
+- **Existing CI/CD solutions**: GitHub Actions, GitLab CI, Octopus Deploy, and [many others](/docs/iac/guides/continuous-delivery/)
 
 **GitHub users**: Install the [Pulumi GitHub App](/docs/integrations/version-control/github-app/) for instant GitOps workflow support, including deployment previews in pull requests.
 
-**GitLab users**: Use the [Pulumi GitLab Integration](https://www.pulumi.com/docs/integrations/version-control/gitlab/) to set up Pipelines and Webhooks for GitLab CI/CD.
+**GitLab users**: Use the [Pulumi GitLab Integration](/docs/integrations/version-control/gitlab/) to set up Pipelines and Webhooks for GitLab CI/CD.
 
 **Setting up CI/CD:**
 
 1. Choose your platform
 2. Define your branching strategy (e.g., does main map to production?)
 3. Configure your pipelines and testing strategies
-4. Set up [Pulumi Cloud access tokens](https://www.pulumi.com/docs/administration/access-identity/access-tokens/) for automation
+4. Set up [Pulumi Cloud access tokens](/docs/administration/access-identity/access-tokens/) for automation
 
 ### Guarding against drift
 
-Drift occurs when changes happen outside your IaC pipeline, causing conflicts between your last known deployment and your cloud resources' current state. This can cause security issues or outages during your next deployment. Pulumi supports [detecting and remediating drift](https://www.pulumi.com/docs/deployments/deployments/drift).
+Drift occurs when changes happen outside your IaC pipeline, causing conflicts between your last known deployment and your cloud resources' current state. This can cause security issues or outages during your next deployment. Pulumi supports [detecting and remediating drift](/docs/deployments/deployments/drift).
 
 ## Integrating with and extending Pulumi
 
@@ -150,26 +150,26 @@ Pulumi was built with extensibility in mind, following a "building blocks" philo
 
 ### Extending Pulumi with custom workflows
 
-**[Pulumi Cloud REST API](https://www.pulumi.com/docs/pulumi-cloud/cloud-rest-api/)**
+**[Pulumi Cloud REST API](/docs/reference/cloud-rest-api/)**
 The well-documented, powerful API that powers the CLI and cloud console experiences.
 
-**[Pulumi Automation API](https://www.pulumi.com/docs/using-pulumi/automation-api/)**
+**[Pulumi Automation API](/docs/iac/automation-api/)**
 Embed IaC capabilities into any software, enabling custom tools, self-serve portals, complex deployment orchestrations, and even SaaS products that provision cloud resources.
 
-**[Pulumi Cloud Webhooks](https://www.pulumi.com/docs/deployments/webhooks/)**
+**[Pulumi Cloud Webhooks](/docs/deployments/webhooks/)**
 React to lifecycle events in Pulumi Cloud by invoking custom REST API endpoints. Use these for posting to Slack channels, triggering test runs after deployments, and more.
 
 ### Writing your own IaC providers
 
 Pulumi supports hundreds of providers out of the box, but you can extend it further:
 
-**[Custom providers](https://www.pulumi.com/docs/iac/packages-and-automation/pulumi-packages/authoring/)**
+**[Custom providers](/docs/iac/guides/building-extending/packages/publishing-packages/)**
 Create providers for new or internal systems where neither Terraform nor Pulumi providers exist. This involves creating resource schemas and CRUD operations.
 
-**[Terraform provider bridging](https://www.pulumi.com/blog/any-terraform-provider/)**
+**[Terraform provider bridging](/blog/any-terraform-provider/)**
 Bridge any Terraform provider at development time to use it from Pulumi IaC programs.
 
-**[Dynamic providers](https://www.pulumi.com/docs/iac/concepts/providers/dynamic-providers/)**
+**[Dynamic providers](/docs/iac/concepts/providers/dynamic-providers/)**
 Write CRUD logic inline in your Pulumi IaC program without building a separate provider.
 
 ### Contributing to open source


### PR DESCRIPTION
Fixes #19329.

The Onboarding Guide pages used absolute `https://www.pulumi.com/...` URLs for links that point back into the same site, violating the `AGENTS.md` link-style convention.

## Changes

- Converted **51 absolute `pulumi.com` links** to site-relative paths across `choose-subscription`, `setting-up-for-success`, `migrating-to-pulumi`, and `ways-of-working`. External `app.pulumi.com` links are correctly left absolute.
- Updated **12 stale aliased paths** to their canonical form (e.g. `/docs/using-pulumi/continuous-delivery/` → `/docs/iac/guides/continuous-delivery/`); each target was verified to resolve to a real content file.
- Fixed the **style-guide violations** Vale flags across the guide: difficulty qualifiers ("easy", "simply", "simple", "just"), weasel words, `click`→`select`, a missing Oxford comma, an ly-adverb hyphen, and vague `[here]` link text.

Vale and `make lint` are both clean on all four files.