### PR TITLE
Fix broken links flagged by the link checker

### DIFF
--- a/content/docs/esc/cli/_index.md
+++ b/content/docs/esc/cli/_index.md
@@ -40,11 +40,10 @@ The most common commands in the CLI that you'll be using are as follows:
 * [esc env get](/docs/esc/cli/commands/esc_env_get/) - Get a value within an environment
 * [esc env init](/docs/esc/cli/commands/esc_env_init/) - Create an empty environment with the given name
 * [esc env ls](/docs/esc/cli/commands/esc_env_ls/) - List environments
-* [esc env version rollback](/docs/esc/cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version
 * [esc env rm](/docs/esc/cli/commands/esc_env_rm/) - Remove an environment or a value from an environment
 * [esc env set](/docs/esc/cli/commands/esc_env_set/) - Set a value within an environment
 * [esc env version](/docs/esc/cli/commands/esc_env_version/) - Manage the versions of an environment
-* [esc env version rollback](/docs/esc/cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version
+* [esc env version rollback](/docs/esc/cli/commands/esc_env_version_rollback/) - Rollback environment definition to a specific version
 * [esc env version tag](/docs/esc/cli/commands/esc_env_version_tag/) - Manage tagged versions
 * [esc login](/docs/esc/cli/commands/esc_login/) - Log in to the Pulumi Cloud
 * [esc open](/docs/esc/cli/commands/esc_open/) - Open the environment with the given name

--- a/content/docs/esc/cli/commands/_index.md
+++ b/content/docs/esc/cli/commands/_index.md
@@ -32,7 +32,7 @@ The most common commands in the CLI that you'll be using are as follows:
 * [esc env rm](/docs/esc/cli/commands/esc_env_rm/) - Remove an environment or a value from an environment
 * [esc env set](/docs/esc/cli/commands/esc_env_set/) - Set a value within an environment
 * [esc env version](/docs/esc/cli/commands/esc_env_version/) - Manage the versions of an environment
-* [esc env version rollback](/docs/esc/cli/commands/esc_env_rollback/) - Rollback environment definition to a specific version
+* [esc env version rollback](/docs/esc/cli/commands/esc_env_version_rollback/) - Rollback environment definition to a specific version
 * [esc env version tag](/docs/esc/cli/commands/esc_env_version_tag/) - Manage tagged versions
 * [esc login](/docs/esc/cli/commands/esc_login/) - Log in to the Pulumi Cloud
 * [esc open](/docs/esc/cli/commands/esc_open/) - Open the environment with the given name

--- a/content/docs/esc/languages-sdks/_index.md
+++ b/content/docs/esc/languages-sdks/_index.md
@@ -11,6 +11,7 @@ menu:
 aliases:
   - /docs/esc/development/
   - /docs/esc/development/languages-sdks/
+  - /docs/esc/sdk/
 ---
 
 The Pulumi ESC SDKs let you create, update, retrieve, and delete environments — and read their evaluated values — from your own code. Use them when you need programmatic access to ESC outside of the `esc` CLI or a Pulumi program.

--- a/content/docs/iac/operations/continuous-delivery/azure-devops.md
+++ b/content/docs/iac/operations/continuous-delivery/azure-devops.md
@@ -10,7 +10,7 @@ menu:
     parent: iac-operations-cicd
     weight: 30
 aliases:
-- /docs/iac/guides/continuous-delivery/azure-devops/
+    - /docs/iac/guides/continuous-delivery/azure-devops/
     - /docs/integrations/azure-devops/
     - /docs/iac/integrations/azure-devops/
     - /docs/iac/using-pulumi/continuous-delivery/azure-devops/

--- a/content/docs/insights/policy/integrations/snyk-policy.md
+++ b/content/docs/insights/policy/integrations/snyk-policy.md
@@ -28,7 +28,7 @@ aliases:
 **Experimental**: This integration is experimental. It shells out to the Snyk CLI tool and may not provide a seamless user experience.
 {{% /notes %}}
 
-[Snyk container scanning](https://github.com/pulumi/templates-policy/tree/master/snyk-typescript) is a Pulumi policy as code template that allows you to uses the [Snyk CLI](https://docs.snyk.io/cli-ide-and-ci-cd-integrations/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container) to scan [`docker.Image`](/registry/packages/docker/api-docs/image/) resources for vulnerabilities.
+[Snyk container scanning](https://github.com/pulumi/templates-policy/tree/master/snyk-typescript) is a Pulumi policy as code template that allows you to uses the [Snyk CLI](https://docs.snyk.io/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-container-images) to scan [`docker.Image`](/registry/packages/docker/api-docs/image/) resources for vulnerabilities.
 
 For more information on Pulumi's Policy as Code solution, see [Get started with Pulumi policy as code](/docs/insights/policy/get-started/).
 

--- a/data/newsroom.toml
+++ b/data/newsroom.toml
@@ -643,7 +643,7 @@ url = "http://vmblog.com/archive/2018/12/12/pulumi-and-atomist-kubecon-2018-talk
 date = "11th December 2018"
 title = "Pulumi #KubeCon 2018 - VMblog Video Interview"
 img = "/logos/press/vmblog.png"
-url = "http://vmblog.com/archive/2018/12/12/pulumi-kubecon-2018-vmblog-video-interview.aspx"
+url = "https://web.archive.org/web/20241014210044/https://vmblog.com/archive/2018/12/12/pulumi-kubecon-2018-vmblog-video-interview.aspx"
 
 [[coverage]]
 date = "24th November 2018"

--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -430,6 +430,11 @@ function getDefaultExcludedKeywords() {
         "https://www.zdnet.com/",                                                   // aggressive bot protection
         "https://gist.github.com/pulumipus/56d1ee83f295971e2a26a8091880c482",        // deleted gist in blog/automation-api-as-platform
         "https://gist.github.com/pulumipus/61edcdd8ab3f50a42b4bd34a7e1f789b",        // deleted gist in blog/automation-api-workflow
+        // Dead/transient third-party links in historical blog posts (#docs-ops 2026-06-01)
+        "https://github.com/aws/aws-lambda-runtime-interface-clients",              // blog/aws-lambda-container-support
+        "https://docs.docker.com/docker-for-mac/kubernetes/",                       // blog/how-to-deploy-jenkins-to-kubernetes-with-pulumi
+        "https://editor.swagger.io",                                                // blog/next-level-iac-pulumi-automation-api (transient 504)
+        "https://github.com/ollama/ollama/blob/main/docs/openai.md",                // blog/run-deepseek-on-aws-ec2-using-pulumi
     ];
 }
 

--- a/scripts/redirects/esc-cli-redirects.txt
+++ b/scripts/redirects/esc-cli-redirects.txt
@@ -13,7 +13,8 @@ docs/esc-cli/commands/esc_env_get/index.html|/docs/esc/cli/commands/esc_env_get/
 docs/esc-cli/commands/esc_env_init/index.html|/docs/esc/cli/commands/esc_env_init/
 docs/esc-cli/commands/esc_env_ls/index.html|/docs/esc/cli/commands/esc_env_ls/
 docs/esc-cli/commands/esc_env_open/index.html|/docs/esc/cli/commands/esc_env_open/
-docs/esc-cli/commands/esc_env_rollback/index.html|/docs/esc/cli/commands/esc_env_rollback/
+docs/esc-cli/commands/esc_env_rollback/index.html|/docs/esc/cli/commands/esc_env_version_rollback/
+docs/esc/cli/commands/esc_env_rollback/index.html|/docs/esc/cli/commands/esc_env_version_rollback/
 docs/esc-cli/commands/esc_env_rm/index.html|/docs/esc/cli/commands/esc_env_rm/
 docs/esc-cli/commands/esc_env_run/index.html|/docs/esc/cli/commands/esc_env_run/
 docs/esc-cli/commands/esc_env_set/index.html|/docs/esc/cli/commands/esc_env_set/

--- a/scripts/redirects/general-broken-links-redirects.txt
+++ b/scripts/redirects/general-broken-links-redirects.txt
@@ -25,7 +25,6 @@ docs/reference/cloud-rest-api/cloud-rest-api/index.html|/docs/reference/cloud-re
 docs/using-pulumi/index.html|/docs/iac/guides/
 topics/containers/index.html|/docs/iac/clouds/kubernetes/
 docs/concepts/options/hidediffs/index.html|/docs/iac/concepts/resources/options/hidediffs/
-docs/iac/guides/building-extending/providers/debugging-providers/index.html|/docs/support/debugging/debugging-providers/
 docs/iac/using-pulumi/pulumi-packages/terraform-provider/index.html|/docs/iac/get-started/terraform/terraform-providers/
 docs/concepts/stacks/index.html|/docs/iac/concepts/stacks/
 docs/insights/policy/metadata/index.html|/docs/insights/policy/policy-packs/metadata/


### PR DESCRIPTION
Fixes the broken links reported by DocsBot in #docs-ops (2026-06-01).

The bulk of the report — every `HTTP_undefined` entry — traced to a single redirect loop, plus a handful of genuine 404s.

## Changes

- **Redirect loop (all `HTTP_undefined`)** — `scripts/redirects/general-broken-links-redirects.txt` redirected the Debugging Providers *canonical* URL to `/docs/support/debugging/debugging-providers/`, which is one of the page's own aliases → S3 redirect → Hugo alias → canonical → loop. The page sits in the site-wide IaC nav, so the loop was reported on every docs page. Removed the stale redirect; the canonical now serves 200 and the alias resolves to it.
- **`esc_env_rollback` 404** — fixed at the source: the esc CLI command index pages (`_index.md`) are hand-maintained (the generated command pages already link correctly), and linked "esc env version rollback" to the non-existent `esc_env_rollback` slug; the real page is `esc_env_version_rollback`. Also removed a stray duplicate entry that broke the alphabetical `esc env` list. Kept a redirect in `esc-cli-redirects.txt` as a safety net for old inbound links (the prior redirect there also dead-ended at the bad slug).
- **`/docs/esc/sdk/` 404** — added the missing alias to the ESC Languages & SDKs index (docs moved to `/docs/esc/languages-sdks/`).
- **`.../packages-and-automation/continuous-delivery/azure-devops/` 404** — the alias existed but the block had malformed YAML indentation (first entry at 0-indent, rest at 4), so Hugo silently dropped 10 of 11 aliases. Normalized the indentation.
- **Snyk docs link** — updated to Snyk's current container-scanning docs URL (they reorganized; old path 404s).
- **VMblog press entry** — repointed `data/newsroom.toml` to a working Wayback snapshot.
- **Checker exclusions** — added four dead/transient third-party links in historical blog posts (left in place per the no-edit-blog-links policy) so they stop being flagged.

The remaining external blog links (aws-lambda, docker-for-mac, ollama, swagger) are historical and left untouched per policy; they're now excluded from the checker.

The Defang registry logo 404 is out of scope here — it comes from the published package's `logoUrl`, not this repo. Filed as pulumi/registry#11226.

## Verification

- `make build` and `make lint` pass clean.
- Confirmed in the build output: the Debugging Providers canonical is now a real page (no redirect), `/docs/esc/sdk/` → `/docs/esc/languages-sdks/`, and `.../packages-and-automation/.../azure-devops/` → `/docs/iac/operations/.../azure-devops/`.