### PR TITLE
fix: derive page "Updated" dates from git history, not build time

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,6 +33,12 @@ jobs:
         uses: pulumi/esc-action@v1
 
       - uses: actions/checkout@v6
+        with:
+          # Full history (not the default shallow fetch-depth: 1) so Hugo's
+          # enableGitInfo can read each file's last commit date. Without this,
+          # .Lastmod falls back to build time and every page (and sitemap entry)
+          # reports "Updated <today>".
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -39,6 +39,10 @@ jobs:
           # .Lastmod falls back to build time and every page (and sitemap entry)
           # reports "Updated <today>".
           fetch-depth: 0
+          # Blobless clone: fetch the full commit graph and trees enableGitInfo
+          # needs, but skip downloading historical file blobs (the asset-heavy
+          # history of a docs repo). Current-tree blobs are fetched on demand.
+          filter: blob:none
 
       - uses: actions/setup-node@v6
         with:

--- a/layouts/partials/schema/collectors/article-entity.html
+++ b/layouts/partials/schema/collectors/article-entity.html
@@ -20,31 +20,34 @@
   "inLanguage" "en-US"
 }}
 
-{{/* Add dates with proper fallback handling */}}
-{{ $publishDate := .PublishDate }}
-{{ $modifiedDate := .Lastmod }}
-
-{{/* Fix invalid dates */}}
-{{ if or (not $publishDate) (eq ($publishDate.Format "2006-01-02") "0001-01-01") }}
-  {{ if and .GitInfo .GitInfo.AuthorDate }}
-    {{ $publishDate = .GitInfo.AuthorDate }}
-  {{ else }}
-    {{ $publishDate = now }}
-  {{ end }}
+{{/*
+  Add dates, but only from a real source of truth — front-matter dates or git
+  commit info. Never fall back to `now`: an absent git history (e.g. a shallow
+  CI checkout) would otherwise stamp every page as modified today, which is both
+  wrong and harmful for SEO/AEO. When no real date exists, omit the fields.
+*/}}
+{{ $publishDate := "" }}
+{{ if and .PublishDate (ne (.PublishDate.Format "2006-01-02") "0001-01-01") }}
+  {{ $publishDate = .PublishDate }}
+{{ else if and .GitInfo .GitInfo.AuthorDate }}
+  {{ $publishDate = .GitInfo.AuthorDate }}
 {{ end }}
 
-{{ if or (not $modifiedDate) (eq ($modifiedDate.Format "2006-01-02") "0001-01-01") }}
-  {{ if and .GitInfo .GitInfo.AuthorDate }}
-    {{ $modifiedDate = .GitInfo.AuthorDate }}
-  {{ else }}
-    {{ $modifiedDate = $publishDate }}
-  {{ end }}
+{{ $modifiedDate := "" }}
+{{ if and .Lastmod (ne (.Lastmod.Format "2006-01-02") "0001-01-01") }}
+  {{ $modifiedDate = .Lastmod }}
+{{ else if and .GitInfo .GitInfo.AuthorDate }}
+  {{ $modifiedDate = .GitInfo.AuthorDate }}
+{{ else }}
+  {{ $modifiedDate = $publishDate }}
 {{ end }}
 
-{{ $schema = merge $schema (dict
-  "datePublished" ($publishDate.Format "2006-01-02T15:04:05Z07:00")
-  "dateModified" ($modifiedDate.Format "2006-01-02T15:04:05Z07:00")
-) }}
+{{ with $publishDate }}
+  {{ $schema = merge $schema (dict "datePublished" (.Format "2006-01-02T15:04:05Z07:00")) }}
+{{ end }}
+{{ with $modifiedDate }}
+  {{ $schema = merge $schema (dict "dateModified" (.Format "2006-01-02T15:04:05Z07:00")) }}
+{{ end }}
 
 {{/* Add description */}}
 {{ with (or .Params.meta_desc .Summary) }}


### PR DESCRIPTION
## Problem

Every page's "Updated" date — and every `lastmod` in the sitemap — currently shows the **build timestamp** instead of the real last-modified date. On the live site, [what-is-pulumi](https://www.pulumi.com/what-is/what-is-pulumi/) reads "Updated June 3, 2026" (today), its JSON-LD `dateModified`/`datePublished` are pinned to the build second, and **every** URL in the production `sitemap.xml` carries the identical build timestamp.

## Root cause

`build-and-deploy.yml` checks out the repo with `actions/checkout@v6` and no `fetch-depth`, which defaults to a shallow clone (latest commit only). With no git history present, Hugo's `enableGitInfo` has nothing to read, so `.Lastmod` falls back to build time across the whole site.

## Changes

- **`.github/workflows/build-and-deploy.yml`** — set `fetch-depth: 0` so the production build has full history for `enableGitInfo`. Root-cause fix; also corrects the sitemap.
- **`layouts/partials/schema/collectors/article-entity.html`** — drop the `now` fallback that actively fabricated today's date into `datePublished`/`dateModified`. Dates now come only from front matter or git; when neither exists the fields are omitted rather than reporting a false "modified today" to search engines.

`layouts/what-is/single.html` is unchanged — its guard was already correct; it only rendered "today" because `.Lastmod` was wrong upstream.

## Verification

Local production build with full git history present:

| Page | Last commit | Rendered "Updated" | JSON-LD `dateModified` |
|---|---|---|---|
| what-is-pulumi | 2026-05-18 | May 18, 2026 ✓ | 2026-05-18T15:31:59 ✓ |
| what-is-devops | 2026-05-19 | May 19, 2026 ✓ | 2026-05-19T14:22:25 ✓ |

Sitemap now carries **378 distinct `lastmod` values** instead of a single build timestamp.

> Note: `fetch-depth: 0` adds some clone time to the deploy — the standard tradeoff for `enableGitInfo`. Takes effect on the next deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)