### PR TITLE
content(iac): document restoring deleted stacks

### DIFF
--- a/content/blog/restore-stacks/index.md
+++ b/content/blog/restore-stacks/index.md
@@ -21,6 +21,9 @@ meta_desc: Pulumi Cloud launches new Restore Stacks feature for Enterprise and B
 # has been provided for you.
 meta_image: meta.png
 
+# Point search engines to the docs page as the authoritative source for this content.
+canonical_url: "https://www.pulumi.com/docs/iac/operations/stack-management/restoring-deleted-stacks/"
+
 # At least one author is required.
 # The values in this list correspond with the `id` properties
 # of the team member files at /data/team/team.
@@ -38,6 +41,8 @@ tags:
 # for additional details,
 # and please remove these comments before submitting for review.
 ---
+
+> This post announced the Restore Stacks feature. For the most up-to-date information on recovering deleted stacks, see the [Restoring deleted stacks](/docs/iac/operations/stack-management/restoring-deleted-stacks/) documentation.
 
 Starting today, you can restore previously deleted stacks in the Pulumi Cloud console. We've had a number of requests from customers to recover stacks, either because the stack was accidentally deleted or the stack was intentionally deleted but, later on, they want to restore and preserve the activity history on the stack and just remove its resources.
 

--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -1172,3 +1172,7 @@ There are scenarios when `pulumi destroy` may fail to delete resources as expect
 To delete a stack with no resources, run `pulumi stack rm`. Removing the stack will remove all stack history from pulumi.com and will delete the stack configuration file `Pulumi.<stack-name>.yaml`.
 
 To force the deletion of a stack that still contains resources---potentially orphaning them---use `pulumi stack rm --force`.
+
+{{% notes type="info" %}}
+If a stack is deleted by mistake, organization administrators can restore it from the Pulumi Cloud console for a limited time. See [Restoring deleted stacks](/docs/iac/operations/stack-management/restoring-deleted-stacks/).
+{{% /notes %}}

--- a/content/docs/iac/guides/basics/pulumi-cloud-vs-oss.md
+++ b/content/docs/iac/guides/basics/pulumi-cloud-vs-oss.md
@@ -58,7 +58,7 @@ Pulumi stores [state](/docs/iac/concepts/state-and-backends/)—the metadata it 
 
 DIY backends include built-in state locking, checkpoint history, project-scoped stacks, and support for several secrets encryption providers. However, they leave operational concerns to you, including securing access to the storage backend, backup and disaster recovery, monitoring availability, and managing team access.
 
-The Pulumi Cloud backend exposes a transactional REST API rather than a blob storage protocol. This allows it to record state incrementally and recover cleanly from partial failures—such as a network interruption during an update—where a blob storage backend has a coarser-grained protocol. Pulumi Cloud also handles the operational concerns above on your behalf. In addition to Pulumi state, Pulumi Cloud can store and manage Terraform state.
+The Pulumi Cloud backend exposes a transactional REST API rather than a blob storage protocol. This allows it to record state incrementally and recover cleanly from partial failures—such as a network interruption during an update—where a blob storage backend has a coarser-grained protocol. Pulumi Cloud also handles the operational concerns above on your behalf, including retaining the state of recently deleted stacks so that an organization administrator can [restore a stack](/docs/iac/operations/stack-management/restoring-deleted-stacks/) that was removed by mistake. In addition to Pulumi state, Pulumi Cloud can store and manage Terraform state.
 
 ## Access management
 

--- a/content/docs/iac/operations/stack-management/_index.md
+++ b/content/docs/iac/operations/stack-management/_index.md
@@ -26,6 +26,8 @@ These pages cover the day-to-day operations of running Pulumi stacks: scoping up
 
 **[Editing state files](/docs/iac/operations/stack-management/editing-state-files/)** - Safe techniques for modifying Pulumi state when normal operations can't recover. Use sparingly and always back up state first.
 
+**[Restoring deleted stacks](/docs/iac/operations/stack-management/restoring-deleted-stacks/)** - Recover a recently deleted stack from the Pulumi Cloud console, including after an accidental `pulumi stack rm --force`.
+
 **[Using a DIY backend](/docs/iac/operations/stack-management/using-a-diy-backend/)** - Configure a self-managed state backend with AWS S3, Azure Blob Storage, Google Cloud Storage, PostgreSQL, or the local filesystem.
 
 **[Refactoring with aliases](/docs/iac/operations/stack-management/refactoring-with-aliases/)** - Use the `aliases` resource option to rename, re-parent, change the type, or move resources across stacks without destroying and recreating them.

