### PR TITLE
content(iac): split dynamic providers into a concepts page and an authoring guide

### DIFF
--- a/content/docs/iac/concepts/providers/dynamic-providers.md
+++ b/content/docs/iac/concepts/providers/dynamic-providers.md
@@ -21,19 +21,11 @@ aliases:
 The dynamic resource provider construct can be used to build a local provider for simple APIs and use-cases. Dynamic resource providers are only able to be used in Pulumi programs written in the same language as the dynamic resource provider. But, they are lighter weight than custom providers and for many use-cases are sufficient to leverage the Pulumi state model. For more sophisticated APIs, one can create a [bridged or native provider](/docs/iac/packages-and-automation/pulumi-packages/).
 
 {{% notes type="info" %}}
-The Pulumi registry includes the [Command Provider](https://www.pulumi.com/registry/packages/command/) as an even lighter weight solution and can be used in place of a dynamic resource provider in some cases.
+Dynamic providers are supported only in TypeScript and Python.
 {{% /notes %}}
 
 {{% notes type="info" %}}
-[Pulumi Policy Packs](/docs/insights/policy/) can be used to validate dynamic provider resources. However, since all dynamic resources share the same resource type (`pulumi-nodejs:dynamic:Resource` for TypeScript or `pulumi-python:dynamic:Resource` for Python), policies must identify specific dynamic providers by checking for unique properties. See [Writing policies for dynamic providers](/docs/insights/policy/policy-packs/authoring/#writing-policies-for-dynamic-providers) for examples and best practices.
-{{% /notes %}}
-
-{{% notes type="warning" %}}
-Dynamic providers in TypeScript are incompatible with projects using pnpm as a package manager. If you're using pnpm, consider using npm or yarn instead. For more information, see [pulumi/pulumi#9085](https://github.com/pulumi/pulumi/issues/9085).
-{{% /notes %}}
-
-{{% notes type="warning" %}}
-Dynamic providers in TypeScript are not supported when using the Bun runtime (`runtime: bun`), as they depend on [function serialization](/docs/iac/concepts/functions/function-serialization/), which requires Node.js v8/inspector APIs that Bun [does not fully implement yet](https://bun.com/docs/runtime/nodejs-compat#nodeinspector). Use `runtime: nodejs` if your program requires dynamic providers.
+A dynamic provider is often not the best tool for the job. An existing provider, [Any Terraform Provider](/docs/iac/concepts/providers/any-terraform-provider/), or the [Command Provider](https://www.pulumi.com/registry/packages/command/) is frequently a better fit. Before authoring one, work through the [decision diagram](/docs/iac/guides/building-extending/providers/dynamic-providers/#when-to-use-a-dynamic-provider) in the guide to confirm you actually need one.
 {{% /notes %}}
 
 There are several reasons why you might want to write a dynamic resource provider. Here are some of them:
@@ -41,13 +33,13 @@ There are several reasons why you might want to write a dynamic resource provide
 - You want to create some new custom resource types.
 - You want to use a cloud provider that Pulumi doesn't support.
 
-All dynamic providers must conform to certain interface requirements. You must at least implement the `create` function but, in practice, you will probably also want to implement the `update` and `delete` functions as well. Note that `read` is not currently functional for dynamic providers; see the [`read` section](#readid-props) below for details.
+All dynamic providers must conform to certain interface requirements. You must at least implement the `create` function but, in practice, you will probably also want to implement the `update` and `delete` functions as well. Note that `read` is not currently functional for dynamic providers. For the full interface, see [Author a Dynamic Provider](/docs/iac/guides/building-extending/providers/dynamic-providers/).
 
 For example, if creating a dynamic resource provider for WordPress, you would probably want to create new blogs, update existing blogs, and destroy them. The mechanics of how these operations happen would be essentially the same as if you used one of the standard resource providers. The difference is that the calls that would've been made on the standard resource provider by the Pulumi engine would now be made on your dynamic resource provider and it, in turn, would make the API calls to WordPress.
 
 Dynamic providers are defined by first implementing the `pulumi.dynamic.ResourceProvider` interface. This interface supports all CRUD operations, but only the create function is required. A minimal implementation might look like this:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python" >}}
 
 {{% choosable language typescript %}}
 
@@ -71,42 +63,16 @@ class MyProvider(ResourceProvider):
 ```
 
 {{% /choosable %}}
-{{% choosable language go %}}
-
-```go
-// Dynamic Providers are currently not supported in Go.
-```
-
-{{% /choosable %}}
-{{% choosable language csharp %}}
-
-```csharp
-// Dynamic Providers are currently not supported in .NET.
-```
-
-{{% /choosable %}}
-{{% choosable language java %}}
-
-```java
-// Dynamic Providers are currently not supported in Java.
-```
-
-{{% /choosable %}}
-{{% choosable language yaml %}}
-
-```yaml
-# Dynamic Providers are currently not supported in YAML.
-```
-
-{{% /choosable %}}
 
 {{< /chooser >}}
 
-This dynamic resource provider is then used to create a new kind of custom resource by inheriting from the `pulumi.dynamic.Resource` base class, which is a subclass of `pulumi.CustomResource`:
+This dynamic resource provider is then used to create a new kind of custom resource by subclassing the dynamic resource base class:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python" >}}
 
 {{% choosable language typescript %}}
+
+Extend `pulumi.dynamic.Resource`, which is a subclass of `pulumi.CustomResource`:
 
 ```typescript
 class MyResource extends pulumi.dynamic.Resource {
@@ -119,6 +85,8 @@ class MyResource extends pulumi.dynamic.Resource {
 {{% /choosable %}}
 {{% choosable language python %}}
 
+Subclass `pulumi.dynamic.Resource`, which is a subclass of `pulumi.CustomResource`:
+
 ```python
 from pulumi import ResourceOptions
 from pulumi.dynamic import Resource
@@ -127,34 +95,6 @@ from typing import Any, Optional
 class MyResource(Resource):
     def __init__(self, name: str, props: Any, opts: Optional[ResourceOptions] = None):
          super().__init__(MyProvider(), name, props, opts)
-```
-
-{{% /choosable %}}
-{{% choosable language go %}}
-
-```go
-// Dynamic Providers are currently not supported in Go.
-```
-
-{{% /choosable %}}
-{{% choosable language csharp %}}
-
-```csharp
-// Dynamic Providers are currently not supported in .NET.
-```
-
-{{% /choosable %}}
-{{% choosable language java %}}
-
-```java
-// Dynamic Providers are currently not supported in Java.
-```
-
-{{% /choosable %}}
-{{% choosable language yaml %}}
-
-```yaml
-# Dynamic Providers are currently not supported in YAML.
 ```
 
 {{% /choosable %}}
@@ -172,7 +112,7 @@ Specifically:
 1. In all cases, Pulumi first calls the check method with the resource arguments to give the provider a chance to verify that the arguments are valid.
 1. If Pulumi needs to read an existing resource without managing it directly, it will call read. (Note: `read` is not currently implemented for dynamic providers.)
 
-See below for details on each of these functions.
+For details on each of these functions, see [Author a Dynamic Provider](/docs/iac/guides/building-extending/providers/dynamic-providers/).
 
 ## How Dynamic Providers Work
 
@@ -182,551 +122,17 @@ These two phases of execution run in separate processes. The construction of a `
 
 Because your implementation of the resource provider interface must be used by a different process, potentially at a different point in time, dynamic providers are built on top of the same [function serialization](/docs/iac/concepts/functions/function-serialization/) that is used for turning callbacks into AWS Lambdas or Google Cloud Functions. Because of this serialization, there are some limits on what can be done inside the implementation of the resource provider interface. You can read more about these limitations in the function serialization documentation.
 
-### Provider code changes
+## Limitations
 
-When you modify the code of a dynamic provider (for example, updating the logic in `create`, `read`, or `update` methods), Pulumi does not automatically detect these changes. The resource's inputs haven't changed from Pulumi's perspective, so no update is triggered.
+Dynamic providers are deliberately lightweight, and that comes with trade-offs. Before choosing one, be aware of the following limitations:
 
-If you need to force an update after changing your provider code, you have several options:
+- **Single language.** A dynamic provider can only be used from programs written in the same language as the provider. For multi-language support, build a [bridged or native provider](/docs/iac/packages-and-automation/pulumi-packages/).
+- **No `read` support.** The `read` method is not currently functional, so [`pulumi import`](/docs/iac/cli/commands/pulumi_import/) and the static [`get` method](/docs/iac/concepts/resources/get/) are not supported. This is tracked in [pulumi/pulumi#16175](https://github.com/pulumi/pulumi/issues/16175).
+- **Function serialization limits.** Provider methods are serialized to run in a separate process, which limits what code they can capture. See [function serialization](/docs/iac/concepts/functions/function-serialization/).
+- **No pnpm support (TypeScript).** Dynamic providers in TypeScript are incompatible with projects using pnpm as a package manager. Use npm or yarn instead. See [pulumi/pulumi#9085](https://github.com/pulumi/pulumi/issues/9085).
+- **No Bun runtime support (TypeScript).** Dynamic providers are not supported with the Bun runtime (`runtime: bun`), because they depend on function serialization, which requires Node.js v8/inspector APIs that Bun [does not fully implement yet](https://bun.com/docs/runtime/nodejs-compat#nodeinspector). Use `runtime: nodejs` instead.
+- **Awkward policy authoring.** All dynamic resources share the same resource type (`pulumi-nodejs:dynamic:Resource` for TypeScript or `pulumi-python:dynamic:Resource` for Python), so [Pulumi Policy Packs](/docs/insights/policy/) must identify specific dynamic providers by checking for unique properties. See [Writing policies for dynamic providers](/docs/insights/policy/policy-packs/authoring/#writing-policies-for-dynamic-providers).
 
-- **Add a version input**: Include a version property in your resource inputs and increment it when you change the provider code. This causes Pulumi to see a difference and trigger an update.
-- **Use `diff` to force changes**: Implement a `diff` method that returns `{ changes: true }` when you want to force an update.
-- **Delete and recreate**: Remove the resource from your program, run `pulumi up`, then add it back. This recreates the resource with the updated provider code.
+## Authoring a dynamic provider
 
-## The Resource Provider Interface
-
-Implementing the `pulumi.dynamic.ResourceProvider` interface requires implementing a subset of the methods listed further down in this section. Each of these methods can be asynchronous, and most implementations of these methods will perform network I/O to provision resources in a backing cloud provider or other resource model. There are several important contracts between a dynamic provider and the Pulumi CLI that inform when these methods are called and with what data.
-
-Though the input properties passed to a `pulumi.dynamic.Resource` instance will usually be [Input values](/docs/concepts/inputs-outputs/), the dynamic provider's functions are invoked with the fully resolved input values in order to compose well with Pulumi resources. Strong typing for the inputs to your provider's functions can help clarify this. You can achieve this by creating a second interface with the same properties as your resource's inputs, but with fully unwrapped types.
-
-{{% notes type="warning" %}}
-There are nuances to how data is passed between the core Pulumi program and your dynamic provider. Learn more here: https://github.com/pulumi/pulumi/issues/16582.
-{{% /notes %}}
-
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
-
-{{% choosable language typescript %}}
-
-```typescript
-// Exported type.
-export interface MyResourceInputs {
-    myStringProp: pulumi.Input<string>;
-    myBoolProp: pulumi.Input<boolean>;
-    ...
-}
-
-// Non-exported type used by the provider functions.
-// This interface contains the same inputs, but as un-wrapped types.
-interface MyResourceProviderInputs {
-    myStringProp: string;
-    myBoolProp: boolean;
-    ...
-}
-
-class MyResourceProvider implements pulumi.dynamic.ResourceProvider {
-    async create(inputs: MyResourceProviderInputs): Promise<pulumi.dynamic.CreateResult> {
-        ...
-    }
-
-    async diff(id: string, oldOutputs: MyResourceProviderOutputs, newInputs: MyResourceProviderInputs): Promise<pulumi.dynamic.DiffResult> {
-        ...
-    }
-    ...
-}
-
-class MyResource extends pulumi.dynamic.Resource {
-    constructor(name: string, props: MyResourceInputs, opts?: pulumi.CustomResourceOptions) {
-        super(new MyResourceProvider(), name, props, opts);
-    }
-}
-```
-
-{{% /choosable %}}
-{{% choosable language python %}}
-
-```python
-from pulumi import Input, Output, ResourceOptions
-from pulumi.dynamic import *
-from typing import Any, Optional
-
-class MyResourceInputs(object):
-    my_string_prop: Input[str]
-    my_bool_prop: Input[bool]
-
-    def __init__(self, my_string_prop, my_bool_prop):
-        self.my_string_prop = my_string_prop
-        self.my_bool_prop = my_bool_prop
-
-class _MyResourceProviderInputs(object):
-    """
-    MyResourceProviderInputs is the unwrapped version of the same inputs
-    from the MyResourceInputs class.
-    """
-    my_string_prop: str
-    my_bool_prop: bool
-
-    def __init__(self, my_string_prop: str, my_bool_prop: bool):
-        self.my_bool_prop = my_bool_prop
-        self.my_string_prop = my_string_prop
-
-class MyResourceProvider(ResourceProvider):
-    def create(self, inputs: _MyResourceProviderInputs) -> CreateResult:
-        ...
-        return CreateResult()
-
-    def diff(self, id: str, oldInputs: _MyResourceProviderInputs, newInputs: _MyResourceProviderInputs) -> DiffResult:
-        ...
-        return DiffResult()
-
-class MyResource(Resource):
-    def __init__(self, name: str, props: MyResourceInputs, opts: Optional[ResourceOptions] = None):
-        super().__init__(MyResourceProvider(), name, {**vars(props)}, opts)
-```
-
-{{% /choosable %}}
-{{% choosable language go %}}
-
-```go
-// Dynamic Providers are currently not supported in Go.
-```
-
-{{% /choosable %}}
-{{% choosable language csharp %}}
-
-```csharp
-// Dynamic Providers are currently not supported in .NET.
-```
-
-{{% /choosable %}}
-{{% choosable language java %}}
-
-```java
-// Dynamic Providers are currently not supported in Java.
-```
-
-{{% /choosable %}}
-{{% choosable language yaml %}}
-
-```yaml
-# Dynamic Providers are currently not supported in YAML.
-```
-
-{{% /choosable %}}
-
-{{< /chooser >}}
-
-### configure(ConfigureRequest)
-
-The `configure` method is invoked after a dynamic resource provider is loaded. This method is optional and is called exactly once for each provider instance. The `configure` method receives a `ConfigureRequest` object as its argument, which contains the configuration of the current stack. This method can be used to perform any necessary setup for the provider, and allows you to read configuration values and store them for later use in other provider methods.
-
-### check(olds, news)
-
-The `check` method is invoked before any other methods. The resolved input properties that were originally provided to the resource constructor by the user are passed to it. The operation is passed both the old input properties that were stored in the *state file* after the previous update to the resource, as well as the new inputs from the current deployment. It has two jobs:
-
-1. Verify that the inputs (particularly the news) are valid or return useful error messages if they are not.
-1. Return a set of checked inputs.
-
-The inputs returned from the call to `check` will be the inputs that the Pulumi engine uses for all further processing of the resource, including the values that will be passed back in to `diff`, `create`, `update`, or other operations. In many cases, the news can be returned directly as the checked inputs. But in cases where the provider needs to populate defaults, or do some normalization on values, it may want to do that in the `check` method so that this data is complete and normalized prior to being passed in to other methods.
-
-### create(inputs)
-
-The `create` method is invoked when the URN of the resource created by the user is not found in the existing state of the deployment. The engine passes the provider the checked inputs returned from the call to `check`. The `create` method creates the resource in the cloud provider. It then returns two pieces of data:
-
-1. An id that can uniquely identify the resource in the backing provider for later lookups, and
-1. A set of outputs from the backing provider that should be returned to the user code as properties on the CustomResource object. These outputs are stored in the checkpoint file. If an error occurs, an exception can be thrown from the create method that should be returned to the user.
-
-### diff(id, olds, news)
-
-The `diff` method is invoked when the URN of the resource created by the user already exists. Because the resource already exists it will need to be either updated or replaced. The `diff` method is passed the `id` of the resource, as returned by `create`, as well as the old outputs from the checkpoint file, which are values returned from a previous call to either `create` or `update`. The checked inputs from the current deployment are passed to the diff method.
-
-It returns four optional values:
-
-- `changes: true` if the provider believes there is a difference between the olds and news and wants to do an update or replace to effect this change.
-- `replaces`: An array of property names that have changed that should force a replacement. Returning a non-zero length array tells the Pulumi engine to schedule a replacement instead of an update. Replacements might involve downtime, so this value should only be used when a diff requested by the user cannot be implemented as an in-place update on the cloud provider.
-- `stables`: An array of property names that are known not to change between updates. Pulumi will use this information to allow some [`apply`](/docs/concepts/inputs-outputs/#apply) calls on [`Output[T]`](/docs/concepts/inputs-outputs/#outputs) to be processed during `previews` because it knows that the values of these property names will stay the same during an update.
-- `deleteBeforeReplace`: true if the proposed replacements require that the existing resource be deleted before creating the new one. By default, Pulumi will try to create the new resource before deleting the old one to avoid downtime. If an error occurs, an exception can be thrown from the diff method to return this error to the user.
-
-### update(id, olds, news)
-
-The `update` method is invoked if the call to diff indicates that a replacement is unnecessary. The method is passed the `id` of the resource as returned by `create`, and the old outputs from the checkpoint file, which are values returned from a previous call to either `create` or `update`. The new checked inputs are also passed from the current deployment. The `update` method is expected to do the work in the cloud provider to update an existing resource to the new desired state. It then returns a new set of `outputs` from the cloud provider that should be returned to the user code as properties on the [`CustomResource`](/docs/concepts/resources/) object, and stored into the checkpoint file. If an error occurs, an exception can be thrown from the `update` method to return this error to the user.
-
-### delete(id, props)
-
-The `delete` operation is invoked if the URN exists in the previous state but not in the new desired state, or if a replacement is needed. The method is passed the `id` of the resource as returned by `create`, and the old outputs from the checkpoint file, which are values returned from a previous call to either `create` or `update`. The method deletes the corresponding resource from the cloud provider. Nothing needs to be returned. If an error occurs, an exception can be thrown from the `delete` method to return this error to the user.
-
-### read(id, props)
-
-{{% notes type="warning" %}}
-The `read` method is not currently functional for dynamic providers. Attempting to invoke it — for example, by running `pulumi import` or using the static `get` method on a dynamic resource — will result in an unimplemented exception. This is a known limitation tracked in [pulumi/pulumi#16175](https://github.com/pulumi/pulumi/issues/16175). If your use case requires importing existing resources, consider implementing a [component resource](/docs/iac/concepts/components/) backed by a [native provider](/docs/iac/concepts/providers/) instead.
-{{% /notes %}}
-
-When `read` is implemented, it is intended to be invoked in three scenarios:
-
-1. When using the static [`get` method](/docs/iac/concepts/resources/get/) to read an existing resource that is not managed by Pulumi.
-1. When using [`pulumi import`](/docs/iac/cli/commands/pulumi_import/) to import an existing resource into Pulumi management.
-1. When running [`pulumi refresh`](/docs/iac/cli/commands/pulumi_refresh/) to synchronize the state with the actual state of the resource in the cloud provider.
-
-The method is passed the `id` of the resource, as tracked in the cloud provider, and an optional bag of additional properties that can be used to disambiguate the request, if needed. The `read` method looks up the requested resource, and returns the canonical `id` and output properties of this resource if found. If an error occurs, an exception can be thrown from the `read` method to return this error to the user.
-
-## Dynamic Resource Inputs
-
-The inputs to your `pulumi.dynamic.ResourceProvider`'s functions come from subclasses of `pulumi.dynamic.Resource`. These inputs include any values in the input arguments passed to the `pulumi.dynamic.Resource` constructor. This is just a map of key/value pairs however, in statically typed languages, you can declare types for these input shapes.
-
-For example, `props`, in the `MyResource` class shown below, defines the inputs to the resource provider functions:
-
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
-
-{{% choosable language typescript %}}
-
-```typescript
-interface MyResourceInputs {
-    myStringProp: pulumi.Input<string>;
-    myBoolProp: pulumi.Input<boolean>;
-    ...
-}
-
-class MyResource extends pulumi.dynamic.Resource {
-    constructor(name: string, props: MyResourceInputs, opts?: pulumi.CustomResourceOptions) {
-        super(myprovider, name, props, opts);
-    }
-}
-```
-
-{{% /choosable %}}
-{{% choosable language python %}}
-
-```python
-from pulumi import Input, ResourceOptions
-from pulumi.dynamic import Resource
-from typing import Any, Optional
-
-class MyResourceInputs(object):
-    my_string_prop: Input[str]
-    my_bool_prop: Input[bool]
-    def __init__(self, my_string_prop, my_bool_prop):
-        self.my_string_prop = my_string_prop
-        self.my_bool_prop = my_bool_prop
-
-class MyResource(Resource):
-    def __init__(self, name: str, props: MyResourceInputs, opts: Optional[ResourceOptions] = None):
-         super().__init__(MyProvider(), name, {**vars(props)}, opts)
-```
-
-{{% /choosable %}}
-{{% choosable language go %}}
-
-```go
-// Dynamic Providers are currently not supported in Go.
-```
-
-{{% /choosable %}}
-{{% choosable language csharp %}}
-
-```csharp
-// Dynamic Providers are currently not supported in .NET.
-```
-
-{{% /choosable %}}
-{{% choosable language java %}}
-
-```java
-// Dynamic Providers are currently not supported in Java.
-```
-
-{{% /choosable %}}
-{{% choosable language yaml %}}
-
-```yaml
-# Dynamic Providers are not supported in YAML.
-```
-
-{{% /choosable %}}
-
-{{< /chooser >}}
-
-## Dynamic Resource Outputs
-
-Any outputs can be returned by your create function in the outs property of `pulumi.dynamic.CreateResult`.
-
-{{% notes "info" %}}
-The following only applies to statically typed languages.
-{{% /notes %}}
-
-If you need to access the outputs of your custom resource outside it with strong typing support, declare each output property returned in the `outs` property by your `create` function as a class member of the `pulumi.dynamic.Resource` itself. For example, in TypeScript, these outputs must be declared using the `declare` keyword in your `pulumi.dynamic.Resource` class. These class members must also have the type `pulumi.Output<T>`.
-
-{{% notes type="warning" %}}
-**Important:** Use the `declare` keyword rather than `public readonly` for output properties. Using `public readonly` with the definite assignment assertion (`!`) can cause outputs to be `undefined` in some TypeScript configurations. The `declare` keyword tells TypeScript the property exists without emitting any JavaScript, which is the correct behavior since Pulumi sets these properties dynamically.
-{{% /notes %}}
-
-The name of the class member must match the names of the output properties as returned by the `create` function.
-
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
-
-{{% choosable language typescript %}}
-
-```typescript
-...
-
-interface MyResourceProviderOutputs {
-    myNumberOutput: number;
-    myStringOutput: string;
-}
-
-class MyResourceProvider implements pulumi.dynamic.ResourceProvider {
-    async create(inputs: MyResourceProviderInputs): Promise<pulumi.dynamic.CreateResult> {
-        ...
-        // Values are for an example only.
-        return { id: "...", outs: { myNumberOutput: 12, myStringOutput: "some value" }};
-    }
-}
-
-export class MyResource extends pulumi.dynamic.Resource {
-    declare readonly myStringOutput: pulumi.Output<string>;
-    declare readonly myNumberOutput: pulumi.Output<number>;
-
-    constructor(name: string, props: MyResourceInputs, opts?: pulumi.CustomResourceOptions) {
-        super(new MyResourceProvider(), name, { myStringOutput: undefined, myNumberOutput: undefined, ...props }, opts);
-    }
-}
-```
-
-{{% /choosable %}}
-{{% choosable language python %}}
-
-```python
-from pulumi import ResourceOptions, Input, Output
-from pulumi.dynamic import Resource, ResourceProvider, CreateResult
-from typing import Any, Optional
-
-...
-...
-
-class MyProvider(ResourceProvider):
-    def create(self, inputs):
-        return CreateResult(id_="foo", outs={ 'my_number_output': 12, 'my_string_output': "some value" })
-
-class MyResource(Resource):
-    my_string_output: Output[str]
-    my_number_output: Output[str]
-
-    def __init__(self, name: str, props: MyResourceInputs, opts: Optional[ResourceOptions] = None):
-         super().__init__(MyProvider(), name, { 'my_string_output': None, 'my_number_output': None, **vars(props) }, opts)
-```
-
-{{% /choosable %}}
-{{% choosable language go %}}
-
-```go
-// Dynamic Providers are not yet supported in Go.
-```
-
-{{% /choosable %}}
-{{% choosable language csharp %}}
-
-```csharp
-// Dynamic Providers are currently not supported in .NET.
-```
-
-{{% /choosable %}}
-{{% choosable language java %}}
-
-```java
-// Dynamic Providers are currently not supported in Java.
-```
-
-{{% /choosable %}}
-{{% choosable language yaml %}}
-
-```yaml
-# Dynamic Providers are not supported in YAML.
-```
-
-{{% /choosable %}}
-
-{{< /chooser >}}
-
-## Dynamic Provider Examples
-
-### Example: Random number generator
-
-This example generates a random number using a dynamic provider. It highlights using dynamic providers to run some code only when a resource is created, and then store the results of that in the state file so that this value is maintained across deployments of the resource. Because we want our random number to be created once, and then remain stable for subsequent updates, we cannot use a random number generator in our program; we need dynamic providers. The result is a provider similar to the one provided in `@pulumi/random`, just specific to our program and language.
-
-Implementing this example requires that we have a provider and resource type:
-
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
-
-{{% choosable language typescript %}}
-
-```typescript
-{{< example-program-snippet path="dynamic-random" language="typescript" >}}
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```python
-{{< example-program-snippet path="dynamic-random" language="python" >}}
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```go
-// Dynamic Providers are currently not supported in Go.
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```csharp
-// Dynamic Providers are currently not supported in .NET.
-```
-
-{{% /choosable %}}
-
-{{% choosable language java %}}
-
-```java
-// Dynamic Providers are currently not supported in Java.
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```yaml
-# Dynamic Providers are not supported in YAML.
-```
-
-{{% /choosable %}}
-
-{{< /chooser >}}
-
-Now, with this, we can construct new `Random` resource instances, and Pulumi will drive the right calls at the right time.
-
-### Example: GitHub Labels REST API (Credentials via Pulumi Config)
-
-This example highlights how to make REST API calls to a backing provider to perform CRUD operations. In this case, the backing provider is the GitHub API.
-
-A fundamental requirement for a dynamic provider that calls an API is managing the credentials needed for the API calls. One approach is to just pass the necessary creds as inputs when declaring resources using the dynamic resource provider. But passing provider credentials when declaring resources is an antipattern, to say the least. Therefore, other mechanisms that allow the dynamic resource provider to consume the needed credentials outside of the resource declaration are preferred. This example uses [Pulumi Config](/docs/concepts/config) to get the credential.
-
-Because the resource provider method implementations will be serialized and used in a different process, we keep all the work to initialize the REST client and to make calls to it, local to each function.
-
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
-
-{{% choosable language typescript %}}
-
-```typescript
-{{< example-program-snippet path="dynamic-github-labels" language="typescript" >}}
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```python
-{{< example-program-snippet path="dynamic-github-labels" language="python" >}}
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```go
-// Dynamic Providers are not currently supported in Go.
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```csharp
-// Dynamic Providers are currently not supported in .NET.
-```
-
-{{% /choosable %}}
-
-{{% choosable language java %}}
-
-```java
-// Dynamic Providers are currently not supported in Java.
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```yaml
-# Dynamic Providers are not supported in YAML.
-```
-
-{{% /choosable %}}
-
-{{< /chooser >}}
-
-### Example: Pulumi Cloud REST API (Creds via Environment Variables)
-
-This example highlights how to make REST API calls to a backing provider to perform CRUD operations. In this case, the backing provider is the [Pulumi Cloud API](/docs/pulumi-cloud/cloud-rest-api).
-
-A fundamental requirement for a dynamic provider that calls an API is managing the credentials needed for the API calls. One approach is to just pass the necessary creds as inputs when declaring resources using the dynamic resource provider. But passing provider credentials when declaring resources is an antipattern, to say the least. Therefore, other mechanisms that allow the dynamic resource provider to consume the needed credentials outside of the resource declaration are preferred. This example uses environment variables to pass the credentials. A big advantage of this approach is that if the credentials change before `pulumi destroy` is run, there is no need to first run a `pulumi up` to update the credentials used by the dynamic provider.
-
-Because the resource provider method implementations will be serialized and used in a different process, we keep all the work to initialize the REST client and to make calls to it, local to each function.
-
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
-
-{{% choosable language typescript %}}
-
-```typescript
-{{< example-program-snippet path="dynamic-pulumi-cloud-env" language="typescript" >}}
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```python
-{{< example-program-snippet path="dynamic-pulumi-cloud-env" language="python" >}}
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```go
-// Dynamic Providers are not currently supported in Go.
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```csharp
-// Dynamic Providers are currently not supported in .NET.
-```
-
-{{% /choosable %}}
-
-{{% choosable language java %}}
-
-```java
-// Dynamic Providers are currently not supported in Java.
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```yaml
-# Dynamic Providers are not supported in YAML.
-```
-
-{{% /choosable %}}
-
-{{< /chooser >}}
-
-### Additional Examples
-
-- [Add a Custom Domain to an Azure CDN endpoint](https://github.com/pulumi/examples/tree/846811de2c7faa4694454c64edc9bbcdb31d533e/classic-azure-ts-dynamicresource)
-    Similar to the previous example, this is another example of a shortcoming of the regular Azure resource provider available in Pulumi. However, due to the availability of a REST API, we can easily add a custom domain to an Azure CDN resource using a dynamic provider.
+Ready to build one? The [Author a Dynamic Provider](/docs/iac/guides/building-extending/providers/dynamic-providers/) guide covers the full resource provider interface, strongly typed inputs and outputs, credential handling, and complete TypeScript and Python examples.

--- a/content/docs/iac/guides/building-extending/providers/_index.md
+++ b/content/docs/iac/guides/building-extending/providers/_index.md
@@ -37,7 +37,7 @@ Providers require a deeper level of Pulumi expertise and maintenance overhead co
 
 - **Is there already a Pulumi provider?** Search the [Pulumi Registry](/registry/). If a well-maintained provider exists, use it.
 - **Is there a well-maintained Terraform or OpenTofu provider?** If so, reach for [Any Terraform Provider](/docs/iac/concepts/providers/any-terraform-provider/), which lets a Pulumi program consume any provider from the OpenTofu registry without writing a Pulumi provider at all.
-- **Do you actually need a provider?** If your goal is to group resources into a reusable abstraction, a [component](/docs/iac/guides/building-extending/components/build-a-component/) is usually the right answer. For one-off programmatic resources, a [dynamic provider](/docs/iac/concepts/providers/dynamic-providers/) may be simpler than a full provider package.
+- **Do you actually need a provider?** If your goal is to group resources into a reusable abstraction, a [component](/docs/iac/guides/building-extending/components/build-a-component/) is usually the right answer. For one-off programmatic resources, a [dynamic provider](/docs/iac/guides/building-extending/providers/dynamic-providers/) may be simpler than a full provider package.
 
 Build a standalone provider when none of the above apply.
 
@@ -54,5 +54,6 @@ For guidance on choosing between the available options, see [Provider Architectu
 
 - [Provider Architecture](/docs/iac/guides/building-extending/providers/provider-architecture/) — the three-layer model of the provider stack and how to choose your layer.
 - [Build a Provider](/docs/iac/guides/building-extending/providers/build-a-provider/) — step-by-step guide to using the Pulumi Go Provider SDK.
+- [Author a Dynamic Provider](/docs/iac/guides/building-extending/providers/dynamic-providers/) — implementing a lightweight provider inline in a TypeScript or Python program.
 - [Provider Configuration](/docs/iac/guides/building-extending/providers/provider-configuration/) — declaring configuration keys, secrets, and environment variable defaults in your provider schema.
 - [Direct Provider Implementation](/docs/iac/guides/building-extending/providers/implementers/) — implementing providers in Python or TypeScript against the gRPC protocol directly.

--- a/content/docs/iac/guides/building-extending/providers/build-a-provider.md
+++ b/content/docs/iac/guides/building-extending/providers/build-a-provider.md
@@ -22,7 +22,7 @@ This guide uses the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending
 
 ## When to use a provider
 
-A Pulumi Provider allows you to define new resource types, enabling integration with virtually any service or tool. Pulumi providers are ideal when you need to manage resources that are not yet supported by existing Pulumi providers or when you require custom behavior for managing external systems or APIs. Providers are a powerful extension point, but before building a full provider consider if your use case can be covered by [building a component](/docs/iac/using-pulumi/extending-pulumi/build-a-component/) or using [dynamic provider functions](/docs/iac/concepts/providers/dynamic-providers/).
+A Pulumi Provider allows you to define new resource types, enabling integration with virtually any service or tool. Pulumi providers are ideal when you need to manage resources that are not yet supported by existing Pulumi providers or when you require custom behavior for managing external systems or APIs. Providers are a powerful extension point, but before building a full provider consider if your use case can be covered by [building a component](/docs/iac/using-pulumi/extending-pulumi/build-a-component/) or authoring a [dynamic provider](/docs/iac/guides/building-extending/providers/dynamic-providers/).
 
 ## What’s needed to implement a provider?
 

--- a/content/docs/iac/guides/building-extending/providers/dynamic-providers.md
+++ b/content/docs/iac/guides/building-extending/providers/dynamic-providers.md
@@ -1,0 +1,423 @@
+---
+title_tag: "Author a Dynamic Provider"
+meta_desc: "Author a dynamic provider inside a Pulumi program: when to choose one, the resource provider interface, and complete TypeScript and Python examples."
+title: Author a Dynamic Provider
+h1: Author a Dynamic Provider
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Author a Dynamic Provider
+        parent: iac-guides-providers
+        weight: 35
+---
+
+A dynamic provider lets you implement a resource's create, read, update, and delete (CRUD) logic directly inside a Pulumi program, without building and publishing a separate provider package. This guide walks through when to choose a dynamic provider, the interface you implement, and complete working examples in TypeScript and Python.
+
+For a conceptual overview of what dynamic providers are and how they execute, see [Dynamic providers](/docs/iac/concepts/providers/dynamic-providers/) in the concepts documentation.
+
+{{% notes type="info" %}}
+Dynamic providers are supported only in TypeScript and Python. For other languages, build a [full provider](/docs/iac/guides/building-extending/providers/build-a-provider/).
+{{% /notes %}}
+
+## When to use a dynamic provider
+
+A dynamic provider is the right tool when you need to manage a resource that no existing Pulumi provider supports, the logic is specific to a single program, and you don't need to share it across languages or teams. Before reaching for one, consider the alternatives:
+
+- **An existing provider.** Search the [Pulumi Registry](/registry/) first. If a well-maintained provider already covers your resource, use it. If a Terraform or OpenTofu provider exists, [Any Terraform Provider](/docs/iac/concepts/providers/any-terraform-provider/) lets you consume it directly.
+- **The Command provider.** If you only need to run a command or script as part of provisioning — rather than model a resource with a real lifecycle — the [Command provider](https://www.pulumi.com/registry/packages/command/) is lighter weight.
+- **A full provider.** If the provider should be reusable across languages, shared with other teams, published to the Registry, or needs `import` support, build a [full provider](/docs/iac/guides/building-extending/providers/build-a-provider/) instead.
+
+```mermaid
+flowchart TD
+    A{Does an existing provider<br/>cover the resource?} -->|Yes| B[Use the existing provider]
+    A -->|No| C{Do you just need to run<br/>a command or script<br/>during deployment?}
+    C -->|Yes| D[Use the Command provider]
+    C -->|No| E{Will it be shared across<br/>languages or teams, or<br/>published to the Registry?}
+    E -->|Yes| F[Build a full provider]
+    E -->|No| G[Author a dynamic provider]
+```
+
+Keep these constraints in mind when choosing a dynamic provider:
+
+- A dynamic provider can only be used from programs written in the same language as the provider.
+- The `read` method is not currently functional, so [`pulumi import`](/docs/iac/cli/commands/pulumi_import/) and the static [`get` method](/docs/iac/concepts/resources/get/) are not supported. This is tracked in [pulumi/pulumi#16175](https://github.com/pulumi/pulumi/issues/16175).
+- Provider methods are serialized to run in a separate process, which limits what code they can capture. See [function serialization](/docs/iac/concepts/functions/function-serialization/).
+
+## The resource provider interface
+
+You author a dynamic provider by implementing the `pulumi.dynamic.ResourceProvider` interface. Only `create` is required; in practice you will usually implement `update` and `delete` as well, and often `check` and `diff`. Each method can be asynchronous, and most implementations perform network I/O to provision resources in a backing API.
+
+Pulumi calls these methods at well-defined points in a deployment:
+
+1. In all cases, Pulumi first calls `check` with the resource arguments to give the provider a chance to verify that the arguments are valid.
+1. If Pulumi determines the resource has not yet been created, it calls `create`.
+1. If another deployment happens and the resource already exists, Pulumi calls `diff` to determine whether a change can be made in place or whether a replacement is needed.
+1. If no replacement is needed, Pulumi calls `update`.
+1. If a replacement is needed, Pulumi calls `create` for the new resource and then `delete` for the old one.
+1. If Pulumi needs to read an existing resource without managing it directly, it calls `read`. (Note: `read` is not currently functional for dynamic providers.)
+
+### configure(ConfigureRequest)
+
+The `configure` method is invoked once after the provider is loaded, before any other method. It receives a `ConfigureRequest` containing the current stack's configuration. Use it to perform setup and to read [configuration values](/docs/iac/concepts/config/) — such as credentials — for use in the other methods. This method is optional.
+
+### check(olds, news)
+
+The `check` method is invoked before any other method. It receives the old input properties stored in state after the previous update, and the new inputs from the current deployment. It has two jobs:
+
+1. Verify that the inputs are valid, returning useful error messages if they are not.
+1. Return a set of checked inputs.
+
+The inputs returned from `check` are the inputs Pulumi uses for all further processing of the resource, including the values passed to `diff`, `create`, and `update`. In many cases the news can be returned directly. When the provider needs to populate defaults or normalize values, do so in `check` so the data is complete before it reaches the other methods.
+
+### create(inputs)
+
+The `create` method is invoked when the resource's URN is not found in the existing state. The engine passes it the checked inputs returned from `check`. The method creates the resource in the backing API and returns:
+
+1. An `id` that uniquely identifies the resource in the backing provider for later lookups.
+1. A set of `outputs` that are returned to the user code as properties on the resource and stored in state.
+
+If an error occurs, throw an exception to surface it to the user.
+
+### diff(id, olds, news)
+
+The `diff` method is invoked when the resource's URN already exists. It receives the `id` returned by `create`, the old outputs from state, and the checked inputs from the current deployment. It returns four optional values:
+
+- `changes`: `true` if the provider believes there is a difference between the olds and news that should trigger an update or replace.
+- `replaces`: an array of property names whose change should force a replacement instead of an in-place update. Replacements might involve downtime, so use this only when a diff cannot be implemented as an in-place update.
+- `stables`: an array of property names known not to change between updates. Pulumi uses this to process some [`apply`](/docs/iac/concepts/inputs-outputs/#working-with-outputs) calls during previews.
+- `deleteBeforeReplace`: `true` if a replacement requires deleting the existing resource before creating the new one. By default, Pulumi creates the new resource before deleting the old one to avoid downtime.
+
+### update(id, olds, news)
+
+The `update` method is invoked when `diff` indicates a replacement is unnecessary. It receives the `id` of the resource, the old outputs from state, and the new checked inputs. It updates the existing resource in the backing API and returns a new set of `outputs`. If an error occurs, throw an exception to surface it to the user.
+
+### delete(id, props)
+
+The `delete` method is invoked when the URN exists in the previous state but not in the new desired state, or when a replacement is needed. It receives the `id` of the resource and the old outputs from state, and deletes the corresponding resource from the backing API. Nothing needs to be returned.
+
+### read(id, props)
+
+{{% notes type="warning" %}}
+The `read` method is not currently functional for dynamic providers. Attempting to invoke it — for example, by running `pulumi import` or using the static `get` method on a dynamic resource — results in an unimplemented exception. This is tracked in [pulumi/pulumi#16175](https://github.com/pulumi/pulumi/issues/16175). If your use case requires importing existing resources, implement a [component resource](/docs/iac/concepts/components/) backed by a [native provider](/docs/iac/guides/building-extending/providers/build-a-provider/) instead.
+{{% /notes %}}
+
+When functional, `read` looks up an existing resource by `id` and returns its canonical `id` and output properties. It is intended to support the static [`get` method](/docs/iac/concepts/resources/get/), [`pulumi import`](/docs/iac/cli/commands/pulumi_import/), and [`pulumi refresh`](/docs/iac/cli/commands/pulumi_refresh/).
+
+## Strongly typed inputs
+
+Although the input properties passed to a `pulumi.dynamic.Resource` are usually [Input values](/docs/iac/concepts/inputs-outputs/), your provider's methods are invoked with the *fully resolved* input values. In statically typed languages, model this with two interfaces: one for the resource constructor, using `Input<T>` types, and one for the provider methods, using the un-wrapped `T` types.
+
+{{< chooser language "typescript,python" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+// Exported type used by the resource constructor.
+export interface MyResourceInputs {
+    myStringProp: pulumi.Input<string>;
+    myBoolProp: pulumi.Input<boolean>;
+}
+
+// Non-exported type used by the provider methods.
+// The same inputs, but as un-wrapped types.
+interface MyResourceProviderInputs {
+    myStringProp: string;
+    myBoolProp: boolean;
+}
+
+class MyResourceProvider implements pulumi.dynamic.ResourceProvider {
+    async create(inputs: MyResourceProviderInputs): Promise<pulumi.dynamic.CreateResult> {
+        // ...
+    }
+}
+
+class MyResource extends pulumi.dynamic.Resource {
+    constructor(name: string, props: MyResourceInputs, opts?: pulumi.CustomResourceOptions) {
+        super(new MyResourceProvider(), name, props, opts);
+    }
+}
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```python
+from pulumi import Input, ResourceOptions
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+from typing import Optional
+
+# Type used by the resource constructor.
+class MyResourceInputs(object):
+    my_string_prop: Input[str]
+    my_bool_prop: Input[bool]
+
+    def __init__(self, my_string_prop, my_bool_prop):
+        self.my_string_prop = my_string_prop
+        self.my_bool_prop = my_bool_prop
+
+# The same inputs, but as un-wrapped types, used by the provider methods.
+class _MyResourceProviderInputs(object):
+    my_string_prop: str
+    my_bool_prop: bool
+
+    def __init__(self, my_string_prop: str, my_bool_prop: bool):
+        self.my_string_prop = my_string_prop
+        self.my_bool_prop = my_bool_prop
+
+class MyResourceProvider(ResourceProvider):
+    def create(self, inputs: _MyResourceProviderInputs) -> CreateResult:
+        # ...
+        return CreateResult(id_="...", outs={})
+
+class MyResource(Resource):
+    def __init__(self, name: str, props: MyResourceInputs, opts: Optional[ResourceOptions] = None):
+        super().__init__(MyResourceProvider(), name, {**vars(props)}, opts)
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+{{% notes type="warning" %}}
+How data is passed between the core Pulumi program and your dynamic provider has some nuances. Learn more in [pulumi/pulumi#16582](https://github.com/pulumi/pulumi/issues/16582).
+{{% /notes %}}
+
+## Strongly typed outputs
+
+Any values returned in the `outs` property of your `create` (or `update`) result become outputs on the resource. By default these outputs are *not* type-safe: the base `pulumi.dynamic.Resource` class knows nothing about them. To access them with strong typing, declare each output as a class member on your `pulumi.dynamic.Resource` subclass. The member name must match the output property name returned by `create`.
+
+{{< chooser language "typescript,python" >}}
+
+{{% choosable language typescript %}}
+
+In TypeScript, declare each output with the `declare` keyword and the type `pulumi.Output<T>`:
+
+```typescript
+interface MyResourceProviderOutputs {
+    myNumberOutput: number;
+    myStringOutput: string;
+}
+
+class MyResourceProvider implements pulumi.dynamic.ResourceProvider {
+    async create(inputs: MyResourceProviderInputs): Promise<pulumi.dynamic.CreateResult> {
+        // Values are for illustration only.
+        return { id: "...", outs: { myNumberOutput: 12, myStringOutput: "some value" } };
+    }
+}
+
+export class MyResource extends pulumi.dynamic.Resource {
+    declare readonly myStringOutput: pulumi.Output<string>;
+    declare readonly myNumberOutput: pulumi.Output<number>;
+
+    constructor(name: string, props: MyResourceInputs, opts?: pulumi.CustomResourceOptions) {
+        super(new MyResourceProvider(), name, { myStringOutput: undefined, myNumberOutput: undefined, ...props }, opts);
+    }
+}
+```
+
+{{% notes type="warning" %}}
+Use the `declare` keyword rather than `public readonly` for output properties. Using `public readonly` with the definite assignment assertion (`!`) can cause outputs to be `undefined` in some TypeScript configurations. The `declare` keyword tells TypeScript the property exists without emitting any JavaScript, which is correct because Pulumi sets these properties dynamically.
+{{% /notes %}}
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+In Python, declare each output as a typed class member of type `Output[T]`, and seed it as `None` in the inputs passed to `super().__init__`:
+
+```python
+from pulumi import ResourceOptions, Output
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+from typing import Optional
+
+class MyResourceProvider(ResourceProvider):
+    def create(self, inputs):
+        # Values are for illustration only.
+        return CreateResult(id_="foo", outs={"my_number_output": 12, "my_string_output": "some value"})
+
+class MyResource(Resource):
+    my_string_output: Output[str]
+    my_number_output: Output[int]
+
+    def __init__(self, name: str, props: MyResourceInputs, opts: Optional[ResourceOptions] = None):
+        super().__init__(MyResourceProvider(), name, {"my_string_output": None, "my_number_output": None, **vars(props)}, opts)
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## A minimal example: a stable random ID
+
+This example generates a random ID once, when the resource is created, and keeps it stable across subsequent deployments by storing it in state. Generating the value in regular program code instead would produce a new value on every run. It implements only `create` — the result is similar to the [`random` provider](https://www.pulumi.com/registry/packages/random/), specific to your program and language.
+
+{{< chooser language "typescript,python" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+{{< example-program-snippet path="dynamic-random" language="typescript" >}}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+{{< example-program-snippet path="dynamic-random" language="python" >}}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## A complete example: managing GitHub labels
+
+This example manages GitHub repository labels through the GitHub REST API. It demonstrates the full interface — `configure`, `check`, `create`, `diff`, `update`, and `delete` — and the strongly typed inputs and outputs patterns described above.
+
+A few things to note as you read it:
+
+- `configure` reads the GitHub token from [Pulumi config](/docs/iac/concepts/config/) once, so individual resource declarations don't have to pass credentials.
+- `check` validates the label color before any other method runs, returning a clear failure message for invalid input.
+- `diff` reports whether the resource changed. Because GitHub labels can be updated in place, it never forces a replacement.
+- The REST client is constructed inside each method rather than shared, because the methods are serialized and run in a separate process.
+
+{{< chooser language "typescript,python" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+{{< example-program-snippet path="dynamic-github-labels" language="typescript" >}}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+{{< example-program-snippet path="dynamic-github-labels" language="python" >}}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## Managing credentials
+
+A dynamic provider that calls an API needs credentials. Passing credentials as resource inputs is an antipattern — it puts secrets in your resource declarations and in state. Instead, supply them to the provider out of band, in one of two ways:
+
+- **Pulumi config**, read in `configure`, as the GitHub labels example does above. Set the value with `pulumi config set githubToken <VALUE> --secret`.
+- **Environment variables**, read inside each provider method. A benefit of this approach is that if the credentials change before `pulumi destroy` runs, there is no need to first run `pulumi up` to refresh them.
+
+The following example manages a fictional widget service through its REST API at `https://api.example.com`, reading an API token from the `WIDGET_API_TOKEN` environment variable. Each method reads the variable itself, rather than sharing a client, because the methods are serialized and run in a separate process:
+
+{{< chooser language "typescript,python" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+interface WidgetInputs {
+    name: string;
+    size: string;
+}
+
+const widgetProvider: pulumi.dynamic.ResourceProvider = {
+    async create(inputs: WidgetInputs): Promise<pulumi.dynamic.CreateResult> {
+        const apiKey = process.env.WIDGET_API_TOKEN;
+        if (!apiKey) {
+            throw new Error("the WIDGET_API_TOKEN environment variable is not set");
+        }
+
+        const response = await fetch("https://api.example.com/widgets", {
+            method: "POST",
+            headers: {
+                "Authorization": `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ name: inputs.name, size: inputs.size }),
+        });
+        if (!response.ok) {
+            throw new Error(`failed to create widget: ${response.status} ${response.statusText}`);
+        }
+
+        const widget = await response.json();
+        return { id: widget.id, outs: { ...inputs, ...widget } };
+    },
+
+    async delete(id: string, props: WidgetInputs): Promise<void> {
+        const apiKey = process.env.WIDGET_API_TOKEN;
+        if (!apiKey) {
+            throw new Error("the WIDGET_API_TOKEN environment variable is not set");
+        }
+
+        const response = await fetch(`https://api.example.com/widgets/${id}`, {
+            method: "DELETE",
+            headers: { "Authorization": `Bearer ${apiKey}` },
+        });
+        if (!response.ok) {
+            throw new Error(`failed to delete widget: ${response.status} ${response.statusText}`);
+        }
+    },
+};
+
+export class Widget extends pulumi.dynamic.Resource {
+    constructor(name: string, props: WidgetInputs, opts?: pulumi.CustomResourceOptions) {
+        super(widgetProvider, name, props, opts);
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+import os
+import requests
+import pulumi
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+
+class WidgetProvider(ResourceProvider):
+    def create(self, inputs) -> CreateResult:
+        api_key = os.environ.get("WIDGET_API_TOKEN")
+        if not api_key:
+            raise Exception("the WIDGET_API_TOKEN environment variable is not set")
+
+        response = requests.post(
+            "https://api.example.com/widgets",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"name": inputs["name"], "size": inputs["size"]})
+        response.raise_for_status()
+
+        widget = response.json()
+        return CreateResult(id_=widget["id"], outs={**inputs, **widget})
+
+    def delete(self, id: str, props):
+        api_key = os.environ.get("WIDGET_API_TOKEN")
+        if not api_key:
+            raise Exception("the WIDGET_API_TOKEN environment variable is not set")
+
+        response = requests.delete(
+            f"https://api.example.com/widgets/{id}",
+            headers={"Authorization": f"Bearer {api_key}"})
+        response.raise_for_status()
+
+class Widget(Resource):
+    def __init__(self, name, props, opts=None):
+        super().__init__(WidgetProvider(), name, props, opts)
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## Forcing updates after provider code changes
+
+When you modify the code of a dynamic provider — for example, changing the logic in `create` or `update` — Pulumi does not automatically detect the change. From Pulumi's perspective the resource's inputs haven't changed, so no update is triggered.
+
+To force an update after changing your provider code, use one of these options:
+
+- **Add a version input.** Include a version property in your resource inputs and increment it when you change the provider code. Pulumi sees the difference and triggers an update.
+- **Use `diff` to force changes.** Implement a `diff` method that returns `{ changes: true }` when you want to force an update.
+- **Delete and recreate.** Remove the resource from your program, run `pulumi up`, then add it back. This recreates the resource with the updated provider code.

--- a/static/programs/dynamic-github-labels-python/__main__.py
+++ b/static/programs/dynamic-github-labels-python/__main__.py
@@ -1,6 +1,8 @@
+import re
 import pulumi
 from pulumi import Input, Output
-from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, ConfigureRequest
+from pulumi.dynamic import (Resource, ResourceProvider, CreateResult, UpdateResult,
+                            ConfigureRequest, CheckResult, CheckFailure, DiffResult)
 from typing import Optional
 from github import Github, GithubObject
 
@@ -23,6 +25,16 @@ class GithubLabelProvider(ResourceProvider):
         # Set a stack config variable named githubToken (e.g. pulumi config set githubToken <VALUE> --secret)
         self.auth = req.config.require("githubToken")
 
+    def check(self, _olds, news):
+        # check runs before any other method and validates the user's inputs.
+        failures = []
+        color = news.get("color") or ""
+        # GitHub label colors are six hexadecimal digits with no leading "#".
+        if not re.fullmatch(r"[0-9a-fA-F]{6}", color):
+            failures.append(CheckFailure("color",
+                f'invalid color "{color}": expected six hexadecimal digits with no leading "#"'))
+        return CheckResult(news, failures)
+
     def create(self, props):
         g = Github(self.auth)
         l = g.get_user(props["owner"]).get_repo(props["repo"]).create_label(
@@ -30,6 +42,12 @@ class GithubLabelProvider(ResourceProvider):
             color=props["color"],
             description=props.get("description", GithubObject.NotSet))
         return CreateResult(l.name, {**props, **l.raw_data})
+    def diff(self, _id, olds, news):
+        # GitHub labels can be updated in place, so a change never forces a replacement.
+        changed = (olds.get("name") != news.get("name")
+                   or olds.get("color") != news.get("color")
+                   or olds.get("description") != news.get("description"))
+        return DiffResult(changes=changed)
     def update(self, id, _olds, props):
         g = Github(self.auth)
         l = g.get_user(props["owner"]).get_repo(props["repo"]).get_label(id)

--- a/static/programs/dynamic-github-labels-typescript/index.ts
+++ b/static/programs/dynamic-github-labels-typescript/index.ts
@@ -24,6 +24,18 @@ class githubLabelProvider implements pulumi.dynamic.ResourceProvider {
         // Set a stack config variable named githubToken (e.g. pulumi config set githubToken <VALUE> --secret)
         this.auth = req.config.require("githubToken");
     }
+    // check runs before any other method and validates the user's inputs.
+    async check(olds: LabelInputs, news: LabelInputs): Promise<pulumi.dynamic.CheckResult> {
+        const failures: pulumi.dynamic.CheckFailure[] = [];
+        // GitHub label colors are six hexadecimal digits with no leading "#".
+        if (!/^[0-9a-fA-F]{6}$/.test(news.color)) {
+            failures.push({
+                property: "color",
+                reason: `invalid color "${news.color}": expected six hexadecimal digits with no leading "#"`,
+            });
+        }
+        return { inputs: news, failures };
+    }
     async create(inputs: LabelInputs) {
         const octokit = new Octokit({ auth: this.auth });
         const label = await octokit.issues.createLabel({
@@ -33,6 +45,15 @@ class githubLabelProvider implements pulumi.dynamic.ResourceProvider {
             color: inputs.color,
         });
         return { id: label.data.id.toString(), outs: label.data };
+    }
+    // diff reports whether the resource needs to change. GitHub labels can be
+    // updated in place, so a change never forces a replacement.
+    async diff(id: string, olds: LabelInputs, news: LabelInputs): Promise<pulumi.dynamic.DiffResult> {
+        const changed =
+            olds.name !== news.name ||
+            olds.color !== news.color ||
+            olds.description !== news.description;
+        return { changes: changed };
     }
     async update(id: string, olds: LabelInputs, news: LabelInputs) {
         const octokit = new Octokit({ auth: this.auth });


### PR DESCRIPTION
Resolves #19358.

## What

The dynamic providers concepts page had grown to ~730 lines and mixed two jobs: explaining *what* a dynamic provider is and *how* to author one. This PR splits it.

- **Concepts** — [`/docs/iac/concepts/providers/dynamic-providers/`](https://www.pulumi.com/docs/iac/concepts/providers/dynamic-providers/) is trimmed to conceptual material only: what a dynamic provider is, when to use one, the caveats (pnpm, Bun, policy packs), and how it executes (two-phase execution / function serialization).
- **New guide** — `Author a Dynamic Provider` at `/docs/iac/guides/building-extending/providers/dynamic-providers/` covers the how-to: when to choose a dynamic provider over the alternatives (full provider, Command provider) with a decision diagram, the full resource provider interface, strongly typed inputs and outputs, credential handling, and complete TypeScript and Python examples.

## Issue requirements

- ✅ Separates "what / when" (Concepts) from "how to author" (Guide).
- ✅ Guide explains when a dynamic provider is the right choice vs. a full provider and the Command provider.
- ✅ Full TypeScript + Python example, reused from the existing `dynamic-github-labels` example program.
- ✅ Covers non-type-safe outputs and the strongly typed inputs/outputs patterns prominently (#12151).
- ✅ Shows the entire interface — `dynamic-github-labels` is extended with `check` and `diff` so one example demonstrates `configure`/`check`/`create`/`diff`/`update`/`delete` (#11577).

## Testing

- `make lint` passes.
- `make build` succeeds; both pages render and all `example-program-snippet` blocks resolve.
- `ONLY_TEST="dynamic-github-labels" ./scripts/programs/test.sh` passes for both the TypeScript and Python programs (preview exercises the new `check` method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)