### PR TITLE
Take down launch week announcement banner

### DIFF
--- a/data/announcements.yml
+++ b/data/announcements.yml
@@ -45,7 +45,7 @@
 
 announcements:
   - id: blog-agentic-infrastructure-era-2026-05-Kp4nQ2
-    active: true
+    active: false
     display: both
     icon: sparkle
     text: "**It's launch week!** The agentic infrastructure era is here, and we've got some new things to share."


### PR DESCRIPTION
### Proposed changes

Takes down the sitewide **"It's launch week! The agentic infrastructure era is here…"** announcement banner by setting `active: false` on its entry in `data/announcements.yml`.

### Why it's still up

The banner is driven entirely by `data/announcements.yml`. The launch-week entry (`id: blog-agentic-infrastructure-era-2026-05-Kp4nQ2`) was still `active: true` on `master` — nobody ever flipped it off. I checked the history and open/merged PRs:

- No merged or open PR ever set this entry to `active: false`.
- The only banner-related PR since launch was #19523 ("Group announcement banner CTA next to text"), a CSS/layout tweak that left `active: true` untouched — likely what was mistaken for taking it down.

So the banner kept rendering on every page simply because the config was never changed.

### The fix

Per the documented convention in `announcements.yml` (comment item 2: *"Set `active: false` to keep the entry without showing it (preserves the id for future re-enabling)"*), this flips the entry to `active: false` rather than deleting it. With no active, in-scope entries remaining, the banner no longer renders.

```diff
   - id: blog-agentic-infrastructure-era-2026-05-Kp4nQ2
-    active: true
+    active: false
     display: both
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017MfKRvHL8j2QMPMqxnC3gL)_