### PR TITLE
Simplify Dependabot labeler: drop risk tiers and quarterly review

### DIFF
--- a/.claude/commands/dashboard/SKILL.md
+++ b/.claude/commands/dashboard/SKILL.md
@@ -57,7 +57,7 @@ Parse the JSON output and present it according to the mode requested. The JSON s
       "labels": [{"name": "string"}],
       "priority": number,        // Calculated priority score
       "age_days": number,        // Days since creation
-      "type": "security|high-risk|medium-risk|normal",
+      "type": "security|lambda-edge|normal",
       "is_assigned": boolean,    // Assigned to current user
       "is_mentioned": boolean    // User mentioned in PR
     }
@@ -121,7 +121,7 @@ If `rate_remaining` < 50, show warning: `⚠️  GitHub API rate limit low ({cou
 - Sort by `priority` (descending), then by `age_days` (descending)
 - Show emojis based on type:
   - 🔒 = `type: "security"`
-  - ⚠️  = `type: "high-risk"`
+  - ⚠️  = `type: "lambda-edge"`
   - 📝 = normal (or draft if `isDraft: true`)
   - 🤖 = bot author (contains `[bot]` in username)
 - Format: `{emoji} #{number}  {title} ({type if special}, {age}d)`
@@ -153,8 +153,8 @@ Generate actionable tasks based on data. Priority order:
    - `🔍 Review assigned PR #{number}: {short_title} → /pr-review {number}`
    - Limit to top 3 by priority
 
-4. **High-risk PRs** (`type: "high-risk"`):
-   - `⚠️  Review high-risk dependency PR #{number} → /pr-review {number}`
+4. **Lambda@Edge-risk PRs** (`type: "lambda-edge"`):
+   - `⚠️  Review Lambda@Edge dependency PR #{number} (bundle-size check) → /pr-review {number}`
    - Limit to top 2
 
 5. **Assigned issues**:
@@ -221,12 +221,11 @@ PRs are scored with these weights (already calculated in JSON):
 - **+100**: Assigned to me
 - **+80**: Mentions me
 - **+70**: Security patch (`deps-security-patch` label)
-- **+60**: High-risk (`deps-risk-high` label)
+- **+60**: Lambda@Edge risk (`deps-lambda-edge-risk` label)
 - **+40**: Ready for review (not draft)
 - **+30**: Team member (internal users only)
 - **+50**: Age > 14 days
 - **+25**: Age > 7 days
-- **+20**: Medium-risk (`deps-risk-medium` label)
 - **-20**: Draft
 
 ---

