### PR TITLE
Add CLI and IaC usage examples to ESC cloud OIDC login providers

### DIFF
--- a/content/docs/esc/providers/login/aws-login.md
+++ b/content/docs/esc/providers/login/aws-login.md
@@ -20,7 +20,7 @@ The `aws-login` provider enables you to log in to your AWS account using OpenID 
 
 ## Example
 
-The `aws-login` provider's outputs can be consumed by the [Pulumi AWS provider](https://www.pulumi.com/registry/packages/aws/), the `aws` CLI, and the AWS SDKs. Because all three read the same standard AWS environment variables, a single `environmentVariables` block covers all of them:
+The `aws-login` provider's outputs can be consumed by the [Pulumi AWS provider](https://www.pulumi.com/registry/packages/aws/), the `aws` CLI, and the AWS SDKs. Because all three read the same standard AWS environment variables, a single `environmentVariables` block covers all three:
 
 ```yaml
 values:

--- a/content/docs/esc/providers/login/aws-login.md
+++ b/content/docs/esc/providers/login/aws-login.md
@@ -20,6 +20,8 @@ The `aws-login` provider enables you to log in to your AWS account using OpenID 
 
 ## Example
 
+The `aws-login` provider's outputs can be consumed by the [Pulumi AWS provider](https://www.pulumi.com/registry/packages/aws/), the `aws` CLI, and the AWS SDKs. Because all three read the same standard AWS environment variables, a single `environmentVariables` block covers all of them:
+
 ```yaml
 values:
   aws:
@@ -30,9 +32,12 @@ values:
           roleArn: arn:aws:iam::012345678912:role/role-abcd123
           sessionName: pulumi-esc
   environmentVariables:
+    # Credentials consumed by the aws CLI, the AWS SDKs, and the Pulumi AWS provider
     AWS_ACCESS_KEY_ID: ${aws.login.accessKeyId}
     AWS_SECRET_ACCESS_KEY: ${aws.login.secretAccessKey}
     AWS_SESSION_TOKEN: ${aws.login.sessionToken}
+    # Sets the region for the aws CLI, the AWS SDKs, and the Pulumi AWS provider
+    AWS_REGION: us-west-2
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/providers/login/azure-login.md
+++ b/content/docs/esc/providers/login/azure-login.md
@@ -20,6 +20,8 @@ The `azure-login` provider enables you to log in to Azure using OpenID Connect o
 
 ## Example
 
+The `azure-login` provider's outputs can be consumed by the Pulumi Azure providers ([azure-native](https://www.pulumi.com/registry/packages/azure-native/), [azure](https://www.pulumi.com/registry/packages/azure/), and [azuread](https://www.pulumi.com/registry/packages/azuread/)) and the Azure SDKs through the standard `ARM_*` environment variables:
+
 ```yaml
 values:
   azure:
@@ -29,7 +31,16 @@ values:
         tenantId: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
         subscriptionId: /subscriptions/00000000-0000-0000-0000-000000000000
         oidc: true
+  environmentVariables:
+    # Consumed by the Pulumi Azure providers (azure-native, azure, azuread) and the Azure SDKs
+    ARM_USE_OIDC: "true"
+    ARM_CLIENT_ID: ${azure.login.clientId}
+    ARM_TENANT_ID: ${azure.login.tenantId}
+    ARM_SUBSCRIPTION_ID: ${azure.login.subscriptionId}
+    ARM_OIDC_TOKEN: ${azure.login.oidc.token}
 ```
