### PR TITLE
ESC: Refresh SDK content (#15464)

### DIFF
--- a/content/docs/esc/_index.md
+++ b/content/docs/esc/_index.md
@@ -39,8 +39,8 @@ sections:
     icon: vault-40
     link: /docs/esc/providers/secrets/vault-secrets/
 - type: cards-logo-label-link
-  heading: Languages
-  description: Manage configuration and secrets intuitively on any cloud using familiar languages.
+  heading: Languages & SDKs
+  description: <p>Use the ESC SDKs to retrieve environment values from your application workloads at runtime and to manage environments programmatically. To consume an environment from a Pulumi IaC program, use <a href="/docs/esc/guides/integrate-with-pulumi-iac/">config</a> instead.</p>
   cards:
   - label: Node.js
     icon: icon-32-32 node-color-32-32
@@ -51,9 +51,9 @@ sections:
   - label: Go
     icon: icon-32-32 go-color-32-32
     link: /docs/esc/languages-sdks/go/
-  - label: YAML
-    icon: icon-32-32 yaml-color-32-32
-    link: /docs/esc/environments/syntax/
+  - label: .NET
+    icon: icon-32-32 dotnet-color-32-32
+    link: /docs/esc/languages-sdks/dotnet/
 - type: button-cards
   heading: Operations
   description: Day-to-day workflows for running Pulumi ESC.

--- a/content/docs/esc/concepts/sdks.md
+++ b/content/docs/esc/concepts/sdks.md
@@ -1,0 +1,40 @@
+---
+title: SDKs
+title_tag: Pulumi ESC SDKs
+h1: Pulumi ESC SDKs
+meta_desc: Learn what the Pulumi ESC SDKs are for, when to use them at runtime, and when to use config in a Pulumi IaC program instead.
+menu:
+  esc:
+    parent: esc-concepts
+    identifier: esc-concepts-sdks
+    weight: 6
+---
+
+The Pulumi ESC SDKs are language libraries that let you work with [environments](/docs/esc/concepts/) from your own code. They provide a programmatic interface to create, read, update, and delete environment definitions, and to open environments so you can read their evaluated configuration and resolved secrets.
+
+{{< esc-sdk-config-note >}}
+
+## When to use the SDK
+
+The SDK is designed for two primary use cases:
+
+- **Retrieving environment values from workloads at runtime.** An application or service opens an environment with the SDK and reads its resolved configuration and secrets while the workload runs. Because environments are evaluated when they are opened, dynamic values—such as short-lived cloud credentials—are generated fresh each time, rather than being baked into the workload.
+- **Managing environments programmatically.** Automation and tooling can use the SDK to create, update, tag, decrypt, and delete environment definitions, list environments and revisions, and check definitions for errors—the same operations you can perform with the `esc` CLI or the Pulumi Cloud console.
+
+## When not to use the SDK
+
+Do not use the ESC SDK to consume environments from inside a Pulumi IaC program. In an IaC program, list the environment in the `environment` block of your `Pulumi.<stack>.yaml` stack configuration so its values flow into the stack as configuration and secrets. See [Use ESC with Pulumi IaC](/docs/esc/guides/integrate-with-pulumi-iac/) for details.
+
+## Supported languages
+
+The ESC SDK is available for the following languages. See each page for installation instructions and examples.
+
+- [TypeScript](/docs/esc/languages-sdks/javascript/)
+- [Python](/docs/esc/languages-sdks/python/)
+- [Go](/docs/esc/languages-sdks/go/)
+- [.NET](/docs/esc/languages-sdks/dotnet/)
+
+## Related integrations
+
+- [Automation API](/docs/esc/integrations/automation-api/) drives ESC from orchestration code.
+- [Pulumi Service Provider](/docs/esc/integrations/pulumi-service-provider/) manages ESC resources from inside a Pulumi program.

--- a/content/docs/esc/languages-sdks/_index.md
+++ b/content/docs/esc/languages-sdks/_index.md
@@ -1,8 +1,13 @@
 ---
-title: Languages & SDKs
 title_tag: Pulumi ESC languages and SDKs
-h1: Languages & SDKs
 meta_desc: Manage Pulumi ESC environments programmatically from .NET, Go, JavaScript, and Python.
+title: Languages & SDKs
+h1: Languages & SDKs
+meta_image: /images/docs/meta-images/docs-meta.png
+docs_home: true
+notitle: true
+norightnav: true
+description: <p>The Pulumi ESC SDKs let you manage environments and read their configuration and secrets from your own code. For what the SDKs are for and when to use config instead, see <a href="/docs/esc/concepts/sdks/">SDKs</a>.</p>
 menu:
   esc:
     identifier: esc-languages-sdks
@@ -12,15 +17,24 @@ aliases:
   - /docs/esc/development/
   - /docs/esc/development/languages-sdks/
   - /docs/esc/sdk/
+
+sections:
+- type: cards-logo-label-link
+  heading: Supported languages
+  cards:
+  - label: Node.js
+    icon: icon-32-32 node-color-32-32
+    link: /docs/esc/languages-sdks/javascript/
+  - label: Python
+    icon: icon-32-32 python-color-32-32
+    link: /docs/esc/languages-sdks/python/
+  - label: Go
+    icon: icon-32-32 go-color-32-32
+    link: /docs/esc/languages-sdks/go/
+  - label: .NET
+    icon: icon-32-32 dotnet-color-32-32
+    link: /docs/esc/languages-sdks/dotnet/
+- type: flat
+  heading: Related integrations
+  description: <p>For driving ESC from orchestration code, see <a href="/docs/esc/integrations/automation-api/">Automation API</a>. For managing ESC resources from inside a Pulumi program, see <a href="/docs/esc/integrations/pulumi-service-provider/">Pulumi Service Provider</a>.</p>
 ---
-
-The Pulumi ESC SDKs let you create, update, retrieve, and delete environments — and read their evaluated values — from your own code. Use them when you need programmatic access to ESC outside of the `esc` CLI or a Pulumi program.
-
-| Language | Reference |
-|---|---|
-| [.NET](/docs/esc/languages-sdks/dotnet/) | C#, F#, VB on .NET 6+. |
-| [Go](/docs/esc/languages-sdks/go/) | Go 1.20+. |
-| [JavaScript / TypeScript](/docs/esc/languages-sdks/javascript/) | Node.js 18+. |
-| [Python](/docs/esc/languages-sdks/python/) | Python 3.9+. |
-
-For driving ESC from orchestration code, see [Automation API](/docs/esc/integrations/automation-api/). For managing ESC resources from inside a Pulumi program, see [Pulumi Service Provider](/docs/esc/integrations/pulumi-service-provider/).

--- a/content/docs/esc/languages-sdks/dotnet.md
+++ b/content/docs/esc/languages-sdks/dotnet.md
@@ -13,7 +13,9 @@ aliases:
   - /docs/esc/development/languages-sdks/dotnet/
 ---
 
-The [.NET SDK](https://www.nuget.org/packages/Pulumi.Esc.Sdk/) for [Pulumi ESC (Environments, Secrets, and Configuration)](/product/esc/) allows you to automate Pulumi ESC.
+Pulumi ESC provides a .NET SDK for managing environments and reading their configuration and secrets from your own code. It supports C#, F#, and Visual Basic.
+
+{{< esc-sdk-config-note >}}
 
 Here are some of the scenarios the SDK can automate:
 
@@ -23,6 +25,10 @@ Here are some of the scenarios the SDK can automate:
     * Supports both structured types and yaml text
 * List environment revisions and create new revision tags
 * Check environment definitions for errors
+
+## Runtime support
+
+The SDK runs on .NET 6 and later, and supports C#, F#, and Visual Basic.
 
 ## Install the SDK package
 
@@ -55,10 +61,6 @@ All of these examples expect a `PULUMI_ACCESS_TOKEN` and `PULUMI_ORG` environmen
 ### Manage environment example
 
 This example creates a new environment, opens that environment to access a secret, and then lists the environments.
-
-{{< chooser language "csharp" >}}
-
-{{% choosable language "csharp" %}}
 
 ```csharp
 using Pulumi.Esc.Sdk;
@@ -96,16 +98,9 @@ foreach (var env in orgEnvs.Environments ?? [])
 }
 ```
 
-{{% /choosable %}}
-{{< /chooser >}}
-
 ### Tag revision example
 
 This example lists revisions for an environment, tags a revision, and lists revision tags.
-
-{{< chooser language "csharp" >}}
-
-{{% choosable language "csharp" %}}
 
 ```csharp
 using Pulumi.Esc.Sdk;
@@ -139,9 +134,7 @@ foreach (var tag in tags.Tags ?? [])
 }
 ```
 
-{{% /choosable %}}
-{{< /chooser >}}
-
 ## Documentation
 
 * [API Reference Documentation](/docs/reference/pkg/dotnet/esc-sdk/)
+* [NuGet package](https://www.nuget.org/packages/Pulumi.Esc.Sdk/)

--- a/content/docs/esc/languages-sdks/dotnet.md
+++ b/content/docs/esc/languages-sdks/dotnet.md
@@ -28,7 +28,7 @@ Here are some of the scenarios the SDK can automate:
 
 ## Runtime support
 
-The SDK runs on .NET 6 and later, and supports C#, F#, and Visual Basic.
+The SDK supports any [supported version](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle) of .NET. We recommend using a recent release for the best experience. The SDK supports C#, F#, and Visual Basic.
 
 ## Install the SDK package
 

--- a/content/docs/esc/languages-sdks/go.md
+++ b/content/docs/esc/languages-sdks/go.md
@@ -13,7 +13,9 @@ aliases:
   - /docs/esc/development/languages-sdks/go/
 ---
 
-The [Go SDK](https://github.com/pulumi/esc-sdk) for [Pulumi ESC (Environments, Secrets, and Configuration)](/product/esc/) allows you to automate Pulumi ESC.
+Pulumi ESC provides a Go SDK for managing environments and reading their configuration and secrets from your own code.
+
+{{< esc-sdk-config-note >}}
 
 Here are some of the scenarios the SDK can automate:
 
@@ -23,6 +25,10 @@ Here are some of the scenarios the SDK can automate:
     * Supports both structured types and yaml text
 * List environment revisions and create new revision tags
 * Check environment definitions for errors
+
+## Runtime support
+
+The SDK runs on Go 1.20 and later.
 
 ## Install the SDK package
 
@@ -60,11 +66,7 @@ All of these examples expect a `PULUMI_ACCESS_TOKEN` and `PULUMI_ORG` environmen
 
 ### Manage environment example
 
-This example creates a new environment, opens that environment to access a secret, and the list the environments.
-
-{{< chooser language "go" >}}
-
-{{% choosable language "go" %}}
+This example creates a new environment, opens that environment to access a secret, and then lists the environments.
 
 ```go
 package main
@@ -130,16 +132,9 @@ func main() {
 
 ```
 
-{{% /choosable %}}
-{{< /chooser >}}
-
 ### Tag revision example
 
 This example lists revisions for an environment, tags a revision, and lists revision tags.
-
-{{< chooser language "go" >}}
-
-{{% choosable language "go" %}}
 
 ```go
 package main
@@ -187,9 +182,7 @@ func main() {
 
 ```
 
-{{% /choosable %}}
-{{< /chooser >}}
-
 ## Documentation
 
 * [API Reference Documentation](https://pkg.go.dev/github.com/pulumi/esc-sdk/sdk/go)
+* [Source repository](https://github.com/pulumi/esc-sdk)

--- a/content/docs/esc/languages-sdks/go.md
+++ b/content/docs/esc/languages-sdks/go.md
@@ -28,7 +28,7 @@ Here are some of the scenarios the SDK can automate:
 
 ## Runtime support
 
-The SDK runs on Go 1.20 and later.
+The SDK supports any [supported version](https://go.dev/doc/devel/release#policy) of Go. We recommend using a recent release for the best experience.
 
 ## Install the SDK package
 

--- a/content/docs/esc/languages-sdks/javascript.md
+++ b/content/docs/esc/languages-sdks/javascript.md
@@ -1,8 +1,8 @@
 ---
-title_tag: TypeScript/JavaScript SDK | Pulumi ESC
-title: TypeScript (Node.js)
-h1: "Pulumi ESC: TypeScript/JavaScript SDK"
-meta_desc: This page provides an overview on how to use Pulumi ESC TypeScript/JavaScript SDK.
+title_tag: TypeScript | Pulumi ESC SDK
+title: TypeScript
+h1: "Pulumi ESC: TypeScript SDK"
+meta_desc: This page provides an overview on how to use the Pulumi ESC TypeScript SDK.
 menu:
   esc:
     parent: esc-languages-sdks
@@ -13,7 +13,9 @@ aliases:
   - /docs/esc/development/languages-sdks/javascript/
 ---
 
-The [JavaScript/TypeScript SDK](https://www.npmjs.com/package/@pulumi/esc-sdk) for [Pulumi ESC (Environments, Secrets, and Configuration)](/product/esc/) allows you to automate Pulumi ESC.
+Pulumi ESC provides a TypeScript SDK for managing environments and reading their configuration and secrets from your own code. The SDK is written for TypeScript and can also be used from JavaScript on Node.js.
+
+{{< esc-sdk-config-note >}}
 
 Here are some of the scenarios the SDK can automate:
 
@@ -24,6 +26,21 @@ Here are some of the scenarios the SDK can automate:
 * List environment revisions and create new revision tags
 * Check environment definitions for errors
 
+## Runtime support
+
+The SDK runs on Node.js 18 and later.
+
+## Languages
+
+Pulumi ESC fully supports both TypeScript and JavaScript. You can use either language to work with the SDK:
+
+* **TypeScript**: Get additional type safety and IDE support with TypeScript (recommended)
+* **JavaScript**: Write programs using standard JavaScript syntax
+
+{{< notes type="info" >}}
+The examples on this page are shown in both TypeScript and JavaScript. The SDK also works with any other language that compiles to JavaScript and runs on Node.js. For the most consistent experience, we recommend using TypeScript.
+{{< /notes >}}
+
 ## Install the SDK package
 
 Run `npm install @pulumi/esc-sdk` or `yarn add @pulumi/esc-sdk` to install the SDK package.
@@ -32,15 +49,36 @@ Run `npm install @pulumi/esc-sdk` or `yarn add @pulumi/esc-sdk` to install the S
 
 The easiest way to initialize an ESC SDK client is to run:
 
+{{< chooser language "typescript,javascript" >}}
+
+{{% choosable language "typescript" %}}
+
 ```typescript
 import * as esc from "@pulumi/esc-sdk";
 
 const client = esc.DefaultClient();
 ```
 
+{{% /choosable %}}
+
+{{% choosable language "javascript" %}}
+
+```javascript
+const esc = require("@pulumi/esc-sdk");
+
+const client = esc.DefaultClient();
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+
 This method will first look for the `PULUMI_ACCESS_TOKEN` environment variable, and if it's not present, it will fall back to CLI credentials that are present on your machine if you have logged in using Pulumi CLI or ESC CLI.
 
 If the default behavior does not work for you, you can always manually initialize the client configuration and pass it into the client constructor:
+
+{{< chooser language "typescript,javascript" >}}
+
+{{% choosable language "typescript" %}}
 
 ```typescript
 import * as esc from "@pulumi/esc-sdk";
@@ -51,15 +89,31 @@ const configuration = new esc.Configuration({
 const client = new esc.EscApi(configuration);
 ```
 
+{{% /choosable %}}
+
+{{% choosable language "javascript" %}}
+
+```javascript
+const esc = require("@pulumi/esc-sdk");
+
+const configuration = new esc.Configuration({
+    accessToken: myAccessToken
+})
+const client = new esc.EscApi(configuration);
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+
 ## Examples
 
 All of these examples expect a `PULUMI_ACCESS_TOKEN` and `PULUMI_ORG` environment variable to be set.
 
 ### Manage environment example
 
-This example creates a new environment, opens that environment to access a secret, and the list the environments.
+This example creates a new environment, opens that environment to access a secret, and then lists the environments.
 
-{{< chooser language "typescript" >}}
+{{< chooser language "typescript,javascript" >}}
 
 {{% choosable language "typescript" %}}
 
@@ -117,18 +171,74 @@ async function main() {
 ```
 
 {{% /choosable %}}
+
+{{% choosable language "javascript" %}}
+
+```javascript
+const esc = require("@pulumi/esc-sdk");
+
+async function main() {
+    const orgName = process.env.PULUMI_ORG;
+    const client = esc.DefaultClient();
+
+    const projName = "examples";
+    const envName = "sdk-javascript-example";
+
+    // Create a new environment
+    await client.createEnvironment(orgName, projName, envName);
+
+    const envDef = {
+        values: {
+            my_secret: {
+                "fn::secret": "shh! don't tell anyone",
+            },
+        },
+    };
+
+    // Update the environment with the new definition
+    await client.updateEnvironment(orgName, projName, envName, envDef);
+
+    // Open and read the environment
+    const openEnv = await client.openAndReadEnvironment(orgName, projName, envName);
+
+    if (!openEnv) {
+        console.error("Failed to open and read the environment");
+        return;
+    }
+
+    // Access the value of the secret
+    const secretValue = openEnv.values?.my_secret;
+    console.log(`Secret value: ${secretValue}\n`);
+
+    // List all the environments in the organization
+    const orgEnvs = await client.listEnvironments(orgName);
+    if (!orgEnvs || !orgEnvs.environments) {
+        console.log("No environments found");
+        return;
+    }
+
+    for (const env of orgEnvs.environments) {
+        console.log(`Environment: ${env.project}/${env.name}`);
+    }
+}
+
+(async () => {
+    await main();
+})();
+```
+
+{{% /choosable %}}
 {{< /chooser >}}
 
 ### Tag revision example
 
 This example lists revisions for an environment, tags a revision, and lists revision tags.
 
-{{< chooser language "typescript" >}}
+{{< chooser language "typescript,javascript" >}}
 
 {{% choosable language "typescript" %}}
 
 ```typescript
-
 import * as esc from "@pulumi/esc-sdk";
 
 async function main() {
@@ -165,8 +275,49 @@ async function main() {
 (async ()=>{
     await main();
 })();
+```
 
+{{% /choosable %}}
 
+{{% choosable language "javascript" %}}
+
+```javascript
+const esc = require("@pulumi/esc-sdk");
+
+async function main() {
+    const orgName = process.env.PULUMI_ORG;
+    const client = esc.DefaultClient();
+
+    const projName = "examples";
+    const envName = "sdk-javascript-example";
+
+    // List environment revisions
+    const revisions = await client.listEnvironmentRevisions(orgName, projName, envName);
+
+    if (!revisions || revisions.length < 2) {
+        throw new Error(`Expected at least 2 revisions for environment ${projName}/${envName}`);
+    }
+
+    // Get the second latest revision
+    const revision = revisions[1];
+    await client.createEnvironmentRevisionTag(orgName, projName, envName, "stable", revision.number);
+
+    console.log(`Tagged revision ${revision.number} as 'stable'`);
+
+    // List tags
+    const tags = await client.listEnvironmentRevisionTags(orgName, projName, envName);
+    if (!tags || !tags.tags) {
+        throw new Error(`Expected tags for environment ${projName}/${envName}`);
+    }
+
+    for (const tag of tags.tags) {
+        console.log(`Tag ${tag.name} at revision ${tag.revision}`);
+    }
+}
+
+(async () => {
+    await main();
+})();
 ```
 
 {{% /choosable %}}
@@ -175,3 +326,4 @@ async function main() {
 ## Documentation
 
 * [API Reference Documentation](/docs/reference/pkg/nodejs/pulumi/esc-sdk/)
+* [npm package](https://www.npmjs.com/package/@pulumi/esc-sdk)

--- a/content/docs/esc/languages-sdks/javascript.md
+++ b/content/docs/esc/languages-sdks/javascript.md
@@ -28,7 +28,7 @@ Here are some of the scenarios the SDK can automate:
 
 ## Runtime support
 
-The SDK runs on Node.js 18 and later.
+The SDK supports Node.js [Current, Active, and Maintenance LTS versions](https://nodejs.org/en/about/previous-releases). We recommend using the latest LTS version for the best experience.
 
 ## Languages
 

--- a/content/docs/esc/languages-sdks/python.md
+++ b/content/docs/esc/languages-sdks/python.md
@@ -28,7 +28,7 @@ Here are some of the scenarios the SDK can automate:
 
 ## Runtime support
 
-The SDK runs on Python 3.9 and later.
+The SDK supports any [currently supported version](https://devguide.python.org/versions/#versions) of Python. We recommend using a recent release for the best experience.
 
 ## Install the SDK package
 

--- a/content/docs/esc/languages-sdks/python.md
+++ b/content/docs/esc/languages-sdks/python.md
@@ -13,7 +13,9 @@ aliases:
   - /docs/esc/development/languages-sdks/python/
 ---
 
-The [Python SDK](https://pypi.org/project/pulumi-esc-sdk/) for [Pulumi ESC (Environments, Secrets, and Configuration)](/product/esc/) allows you to automate Pulumi ESC.
+Pulumi ESC provides a Python SDK for managing environments and reading their configuration and secrets from your own code.
+
+{{< esc-sdk-config-note >}}
 
 Here are some of the scenarios the SDK can automate:
 
@@ -23,6 +25,10 @@ Here are some of the scenarios the SDK can automate:
     * Supports both structured types and yaml text
 * List environment revisions and create new revision tags
 * Check environment definitions for errors
+
+## Runtime support
+
+The SDK runs on Python 3.9 and later.
 
 ## Install the SDK package
 
@@ -57,11 +63,7 @@ All of these examples expect a `PULUMI_ACCESS_TOKEN` and `PULUMI_ORG` environmen
 
 ### Manage environment example
 
-This example creates a new environment, opens that environment to access a secret, and the list the environments.
-
-{{< chooser language "python" >}}
-
-{{% choosable language "python" %}}
+This example creates a new environment, opens that environment to access a secret, and then lists the environments.
 
 ```python
 import pulumi_esc_sdk as esc
@@ -108,16 +110,9 @@ for env in environments.environments:
 
 ```
 
-{{% /choosable %}}
-{{< /chooser >}}
-
 ### Tag revision example
 
 This example lists revisions for an environment, tags a revision, and lists revision tags.
-
-{{< chooser language "python" >}}
-
-{{% choosable language "python" %}}
 
 ```python
 import pulumi_esc_sdk as esc
@@ -150,9 +145,7 @@ for tag in tags.tags:
 
 ```
 
-{{% /choosable %}}
-{{< /chooser >}}
-
 ## Documentation
 
 * [API Reference Documentation](/docs/reference/pkg/python/pulumi_esc_sdk/)
+* [PyPI package](https://pypi.org/project/pulumi-esc-sdk/)

--- a/layouts/shortcodes/esc-sdk-config-note.html
+++ b/layouts/shortcodes/esc-sdk-config-note.html
@@ -1,0 +1,13 @@
+<div class="note note-info">
+    <div class="icon-and-line">
+        {{ partial "icon.html" (dict "name" "info" "weight" "fill") }}
+        <div class="line"></div>
+    </div>
+    <div class="content">
+        Use the ESC SDK to retrieve environment values from your application
+        workloads at runtime and to manage environments programmatically. If you
+        want to consume an environment from within a Pulumi IaC program, use
+        <a href="{{ relref . "/docs/esc/guides/integrate-with-pulumi-iac/" }}">config</a>
+        instead of the SDK.
+    </div>
+</div>

--- a/layouts/shortcodes/esc-sdk-config-note.markdown.md
+++ b/layouts/shortcodes/esc-sdk-config-note.markdown.md
@@ -1,0 +1,1 @@
+> **Note:** Use the ESC SDK to retrieve environment values from your application workloads at runtime and to manage environments programmatically. If you want to consume an environment from within a Pulumi IaC program, use [config](/docs/esc/guides/integrate-with-pulumi-iac/) instead of the SDK.


### PR DESCRIPTION
Fixes #15464.

## What this does

A customer got confused and used the **ESC SDK** inside their **Pulumi IaC program**. The ESC SDK is meant for application workloads (usually at runtime) and for programmatically managing environments — *not* for use inside an IaC program, where environments should be consumed via **config** (the `environment:` block in `Pulumi.<stack>.yaml`). This PR refreshes the ESC SDK content to make that distinction clear and to clean up the SDK pages.

### Changes

- **New `esc-sdk-config-note` shortcode** (`layouts/shortcodes/esc-sdk-config-note.{html,markdown.md}`) — the SDK-vs-config callout, reused on the concepts page and all four SDK pages instead of copy-pasted prose.
- **New ESC SDKs concepts page** (`content/docs/esc/concepts/sdks.md`) — explains the SDK is for retrieving environment values from workloads at runtime and for managing environments programmatically, and that IaC programs should consume environments via config. Defers to the per-language pages for installation/examples.
- **Home page** (`content/docs/esc/_index.md`) — renamed the "Languages" card section to "Languages & SDKs", clarified the SDK purpose, **added .NET**, and **dropped the YAML card** (it pointed to environment syntax, not an SDK).
- **Languages & SDKs index** (`languages-sdks/_index.md`) — trimmed to a short section intro that defers to the new concepts page.
- **JavaScript page** — title parity with the IaC SDK page (`TypeScript`), added a runtime-support note (Node.js 18+) and a TS/JS "Languages" note, and now shows **both TypeScript and JavaScript** examples (focused on TypeScript), mirroring the IaC JS page.
- **Python / Go / .NET pages** — removed the unneeded single-language choosers and added runtime-support notes (Python 3.9+, Go 1.20+, .NET 6+). Per the issue, package-manager support is out of scope; runtime support is included.

`make build` and `make lint` both pass.

## Open questions for full parity with the IaC SDK pages

These would close the remaining parity gap but need product/SDK input — not addressed here:

- Are the stated runtime minimums current/authoritative? (Node.js 18+, Python 3.9+, Go 1.20+, .NET 6+)
- Is there **testing** guidance for the ESC SDK (the IaC pages have unit/integration testing sections)?
- Are there **dev / pre-release** SDK builds to document (IaC documents `@dev`)?
- Is **Bun** supported by the ESC JavaScript SDK (IaC documents the Bun runtime)?
- Is the API reference complete and linked for all four languages?
- Should single-language choosers elsewhere under `content/docs/esc/` also be cleaned up? (Deferred — out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)