### PR TITLE
content(iac): document official Docker images

### DIFF
--- a/content/docs/deployments/deployments/runs/images.md
+++ b/content/docs/deployments/deployments/runs/images.md
@@ -25,7 +25,7 @@ By default, every deployment runs in [`pulumi/pulumi`](https://hub.docker.com/r/
 
 For most projects this is the right choice. The image is updated with every Pulumi CLI release, security-patched on a regular cadence, and pre-cached on Pulumi-hosted workflow runners, so deployments start quickly without paying a registry pull.
 
-The image is published in [`pulumi/pulumi-docker-containers`](https://github.com/pulumi/pulumi-docker-containers). That repository also publishes smaller variants you can use as a base for a custom image. See [Choosing a base image](#choosing-a-base-image) below.
+The image is published in [`pulumi/pulumi-docker-containers`](https://github.com/pulumi/pulumi-docker-containers). That repository also publishes smaller variants you can use as a base for a custom image. See [Choosing a base image](#choosing-a-base-image) below. For the full image catalog — variants, release cadence, and language-version pinning — see [Pulumi Docker images](/docs/iac/operations/docker-images/).
 
 ## When to customize
 
@@ -132,4 +132,5 @@ If your image lives in a private registry, you must supply static username and p
 - [Deployment settings](/docs/deployments/deployments/using/settings/): UI walkthrough for configuring the executor image on a stack
 - [Customer-Managed Workflow Runners](/docs/deployments/deployments/runs/customer-managed-agents/): full control over the runner host, registry pulls, network access, and lifecycle
 - [Pre-run commands](/docs/deployments/deployments/using/settings/#pre-run-commands): where pre-run installs run
+- [Pulumi Docker images](/docs/iac/operations/docker-images/): the full catalog of official images, variants, and release cadence
 - [`pulumi/pulumi-docker-containers`](https://github.com/pulumi/pulumi-docker-containers): image source, variants, and contribution guide

--- a/content/docs/iac/operations/_index.md
+++ b/content/docs/iac/operations/_index.md
@@ -26,4 +26,6 @@ These pages cover the Day 2 workflows for running Pulumi at scale.
 
 **[Debugging](/docs/iac/operations/debugging/)** - Attach a debugger, capture verbose logs, and trace performance for your Pulumi programs.
 
+**[Docker images](/docs/iac/operations/docker-images/)** - Pulumi's officially published container images: what's in each, where to pull from, release cadence, and how to use them as a base for custom images.
+
 **[Least privilege security](/docs/iac/operations/iac-least-privileges/)** - Configure cloud provider credentials with the minimum permissions needed for safe infrastructure operations.

--- a/content/docs/iac/operations/continuous-delivery/aws-code-services.md
+++ b/content/docs/iac/operations/continuous-delivery/aws-code-services.md
@@ -29,6 +29,8 @@ Pulumi runs in **CodeBuild**: it executes your Pulumi program to compute the des
 This guide assumes you use [Pulumi Cloud](https://app.pulumi.com/signin) as your [state backend](/docs/iac/concepts/state-and-backends/). Pulumi also supports [self-managed backends](/docs/iac/concepts/state-and-backends/#using-a-diy-backend) in CI/CD, but the authentication steps in this guide are written for Pulumi Cloud.
 {{% /notes %}}
 
+{{< pulumi-docker-images-note >}}
+
 ## How Pulumi works with AWS Code Services
 
 To apply infrastructure changes, Pulumi has to run your program with the Pulumi CLI. A CodeBuild project provides that environment: it checks out your source, installs the CLI and your program's dependencies, and runs `pulumi` commands.

--- a/content/docs/iac/operations/continuous-delivery/azure-devops.md
+++ b/content/docs/iac/operations/continuous-delivery/azure-devops.md
@@ -31,6 +31,8 @@ The task runs CLI commands, so it works with a Pulumi program written in any [su
 This guide assumes you use [Pulumi Cloud](https://app.pulumi.com/signin) as your [state backend](/docs/iac/concepts/state-and-backends/). Pulumi also supports [self-managed backends](/docs/iac/concepts/state-and-backends/#using-a-diy-backend) in CI/CD, but the authentication steps in this guide are written for Pulumi Cloud.
 {{% /notes %}}
 
+{{< pulumi-docker-images-note >}}
+
 ## Prerequisites
 
 Before you begin, make sure you have:

--- a/content/docs/iac/operations/continuous-delivery/bitbucket.md
+++ b/content/docs/iac/operations/continuous-delivery/bitbucket.md
@@ -25,6 +25,8 @@ aliases:
 
 Pulumi runs in a pipeline as plain CLI commands, so this guide works with a Pulumi program written in any [supported language](/docs/iac/languages-sdks/) and targeting [any cloud provider](/registry/).
 
+{{< pulumi-docker-images-note >}}
+
 ## Prerequisites
 
 Before you begin, make sure you have:

--- a/content/docs/iac/operations/continuous-delivery/buildkite.md
+++ b/content/docs/iac/operations/continuous-delivery/buildkite.md
@@ -22,6 +22,8 @@ Because the plugin runs CLI commands, it works with a Pulumi program written in 
 This guide assumes [Pulumi Cloud](/docs/pulumi-cloud/) as your backend. Pulumi Cloud isn't required to run Pulumi in CI/CD — Pulumi also supports [self-managed backends](/docs/iac/concepts/state-and-backends/) — but the access token, OIDC, and ESC features described here are specific to Pulumi Cloud.
 {{% /notes %}}
 
+{{< pulumi-docker-images-note >}}
+
 ## Prerequisites
 
 Before you begin, make sure you have:

--- a/content/docs/iac/operations/continuous-delivery/circleci.md
+++ b/content/docs/iac/operations/continuous-delivery/circleci.md
@@ -29,6 +29,8 @@ The orb runs CLI commands, so it works with a Pulumi program written in any [sup
 This guide assumes you use [Pulumi Cloud](https://app.pulumi.com/signin) as your [state backend](/docs/iac/concepts/state-and-backends/). Pulumi also supports [self-managed backends](/docs/iac/concepts/state-and-backends/#using-a-diy-backend) in CI/CD, but the authentication steps in this guide are written for Pulumi Cloud.
 {{% /notes %}}
 
+{{< pulumi-docker-images-note >}}
+
 ## Prerequisites
 
 Before you begin, make sure you have:

--- a/content/docs/iac/operations/continuous-delivery/codefresh.md
+++ b/content/docs/iac/operations/continuous-delivery/codefresh.md
@@ -25,6 +25,8 @@ aliases:
 This guide assumes Pulumi Cloud as the [state backend](/docs/iac/concepts/state-and-backends/). Pulumi can also run in CI/CD with a self-managed backend, but Pulumi Cloud is assumed throughout because it simplifies pipeline authentication and is the most common choice.
 {{% /notes %}}
 
+{{< pulumi-docker-images-note >}}
+
 ## How Pulumi works with Codefresh
 
 To apply infrastructure changes, Pulumi runs your program with the Pulumi CLI. A Codefresh [freestyle step](https://codefresh.io/docs/docs/pipelines/steps/freestyle/) provides that environment: it runs a set of commands inside a container image you choose. Point the step at `pulumi/pulumi` and it can run any `pulumi` command — `install`, `preview`, `up` — exactly as you would on your own machine.

--- a/content/docs/iac/operations/continuous-delivery/gitlab-ci.md
+++ b/content/docs/iac/operations/continuous-delivery/gitlab-ci.md
@@ -27,6 +27,8 @@ You run Pulumi in a pipeline by invoking the Pulumi CLI directly. The official [
 
 {{< cicd-cloud-note >}}
 
+{{< pulumi-docker-images-note >}}
+
 ## Prerequisites
 
 Before you begin, make sure you have:

--- a/content/docs/iac/operations/continuous-delivery/google-cloud-build.md
+++ b/content/docs/iac/operations/continuous-delivery/google-cloud-build.md
@@ -27,6 +27,8 @@ You run Pulumi in a build step by using one of Pulumi's official Docker images a
 
 {{< cicd-cloud-note >}}
 
+{{< pulumi-docker-images-note >}}
+
 ## Prerequisites
 
 Before you begin, make sure you have:

--- a/content/docs/iac/operations/continuous-delivery/harness.md
+++ b/content/docs/iac/operations/continuous-delivery/harness.md
@@ -20,6 +20,8 @@ You run Pulumi in Harness with standard [`Run` steps](https://developer.harness.
 
 {{< cicd-cloud-note >}}
 
+{{< pulumi-docker-images-note >}}
+
 ## Prerequisites
 
 Before you begin, make sure you have:

--- a/content/docs/iac/operations/continuous-delivery/jenkins.md
+++ b/content/docs/iac/operations/continuous-delivery/jenkins.md
@@ -22,6 +22,8 @@ aliases:
 
 {{< cicd-cloud-note >}}
 
+{{< pulumi-docker-images-note >}}
+
 ## How Pulumi works with Jenkins
 
 To apply infrastructure changes, Pulumi runs your program with the Pulumi CLI. A Jenkins pipeline stage with a [Docker agent](https://www.jenkins.io/doc/book/pipeline/docker/) provides that environment: it runs the stage's steps inside a container image you choose. Point the agent at `pulumi/pulumi` and the stage can run any `pulumi` command — `install`, `preview`, `up` — exactly as you would on your own machine.

--- a/content/docs/iac/operations/continuous-delivery/octopus-deploy.md
+++ b/content/docs/iac/operations/continuous-delivery/octopus-deploy.md
@@ -21,6 +21,8 @@ aliases:
 
 {{< cicd-cloud-note >}}
 
+{{< pulumi-docker-images-note >}}
+
 ## How Pulumi works with Octopus Deploy
 
 Octopus Deploy is a *continuous delivery* server, not a continuous integration server: it does not track your version control system, and it does not watch for pull requests or branch pushes. Octopus is typically paired with an upstream CI system — such as [GitHub Actions](/docs/iac/operations/continuous-delivery/github-actions/), [Jenkins](/docs/iac/operations/continuous-delivery/jenkins/), or [TeamCity](/docs/iac/operations/continuous-delivery/teamcity/) — that builds and tests your code, runs pull request previews, and produces the versioned package Octopus releases.

--- a/content/docs/iac/operations/continuous-delivery/teamcity.md
+++ b/content/docs/iac/operations/continuous-delivery/teamcity.md
@@ -21,6 +21,8 @@ aliases:
 
 {{< cicd-cloud-note >}}
 
+{{< pulumi-docker-images-note >}}
+
 ## How Pulumi works with TeamCity
 
 A TeamCity [build configuration](https://www.jetbrains.com/help/teamcity/creating-and-editing-build-configurations.html) is an ordered sequence of [build steps](https://www.jetbrains.com/help/teamcity/configuring-build-steps.html). To apply infrastructure changes, Pulumi runs your program with the Pulumi CLI, so you add a **Command Line** build step that runs `pulumi` commands — `install`, `preview`, `up` — exactly as you would on your own machine.

--- a/content/docs/iac/operations/continuous-delivery/travis.md
+++ b/content/docs/iac/operations/continuous-delivery/travis.md
@@ -27,6 +27,8 @@ Because Travis runs the CLI directly, this works with a Pulumi program written i
 
 {{< cicd-cloud-note >}}
 
+{{< pulumi-docker-images-note >}}
+
 ## Prerequisites
 
 Before you begin, make sure you have:

--- a/content/docs/iac/operations/docker-images.md
+++ b/content/docs/iac/operations/docker-images.md
@@ -40,11 +40,11 @@ Pull from whichever is closest to your runner to minimize cold-start time.
 
 ## Tags and release cadence
 
-Image tags mirror the Pulumi CLI's git tags. When [`pulumi v3.244.0`](https://github.com/pulumi/pulumi/releases) is released, you'll find a corresponding [`pulumi/pulumi:3.244.0`](https://hub.docker.com/r/pulumi/pulumi) in all three registries. The `latest` tag tracks the latest stable Pulumi CLI release.
+Image tags mirror the Pulumi CLI's git tags. When [`pulumi v3.243.0`](https://github.com/pulumi/pulumi/releases) is released, you'll find a corresponding [`pulumi/pulumi:3.243.0`](https://hub.docker.com/r/pulumi/pulumi) in all three registries. The `latest` tag tracks the latest stable Pulumi CLI release.
 
 The images are released automatically as part of the Pulumi CLI's release process. New minor releases arrive roughly weekly, with patch releases more frequently as needed.
 
-For reproducible builds, pin to a specific version (`pulumi/pulumi:3.244.0`) rather than `latest`. Pinning also keeps the image and your local CLI from drifting apart.
+For reproducible builds, pin to a specific version (e.g., `pulumi/pulumi:3.243.0` — check the [releases page](https://github.com/pulumi/pulumi/releases) for the current version) rather than `latest`. Pinning also keeps the image and your local CLI from drifting apart.
 
 ## Base images and platforms
 
@@ -98,7 +98,9 @@ If you build your own image on top of `pulumi/pulumi`, you can change the defaul
 The base and SDK images intentionally don't ship tools that are specific to a single provider or workflow — for example, `helm` and `kubectl` for the [Kubernetes provider](/registry/packages/kubernetes/), cloud-provider CLIs, or private credential helpers. When you need one of those tools available alongside the Pulumi CLI, derive your own image from the closest Pulumi image and install what you need:
 
 ```dockerfile
-FROM pulumi/pulumi-base:3.244.0
+# Replace the tag with the current Pulumi CLI version:
+# https://github.com/pulumi/pulumi/releases
+FROM pulumi/pulumi-base:3.243.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends helm kubectl \

--- a/content/docs/iac/operations/docker-images.md
+++ b/content/docs/iac/operations/docker-images.md
@@ -1,0 +1,122 @@
+---
+title_tag: "Pulumi Docker Images | IaC Operations"
+meta_desc: Pulumi's official Docker images bundle the CLI with language runtimes — for CI/CD, Kubernetes pods, Deployments, or as a base for custom images.
+title: Docker Images
+h1: Pulumi Docker Images
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Docker Images
+        parent: iac-operations
+        weight: 45
+        identifier: iac-operations-docker-images
+---
+
+Pulumi publishes and supports an official family of Docker images that bundle the [Pulumi CLI](/docs/iac/cli/) with one or more language runtimes. The images are scanned nightly for vulnerabilities and released on the same cadence as the Pulumi CLI, so a given tag matches a known Pulumi release. They are useful wherever you need a turnkey Pulumi environment — running Pulumi in CI/CD, in Kubernetes pods, as a [Pulumi Deployments custom executor](/docs/deployments/deployments/runs/images/), or as a base for derivative images that add tools the default images don't ship.
+
+The image source lives at [`pulumi/pulumi-docker-containers`](https://github.com/pulumi/pulumi-docker-containers) on GitHub.
+
+## Available images
+
+- [`pulumi/pulumi`](https://hub.docker.com/r/pulumi/pulumi) — the kitchen sink: the Pulumi CLI plus every supported language runtime (Go, Python, Node.js, .NET, Java). Approximately 2 GB. Right when you want one image that works for any language, or for polyglot projects.
+- [`pulumi/pulumi-base`](https://hub.docker.com/r/pulumi/pulumi-base) — the Pulumi CLI only, no language runtime. Approximately 200 MB. Right when you'll install your own language runtime, or when you only use the CLI (for example, to manage stacks or run `pulumi import`).
+- Language-specific slim images — the Pulumi CLI plus a single language runtime, 200–300 MB each. Right for single-language projects:
+  - [`pulumi/pulumi-go`](https://hub.docker.com/r/pulumi/pulumi-go)
+  - [`pulumi/pulumi-python`](https://hub.docker.com/r/pulumi/pulumi-python)
+  - [`pulumi/pulumi-nodejs`](https://hub.docker.com/r/pulumi/pulumi-nodejs)
+  - [`pulumi/pulumi-dotnet`](https://hub.docker.com/r/pulumi/pulumi-dotnet)
+  - [`pulumi/pulumi-java`](https://hub.docker.com/r/pulumi/pulumi-java)
+- Per-language-version variants of the slim images — for example, `pulumi/pulumi-nodejs-22`, `pulumi/pulumi-python-3.12`, `pulumi/pulumi-dotnet-9.0`. The unsuffixed image is built on the current default runtime version; see [Choosing a language version](#choosing-a-language-version).
+
+## Where to get them
+
+Every image is pushed to three registries:
+
+- [Docker Hub](https://hub.docker.com/u/pulumi)
+- [Amazon ECR Public Gallery](https://gallery.ecr.aws/pulumi/)
+- [GitHub Container Registry](https://github.com/orgs/pulumi/packages)
+
+Pull from whichever is closest to your runner to minimize cold-start time.
+
+## Tags and release cadence
+
+Image tags mirror the Pulumi CLI's git tags. When [`pulumi v3.244.0`](https://github.com/pulumi/pulumi/releases) is released, you'll find a corresponding [`pulumi/pulumi:3.244.0`](https://hub.docker.com/r/pulumi/pulumi) in all three registries. The `latest` tag tracks the latest stable Pulumi CLI release.
+
+The images are released automatically as part of the Pulumi CLI's release process. New minor releases arrive roughly weekly, with patch releases more frequently as needed.
+
+For reproducible builds, pin to a specific version (`pulumi/pulumi:3.244.0`) rather than `latest`. Pinning also keeps the image and your local CLI from drifting apart.
+
+## Base images and platforms
+
+The `pulumi/pulumi` kitchen-sink image is built on Debian for both `linux/amd64` and `linux/arm64`.
+
+Each slim image is built on a matrix of base images and platforms, with a suffix on the tag:
+
+- `-debian-amd64`, `-debian-arm64` — single-platform Debian images.
+- `-debian` — manifest list combining the two Debian platforms. `docker pull` picks the right one for the host architecture, so this is the default choice.
+- `-ubi` — Red Hat UBI-minimal base, available for `linux/amd64` only. UBI uses [`microdnf`](https://github.com/rpm-software-management/microdnf) as a package manager instead of `yum` to keep the image small.
+
+The unsuffixed tag is identical to the corresponding `-debian` tag. For the current Debian and UBI major versions, see the [Build Matrix](https://github.com/pulumi/pulumi-docker-containers#build-matrix) in the source repo's README.
+
+## Default language versions
+
+Unsuffixed images use a default version of each language runtime, generally tracking current LTS releases. The defaults rotate as new releases land, so the source repo's README is the authoritative reference — see [Language Versions](https://github.com/pulumi/pulumi-docker-containers#language-versions) for the current default per language and the policy that drives them.
+
+Pin the image tag to a specific Pulumi CLI version to avoid an unintended runtime upgrade when the default rotates.
+
+## Choosing a language version
+
+### Slim images
+
+For the language-specific slim images, use the suffixed tag to select a runtime version. For example, `pulumi/pulumi-nodejs-22` for Node.js 22, `pulumi/pulumi-python-3.12` for Python 3.12, `pulumi/pulumi-dotnet-9.0` for .NET 9.0. The currently published variants are listed on each image's Docker Hub page.
+
+### Kitchen-sink (`pulumi/pulumi`)
+
+The kitchen-sink image carries several language runtimes simultaneously. How you select among them depends on the language:
+
+**.NET** — the `TargetFramework` property in your project's `.csproj` or `.fsproj` file selects the SDK:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    ...
+```
+
+**Go** — the `go` directive in your `go.mod` file selects the toolchain. See [Go Toolchains](https://go.dev/doc/toolchain).
+
+**Java** — the kitchen-sink image ships a single JDK.
+
+**Node.js** — the image uses [`fnm`](https://github.com/Schniz/fnm) to manage Node.js versions and ships the latest patch releases of several Node.js majors pre-installed (see the [README](https://github.com/pulumi/pulumi-docker-containers#language-versions) for the bundled set). To select a version, place a `.node-version` file containing the version number in your project directory and run `pulumi install --use-language-version-tools`. To avoid re-downloading Node.js on each run, specify only the major version; `fnm` then picks the pre-installed patch release for that major.
+
+**Python** — the image uses [`pyenv`](https://github.com/pyenv/pyenv) and ships several Python minor versions pre-installed (see the [README](https://github.com/pulumi/pulumi-docker-containers#language-versions) for the bundled set). To select a version, place a `.python-version` file in your project directory. As with Node.js, specify only the major.minor version so the pre-installed build is used instead of being rebuilt at runtime.
+
+If you build your own image on top of `pulumi/pulumi`, you can change the default Node.js version with `fnm alias <version> default`.
+
+## Extending the images
+
+The base and SDK images intentionally don't ship tools that are specific to a single provider or workflow — for example, `helm` and `kubectl` for the [Kubernetes provider](/registry/packages/kubernetes/), cloud-provider CLIs, or private credential helpers. When you need one of those tools available alongside the Pulumi CLI, derive your own image from the closest Pulumi image and install what you need:
+
+```dockerfile
+FROM pulumi/pulumi-base:3.244.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends helm kubectl \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Build the image, push it to a registry your runner can reach, and reference it from your CI/CD job's container image setting or from your [Pulumi Deployments custom executor settings](/docs/deployments/deployments/runs/images/#custom-executor-image). Pin the `FROM` line to a specific Pulumi CLI tag rather than `latest` so that the image and your local CLI don't drift apart between rebuilds.
+
+This same pattern lets you bake provider plugins into the image with `pulumi plugin install`, eliminating the per-run plugin download in ephemeral runners. See the [plugins documentation](/docs/iac/concepts/plugins/) for details.
+
+## Scanning
+
+Images are scanned for vulnerabilities nightly. Pulumi remediates issues where it can, on a best-effort basis. Some vulnerabilities — for example, CVEs in upstream base images with no published fix — are outside Pulumi's direct control and persist until the upstream is patched.
+
+## See also
+
+- [`pulumi/pulumi-docker-containers`](https://github.com/pulumi/pulumi-docker-containers) — image source and contribution guide.
+- [Pulumi Deployments executor images](/docs/deployments/deployments/runs/images/) — using and customizing the executor image for Pulumi Deployments.
+- [Continuous Delivery](/docs/iac/operations/continuous-delivery/) — CI/CD guides for the systems where these images are commonly used.
+- [Docker provider](/registry/packages/docker/) — manage Docker resources (containers, networks, volumes) with Pulumi.
+- [Docker Build provider](/registry/packages/docker-build/) — build and push Docker images to any registry with Pulumi.

--- a/layouts/shortcodes/pulumi-docker-images-note.html
+++ b/layouts/shortcodes/pulumi-docker-images-note.html
@@ -1,0 +1,14 @@
+<div class="note note-info">
+    <div class="icon-and-line">
+        {{ partial "icon.html" (dict "name" "info" "weight" "fill") }}
+        <div class="line"></div>
+    </div>
+    <div class="content">
+        <p>
+            Pulumi publishes <a href="/docs/iac/operations/docker-images/">official container images</a>
+            with the CLI and language runtimes preinstalled, on a weekly release cadence matching the
+            Pulumi CLI. The examples on this page use those images directly; you can also derive your
+            own image from them to add tools like <code>helm</code> or <code>kubectl</code>.
+        </p>
+    </div>
+</div>

--- a/layouts/shortcodes/pulumi-docker-images-note.markdown.md
+++ b/layouts/shortcodes/pulumi-docker-images-note.markdown.md
@@ -1,0 +1,1 @@
+> **Note:** Pulumi publishes [official container images](/docs/iac/operations/docker-images/) with the CLI and language runtimes preinstalled, on a weekly release cadence matching the Pulumi CLI. The examples on this page use those images directly; you can also derive your own image from them to add tools like `helm` or `kubectl`.


### PR DESCRIPTION
Adds an IaC Operations page cataloging pulumi/pulumi-docker-containers, drops a reusable callout into the CI/CD guides whose target system supports a custom container image, and cross-links the Deployments executor-images page.

## Changes

- **New page:** `content/docs/iac/operations/docker-images.md` — image catalog, registries, release cadence, language-version selection, how to extend the images.
- **New shortcode:** `pulumi-docker-images-note` — info-note callout linking to the new page; mirrors `cicd-cloud-note` structurally.
- **Shortcode inserted** into 13 CI/CD guides (every system that supports a custom container image; skipped `argocd` and `github-actions`, where the recommended path isn't container-based).
- **Cross-link** added to `content/docs/deployments/deployments/runs/images.md` and an entry added to `content/docs/iac/operations/_index.md`.

Fact-rotten values (default language versions, bundled Node/Python majors, Debian and UBI major versions) are deferred to the source repo's README so the page stays current without per-release edits.

Fixes #19209