### PR TITLE
Tweak getting-support page copy

### DIFF
--- a/content/docs/support/getting-support.md
+++ b/content/docs/support/getting-support.md
@@ -12,7 +12,7 @@ menu:
         identifier: support-getting-support
 ---
 
-The right way to get help with Pulumi depends on whether your organization has a paid support plan. Pulumi offers community channels that are open to everyone and direct support channels available to customers on a paid plan.
+Pulumi is committed to helping our customers and community succeed. We offer community channels that are open to everyone and direct support channels available to customers on a paid plan.
 
 ## Without a paid support plan
 
@@ -20,7 +20,7 @@ Anyone using Pulumi — including users of Pulumi open source and the free tier 
 
 - **[Pulumi Community Slack](https://slack.pulumi.com/)** — Ask questions and discuss Pulumi with other users. The community Slack is used by other Pulumi users and is regularly monitored by Pulumi employees, including engineers and members of the developer relations team.
 - **[GitHub issues](/docs/support/filing-issues/)** — Report bugs and request features. The linked guide explains how to pick the right Pulumi repository for your issue.
-- **[Documentation FAQs](/docs/support/faq/)** — Find answers to common questions about Pulumi infrastructure, secrets, policies, and platform features.
+- **[Documentation](/docs/)** — Find answers to common questions about Pulumi infrastructure, secrets, policies, and platform features.
 
 Pulumi staff are active in both the community Slack and on GitHub, but response times depend on availability and are not covered by an SLA.
 
@@ -37,5 +37,5 @@ If you are on a paid plan and aren't sure how to reach your support channel, con
 
 Paid support plans are available for organizations using either Pulumi Cloud or Pulumi open source.
 
-- **Pulumi Cloud customers** — Paid support is included with the Enterprise and Business Critical editions of Pulumi Cloud. [Contact sales](/contact/?form=sales) to upgrade.
+- **Pulumi Cloud customers** — Paid support plans are available at all editions of Pulumi Cloud. [Contact sales](/contact/?form=sales) to upgrade.
 - **Pulumi open source users** — Pulumi offers paid support plans for qualified organizations using Pulumi open source without Pulumi Cloud. [Contact sales](/contact/?form=sales) to discuss options.

--- a/content/docs/support/getting-support.md
+++ b/content/docs/support/getting-support.md
@@ -20,7 +20,7 @@ Anyone using Pulumi — including users of Pulumi open source and the free tier 
 
 - **[Pulumi Community Slack](https://slack.pulumi.com/)** — Ask questions and discuss Pulumi with other users. The community Slack is used by other Pulumi users and is regularly monitored by Pulumi employees, including engineers and members of the developer relations team.
 - **[GitHub issues](/docs/support/filing-issues/)** — Report bugs and request features. The linked guide explains how to pick the right Pulumi repository for your issue.
-- **[Documentation](/docs/)** — Find answers to common questions about Pulumi infrastructure, secrets, policies, and platform features.
+- **[Documentation](/docs/)** — Browse the full Pulumi documentation for guidance on infrastructure, secrets, policies, and platform features.
 
 Pulumi staff are active in both the community Slack and on GitHub, but response times depend on availability and are not covered by an SLA.
 


### PR DESCRIPTION
## Summary

- Reframe the lead sentence to open with Pulumi's commitment to helping customers and community, replacing the "right way to get help" framing.
- Replace the "Documentation FAQs" bullet with a link to the docs root.
- Clarify that paid support plans are *available* (not "included") and apply at all Pulumi Cloud editions.

## Test plan

- [ ] Render `/docs/support/getting-support/` locally and confirm the three edits read correctly.
- [ ] Confirm the `/docs/` link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)