### PR TITLE
content(iac): correct resource options classification for components

### DIFF
--- a/content/docs/iac/concepts/resources/options/_index.md
+++ b/content/docs/iac/concepts/resources/options/_index.md
@@ -23,8 +23,18 @@ Resource constructors accept the following resource options. Each option's refer
 
 ## Resource options and component resources
 
-Not all resource options apply to [component resources](/docs/iac/concepts/components/). Component resources are logical groupings that don't have a backing cloud provider, so options that affect provider behavior have no effect on the component itself (though they may affect child resources). The **Applies to** column in the table above shows which options apply to component resources; each option's reference page explains the behavior in detail.
+Not all resource options apply to [component resources](/docs/iac/concepts/components/). Component resources are logical groupings that don't have a backing cloud provider, so options that affect provider behavior have no effect on the component itself (though, as described below, several of them are inherited by the component's children). The **Applies to** column in the table above shows which options have a direct effect on the component itself; each option's reference page explains the behavior in detail.
 
 {{% notes type="info" %}}
-When you apply a resource option to a component that doesn't support it, the option is silently ignored. To apply options like `protect` or `ignoreChanges` to the child resources within a component, use the `transforms` option to modify child resources as they're created.
+When you apply a resource option to a component that doesn't support it, the option has no direct effect on the component. To apply options like `ignoreChanges` to the child resources within a component, use the `transforms` option to modify child resources as they're created.
 {{% /notes %}}
+
+### Options inherited from a component to its children
+
+When a resource option is set on a component, several options propagate from the component to each of its child resources automatically. The child resource doesn't need to set the option itself; the engine carries the value down the parent/child chain at resource registration time. Each option's reference page describes how the option behaves on a component in detail.
+
+{{< resource-options-inheritance-table >}}
+
+Options marked **N/A** can't be set on a component to begin with: `additionalSecretOutputs`, `deleteBeforeReplace`, and `import` are custom-resource-only (and a compile-time error on components in TypeScript, C#, and Java); `envVarMappings` only applies to explicitly configured provider resources; and `parent` defines the parent/child relationship itself rather than being a value that's inherited.
+
+For options that aren't inherited, set them on each child resource that needs the behavior, or use `transforms` on the component to inject the option into matching child registrations as they're created.

--- a/content/docs/iac/concepts/resources/options/deletedwith.md
+++ b/content/docs/iac/concepts/resources/options/deletedwith.md
@@ -105,3 +105,5 @@ resources:
 ## Inheritance from parent
 
 `deletedWith` is inherited from a resource's [`parent`](/docs/iac/concepts/options/parent). Setting `deletedWith` on a parent causes every descendant in the resource tree to skip its provider delete as well, which makes it the idiomatic way to apply `deletedWith` for [component resources](/docs/iac/concepts/components/).
+
+Because the Pulumi engine never invokes Delete on a component itself, setting `deletedWith` on a component has no direct effect on the component. Its effect comes entirely from propagating the value to each of the component's child custom resources, which then skip their own deletes.

--- a/content/docs/iac/concepts/resources/options/hooks.md
+++ b/content/docs/iac/concepts/resources/options/hooks.md
@@ -23,6 +23,8 @@ The `hooks` resource option provides a set of resource hooks linked to a resourc
 Resource hooks are supported in TypeScript/JavaScript, Python, Go, and C#/.NET. Java and YAML do not support resource hooks.
 {{% /notes %}}
 
+Hooks can be attached to both custom resources and component resources. A hook attached to a component fires on the component's own create, update, and delete lifecycle events. Hooks are not automatically inherited by a component's child resources — attach hooks to each child individually if you want them to fire there as well.
+
 Each hook is a callback that gets invoked by the Pulumi engine. Hooks that execute before an action are called **before hooks** and have names beginning with `before` or `Before` depending on the language. Hooks that execute after an action are called **after hooks** and have names beginning with `after` or `After` depending on the language. Pulumi currently supports the following hook types:
 
 * *Create hooks* are called before or after a resource is created. This may occur during the initial creation of a resource or when a resource requires replacement due to e.g. a change in an immutable property.