+
+The [azuredevops](https://www.pulumi.com/registry/packages/azuredevops/) provider accepts the same `ARM_CLIENT_ID`, `ARM_TENANT_ID`, `ARM_OIDC_TOKEN`, and `ARM_USE_OIDC` credentials. It does not use `ARM_SUBSCRIPTION_ID`; instead, set your organization URL with the `AZDO_ORG_SERVICE_URL` environment variable.
 
 ## Configuring OIDC
 

--- a/content/docs/esc/providers/login/gcp-login.md
+++ b/content/docs/esc/providers/login/gcp-login.md
@@ -18,9 +18,11 @@ aliases:
 
 The `gcp-login` provider enables you to log in to Google Cloud using OpenID Connect or by providing static credentials. The provider will return a set of credentials that can be used to access Google Cloud resources or fetch secrets using the `gcp-secrets` provider.
 
-## Example
+## Examples
 
-### Basic configuration
+### Using outputs with Pulumi IaC
+
+The [Pulumi Google Cloud provider](https://www.pulumi.com/registry/packages/gcp/) reads the project and OAuth access token from the environment:
 
 ```yaml
 values:
@@ -32,11 +34,15 @@ values:
           workloadPoolId: pulumi-esc
           providerId: pulumi-esc
           serviceAccount: pulumi-esc@foo-bar-123456.iam.gserviceaccount.com
+  environmentVariables:
+    # The Pulumi Google Cloud provider reads the project (as a numeric ID) and the access token
+    GOOGLE_CLOUD_PROJECT: ${gcp.login.project}
+    GOOGLE_OAUTH_ACCESS_TOKEN: ${gcp.login.accessToken}
 ```
 
-### Using outputs with Pulumi IaC and gcloud CLI
+### Using outputs with the gcloud CLI
 
-The `gcp-login` provider outputs credentials for use with both Pulumi's Google Cloud provider and the `gcloud` CLI. This example shows how to configure both:
+The `gcloud` CLI reads the project by name and the access token from its own `CLOUDSDK_*` environment variables, which differ from the ones the Pulumi provider uses:
 
 ```yaml
 values:
@@ -48,24 +54,12 @@ values:
           workloadPoolId: pulumi-esc
           providerId: pulumi-esc
           serviceAccount: pulumi-esc@foo-bar-123456.iam.gserviceaccount.com
-  pulumiConfig:
-    gcp:project: ${gcp.login.project}
   environmentVariables:
-    # The Google Cloud SDK (used by Pulumi's GCP provider) requires the project to be set by number
-    GOOGLE_CLOUD_PROJECT: ${gcp.login.project}
-    # The gcloud CLI requires the project to be set by name, and via a different env var
+    # The gcloud CLI requires the project by name (not the numeric ID)
     # See: https://cloud.google.com/sdk/docs/properties#setting_properties_using_environment_variables
     CLOUDSDK_CORE_PROJECT: my-project-name
-    # Provide OAuth access tokens to both the Google Cloud SDK and gcloud CLI
-    GOOGLE_OAUTH_ACCESS_TOKEN: ${gcp.login.accessToken}
     CLOUDSDK_AUTH_ACCESS_TOKEN: ${gcp.login.accessToken}
 ```
-
-Note that both `GOOGLE_CLOUD_PROJECT` (numeric project ID) and `CLOUDSDK_CORE_PROJECT` (project name) are set because the Google Cloud SDK and gcloud CLI have different requirements for project identification.
-
-This configuration enables:
-- **Pulumi IaC**: The `pulumiConfig` section sets the GCP project for Pulumi's Google Cloud provider.
-- **gcloud CLI**: The `environmentVariables` section configures authentication for the `gcloud` command-line tool.
 
 ## Configuring OIDC
 

--- a/content/docs/esc/providers/login/gcp-login.md
+++ b/content/docs/esc/providers/login/gcp-login.md
@@ -42,7 +42,7 @@ values:
 
 ### Using outputs with the gcloud CLI
 
-The `gcloud` CLI reads the project by name and the access token from its own `CLOUDSDK_*` environment variables, which differ from the ones the Pulumi provider uses:
+The `gcloud` CLI reads the project ID (a string identifier, not the numeric project number used by the Pulumi provider) and the access token from its own `CLOUDSDK_*` environment variables, which differ from the ones the Pulumi provider uses:
 
 ```yaml
 values:
@@ -55,9 +55,9 @@ values:
           providerId: pulumi-esc
           serviceAccount: pulumi-esc@foo-bar-123456.iam.gserviceaccount.com
   environmentVariables:
-    # The gcloud CLI requires the project by name (not the numeric ID)
+    # CLOUDSDK_CORE_PROJECT takes the project ID string (e.g. "my-project-12345"), not the numeric project number used by GOOGLE_CLOUD_PROJECT above
     # See: https://cloud.google.com/sdk/docs/properties#setting_properties_using_environment_variables
-    CLOUDSDK_CORE_PROJECT: my-project-name
+    CLOUDSDK_CORE_PROJECT: my-project-12345
     CLOUDSDK_AUTH_ACCESS_TOKEN: ${gcp.login.accessToken}
 ```
 

--- a/content/docs/esc/providers/login/snowflake-login.md
+++ b/content/docs/esc/providers/login/snowflake-login.md
@@ -59,7 +59,7 @@ Replace `<role>` with the role that has the necessary permissions for your use c
 
 ## Using with Pulumi ESC
 
-Once you've configured OIDC in Snowflake, you can use the `snowflake-login` provider in your Pulumi ESC environment:
+Once you've configured OIDC in Snowflake, you can use the `snowflake-login` provider in your Pulumi ESC environment. The outputs are consumed by the [Pulumi Snowflake provider](https://www.pulumi.com/registry/packages/snowflake/), the Snowflake SDKs, and the `snowsql` CLI:
 
 ```yaml
 values:
@@ -70,6 +70,12 @@ values:
           account: myorganization-account
           user: ESC_LOGIN_USER
           role: ESC_ROLE  # Optional
+  environmentVariables:
+    # Consumed by the Pulumi Snowflake provider, the Snowflake SDKs, and the snowsql CLI
+    SNOWFLAKE_ACCOUNT: ${snowflake.login.account}
+    SNOWFLAKE_USER: ${snowflake.login.user}
+    SNOWFLAKE_AUTHENTICATOR: OAUTH
+    SNOWFLAKE_TOKEN: ${snowflake.login.token}
 ```
 
 ### Validation


### PR DESCRIPTION
Ensures the four ESC cloud OIDC login provider pages each show how to use the login outputs with both the cloud's CLI/SDK and the recommended Pulumi IaC provider, with per-tool YAML comments and registry links.

## Changes
- **aws-login**: credentials + `AWS_REGION` via `environmentVariables` (read by the aws CLI, SDKs, and Pulumi AWS provider)
- **azure-login**: `ARM_*` env vars for the Pulumi Azure providers/SDKs; note on the azuredevops provider
- **gcp-login**: split into separate "Pulumi IaC" and "gcloud CLI" examples; clarified which values each consumes
- **snowflake-login**: `SNOWFLAKE_*` env vars for the Pulumi Snowflake provider, SDKs, and snowsql CLI
- Added Pulumi registry links to each recommended provider

Fixes #19487