### PR TITLE
Add missing event tiles: PUG SF (June 3), AICamp SV & NY (June 9-17)

### DIFF
--- a/content/events/aicamp-new-york-2026/index.md
+++ b/content/events/aicamp-new-york-2026/index.md
@@ -41,7 +41,7 @@ location: New York, NY
 
 # Description of the event.
 description: |
-    This workshop teaches developers how to deploy agentic AI systems by combining Pulumi's infrastructure capabilities with AWS cloud services. Learn practical techniques for building and deploying AI agents at scale in a hands-on setting.
+    Learn how to deploy agentic AI systems by combining Pulumi's infrastructure capabilities with AWS cloud services. This hands-on workshop covers practical techniques for building and deploying AI agents at scale using Pulumi and AWS.
 
 # The event presenters
 presenters:

--- a/content/events/aicamp-new-york-2026/index.md
+++ b/content/events/aicamp-new-york-2026/index.md
@@ -41,7 +41,7 @@ location: New York, NY
 
 # Description of the event.
 description: |
-    Learn how to deploy agentic AI systems by combining Pulumi's infrastructure capabilities with AWS cloud services. This hands-on workshop covers practical techniques for building and deploying AI agents at scale using Pulumi and AWS.
+    This hands-on workshop bridges the gap between AI agent prototypes and production deployments. Build a multi-tool, multi-agent system running on Amazon Bedrock AgentCore, with all infrastructure defined as code using Pulumi. Attendees will gain a functioning multi-agent system, reusable infrastructure-as-code templates, and practical experience with Amazon Bedrock AgentCore and Pulumi.
 
 # The event presenters
 presenters:

--- a/content/events/aicamp-new-york-2026/index.md
+++ b/content/events/aicamp-new-york-2026/index.md
@@ -17,12 +17,12 @@ gated: false
 # landing/registration page. If the event is external you will need
 # set the 'block_external_search_index' flag to true so Google does not index
 # the event page created.
-external: false
-block_external_search_index: false
+external: true
+block_external_search_index: true
 
 # The url slug for the event landing page. If this is an external
 # event, use the external URL as the value here.
-url_slug: aicamp-new-york-2026
+url_slug: https://www.aicamp.ai/event/eventdetails/W2026061714
 
 # The event type (workshop, webinar, talk).
 event_type: workshop

--- a/content/events/aicamp-new-york-2026/index.md
+++ b/content/events/aicamp-new-york-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: "AICamp New York"
+meta_desc: Hands-on workshop for deploying multi-agent systems using Amazon Bedrock AgentCore with infrastructure defined as code.
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: aicamp-new-york-2026
+
+# The event type (workshop, webinar, talk).
+event_type: workshop
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-06-17T09:00:00-04:00
+
+# Duration of the event.
+duration: Full day
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: New York, NY
+
+# Description of the event.
+description: |
+    Learn how to deploy multi-agent systems using Amazon Bedrock AgentCore with all infrastructure defined as code. This hands-on workshop covers practical techniques for building and deploying AI agents at scale.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: Intermediate # Beginner, Intermediate, Advanced
+    topics: ["AI", "Multi-agent Systems", "Infrastructure as Code"]
+    languages: []
+    clouds: ["AWS"]
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+
+---

--- a/content/events/aicamp-new-york-2026/index.md
+++ b/content/events/aicamp-new-york-2026/index.md
@@ -1,7 +1,7 @@
 ---
 # Name of the event, <= 60 characters
-title: "AICamp New York"
-meta_desc: Hands-on workshop for deploying multi-agent systems using Amazon Bedrock AgentCore with infrastructure defined as code.
+title: "Deploying AI Agents with Pulumi and AWS (NY)"
+meta_desc: Hands-on workshop on deploying AI agents using Pulumi infrastructure tools and AWS services.
 
 # A featured event will display first in the list.
 featured: false
@@ -31,20 +31,24 @@ event_type: workshop
 youtube_url:
 
 # Sortable date. The datetime Hugo will use to sort the events in date order.
-sortable_date: 2026-06-17T09:00:00-04:00
+sortable_date: 2026-06-17T17:30:00-04:00
 
 # Duration of the event.
-duration: Full day
+duration: Evening workshop
 
 # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
 location: New York, NY
 
 # Description of the event.
 description: |
-    Learn how to deploy multi-agent systems using Amazon Bedrock AgentCore with all infrastructure defined as code. This hands-on workshop covers practical techniques for building and deploying AI agents at scale.
+    This workshop teaches developers how to deploy agentic AI systems by combining Pulumi's infrastructure capabilities with AWS cloud services. Learn practical techniques for building and deploying AI agents at scale in a hands-on setting.
 
 # The event presenters
 presenters:
