### PR TITLE
Group announcement banner CTA next to text

### DIFF
--- a/layouts/partials/announcement-banner.html
+++ b/layouts/partials/announcement-banner.html
@@ -45,18 +45,20 @@
   {{- end }}
   <div class="announcement hidden h-10 items-center gap-3 px-4 md:px-6"
        data-announcement-id="{{ .id }}">
-    {{ if $href }}<a href="{{ $href }}" tabindex="-1" class="contents text-white group-hover:text-white/90 hover:no-underline">{{ end }}
-      {{ with .badge }}<span class="shrink-0 inline-flex items-center rounded-full bg-violet-300 text-violet-950 px-2 py-0.5 font-mono text-xs font-semibold uppercase tracking-wide">{{ . }}</span>{{ end }}
-      {{ with .icon }}{{ partial "icon.html" (dict "name" . "class" "size-5 shrink-0 text-violet-300" "weight" "fill") }}{{ end }}
-      <div class="min-w-0 flex-1 overflow-hidden whitespace-nowrap" data-announcement-marquee>
-        <span class="inline-block" data-announcement-content>
-          <span class="announcement-text inline-block">{{ .text | markdownify }}</span>
-        </span>
-      </div>
-    {{ if $href }}</a>{{ end }}
-    {{ with .cta }}
-    <a href="{{ .href }}" class="shrink-0 inline-flex items-center rounded-md border border-white/20 px-2 py-0.5 text-xs font-medium text-white hover:bg-white/10 hover:no-underline">{{ .label }}</a>
-    {{ end }}
+    <div class="flex flex-1 min-w-0 items-center gap-3">
+      {{ if $href }}<a href="{{ $href }}" tabindex="-1" class="contents text-white group-hover:text-white/90 hover:no-underline">{{ end }}
+        {{ with .badge }}<span class="shrink-0 inline-flex items-center rounded-full bg-violet-300 text-violet-950 px-2 py-0.5 font-mono text-xs font-semibold uppercase tracking-wide">{{ . }}</span>{{ end }}
+        {{ with .icon }}{{ partial "icon.html" (dict "name" . "class" "size-5 shrink-0 text-violet-300" "weight" "fill") }}{{ end }}
+        <div class="min-w-0 overflow-hidden whitespace-nowrap" data-announcement-marquee>
+          <span class="inline-block" data-announcement-content>
+            <span class="announcement-text inline-block">{{ .text | markdownify }}</span>
+          </span>
+        </div>
+      {{ if $href }}</a>{{ end }}
+      {{ with .cta }}
+      <a href="{{ .href }}" class="shrink-0 inline-flex items-center rounded-md border border-white/20 px-2 py-0.5 text-xs font-medium text-white hover:bg-white/10 hover:no-underline">{{ .label }}</a>
+      {{ end }}
+    </div>
     {{ if $dismissible }}
     <button type="button" aria-label="Dismiss announcement"
             class="shrink-0 inline-flex h-6 w-6 items-center justify-center rounded text-white hover:bg-white/10"


### PR DESCRIPTION
**Generated description of changes:**

### Proposed changes

Wraps the announcement text and CTA in a shared flex container so the CTA sits adjacent to the message instead of being pushed to the far right edge of the banner. The dismiss button stays anchored at the right.

### Related issues

Fixes #19393