### PR TITLE
ESC docs: fix broken link, clarify rotation, add SDK retrieval and multi-line secrets

### DIFF
--- a/content/docs/esc/operations/managing-secrets.md
+++ b/content/docs/esc/operations/managing-secrets.md
@@ -83,6 +83,26 @@ values:
       ciphertext: ZXNjeAA...
 ```
 
+### Multi-line secrets
+
+For multi-line values such as private keys, TLS certificates, or SSH keys, use a YAML block scalar with `fn::secret`:
+
+```yaml
+values:
+  tlsCert:
+    fn::secret: |
+      -----BEGIN CERTIFICATE-----
+      MIIDXTCCAkWgAwIBAgIJAMqBbsYRO...
+      -----END CERTIFICATE-----
+  privateKey:
+    fn::secret: |
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIEowIBAAKCAQEA0Z3VS5JJcds3...
+      -----END RSA PRIVATE KEY-----
+```
+
+The `|` character tells YAML to preserve newlines, which is required for PEM-formatted values. Using `esc env set` for multi-line secrets is not recommended — use the console editor or edit the environment YAML directly.
+
 ## Retrieving secrets
 
 ### Via the CLI
@@ -113,6 +133,56 @@ esc env get <org>/<project>/<env-name> apiKey
 1. Select your environment in Pulumi Cloud
 1. Select **Open** to evaluate the environment
 1. Toggle **Show secrets** to reveal encrypted values
+
+### Via Pulumi IaC or language SDKs
+
+The most common way to consume ESC secrets in practice is programmatically — either through Pulumi IaC stacks that import the environment, or directly using the ESC SDK.
+
+**In a Pulumi IaC stack** — import the environment in `Pulumi.<stack>.yaml` and reference secrets as stack config:
+
+```yaml
+environment:
+  - my-org/my-project/dev
+```
+
+Secrets become available to your program via `pulumi.Config`:
+
+```typescript
+const config = new pulumi.Config();
+const apiKey = config.requireSecret("apiKey");
+```
+
+**Using the ESC SDK** — read secrets directly from application code:
+
+{{< chooser language "typescript,python,go" >}}
+{{% choosable language typescript %}}
+```typescript
+import * as esc from "@pulumi/esc-sdk";
+
+const client = new esc.EscApi();
+const env = await client.openAndReadEnvironment("my-org", "my-project", "dev");
+const apiKey = env.values?.apiKey;
+```
+{{% /choosable %}}
+{{% choosable language python %}}
+```python
+import pulumi_esc_sdk as esc
+
+client = esc.EscApi()
+_, values, _ = client.open_and_read_environment("my-org", "my-project", "dev")
+api_key = values.get("apiKey")
+```
+{{% /choosable %}}
+{{% choosable language go %}}
+```go
+client := esc.NewEscClient(esc.NewConfiguration())
+_, values, _, err := client.EscAPI.OpenAndReadEnvironment(ctx, "my-org", "my-project", "dev")
+apiKey := values["apiKey"]
+```
+{{% /choosable %}}
+{{< /chooser >}}
+
+See the [ESC SDK docs](/docs/esc/concepts/sdks/) for authentication setup and full API reference.
 
 ## Organizing secrets
 
@@ -171,13 +241,17 @@ These can be plain text:
 
 ### Rotate secrets regularly
 
-Update secrets by setting new values:
+ESC supports two approaches to secret rotation:
+
+**Manual update** — Replace a secret value by setting a new one:
 
 ```bash
 esc env set my-org/my-project/prod apiKey new-secret-value --secret
 ```
 
-ESC versions every change, allowing you to roll back if needed.
+ESC versions every change, so you can audit the history or roll back if needed.
+
+**Automated rotation** — For supported secret types (database passwords, AWS IAM keys, and others), ESC can automatically rotate credentials on a schedule using `fn::rotate` and a [rotation connector](/docs/esc/operations/rotation/). This is the recommended approach for production secrets, as it eliminates manual steps and reduces exposure windows.
 
 ### Control access with RBAC
 
@@ -192,4 +266,4 @@ Use [Role-Based Access Control](/docs/esc/administration/access-control/) to lim
 - [Integrate with Pulumi IaC](/docs/esc/guides/integrate-with-pulumi-iac/) - Use secrets in your infrastructure code
 - [Dynamic secrets](/docs/esc/providers/secrets/) - Pull secrets from AWS, Azure, GCP secret stores
 - [Running commands with esc run](/docs/esc/guides/running-commands/) - Inject secrets into any command
-- [Access control reference](/docs/esc/environments/access-control/) - Complete RBAC documentation
+- [Access control reference](/docs/esc/administration/access-control/) - Complete RBAC documentation

--- a/content/docs/esc/operations/managing-secrets.md
+++ b/content/docs/esc/operations/managing-secrets.md
@@ -136,16 +136,16 @@ esc env get <org>/<project>/<env-name> apiKey
 
 ### Via Pulumi IaC or language SDKs
 
-The most common way to consume ESC secrets in practice is programmatically — either through Pulumi IaC stacks that import the environment, or directly using the ESC SDK.
+You can also consume ESC secrets programmatically — either through Pulumi IaC stacks that import the environment, or directly using the ESC SDK.
 
 **In a Pulumi IaC stack** — import the environment in `Pulumi.<stack>.yaml` and reference secrets as stack config:
 
 ```yaml
 environment:
-  - my-org/my-project/dev
+  - my-project/dev
 ```
 
-Secrets become available to your program via `pulumi.Config`:
+Values nested under a `pulumiConfig` block in your environment become available to your program via `pulumi.Config` (see [Integrate with Pulumi IaC](/docs/esc/guides/integrate-with-pulumi-iac/)):
 
 ```typescript
 const config = new pulumi.Config();
@@ -156,29 +156,40 @@ const apiKey = config.requireSecret("apiKey");
 
 {{< chooser language "typescript,python,go" >}}
 {{% choosable language typescript %}}
+
 ```typescript
 import * as esc from "@pulumi/esc-sdk";
 
-const client = new esc.EscApi();
+const configuration = new esc.Configuration({ accessToken: myAccessToken });
+const client = new esc.EscApi(configuration);
 const env = await client.openAndReadEnvironment("my-org", "my-project", "dev");
-const apiKey = env.values?.apiKey;
+const apiKey = env?.values?.apiKey;
 ```
+
 {{% /choosable %}}
 {{% choosable language python %}}
+
 ```python
 import pulumi_esc_sdk as esc
 
-client = esc.EscApi()
-_, values, _ = client.open_and_read_environment("my-org", "my-project", "dev")
-api_key = values.get("apiKey")
+client = esc.esc_client.default_client()
+env, values, yaml = client.open_and_read_environment("my-org", "my-project", "dev")
+api_key = values["apiKey"]
 ```
+
 {{% /choosable %}}
 {{% choosable language go %}}
+
 ```go
-client := esc.NewEscClient(esc.NewConfiguration())
-_, values, _, err := client.EscAPI.OpenAndReadEnvironment(ctx, "my-org", "my-project", "dev")
+client := esc.NewClient(esc.NewConfiguration())
+authCtx := esc.NewAuthContext(os.Getenv("PULUMI_ACCESS_TOKEN"))
+_, values, err := client.OpenAndReadEnvironment(authCtx, "my-org", "my-project", "dev")
+if err != nil {
+	log.Fatal(err)
+}
 apiKey := values["apiKey"]
 ```
+
 {{% /choosable %}}
 {{< /chooser >}}
 
@@ -251,7 +262,7 @@ esc env set my-org/my-project/prod apiKey new-secret-value --secret
 
 ESC versions every change, so you can audit the history or roll back if needed.
 
-**Automated rotation** — For supported secret types (database passwords, AWS IAM keys, and others), ESC can automatically rotate credentials on a schedule using `fn::rotate` and a [rotation connector](/docs/esc/operations/rotation/). This is the recommended approach for production secrets, as it eliminates manual steps and reduces exposure windows.
+**Automated rotation** — For supported secret types (database passwords, AWS IAM keys, and others), ESC can [automatically rotate credentials on a schedule](/docs/esc/environments/rotation/) using `fn::rotate`. If the rotation target lives in a private network, a [rotation connector](/docs/esc/operations/rotation/) runs the rotation on Pulumi Cloud's behalf. This is the recommended approach for production secrets, as it eliminates manual steps and reduces exposure windows.
 
 ### Control access with RBAC
 


### PR DESCRIPTION
Fixes #19462

## Changes
- Fix broken Next Steps link: `/docs/esc/environments/access-control/` → `/docs/esc/administration/access-control/`
- Split 'Rotate secrets regularly' into manual update vs. automated `fn::rotate` rotation
- Add programmatic retrieval section (Pulumi IaC + ESC SDK with language chooser tabs)
- Add multi-line secrets example for PEM certs/private keys

## Testing
- All internal links verified live
- Shortcode syntax validated (chooser balanced, 3 language tabs)
- Code fences balanced, frontmatter intact