### PR TITLE
Document `read ".pulumi/meta.yaml"` error in DIY backend guide

### DIFF
--- a/content/docs/iac/guides/basics/using-a-diy-backend.md
+++ b/content/docs/iac/guides/basics/using-a-diy-backend.md
@@ -139,3 +139,27 @@ Existing DIY backends will continue to use the global namespace for stacks. You 
 {{% notes type="info" %}}
 `pulumi state upgrade` will make upgraded stacks inaccessible to older versions of Pulumi. This is a one-way operation. Once you have upgraded your backend, you cannot downgrade to the previous version.
 {{% /notes %}}
+
+## Troubleshooting
+
+### Error reading `.pulumi/meta.yaml`
+
+When the Pulumi CLI can't access your DIY backend's storage, you'll see an error similar to one of these when you run `pulumi login`, `pulumi config`, or another command that reads state:
+
+```
+error: read ".pulumi\\meta.yaml": blob (key ".pulumi/meta.yaml") (code=Unknown): AccessDenied: Access Denied
+        status code: 403
+```
+
+```
+error: read ".pulumi\\meta.yaml": blob (key ".pulumi/meta.yaml") (code=Unknown): MissingRegion: could not find region configuration
+```
+
+`meta.yaml` is the first file Pulumi reads from a DIY backend, so this error almost always means the CLI reached the storage provider but couldn't authenticate or wasn't configured correctly—not that the file itself is missing or corrupt. The error is surfaced directly from the cloud provider's SDK, which is why it can be hard to interpret. Common causes:
+
+- **Expired or invalid credentials.** Temporary credentials—such as those from AWS SSO, `aws sts assume-role`, or short-lived Azure service principal tokens—may have expired. Refresh your credentials and try the command again.
+- **Insufficient permissions.** The identity in use can authenticate but lacks read/write access to the bucket or container. Confirm it has the permissions required to read, write, and delete blobs. For Azure Blob Storage, this means the [Storage Blob Data Contributor role](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor) or an equivalent role.
+- **Missing region configuration (AWS S3).** The AWS SDK can't determine which region the bucket is in. Specify the region in the backend URL—for example, `pulumi login 's3://<bucket-name>?region=us-east-1'`—or set the `AWS_REGION` environment variable before logging in.
+- **Missing authentication environment variables.** DIY backends authenticate using the cloud provider's own SDK. Verify that the variables that SDK expects are set—see the section for your backend ([AWS S3](#aws-s3), [Azure Blob Storage](#azure-blob-storage), or [Google Cloud Storage](#google-cloud-storage)) above for the specifics.
+
+To get more detail while diagnosing the problem, re-run the command with [CLI verbose logging](/docs/support/debugging/logging/#cli-verbose-logging) enabled.

--- a/content/docs/support/troubleshooting/common-issues/_index.md
+++ b/content/docs/support/troubleshooting/common-issues/_index.md
@@ -21,6 +21,7 @@ Guide to fixing specific problems that may arise in Pulumi programs, including u
 - **[Server errors](/docs/support/troubleshooting/common-issues/server-errors/)** - Handle 500 internal server errors from Pulumi Cloud
 - **[Post-step event errors](/docs/support/troubleshooting/common-issues/post-step-errors/)** - Troubleshoot post-step event failures and engine bugs
 - **[Connection issues](/docs/support/troubleshooting/common-issues/connection-issues/)** - Fix network connectivity and proxy problems
+- **[DIY backend access errors](/docs/iac/guides/basics/using-a-diy-backend/#error-reading-pulumimetayaml)** - Resolve `read ".pulumi/meta.yaml"` errors when the CLI can't access a self-managed state backend
 - **[Destroy failures](/docs/support/troubleshooting/common-issues/destroy-failures/)** - Handle scenarios when `pulumi destroy` fails
 - **[Interrupted updates](/docs/support/troubleshooting/common-issues/interrupted-updates/)** - Recover from interrupted deployments
 - **[macOS architecture mismatch](/docs/support/troubleshooting/common-issues/architecture-mismatch/)** - Fix crashes or hangs on Apple Silicon caused by x86_64 binaries running under Rosetta 2

--- a/content/docs/support/troubleshooting/common-issues/connection-issues.md
+++ b/content/docs/support/troubleshooting/common-issues/connection-issues.md
@@ -34,3 +34,7 @@ $
 ```
 
 If you have a system-wide proxy server running on your machine, it may be misconfigured. The [Pulumi architecture](/docs/iac/guides/basics/how-pulumi-works/) has three different components, running as separate processes that talk to each other using a bidirectional gRPC protocol on IP address `127.0.0.1`. Your proxy server should be configured **NOT** to proxy these local network connections. Add both `127.0.0.1` and `localhost` to the exclusion list of your proxy server.
+
+## Cannot access a DIY backend
+
+If you're using a [DIY backend](/docs/iac/concepts/state-and-backends/#using-a-diy-backend) and see an error like `read ".pulumi\\meta.yaml": blob (key ".pulumi/meta.yaml") ... AccessDenied` when running `pulumi login` or other commands, the CLI reached your storage provider but couldn't authenticate or wasn't configured correctly. See [Error reading `.pulumi/meta.yaml`](/docs/iac/guides/basics/using-a-diy-backend/#error-reading-pulumimetayaml) for common causes and fixes.


### PR DESCRIPTION
Documents the `AccessDenied` / `MissingRegion` errors users hit when the Pulumi CLI can't access a DIY (self-managed) state backend.

## Changes
- Added a Troubleshooting section to the DIY backend guide explaining the `read ".pulumi/meta.yaml"` error, its common causes, and fixes
- Linked to it from the common-issues troubleshooting index
- Added a "Cannot access a DIY backend" section to the connection-issues page

Closes #11467