### PR TITLE
SEO keyword pass on ten-more-things post

### DIFF
--- a/content/blog/10-more-things-you-can-do-with-neo/index.md
+++ b/content/blog/10-more-things-you-can-do-with-neo/index.md
@@ -39,7 +39,7 @@ So here are **10 more** things you can do with Neo.
 
 ## 1. Deploy your app to AWS without writing IaC
 
-*Hand Neo a repo and a target cloud. Neo picks the right services, writes the Pulumi, and opens a PR.*
+*Hand Neo a repo. Neo picks the right services — ECS, AWS Fargate, ALB — writes the Pulumi, and opens a PR.*
 
 The cloud infrastructure part of getting a new service running, especially one in a new language, is always a few hours of boilerplate: a VPC and subnets, an IAM role, security groups, a load balancer, DNS, and a TLS cert.
 
@@ -47,7 +47,7 @@ With Neo, that work collapses into a prompt. Point Neo at a repo and ask:
 
 > Deploy this app to AWS as a publicly accessible service.
 
-[Plan mode](/blog/neo-plan-mode/) comes back with the resources Neo will create, named and sized: ECS Fargate, an ALB, and the VPC wiring. Approve, and Neo writes the Pulumi program, runs a preview, and opens a PR. You, the human in the loop, merge it after review.
+[Plan mode](/blog/neo-plan-mode/) comes back with the resources Neo will create, named and sized: ECS running on AWS Fargate, an ALB, and the VPC wiring. Approve, and Neo writes the Pulumi program, runs a preview, and opens a PR. You, the human in the loop, merge it after review.
 
 {{< video title="Neo deploying an app to AWS: prompt, plan mode, PR, public URL" src="deploy-to-aws2.mp4" autoplay="true" loop="true" controls="false" >}}
 {{< figcaption >}}Neo planning a PR and deploying an app to AWS.{{< /figcaption >}}
@@ -58,9 +58,9 @@ With Neo, that work collapses into a prompt. Point Neo at a repo and ask:
 
 *Slow endpoints live at the seam between runtime metrics and the stack that runs them. Neo reads both and proposes a fix with the metric evidence as the rationale.*
 
-Production incidents often involve multiple tools. When the `checkout` endpoint's p95 climbs from 200ms to 1.2s, the metric is in Datadog, but the cause might be somewhere in your AWS account: maybe RDS is out of IOPS, maybe the connection pool is too small, maybe the autoscaler isn't keeping up. Connecting "this metric looks bad" to a recent backend change and then to a one-line fix in your Pulumi program is an exercise in detective work.
+Production incidents often involve multiple tools. When the `checkout` endpoint's p95 latency climbs from 200ms to 1.2s, the metric is in Datadog, but the cause might be somewhere in your AWS account: maybe RDS is out of IOPS, maybe the connection pool is too small, maybe the autoscaler isn't keeping up. Connecting "this metric looks bad" to a recent backend change and then to a one-line fix in your Pulumi program is an exercise in detective work.
 
-Neo's [integration catalog](/blog/neo-integration-catalog/) bridges this gap. With built-in Datadog, PagerDuty, and Honeycomb integrations sitting alongside your Pulumi state, Neo can read traces and metrics from the tools your team already uses and take action.
+Neo's [integration catalog](/blog/neo-integration-catalog/) bridges this gap. With built-in Datadog APM, PagerDuty, and Honeycomb integrations sitting alongside your Pulumi state, Neo can read traces and metrics from the tools your team already uses and take action.
 
 Ask Neo:
 
@@ -83,7 +83,7 @@ You mention Neo in the on-call Slack channel:
 
 Neo starts querying metrics and traces. With PagerDuty and Datadog in the integration catalog, it correlates the alert with every deploy and stack change tagged with the alert's service in the last hour, and finds the change that lines up:
 
-> Two deploys in the last hour touched services tagged `service:checkout`: `checkout-api@a3f9c2` (12 min ago, app-layer deploy) and Pulumi stack `prod-checkout-rds` (45 min ago, decreased `max_connections` from 200 → 100). p99 inflection at 14:03 lines up with the stack change. Likely cause: the connection-pool reduction is starving the API under current load.
+> Two deploys in the last hour touched services tagged `service:checkout`: `checkout-api@a3f9c2` (12 min ago, app-layer deploy) and Pulumi stack `prod-checkout-rds` (45 min ago, decreased `max_connections` from 200 → 100). p99 latency inflection at 14:03 lines up with the stack change. Likely cause: the connection-pool reduction is starving the API under current load.
 
 You ask a couple of clarifying questions in-thread, then ask Neo to open a rollback PR against the Pulumi stack.
 
