### PR TITLE
Add CascadiaJS 2026 workshop to Engin Diri's talks

### DIFF
--- a/content/community/team/engin-diri.md
+++ b/content/community/team/engin-diri.md
@@ -9,6 +9,10 @@ aliases:
   - /engin
   - /community/community-engineering/engin-diri/
 talks:
+- event: "CascadiaJS 2026"
+  title: "Workshop: Deploying AI Agents on AWS With Pulumi and Amazon Bedrock AgentCore"
+  url: "https://cascadiajs.com/2026/talks/deploying-ai-agents-on-aws-with-pulumi-and-amazon-bedrock-agentcore"
+  date: 2026-06-02T13:40:00.000-07:00
 - event: "PlatforMa 2026"
   title: "Stop Building Portals, Start Building Conversations"
   url: "https://www.platfor-ma.com/agenda2026"


### PR DESCRIPTION
Adds Engin Diri's CascadiaJS 2026 workshop to his team profile talk list.

- **Event:** CascadiaJS 2026 (Town Hall Seattle, June 1–2, 2026)
- **Title:** Workshop: Deploying AI Agents on AWS With Pulumi and Amazon Bedrock AgentCore
- **Date/time:** June 2, 2026, 1:40pm PDT
- **Source:** https://cascadiajs.com/2026/talks/deploying-ai-agents-on-aws-with-pulumi-and-amazon-bedrock-agentcore

Placed at the top of the `talks:` list to maintain reverse-chronological order.