### PR TITLE
build-and-deploy: move daily schedule off the top of the hour

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,10 +4,17 @@ on:
     branches:
       - master
   schedule:
-    # Run at 6 AM Eastern
-    - cron: '0 11 * * *'
-    # Run at noon Pacific
-    - cron: '0 20 * * *'
+    # Three off-hour slots to dodge GHA's top-of-hour scheduling congestion.
+    # GHA silently drops scheduled runs when load is high (no notification, no
+    # retry); off-hour minutes (:17, :43, :23) hit a fraction of the load that
+    # :00 does. Morning has two slots ahead of the 10am ET social-post fire
+    # so a future-dated blog goes live before its social goes out.
+    # Primary morning rebuild — 7:17 AM Eastern
+    - cron: '17 11 * * *'
+    # Fallback morning rebuild — 8:43 AM Eastern (86 min after primary)
+    - cron: '43 12 * * *'
+    # Afternoon rebuild for hour-granular dates — 4:23 PM Eastern
+    - cron: '23 20 * * *'
   workflow_dispatch: null
   # Allows manual triggering of the workflow
 permissions:


### PR DESCRIPTION
## Summary

- Move the three daily `Build and deploy` cron fires off the top of the hour (`:17`, `:43`, `:23` instead of `:00`)
- Add a second morning slot 86 min after the primary so the morning window has redundancy ahead of the 10am ET social-post fire

## Why

GitHub Actions silently drops scheduled runs during platform-wide high load — no notification, no retry. Today (2026-05-26) GHA dropped the `0 11 * * *` fire. That meant the harness blog post (`date: 2026-05-26`) didn't get rebuilt by Hugo this morning, but upload-post.com's scheduled LinkedIn post fired at 10am ET on schedule — landing a 404 link card.

Off-hour cron minutes (`:17`, `:43`, etc.) hit a fraction of `:00`'s contention because every team's default cron picks the top of the hour. Two morning slots 86 min apart give us very high redundancy against same-event drops.

## Changes

```yaml
schedule:
  - cron: '17 11 * * *'   # 7:17 AM ET — primary morning
  - cron: '43 12 * * *'   # 8:43 AM ET — fallback morning (86 min after primary)
  - cron: '23 20 * * *'   # 4:23 PM ET — afternoon (was 0 20)
```

Was:
```yaml
schedule:
  - cron: '0 11 * * *'    # 6 AM ET
  - cron: '0 20 * * *'    # noon Pacific
```

The afternoon slot stays because ~37% of blog posts use hour-granular `date:` frontmatter (e.g. `2026-05-19T05:00:00-07:00`) and may target an afternoon publish hour.

## Test plan

- [ ] CI green
- [ ] After merge, watch tomorrow morning (2026-05-27) for the 11:17 UTC fire in the Actions tab
- [ ] No follow-up needed if `schedule-social` keeps firing as expected via `workflow_run` on the new slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)