### PR TITLE
Remove 'Neo is free in public preview' copy; mark Neo GA on product page

### DIFF
--- a/content/docs/ai/get-started/_index.md
+++ b/content/docs/ai/get-started/_index.md
@@ -16,10 +16,6 @@ menu:
         identifier: ai-get-started
 ---
 
-## Public Preview Access
-
-Neo is in public preview and currently free to use. Users will receive ample warning before any pricing changes go into effect. Using Neo to optionally run [`pulumi preview`](/docs/iac/neo/running-previews/) consumes workflow minutes. Learn more about workflow minutes on our [pricing page](https://www.pulumi.com/pricing/#faq-pricing).
-
 ## Enabling and Disabling Neo
 
 Neo is enabled by default. To disable Neo for your organization, navigate to **Settings > Neo Settings > General** in the Pulumi Cloud console.

--- a/content/docs/ai/running-previews/_index.md
+++ b/content/docs/ai/running-previews/_index.md
@@ -18,10 +18,6 @@ menu:
 
 Neo can run [preview](/docs/iac/cli/commands/pulumi_preview/) directly from Pulumi Cloud to validate proposed infrastructure changes before creating pull requests. This capability provides confidence that suggested modifications do not result in unexpected resource changes and comply with [policies](/docs/insights/policy/).
 
-## Public Preview Access
-
-Neo is in public preview and currently free to use. Users will receive ample warning before any pricing changes go into effect. Using Neo to optionally run `pulumi preview` consumes workflow minutes. Lean more about workflow minutes on our [pricing page](https://www.pulumi.com/pricing/#faq-pricing).
-
 ## Prerequisites
 
 ### Configuration and Credentials

--- a/content/product/neo.md
+++ b/content/product/neo.md
@@ -107,7 +107,7 @@ sections:
     highlight_first_card: true
     columns:
       - title: Experience Neo today
-        description: Neo is available in preview for all Pulumi users. Experience the future of platform engineering automation.
+        description: Neo is generally available to all Pulumi users. Experience the future of platform engineering automation.
         cta_primary_text: Start Free
         cta_primary_link: https://app.pulumi.com/signup
         cta_text: Book a Demo


### PR DESCRIPTION
### Proposed changes

The Neo **Get Started** and **Running Previews** docs both carried a "Public Preview Access" block stating:

> Neo is in public preview and currently free to use.

Neo is generally available and not free, so this copy is inaccurate. It is also reaching customers: a Neo task quoted this line back to a user who asked about pricing, telling them Neo was free in preview. This removes both blocks.

It also updates the Neo product-page hero copy from "Neo is available in preview for all Pulumi users." to "Neo is generally available to all Pulumi users."

For reference, the [pricing page](https://www.pulumi.com/pricing/) already treats Neo as a Team-and-up feature (not available on the free Individual tier), so these changes bring the docs and product page in line with it.

Mirrors pulumi/docs-private#265 (originally opened against the wrong repo).
