### PR TITLE
Document VCS individual access across all native providers

### DIFF
--- a/content/docs/integrations/version-control/azure-devops-integration.md
+++ b/content/docs/integrations/version-control/azure-devops-integration.md
@@ -55,6 +55,16 @@ Select **Save**. Pulumi registers service hooks in your ADO project for `git.pus
 To disconnect, remove all ADO integrations first, then select **Disconnect** from the identity dropdown.
 {{% /notes %}}
 
+### Individual user setup
+
+Separately from the org-level integration, individual users can complete an OAuth flow under **Management** > **Version control** to grant Pulumi access to their Azure DevOps account. The integration card shows your status: "Individual access is authorized for this account" once you've connected, or "Individual access is recommended for this account" with an **Add Individual Account** button if you haven't.
+
+Individual access lets Pulumi create repositories on your behalf — for example, cloning project templates into a new repository or letting [Neo](/docs/ai/) create a repository for you. It does not create service hooks. The org-level integration continues to handle pull request comments and deployments regardless of whether you grant individual access.
+
+{{% notes type="info" %}}
+To remove your individual identity, select your identity on the integration card and choose **Remove Identity**.
+{{% /notes %}}
+
 ## Integration settings
 
 After creating an integration, you can configure PR behavior. Toggle these settings per integration:

--- a/content/docs/integrations/version-control/bitbucket.md
+++ b/content/docs/integrations/version-control/bitbucket.md
@@ -47,7 +47,9 @@ If your workspace does not support workspace access tokens, Pulumi Cloud prompts
 
 ### Individual user setup
 
-Separately from the org-level integration, individual users can complete an OAuth flow under **Management** > **Version control** to grant Pulumi access to their Bitbucket account. This is used for features like Neo Agent repository creation on the user's behalf and does not create webhooks.
+Separately from the org-level integration, individual users can complete an OAuth flow under **Management** > **Version control** to grant Pulumi access to their Bitbucket account. The integration card shows your status: "Individual access is authorized for this account" once you've connected, or "Individual access is recommended for this account" with an **Add Individual Account** button if you haven't.
+
+Individual access lets Pulumi create repositories on your behalf — for example, cloning project templates into a new repository or letting [Neo](/docs/ai/) create a repository for you. It does not create webhooks. The org-level integration continues to handle pull request comments and deployments regardless of whether you grant individual access.
 
 {{% notes type="info" %}}
 To remove your individual identity, select your identity on the integration card and choose **Remove Identity**.

--- a/content/docs/integrations/version-control/github-app.md
+++ b/content/docs/integrations/version-control/github-app.md
@@ -52,6 +52,16 @@ Mapping a single GitHub organization to multiple Pulumi organizations requires c
 
 GitHub Enterprise Server is supported for [Pulumi Business Critical Edition](https://www.pulumi.com/enterprise/). Only one GitHub Enterprise Server integration is supported per Pulumi organization.
 
+### Individual user setup
+
+Separately from the org-level GitHub app, individual users can complete an OAuth flow under **Management** > **Version control** to grant Pulumi access to their personal GitHub account. The integration card shows your status: "Individual access is authorized for this account" once you've connected, or "Individual access is recommended for this account" with an **Add Individual Account** button if you haven't.
+
+Individual access lets Pulumi create repositories on your behalf — for example, cloning project templates into a new repository or letting [Neo](/docs/ai/) create a repository for you. It does not create webhooks. The org-level GitHub app continues to handle pull request comments, checks, and push-to-deploy regardless of whether you grant individual access. This option is not available for GitHub Enterprise Server.
+
+{{% notes type="info" %}}
+To remove your individual identity, select your identity on the integration card and choose **Remove Identity**.
+{{% /notes %}}
+
 ## Capabilities
 
 ### Pull request comments

--- a/content/docs/integrations/version-control/gitlab.md
+++ b/content/docs/integrations/version-control/gitlab.md
@@ -46,7 +46,9 @@ If the selected group does not support Group Access Tokens, Pulumi Cloud prompts
 
 ### Individual user setup
 
-Separately from the org-level integration, individual users can complete a 3-step OAuth flow under **Management** > **Version control** to grant Pulumi access to their GitLab account. This is used for features like Neo Agent repository creation on the user's behalf and does not create webhooks.
+Separately from the org-level integration, individual users can complete a 3-step OAuth flow under **Management** > **Version control** to grant Pulumi access to their GitLab account. The integration card shows your status: "Individual access is authorized for this account" once you've connected, or "Individual access is recommended for this account" with an **Add Individual Account** button if you haven't.
+
+Individual access lets Pulumi create repositories on your behalf — for example, cloning project templates into a new repository or letting [Neo](/docs/ai/) create a repository for you. It does not create webhooks. The org-level integration continues to handle merge request comments and deployments regardless of whether you grant individual access.
 
 {{% notes type="info" %}}
 To remove your individual identity, select your identity on the integration card and choose **Remove Identity**.


### PR DESCRIPTION
## What

Documents the **"Individual access is recommended for this account"** message (and its **"...is authorized..."** counterpart) shown on VCS integration cards under **Management → Version control** in the Pulumi Console, plus the **Add Individual Account** button.

This was previously **undocumented** for GitHub and Azure DevOps, and only **partially covered** for GitLab and Bitbucket (the "Individual user setup" sections described the concept but never named what users actually see).

## Changes

All four native-provider pages now read identically for this feature:

- `github-app.md` — **new** `Individual user setup` section
- `azure-devops-integration.md` — **new** `Individual user setup` section
- `gitlab.md` — leveled up (added status-message + button, fuller "what it grants")
- `bitbucket.md` — leveled up (same)

Each section now:
- Names both on-card status states and the **Add Individual Account** button
- Explains individual access lets Pulumi create repositories on the user's behalf (template cloning, Neo repo creation)
- Notes it does not create webhooks/service hooks
- Clarifies the org-level integration keeps working regardless

Provider-specific wording preserved (GitLab merge requests / 3-step flow, ADO service hooks, GitHub Enterprise Server exclusion). `custom-vcs.md` is intentionally untouched — it has no Console-managed OAuth.

## Notes

Source of the behavior is the `app.pulumi.com` Console (`vcs-integration-card.component.html`); `hasUserToken` drives which message renders. `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)