### PR TITLE
fix: prefill content in blog LinkedIn share button

### DIFF
--- a/layouts/partials/blog/right-nav.html
+++ b/layouts/partials/blog/right-nav.html
@@ -5,7 +5,7 @@
             <a data-track="share-x" class="mr-2" href="https://x.com/intent/post?text=={{ $.Page.Title }}&tw_p=tweetbutton&url={{ $.Page.Permalink }}" target="_blank">
                 {{ partial "icon.html" (dict "name" "brand/x" "class" "text-xl") }}
             </a>
-            <a data-track="share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url={{ $.Page.Permalink }}" target="_blank">
+            <a data-track="share-linkedin" href="https://www.linkedin.com/feed/?shareActive=true&text={{ (printf "%s %s" $.Page.Title $.Page.Permalink) | urlquery }}" target="_blank">
                 {{ partial "icon.html" (dict "name" "brand/linkedin" "class" "text-xl") }}
             </a>
         </li>


### PR DESCRIPTION
## Problem

On blog posts, the **Share this post → LinkedIn** button opens an empty composer — no title, no description, nothing. By contrast the X button next to it prefills the post title, so the LinkedIn one looks broken.

## Cause

`layouts/partials/blog/right-nav.html` used LinkedIn's `share-offsite` endpoint:

```
https://www.linkedin.com/sharing/share-offsite/?url={{ $.Page.Permalink }}
```

That endpoint hands LinkedIn only a URL and depends on LinkedIn's crawler to render a preview card in the dialog. LinkedIn no longer supports prefilling commentary text via URL params on this endpoint, so the composer comes up blank. (The blog OG tags themselves are fine — `og:title`, `og:description`, `og:image`, `og:url` all render correctly — the endpoint just doesn't surface them as editable content.)

## Fix

Switch to the LinkedIn feed composer, prefilling the post title and permalink:

```
https://www.linkedin.com/feed/?shareActive=true&text={{ (printf "%s %s" $.Page.Title $.Page.Permalink) | urlquery }}
```

- Opens the "Start a post" composer with the title + URL already in the text box, mirroring the X button.
- LinkedIn attaches the Open Graph preview card from the permalink, so the post still gets the rich image/description.
- Text is URL-encoded with `urlquery`, matching the existing pattern in `layouts/shortcodes/neo-card.html`.

## Verification

Built the site (`hugo -e production`) and inspected a rendered blog post. The LinkedIn link resolves to:

```
https://www.linkedin.com/feed/?shareActive=true&text=The+Agentic+Infrastructure+Era+https%3A%2F%2Fwww.pulumi.com%2Fblog%2Fthe-agentic-infrastructure-era%2F
```

> Note: this is a separate fix from #19511 (the X button's stray `=`), which touches an adjacent line in the same file. They can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)