### PR TITLE
Add weekly digest workflow for docs team review

### DIFF
--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -1,0 +1,162 @@
+name: Weekly review digest
+
+# Replaces the recurring docs review meeting with two Slack messages to
+# #docs-ops every Monday: one for the PR review queue, one for the issue
+# backlog. A single deterministic collection pass (digest.py) feeds one
+# Claude synthesis call, whose two outputs post as two separate messages.
+on:
+  schedule:
+    # Mondays 14:00 UTC.
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run — collect + synthesize, print both bodies to the log, no Slack posts"
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: weekly-digest
+  cancel-in-progress: false
+
+jobs:
+  weekly-digest:
+    if: github.repository == 'pulumi/docs'
+    name: Weekly review digest
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: astral-sh/setup-uv@v7
+
+      # 1. COLLECT — deterministic, no model. Dumps the full digest JSON;
+      # under dry_run it also echoes the raw JSON so queries are inspectable
+      # before any model or Slack step runs.
+      - name: Collect digest data
+        id: collect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          uv run scripts/weekly-digest/digest.py > /tmp/digest.json
+          echo "Collected $(jq '.prs | length' /tmp/digest.json) open PRs and $(jq '.issues.all_open_count' /tmp/digest.json) open issues."
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "----- raw digest JSON -----"
+            cat /tmp/digest.json
+          fi
+
+      # 2. SYNTHESIZE — one raw curl to the Anthropic API (cloned from
+      # claude-triage.yml). Pure JSON-in / prose-out; no agency, so no Claude
+      # Code action. Returns {"pr_digest":...,"backlog_digest":...}; we strip
+      # any ```json fences defensively before parsing.
+      - name: Synthesize digests
+        id: synth
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          PROMPT=$(cat scripts/weekly-digest/synthesis-prompt.md)
+          DIGEST=$(cat /tmp/digest.json)
+          REQUEST=$(jq -n \
+            --arg prompt "$PROMPT" \
+            --arg digest "$DIGEST" \
+            '{
+              model: "claude-sonnet-4-6",
+              max_tokens: 2000,
+              messages: [{
+                role: "user",
+                content: ($prompt + "\n\n=== DATA (JSON) ===\n\n" + $digest)
+              }]
+            }')
+          RESPONSE=$(curl -sS https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "$REQUEST" || echo '{"error":"curl_failed"}')
+          TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
+          if [[ -z "$TEXT" ]]; then
+            echo "::error::Anthropic API returned no text"
+            echo "$RESPONSE" | head -c 2000 >&2
+            exit 1
+          fi
+          CLEAN=$(echo "$TEXT" \
+            | sed -E 's/^[[:space:]]*```(json)?[[:space:]]*//' \
+            | sed -E 's/[[:space:]]*```[[:space:]]*$//' \
+            | tr -d '\r')
+          if ! echo "$CLEAN" | jq -e . >/dev/null 2>&1; then
+            echo "::error::Synthesis output was not valid JSON"
+            echo "$CLEAN" | head -c 2000 >&2
+            exit 1
+          fi
+          PR_DIGEST=$(echo "$CLEAN" | jq -r '.pr_digest // empty')
+          BACKLOG_DIGEST=$(echo "$CLEAN" | jq -r '.backlog_digest // empty')
+          if [[ -z "$PR_DIGEST" || -z "$BACKLOG_DIGEST" ]]; then
+            echo "::error::Synthesis JSON missing pr_digest or backlog_digest"
+            exit 1
+          fi
+          {
+            echo "pr_digest<<DIGEST_EOF"
+            echo "$PR_DIGEST"
+            echo "DIGEST_EOF"
+            echo "backlog_digest<<DIGEST_EOF"
+            echo "$BACKLOG_DIGEST"
+            echo "DIGEST_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # 3a. DRY RUN — print both bodies, skip posting.
+      - name: Print digests (dry run)
+        if: ${{ inputs.dry_run }}
+        env:
+          PR_DIGEST: ${{ steps.synth.outputs.pr_digest }}
+          BACKLOG_DIGEST: ${{ steps.synth.outputs.backlog_digest }}
+        run: |
+          echo "===== PR DIGEST ====="
+          printf '%s\n\n' "$PR_DIGEST"
+          echo "===== BACKLOG DIGEST ====="
+          printf '%s\n' "$BACKLOG_DIGEST"
+
+      # 3b. POST — two separate messages so each threads independently in
+      # #docs-ops. Webhook + channel come from ESC; posts as docsbot.
+      - name: Post PR digest to Slack
+        if: ${{ !inputs.dry_run }}
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_USERNAME: docsbot
+          SLACK_TITLE: "Weekly PR review queue"
+          SLACK_MESSAGE: ${{ steps.synth.outputs.pr_digest }}
+          SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png
+          MSG_MINIMAL: "true"
+
+      - name: Post backlog digest to Slack
+        if: ${{ !inputs.dry_run }}
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_USERNAME: docsbot
+          SLACK_TITLE: "Weekly issue backlog"
+          SLACK_MESSAGE: ${{ steps.synth.outputs.backlog_digest }}
+          SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png
+          MSG_MINIMAL: "true"
+
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false

--- a/scripts/weekly-digest/digest.py
+++ b/scripts/weekly-digest/digest.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Collect open PRs and the full issue backlog for the weekly #docs-ops digest.
+
+Deterministic collection only -- no model, no prose, no grouping. Emits a
+single JSON object to stdout that weekly-digest.yml feeds to one Claude
+synthesis call. Shells out to `gh`; runs via `uv run` in the workflow.
+
+Mirrors the query patterns in .claude/commands/dashboard/scripts/dashboard.sh
+but broadened: the issue query is the whole open backlog, not assignee-scoped.
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+REPO = "pulumi/docs"
+BOT_LOGINS = {"pulumi-bot", "dependabot[bot]"}
+WINDOW_DAYS = 7
+NOW = datetime.now(timezone.utc)
+
+
+def run_gh(args):
+    """Run a gh command; return stdout, or "" on failure (logged to stderr)."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, check=True
+        )
+        return proc.stdout
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(f"warning: gh {' '.join(args)} failed: {exc.stderr.strip()}\n")
+        return ""
+
+
+def gh_json(args):
+    """Run a gh command that emits JSON; parse it, or return [] on failure."""
+    out = run_gh(args)
+    try:
+        return json.loads(out) if out.strip() else []
+    except json.JSONDecodeError:
+        sys.stderr.write(f"warning: could not parse JSON from gh {' '.join(args)}\n")
+        return []
+
+
+def days_since(iso):
+    """Whole days between an ISO-8601 timestamp and now; None if unparseable."""
+    if not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (NOW - dt).days
+
+
+def rollup_state(pr):
+    """Reduce a PR's statusCheckRollup to green | red | pending | none.
+
+    statusCheckRollup mixes CheckRun nodes (status/conclusion) and legacy
+    StatusContext nodes (state). Red wins over pending wins over green.
+    """
+    rollup = pr.get("statusCheckRollup") or []
+    if not rollup:
+        return "none"
+    states = set()
+    for check in rollup:
+        if check.get("conclusion"):
+            states.add(check["conclusion"].upper())
+        elif check.get("state"):
+            states.add(check["state"].upper())
+        elif check.get("status"):
+            states.add(check["status"].upper())
+    if states & {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}:
+        return "red"
+    if states & {"IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED", "EXPECTED"}:
+        return "pending"
+    if states & {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+        return "green"
+    return "none"
+
+
+def shape_prs(raw):
+    """Pure transform: raw `gh pr list` objects -> digest PR records."""
+    prs = []
+    for pr in raw:
+        login = (pr.get("author") or {}).get("login", "")
+        prs.append(
+            {
+                "number": pr["number"],
+                "title": pr["title"],
+                "author": login,
+                "age_days": days_since(pr.get("createdAt")),
+                "updated_days": days_since(pr.get("updatedAt")),
+                "labels": [lbl["name"] for lbl in pr.get("labels", [])],
+                "isDraft": pr.get("isDraft", False),
+                "checks": rollup_state(pr),
+                "is_bot": login in BOT_LOGINS,
+            }
+        )
+    return prs
+
+
+def shape_issues(raw):
+    """Pure transform: raw `gh issue list` objects -> backlog summary.
+
+    Surfaces only what the digest needs: a count, the issues opened this week,
+    and the three staleest open issues. The full list is never emitted.
+    """
+    enriched = []
+    for issue in raw:
+        login = (issue.get("author") or {}).get("login", "")
+        enriched.append(
+            {
+                "number": issue["number"],
+                "title": issue["title"],
+                "author": login,
+                "age_days": days_since(issue.get("createdAt")),
+            }
+        )
+    aged = [i for i in enriched if i["age_days"] is not None]
+    new_this_week = sorted(
+        (i for i in aged if i["age_days"] < WINDOW_DAYS),
+        key=lambda x: x["age_days"],
+    )
+    oldest_open = sorted(aged, key=lambda x: x["age_days"], reverse=True)[:3]
+    return {
+        "all_open_count": len(enriched),
+        "new_this_week": [
+            {k: i[k] for k in ("number", "title", "author", "age_days")}
+            for i in new_this_week
+        ],
+        "oldest_open": [
+            {k: i[k] for k in ("number", "title", "age_days")} for i in oldest_open
+        ],
+    }
+
+
+def shape_ci_health(raw):
+    """Pure transform: raw `gh run list` objects -> CI health over last 24h.
+
+    Thresholds mirror dashboard.sh: 0 failures and >=95% success -> HEALTHY;
+    <=2 failures and >=85% success -> WARNING; otherwise CRITICAL.
+    """
+    cutoff = NOW - timedelta(hours=24)
+    recent = []
+    for run in raw:
+        dt = run.get("createdAt")
+        if not dt:
+            continue
+        try:
+            when = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if when >= cutoff:
+            recent.append(run)
+    if not recent:
+        return {"status": "UNKNOWN", "success_rate": None, "failures": 0, "total": 0}
+    completed = [r for r in recent if r.get("conclusion")]
+    failures = sum(1 for r in completed if r.get("conclusion") == "failure")
+    successes = sum(
+        1 for r in completed if r.get("conclusion") in ("success", "skipped")
+    )
+    rate = round(100 * successes / len(completed)) if completed else None
+    if failures == 0 and (rate is None or rate >= 95):
+        status = "HEALTHY"
+    elif failures <= 2 and rate is not None and rate >= 85:
+        status = "WARNING"
+    else:
+        status = "CRITICAL"
+    return {
+        "status": status,
+        "success_rate": rate,
+        "failures": failures,
+        "total": len(recent),
+    }
+
+
+def search_count(qualifier):
+    """Exact issue count via the search API's total_count (REST, not GraphQL)."""
+    out = run_gh(
+        [
+            "api",
+            "-X",
+            "GET",
+            "search/issues",
+            "-f",
+            f"q=repo:{REPO} {qualifier}",
+            "-f",
+            "per_page=1",
+            "--jq",
+            ".total_count",
+        ]
+    )
+    try:
+        return int(out.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def main():
+    cutoff = (NOW - timedelta(days=WINDOW_DAYS)).date().isoformat()
+    prs = shape_prs(
+        gh_json(
+            [
+                "pr", "list", "--repo", REPO, "--state", "open", "--limit", "200",
+                "--json",
+                "number,title,author,createdAt,updatedAt,labels,isDraft,statusCheckRollup",
+            ]
+        )
+    )
+    issues = shape_issues(
+        gh_json(
+            [
+                "issue", "list", "--repo", REPO, "--state", "open", "--limit", "500",
+                "--json", "number,title,author,createdAt,updatedAt,labels",
+            ]
+        )
+    )
+    issues["opened_last_7d"] = search_count(f"is:issue created:>={cutoff}")
+    issues["closed_last_7d"] = search_count(f"is:issue closed:>={cutoff}")
+    ci_health = shape_ci_health(
+        gh_json(
+            [
+                "run", "list", "--repo", REPO, "--limit", "50",
+                "--json", "status,conclusion,createdAt",
+            ]
+        )
+    )
+    digest = {
+        "window_days": WINDOW_DAYS,
+        "prs": prs,
+        "issues": issues,
+        "ci_health": ci_health,
+    }
+    json.dump(digest, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/weekly-digest/synthesis-prompt.md
+++ b/scripts/weekly-digest/synthesis-prompt.md
@@ -1,0 +1,61 @@
+You are writing the docs team's weekly review digest for the #docs-ops Slack
+channel. You receive a JSON object describing every open pull request and the
+open-issue backlog for the pulumi/docs repo. Turn it into two short Slack
+messages that replace a live review meeting.
+
+Return ONLY a JSON object of the exact shape:
+
+{"pr_digest": "<message 1>", "backlog_digest": "<message 2>"}
+
+No markdown fences, no preamble, no trailing commentary. Both values are Slack
+message strings (Slack mrkdwn: use *bold*, `code`, and <url|text> sparingly).
+Reference items as <https://github.com/pulumi/docs/pull/NUMBER|#NUMBER> for PRs
+and <https://github.com/pulumi/docs/issues/NUMBER|#NUMBER> for issues.
+
+## Voice
+
+Terse, direct, useful. No sycophancy, no "happy to report," no filler. Lead with
+what needs action. At most one section-marker emoji in each message. Each flagged
+item gets: the number, a short title, and one sentence on why it is here or what
+to do. Empty buckets collapse to a single line (for example "Nothing ready to
+merge") -- never drop a bucket entirely.
+
+## Message 1 -- pr_digest
+
+Group PRs by review STATE, not by age. Each PR belongs to exactly ONE bucket;
+assign by first match in this order:
+
+1. *Ready to merge* -- has label `review:no-blockers`, is not a draft, and
+   `checks == "green"`. These need a final click. List one per line.
+2. *Needs another review (stale)* -- has label `review:stale`. A re-review may be
+   required before it can merge, so a human should look. List one per line.
+3. *Waiting on author* -- has label `needs-author-response`. Include the age in
+   days. List one per line.
+4. *Stale by age* -- not a draft, `age_days > 14`, and not already placed in
+   buckets 1-3 (no terminal review label). These are neglected and untriaged;
+   list one per line and frame each as a keep-or-kill call.
+5. *In flight* -- everything else: drafts, PRs labeled
+   `review:outstanding-issues`, and fresh untriaged PRs. Do NOT list these one
+   per line. Emit a SINGLE line: the total count followed by a compact per-author
+   tally, e.g. "8 in flight -- @alice 3, @bob 2, @carol 1". (A PR labeled
+   `review:outstanding-issues` already has known issues for the author to fix, so
+   it belongs here, not in a human-review bucket.)
+
+Then:
+
+- Exclude bot PRs (`is_bot == true`, i.e. pulumi-bot / dependabot) from all of
+  the narrative above. At most, mention them as a bare trailing count.
+- End with ONE line of CI health derived from `ci_health` (status plus success
+  rate / failure count if useful).
+
+## Message 2 -- backlog_digest
+
+A scan of the open-issue backlog, not a recital. Do not list the whole backlog.
+
+- *New this week* -- the issues in `issues.new_this_week` (opened in the trailing
+  `window_days` days). One line each.
+- *Oldest open* -- the issues in `issues.oldest_open` (the 2-3 staleest). One
+  line each, framed to force a keep-or-kill call.
+- *Net delta* -- one line comparing `issues.opened_last_7d` against
+  `issues.closed_last_7d` (for example "12 opened vs 19 closed -- backlog
+  shrank by 7"). Mention `issues.all_open_count` as the running total.


### PR DESCRIPTION
### Proposed changes

Introduces an automated weekly digest workflow that replaces the recurring docs review meeting with two Slack messages to #docs-ops every Monday. The workflow:

1. **Collects** repository data deterministically via `digest.py` — queries all open PRs, the full issue backlog, and CI health metrics, emitting a single JSON object
2. **Synthesizes** the raw data via Claude (Sonnet 4.6) using a structured prompt that groups PRs by review state and surfaces actionable issue backlog insights
3. **Posts** two separate Slack messages (PR review queue and issue backlog) as `docsbot` to enable independent threading

**Key files:**
- `scripts/weekly-digest/digest.py` — deterministic data collection script (no model, no prose). Shells out to `gh` CLI; runs via `uv run`. Mirrors query patterns from the existing dashboard but broadened to the full backlog.
- `.github/workflows/weekly-digest.yml` — scheduled workflow (Mondays 14:00 UTC) with manual `dry_run` option for testing. Fetches secrets from ESC, collects data, calls Anthropic API once, and posts results.
- `scripts/weekly-digest/synthesis-prompt.md` — structured prompt that groups PRs by review state (ready to merge, stale, waiting on author, stale by age, in flight) and surfaces new/oldest issues plus backlog delta.

The workflow includes safeguards: JSON validation at each step, error handling for API failures, and a dry-run mode that prints both digests to the log without posting to Slack.

### Related issues (optional)

Replaces the recurring docs review meeting with an automated, Claude-synthesized digest.

https://claude.ai/code/session_01WvtrTnX65jQwBMPfxPFv4H