--- a/content/docs/iac/operations/stack-management/restoring-deleted-stacks.md
+++ b/content/docs/iac/operations/stack-management/restoring-deleted-stacks.md
@@ -1,0 +1,53 @@
+---
+title_tag: "Restoring deleted stacks | Pulumi Operations"
+meta_desc: Restore a deleted stack in Pulumi Cloud to recover its state file and history after an accidental removal with the Pulumi CLI.
+title: Restoring deleted stacks
+h1: Restoring deleted stacks
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Restoring deleted stacks
+        parent: iac-operations-stack-management
+        weight: 35
+---
+
+Pulumi Cloud retains the state file versions of recently deleted stacks so that organization administrators can recover them through the Pulumi Cloud console. This is useful when a stack is deleted accidentally — most often by `pulumi stack rm --force`, which removes the state file even when the stack still has resources associated with it — or when a stack was intentionally deleted but its activity history is later needed.
+
+{{% notes type="info" %}}
+Restoring deleted stacks is a [Pulumi Cloud](/docs/pulumi-cloud/) feature. Stacks stored in a [DIY backend](/docs/iac/operations/stack-management/using-a-diy-backend/) cannot be restored this way; if you operate a DIY backend, you are responsible for your own backup and recovery process for the underlying storage.
+{{% /notes %}}
+
+## What gets restored
+
+When you restore a deleted stack, Pulumi Cloud restores the stack's state file and update history. Restoring a stack does not re-create any cloud resources that were destroyed by a prior `pulumi destroy`; it only brings back the stack record and its state so you can resume managing it from Pulumi.
+
+If the stack was deleted with `pulumi stack rm --force` while resources still existed, the cloud resources themselves were not deleted — they were orphaned. Once you restore the stack, those resources are again represented in state and you can manage them with Pulumi as before.
+
+## Limits
+
+- Only the **last 25 deleted stacks** in an organization are available for self-service restore.
+- Only **organization administrators** can restore stacks.
+- If you need to restore an older stack that is no longer in the list, [contact Pulumi support](/support/).
+
+## Restore a stack
+
+1. Sign in to the [Pulumi Cloud console](https://app.pulumi.com/) as an organization administrator and select the organization the stack belonged to.
+1. Navigate to the **Stacks** page for the organization.
+1. Next to the **Create project** button, open the three-dot menu and choose **Restore stacks**.
+1. Locate the stack you want to restore in the list of recently deleted stacks and select **Restore**.
+
+After the stack is restored, it appears in the organization's stack list with its prior state and history.
+
+## Avoiding accidental deletion
+
+The restore window is finite, so the best protection against accidental loss is preventing the deletion in the first place:
+
+- Prefer `pulumi stack rm` (without `--force`) so the CLI refuses to remove a stack that still has resources tracked in state. Use `pulumi destroy` first, confirm the stack is empty, and then remove it.
+- Reserve `pulumi stack rm --force` for cases where you have intentionally decided to orphan the underlying cloud resources or where you are certain the state file does not need to be preserved.
+- For stacks that should never be removable through routine operations, restrict who has organization-admin or stack-write permissions. See [Teams and RBAC](/docs/administration/organizations-teams/teams/).
+
+## Related
+
+- [Stacks](/docs/iac/concepts/stacks/) — concept reference, including how to delete a stack.
+- [Editing state files](/docs/iac/operations/stack-management/editing-state-files/) — safe techniques for modifying state when normal operations cannot recover.
+- [Troubleshooting](/docs/iac/operations/troubleshooting/) — diagnosing and resolving common Pulumi failures.

--- a/content/docs/iac/operations/troubleshooting/_index.md
+++ b/content/docs/iac/operations/troubleshooting/_index.md
@@ -81,6 +81,11 @@ sections:
     link: /docs/iac/operations/stack-management/editing-state-files/
     description: Safe techniques for modifying Pulumi state files when necessary.
 
+  - icon: clock-counter-clockwise
+    heading: Restoring Deleted Stacks
+    link: /docs/iac/operations/stack-management/restoring-deleted-stacks/
+    description: Recover a recently deleted stack from the Pulumi Cloud console, including after an accidental `pulumi stack rm --force`.
+
   - icon: target
     heading: Targeted Updates
     link: /docs/iac/operations/stack-management/targeted-updates/


### PR DESCRIPTION
Documents recovering deleted stacks via Pulumi Cloud's Restore Stacks feature, and makes the new docs page the canonical source for the original announcement blog post.

## Changes
- New page: Restoring deleted stacks (stack management)
- Cross-links from the Stacks concept, Troubleshooting index, stack-management index, and Cloud vs. OSS
- Set `canonical_url` on the Restore Stacks blog post to point at the docs page, with a note linking readers to it

Closes #19372.