### PR TITLE
Add horizontal padding to logo nav dropdown

### DIFF
--- a/layouts/partials/docs-top-nav.html
+++ b/layouts/partials/docs-top-nav.html
@@ -23,7 +23,7 @@
         data-logo-nav-menu
         role="menu"
         hidden
-        class="card absolute left-0 top-full z-50 mt-1 w-[240px] bg-white py-2 text-gray-950 shadow">
+        class="card absolute left-0 top-full z-50 mt-1 w-[240px] bg-white p-2 text-gray-950 shadow">
         <ul class="flex flex-col gap-0.5">
           {{ range $item := $nav.logoMenu }}
             <li role="none"><a role="menuitem" href="{{ $item.href }}"


### PR DESCRIPTION
### Proposed changes

Change `py-2` to `p-2` on the docs top nav logo menu dropdown so its items have horizontal padding from the dropdown edges, matching the existing vertical spacing.