@@ -96,7 +96,7 @@ You ask a couple of clarifying questions in-thread, then ask Neo to open a rollb
 
 Tickets often pile up not because they're unimportant, but because they're not urgent. Ongoing maintenance quietly accumulates. Bumping a provider version, centralizing secret management, working through small policy violations: each one matters, but none of them ever moves to the top of the queue. Explaining each one to an agent is its own overhead.
 
-The fix is letting Neo read the ticket itself. Connect Linear or Jira through the integration catalog (GitHub Issues works too), and Neo pulls the ticket the same way an engineer would: title, description, acceptance criteria.
+The fix is letting Neo read the ticket itself. Connect Linear integration or Jira automation through the integration catalog (GitHub Issues works too), and Neo pulls the ticket the same way an engineer would: title, description, acceptance criteria.
 
 Ask Neo:
 
@@ -109,7 +109,7 @@ Neo reads the ticket, plans against your existing stack, opens a PR, and drops a
 
 {{< neo-card title="Implement a Linear ticket end-to-end" prompt="I'd like to implement a ticket from Linear (or Jira, or GitHub Issues). Ask me for the ticket number." >}}
 
-## 5. Tighten over-privileged IAM roles
+## 5. Audit and tighten over-privileged IAM roles
 
 *Neo audits each role against what your stack code actually does, and proposes scoped policies that improve your security posture.*
 
@@ -130,7 +130,7 @@ If you're unclear about which roles count as in-scope or what your team consider
 
 ## 6. Migrate from AWS CDK onto your platform's golden paths
 
-*Neo reads your existing CDK app and lands a PR that swaps AWS's defaults for your team's published components.*
+*Neo reads your existing AWS CDK app and lands a PR that swaps AWS's defaults for your team's published components.*
 
 CDK's L2 constructs encode AWS's defaults. `s3.Bucket` with `encryption: BucketEncryption.S3_MANAGED` is a sane choice, but it's AWS's idea of sane, not yours. A platform team that's published its own components to the [Pulumi Private Registry](/docs/idp/concepts/private-registry/) has already decided what *your* bucket defaults look like: encryption with the right KMS key, tagging by cost center.
 
