### PR TITLE
Migrate releases templates to shared typography utilities

### DIFF
--- a/layouts/partials/releases/card-text-block.html
+++ b/layouts/partials/releases/card-text-block.html
@@ -29,10 +29,10 @@
     </div>
     {{ end }}
     {{ with $title }}
-    <h3 class="text-xl md:text-2xl lg:text-3xl font-display font-semibold tracking-tighter text-service-black m-0 leading-[1.1]">{{ . }}</h3>
+    <h3 class="heading-2 font-display font-semibold tracking-tighter text-service-black m-0 leading-[1.1]">{{ . }}</h3>
     {{ end }}
     {{ with $description }}
-    <div class="text-base text-service-black leading-6">
+    <div class="body-base text-service-black leading-6">
         {{ . | markdownify }}
         {{ if $isLinked }}
         <span class="inline-flex items-center text-violet-primary ml-1 align-middle -mt-1">

--- a/layouts/partials/releases/hero-card.html
+++ b/layouts/partials/releases/hero-card.html
@@ -40,7 +40,7 @@
 <div class="bg-violet-950 text-white rounded-lg overflow-hidden">
     <div class="flex flex-col items-center text-center gap-12 px-8 pt-16 md:px-12 md:pt-20 lg:px-16 lg:pt-24">
         <div class="flex flex-col items-center gap-6 max-w-3xl">
-            <p class="font-mono text-sm tracking-wider uppercase m-0 flex items-center gap-2">
+            <p class="font-overline m-0 flex items-center gap-2">
                 <a href="/releases/" class="text-violet-500 hover:text-white no-underline hover:no-underline">Releases</a>
                 {{ if $breadcrumbLabel }}
                 <span class="text-violet-500" aria-hidden="true">/</span>
@@ -48,10 +48,10 @@
                 {{ end }}
             </p>
             {{ with $heading }}
-            <h1 class="text-4xl md:text-5xl lg:text-6xl font-display font-semibold tracking-tighter text-white m-0 leading-[1.1]">{{ . }}</h1>
+            <h1 class="heading-xl font-display font-semibold tracking-tighter text-white m-0 leading-[1.1]">{{ . }}</h1>
             {{ end }}
             {{ with $description }}
-            <div class="text-lg text-gray-300 max-w-2xl leading-relaxed">{{ . | markdownify }}</div>
+            <div class="body-lg text-gray-300 max-w-2xl leading-relaxed">{{ . | markdownify }}</div>
             {{ end }}
         </div>
     </div>

--- a/layouts/partials/releases/intro-toc-row.html
+++ b/layouts/partials/releases/intro-toc-row.html
@@ -20,10 +20,10 @@
         {{ if $hasLink }}{{ $introClasses = printf "%s transition-colors duration-200 hover:bg-violet-50 hover:border-violet-primary group" $introClasses }}{{ end }}
         {{ if $hasLink }}<a href="{{ .link }}" class="{{ $introClasses }}">{{ else }}<div class="{{ $introClasses }}">{{ end }}
             {{ with .quote }}
-            <div class="text-2xl md:text-3xl font-display font-semibold tracking-tighter text-service-black leading-[1.1]">{{ . | markdownify }}</div>
+            <div class="heading-2 m-0! font-display font-semibold tracking-tighter text-service-black leading-[1.1]">{{ . | markdownify }}</div>
             {{ end }}
             {{ with .attribution }}
-            <div class="text-base text-gray-900 flex flex-col md:flex-row md:items-end justify-between gap-4 mt-auto leading-6">
+            <div class="body-base text-gray-900 flex flex-col md:flex-row md:items-end justify-between gap-4 mt-auto leading-6">
                 <div class="flex-1">{{ . | markdownify }}</div>
                 {{ if $hasLink }}
                 <span class="inline-flex gap-1 items-center text-violet-primary shrink-0 font-semibold">
@@ -39,12 +39,12 @@
     {{/* TOC card */}}
     {{ with $sections }}
     <aside class="card bg-white p-8 lg:p-10 self-start h-full">
