### PR TITLE
Flag needs-triage on new issues in the weekly digest

### DIFF
--- a/scripts/weekly-digest/digest.py
+++ b/scripts/weekly-digest/digest.py
@@ -119,6 +119,8 @@ def shape_issues(raw):
                 "title": issue["title"],
                 "author": login,
                 "age_days": days_since(issue.get("createdAt")),
+                "needs_triage": "needs-triage"
+                in [lbl["name"] for lbl in issue.get("labels", [])],
             }
         )
     aged = [i for i in enriched if i["age_days"] is not None]
@@ -130,7 +132,7 @@ def shape_issues(raw):
     return {
         "all_open_count": len(enriched),
         "new_this_week": [
-            {k: i[k] for k in ("number", "title", "author", "age_days")}
+            {k: i[k] for k in ("number", "title", "author", "age_days", "needs_triage")}
             for i in new_this_week
         ],
         "oldest_open": [

--- a/scripts/weekly-digest/synthesis-prompt.md
+++ b/scripts/weekly-digest/synthesis-prompt.md
@@ -31,6 +31,6 @@ Then:
 
 A scan of the open-issue backlog, not a recital. Do not list the whole backlog.
 
-- New this week -- the issues in `issues.new_this_week` (opened in the trailing `window_days` days). One line each.
+- New this week -- the issues in `issues.new_this_week` (opened in the trailing `window_days` days). One line each. Mark any issue with `needs_triage == true` as still needing triage (for example a trailing `needs-triage` tag on its line), and lead the bucket with a count of how many of the new issues are untriaged so the team can see the triage load at a glance.
 - Oldest open -- the issues in `issues.oldest_open` (the 2-3 staleest). One line each, framed to force a keep-or-kill call.
 - Net delta -- one line comparing `issues.opened_last_7d` against `issues.closed_last_7d` (for example "12 opened vs 19 closed -- backlog shrank by 7"). Mention `issues.all_open_count` as the running total.


### PR DESCRIPTION
Follow-up to #19489. The weekly digest's backlog "new this week" bucket didn't distinguish triaged from untriaged issues, so the team couldn't see the incoming triage load at a glance.

## Changes
- **`scripts/weekly-digest/digest.py`** — each `new_this_week` issue now carries a `needs_triage` boolean, true when the issue has the `needs-triage` label. The label data was already fetched by the `gh issue list` query but discarded in `shape_issues`. (`oldest_open`'s shape is unchanged.)
- **`scripts/weekly-digest/synthesis-prompt.md`** — the *New this week* bucket now marks untriaged issues (e.g. a trailing `needs-triage` tag) and leads with a count of how many of the week's new issues are still untriaged.

## Validation
- `shape_issues` unit-tested: `needs-triage`-labeled issues come back `needs_triage: true`, others `false`; `oldest_open` records don't gain the field.
- `py_compile` clean.

Why a separate PR: this change was pushed to the branch just after #19489 squash-merged, so it never made it into master.

https://claude.ai/code/session_01WvtrTnX65jQwBMPfxPFv4H

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvtrTnX65jQwBMPfxPFv4H)_