### PR TITLE
Update Adam Gordon Bell community engineer page

### DIFF
--- a/content/community/community-engineering/adam-gordon-bell.md
+++ b/content/community/community-engineering/adam-gordon-bell.md
@@ -2,13 +2,52 @@
 title: Adam Gordon Bell
 id: adam-gordon-bell
 first_name: Adam
-meta_desc: Adam Gordon Bell is a community engineer at Pulumi, focusing on developer experience and infrastructure as code.
+meta_desc: Adam Gordon Bell is a Community Engineer at Pulumi, focused on developer communication around infrastructure-as-code.
 meta_image: community/community-engineering/adam-social-card.png
 layout: community-engineering/single
 aliases:
   - /adam
+talks:
+- event: "KCDC 2026"
+  title: "Demystifying the Magic: Let's Build an Infrastructure-as-Code Tool from Scratch"
+  url: "https://www.kcdc.info/"
+  date: 2026-09-10T09:00:00.000-05:00
+- event: "MLCon San Diego 2026"
+  title: "Building Action-Taking AI Agents: Reliability Lessons from Real Systems"
+  url: "https://mlconference.ai/"
+  date: 2026-06-03T09:00:00.000-07:00
+- event: "SCaLE 23x"
+  title: "When AI Agents Meet Production Infrastructure"
+  url: "https://www.socallinuxexpo.org/scale/23x/presentations/when-ai-agents-meet-production-infrastructure"
+  date: 2026-03-07T09:00:00.000-08:00
+- event: "SCaLE 23x"
+  title: "I Built an AI Running Coach"
+  url: "https://adamgordonbell.com/speaking/"
+  date: 2026-03-07T09:00:00.000-08:00
+- event: "MCP Academy"
+  title: "When AI Agents Meet Production Infrastructure"
+  url: "https://adamgordonbell.com/speaking/"
+  date: 2025-10-01T09:00:00.000-07:00
+- event: "Pulumi Workshop"
+  title: "Discover Pulumi Through Hands-On Practice"
+  url: "https://www.youtube.com/watch?v=ttUVmRPAzCo"
+  date: 2025-01-01T09:00:00.000-08:00
+- event: "Pulumi"
+  title: "Pulumi Interview / Demo"
+  url: "https://www.youtube.com/watch?v=9KMIpOofv0s"
+  date: 2025-01-01T09:00:00.000-08:00
+- event: "SCaLE 20x"
+  title: "Build Your Own Container Runtime with chroot"
+  url: "https://www.youtube.com/watch?v=89ESCBzM-3Q"
+  date: 2023-03-09T09:00:00.000-08:00
+- event: "ConFoo 2023"
+  title: "Beating Timsort"
+  url: "https://confoo.ca/en/2023/session/beating-timsort"
+  date: 2023-02-22T09:00:00.000-08:00
 ---
 
-Adam Gordon Bell is a Community Engineer at Pulumi. With a background in software development and a passion for developer tooling, Adam brings practical insights to the infrastructure as code space.
+Over twenty years in software. I started at Operitel on learning management (later acquired by OpenText), then three years at Tenable building application security tools in Scala — the kind of work that sits at the intersection of static analysis and functional programming.
 