--- a/data/resource_options.yaml
+++ b/data/resource_options.yaml
@@ -5,8 +5,11 @@
 #   - the `resource-option-scope` shortcode (the per-page classification
 #     callout: layouts/shortcodes/resource-option-scope.html, which builds its
 #     text via layouts/partials/resource-option-scope-body.html)
-#   - the `resource-options-table` shortcode (the options table in
+#   - the `resource-options-table` shortcode (the summary options table in
 #     options/_index.md: layouts/shortcodes/resource-options-table.html)
+#   - the `resource-options-inheritance-table` shortcode (the inheritance
+#     table in options/_index.md:
+#     layouts/shortcodes/resource-options-inheritance-table.html)
 #
 # -----------------------------------------------------------------------------
 # ADDING A NEW RESOURCE OPTION
@@ -17,13 +20,14 @@
 #      content/docs/iac/concepts/resources/options/<name>.md (lowercase file
 #      name; camelCase `title` in frontmatter, like the existing pages).
 #   2. Add an entry to THIS file, keyed by the camelCase option name, filling
-#      in every field documented below. Verify `applies_to` and `typed_on`
-#      against the SDK source (see "Determining typed_on" below).
+#      in every field documented below. Verify `applies_to`, `typed_on`, and
+#      `inherited_by_children` against the SDK source and the engine's actual
+#      runtime behavior (see "Re-verifying applies_to" below).
 #   3. In the new page, add the callout immediately after the opening
 #      descriptive paragraph:  {{< resource-option-scope "<name>" >}}
 #      The argument MUST exactly match the key you added in step 2.
-#   4. Nothing else to update: the options table in options/_index.md is
-#      generated from this file, so it picks up the new option automatically.
+#   4. Nothing else to update: the options tables in options/_index.md are
+#      generated from this file, so they pick up the new option automatically.
 #   5. Run `make build`. The `resource-option-scope` shortcode fails the build
 #      if its argument has no matching key here, so a forgotten entry can't
 #      ship silently.
@@ -38,63 +42,91 @@
 #   type and never enforce this distinction, so they need no per-SDK lookup.
 #
 # Fields per option:
-#   description      One-line, sentence-case summary rendered in the
-#                    options/_index.md table.
-#   applies_to       custom | component | both | provider
-#                    Whether the option has a meaningful effect on custom
-#                    resources, component resources, both, or only on
-#                    explicitly configured provider resources.
-#   typed_on         base | custom-options | component-options
-#                    Where the option is declared in the strongly typed SDKs
-#                    (TypeScript, C#, Java). Options on `CustomResourceOptions`
-#                    or `ComponentResourceOptions` are compile-time enforced;
-#                    options on the base `ResourceOptions` type are not.
-#   components_note  Short note on component behavior, used in the per-page
-#                    callout reasoning.
-#   note             Optional extra sentence appended to the per-page callout
-#                    for behavior that needs more explanation.
+#   description             One-line, sentence-case summary rendered in the
+#                           options/_index.md summary table.
+#   applies_to              custom | component | both | provider
+#                           Whether the option has a meaningful effect when
+#                           set DIRECTLY on a resource of that scope.
+#                           Inheritance from a component parent to its
+#                           children is a separate axis (see
+#                           `inherited_by_children` below and `note`).
+#   typed_on                base | custom-options | component-options
+#                           Where the option is declared in the strongly
+#                           typed SDKs (TypeScript, C#, Java). Options on
+#                           `CustomResourceOptions` or
+#                           `ComponentResourceOptions` are compile-time
+#                           enforced; options on the base `ResourceOptions`
+#                           type are not.
+#   inherited_by_children   yes | no | n/a
+#                           Whether a child custom resource of a component
+#                           automatically picks up this option from the
+#                           component at resource-registration time. `n/a`
+#                           for custom-only options, provider-scoped options,
+#                           and `parent` (which defines the relationship
+#                           rather than being inheritable).
+#   note                    Optional extra sentence(s) appended to the
+#                           per-page callout. Use this for everything that
+#                           needs more explanation than the generic
+#                           boilerplate from `applies_to`/`typed_on` — in
+#                           particular, inheritance from a component parent
+#                           to its children, or options that are settable on
+#                           a component but silently ignored by the engine.
+#
+# -----------------------------------------------------------------------------
+# RE-VERIFYING `applies_to` / `inherited_by_children`
+# -----------------------------------------------------------------------------
+# To re-verify an entry, write a small program that sets the option on a
+# custom component resource, runs `pulumi up`, and inspects state via
+# `pulumi stack export` (and any side effects like engine warnings or refusal
+# to delete). The `random` provider works without cloud credentials.
 
 additionalSecretOutputs:
   description: Specify output properties that must be encrypted as secrets.
   applies_to: custom
   typed_on: custom-options
