### PR TITLE
Fix inconsistent font size in multi-paragraph notes

### DIFF
--- a/theme/src/scss/_notes.scss
+++ b/theme/src/scss/_notes.scss
@@ -135,6 +135,10 @@ section.docs-content div.note {
     :last-child {
         padding-bottom: 0;
     }
+
+    div.content p {
+        font-size: inherit; // 14px normally, 17px for .note-large; overrides the 16px docs-content p rule
+    }
 }
 
 blockquote.pullquote {


### PR DESCRIPTION
Notes rendered via `{{% notes %}}` were inconsistently sized: multi-paragraph notes rendered body text at 16px while single-paragraph notes rendered at 14px.

Hugo wraps multiple paragraphs in `<p>` tags, which got caught by the global `section.docs-content p { font-size: 16px }` rule, overriding the note's 14px. Single-paragraph notes emit raw text and correctly inherited 14px.

## Changes
- Add `div.content p { font-size: inherit }` scoped to `section.docs-content div.note` in `theme/src/scss/_notes.scss`, so all notes size consistently (preserves `.note-large` 17px sizing)

Fixes #19427