### PR TITLE
Automate broken link fixes with Claude Code action

### DIFF
--- a/.claude/commands/fix-broken-links/SKILL.md
+++ b/.claude/commands/fix-broken-links/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: fix-broken-links
+description: Fix broken links reported by the daily link checker. Reads .broken-links.json, triages each link to a fix strategy (alias, S3 redirect, source edit, exclusion, or out-of-scope issue), and opens an auditable PR. Invoked by the check-links workflow; not user-invocable.
+user-invocable: false
+---
+
+# Fix Broken Links
+
+You are fixing the broken links found by the daily link checker
+(`scripts/link-checker/check-links.js`, run against `https://www.pulumi.com`).
+Work through every reported link, pick the right strategy for each, open one
+auditable PR, and file issues for anything that can't be fixed in this repo.
+
+This skill is the **single source of truth** for how broken links get fixed
+here. The strategies below are codified from how broken links have actually been
+resolved in this repo (PRs #19469, #17418, #19123, #19327, #19053).
+
+## Input
+
+Read `.broken-links.json` from the repo root. Shape:
+
+```json
+{
+  "generated": "2026-06-02T15:00:00.000Z",
+  "internal": [{ "source": "...", "destination": "...", "reason": "HTTP_404" }],
+  "external": [{ "source": "...", "destination": "...", "reason": "HTTP_404" }]
+}
+```
+
+- `source` — the live page the broken link was found **on**.
+- `destination` — the URL that failed.
+- `reason` — BLC reason code (`HTTP_404`, `HTTP_410`, `ERRNO_ENOTFOUND`, …).
+- `internal` — `destination` is on `pulumi.com`; `external` — third-party.
+
+If both lists are empty, do nothing (the workflow won't invoke you in that case,
+but be defensive).
+
+## Mapping a live URL back to its source file
+
+`source` and `destination` are live `https://www.pulumi.com/...` URLs. To edit
+or redirect them you must find the file that produces them:
+
+1. Strip the origin to get the path, e.g. `/docs/iac/concepts/stacks/`.
+2. Hugo content lives under `content/`. A path like `/docs/iac/concepts/stacks/`
+   is produced by `content/docs/iac/concepts/stacks/_index.md` or
+   `.../stacks.md`. Use **Glob**/**Grep** under `content/` to locate it.
+3. To find *which* file emits a broken **destination** link, Grep for the link
+   text under `content/`, `data/`, `layouts/`, and `static/` — it may come from
+   a data file, a shortcode, or a template, not prose.
+4. Registry, API-docs, and other generated paths have **no** source file in this
+   repo (see "Out of scope" below).
+
+## Per-link triage
+
+Apply the first row that matches.
+
+| Situation | Strategy | Mechanism |
+|---|---|---|
+| Internal link points at a moved/renamed path, but the destination page still exists at a new path | **Hugo alias** | Add the old path to `aliases:` on the destination page's frontmatter |
+| Internal link to a page that was deleted/restructured, or a non-Hugo path (registry, generated docs) | **S3 redirect** | Add a redirect line to the topic-appropriate file in `scripts/redirects/` |
+| Broken link living in **editable** content (`content/docs`, `content/product`, `content/tutorials`) | **Edit at source** | Fix the link in place; use the full root-relative path (`/docs/...`), never `../` |
+| Broken link in a **blog** post **and** an equivalent replacement exists (same content, or close enough that the post's meaning is unchanged) | **Edit at source + stamp `lastmod`** | Swap the link; add/update `lastmod:` in that post's frontmatter (leave `date:` alone) |
+| Broken link in a **blog** post with **no** equivalent replacement | **Route around the prose** | Add an alias/redirect so it resolves; if it's a dead external link, add it to the exclusion list. **Do not reword blog prose** |
+| Dead / transient / bot-protected **external** link | **Exclusion list** | Add the URL to `getDefaultExcludedKeywords()` in `check-links.js` with an inline `//` comment naming the reason + blog post/issue. If the page mattered, prefer swapping to a Wayback snapshot |
+| Redirect **loop** or malformed alias YAML | **Repair** | Remove the stale redirect / fix the alias indentation |
+| Breakage owned by **another repo** (e.g. registry `logoUrl`, generated SDK docs) or otherwise unfixable here | **Out of scope** | File a GitHub issue and document it in the PR description — do not hack around it |
+
+### Mechanics
+
+**Hugo alias.** Add the old path under `aliases:` in the destination page's
+frontmatter (root-relative, trailing slash):
+
+```yaml
+aliases:
+- /docs/old/path/
+```
+
+Full mechanics and edge cases: `move-doc:references:alias-injection`.
+
+**S3 redirect.** Append one line to the topic-appropriate file in
+`scripts/redirects/` (e.g. `cicd-redirects.txt`, `iac-cli-redirects.txt`,
+`general-broken-links-redirects.txt` when nothing more specific fits). Format is
+`source-path|destination-url`, one per line. The source is the path **without**
+a leading slash and usually ends in `/index.html`; the destination is
+root-relative (`/docs/.../`) or a full URL for off-site targets:
+
+```
+docs/old/path/index.html|/docs/iac/new/path/
+```
+
+**Edit at source.** Replace the broken link with the correct one. Internal docs
+links use the full canonical root-relative path (`/docs/iac/concepts/stacks/`);
+never `../`. This is the only strategy that touches prose, and for blog posts
+it's limited to equivalent-content link swaps.
+
+**Blog `lastmod`.** Any blog edit must add or update `lastmod:` (ISO date,
+today) in that post's frontmatter so the change is reflected, while the original
+`date:`/publish date stays put so post ordering doesn't shift.
+
+**Exclusion list.** Add the URL to the array returned by
+`getDefaultExcludedKeywords()` in `scripts/link-checker/check-links.js`, grouped
+with similar entries, with an inline comment naming the reason and the
+post/issue, matching the existing style:
+
+```js
+"https://example.com/gone",  // blog/<post>: 404, no replacement (#<issue>)
+```
+
+## Editing guardrails
+
+- **Tutorials are editable** like docs — fix their links at the source.
+- **Blog prose is editable only** to substitute a broken link for an
+  equivalent-content replacement, and every such edit stamps `lastmod`. Blog
+  links with no equivalent replacement are routed around with an
+  alias/redirect/exclusion, never reworded.
+- Internal links use full root-relative paths, never `../`.
+- `make lint` and `make build` must both pass before you open the PR.
+
+## Output
+
+1. Create a branch `fix/broken-links-<date>` (date from the workflow, e.g.
+   `fix/broken-links-2026-06-02`).
+2. Make the fixes, grouping related changes into clear commits.
+3. File a GitHub issue (`gh issue create`) for every out-of-scope item.
+4. Run `make lint` and `make build`; fix anything they surface.
+5. Open a **ready** (non-draft) PR to `master`.
+6. Write the final PR URL plus a one-line summary to `.broken-links-pr.txt` for
+   the workflow's Slack step, e.g.:
+   `:link: Fixed 7 broken links — <PR URL> (2 aliases, 1 redirect, 3 source edits, 1 issue filed)`
+
+## PR description contract (auditability)
+
+The reviewer must be able to audit every decision without re-deriving it. Model
+the description on PR #19469. Include:
+
+- **A table or list of every broken link** → the strategy applied → one line of
+  non-obvious reasoning (why a redirect vs. an alias, why excluded, etc.).
+- A **Verification** section: confirm `make lint` and `make build` passed, and
+  note any spot-checks.
+- An **Out of scope / filed issues** section linking every issue you created for
+  breakage owned by other repos or otherwise unfixable here.

--- a/.claude/commands/fix-broken-links/SKILL.md
+++ b/.claude/commands/fix-broken-links/SKILL.md
@@ -6,14 +6,7 @@ user-invocable: false
 
 # Fix Broken Links
 
-You are fixing the broken links found by the daily link checker
-(`scripts/link-checker/check-links.js`, run against `https://www.pulumi.com`).
-Work through every reported link, pick the right strategy for each, open one
-auditable PR, and file issues for anything that can't be fixed in this repo.
-
-This skill is the **single source of truth** for how broken links get fixed
-here. The strategies below are codified from how broken links have actually been
-resolved in this repo (PRs #19469, #17418, #19123, #19327, #19053).
+You are fixing the broken links found by the daily link checker (`scripts/link-checker/check-links.js`, run against `https://www.pulumi.com`). Work through every reported link, pick the right strategy for each, open one auditable PR, and file issues for anything that can't be fixed in this repo.
 
 ## Input
 
@@ -32,23 +25,16 @@ Read `.broken-links.json` from the repo root. Shape:
 - `reason` — BLC reason code (`HTTP_404`, `HTTP_410`, `ERRNO_ENOTFOUND`, …).
 - `internal` — `destination` is on `pulumi.com`; `external` — third-party.
 
-If both lists are empty, do nothing (the workflow won't invoke you in that case,
-but be defensive).
+If both lists are empty, do nothing (the workflow won't invoke you in that case, but be defensive).
 
 ## Mapping a live URL back to its source file
 
-`source` and `destination` are live `https://www.pulumi.com/...` URLs. To edit
-or redirect them you must find the file that produces them:
+`source` and `destination` are live `https://www.pulumi.com/...` URLs. To edit or redirect them you must find the file that produces them:
 
 1. Strip the origin to get the path, e.g. `/docs/iac/concepts/stacks/`.
-2. Hugo content lives under `content/`. A path like `/docs/iac/concepts/stacks/`
-   is produced by `content/docs/iac/concepts/stacks/_index.md` or
-   `.../stacks.md`. Use **Glob**/**Grep** under `content/` to locate it.
-3. To find *which* file emits a broken **destination** link, Grep for the link
-   text under `content/`, `data/`, `layouts/`, and `static/` — it may come from
-   a data file, a shortcode, or a template, not prose.
-4. Registry, API-docs, and other generated paths have **no** source file in this
-   repo (see "Out of scope" below).
+2. Hugo content lives under `content/`. A path like `/docs/iac/concepts/stacks/` is produced by `content/docs/iac/concepts/stacks/_index.md` or `.../stacks.md`. Use **Glob**/**Grep** under `content/` to locate it.
+3. To find *which* file emits a broken **destination** link, Grep for the link text under `content/`, `data/`, `layouts/`, and `static/` — it may come from a data file, a shortcode, or a template, not prose.
+4. Registry, API-docs, and other generated paths have **no** source file in this repo (see "Out of scope" below).
 
 ## Per-link triage
 
@@ -67,8 +53,7 @@ Apply the first row that matches.
 
 ### Mechanics
 
-**Hugo alias.** Add the old path under `aliases:` in the destination page's
-frontmatter (root-relative, trailing slash):
+**Hugo alias.** Add the old path under `aliases:` in the destination page's frontmatter (root-relative, trailing slash):
 
 ```yaml
 aliases:
@@ -77,30 +62,17 @@ aliases:
 
 Full mechanics and edge cases: `move-doc:references:alias-injection`.
 
-**S3 redirect.** Append one line to the topic-appropriate file in
-`scripts/redirects/` (e.g. `cicd-redirects.txt`, `iac-cli-redirects.txt`,
-`general-broken-links-redirects.txt` when nothing more specific fits). Format is
-`source-path|destination-url`, one per line. The source is the path **without**
-a leading slash and usually ends in `/index.html`; the destination is
-root-relative (`/docs/.../`) or a full URL for off-site targets:
+**S3 redirect.** Append one line to the topic-appropriate file in `scripts/redirects/` (e.g. `cicd-redirects.txt`, `iac-cli-redirects.txt`, `general-broken-links-redirects.txt` when nothing more specific fits). Format is `source-path|destination-url`, one per line. The source is the path **without** a leading slash and usually ends in `/index.html`; the destination is root-relative (`/docs/.../`) or a full URL for off-site targets:
 
 ```
 docs/old/path/index.html|/docs/iac/new/path/
 ```
 
-**Edit at source.** Replace the broken link with the correct one. Internal docs
-links use the full canonical root-relative path (`/docs/iac/concepts/stacks/`);
-never `../`. This is the only strategy that touches prose, and for blog posts
-it's limited to equivalent-content link swaps.
+**Edit at source.** Replace the broken link with the correct one. Internal docs links use the full canonical root-relative path (`/docs/iac/concepts/stacks/`); never `../`. This is the only strategy that touches prose, and for blog posts it's limited to equivalent-content link swaps.
 
-**Blog `lastmod`.** Any blog edit must add or update `lastmod:` (ISO date,
-today) in that post's frontmatter so the change is reflected, while the original
-`date:`/publish date stays put so post ordering doesn't shift.
+**Blog `lastmod`.** Any blog edit must add or update `lastmod:` (ISO date, today) in that post's frontmatter so the change is reflected, while the original `date:`/publish date stays put so post ordering doesn't shift.
 
-**Exclusion list.** Add the URL to the array returned by
-`getDefaultExcludedKeywords()` in `scripts/link-checker/check-links.js`, grouped
-with similar entries, with an inline comment naming the reason and the
-post/issue, matching the existing style:
+**Exclusion list.** Add the URL to the array returned by `getDefaultExcludedKeywords()` in `scripts/link-checker/check-links.js`, grouped with similar entries, with an inline comment naming the reason and the post/issue, matching the existing style:
 
 ```js
 "https://example.com/gone",  // blog/<post>: 404, no replacement (#<issue>)
@@ -109,33 +81,24 @@ post/issue, matching the existing style:
 ## Editing guardrails
 
 - **Tutorials are editable** like docs — fix their links at the source.
-- **Blog prose is editable only** to substitute a broken link for an
-  equivalent-content replacement, and every such edit stamps `lastmod`. Blog
-  links with no equivalent replacement are routed around with an
-  alias/redirect/exclusion, never reworded.
+- **Blog prose is editable only** to substitute a broken link for an equivalent-content replacement, and every such edit stamps `lastmod`. Blog links with no equivalent replacement are routed around with an alias/redirect/exclusion, never reworded.
 - Internal links use full root-relative paths, never `../`.
 - `make lint` and `make build` must both pass before you open the PR.
 
 ## Output
 
-1. Create a branch `fix/broken-links-<date>` (date from the workflow, e.g.
-   `fix/broken-links-2026-06-02`).
+1. Create a branch `fix/broken-links-<date>` (date from the workflow, e.g. `fix/broken-links-2026-06-02`).
 2. Make the fixes, grouping related changes into clear commits.
 3. File a GitHub issue (`gh issue create`) for every out-of-scope item.
 4. Run `make lint` and `make build`; fix anything they surface.
 5. Open a **ready** (non-draft) PR to `master`.
-6. Write the final PR URL plus a one-line summary to `.broken-links-pr.txt` for
-   the workflow's Slack step, e.g.:
+6. Write the final PR URL plus a one-line summary to `.broken-links-pr.txt` for the workflow's Slack step, e.g.:
    `:link: Fixed 7 broken links — <PR URL> (2 aliases, 1 redirect, 3 source edits, 1 issue filed)`
 
 ## PR description contract (auditability)
 
-The reviewer must be able to audit every decision without re-deriving it. Model
-the description on PR #19469. Include:
+The reviewer must be able to audit every decision without re-deriving it. Model the description on PR #19469. Include:
 
-- **A table or list of every broken link** → the strategy applied → one line of
-  non-obvious reasoning (why a redirect vs. an alias, why excluded, etc.).
-- A **Verification** section: confirm `make lint` and `make build` passed, and
-  note any spot-checks.
-- An **Out of scope / filed issues** section linking every issue you created for
-  breakage owned by other repos or otherwise unfixable here.
+- **A table or list of every broken link** → the strategy applied → one line of non-obvious reasoning (why a redirect vs. an alias, why excluded, etc.).
+- A **Verification** section: confirm `make lint` and `make build` passed, and note any spot-checks.
+- An **Out of scope / filed issues** section linking every issue you created for breakage owned by other repos or otherwise unfixable here.

--- a/.claude/commands/fix-broken-links/SKILL.md
+++ b/.claude/commands/fix-broken-links/SKILL.md
@@ -39,6 +39,38 @@ For **every** reported link, confirm it's genuinely broken before touching anyth
 
 Only links you've confirmed broken proceed to triage below.
 
+## Skip links already being handled (deduplication)
+
+Broken links persist for days, so the same ones surface in consecutive runs while
+a fix is already in flight. **Before actioning a confirmed-broken link, check
+whether it's already covered** — never open a second PR for a fix that's pending,
+or file a duplicate issue.
+
+For each confirmed-broken link, search for prior work:
+
+1. **Open PRs in `pulumi/docs`.** List candidates with
+   `gh pr list --state open --search "broken link" --json number,title,url,headRefName`
+   (prior runs use the `fix/broken-links-*` branch pattern). For a likely match,
+   confirm with `gh pr view <n>` / `gh pr diff <n>` that it actually covers this
+   link (same destination URL, source file, redirect, or exclusion entry).
+2. **Existing issues, before filing a new one.** For an out-of-scope item that
+   would become an issue in another repo, search that repo first —
+   `gh issue list --repo pulumi/<repo> --state open --search "<url-or-path>"`
+   (or `gh search issues`). If an open issue already tracks it, treat it as a
+   duplicate and reuse that issue's link; do **not** file another.
+
+Classify each confirmed-broken link as **actionable** (no existing PR/issue
+covers it) or **duplicate** (one does — capture the PR/issue URL). Then:
+
+- **All duplicates** (every confirmed-broken link is already covered): do **not**
+  create a branch, PR, or any issue. Write a Slack summary to
+  `.broken-links-pr.txt` saying so and listing each link with its existing
+  PR/issue link, e.g. `:link: 5 broken links — all already tracked (no new PR): <url> → #19470, …`. Stop here.
+- **Some actionable, some duplicates:** action only the non-duplicates (open the
+  PR, file new issues). **Omit duplicates from the fixes**, but list them in a
+  short **Already tracked** section in the PR description (one line each, linking
+  the existing PR/issue). Don't re-file or re-fix them.
+
 ## Mapping a live URL back to its source file
 
 `source` and `destination` are live `https://www.pulumi.com/...` URLs. To edit or redirect them you must find the file that produces them:
@@ -99,9 +131,14 @@ docs/old/path/index.html|/docs/iac/new/path/
 
 ## Output
 
+If **every** confirmed-broken link is a duplicate (see deduplication above), skip
+all of the below: open no branch, PR, or issue, write the "all already tracked"
+Slack summary to `.broken-links-pr.txt`, and stop. Otherwise, for the actionable
+(non-duplicate) links:
+
 1. Create a branch `fix/broken-links-<date>` (date from the workflow, e.g. `fix/broken-links-2026-06-02`).
 2. Make the fixes, grouping related changes into clear commits.
-3. File a GitHub issue (`gh issue create`) for every out-of-scope item.
+3. File a GitHub issue (`gh issue create`) for every **new** out-of-scope item (reuse the existing issue for duplicates).
 4. Run `make lint` and `make build`; fix anything they surface.
 5. Open a **ready** (non-draft) PR to `master`.
 6. Write the final PR URL plus a one-line summary to `.broken-links-pr.txt` for the workflow's Slack step, e.g.:
@@ -114,4 +151,5 @@ The reviewer must be able to audit every decision without re-deriving it. Model 
 - **A table or list of every broken link** → the strategy applied → one line of non-obvious reasoning (why a redirect vs. an alias, why excluded, etc.).
 - A **Verification** section: confirm `make lint` and `make build` passed, and note that each link was re-checked before fixing.
 - A **False positives / not actioned** section listing every reported link you confirmed was actually fine, with its reason code and why (so the reviewer knows it was checked, not missed).
+- An **Already tracked** section, when any link was skipped as a duplicate: one succinct line per link linking the existing PR or issue that covers it.
 - An **Out of scope / filed issues** section linking every issue you created for breakage owned by other repos or otherwise unfixable here.

--- a/.claude/commands/fix-broken-links/SKILL.md
+++ b/.claude/commands/fix-broken-links/SKILL.md
@@ -27,6 +27,18 @@ Read `.broken-links.json` from the repo root. Shape:
 
 If both lists are empty, do nothing (the workflow won't invoke you in that case, but be defensive).
 
+## Verify each link before fixing it
+
+**The checker produces false positives — never fix a link without confirming it's actually broken.** The crawler hits live URLs with a bot user agent, so it routinely mis-flags links that are fine in a browser: bot-protected sites, transient `5xx`/timeouts, rate-limiting, auth walls, and pages that block automated clients. `excludeAcceptable()` already filters the common transient reasons, but plenty slip through — especially in the `external` list.
+
+For **every** reported link, confirm it's genuinely broken before touching anything:
+
+1. **Re-check the destination** — `WebFetch` (or `curl -sIL`) the URL. If it resolves, it's a false positive.
+2. **Weigh the reason code.** Internal `HTTP_404`/`HTTP_410` on a `pulumi.com` path is almost always real. External failures, and codes like `HTTP_403`, `HTTP_401`, `HTTP_429`, `HTTP_503`, or connection/timeout errors, are frequently bot protection or transient — treat as suspect until confirmed.
+3. **If it's a false positive, do not edit, redirect, or exclude it.** Leave the link as-is and record it in the PR audit trail under a **False positives / not actioned** section, with the URL, the reason code, and one line on why it's fine (e.g. "resolves in browser; 403 is Cloudflare bot protection"). Optionally suggest it as a future exclusion-list candidate, but don't add it unless it's a recurring offender.
+
+Only links you've confirmed broken proceed to triage below.
+
 ## Mapping a live URL back to its source file
 
 `source` and `destination` are live `https://www.pulumi.com/...` URLs. To edit or redirect them you must find the file that produces them:
@@ -100,5 +112,6 @@ docs/old/path/index.html|/docs/iac/new/path/
 The reviewer must be able to audit every decision without re-deriving it. Model the description on PR #19469. Include:
 
 - **A table or list of every broken link** → the strategy applied → one line of non-obvious reasoning (why a redirect vs. an alias, why excluded, etc.).
-- A **Verification** section: confirm `make lint` and `make build` passed, and note any spot-checks.
+- A **Verification** section: confirm `make lint` and `make build` passed, and note that each link was re-checked before fixing.
+- A **False positives / not actioned** section listing every reported link you confirmed was actually fine, with its reason code and why (so the reviewer knows it was checked, not missed).
 - An **Out of scope / filed issues** section linking every issue you created for breakage owned by other repos or otherwise unfixable here.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git commit:*)"
+    ]
+  }
+}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -89,17 +89,26 @@ jobs:
             Follow `.claude/commands/fix-broken-links/SKILL.md` exactly. In short:
 
             1. Read `.broken-links.json`.
-            2. Create a branch `fix/broken-links-${{ steps.detect.outputs.date }}`.
-            3. Triage and fix every broken link using the strategies in the skill
+            2. Verify each link is genuinely broken (the checker has false
+               positives), then skip any already covered by an open PR or
+               existing issue (deduplication — see the skill).
+            3. If every confirmed-broken link is a duplicate, open no PR: just
+               write the "all already tracked" Slack summary to
+               `.broken-links-pr.txt` and stop. Otherwise, for the actionable
+               (non-duplicate) links:
+            4. Create a branch `fix/broken-links-${{ steps.detect.outputs.date }}`.
+            5. Triage and fix each broken link using the strategies in the skill
                (alias, S3 redirect, source edit, exclusion, or out-of-scope issue).
-            4. File a GitHub issue for anything that can't be fixed in this repo.
-            5. Run `make lint` and `make build`; resolve anything they surface.
-            6. Open a **ready** (non-draft) PR to `master` with the auditable
+            6. File a GitHub issue for new out-of-scope items (reuse the existing
+               issue for duplicates).
+            7. Run `make lint` and `make build`; resolve anything they surface.
+            8. Open a **ready** (non-draft) PR to `master` with the auditable
                description the skill describes (every link → strategy → reasoning,
-               a Verification section, and an Out-of-scope/filed-issues section).
-            7. Write the final PR URL and a one-line summary to
+               plus Verification, False-positives, Already-tracked, and
+               Out-of-scope/filed-issues sections).
+            9. Write the final PR URL and a one-line summary to
                `.broken-links-pr.txt` for the Slack notification.
-          claude_args: '--model claude-opus-4-7 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh api:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(curl:*)"'
+          claude_args: '--model claude-opus-4-7 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(curl:*)"'
       # Post the PR link to #docs-ops. Gated on the results file the Claude step
       # writes, so a run where Claude couldn't open a PR stays silent rather than
       # posting an empty message.

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,4 +1,3 @@
-permissions: write-all # Equivalent to default permissions + id-token: write
 name: "Scheduled jobs: Check links"
 on:
   schedule:
@@ -6,6 +5,12 @@ on:
     # Run every day at 3:00PM UTC.
     - cron: '0 15 * * *'
   workflow_dispatch: null
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write # Required for ESC OIDC auth
+  actions: read
 jobs:
   all:
     env:
@@ -13,10 +18,17 @@ jobs:
     name: Check links
     runs-on: ubuntu-latest
     steps:
+      # ESC runs before checkout so the bot token can authenticate the
+      # checkout — the PR opened by claude-code-action later then goes out as
+      # pulumi-bot rather than github-actions[bot], which is what lets
+      # downstream workflows (build-and-deploy, docs review, etc.) fire on it.
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
-      - uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Install Node
         uses: actions/setup-node@v6
         with:
@@ -32,10 +44,75 @@ jobs:
         with:
           hugo-version: '0.157.0'
           extended: true
+      # No SLACK_ACCESS_TOKEN in env: the checker no longer posts to Slack. It
+      # writes its results to .broken-links.json, and Slack posting (the PR
+      # link) happens at the end of this workflow instead.
       - name: Run make check_links
         run: make check_links
+      # Branch the rest of the workflow on whether anything is actually broken.
+      # On a clean run the Claude and Slack steps below are skipped entirely, so
+      # quiet days cost no API spend and post nothing.
+      - name: Detect broken links
+        id: detect
+        run: |
+          if [ ! -f .broken-links.json ]; then
+            echo "has_broken=false" >> "$GITHUB_OUTPUT"
+            echo "No .broken-links.json produced; nothing to do."
+            exit 0
+          fi
+          COUNT=$(jq '(.internal | length) + (.external | length)' .broken-links.json)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "has_broken=true" >> "$GITHUB_OUTPUT"
+            echo "Found $COUNT broken link(s)."
+          else
+            echo "has_broken=false" >> "$GITHUB_OUTPUT"
+            echo "No broken links."
+          fi
+      # Hand the broken-link list to the Claude Code action, which follows the
+      # fix-broken-links skill: triage each link, fix in-repo, file issues for
+      # out-of-scope breakage, open a ready PR, and write the PR link to
+      # .broken-links-pr.txt for the Slack step.
+      - name: Run Claude Code
+        if: steps.detect.outputs.has_broken == 'true'
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Bot token so the PR/pushes trigger downstream workflows.
+          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          prompt: |
+            The daily link checker found broken links on https://www.pulumi.com.
+            The results are in `.broken-links.json` at the repo root.
+
+            Follow `.claude/commands/fix-broken-links/SKILL.md` exactly. In short:
+
+            1. Read `.broken-links.json`.
+            2. Create a branch `fix/broken-links-${{ steps.detect.outputs.date }}`.
+            3. Triage and fix every broken link using the strategies in the skill
+               (alias, S3 redirect, source edit, exclusion, or out-of-scope issue).
+            4. File a GitHub issue for anything that can't be fixed in this repo.
+            5. Run `make lint` and `make build`; resolve anything they surface.
+            6. Open a **ready** (non-draft) PR to `master` with the auditable
+               description the skill describes (every link → strategy → reasoning,
+               a Verification section, and an Out-of-scope/filed-issues section).
+            7. Write the final PR URL and a one-line summary to
+               `.broken-links-pr.txt` for the Slack notification.
+          claude_args: '--model claude-opus-4-7 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh api:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(curl:*)"'
+      # Post the PR link to #docs-ops. Gated on the results file the Claude step
+      # writes, so a run where Claude couldn't open a PR stays silent rather than
+      # posting an empty message.
+      - name: Post PR link to Slack
+        if: steps.detect.outputs.has_broken == 'true' && hashFiles('.broken-links-pr.txt') != ''
         env:
-            SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
+          SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
+        run: |
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data "$(jq -n --arg ch "#docs-ops" --rawfile txt .broken-links-pr.txt \
+              '{channel: $ch, text: $txt, unfurl_links: true}')"
 env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,10 @@ _vendor/
 # Ignore log files.
 /scripts/link-checker/pages-with-broken-links.txt
 
+# Link-checker outputs consumed by the check-links workflow (generated at runtime).
+/.broken-links.json
+/.broken-links-pr.txt
+
 .doctrees/
 .buildinfo
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -55,4 +55,5 @@ static/js
 # Conductor workspace state
 .context
 
+**/.claude/settings.json
 **/.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,8 @@ Use the `/move-doc` skill for Hugo content files — it handles `git mv`, alias 
 
 When moving documentation, aliases handle redirects automatically. Update internal links strategically:
 
-- **DO update** links in `/content/docs/` and `/content/product/`.
-- **DO NOT update** links in `/content/blog/` or `/content/tutorials/` — they're historical.
+- **DO update** links in `/content/docs/`, `/content/product/`, and `/content/tutorials/`.
+- **`/content/blog/`** is historical — swap a broken link only for an equivalent replacement (stamp `lastmod`); otherwise route around it with an alias/redirect.
 - **Link style**: links within `/docs/` must use the full canonical path (e.g. `/docs/iac/concepts/stacks/`). Never use parent-directory references (`../stacks/`) — they break when files move.
 
 For find/sed implementation patterns, see `.claude/commands/move-doc/SKILL.md`.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1041.0",
     "@octokit/rest": "^21.1.1",
-    "@slack/web-api": "^7.15.1",
     "algoliasearch": "^5.52.0",
     "axios": "^1.16.0",
     "axios-retry": "^4.5.0",

--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -1,5 +1,4 @@
 const { HtmlUrlChecker } = require("broken-link-checker");
-const { WebClient, LogLevel } = require('@slack/web-api');
 const httpServer = require("http-server");
 const Sitemapper = require("sitemapper").default;
 const sitemap = new Sitemapper();
@@ -22,6 +21,10 @@ function isInternalLink(url) {
         return false;
     }
 }