-  components_note: Components don't have provider-managed outputs.
+  inherited_by_children: n/a
 
 aliases:
   description: Specify aliases so that renaming or refactoring doesn't replace a resource.
   applies_to: both
   typed_on: base
-  components_note: Works for renaming or refactoring components.
+  inherited_by_children: no
 
 customTimeouts:
   description: Override the default retry/timeout behavior for resource provisioning.
   applies_to: custom
   typed_on: base
-  components_note: Components don't have provider operations to time out.
+  inherited_by_children: no
 
 deleteBeforeReplace:
   description: Delete the existing resource before creating its replacement.
   applies_to: custom
   typed_on: custom-options
-  components_note: A provider doesn't replace component resources.
+  inherited_by_children: n/a
 
 deletedWith:
   description: Skip this resource's delete when the named resource is also being deleted.
-  applies_to: both
+  applies_to: custom
   typed_on: base
-  components_note: Controls deletion behavior for the component.
+  inherited_by_children: yes
+  note: >-
+    Setting `deletedWith` on a component is accepted by the SDK but has no
+    direct effect, because the engine never calls Delete on components. The
+    value does propagate to every child custom resource of the component, so
+    using it on a component is the idiomatic way to apply `deletedWith` to a
+    whole subtree.
 
 dependsOn:
   description: Specify explicit dependencies in addition to those in the dependency graph.
   applies_to: both
   typed_on: base
-  components_note: Creates explicit dependencies on the component.
+  inherited_by_children: no
 
 envVarMappings:
   description: Remap environment variables to custom keys for provider authentication.
   applies_to: provider
   typed_on: base
-  components_note: Affects only explicitly configured provider resources.
+  inherited_by_children: n/a
   note: >-
     In the C# SDK, `envVarMappings` is defined on `CustomResourceOptions`, so
     passing it to a component resource is a compile-time error; in the other
@@ -105,21 +137,24 @@ hideDiffs:
   description: Compact the display of diffs for specified properties in CLI output.
   applies_to: custom
   typed_on: base
-  components_note: Components don't have provider-generated diffs.
+  inherited_by_children: no
 
 hooks:
   description: Run custom logic at specific points in the resource lifecycle.
-  applies_to: custom
+  applies_to: both
   typed_on: base
-  components_note: Components don't have provider lifecycle events.
+  inherited_by_children: no
+  note: >-
+    Hooks attached to a component fire on the component's own
+    create/update/delete lifecycle events. They are not automatically
+    inherited by the component's child resources — attach hooks to each child
+    individually if you want them to fire there as well.
 
 ignoreChanges:
   description: Ignore changes to specified properties during a diff.
   applies_to: custom
   typed_on: base
-  components_note: >-
-    Components don't have provider-managed inputs; a component's implementation
-    may choose to propagate this to its children.
+  inherited_by_children: no
   note: >-
     `ignoreChanges` is not applied automatically to a component resource's
     inputs. If you pass it to a component, that component's implementation
@@ -129,61 +164,82 @@ import:
   description: Bring an existing cloud resource under Pulumi management.
   applies_to: custom
   typed_on: custom-options
-  components_note: Components can't be imported from a cloud provider.
+  inherited_by_children: n/a
 
 parent:
   description: Establish a parent/child relationship between resources.
   applies_to: both
   typed_on: base
-  components_note: Establishes parent-child relationships.
+  inherited_by_children: n/a
 
 protect:
   description: Prevent accidental deletion by marking the resource as protected.
   applies_to: both
   typed_on: base
