### PR TITLE
Add optional link label to release intro card

### DIFF
--- a/content/releases/agentic-infrastructure-era.md
+++ b/content/releases/agentic-infrastructure-era.md
@@ -26,6 +26,7 @@ intro:
   attribution: |
     — Joe Duffy, co-founder and CEO, on the increasing pace at which teams are adopting AI-driven infrastructure
   link: /blog/the-agentic-infrastructure-era/
+  link_label: Read the blog post
 
 toc_heading: What's New in This Release
 

--- a/layouts/partials/releases/card-text-block.html
+++ b/layouts/partials/releases/card-text-block.html
@@ -35,7 +35,7 @@
     <div class="text-base text-service-black leading-6">
         {{ . | markdownify }}
         {{ if $isLinked }}
-        <span class="inline-flex items-center text-violet-primary ml-1 align-middle">
+        <span class="inline-flex items-center text-violet-primary ml-1 align-middle -mt-1">
             {{ partial "icon.html" (dict "name" "arrow-right" "weight" "bold" "class" "size-4") }}
         </span>
         {{ end }}

--- a/layouts/partials/releases/intro-toc-row.html
+++ b/layouts/partials/releases/intro-toc-row.html
@@ -15,6 +15,7 @@
     {{/* Intro / quote card */}}
     {{ with $intro }}
         {{ $hasLink := .link }}
+        {{ $hasLinkLabel := .link_label }}
         {{ $introClasses := "card bg-white p-8 lg:p-10 flex flex-col gap-6 no-underline hover:no-underline h-full" }}
         {{ if $hasLink }}{{ $introClasses = printf "%s transition-colors duration-200 hover:bg-violet-50 hover:border-violet-primary group" $introClasses }}{{ end }}
         {{ if $hasLink }}<a href="{{ .link }}" class="{{ $introClasses }}">{{ else }}<div class="{{ $introClasses }}">{{ end }}
@@ -22,10 +23,11 @@
             <div class="text-2xl md:text-3xl font-display font-semibold tracking-tighter text-service-black leading-[1.1]">{{ . | markdownify }}</div>
             {{ end }}
             {{ with .attribution }}
-            <div class="text-base text-gray-900 flex items-end justify-between gap-4 mt-auto leading-6">
+            <div class="text-base text-gray-900 flex flex-col md:flex-row md:items-end justify-between gap-4 mt-auto leading-6">
                 <div class="flex-1">{{ . | markdownify }}</div>
                 {{ if $hasLink }}
-                <span class="inline-flex items-center text-violet-primary shrink-0">
+                <span class="inline-flex gap-1 items-center text-violet-primary shrink-0 font-semibold">
+                    {{ if $hasLinkLabel }}{{ $hasLinkLabel }}{{ end }}
                     {{ partial "icon.html" (dict "name" "arrow-right" "weight" "bold" "class" "size-5") }}
                 </span>
                 {{ end }}


### PR DESCRIPTION
### Proposed changes

Adds an optional `link_label` field to the release page intro card so it can render a text label (e.g. "Read the blog post") next to the arrow when a link is set, and wires it up on the agentic-infrastructure-era release page. Also stacks the attribution row on mobile (`flex-col md:flex-row`) and nudges the arrow alignment in `card-text-block` with `-mt-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)