### PR TITLE
Fix /pricing/open-source-free-tier layout

### DIFF
--- a/content/pricing/open-source-free-tier.md
+++ b/content/pricing/open-source-free-tier.md
@@ -4,15 +4,13 @@ meta_desc: Free access to Pulumi Cloud Team Edition for community-driven open so
 type: page
 layout: pricing-oss
 
-hero:
+intro:
     title: Pulumi Cloud for Open Source
     description: |
         Open-source maintainers who use Pulumi can get free access to
         <a class="text-violet-primary" href="/pricing/">Pulumi Cloud Team Edition</a>, giving your project
         collaboration features, visibility into deployments, and the tools
         you need to manage infrastructure across contributors.
-
-    cta_text: Apply
 
 features:
     title: What you get
@@ -23,28 +21,19 @@ features:
 
 requirements:
     title: Requirements
-    description: |
-        This program is for community-driven open source projects, not commercially backed products. To qualify:
-
-        - **OSI-approved open source license** --- Your project must be published under an [OSI-approved](https://opensource.org/licenses) open source license.
-
-        - **Community-driven** --- The project must not be seeking profit, which means it cannot be primarily funded or controlled by a for-profit company. Projects maintained by individuals, volunteer communities, nonprofits, and foundations are welcome.
-
-        - You must be a maintainer or core contributor of the project.
-
-        - The project must be active and more than 30 days old.
-
-        - Your Pulumi code must be publicly available.
+    intro: "This program is for community-driven open source projects, not commercially backed products. To qualify:"
+    items:
+        - "**OSI-approved open source license.** Your project must be published under an [OSI-approved](https://opensource.org/licenses) open source license."
+        - "**Community-driven.** The project must not be seeking profit, which means it cannot be primarily funded or controlled by a for-profit company. Projects maintained by individuals, volunteer communities, nonprofits, and foundations are welcome."
+        - "You must be a maintainer or core contributor of the project."
+        - "The project must be active and more than 30 days old."
+        - "Your Pulumi code must be publicly available."
 
 contact:
-    title: Application Process
+    title: How to apply
     description: |
-        To apply, [contact us](/contact/) and tell us about your project — what it does, how you use Pulumi, and how many contributors you have.
+        Tell us about your project — what it does, how you use Pulumi, and how many contributors you have.
         You can expect an initial response within 2-5 business days.
-
-        If accepted, we will work with you to enroll your account. The program renews annually with a brief review
-        to confirm your project still meets the requirements. If your project no longer qualifies,
-        we will work with you to make the transition as smooth as possible.
 
     form:
         headline: Pulumi Cloud for Open Source

--- a/layouts/page/pricing-oss.html
+++ b/layouts/page/pricing-oss.html
@@ -1,54 +1,38 @@
-{{ define "hero" }}
-    <header class="header-hero-home mb-8 relative px-4 pb-56 lg:pb-10">
-        <div class="container mx-auto px-4">
-            <h1>{{ .Params.hero.title }}</h1>
-            <div class="my-4 mb-16 text-2xl">
-                {{ .Params.hero.description | markdownify }}
-            </div>
-            <div class="flex flex-col lg:flex-row mt-4">
-                <a
-                    class="btn btn-lg text-center mb-4 lg:mb-0 lg:mr-4"
-                    href="/contact/"
-                    >{{ .Params.hero.cta_text }}</a
-                >
-            </div>
-        </div>
-    </header>
-{{ end }}
-
 {{ define "main" }}
-    <section id="feature" class="mb-4 pt-8">
-        <div class="container mx-auto flex flex-col lg:flex-row">
-            <div class="w-full lg:w-3/4 px-8">
-                <h2>{{ .Params.features.title }}</h2>
-                <p>{{ .Params.features.description | markdownify }}</p>
+    <section class="container mx-auto max-w-5xl px-4 py-12 lg:py-16">
+        <div class="flex flex-col lg:flex-row gap-8 lg:gap-12">
+            <div class="w-full lg:w-1/2">
+                <h1>{{ .Params.intro.title }}</h1>
+                <div class="my-4 text-xl text-gray-700">
+                    {{ .Params.intro.description | markdownify }}
+                </div>
 
-                <h2>{{ .Params.requirements.title }}</h2>
-                <p>{{ .Params.requirements.description | markdownify }}</p>
+                <h2 class="mt-12">{{ .Params.features.title }}</h2>
+                {{ .Params.features.description | markdownify }}
+
+                <h2 class="mt-12">{{ .Params.requirements.title }}</h2>
+                <p>{{ .Params.requirements.intro | markdownify }}</p>
+                <ul class="list-none p-0 m-0 flex flex-col gap-3">
+                    {{ range .Params.requirements.items }}
+                        <li class="flex items-start gap-3 m-0">
+                            {{ partial "icon.html" (dict "name" "phosphor/check-circle" "class" "text-violet-primary size-6 mt-0.5 flex-shrink-0" "weight" "fill") }}
+                            <span>{{ . | markdownify }}</span>
+                        </li>
+                    {{ end }}
+                </ul>
             </div>
-        </div>
-    </section>
-    <section id="contact" class="container mx-auto w-full relative overflow-visible py-10 px-4">
-        <div class="flex justify-center mt-8">
-            <div class="card w-full rounded-xl p-0.5 bg-violet-primary">
-                <div class="flex justify-center rounded-xl bg-violet-100">
-                    <div class="p-8 md:p-16 lg:pt-8 lg:pb-8 inline-flex flex-col items-center">
-                        <h2 class="mb-4 text-center">How to Apply</h2>
-                        <p class="container mx-auto max-w-3xl text-lg text-center my-4">
-                            {{ .Params.contact.description | markdownify }}
-                        </p>
-                        <div class="flex flex-col self-stretch items-center lg:justify-between">
-                            <div class="flex flex-col justify-center align-center text-center w-full md:w-2/4 lg:ml-14 lg:mr-14 mb-4 lg:mb-0 z-0">
-                                <a
-                                    href="/contact/"
-                                    class="btn btn-primary btn-xl py-3"
-                                    >Apply</a
-                                >
-                            </div>
-                        </div>
+
+            <aside class="w-full lg:w-1/2">
+                <div class="card p-8 lg:sticky lg:top-8">
+                    <h2 class="mt-0">{{ .Params.contact.title }}</h2>
+                    <div class="text-gray-700">
+                        {{ .Params.contact.description | markdownify }}
+                    </div>
+                    <div class="hs-form hs-form-fg-dark font-normal mt-6">
+                        <pulumi-hubspot-form form-id="{{ .Params.contact.form.hubspot_form_id }}"></pulumi-hubspot-form>
                     </div>
                 </div>
-            </div>
+            </aside>
         </div>
     </section>
 {{ end }}


### PR DESCRIPTION
### Proposed changes

Rebuild the Open Source Free Tier pricing page with a two-column layout: intro/features/requirements on the left, sticky "How to apply" card on the right that now actually renders the HubSpot form. The old standalone hero (with a redundant Apply button) is gone, the requirements list uses phosphor `check-circle` bullets, and the page is constrained to `max-w-5xl`. Frontmatter is restructured to match (`hero` → `intro`, requirements split into `intro` + `items`).