### PR TITLE
Fix mobile TOC accordion stuck open

### DIFF
--- a/layouts/partials/docs/table-of-contents.html
+++ b/layouts/partials/docs/table-of-contents.html
@@ -24,7 +24,7 @@
                         <div class="icon icon-18-18 expand-more-18-18"></div>
                     </div>
                 </label>
-                <div class="accordion-content flex">
+                <div class="accordion-content">
                     <div class="content">
                         <ul class="table-of-contents-list">
                             {{/* This will be populated dynamically with all H2s and H3s on the page; see ts/misc.ts */}}


### PR DESCRIPTION
**Generated description of changes:**

### Proposed changes

The accordion-content div in the docs table-of-contents partial had a Tailwind `.flex` utility class that won out over the `display: none` rule from `docs/_docs-main.scss` (imported inside `@layer components`), preventing `#accordion-table-of-contents` from collapsing on mobile. Dropping the `flex` class lets the SCSS cascade control show/hide again.