-Adam is known for his work in the developer community and sharing knowledge through technical content, videos, and podcasts.
+While at Tenable I started podcasting — first guest-hosting for Software Engineering Daily, then IEEE Software, and eventually launching my own show, [CoRecursive](https://corecursive.com/). The podcast led to a role at Earthly Technologies, where I spent three years writing and speaking for developers about build tools and the case for treating builds like code.
+
+Pulumi was the natural next step — infrastructure as actual code, in real programming languages, with the same engineering practices we apply everywhere else. As a Community Engineer here I do developer communication: writing, recording, and live demos that explain how the tools actually work.

--- a/content/community/community-engineering/adam-gordon-bell.md
+++ b/content/community/community-engineering/adam-gordon-bell.md
@@ -33,6 +33,10 @@ talks:
   url: "https://www.youtube.com/watch?v=89ESCBzM-3Q"
   date: 2023-03-09T09:00:00.000-08:00
 - event: "ConFoo 2023"
+  title: "The Other Kind of Staff Software Engineer"
+  url: "https://confoo.ca/en/2023/session/the-other-kind-of-staff-software-engineer"
+  date: 2023-02-23T09:00:00.000-08:00
+- event: "ConFoo 2023"
   title: "Beating Timsort"
   url: "https://confoo.ca/en/2023/session/beating-timsort"
   date: 2023-02-22T09:00:00.000-08:00

--- a/content/community/community-engineering/adam-gordon-bell.md
+++ b/content/community/community-engineering/adam-gordon-bell.md
@@ -14,7 +14,7 @@ talks:
   date: 2026-06-03T09:00:00.000-07:00
 - event: "PyTexas 2026"
   title: "I Built an AI Running Coach (That Actually Remembers My Training)"
-  url: "https://www.pytexas.org/2026/talks/#i-built-an-ai-running-coach-that-actually-remembers-my-training"
+  url: "https://www.pytexas.org/2026/schedule/talks/#i-built-an-ai-running-coach-that-actually-remembers-my-training"
   date: 2026-04-18T09:00:00.000-05:00
 - event: "SCaLE 23x"
   title: "When AI Agents Meet Production Infrastructure"

--- a/content/community/community-engineering/adam-gordon-bell.md
+++ b/content/community/community-engineering/adam-gordon-bell.md
@@ -48,21 +48,12 @@ talks:
   title: "Beating TimSort at Merging"
   url: "https://www.youtube.com/watch?v=L4a0SSinGi8"
   date: 2022-12-03T09:00:00.000-08:00
-- event: "Conf42 Cloud Native 2021"
-  title: "Compiling Containers"
-  url: "https://www.youtube.com/watch?v=RHqNNTqmfEA"
-  date: 2021-06-02T09:00:00.000-07:00
 - event: "DockerCon 2021"
   title: "Compiling to Containers with BuildKit"
   url: "https://www.youtube.com/watch?v=1x9OJ-Z-gnc"
   date: 2021-05-27T09:00:00.000-07:00
-- event: "Dev Ops Exchange"
-  title: "What if Dockerfiles and Makefiles Had a Baby?"
-  url: "https://www.youtube.com/watch?v=bL432C2Hqfo"
-  date: 2020-11-26T09:00:00.000-08:00
 - event: "Houston Functional Programmers Meetup"
   title: "Trends in FP"
-  url: "https://www.meetup.com/houston-functional-programmers/"
   date: 2020-10-21T19:00:00.000-05:00
 ---
 

--- a/content/community/community-engineering/adam-gordon-bell.md
+++ b/content/community/community-engineering/adam-gordon-bell.md
@@ -24,6 +24,10 @@ talks:
   title: "I Built an AI Running Coach"
   url: "https://www.socallinuxexpo.org/scale/23x/presentations/i-built-ai-running-coach-and-my-homebrew-bot-runs-my-training"
   date: 2026-03-07T09:00:00.000-08:00
+- event: "Houston AWS SIG"
+  title: "AWS's AI Bet: What re:Invent 2025 Actually Means"
+  url: "https://www.youtube.com/watch?v=M1OEOmqLz9s"
+  date: 2026-01-22T17:30:00.000-06:00
 - event: "MCP Academy PNW"
   title: "Bridge Agents and Infrastructure to Extend Agents into Cloud Environments"
   url: "https://www.youtube.com/watch?v=StEKKBRnqYc"
@@ -40,6 +44,26 @@ talks:
   title: "Beating Timsort"
   url: "https://confoo.ca/en/2023/session/beating-timsort"
   date: 2023-02-22T09:00:00.000-08:00
+- event: "PyjamasConf 2022"
+  title: "Beating TimSort at Merging"
+  url: "https://www.youtube.com/watch?v=L4a0SSinGi8"
+  date: 2022-12-03T09:00:00.000-08:00
+- event: "Conf42 Cloud Native 2021"
+  title: "Compiling Containers"
+  url: "https://www.youtube.com/watch?v=RHqNNTqmfEA"
+  date: 2021-06-02T09:00:00.000-07:00
+- event: "DockerCon 2021"
+  title: "Compiling to Containers with BuildKit"
+  url: "https://www.youtube.com/watch?v=1x9OJ-Z-gnc"
+  date: 2021-05-27T09:00:00.000-07:00
+- event: "Dev Ops Exchange"
+  title: "What if Dockerfiles and Makefiles Had a Baby?"
+  url: "https://www.youtube.com/watch?v=bL432C2Hqfo"
+  date: 2020-11-26T09:00:00.000-08:00
+- event: "Houston Functional Programmers Meetup"
+  title: "Trends in FP"
+  url: "https://www.meetup.com/houston-functional-programmers/"
+  date: 2020-10-21T19:00:00.000-05:00
 ---
 
 Over twenty years in software. I started at Operitel on learning management (later acquired by OpenText), then three years at Tenable building application security tools in Scala — the kind of work that sits at the intersection of static analysis and functional programming.

--- a/content/community/community-engineering/adam-gordon-bell.md
+++ b/content/community/community-engineering/adam-gordon-bell.md
@@ -8,34 +8,26 @@ layout: community-engineering/single
 aliases:
   - /adam
 talks:
-- event: "KCDC 2026"
-  title: "Demystifying the Magic: Let's Build an Infrastructure-as-Code Tool from Scratch"
-  url: "https://www.kcdc.info/"
-  date: 2026-09-10T09:00:00.000-05:00
 - event: "MLCon San Diego 2026"
   title: "Building Action-Taking AI Agents: Reliability Lessons from Real Systems"
   url: "https://mlconference.ai/"
   date: 2026-06-03T09:00:00.000-07:00
+- event: "PyTexas 2026"
+  title: "I Built an AI Running Coach (That Actually Remembers My Training)"
+  url: "https://www.pytexas.org/2026/talks/#i-built-an-ai-running-coach-that-actually-remembers-my-training"
+  date: 2026-04-18T09:00:00.000-05:00
 - event: "SCaLE 23x"
   title: "When AI Agents Meet Production Infrastructure"
   url: "https://www.socallinuxexpo.org/scale/23x/presentations/when-ai-agents-meet-production-infrastructure"
   date: 2026-03-07T09:00:00.000-08:00
 - event: "SCaLE 23x"
   title: "I Built an AI Running Coach"
-  url: "https://adamgordonbell.com/speaking/"
+  url: "https://www.socallinuxexpo.org/scale/23x/presentations/i-built-ai-running-coach-and-my-homebrew-bot-runs-my-training"
   date: 2026-03-07T09:00:00.000-08:00
-- event: "MCP Academy"
-  title: "When AI Agents Meet Production Infrastructure"
-  url: "https://adamgordonbell.com/speaking/"
-  date: 2025-10-01T09:00:00.000-07:00
-- event: "Pulumi Workshop"
-  title: "Discover Pulumi Through Hands-On Practice"
-  url: "https://www.youtube.com/watch?v=ttUVmRPAzCo"
-  date: 2025-01-01T09:00:00.000-08:00
-- event: "Pulumi"
-  title: "Pulumi Interview / Demo"
-  url: "https://www.youtube.com/watch?v=9KMIpOofv0s"
-  date: 2025-01-01T09:00:00.000-08:00
+- event: "MCP Academy PNW"
+  title: "Bridge Agents and Infrastructure to Extend Agents into Cloud Environments"
+  url: "https://www.youtube.com/watch?v=StEKKBRnqYc"
+  date: 2025-10-29T13:40:00.000-08:00
 - event: "SCaLE 20x"
   title: "Build Your Own Container Runtime with chroot"
   url: "https://www.youtube.com/watch?v=89ESCBzM-3Q"


### PR DESCRIPTION
## Summary

- Refresh the Adam Gordon Bell community engineer page to match the shape of Engin Diri's page
- Add a Speaking section with 7 talks (MLCon, PyTexas, SCaLE 23x ×2, MCP Academy PNW, SCaLE 20x, ConFoo)
- Replace the generic two-sentence body with a three-paragraph career narrative

## Test plan

- [ ] Visit `/community/community-engineering/adam-gordon-bell/` locally — confirm Speaking table renders all 7 rows with working event links
- [ ] Confirm Recent Blog Posts section still auto-pulls from authored posts
- [ ] Confirm Engin's page (`/community/community-engineering/engin-diri/`) is unaffected