--- a/.claude/commands/dashboard/scripts/dashboard.sh
+++ b/.claude/commands/dashboard/scripts/dashboard.sh
@@ -98,8 +98,8 @@ calculate_priority() {
     priority=$((priority + 70))
   fi
 
-  # High-risk Dependabot
-  if echo "$labels" | grep -q "deps-risk-high"; then
+  # Lambda@Edge-risk Dependabot (needs bundle-size/deployment check)
+  if echo "$labels" | grep -q "deps-lambda-edge-risk"; then
     priority=$((priority + 60))
   fi
 
@@ -124,11 +124,6 @@ calculate_priority() {
     elif [ $age_days -gt 7 ]; then
       priority=$((priority + 25))
     fi
-  fi
-
-  # Medium-risk Dependabot
-  if echo "$labels" | grep -q "deps-risk-medium"; then
-    priority=$((priority + 20))
   fi
 
   # Draft penalty
@@ -164,10 +159,8 @@ if [ -f "$TMPDIR/prs_all.json" ]; then
     type="normal"
     if echo "$labels" | grep -q "deps-security-patch"; then
       type="security"
-    elif echo "$labels" | grep -q "deps-risk-high"; then
-      type="high-risk"
-    elif echo "$labels" | grep -q "deps-risk-medium"; then
-      type="medium-risk"
+    elif echo "$labels" | grep -q "deps-lambda-edge-risk"; then
+      type="lambda-edge"
     fi
 
     # Check if assigned or mentions me

--- a/.claude/commands/pr-review/references/action-menus.md
+++ b/.claude/commands/pr-review/references/action-menus.md
@@ -9,49 +9,34 @@ Select the appropriate section based on contributor type and review findings. Au
 
 ## Dependabot PRs
 
-Parse Dependabot risk and special-handling labels per `pr-review:references:dependabot-labels`.
+Parse Dependabot special-handling labels per `pr-review:references:dependabot-labels`. There is no risk tier — evaluate and merge.
 
 ### Display Header
 
 Use AskUserQuestion with header:
 
 ```text
-🤖 Dependabot PR | Risk: [HIGH/MEDIUM/LOW/UNKNOWN]
+🤖 Dependabot PR
 [If security] 🔒 Security Update
 [If lambda-edge] 🚨 Lambda@Edge Risk - Review deployment
 [If bulk] 📦 Bulk Update (10+ deps)
 ```
 
-### Options (Max 4 - Adjust Based on Risk Tier)
+### Options (Max 4)
 
-#### For HIGH Risk or Security Patches
-
-1. **Approve** (Recommended after testing)
+1. **Approve** (Recommended after evaluating)
 2. **Request changes** - Technical feedback needed
 3. **Close PR** - Reject the dep update
 4. **Do nothing yet** - Need to test/investigate
 
-#### For LOW/MEDIUM Risk with quarterly-review Label
+### Testing Checklist
 
-1. **Approve** (Recommended)
-2. **Close with quarterly note** - Defer to next quarterly batch
-3. **Request changes** - Technical feedback needed
-4. **Do nothing yet** - Need to test/investigate
+Default evaluate-and-merge pass:
 
-#### For Other Dependabot PRs (No Clear Risk Label)
+- Run `make build` (or `make serve-all` for browser-facing packages), then spot-check search, console errors, and markdown rendering
+- Merge once CI is green
 
-1. **Approve** (Recommended)
-2. **Request changes** - Technical feedback needed
-3. **Close PR** - Reject
-4. **Do nothing yet** - Need investigation
-
-### Testing Checklist (Show by Risk)
-
-Display appropriate checklist based on risk tier:
-
-- **HIGH**: `make serve-all`, search, console errors, markdown, PR deployment (URL loads, Lambda@Edge errors via F12, search, navigation)
-- **MEDIUM**: `make build`, warnings, [if build tools] PR deployment URL loads
-- **LOW**: `make lint`
+When `deps-lambda-edge-risk` is present, add: check the Lambda@Edge bundle size against the 1 MB limit and confirm the PR deployment URL loads (Lambda@Edge errors via F12, search, navigation) before merging.
 
 ## Other Bot PRs
 

--- a/.claude/commands/pr-review/references/dependabot-labels.md
+++ b/.claude/commands/pr-review/references/dependabot-labels.md
@@ -1,65 +1,34 @@
 ---
 user-invocable: false
-description: Dependabot label taxonomy and risk classification
+description: Dependabot label taxonomy and handling
 ---
 
 # Dependabot Labels
 
 ## Label Taxonomy
 
-Parse these labels from PR data to determine risk level and handling approach:
+The `label-dependabot.yml` workflow applies these labels. There is no risk-tier
+classification — dependency updates are grouped per ecosystem and arrive at low
+volume, so the policy is to evaluate each PR and merge it once CI is green. The
+labels below flag the only two cases that change handling.
 
-### Risk Classification Labels
+- `dependencies` - Standard label (applied by Dependabot itself)
+- `deps-security-patch` - Security vulnerability fix; prioritize
+- `deps-lambda-edge-risk` - Affects Lambda@Edge bundling/runtime (webpack/bundler/AWS SDK; ESM/CommonJS and 1 MB bundle-size concerns)
+- `deps-bulk-update` - 10+ dependencies in a single PR
 
-- `deps-risk-high` - High risk dependencies (runtime, bundling, core functionality)
-- `deps-risk-medium` - Medium risk dependencies (build tools, dev dependencies with production impact)
-- `deps-risk-low` - Low risk dependencies (dev-only tools, testing frameworks)
-- `deps-risk-unknown` - Risk not yet classified
+## Handling
 
-### Special Handling Labels
+Default path for every Dependabot PR:
 
-- `deps-security-patch` - Security vulnerability fix (always HIGH priority)
-- `deps-lambda-edge-risk` - Affects Lambda@Edge bundling/runtime (ESM/CommonJS issues, webpack changes)
-- `deps-bulk-update` - 10+ dependencies in single PR
-- `deps-merge-after-test` - Requires testing before merge
-- `deps-quarterly-review` - Part of quarterly batch update cycle
+1. **Evaluate** - build and spot-check (the testing checklist lives in `pr-review:references:action-menus`).
+2. **Approve + merge** once CI is green.
 
-## Risk Classification Logic
+Two flags adjust this:
 
-Determine risk tier from labels:
+- `deps-security-patch` - prioritize over the regular cadence; evaluate and merge promptly.
+- `deps-lambda-edge-risk` - before merging, verify the Lambda@Edge function size against the 1 MB compressed limit and confirm the CloudFront deployment succeeds in the testing environment. See the Infrastructure Change Review section of `BUILD-AND-DEPLOY.md`.
 
-1. **HIGH Risk**:
-   - Has `deps-security-patch` label, OR
-   - Has `deps-lambda-edge-risk` label, OR
-   - Has `deps-risk-high` label
-
-2. **MEDIUM Risk**:
-   - Has `deps-risk-medium` label
-
-3. **LOW Risk**:
-   - Has `deps-risk-low` label
-
-4. **UNKNOWN Risk**:
-   - No risk label present, OR
-   - Has `deps-risk-unknown` label
-
-Testing checklists by risk tier live in `pr-review:references:action-menus`.
-
-## Quarterly Review Workflow
-
-For PRs with `deps-quarterly-review` label, accumulate LOW/MEDIUM risk updates and merge quarterly.
-
-Handling options:
-
-1. **Approve for batch** - Add to quarterly batch (recommended)
-2. **Merge now** - Urgent update needed before quarterly cycle
-3. **Close with quarterly note** - Defer to next quarterly batch (duplicate or superseded)
-4. **Investigate** - Need risk assessment before deciding
-
-### Close Message for Quarterly Batching
-
-When closing to batch with other quarterly updates:
-
-```text
-Closing to batch with other quarterly dependency updates. We'll merge accumulated quarterly updates together after comprehensive testing. This reduces testing overhead while keeping dependencies current.
-```
+`deps-bulk-update` is informational: a 10+ dependency PR warrants a more careful
+build/test pass and a check for hidden major versions, but is handled the same
+way otherwise.

--- a/.claude/commands/pr-review/references/execution-results.md
+++ b/.claude/commands/pr-review/references/execution-results.md
@@ -12,7 +12,7 @@ Report results to user after executing confirmed action.
 | Action | Result Message | Additional Info |
 |--------|---------------|-----------------|
 | **Approve** | ✅ PR #{{arg}} approved successfully!<br><br>Approval comment posted. | PR URL |
-| **Approve and merge** | ✅ PR #{{arg}} approved with auto-merge enabled!<br><br>PR will merge using squash when checks pass. Verify with: `gh pr view {{arg}} --json state,mergedAt,autoMergeRequest` | PR URL<br>Bot context (if bot): @username, Risk tier, Labels<br>If Dependabot HIGH/MEDIUM: "⚠️ Next merge to master triggers pulumi-test.io deployment" |
+| **Approve and merge** | ✅ PR #{{arg}} approved with auto-merge enabled!<br><br>PR will merge using squash when checks pass. Verify with: `gh pr view {{arg}} --json state,mergedAt,autoMergeRequest` | PR URL<br>Bot context (if bot): @username, Labels<br>If Dependabot dependency PR: "⚠️ Next merge to master triggers pulumi-test.io deployment" |
 | **Make changes and approve** | ✅ Changes applied and PR #{{arg}} approved!<br><br>Changes committed: [SHA]<br>Files: [list] | PR URL/commits |
 | **Request changes** | ✅ Changes requested on PR #{{arg}}<br><br>Review posted with request-changes flag. | PR URL |
 | **Close PR** | ✅ PR #{{arg}} closed<br><br>Closing comment posted. | PR URL |
@@ -20,7 +20,7 @@ Report results to user after executing confirmed action.
 
 **Examples** to model:
 
-- *Dependabot HIGH with merge*: `✅ PR #1234 approved with auto-merge enabled! PR will merge using squash when checks pass. Verify with: gh pr view 1234 --json state,mergedAt,autoMergeRequest | Bot: @dependabot[bot] | Risk: HIGH | Labels: deps-security-patch | ⚠️ Next merge to master triggers pulumi-test.io deployment`
+- *Dependabot with merge*: `✅ PR #1234 approved with auto-merge enabled! PR will merge using squash when checks pass. Verify with: gh pr view 1234 --json state,mergedAt,autoMergeRequest | Bot: @dependabot[bot] | Labels: deps-security-patch | ⚠️ Next merge to master triggers pulumi-test.io deployment`
 - *Make changes and approve*: `✅ Changes applied and PR #1234 approved! Changes committed: a1b2c3d | Files: content/docs/intro/index.md (typo fixes), content/docs/install/index.md (formatting) | View: [URL]`
 
 ## GitHub CLI Field Reference

--- a/.claude/commands/pr-review/references/message-templates.md
+++ b/.claude/commands/pr-review/references/message-templates.md
@@ -26,11 +26,11 @@ These rules apply even on PRs that triggered heightened scrutiny or AI-suspect. 
 
 | Action | External | Internal | Bot |
 |--------|----------|----------|-----|
-| **Approve** | `Thanks! LGTM. 🎉` (+ one welcome sentence only if it's a first-time contributor) | `LGTM.` (+ at most one sentence if there's a genuine concern or non-obvious suggestion) | **Dependabot**: `Security patch approved.` (security) / `High-risk update reviewed.` (high) / `Approved for quarterly batch.` (med/low)<br>**Other**: `Approved.` |
+| **Approve** | `Thanks! LGTM. 🎉` (+ one welcome sentence only if it's a first-time contributor) | `LGTM.` (+ at most one sentence if there's a genuine concern or non-obvious suggestion) | **Dependabot**: `Security patch approved.` (security) / `Approved.` (otherwise)<br>**Other**: `Approved.` |
 | **Approve and merge** | Same as Approve. Do not add "Auto-merge enabled." | Same as Approve. Do not add "Auto-merge enabled." | **Dependabot**: same as Approve. Do not add merge narration.<br>**Other**: `Approved.` |
 | **Make changes and approve** | `Applied minor style fixes. Thanks! 🙏` | `Applied style fixes. LGTM.` | N/A (excluded for bots) |
 | **Request changes** | Brief thanks, then line-anchored issues with suggestion blocks, then `Mention @claude if you need help.` | Line-anchored issues with suggestion blocks. No filler. | Technical issue description, line numbers, what needs changing. No suggestion blocks. Close with: `This automated PR may need closing and regeneration after fixing source configuration.` |
-| **Close PR** | `Thanks for contributing!` then one-sentence reason, then (if applicable) one-sentence alternative. | One-sentence reason. | **Dependabot quarterly**: `Closing to batch with other quarterly updates. See [Dependency Management](https://github.com/pulumi/docs/blob/master/BUILD-AND-DEPLOY.md#dependency-management).`<br>**Dependabot other / other bots**: `Closing. [one-sentence technical reason]` |
+| **Close PR** | `Thanks for contributing!` then one-sentence reason, then (if applicable) one-sentence alternative. | One-sentence reason. | **Dependabot / other bots**: `Closing. [one-sentence technical reason]` |
 
 ## Good and bad examples
 

--- a/.github/workflows/label-dependabot.yml
+++ b/.github/workflows/label-dependabot.yml
@@ -47,26 +47,8 @@ jobs:
               prBody = context.payload.pull_request.body || '';
             }
 
-            // Dependency categorization by risk tier
-            const highRiskDeps = [
-              '@algolia/', 'algoliasearch', 'marked',
-              'clipboard-polyfill', 'search-insights', '@stencil/',
-              'swiper', 'uuid', 'markdown-it', 'js-yaml', 'cheerio', 'gray-matter'
-            ];
-
-            const mediumRiskDeps = [
-              'webpack', '-loader', '-webpack-plugin', 'postcss',
-              'sass', 'typescript', 'cssnano', 'autoprefixer',
-              '@fullhuman/postcss-purgecss', '@pulumi/', '@aws-sdk/',
-              'tailwindcss'
-            ];
-
-            const lowRiskDeps = [
-              'cypress', 'jest', 'puppeteer', 'workbox-build',
-              'prettier', 'eslint', 'markdownlint', 'husky',
-              'lint-staged', 'http-server', 'concurrently', 'typedoc'
-            ];
-
+            // Bundler/AWS SDK updates can blow the 1MB Lambda@Edge bundle limit.
+            // This is the one piece of risk signal worth flagging automatically.
             const lambdaEdgeRiskDeps = [
               'webpack', '-loader', '-webpack-plugin', '@aws-sdk/'
             ];
@@ -85,40 +67,17 @@ jobs:
               dependencies.push(titleMatch[1]);
             }
 
