### PR TITLE
Update docs on failed hooks

### DIFF
--- a/content/docs/iac/concepts/resources/options/hooks.md
+++ b/content/docs/iac/concepts/resources/options/hooks.md
@@ -29,7 +29,7 @@ Each hook is a callback that gets invoked by the Pulumi engine. Hooks that execu
 
 * *Delete hooks* are called before or after a resource is deleted. This may occur during the deletion of a resource due to a `destroy` or that resource's removal from the program, or as part of a resource replacement due to e.g. a change in an immutable property.
 
-When a hook is executed as part of a resource operation, it receives the resource's [URN](/docs/iac/concepts/resources/names/#urns) and ID, as well as any relevant input and output properties. Hooks may return errors. If a before hook returns an error, the action it precedes will *not* be executed and the Pulumi operation will fail with that error. If an after hook returns an error, the underlying resource operation has already completed and is recorded in the state, but the deployment is then failed. To opt out of this behavior and instead log a warning and continue, set the `ignoreErrors` option on the hook (see [Ignoring hook errors](#ignoring-hook-errors) below). The table below illustrates the combinations of inputs, outputs, and error behaviors for each hook type:
+When a hook is executed as part of a resource operation, it receives the resource's [URN](/docs/iac/concepts/resources/names/#urns) and ID, as well as any relevant input and output properties. Hooks may return errors. If a before hook returns an error, the action it precedes will *not* be executed and the Pulumi operation will fail with that error. If an after hook returns an error, the underlying resource operation has already completed and is recorded in the state, but the deployment is then failed. To opt out of this behavior and instead log a warning and continue, set the [`ignoreErrors`](#ignoring-hook-errors) option on the hook. The table below illustrates the combinations of inputs, outputs, and error behaviors for each hook type:
 
 | Hook type     | Old inputs | New inputs | Old outputs | New outputs | Error behavior                                 |
 |---------------|------------|------------|-------------|-------------|------------------------------------------------|
@@ -508,7 +508,7 @@ nohup python3 -m http.server 80 &";
 
 By default, when any hook (before or after) returns an error, the Pulumi deployment fails. For after hooks, the underlying resource operation has already succeeded by the time the hook runs, so its result is recorded in the state before the deployment is failed.
 
