### PR TITLE
docs(project-file): add missing fields from upstream JSON schema

### DIFF
--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -32,6 +32,9 @@ For Pulumi programs specifically written in Pulumi YAML, the project file not on
 | `name` | required | Name of the project containing alphanumeric characters, hyphens, underscores, and periods. | None |
 | `runtime` | required | Installed language runtime of the project: `nodejs`, `python`, `go`, `dotnet`, `java`, `yaml`, or `bun`. | [runtime options](#runtime-options)
 | `description` | optional | A brief description of the project. | None |
+| `author` | optional | The author of the project. | None |
+| `website` | optional | A URL for the project's website or repository. | None |
+| `license` | optional | The license governing this project's usage (e.g. `Apache-2.0`, `MIT`). | None |
 | `config` | optional | Project level config (Added in v3.44). | [config options](#config-options) |
 | `packages` | optional | Additional packages to be used in the program (Added in v3.157.0.) | [packages](#packages-options) |
 | `main` | optional | Path to the Pulumi program, relative to the location of `Pulumi.yaml`. The default is the current working directory. | None |
@@ -167,6 +170,7 @@ Schemas are only valid for project property keys. For setting the value of a pro
 | `displayName` | optional | A user-friendly name for the template. This should follow `Title Case` format and be succinct. This field is only supported by Pulumi CLI >= 3.95. |
 | `description` | optional | Description of the template. |
 | `quickstart` | optional | Text to display after the template is instantiated — for example, after `pulumi new` generates a new project. Use this field to surface follow-up instructions specific to the template, such as required environment variables, dependency installation steps, or links to getting-started guides. |
+| `important` | optional | Boolean indicating whether the template is important and should be listed by default. |
 | `config` | required | Config to request when using this template with `pulumi new`. |
 | `metadata` | optional | A map of user-defined tags to attach to the template. The Pulumi Cloud [New Project Wizard](/docs/idp/concepts/new-project-wizard/) recognizes a `cloud` key for filtering templates by target cloud — see [Organization templates](/docs/idp/concepts/organization-templates/#new-project-wizard-cloud-filter) for accepted values. This field is only supported by Pulumi CLI >= 3.95. |
 
@@ -230,6 +234,9 @@ runtime:
   options:
     compiler: cue export
 description: An example project with all attributes
+author: Your Name
+website: https://example.com
+license: Apache-2.0
 main: example-project/
 stackConfigDir: config/
 backend:
@@ -240,6 +247,7 @@ template:
   displayName: Example Template
   description: An example template
   quickstart: Run npm install to install dependencies, then pulumi up to deploy.
+  important: false
   config:
     aws:region:
       description: The AWS region to deploy into


### PR DESCRIPTION
Add `author`, `website`, and `license` top-level attributes, plus `template.important`, which are defined in the upstream project.json schema but were absent from the hand-written reference page.

Closes #11659

Generated with [Claude Code](https://claude.ai/code)