-  components_note: Protects the component from deletion.
+  inherited_by_children: yes
+  note: >-
+    Setting `protect: true` on a component propagates `protect: true` to every
+    child custom resource. The engine refuses to delete any protected resource
+    in the subtree until the flag is removed (or the resource is unprotected
+    with `pulumi state unprotect`).
 
 provider:
   description: Pass an explicitly configured provider instead of the default.
-  applies_to: custom
+  applies_to: both
   typed_on: base
-  components_note: Use `providers` instead to configure a component's child resources.
+  inherited_by_children: yes
+  note: >-
+    A `provider` set on a component is inherited by its child custom resources
+    of the same package, acting as the default provider for the subtree. For
+    components whose children span multiple packages, prefer `providers`,
+    which accepts a list keyed by package name.
 
 providers:
   description: Pass explicitly configured providers for a component's child resources.
   applies_to: component
   typed_on: component-options
-  components_note: Passes providers used by the component's child resources.
+  inherited_by_children: yes
 
 replacementTrigger:
   description: Force a replacement whenever a specified trigger value changes.
-  applies_to: both
+  applies_to: custom
   typed_on: base
-  components_note: A component is replaced when the trigger value changes.
+  inherited_by_children: no
+  note: >-
+    `replacementTrigger` is settable on a component, but the engine never
+    replaces components, so it has no effect there. It also is not inherited
+    by the component's children — set it on each child custom resource that
+    you want to be replaced by the trigger, or use a `transforms` function on
+    the component to inject it into matching children.
 
 replaceOnChanges:
   description: Treat changes to specified properties as forcing a replacement.
   applies_to: custom
   typed_on: base
-  components_note: A provider doesn't replace component resources.
+  inherited_by_children: no
 
 replaceWith:
   description: Replace this resource whenever one of the named resources is replaced.
   applies_to: custom
   typed_on: base
-  components_note: A provider doesn't replace component resources.
+  inherited_by_children: no
 
 retainOnDelete:
   description: Retain the resource in the cloud provider when Pulumi deletes it.
   applies_to: custom
   typed_on: base
-  components_note: Components don't have cloud resources to retain.
+  inherited_by_children: yes
+  note: >-
+    Setting `retainOnDelete` on a component has no direct effect — components
+    don't have cloud resources to retain. The value propagates to every child
+    custom resource of the component, which is the idiomatic way to retain a
+    whole subtree.
 
 transformations:
   description: Dynamically transform a resource's properties (prefer `transforms`).
   applies_to: both
   typed_on: base
-  components_note: Transforms the component's child resources.
+  inherited_by_children: yes
   note: >-
     When applied to a component resource, `transformations` runs against the
     component's child resources rather than the component itself.
@@ -192,7 +248,7 @@ transforms:
   description: Dynamically transform a resource's properties on the fly.
   applies_to: both
   typed_on: base
-  components_note: Transforms the component's child resources.
+  inherited_by_children: yes
   note: >-
     When applied to a component resource, `transforms` runs against the
     component's child resources rather than the component itself.
@@ -201,4 +257,4 @@ version:
   description: Pin the provider plugin version used when operating on a resource.
   applies_to: custom
   typed_on: base
-  components_note: Components don't use provider plugins.
+  inherited_by_children: no

--- a/data/resource_options.yaml
+++ b/data/resource_options.yaml
@@ -90,7 +90,13 @@ aliases:
   description: Specify aliases so that renaming or refactoring doesn't replace a resource.
   applies_to: both
   typed_on: base
-  inherited_by_children: no
+  inherited_by_children: yes
+  note: >-
+    A child resource's stored state does not contain a copy of its parent's
+    `aliases`. Instead, the engine combines a parent's aliases with each
+    child's own name and type when computing the child's identity, so renaming
+    or retyping a component with `aliases` set on the component preserves its
+    children without requiring per-child aliases.
 
 customTimeouts:
   description: Override the default retry/timeout behavior for resource provisioning.

