### PR TITLE
infra: route bare /guides path to the guides origin

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -739,7 +739,10 @@ if (config.guidesStack) {
         {
             ...baseCacheBehavior,
             targetOriginId: guidesCDN,
-            pathPattern: "/guides/*",
+            // "/guides*" (no slash) matches /guides, /guides.md, and
+            // /guides/... so the bare path reaches the guides origin and gets
+            // the native trailing-slash redirect, matching registry's behavior.
+            pathPattern: "/guides*",
             cachePolicyId: thirtyMinuteCachePolicy.id,
             originRequestPolicyId: allViewerExceptHostHeaderId,
         },


### PR DESCRIPTION
Human Chris here: See https://github.com/pulumi/guides/pull/123 for context.

---

## What

Change the guides CloudFront cache behavior `pathPattern` from `/guides/*` to `/guides*` (no slash) in `infrastructure/index.ts`.

## Why

`https://www.pulumi.com/guides` (no trailing slash) currently returns **404**, while `/guides/` and every nested path work fine. Reported in pulumi/guides#82.

The cause is purely a routing pattern. The guides behavior matches `/guides/*`, which does **not** match the bare `/guides`. So that request never reaches the guides origin — it falls through to the docs default origin and 404s. Confirmed against production via the `via:` CloudFront hop count:

```
$ curl -sI https://www.pulumi.com/guides        # 404, ONE hop  -> dies at docs origin
$ curl -sI https://www.pulumi.com/guides/        # 200, TWO hops -> reaches guides origin
$ curl -sI https://www.pulumi.com/guides/solutions
HTTP/2 302
location: /guides/solutions/                      # TWO hops -> guides origin already redirects natively
```

Registry already gets this right with `/registry*` (no slash), and the bare `/registry` 302-redirects correctly today:

```
$ curl -sI https://www.pulumi.com/registry
HTTP/2 302
location: /registry/
```

This change makes guides match registry. Once the bare path routes to the guides origin, the S3 website endpoint behind that distribution issues the trailing-slash 302 natively — no per-directory redirect objects or placeholder pages needed.

## Impact

`/guides` will 302-redirect to `/guides/` instead of 404ing. Like `/registry*`, the no-slash glob also matches sibling prefixes (e.g. `/guides-foo`), which is consistent with the registry precedent; there are no other `/guides`-prefixed docs paths today.

Fixes pulumi/guides#82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)