### PR TITLE
Add PlatforMa 2026 talk to Engin Diri's community page

### DIFF
--- a/content/community/community-engineering/engin-diri.md
+++ b/content/community/community-engineering/engin-diri.md
@@ -8,6 +8,10 @@ layout: community-engineering/single
 aliases:
   - /engin
 talks:
+- event: "PlatforMa 2026"
+  title: "Stop Building Portals, Start Building Conversations"
+  url: "https://www.platfor-ma.com/agenda2026"
+  date: 2026-05-26T09:45:00.000+03:00
 - event: "KCD Texas 2026"
   title: "Stop Wasting GPUs: How We Built a Golden Path for GPU Sharing on Kubernetes"
   url: "https://kcd-texas-2026.sessionize.com/session/1144033"


### PR DESCRIPTION
## Description

Adds Engin Diri's upcoming talk to his community page.

- **Event:** PlatforMa 2026 — Habima, Tel Aviv, May 26, 2026
- **Talk:** "Stop Building Portals, Start Building Conversations" (09:45, co-presented with Hila Fish, AWS)
- Placed at the top of the `talks` list since it's the newest entry (the list is newest-first).

Details sourced from https://www.platfor-ma.com/agenda2026 and the event homepage.

## Notes

- The agenda site is still mid-build (the adjacent session is placeholder lorem ipsum), so the abstract/title could change before the event.
- Used the agenda page URL since there's no per-session deep link yet.