@@ -161,11 +161,11 @@ const bucket = new platform.Bucket("assets", {
 
 {{< neo-card title="Migrate CDK onto your golden paths" prompt="I'd like to migrate this CDK stack to Pulumi. Use our published components where you can." >}}
 
-## 7. Migrate a service to Kubernetes from a runbook
+## 7. Containerize a service and migrate it to Kubernetes from a runbook
 
-*Once the migration pattern is written down, the next service to move is a prompt away.*
+*Write the containerization pattern down once. Every service after that is a prompt away.*
 
-Containerizing an app and moving it to Kubernetes involves several small decisions: which base image, what labels go on deployments, how ingress is wired, and how secrets reach the pod. But after a team has moved two or three services, the pattern is set. The decisions get written down in a runbook, and every subsequent migration is mostly the same shape.
+Containerizing an application and moving it to Kubernetes involves several small decisions: which Docker image, what labels go on deployments, how ingress is wired, and how secrets reach the pod. But after a team has moved two or three services, the pattern is set. The decisions get written down in a runbook, and every subsequent migration is mostly the same shape.
 
 Ask Neo:
 
@@ -182,13 +182,13 @@ You're still the one reviewing the PRs and deciding what the cutover looks like 
 
 Once you've delegated something a few times, the next move is to automate it. The remaining three tasks are the kind Neo doesn't need to be asked for. Drift, deps, compliance: they're the operations you put on a schedule.
 
-## 8. Schedule daily drift checks across your cloud infrastructure
+## 8. Schedule daily configuration drift checks across your cloud infrastructure
 
 *Schedule a daily drift check across your cloud. Wake up to PRs that fix what changed overnight.*
 
 Configuration drift is an ongoing challenge. The security team rotated an IAM role at 04:47 UTC. Someone changed a security group in the AWS console three weeks ago. Left alone, drift turns into security gaps, into compliance issues, and into the kind of "wait, who changed that?" confusion nobody wants to chase down.
 
-Pulumi Cloud is already good at drift detection. Neo takes it a step further.
+Pulumi Cloud is already good at configuration drift detection. Neo takes it a step further.
 
 Ask Neo:
 
@@ -203,17 +203,17 @@ Some drift gets encoded into the Pulumi program, like the IAM rotation above. So
 
 {{< neo-card title="Schedule a daily drift check" prompt="Every morning at 6 AM, check all production infrastructure for drift and create PRs to fix any issues you find." >}}
 
-## 9. Schedule weekly upgrades for outdated providers and runtimes
+## 9. Schedule weekly upgrades for outdated Lambda runtimes and providers
 
 *Lambda runtimes and container base images age out. Schedule the upgrade pass; review the PRs Neo opens.*
 
-AWS Lambda end-of-life notices come out months ahead. Node 20 stopped receiving runtime updates at the end of April. Python 3.9 ended last December. After the deadline, AWS blocks new deploys and eventually stops invoking the function. Each one needs to move to a supported runtime before the cutoff.[^9-original]
+AWS Lambda end-of-life notices come out months ahead. Node 20 stopped receiving updates as an AWS Lambda runtime at the end of April. Python 3.9 reached end-of-support last December. After the deadline, AWS blocks new deploys and eventually stops invoking the function. Each one needs to move to a supported runtime before the cutoff.[^9-original]
 
 Schedule it:
 
-> Every Sunday night at 10 PM, check our Lambdas for runtimes nearing end-of-support and open PRs to upgrade them.
+> Every Sunday night at 10 PM, check our Lambda functions for runtimes nearing end-of-support and open PRs to upgrade them.
 
-Neo reads the AWS Lambda runtime deprecation page, matches the end-of-support runtimes against every Lambda in your stacks, and opens one PR per stack.
+Neo reads the AWS Lambda runtime deprecation page, matches the end-of-support runtimes against every Lambda function in your stacks, and opens one PR per stack.
 
 If Python 3.9 is reaching end-of-support, the upgrade is to Python 3.12, and `datetime.utcnow()` calls need to move to `datetime.now(datetime.UTC)`. Neo can make all of those replacements in the same PR.
 
@@ -222,9 +222,9 @@ The same task can catch container base images with critical CVEs and bump them t
 {{< video title="Setting up a weekly scheduled task in Neo" src="neo-schedule-setup.mp4" autoplay="true" loop="true" controls="false" >}}
 {{< figcaption >}}Setting up a weekly task in the Scheduled Tasks UI. Once saved, Neo runs the prompt every Sunday night and opens PRs you review on Monday.{{< /figcaption >}}
 
-{{< neo-card title="Schedule a weekly runtime upgrade check" prompt="Every Sunday night at 10 PM, check our Lambdas for runtimes nearing end-of-support and open PRs to upgrade them." >}}
+{{< neo-card title="Schedule a weekly runtime upgrade check" prompt="Every Sunday night at 10 PM, check our Lambda functions for runtimes nearing end-of-support and open PRs to upgrade them." >}}
 
-## 10. Fix CIS Benchmark failures with daily PRs
+## 10. Fix AWS CIS Benchmark failures with daily PRs
 
 *Run the benchmark on a schedule. Wake up to PRs that fix what failed.*
 
@@ -245,7 +245,7 @@ The runbook is where your security team writes down what each control means for 
 
 ## Neo: your newest platform engineer
 
-Over the past year, many product teams have stopped treating AI as a request-by-request assistant and started delegating to it outright. Agents open pull requests, investigate issues, and iterate on review feedback.
+Over the past year, many product teams have stopped treating AI as a request-by-request assistant and started delegating to it outright.[^compostable] Agents open pull requests, investigate issues, and iterate on review feedback.
 
 But platform engineers have held back because a bad infrastructure change doesn't just fail, it can take production down. Coding agents benefit from fast, forgiving feedback loops, but infrastructure recovery is rarely as simple as reverting a commit.
 
@@ -254,6 +254,8 @@ What was missing wasn't the appetite. It was an agent with enough organizational
 The theme across these tasks is clear. A thing platform engineers used to keep in their heads becomes a task you delegate, then becomes work that runs without you. Neo isn't generating infrastructure from a template. It's a teammate who knows your code, your providers, your conventions, your production metrics, and can raise PRs for you to review.
 
 Neo now lives in your terminal, in your pull requests, in your Slack workspace, and in Pulumi Cloud. Pick one of these workflows and [give it a try](/docs/pulumi-cloud/neo/).
+
+[^compostable]: For a concrete example, see [Seven Rules for Building an AI-Native Software Factory](/blog/seven-rules-ai-native-software-factory/): Ewan Dawson, CTO of Compostable AI, runs nineteen client deployments with five engineers, using Pulumi Neo to handle most of the infrastructure work.
 
 [^6-original]: The observant reader will notice Terraform-to-Pulumi was covered [in the original post](/blog/10-things-you-can-do-with-neo/).
 

--- a/content/blog/10-more-things-you-can-do-with-neo/index.md
+++ b/content/blog/10-more-things-you-can-do-with-neo/index.md
@@ -12,6 +12,7 @@ tags:
     - platform-engineering
     - pulumi-neo
     - aws
+    - neo-things
 social:
     twitter: |
         Last fall we wrote up 10 things you could do with Pulumi Neo. Since then platform teams have handed Neo real work: drift, dependency upgrades, on-call triage from Slack.
@@ -161,6 +162,8 @@ const bucket = new platform.Bucket("assets", {
 
 {{< neo-card title="Migrate CDK onto your golden paths" prompt="I'd like to migrate this CDK stack to Pulumi. Use our published components where you can." >}}
 
+Neo handles [Terraform and Azure ARM migrations](/blog/neo-migration/) the same way.
+
 ## 7. Containerize a service and migrate it to Kubernetes from a runbook
 
 *Write the containerization pattern down once. Every service after that is a prompt away.*
@@ -180,7 +183,7 @@ You're still the one reviewing the PRs and deciding what the cutover looks like 
 ![Five GitHub PRs in a row, one per migration step (Dockerfile, Deployment, Service+Ingress, ExternalSecret, HPA+PDB), each citing the runbook section it implements](neo-migration-prs.png)
 {{< figcaption >}}Neo migrating a VM-based service to Kubernetes step by step, following the team's Confluence runbook.{{< /figcaption >}}
 
-Once you've delegated something a few times, the next move is to automate it. The remaining three tasks are the kind Neo doesn't need to be asked for. Drift, deps, compliance: they're the operations you put on a schedule.
+Once you've delegated something a few times, the next move is to automate it. The remaining three tasks are the kind Neo doesn't need to be asked for. Drift, deps, compliance: they're the operations you put on a schedule via [Neo Automations](/blog/neo-automations/).
 
 ## 8. Schedule daily configuration drift checks across your cloud infrastructure
 

--- a/content/blog/10-things-you-can-do-with-neo/index.md
+++ b/content/blog/10-things-you-can-do-with-neo/index.md
@@ -11,6 +11,7 @@ tags:
     - platform-engineering
     - pulumi-neo
     - aws
+    - neo-things
 
 social:
     twitter: "10 concrete workflows you can use Pulumi Neo, our new infrastructure agent, for: auto-fix AWS config violations, upgrade Lambda runtimes across accounts, generate infrastructure templates, respond to CVEs. Neo generates PRs, not production changes."

--- a/data/blog_series.yml
+++ b/data/blog_series.yml
@@ -2,6 +2,10 @@
 # These tags will be displayed on the /blog/series/ page
 # Ordered by most recent post date (newest first)
 series:
+  - slug: "neo-things"
+    title: "Things You Can Do With Neo"
+    description: "Real workflows platform teams are handing to Pulumi Neo: one-off deploys, incident triage, IAM audits, drift checks, runtime upgrades, and compliance fixes that run on a schedule."
+    meta_image: "/blog/10-things-you-can-do-with-neo/meta.png"
   - slug: "idp-best-practices"
     title: "IDP Best Practices Series"
     description: "A 6-part blog series on how to design, build, and scale an Internal Developer Platform (IDP). Learn best practices for developer self-service, platform engineering, security, and infrastructure automation using Pulumi."


### PR DESCRIPTION
- Embed ECS, AWS Fargate, ALB in section 1 heading/body for specificity
- Add Datadog APM, p95/p99 latency, Linear integration, Jira automation
- Expand section headings: IAM audit, configuration drift, Lambda runtimes, AWS CIS Benchmark, containerize + Kubernetes
- Embed Lambda runtime context naturally 
- Switch "base image" → "Docker image" in section 7 

