### PR TITLE
docs: rename "Neo summaries" to "Neo Code Reviews" in VCS integration settings

### DIFF
--- a/content/docs/integrations/version-control/azure-devops-integration.md
+++ b/content/docs/integrations/version-control/azure-devops-integration.md
@@ -72,8 +72,8 @@ After creating an integration, you can configure PR behavior. Toggle these setti
 | Setting | Default | Description |
 |---|---|---|
 | PR Comments | Enabled | Post deployment status and resource changes as comments on ADO pull requests |
-| Neo Summaries | Enabled | Include AI-generated summaries of infrastructure changes in PR comments |
-| Detailed Diff | Disabled | Show property-level before/after diffs for changed resources in PR comments |
+| Neo Code Reviews | Enabled | Include Neo's AI-generated review of infrastructure changes in PR comments (requires [Pulumi Neo](/docs/ai/get-started/#enabling-and-disabling-neo) to be enabled for your organization) |
+| Detailed Diff | Enabled | Show property-level before/after diffs for changed resources in PR comments |
 
 To update, toggle the setting directly. Changes save automatically.
 
@@ -115,7 +115,7 @@ Neo, Pulumi's AI assistant, works with Azure DevOps pull requests. When enabled 
 
 These appear as comments on your ADO pull requests alongside standard deployment status updates.
 
-To disable Neo summaries, toggle **Neo Summaries** off in your [integration settings](#integration-settings).
+To disable these, toggle **Neo Code Reviews** off in your [integration settings](#integration-settings).
 
 ## Troubleshooting
 

--- a/content/docs/integrations/version-control/bitbucket.md
+++ b/content/docs/integrations/version-control/bitbucket.md
@@ -62,7 +62,7 @@ After creating an integration, you can configure pull request behavior. Toggle t
 | Setting | Default | Description |
 |---|---|---|
 | Pull request comments | Enabled | Post deployment status and resource changes as comments on Bitbucket pull requests |
-| Neo summaries for pull request comments | Enabled | Include AI-generated summaries of infrastructure changes in pull request comments (requires [AI Agents](/docs/ai/) to be enabled for your organization) |
+| Neo Code Reviews | Enabled | Include Neo's AI-generated review of infrastructure changes in pull request comments (requires [Pulumi Neo](/docs/ai/get-started/#enabling-and-disabling-neo) to be enabled for your organization) |
 | Detailed diff for pull request comments | Enabled | Show property-level before/after diffs for changed resources in pull request comments |
 
 To delete an integration, select **Delete Integration** on the integration card. This removes the webhooks Pulumi created on your Bitbucket repositories and disconnects all stacks using that integration.

--- a/content/docs/integrations/version-control/github-app.md
+++ b/content/docs/integrations/version-control/github-app.md
@@ -62,6 +62,21 @@ Individual access lets Pulumi create repositories on your behalf — for example
 To remove your individual identity, select your identity on the integration card and choose **Remove Identity**.
 {{% /notes %}}
 
+## Integration settings
+
+After installing the app, you can configure pull request behavior. Toggle these settings per integration under **Management** > **Version control**:
+
+| Setting | Default | Description |
+|---|---|---|
+| Pull request comments | Enabled | Post deployment status and resource changes as comments on GitHub pull requests |
+| Neo Code Reviews | Enabled | Include Neo's AI-generated review of infrastructure changes in pull request comments (requires [Pulumi Neo](/docs/ai/get-started/#enabling-and-disabling-neo) to be enabled for your organization) |
+| Code access for AI reviews | Enabled | Let Neo read pull request code diffs when generating reviews instead of relying on Pulumi engine output alone |
+| Detailed diff for pull request comments | Enabled | Show property-level before/after diffs for changed resources in pull request comments |
+
+Changes save automatically. Neo Code Reviews and detailed diff require pull request comments to be enabled, and code access for AI reviews requires Neo Code Reviews. Code access for AI reviews is specific to the GitHub app and appears once the capability is enabled for your organization.
+
+To remove an integration, see [Uninstallation](#uninstallation).
+
 ## Capabilities
 
 ### Pull request comments
@@ -71,7 +86,7 @@ The Pulumi GitHub app automatically adds comments to pull requests with the resu
 When you run `pulumi preview` or `pulumi up`, the Pulumi CLI examines the closest `.git` directory to extract commit metadata (such as the commit SHA, branch name, and repository information). This metadata is included with the update and sent to Pulumi Cloud, which uses it to identify the associated pull request and post comments.
 
 {{% notes type="info" %}}
-When pull request comments are disabled in your Pulumi Cloud organization settings, the GitHub app does not post comments on pull requests. However, it still reports check run statuses via [GitHub's Checks API](#checks), so preview results remain accessible in the pull request's **Checks** tab.
+When you disable pull request comments in your [integration settings](#integration-settings), the GitHub app does not post comments on pull requests. However, it still reports check run statuses via [GitHub's Checks API](#checks), so preview results remain accessible in the pull request's **Checks** tab.
 {{% /notes %}}
 
 ### Checks

--- a/content/docs/integrations/version-control/gitlab.md
+++ b/content/docs/integrations/version-control/gitlab.md
@@ -61,7 +61,7 @@ After creating an integration, you can configure merge request behavior. Toggle 
 | Setting | Default | Description |
 |---|---|---|
 | Pull request comments | Enabled | Post deployment status and resource changes as comments on GitLab merge requests |
-| Neo summaries for pull request comments | Enabled | Include AI-generated summaries of infrastructure changes in merge request comments (requires [AI Agents](/docs/ai/) to be enabled for your organization) |
+| Neo Code Reviews | Enabled | Include Neo's AI-generated review of infrastructure changes in merge request comments (requires [Pulumi Neo](/docs/ai/get-started/#enabling-and-disabling-neo) to be enabled for your organization) |
 | Detailed diff for pull request comments | Enabled | Show property-level before/after diffs for changed resources in merge request comments |
 
 To delete an integration, select **Delete Integration** on the integration card. This removes the webhook from your GitLab group and disconnects all stacks using that integration.


### PR DESCRIPTION
### Proposed changes

The pull-request preview-summary feature was renamed to **Neo Code Reviews** in the Pulumi Cloud UI. 

### Related issues

Dependent on pulumi/pulumi-service#44261.