-        <p class="font-mono text-xs md:text-sm tracking-wider uppercase text-service-black m-0 mb-6">{{ $tocHeading }}</p>
+        <p class="font-overline text-service-black m-0 mb-6">{{ $tocHeading }}</p>
         <ul class="list-none p-0 m-0 flex flex-col gap-4">
             {{ range $i, $section := . }}
             <li class="m-0 flex items-baseline gap-4">
                 <span class="font-mono text-sm tracking-wider text-violet-primary shrink-0">.{{ printf "%02d" (add $i 1) }}</span>
-                <a href="#{{ $section.anchor }}" class="text-service-black hover:text-violet-primary no-underline hover:no-underline text-xl md:text-2xl font-display font-semibold tracking-tighter leading-[1.1]">{{ $section.label | default $section.heading }}</a>
+                <a href="#{{ $section.anchor }}" class="text-service-black hover:text-violet-primary no-underline hover:no-underline heading-3 m-0! font-display font-semibold tracking-tighter leading-[1.1]">{{ $section.label | default $section.heading }}</a>
             </li>
             {{ end }}
         </ul>

--- a/layouts/partials/releases/release-item.html
+++ b/layouts/partials/releases/release-item.html
@@ -43,7 +43,7 @@
             >
             {{ end }}
             {{ with $heading }}
-            <h2 class="text-3xl md:text-4xl lg:text-5xl font-display font-semibold tracking-tighter text-service-black m-0 leading-[1.1]">{{ . }}</h2>
+            <h2 class="heading-xl font-display font-semibold tracking-tighter text-service-black m-0 leading-[1.1]">{{ . }}</h2>
             {{ end }}
             {{ with $description }}
             <div class="text-lg max-w-xl leading-6">{{ . | markdownify }}</div>

--- a/layouts/partials/releases/section.html
+++ b/layouts/partials/releases/section.html
@@ -22,13 +22,13 @@
     {{ if or $heading $description (ne $number nil) }}
     <div class="md:text-center max-w-3xl mx-auto">
         {{ if ne $number nil }}
-        <p class="font-mono text-sm tracking-wider uppercase text-violet-primary m-0 mb-4">.{{ printf "%02d" (add $number 1) }}</p>
+        <p class="font-overline text-violet-primary m-0 mb-4">.{{ printf "%02d" (add $number 1) }}</p>
         {{ end }}
         {{ with $heading }}
-        <h2 class="text-3xl md:text-4xl lg:text-5xl font-display font-semibold tracking-tighter text-service-black m-0 mb-4 leading-[1.1]">{{ . }}</h2>
+        <h2 class="heading-1 font-display font-semibold tracking-tighter text-service-black m-0 mb-4 leading-[1.1]">{{ . }}</h2>
         {{ end }}
         {{ with $description }}
-        <p class="md:text-lg text-gray-900 m-0 leading-relaxed">{{ . | markdownify }}</p>
+        <p class="body-lg text-gray-900 m-0 leading-relaxed">{{ . | markdownify }}</p>
         {{ end }}
     </div>
     {{ end }}

--- a/layouts/releases/list.html
+++ b/layouts/releases/list.html
@@ -5,7 +5,7 @@
 <div class="font-body container mx-auto mb-16 mt-8 px-4 md:px-8 flex flex-col gap-6 md:gap-8">
 
     <header class="text-center max-w-3xl mx-auto">
-        <h1 class="text-4xl lg:text-5xl font-display font-semibold m-0 md:my-4">{{ .Title }}</h1>
+        <h1 class="heading-xl font-display font-semibold m-0 md:my-4">{{ .Title }}</h1>
     </header>
 
     <div class="flex flex-col gap-8">


### PR DESCRIPTION
**Generated description of changes:**

Replaces ad-hoc text/heading class lists across the releases templates (`hero-card`, `section`, `intro-toc-row`, `card-text-block`, `release-item`, and the releases `list` layout) with the `heading-*`, `body-*`, and `font-overline` `@utility` classes introduced in #19289, so the releases pages pick up the shared type scale. Margin overrides (`m-0!`) are added where a heading utility would otherwise inject an unwanted `mb-2`.