+
+// Path of the file the checker writes its final results to. Downstream tooling
+// (the link-fix workflow) reads this and hands it to the Claude Code action.
+const RESULTS_FILE = ".broken-links.json";
 
 // Additional routes to check that are not included in the sitemap.
 const additionalRoutes = [
@@ -188,42 +191,35 @@ async function onComplete(brokenLinks) {
 
     const totalFiltered = filteredInternal.length + filteredExternal.length;
 
-    if (totalFiltered > 0) {
-
-        // If we failed and a retry count was provided, retry. Note that retry count !==
-        // run count, so a retry count of 1 means run once, then retry once, which means a
-        // total run count of two.
-        if (maxRetries > 0 && retryCount < maxRetries) {
-            retryCount += 1;
-            console.log(`Retrying (${retryCount} of ${maxRetries})...`);
-            checkLinks();
-            return;
-        }
-
-        // Post internal broken links first (if any)
-        if (filteredInternal.length > 0) {
-            const internalList = filteredInternal
-                .map(link => `:link: <${link.source}|${new URL(link.source).pathname}> → ${link.destination} (${link.reason})`)
-                .join("\n");
-
-            const internalMessage = `:pulumipus-jedi: *Internal Broken Links (${filteredInternal.length} found)*\nThese are links within pulumi.com that need attention:\n\n${internalList}`;
-
-            console.warn("Posting internal broken links to Slack: " + internalList);
-            await postToSlack("docs-ops", internalMessage);
-        }
-
-        // Post external broken links second (if any)
-        if (filteredExternal.length > 0) {
-            const externalList = filteredExternal
-                .map(link => `:link: <${link.source}|${new URL(link.source).pathname}> → ${link.destination} (${link.reason})`)
-                .join("\n");
-
-            const externalMessage = `:pulumipus-sith: *External Broken Links (${filteredExternal.length} found)*\nThese are links to third-party sites (may be false positives due to bot protection):\n\n${externalList}`;
-
-            console.warn("Posting external broken links to Slack: " + externalList);
-            await postToSlack("docs-ops", externalMessage);
-        }
+    // If we failed and a retry count was provided, retry. Note that retry count !==
+    // run count, so a retry count of 1 means run once, then retry once, which means a
+    // total run count of two.
+    if (totalFiltered > 0 && maxRetries > 0 && retryCount < maxRetries) {
+        retryCount += 1;
+        console.log(`Retrying (${retryCount} of ${maxRetries})...`);
+        checkLinks();
+        return;
     }
+
+    // Write the final results to disk for downstream tooling. We write on every
+    // final pass — including clean runs, which produce empty lists — so the
+    // workflow can branch on the contents and stay silent when nothing is
+    // broken. Slack posting now happens at the workflow level (the link-fix PR
+    // link), not here. Broken links are already logged to the console as they're
+    // found, in onLink.
+    writeResults(filteredInternal, filteredExternal);
+}
+
+// Writes the final broken-link results to RESULTS_FILE in the shape downstream
+// tooling expects: a generation timestamp plus separate internal/external lists.
+function writeResults(internal, external) {
+    const results = {
+        generated: new Date().toISOString(),
+        internal,
+        external,
+    };
+    fs.writeFileSync(RESULTS_FILE, JSON.stringify(results, null, 2) + "\n");
+    console.log(`Wrote ${internal.length + external.length} broken link(s) to ${RESULTS_FILE}.`);
 }
 
 /**
@@ -482,25 +478,6 @@ function excludeAcceptable(links) {
         // https://github.com/stevenvachon/broken-link-checker/blob/43770535ad7b84cadec9dc54c5140694389e33dc/lib/internal/streamHTML.js#L36-L39
         .filter(b => !b.reason.startsWith(`Expected type "text/html"`))
     );
-}
-
-// Posts a message to the designated Slack channel.
-async function postToSlack(channel, text) {
-    const token = process.env.SLACK_ACCESS_TOKEN;
-
-    if (!token) {
-        console.warn("No SLACK_ACCESS_TOKEN on the environment. Skipping.");
-        return;
-    }
-
-    const client = new WebClient(token, { logLevel: LogLevel.ERROR });
-    return await client.chat.postMessage({
-        text,
-        channel: `#${channel}`,
-        as_user: true,
-        mrkdwn: true,
-        unfurl_links: false,
-    });
 }
 
 // Adds a broken link to the running list.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,36 +1341,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.6.0.tgz#41dd6093d34652cddb5d5bdeee04eafc33826668"
   integrity sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==
 
-"@slack/logger@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-4.0.1.tgz#d8eed47117b6b106c976f5f76c9e5845f6de721b"
-  integrity sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==
-  dependencies:
-    "@types/node" ">=18"
-
-"@slack/types@^2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.20.1.tgz#2528592813eb088691a8665d55e21ec47ddc8217"
-  integrity sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==
-
-"@slack/web-api@^7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-7.15.1.tgz#164b95ba3a9b4f1f0d5f30793e3d42e02afe8bb3"
-  integrity sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==
-  dependencies:
-    "@slack/logger" "^4.0.1"
-    "@slack/types" "^2.20.1"
-    "@types/node" ">=18"
-    "@types/retry" "0.12.0"
-    axios "^1.15.0"
-    eventemitter3 "^5.0.1"
-    form-data "^4.0.4"
-    is-electron "2.2.2"
-    is-stream "^2"
-    p-queue "^6"
-    p-retry "^4"
-    retry "^0.13.1"
-
 "@smithy/chunked-blob-reader-native@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz#9e79a80d8d44798e7ce7a8f968cbbbaf5a40d950"
@@ -1918,7 +1888,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=18":
+"@types/node@*":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.5.0.tgz#5c99f37c443d9ccc4985866913f1ed364217da31"
   integrity sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==
@@ -1949,11 +1919,6 @@
     "@types/node" "*"
     pg-protocol "*"
     pg-types "^2.2.0"
-
-"@types/retry@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz"
-  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/shimmer@^1.2.0":
   version "1.2.0"
@@ -2177,7 +2142,7 @@ axios-retry@^4.5.0:
   dependencies:
     is-retry-allowed "^2.2.0"
 
-axios@^1.15.0, axios@^1.16.0:
+axios@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
   integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
@@ -3337,7 +3302,7 @@ eventemitter2@6.4.7:
   resolved "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz"
   integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
-eventemitter3@^4.0.0, eventemitter3@^4.0.4:
+eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -3489,7 +3454,7 @@ form-data2@^1.0.0:
     mime "^1.3.4"
     uuid "^2.0.1"
 
-form-data@^4.0.0, form-data@^4.0.4, form-data@^4.0.5, form-data@~4.0.4:
+form-data@^4.0.0, form-data@^4.0.5, form-data@~4.0.4:
   version "4.0.5"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
@@ -3924,11 +3889,6 @@ is-docker@^2.0.0, is-docker@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
-is-electron@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz"
-  integrity sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==
-
 is-extendable@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
@@ -4001,7 +3961,7 @@ is-stream@^1.0.1:
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
   integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
 
-is-stream@^2, is-stream@^2.0.0:
+is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
@@ -4905,40 +4865,12 @@ p-cancelable@^3.0.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-3.0.0.tgz#63826694b54d61ca1c20ebcb6d3ecf5e14cd8050"
   integrity sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==
 
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
-  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
-
 p-limit@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz"
   integrity sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==
   dependencies:
     yocto-queue "^1.1.1"
-
-p-queue@^6:
-  version "6.6.2"
-  resolved "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz"
-  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
-  dependencies:
-    eventemitter3 "^4.0.4"
-    p-timeout "^3.2.0"
-
-p-retry@^4:
-  version "4.6.2"
-  resolved "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz"
-  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
-  dependencies:
-    "@types/retry" "0.12.0"
-    retry "^0.13.1"
-
-p-timeout@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 pac-proxy-agent@^7.1.0:
   version "7.2.0"
@@ -5609,11 +5541,6 @@ restore-cursor@^5.0.0:
   dependencies:
     onetime "^7.0.0"
     signal-exit "^4.1.0"
-
-retry@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz"
-  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 rfdc@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
### Proposed changes

This PR restructures the daily link-checker workflow to automate broken link remediation using the Claude Code action, replacing manual Slack notifications with an automated fix-and-PR pipeline.

**Key changes:**

1. **New skill: `fix-broken-links`** (`.claude/commands/fix-broken-links/SKILL.md`)
   - Comprehensive guide for triaging and fixing broken links
   - Documents five fix strategies: Hugo aliases, S3 redirects, source edits, exclusions, and out-of-scope issues
   - Establishes editing guardrails (e.g., blog prose only for equivalent-content swaps, always use root-relative paths)
   - Specifies PR description contract for auditability

2. **Refactored `check-links.js`**
   - Removed Slack posting and `@slack/web-api` dependency
   - Added `writeResults()` function to persist broken links to `.broken-links.json` (timestamp + internal/external lists)
   - Removed `postToSlack()` function
   - Broken links are now logged to console as found; final results written to disk for downstream tooling

3. **Enhanced `check-links.yml` workflow**
   - Added ESC OIDC auth and bot token checkout so PR/pushes trigger downstream workflows as `pulumi-bot`
   - New `detect` step: branches workflow on whether `.broken-links.json` contains broken links (skips Claude/Slack on clean runs)
   - New `claude` step: invokes Claude Code action with `fix-broken-links` skill prompt and restricted tool allowlist
   - Moved Slack posting to end of workflow: reads `.broken-links-pr.txt` written by Claude and posts PR link only if present
   - Permissions refined to `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`

4. **Added `.claude/settings.json`**
   - Permits `Bash(git commit:*)` for Claude to commit changes

5. **Updated `AGENTS.md`**
   - Clarified that `/content/tutorials/` links should be updated (like docs/product)
   - Noted blog prose is historical; broken links routed around rather than reworded

**Workflow behavior:**
- On clean runs: no `.broken-links.json` produced → Claude and Slack steps skipped → silent
- On broken links: Claude reads `.broken-links.json`, triages each link per the skill, opens a ready PR, files out-of-scope issues, writes PR link to `.broken-links-pr.txt` → Slack posts the link
- All fixes are auditable: PR description includes every link → strategy → reasoning

### Related issues (optional)

Implements the automated broken-link-fix pipeline described in the skill documentation, codified from patterns in PRs #19469, #17418, #19123, #19327, #19053.

https://claude.ai/code/session_01UCboXYM4pPdVatzJwWm66d