### PR TITLE
fix: remove stray = from blog X share URL

### DIFF
--- a/layouts/partials/blog/right-nav.html
+++ b/layouts/partials/blog/right-nav.html
@@ -2,7 +2,7 @@
     <p class="text-gray-500 text-xs">Share this post</p>
     <ul class="p-0 list-none">
         <li>
-            <a data-track="share-x" class="mr-2" href="https://x.com/intent/post?text=={{ $.Page.Title }}&tw_p=tweetbutton&url={{ $.Page.Permalink }}" target="_blank">
+            <a data-track="share-x" class="mr-2" href="https://x.com/intent/post?text={{ $.Page.Title }}&tw_p=tweetbutton&url={{ $.Page.Permalink }}" target="_blank">
                 {{ partial "icon.html" (dict "name" "brand/x" "class" "text-xl") }}
             </a>
             <a data-track="share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url={{ $.Page.Permalink }}" target="_blank">


### PR DESCRIPTION
## Problem

The "Share this post" → X (Twitter) button on blog posts prefills the tweet with a leading `=` before the post title.

## Cause

`layouts/partials/blog/right-nav.html` built the intent URL with a double equals:

```
https://x.com/intent/post?text=={{ $.Page.Title }}&...
```

The `text=` query param plus the extra `=` meant the tweet text literally began with `=`.

## Fix

Drop the stray `=` so the param is `text={{ $.Page.Title }}` and the tweet text is just the title.

The challenge page's tweet button (`layouts/challenge/single.html`) uses a different widget-based mechanism and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)