### PR TITLE
content(cjs26): simplify CLI steps and clarify README link

### DIFF
--- a/layouts/cjs26/list.html
+++ b/layouts/cjs26/list.html
@@ -175,6 +175,7 @@ brew install pulumi/tap/pulumi
 # Create your ID card and deploy it to Cloudflare
 mkdir cjs26 && cd cjs26
 pulumi new https://github.com/pulumi/cjs26
+pulumi up
 
 # Add a photo to your card
 open $(pulumi stack output url)

--- a/layouts/cjs26/list.html
+++ b/layouts/cjs26/list.html
@@ -175,17 +175,15 @@ brew install pulumi/tap/pulumi
 # Create your ID card and deploy it to Cloudflare
 mkdir cjs26 && cd cjs26
 pulumi new https://github.com/pulumi/cjs26
-pulumi config set cloudflare:apiToken &lt;your-token&gt; --secret
-pulumi up
 
 # Add a photo to your card
 open $(pulumi stack output url)
 
-# Return here, enter the laptop password ^^
+# Return here and enter the laptop password ^^
 # Visit the Pulumi booth for your membership sticker
 </pre>
 
-<a href="https://github.com/pulumi/cjs26" class="hover:underline block" target="_blank">README ></a>
+<a href="https://github.com/pulumi/cjs26" class="hover:underline block" target="_blank">QUESTIONS? README ></a>
 </main>
 
         <div class="flex justify-center px-6 pb-24">


### PR DESCRIPTION
Tweaks to the CascadiaJS 2026 event page (`layouts/cjs26/list.html`):

- Trim the on-screen CLI steps to the essentials (drop the `pulumi config set` token line and `pulumi up`)
- Tighten the laptop-password comment wording
- Relabel the README link as **QUESTIONS? README >** so attendees know where to look

🤖 Generated with [Claude Code](https://claude.com/claude-code)