--- a/layouts/partials/resource-option-scope-body.html
+++ b/layouts/partials/resource-option-scope-body.html
@@ -15,9 +15,9 @@
 {{- else if eq $applies "provider" -}}
   {{- $text = printf "**Applies to provider resources only.** The `%s` resource option affects only explicitly configured [provider resources](/docs/iac/concepts/providers/). It has no effect on ordinary custom resources or on component resources." $name -}}
 {{- else if eq $typed "custom-options" -}}
-  {{- $text = printf "**Applies to custom resources only.** The `%s` resource option applies only to custom resources. In the TypeScript, C#, and Java SDKs it is defined on `CustomResourceOptions`, so passing it to a [component resource](/docs/iac/concepts/components/) is a compile-time error. The Python and Go SDKs expose a single resource-options type, so the option is accepted at compile time and silently ignored at runtime when applied to a component resource." $name -}}
+  {{- $text = printf "**Applies to custom resources only.** The `%s` resource option applies only to custom resources. In the TypeScript, C#, and Java SDKs it is defined on `CustomResourceOptions`, so passing it to a [component resource](/docs/iac/concepts/components/) is a compile-time error. The Python and Go SDKs expose a single resource-options type, so the option is accepted at compile time and has no direct effect when applied to a component resource." $name -}}
 {{- else -}}
-  {{- $text = printf "**Applies to custom resources only.** The `%s` resource option has no effect on [component resources](/docs/iac/concepts/components/). It is defined on the base resource-options type in every Pulumi SDK, so no SDK rejects it at compile time — passing it to a component resource is silently ignored at runtime." $name -}}
+  {{- $text = printf "**Applies to custom resources only.** The `%s` resource option has no direct effect on [component resources](/docs/iac/concepts/components/). It is defined on the base resource-options type in every Pulumi SDK, so no SDK rejects it at compile time — passing it to a component resource has no direct effect at runtime." $name -}}
 {{- end -}}
 {{- with $data.note -}}
   {{- $text = printf "%s %s" $text (. | chomp) -}}

--- a/layouts/shortcodes/resource-options-inheritance-table.html
+++ b/layouts/shortcodes/resource-options-inheritance-table.html
@@ -1,0 +1,18 @@
+{{- /*
+  Renders the inheritance table — which options propagate from a component
+  to its child custom resources at registration time — driven by
+  data/resource_options.yaml.
+  Usage: {{< resource-options-inheritance-table >}}
+*/ -}}
+{{- $labels := dict
+  "yes" "Yes"
+  "no" "No"
+  "n/a" "N/A" -}}
+{{- $rows := slice -}}
+{{- range $name, $d := site.Data.resource_options -}}
+  {{- $link := printf "[%s](/docs/iac/concepts/resources/options/%s/)" $name (lower $name) -}}
+  {{- $inherited := index $labels (printf "%v" $d.inherited_by_children) -}}
+  {{- $rows = $rows | append (printf "| %s | %s |" $link $inherited) -}}
+{{- end -}}
+{{- $table := printf "| Resource option | Inherited by children of a component |\n|---|---|\n%s\n" (delimit $rows "\n") -}}
+{{ $table | markdownify }}


### PR DESCRIPTION
Verifies and corrects the per-option `applies_to` classifications in `data/resource_options.yaml` against observed engine behavior, and documents which options propagate from a component to its children at resource registration time.

## Reclassifications
- `hooks`: `custom` → `both` (hooks fire on the component itself)
- `deletedWith`: `both` → `custom` (no-op on a component but inherited by children)
- `replacementTrigger`: `both` → `custom` (components are never replaced)
- `provider`: `custom` → `both` (propagates to children of the same package)

## What else changed
- New `inherited_by_children` field on every YAML entry, with a new `resource-options-inheritance-table` shortcode rendering the inheritance table on the options landing page from the YAML.
- Drops the unused `components_note` field (no template consumed it).
- Tweaks the scope-body partial to say "has no direct effect" instead of "silently ignored", so the boilerplate doesn't contradict the new inheritance notes.

Behavior was verified by running small Pulumi programs against the random provider on a local file backend and inspecting `pulumi stack export` for each option set on a custom component.

Closes #19397.