-If a hook failure should not be treated as, set the `ignoreErrors` option when constructing the hook. Errors from that hook will then be logged as warnings and the deployment will continue.
+If a hook failure should not be treated as fatal — for example, a best-effort notification or audit step — set the `ignoreErrors` option when constructing the hook. Errors from that hook will then be logged as warnings and the deployment will continue.
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
@@ -616,7 +616,7 @@ var notifyHook = new ResourceHook(
 
 {{< /chooser >}}
 
-To keep applying other resources after a hook failure on a single update, you can also run `pulumi up` (or `pulumi destroy`) with the `--continue-on-error` flag. This applies to the whole deployment, not just hooks.
+To keep applying other resources after a hook failure on a single update, you can also run `pulumi up` (or `pulumi destroy`) with the `--continue-on-error` flag. This applies to the whole deployment, not only to hooks.
 
 ## Deletions and delete hooks
 

--- a/content/docs/iac/concepts/resources/options/hooks.md
+++ b/content/docs/iac/concepts/resources/options/hooks.md
@@ -29,16 +29,20 @@ Each hook is a callback that gets invoked by the Pulumi engine. Hooks that execu
 
 * *Delete hooks* are called before or after a resource is deleted. This may occur during the deletion of a resource due to a `destroy` or that resource's removal from the program, or as part of a resource replacement due to e.g. a change in an immutable property.
 
-When a hook is executed as part of a resource operation, it receives the resource's [URN](/docs/iac/concepts/resources/names/#urns) and ID, as well as any relevant input and output properties. Hooks may return errors. If a before hook returns an error, the action it precedes will *not* be executed and the Pulumi operation will fail with that error. If an after hook returns an error, Pulumi will log a warning diagnostic and the Pulumi operation will continue. The table below illustrates the combinations of inputs, outputs, and error behaviors for each hook type:
+When a hook is executed as part of a resource operation, it receives the resource's [URN](/docs/iac/concepts/resources/names/#urns) and ID, as well as any relevant input and output properties. Hooks may return errors. If a before hook returns an error, the action it precedes will *not* be executed and the Pulumi operation will fail with that error. If an after hook returns an error, the underlying resource operation has already completed and is recorded in the state, but the deployment is then failed. To opt out of this behavior and instead log a warning and continue, set the `ignoreErrors` option on the hook (see [Ignoring hook errors](#ignoring-hook-errors) below). The table below illustrates the combinations of inputs, outputs, and error behaviors for each hook type:
 
-| Hook type     | Old inputs | New inputs | Old outputs | New outputs | Error behavior                    |
-|---------------|------------|------------|-------------|-------------|-----------------------------------|
-| Before create |            | ✓          |             |             | Prevent creation, fail deployment |
-| After create  |            | ✓          |             | ✓           | Log warning, continue deployment  |
-| Before update | ✓          | ✓          | ✓           |             | Prevent update, fail deployment   |
-| After update  | ✓          | ✓          | ✓           | ✓           | Log warning, continue deployment  |
-| Before delete | ✓          |            | ✓           |             | Prevent deletion, fail deployment |
-| After delete  | ✓          |            | ✓           |             | Log warning, continue deployment  |
+| Hook type     | Old inputs | New inputs | Old outputs | New outputs | Error behavior                                 |
+|---------------|------------|------------|-------------|-------------|------------------------------------------------|
+| Before create |            | ✓          |             |             | Prevent creation, fail deployment              |
+| After create  |            | ✓          |             | ✓           | Record resource in state, then fail deployment |
+| Before update | ✓          | ✓          | ✓           |             | Prevent update, fail deployment                |
+| After update  | ✓          | ✓          | ✓           | ✓           | Record update in state, then fail deployment   |
+| Before delete | ✓          |            | ✓           |             | Prevent deletion, fail deployment              |
+| After delete  | ✓          |            | ✓           |             | Record deletion in state, then fail deployment |
+
+{{% notes type="info" %}}
+Before Pulumi v3.238.0, after hooks that returned an error logged a warning and the deployment continued. Starting with v3.238.0, an after-hook failure fails the deployment by default. Use the `ignoreErrors` hook option to restore the previous behavior, or pass `--continue-on-error` to `pulumi up`/`pulumi destroy` to keep processing other resources after a hook failure.
+{{% /notes %}}
 
 ## Health checking example
 
@@ -499,6 +503,120 @@ nohup python3 -m http.server 80 &";
 {{% /choosable %}}
 
 {{< /chooser >}}
+
+## Ignoring hook errors
+
+By default, when any hook (before or after) returns an error, the Pulumi deployment fails. For after hooks, the underlying resource operation has already succeeded by the time the hook runs, so its result is recorded in the state before the deployment is failed.
+
+If a hook failure should not be treated as, set the `ignoreErrors` option when constructing the hook. Errors from that hook will then be logged as warnings and the deployment will continue.
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+const notifyHook = new pulumi.ResourceHook("notify", async args => {
+    // Best-effort notification. Failures here should not fail the deployment.
+    await sendNotification(args);
+}, {
+    ignoreErrors: true,
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+import pulumi
+
+
+def notify(args: pulumi.ResourceHookArgs):
+    # Best-effort notification. Failures here should not fail the deployment.
+    send_notification(args)
+
+
+notify_hook = pulumi.ResourceHook(
+    "notify",
+    notify,
+    opts=pulumi.ResourceHookOptions(ignore_errors=True),
+)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+    pulumi.Run(func(ctx *pulumi.Context) error {
+        _, err := ctx.RegisterResourceHook(
+            "notify",
+            func(args *pulumi.ResourceHookArgs) error {
+                // Best-effort notification. Failures here should not fail the deployment.
+                return sendNotification(args)
+            },
+            &pulumi.ResourceHookOptions{
+                IgnoreErrors: true,
+            },
+        )
+        if err != nil {
+            return err
+        }
+        return nil
+    })
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+using Pulumi;
+
+var notifyHook = new ResourceHook(
+    "notify",
+    async (args, cancellationToken) =>
+    {
+        // Best-effort notification. Failures here should not fail the deployment.
+        await SendNotificationAsync(args, cancellationToken);
+    },
+    new ResourceHookOptions
+    {
+        IgnoreErrors = true,
+    });
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+// Pulumi Java does not support resource hooks
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+# Pulumi YAML does not support resource hooks
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+To keep applying other resources after a hook failure on a single update, you can also run `pulumi up` (or `pulumi destroy`) with the `--continue-on-error` flag. This applies to the whole deployment, not just hooks.
 
 ## Deletions and delete hooks
 


### PR DESCRIPTION
This updates the after-* hook docs to reflect the change in behavior from https://github.com/pulumi/pulumi/pull/22935. We changed how the engine reacts to failing hooks, and we need to make the commensurate change to our documentation. 