### PR TITLE
content(iac): document --run-program for refresh and destroy

### DIFF
--- a/content/docs/iac/concepts/resources/options/hooks.md
+++ b/content/docs/iac/concepts/resources/options/hooks.md
@@ -626,7 +626,7 @@ In order for delete hooks to run successfully, Pulumi must have access to any ne
 
 * When removing resources from your program, first remove *only* the resources you wish to delete, *leaving any delete hooks in place*. Upon running e.g. `pulumi up`, Pulumi will delete the resources and run any relevant delete hooks. Once this operation is complete, you can then remove the delete hooks from your program.
 
-* When running `pulumi destroy`, you must pass the `--run-program` flag to instruct Pulumi to run your program and register any hooks that are to be executed. If Pulumi detects that you are trying to `destroy` a stack that contains hooks _without_ the `--run-program` flag, it will fail with an error.
+* When running `pulumi destroy`, you must pass the `--run-program` flag to instruct Pulumi to run your program and register any hooks that are to be executed. If Pulumi detects that you are trying to `destroy` a stack that contains hooks _without_ the `--run-program` flag, it will fail with an error. See [Running your program on refresh and destroy](/docs/iac/operations/stack-management/run-program/) for other situations where the flag is useful.
 
 ## Error hooks
 

--- a/content/docs/iac/operations/stack-management/_index.md
+++ b/content/docs/iac/operations/stack-management/_index.md
@@ -18,6 +18,8 @@ These pages cover the day-to-day operations of running Pulumi stacks: scoping up
 
 **[Targeted updates](/docs/iac/operations/stack-management/targeted-updates/)** - Limit which resources Pulumi operates on with `--target`, `--exclude`, and `--target-replace`. Learn the trade-offs of partial operations and when to use them.
 
+**[Running your program on refresh and destroy](/docs/iac/operations/stack-management/run-program/)** - Use `--run-program` to execute your Pulumi program before `refresh` or `destroy`. Required for dynamic credentials and useful for diff-clean provider upgrades.
+
 **[Update plans](/docs/iac/operations/stack-management/update-plans/)** - Preview and review infrastructure changes before applying them. Update plans help you catch unintended modifications and coordinate changes across teams.
 
 **[Editing state files](/docs/iac/operations/stack-management/editing-state-files/)** - Safe techniques for modifying Pulumi state when normal operations can't recover. Use sparingly and always back up state first.

