### PR TITLE
Refine weekly digest synthesis prompt (drafts FYI-only)

### DIFF
--- a/scripts/weekly-digest/synthesis-prompt.md
+++ b/scripts/weekly-digest/synthesis-prompt.md
@@ -18,23 +18,32 @@ Terse, direct, useful. No sycophancy, no "happy to report," no filler. Lead with
 what needs action. At most one section-marker emoji in each message. Each flagged
 item gets: the number, a short title, and one sentence on why it is here or what
 to do. Empty buckets collapse to a single line (for example "Nothing ready to
-merge") -- never drop a bucket entirely.
+merge") -- never drop a bucket entirely. The single allowed emoji is the
+message's lead marker; do not sprinkle additional emoji elsewhere (including
+status glyphs in the CI line).
 
 ## Message 1 -- pr_digest
 
 Group PRs by review STATE, not by age. Each PR belongs to exactly ONE bucket;
-assign by first match in this order:
+assign by first match in this order.
+
+HARD RULE FIRST: any draft PR (`isDraft == true`) goes straight to bucket 5
+(In flight), no matter what labels it carries. We do not care about drafts
+beyond their existence as an FYI count -- they NEVER appear in buckets 1-4, only
+in the bucket 5 tally.
 
 1. *Ready to merge* -- has label `review:no-blockers`, is not a draft, and
    `checks == "green"`. These need a final click. List one per line.
-2. *Needs another review (stale)* -- has label `review:stale`. A re-review may be
-   required before it can merge, so a human should look. List one per line.
-3. *Waiting on author* -- has label `needs-author-response`. Include the age in
-   days. List one per line.
+2. *Needs another review (stale)* -- has label `review:stale` and is NOT a draft.
+   A re-review may be required before it can merge, so a human should look. List
+   one per line. (Stale DRAFTS are not up for review yet -- they fall through to
+   the In flight bucket below, not here.)
+3. *Waiting on author* -- has label `needs-author-response` and is not a draft.
+   Include the age in days. List one per line.
 4. *Stale by age* -- not a draft, `age_days > 14`, and not already placed in
    buckets 1-3 (no terminal review label). These are neglected and untriaged;
    list one per line and frame each as a keep-or-kill call.
-5. *In flight* -- everything else: drafts, PRs labeled
+5. *In flight* -- everything else: drafts (including stale drafts), PRs labeled
    `review:outstanding-issues`, and fresh untriaged PRs. Do NOT list these one
    per line. Emit a SINGLE line: the total count followed by a compact per-author
    tally, e.g. "8 in flight -- @alice 3, @bob 2, @carol 1". (A PR labeled
@@ -46,7 +55,8 @@ Then:
 - Exclude bot PRs (`is_bot == true`, i.e. pulumi-bot / dependabot) from all of
   the narrative above. At most, mention them as a bare trailing count.
 - End with ONE line of CI health derived from `ci_health` (status plus success
-  rate / failure count if useful).
+  rate / failure count if useful). `ci_health` is computed over the last 24
+  hours, so describe the window that way -- do NOT call it "last N runs".
 
 ## Message 2 -- backlog_digest
 


### PR DESCRIPTION
Follow-up to #19483 (merged), which added the weekly `#docs-ops` review digest. This PR refines only the synthesis prompt (`scripts/weekly-digest/synthesis-prompt.md`) based on a `dry_run` dispatch of the merged workflow.

## Changes
- **Drafts are an FYI only.** A draft PR now goes straight to the *In flight* tally regardless of its labels and never appears in any other bucket (ready-to-merge, needs-review/stale, waiting-on-author, stale-by-age). Adds a hard override rule up front and closes the one bucket (waiting-on-author) that didn't previously exclude drafts.
- **Stale bucket is non-draft only.** `review:stale` PRs surface under *Needs another review* only when they're not drafts; stale drafts fall through to the in-flight tally.
- **CI line wording.** `ci_health` is a 24-hour window, so the prompt now tells the model to describe it that way instead of "last N runs".
- **Single emoji.** The one allowed section emoji is the message lead marker; no extra status glyphs (e.g. in the CI line).

## Validation
The merged workflow was dispatched with `dry_run=true` (run #1, success): collection + synthesis ran against live data and both Slack posts were correctly skipped. The earlier output is what motivated these tweaks — the *Needs another review* bucket was dominated by stale drafts. Net diff here is the prompt file only; no code or workflow changes.

https://claude.ai/code/session_01WvtrTnX65jQwBMPfxPFv4H

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvtrTnX65jQwBMPfxPFv4H)_