### PR TITLE
Fix Snowflake logo

### DIFF
--- a/data/partners/partners.yaml
+++ b/data/partners/partners.yaml
@@ -72,7 +72,7 @@
 
 - name: Snowflake
   link: https://www.snowflake.com/
-  logo: /logos/pkg/snowflake.svg
+  logo: /logos/tech/snowflake.svg
 
 - name: Snyk
   link: https://partners.snyk.io/English/solutions/solution/2908/pulumi


### PR DESCRIPTION


### Proposed changes

Fixes Snowflake's logo on the partner page. Was 404'ing.