--- a/content/docs/iac/operations/stack-management/run-program.md
+++ b/content/docs/iac/operations/stack-management/run-program.md
@@ -1,0 +1,72 @@
+---
+title_tag: "Running your program on refresh and destroy | Pulumi Operations"
+meta_desc: Use --run-program to execute your Pulumi program before refresh or destroy. Required for dynamic credentials and useful for diff-clean provider upgrades.
+title: Running your program on refresh and destroy
+h1: Running your program on refresh and destroy
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Running your program on refresh and destroy
+        parent: iac-operations-stack-management
+        weight: 15
+---
+
+By default, `pulumi refresh` and `pulumi destroy` do not execute your program. They operate on stack configuration and the resources already recorded in state. The `--run-program` flag opts in to running your program first, so the operation sees whatever your program computes at runtime — provider credentials, dynamic resources, or updated provider inputs.
+
+Reach for `--run-program` whenever the values that `refresh` or `destroy` depend on are produced by code rather than persisted in state. The two most common situations are dynamic credentials and provider upgrades.
+
+## Refreshing or destroying with expired credentials
+
+Most cloud credentials are short-lived: OIDC-issued tokens and STS session credentials expire on the order of minutes to hours, and credentials brokered through a secrets manager are often similarly time-bound. When `pulumi up` runs, the program fetches a fresh credential and Pulumi records the resulting provider configuration in state. The credential is not re-fetched on later operations.
+
+A few hours or days later, running `pulumi refresh` or `pulumi destroy` reuses that recorded provider configuration. The token has expired, the operation fails, and the failure looks like an auth error from the cloud rather than a stale-credential problem.
+
+Add `--run-program` to re-run your program so the provider gets a fresh credential:
+
+```bash
+pulumi refresh --run-program
+pulumi destroy --run-program
+```
+
+## Removing spurious diffs after a provider upgrade
+
+Major-version provider releases typically change resource schemas: property names and types shift, deprecated fields disappear, and the inputs the provider expects look different from what is currently in state. Running `pulumi refresh` after a major provider update without running the program can surface spurious diffs that reflect schema differences rather than real drift in the cloud.
+
+Running the program gives the new provider the inputs it needs to compute a clean diff between your program's intent and the cloud state. After upgrading a provider's major version, run:
+
+```bash
+pulumi up --refresh --run-program
+```
+
+The [AWS provider 6.x → 7.x migration guide](https://www.pulumi.com/registry/packages/aws/how-to-guides/7-0-migration/) prescribes exactly this command for that reason. The same pattern applies to any provider upgrade where the schema changes — Azure, GCP, Kubernetes, or any other.
+
+## Using the flag
+
+`--run-program` is accepted by `pulumi refresh`, `pulumi destroy`, and by `pulumi up` and `pulumi preview` when they perform a refresh step (`--refresh`):
+
+```bash
+pulumi refresh --run-program
+pulumi destroy --run-program
+pulumi up --refresh --run-program
+pulumi preview --refresh --run-program
+```
+
+To set it once per shell or in CI, use the equivalent environment variable:
+
+```bash
+export PULUMI_RUN_PROGRAM=true
+```
+
+See [Pulumi CLI environment variables](/docs/iac/cli/environment-variables/) for the full list.
+
+## Related uses
+
+- **Resource hooks.** Delete hooks require `--run-program` on `pulumi destroy` — without it, Pulumi cannot register the hooks before deletion and the operation fails. See [Deletions and delete hooks](/docs/iac/concepts/resources/options/hooks/#deletions-and-delete-hooks).
+- **Dynamic providers.** Programs that use [dynamic providers](/docs/iac/concepts/providers/dynamic-providers/) need the program to run so Pulumi can load the provider's implementation from your code.
+
+## See also
+
+- [`pulumi refresh`](/docs/iac/cli/commands/pulumi_refresh/) — CLI reference.
+- [`pulumi destroy`](/docs/iac/cli/commands/pulumi_destroy/) — CLI reference.
+- [Improved refresh and destroy experience for Pulumi IaC](/blog/improved-refresh-destroy-experience/) — original announcement, with extended examples.
+- [Resource hooks](/docs/iac/concepts/resources/options/hooks/) — when delete hooks force the use of `--run-program`.

--- a/content/docs/iac/operations/troubleshooting/destroy-failures.md
+++ b/content/docs/iac/operations/troubleshooting/destroy-failures.md
@@ -17,6 +17,18 @@ aliases:
 
 There are scenarios when `pulumi destroy` will fail to delete resources as expected. This is anticipated due to the nature of cloud provider dependencies, permissions, resources being in a state that prevents their deletion, or when a timeout is not long enough for the cloud provider to complete its operation. Review the output to identify which resources were not deleted and consider the following steps depending on the nature of the failure.
 
+## Stale or expired credentials
+
+If your Pulumi program fetches provider credentials at runtime — from an OIDC exchange, a secrets manager, or a platform-team library — `pulumi destroy` does not re-run the program by default. It reuses the provider configuration recorded during the last update, so any short-lived credential it captured has likely expired. The destroy then fails with what looks like an auth error from the cloud provider.
+
+Re-run the program before destroying by passing `--run-program`:
+
+```bash
+pulumi destroy --run-program
+```
+
+See [Running your program on refresh and destroy](/docs/iac/operations/stack-management/run-program/) for the full explanation.
+
 ## Check to see if a resource was deleted after all
 
 Some resources take time to be removed. Common examples include CloudFront Lambda@Edge functions, which will fail to `destroy` but will eventually disappear without requiring further action. In these cases, you can wait and run `pulumi refresh` to see if the cloud provider was able to remove the resource.


### PR DESCRIPTION
Adds a stack-management page documenting `pulumi refresh --run-program` and `pulumi destroy --run-program` for the two common scenarios: expired dynamic credentials and spurious diffs after a major provider upgrade (with the AWS v6 → v7 migration as a worked example).

## Changes
- New: `content/docs/iac/operations/stack-management/run-program.md`
- Pages entry added to the stack-management index
- New "Stale or expired credentials" section in `destroy-failures.md`
- See-also link added at the `--run-program` mention in resource hooks

Closes #19369.