-            // Categorize dependencies
-            let highestRisk = 'LOW';
+            // Flag Lambda@Edge bundling risk
             let hasLambdaEdgeRisk = false;
-
             for (const dep of dependencies) {
               const depLower = dep.toLowerCase();
-
-              // Check HIGH risk
-              if (highRiskDeps.some(pattern => depLower.includes(pattern.toLowerCase()))) {
-                highestRisk = 'HIGH';
-              }
-
-              // Check MEDIUM risk (only if not already HIGH)
-              if (highestRisk !== 'HIGH' && mediumRiskDeps.some(pattern => depLower.includes(pattern.toLowerCase()))) {
-                highestRisk = 'MEDIUM';
-              }
-
-              // Check Lambda@Edge risk
               if (lambdaEdgeRiskDeps.some(pattern => depLower.includes(pattern.toLowerCase()))) {
                 hasLambdaEdgeRisk = true;
               }
             }
 
-            // Prepare labels to add
+            // Prepare labels to add (`dependencies` is already applied via dependabot.yml)
             const labelsToAdd = ['dependencies'];
-
-            // Add risk tier label
-            if (highestRisk === 'HIGH') {
-              labelsToAdd.push('deps-risk-high');
-            } else if (highestRisk === 'MEDIUM') {
-              labelsToAdd.push('deps-risk-medium');
-            } else {
-              labelsToAdd.push('deps-risk-low');
-            }
 
             // Check for security updates
             const isSecurity = prTitle.toLowerCase().includes('security') ||
