### PR TITLE
Stop the weekly digest Slack post from hanging on IPv6

### DIFF
--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -136,6 +136,7 @@ jobs:
       # checker's posting path: SLACK_ACCESS_TOKEN from ESC, mrkdwn on, no unfurl.
       - name: Post digest to Slack
         if: ${{ !inputs.dry_run }}
+        timeout-minutes: 3
         env:
           SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
           SLACK_CHANNEL: docs-ops

--- a/scripts/weekly-digest/post-to-slack.py
+++ b/scripts/weekly-digest/post-to-slack.py
@@ -22,15 +22,36 @@ Env: SLACK_ACCESS_TOKEN (required unless --dry-run), SLACK_CHANNEL (default
 
 import json
 import os
+import socket
 import sys
 import time
-import urllib.error
 import urllib.request
 
 # Conservative ceiling. Slack's hard limit is ~40k chars, but long messages
 # render unreliably; keeping chunks well under ~4k is the safe, readable choice.
 MAX_CHARS = 3500
 POST_URL = "https://slack.com/api/chat.postMessage"
+# Per-request socket timeout. Python connects to addresses sequentially with no
+# Happy Eyeballs, so this is also the per-address budget -- keep it short.
+REQUEST_TIMEOUT = 10
+
+
+def _force_ipv4():
+    """Make getaddrinfo return only IPv4 records.
+
+    slack.com resolves to both IPv4 and IPv6 addresses. On runners without IPv6
+    egress, Python's sequential socket.create_connection burns the full socket
+    timeout on each unreachable IPv6 address before falling through, stacking up
+    to multi-minute "timeouts" on a 10s budget (this hung a real run for ~7.5min
+    per attempt). @slack/web-api dodges it via Happy Eyeballs; we don't, so we
+    drop AF_INET6 from resolution entirely -- this process only talks to Slack.
+    """
+    real_getaddrinfo = socket.getaddrinfo
+
+    def ipv4_only(host, port, family=0, type=0, proto=0, flags=0):
+        return real_getaddrinfo(host, port, socket.AF_INET, type, proto, flags)
+
+    socket.getaddrinfo = ipv4_only
 
 
 def _split_long_line(line, max_chars):
@@ -63,7 +84,7 @@ def chunk_text(text, max_chars=MAX_CHARS):
     return [c for c in chunks if c.strip()]
 
 
-def post_chunk(token, channel, text, retries=4):
+def post_chunk(token, channel, text, retries=3):
     body = json.dumps(
         {"channel": channel, "text": text, "mrkdwn": True, "unfurl_links": False, "as_user": True}
     ).encode("utf-8")
@@ -78,13 +99,15 @@ def post_chunk(token, channel, text, retries=4):
     delay = 2
     for attempt in range(1, retries + 1):
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
                 data = json.loads(resp.read())
             if data.get("ok"):
                 return data
             # ok:false is a hard error (bad token, channel, etc.) -- don't retry.
             raise RuntimeError(f"Slack API error: {data.get('error')}")
-        except urllib.error.URLError as exc:
+        # OSError covers URLError, socket timeouts, and connection resets; a
+        # RuntimeError (ok:false) is not caught and fails fast.
+        except OSError as exc:
             if attempt == retries:
                 raise
             sys.stderr.write(f"post attempt {attempt} failed ({exc}); retrying in {delay}s\n")
@@ -113,6 +136,7 @@ def main():
     token = os.environ.get("SLACK_ACCESS_TOKEN")
     if not token:
         sys.exit("SLACK_ACCESS_TOKEN is not set")
+    _force_ipv4()
     channel = os.environ.get("SLACK_CHANNEL", "#docs-ops")
     if not channel.startswith(("#", "C", "G")):
         channel = f"#{channel}"


### PR DESCRIPTION
## What happened
A manual dispatch of the weekly digest (run [#26856266206](https://github.com/pulumi/docs/actions/runs/26856266206)) wedged on the **Post digest to Slack** step and had to be cancelled. The job logs show the root cause:

```
00:31:10  Run uv run scripts/weekly-digest/post-to-slack.py ...
00:38:40  post attempt 1 failed (<urlopen error timed out>); retrying in 2s
00:39:30  ##[error]The operation was canceled.
```

A **single** `chat.postMessage` attempt took ~7.5 minutes to time out despite a 30s timeout. `slack.com` resolves to both IPv4 and IPv6 addresses, and Python's `socket.create_connection` tries them **sequentially with no Happy Eyeballs** — on a runner without IPv6 egress, each unreachable IPv6 address burns the full socket timeout before falling through, stacking far past the per-request budget. The link checker doesn't hit this because `@slack/web-api` races addresses in parallel.

The exception handling itself worked (it caught the timeout and was retrying) — the problems were the per-attempt latency and the absence of any hard ceiling.

## Fix
- **`post-to-slack.py`** — drop `AF_INET6` from resolution so we only dial IPv4, cut the per-request timeout to 10s, and catch `OSError` (covers socket timeouts and connection resets, not just `URLError`) so transient failures retry cleanly. An `ok:false` from Slack still fails fast.
- **`weekly-digest.yml`** — add `timeout-minutes: 3` to the post step as a hard ceiling, so a stuck post can never hold the runner for the default 6 hours again.

## Validation
- After `_force_ipv4()`, `getaddrinfo("slack.com", 443)` returns only `AF_INET`; chunker and `--dry-run` unaffected; `py_compile` + YAML parse clean.
- The live `chat.postMessage` path still only runs in CI. Recommend a real `workflow_dispatch` on this branch to confirm the post now completes in seconds.

Follow-up consideration (not in this PR): for full parity with the link checker we could move posting to Node + `@slack/web-api`, which gets Happy Eyeballs and retries for free. The IPv4 pin above is the smaller, targeted fix for the observed failure.

https://claude.ai/code/session_01WvtrTnX65jQwBMPfxPFv4H

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvtrTnX65jQwBMPfxPFv4H)_