+    - name: Engin Diri
+      role: Speaker
+    - name: Adam Gordon Bell
+      role: Speaker
 
 # case-sensitive
 tags:

--- a/content/events/aicamp-silicon-valley-2026/index.md
+++ b/content/events/aicamp-silicon-valley-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: "AICamp Silicon Valley"
+meta_desc: Hands-on workshop for deploying multi-agent systems using Amazon Bedrock AgentCore with infrastructure defined as code.
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: aicamp-silicon-valley-2026
+
+# The event type (workshop, webinar, talk).
+event_type: workshop
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-06-09T09:00:00-07:00
+
+# Duration of the event.
+duration: Full day
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: Sunnyvale, CA
+
+# Description of the event.
+description: |
+    Learn how to deploy multi-agent systems using Amazon Bedrock AgentCore with all infrastructure defined as code. This hands-on workshop covers practical techniques for building and deploying AI agents at scale.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: Intermediate # Beginner, Intermediate, Advanced
+    topics: ["AI", "Multi-agent Systems", "Infrastructure as Code"]
+    languages: []
+    clouds: ["AWS"]
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+
+---

--- a/content/events/aicamp-silicon-valley-2026/index.md
+++ b/content/events/aicamp-silicon-valley-2026/index.md
@@ -17,12 +17,12 @@ gated: false
 # landing/registration page. If the event is external you will need
 # set the 'block_external_search_index' flag to true so Google does not index
 # the event page created.
-external: false
-block_external_search_index: false
+external: true
+block_external_search_index: true
 
 # The url slug for the event landing page. If this is an external
 # event, use the external URL as the value here.
-url_slug: aicamp-silicon-valley-2026
+url_slug: https://www.aicamp.ai/event/eventdetails/W2026060917
 
 # The event type (workshop, webinar, talk).
 event_type: workshop

--- a/content/events/aicamp-silicon-valley-2026/index.md
+++ b/content/events/aicamp-silicon-valley-2026/index.md
@@ -41,7 +41,7 @@ location: Sunnyvale, CA
 
 # Description of the event.
 description: |
-    A hands-on workshop focused on deploying AI agents using Pulumi infrastructure tools alongside AWS services. Learn practical techniques for combining Pulumi's infrastructure capabilities with AWS cloud services to build and deploy agentic AI systems.
+    Learn how to deploy agentic AI systems by combining Pulumi's infrastructure capabilities with AWS cloud services. This hands-on workshop covers practical techniques for building and deploying AI agents at scale using Pulumi and AWS.
 
 # The event presenters
 presenters:

--- a/content/events/aicamp-silicon-valley-2026/index.md
+++ b/content/events/aicamp-silicon-valley-2026/index.md
@@ -1,7 +1,7 @@
 ---
 # Name of the event, <= 60 characters
-title: "AICamp Silicon Valley"
-meta_desc: Hands-on workshop for deploying multi-agent systems using Amazon Bedrock AgentCore with infrastructure defined as code.
+title: "Deploying AI Agents with Pulumi and AWS (SV)"
+meta_desc: Hands-on workshop on deploying AI agents using Pulumi infrastructure tools and AWS services.
 
 # A featured event will display first in the list.
 featured: false
@@ -31,20 +31,22 @@ event_type: workshop
 youtube_url:
 
 # Sortable date. The datetime Hugo will use to sort the events in date order.
-sortable_date: 2026-06-09T09:00:00-07:00
+sortable_date: 2026-06-09T17:30:00-07:00
 
 # Duration of the event.
-duration: Full day
+duration: Evening workshop
 
 # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
 location: Sunnyvale, CA
 
 # Description of the event.
 description: |
-    Learn how to deploy multi-agent systems using Amazon Bedrock AgentCore with all infrastructure defined as code. This hands-on workshop covers practical techniques for building and deploying AI agents at scale.
+    A hands-on workshop focused on deploying AI agents using Pulumi infrastructure tools alongside AWS services. Learn practical techniques for combining Pulumi's infrastructure capabilities with AWS cloud services to build and deploy agentic AI systems.
 
 # The event presenters
 presenters:
+    - name: Laci Videmsky
+      role: Speaker
 
 # case-sensitive
 tags:

--- a/content/events/aicamp-silicon-valley-2026/index.md
+++ b/content/events/aicamp-silicon-valley-2026/index.md
@@ -41,7 +41,7 @@ location: Sunnyvale, CA
 
 # Description of the event.
 description: |