@@ -136,15 +95,6 @@ jobs:
             // Add Lambda@Edge risk flag
             if (hasLambdaEdgeRisk) {
               labelsToAdd.push('deps-lambda-edge-risk');
-            }
-
-            // Determine action label
-            if (isSecurity) {
-              labelsToAdd.push('deps-merge-after-test');
-            } else if (highestRisk === 'HIGH') {
-              labelsToAdd.push('deps-merge-after-test');
-            } else {
-              labelsToAdd.push('deps-quarterly-review');
             }
 
             // Add ecosystem label based on PR labels
@@ -168,23 +118,16 @@ jobs:
 
             // Generate triage comment
             let triageComment = '## Automated Dependabot Triage\n\n';
-            triageComment += `**Risk Tier:** ${highestRisk}\n`;
             triageComment += `**Dependencies:** ${dependencies.length > 0 ? dependencies.join(', ') : 'See PR body'}\n\n`;
 
             if (isSecurity) {
-              triageComment += '🔒 **Security Update** - Test locally and merge immediately.\n\n';
-            } else if (highestRisk === 'HIGH') {
-              triageComment += '⚠️ **High Risk** - Runtime/browser dependencies. Test locally before merging.\n\n';
-              triageComment += '**Testing checklist:**\n';
-              triageComment += '- [ ] Run `make serve-all` and verify site loads\n';
-              triageComment += '- [ ] Test search functionality\n';
-              triageComment += '- [ ] Check for console errors\n';
-              triageComment += '- [ ] Verify markdown rendering\n\n';
-            } else if (highestRisk === 'MEDIUM') {
-              triageComment += '⚡ **Medium Risk** - Build tools/infrastructure. Consider for quarterly review.\n\n';
-            } else {
-              triageComment += '✅ **Low Risk** - Dev tools only. Safe to defer to quarterly review.\n\n';
+              triageComment += '🔒 **Security Update** - Prioritize: evaluate and merge promptly.\n\n';
             }