-    Learn how to deploy agentic AI systems by combining Pulumi's infrastructure capabilities with AWS cloud services. This hands-on workshop covers practical techniques for building and deploying AI agents at scale using Pulumi and AWS.
+    This hands-on workshop bridges the gap between AI agent prototypes and production deployments. Build a multi-tool, multi-agent system running on Amazon Bedrock AgentCore, with all infrastructure defined as code using Pulumi. Attendees will gain a functioning multi-agent system, reusable infrastructure-as-code templates, and practical experience with Amazon Bedrock AgentCore and Pulumi.
 
 # The event presenters
 presenters:

--- a/content/events/aks-kubernetes-azure-2026/index.md
+++ b/content/events/aks-kubernetes-azure-2026/index.md
@@ -1,0 +1,64 @@
+---
+# Name of the event, <= 60 characters
+title: "Getting Started with Kubernetes on Azure"
+meta_desc: Learn the fundamentals of running Kubernetes on Azure using AKS and Pulumi infrastructure-as-code tools.
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://luma.com/4eia7arb
+
+# The event type (workshop, webinar, talk).
+event_type: workshop
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-06-10T09:00:00-07:00
+
+# Duration of the event.
+duration: 1 hour
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: Virtual
+
+# Description of the event.
+description: |
+    This introductory workshop covers the fundamentals of running Kubernetes on Azure using Azure Kubernetes Service (AKS). Participants will learn how Kubernetes fits into the Azure platform and how clusters and containerized workloads are created and managed through hands-on exercises. Attendees will gain understanding of establishing an AKS cluster via Pulumi, how Pulumi coordinates Azure and Kubernetes resources, deploying containerized applications to AKS with secure, repeatable processes, and managing infrastructure safely through preview, update, and teardown workflows.
+
+# The event presenters
+presenters:
+    - name: Adam Gordon Bell
+      role: Speaker
+
+# case-sensitive
+tags:
+    level: Beginner # Beginner, Intermediate, Advanced
+    topics: ["Kubernetes", "Infrastructure as Code", "Cloud Platforms"]
+    languages: []
+    clouds: ["Azure"]
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+
+---

--- a/content/events/pug-san-francisco-iac-ai-agents-2026/index.md
+++ b/content/events/pug-san-francisco-iac-ai-agents-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: "Pulumi User Group San Francisco: IaC in the Age of AI and Agents"
+meta_desc: Join Pulumi for a fireside chat with Jay Smith on IaC in the age of AI and agents, featuring refreshments and networking.
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://luma.com/pulumi-ro95
+
+# The event type (workshop, webinar, talk).
+event_type: event
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-06-03T18:00:00-07:00
+
+# Duration of the event.
+duration: 2 hours
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: San Francisco, CA
+
+# Description of the event.
+description: |
+    Join Pulumi for an evening fireside chat with Jay Smith discussing the intersection of Infrastructure as Code and the emerging world of AI agents. Perfect for platform engineers and SREs looking to understand how these technologies intersect. Enjoy refreshments and network with fellow attendees at The Gambit in San Francisco.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: # Beginner, Intermediate, Advanced
+    topics: ["Infrastructure as Code", "AI"]
+    languages: []
+    clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+
+---

--- a/content/events/pug-san-francisco-iac-ai-agents-2026/index.md
+++ b/content/events/pug-san-francisco-iac-ai-agents-2026/index.md
@@ -41,7 +41,7 @@ location: San Francisco, CA
 
 # Description of the event.
 description: |
-    Join Pulumi for an evening fireside chat with Jay Smith discussing the intersection of Infrastructure as Code and the emerging world of AI agents. Perfect for platform engineers and SREs looking to understand how these technologies intersect. Enjoy refreshments and network with fellow attendees at The Gambit in San Francisco.
+    Join Pulumi for a fireside chat with Jay Smith from Google on how AI agents are changing infrastructure-as-code practices. Explore what happens when agents are the ones writing, reviewing, and shipping infrastructure. This casual gathering for platform engineers, SREs, and infrastructure builders features candid discussion, industry war stories, refreshments, and networking at The Gambit.
 
 # The event presenters
 presenters:


### PR DESCRIPTION
Adds three missing event tiles:

- Pulumi User Group San Francisco: IaC in the Age of AI and Agents (June 3, 2026)
- AICamp Silicon Valley (June 9, 2026)
- AICamp New York (June 17, 2026)

Resolves #18993 and #19284.