+
+            triageComment += '**Evaluate and merge:**\n';
+            triageComment += '- [ ] Run `make build` (or `make serve-all` for browser-facing changes) and verify the site builds and loads\n';
+            triageComment += '- [ ] Spot-check search, console errors, and markdown rendering\n';
+            triageComment += '- [ ] Merge once CI is green\n\n';
 
             if (hasLambdaEdgeRisk) {
               triageComment += '🚨 **Lambda@Edge Risk** - This update affects webpack, bundlers, or AWS SDK. ';

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -3439,7 +3439,7 @@ This section provides comprehensive guidance for triaging and managing Dependabo
 
 **Security Updates:** Arrive immediately regardless of schedule (Dependabot auto-override)
 
-### Automated risk labeling
+### Automated labeling
 
 All Dependabot PRs automatically receive:
 
@@ -3449,160 +3449,30 @@ All Dependabot PRs automatically receive:
 
 **Auto-applied labels (via label-dependabot.yml workflow):**
 
-**Risk Tier Labels:**
-
-- `deps-risk-high` - Runtime/browser/parser dependencies
-- `deps-risk-medium` - Build tools/infrastructure dependencies
-- `deps-risk-low` - Dev tools only
-
-**Action Labels:**
-
-- `deps-merge-after-test` - Test locally, then merge (HIGH risk or security patches)
-- `deps-security-patch` - Security update, merge immediately after testing
-- `deps-quarterly-review` - Close for batch review in quarterly cycle (MEDIUM/LOW risk)
-
-**Special Flags:**
-
+- `deps-security-patch` - Security update; evaluate and merge promptly
 - `deps-lambda-edge-risk` - Webpack/bundler/AWS SDK updates (see Infrastructure Change Review)
 - `deps-bulk-update` - 10+ dependencies in single PR
 
-### Dependency risk tiers
-
-#### HIGH RISK - Runtime/browser/parser dependencies
-
-**Characteristics:**
-
-- Execute in browser or server runtime
-- Parse user content or external data
-- Directly affect site functionality and user experience
-
-**Packages:**
-
-- **Search:** `@algolia/*`, `algoliasearch`, `search-insights`
-- **Content Parsing:** `marked`, `markdown-it`, `js-yaml`, `cheerio`, `gray-matter`
-- **Browser APIs:** `clipboard-polyfill`
-- **Web Components:** `@stencil/*`, `swiper`
-- **Utilities:** `uuid`
-
-**Triage Action:** `deps-merge-after-test`
-
-**Testing Checklist:**
-
-1. Run `make serve-all` and verify site loads
-1. Test search functionality (Algolia integration)
-1. Check browser console for errors
-1. Verify markdown rendering on multiple pages
-1. Test interactive components (code copy, tabs, etc.)
-
-#### MEDIUM RISK - Build tools/infrastructure dependencies
-
-**Characteristics:**
-
-- Affect build process and bundling
-- Infrastructure as code dependencies
-- Lambda@Edge function dependencies (special attention required)
-
-**Packages:**
-
-- **Webpack Ecosystem:** `webpack*`, `*-loader`, `*-webpack-plugin*`
-- **CSS Processing:** `postcss*`, `sass*`, `cssnano`, `autoprefixer`, `tailwindcss`
-- **TypeScript:** `typescript`
-- **Pulumi:** `@pulumi/*`
-- **AWS SDK:** `@aws-sdk/*` (Lambda@Edge risk)
-
-**Triage Action:** `deps-quarterly-review` (unless security patch)
-
-**Special Considerations:**
-
-- **Lambda@Edge Risk:** Webpack, bundlers, and AWS SDK updates affect Lambda@Edge function size. See [Infrastructure Change Review](#infrastructure-change-review) section for deployment risks and 1MB compressed size limit.
-- **Build Performance:** CSS/PostCSS updates can affect build times
-- **TypeScript:** Breaking changes may require code updates
-
-**Quarterly Review Process:**
-
-1. Batch all MEDIUM-risk PRs from the quarter
-1. Test webpack/bundler updates first (Lambda@Edge size check)
-1. Test CSS processing updates second (build time check)
-1. Test TypeScript updates last (compilation check)
-1. Merge in order of successful testing
-
-#### LOW RISK - Dev tools only
-
-**Characteristics:**
-
-- Testing and development tools
-- Code quality and formatting tools
-- Documentation generation tools
-- Local development servers
-
-**Packages:**
-
-- **Testing:** `cypress`, `jest*`, `puppeteer`
-- **Build Optimization:** `workbox-build`
-- **Code Quality:** `prettier`, `eslint*`, `markdownlint`, `husky`, `lint-staged`
-- **Dev Servers:** `http-server`, `concurrently`
-- **Documentation:** `typedoc`
-
-**Triage Action:** `deps-quarterly-review`
-
-**Quarterly Review Process:**
-
-1. Batch all LOW-risk PRs from the quarter
-1. Quick smoke test: `make test && make lint`
-1. Merge all if tests pass
-1. If failures, debug individually
+The workflow does not classify PRs into risk tiers. Dependency updates are
+grouped per ecosystem and arrive at a low, predictable volume, so the policy is
+simply to evaluate each PR and merge it once CI is green (see below). The two
+flags above surface the only signals that change handling: security patches get
+priority, and `deps-lambda-edge-risk` PRs need the bundle-size check.
 
 ### Monthly triage workflow
 
-On the first Monday of each month, Dependabot generates exactly 5 grouped PRs (one per ecosystem). Follow this workflow:
+On the first Monday of each month, Dependabot generates roughly 5 grouped PRs (one per ecosystem), plus security patches as they arise. The policy is to **evaluate each PR and merge it as it comes in** — there is no risk tiering and no quarterly deferral. Grouping already keeps volume low, so batching buys nothing.
 
-**Step 1: Check Labels (30 seconds per PR)**
+For each PR:
 
-- Look at auto-applied risk tier and action labels
-- No need to read PR bodies initially—labels tell you everything
+1. **Build and spot-check.** Run `make build` (or `make serve-all` when the PR touches browser-facing packages such as search, markdown rendering, or web components) and confirm the site builds and loads. Spot-check search, console errors, and markdown rendering.
+1. **Let CI gate it.** The PR's build/lint/Cypress checks (`pull-request.yml`) are the merge gate. Merge once they're green.
+1. **Prioritize security patches.** PRs labeled `deps-security-patch` arrive off-schedule — evaluate and merge them promptly rather than waiting for the monthly batch.
+1. **Give Lambda@Edge updates the bundle check.** For PRs labeled `deps-lambda-edge-risk` (webpack/bundler/AWS SDK), cross-reference the [Infrastructure Change Review](#infrastructure-change-review) section, check the Lambda@Edge function size against the 1MB compressed limit, and verify the CloudFront deployment succeeds in the testing environment before merging.
 
-**Step 2: Security Patches (Immediate)**
+Automated Claude review does not run on Dependabot PRs (the review pipeline is built for prose, not dependency bumps). To get a Claude pass on a specific PR, run `/pr-review <number>`.
 
-- PRs with `deps-security-patch` label: Test and merge immediately
-- Run testing checklist for applicable risk tier
-- Merge within 24 hours
-
-**Step 3: HIGH Risk Runtime Dependencies (Same Day)**
-
-- PRs with `deps-risk-high` + `deps-merge-after-test` labels
-- Run HIGH risk testing checklist (see above)
-- Merge if tests pass, or debug and fix issues
-
-**Step 4: MEDIUM/LOW Risk Dependencies (Defer)**
-
-- PRs with `deps-quarterly-review` label
-- Close with comment: "Deferring to quarterly review cycle. Will batch with other MEDIUM/LOW-risk updates."
-- Do not merge monthly—wait for quarterly batch
-
-**Step 5: Lambda@Edge Risk Flag (Extra Attention)**
-
-- PRs with `deps-lambda-edge-risk` label
-- Cross-reference [Infrastructure Change Review](#infrastructure-change-review) section
-- Check Lambda@Edge function size after webpack/bundler updates
-- Verify CloudFront deployment succeeds in testing environment
-
-**Expected Monthly Time:** 5-10 minutes for triage + 20-30 minutes for HIGH-risk testing
-
-### Quarterly review cycle
-
-**Schedule:** January, April, July, October (first week)
-
-**Process:**
-
-1. Review all closed PRs from past 3 months with `deps-quarterly-review` label
-1. Check if newer versions are available (Dependabot may have newer PRs open)
-1. Create consolidated testing branch with all MEDIUM/LOW updates
-1. Run full test suite: `make test && make lint && make build`
-1. Test Lambda@Edge function size for webpack/bundler updates
-1. Merge if all tests pass
-1. If failures, debug individually and merge successful updates only
-
-**Expected Quarterly Time:** 1-2 hours for batch testing and merging
+**Expected Monthly Time:** 5-10 minutes for triage + extra time only for Lambda@Edge or bulk PRs that warrant deeper testing.
 
 ### Security patch handling
 
@@ -3610,21 +3480,21 @@ On the first Monday of each month, Dependabot generates exactly 5 grouped PRs (o
 
 **Arrival:** Immediately when vulnerability discovered (ignores monthly schedule)
 
-**Labels:** Auto-labeled with `deps-security-patch` + applicable risk tier
+**Labels:** Auto-labeled with `deps-security-patch`
 
 **Workflow:**
 
 1. Dependabot opens PR immediately (any time of month)
-1. Auto-labeling workflow adds `deps-security-patch` + risk tier
-1. Test using checklist for applicable risk tier
-1. Merge within 24 hours regardless of risk tier
+1. Auto-labeling workflow adds `deps-security-patch`
+1. Build and spot-check (`make build`, or `make serve-all` for browser-facing packages)
+1. Merge within 24 hours once CI is green
 1. Deploy to production immediately
 
-**Example:** CVE in `marked` (HIGH risk parser)
+**Example:** CVE in `marked`
 
 - PR arrives immediately
-- Labels: `deps-security-patch`, `deps-risk-high`, `deps-merge-after-test`
-- Run HIGH risk testing checklist
+- Labels: `deps-security-patch` (and `deps-lambda-edge-risk` if a bundler/AWS SDK update)
+- Build and spot-check search/markdown rendering
 - Merge and deploy within 24 hours
 
 ### Bulk updates (10+ dependencies)


### PR DESCRIPTION
## What & why

The `label-dependabot` workflow classified each PR into HIGH/MEDIUM/LOW risk from three hand-maintained allowlists and routed MEDIUM/LOW PRs into a "quarterly review" batch. That machinery doesn't earn its keep here:

- **Grouping defeats the tiering.** `dependabot.yml` groups every dep per ecosystem into one PR (`patterns: ["*"]`), so the classifier always takes the highest-risk member — effectively always HIGH. The MEDIUM/LOW + quarterly path was near-dead code.
- **Volume is trivial** (~5–6 grouped, minor/patch-only PRs a month).
- **Quarterly batching was net-negative toil** — close monthly PRs, then hand-rebuild a consolidated branch each quarter to recover overhead that grouping already removes. The allowlists also rot (duplicated across two files, no check against `package.json`).

The policy is now simply: **evaluate each Dependabot PR and merge it once CI is green.**

## What's kept

The two tier-independent signals that actually change handling survive:

- `deps-security-patch` — prioritize.
- `deps-lambda-edge-risk` — the real 1 MB Lambda@Edge bundle hazard on webpack/`@aws-sdk` bumps; still gets a bundle-size/deployment check.

Plus `deps-bulk-update` (informational) and a slim "evaluate and merge" triage comment.

## Changes

- **`.github/workflows/label-dependabot.yml`** — remove the three risk allowlists, the `highestRisk` computation, the `deps-risk-*` labels, and the `deps-merge-after-test` / `deps-quarterly-review` action labels. Keep `lambdaEdgeRiskDeps` detection and the security/bulk/lambda-edge flags. Rewrite the triage comment.
- **`BUILD-AND-DEPLOY.md`** — drop the risk-tier subsections and the quarterly-review cycle; rewrite the monthly triage as evaluate-and-merge; scrub residual `deps-risk-*` mentions. Security-patch, bulk-update, Lambda@Edge cross-refs, and known exceptions retained.
- **`pr-review` skill refs** — `dependabot-labels.md`, `action-menus.md`, `message-templates.md`, `execution-results.md` updated to match.
- **`dashboard` skill** — repoint priority scoring / PR categorization from `deps-risk-high|medium` to `deps-lambda-edge-risk`.

## Out of scope (confirmed with maintainer)

- **`.github/dependabot.yml` grouping** — unchanged. Grouping keeps manual-merge load low; it's the right trade-off.
- **Merge stays fully manual** — no auto-merge automation added. (Dependabot PRs are already excluded from the Claude review pipeline by design; the triage comment is their lightweight substitute, and `/pr-review` is the manual bridge.)
- The pr-review **infra "risk tier"** (`contributor-detection.sh`, `trust-and-scrutiny.md`, `infrastructure-deployment.md`) is a separate concept and is left intact.

## Verification

- Workflow YAML parses; extracted `github-script` body passes `node --check`.
- `dashboard.sh` passes `bash -n`.
- Repo-wide sweep confirms no stragglers for `deps-risk*`, `deps-quarterly-review`, `deps-merge-after-test`.
- Post-merge: the workflow's `workflow_dispatch` (`pr_number` input) can be run against an existing Dependabot PR to confirm it applies only the kept labels and posts the slimmed comment.

https://claude.ai/code/session_01AR7nGiuzYDSYkC8FcjyoUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR7nGiuzYDSYkC8FcjyoUs)_