### PR TITLE
content(what-is): add cross-references and a NoSQL alternatives section

### DIFF
--- a/content/what-is/amazon-dynamodb-vs-google-cloud-bigtable.md
+++ b/content/what-is/amazon-dynamodb-vs-google-cloud-bigtable.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon DynamoDB vs Google Cloud Bigtable
 meta_desc: |
-     Compare Bigtable vs DynamoDB to learn the many similarities and differences between these two noSQL databases. Learn which is best with Pulumi.
+     Compare Amazon DynamoDB vs Google Cloud Bigtable, plus other DynamoDB alternatives like Cassandra, MongoDB, and Cosmos DB, to pick the right NoSQL database.
 
 meta_image: /images/what-is/amazon-dynamodb-vs-google-cloud-bigtable-meta.png
 type: what-is
@@ -66,6 +66,18 @@ DynamoDB offers two different pricing models: on-demand capacity mode, and provi
 Google Cloud Bigtable and AWS DynamoDB both have strengths and weaknesses that will benefit some teams but hinder others. If your infrastructure is already on AWS, DynamoDB is the stronger offering.
 
 If you have truly large amounts of data that you will require very fast access to, are most comfortable with something that looks like SQL, or the rest of your infrastructure is hosted on Google Cloud, you want Bigtable.
+
+## Other NoSQL Alternatives to DynamoDB
+
+Bigtable is one of several alternatives to DynamoDB. If you're evaluating options beyond AWS, the main NoSQL databases worth considering are:
+
+- **Google Cloud Bigtable**: the wide-column store on Google Cloud covered in detail above — the closest GCP equivalent to DynamoDB for large-scale, low-latency workloads.
+- **Apache Cassandra and ScyllaDB**: open-source wide-column databases you can self-host or run as a managed service (DataStax Astra, ScyllaDB Cloud). A good fit when you want to avoid cloud lock-in.
+- **MongoDB and Amazon DocumentDB**: document databases for flexible, JSON-like data models. MongoDB Atlas runs on any cloud; DocumentDB is AWS's MongoDB-compatible managed option.
+- **Azure Cosmos DB**: a multi-model, globally distributed managed database, and the natural choice on Microsoft Azure.
+- **Redis**: an in-memory key-value store for caching and low-latency lookups, often used alongside DynamoDB rather than as a full replacement.
+
+Whichever you choose, Pulumi can provision and manage it as [infrastructure as code](/what-is/what-is-infrastructure-as-code/) in the language you already use.
 
 ## Conclusion
 

--- a/content/what-is/what-is-an-internal-developer-platform.md
+++ b/content/what-is/what-is-an-internal-developer-platform.md
@@ -71,7 +71,7 @@ Organizations that successfully implement IDPs realize several significant benef
 
 While closely related, Platform Engineering and Internal Developer Platforms are not the same:
 
-* **Platform Engineering** is the discipline and practice of designing, building, and maintaining developer platforms. It involves the people, processes, and cultural aspects of creating developer-centric infrastructure solutions.
+* **[Platform Engineering](/what-is/what-is-platform-engineering/)** is the discipline and practice of designing, building, and maintaining developer platforms. It involves the people, processes, and cultural aspects of creating developer-centric infrastructure solutions.
 * **Internal Developer Platforms** are the actual products that platform engineering teams build - the technical implementation that developers interact with daily.
 
 Think of Platform Engineering as the discipline, and the IDP as the product of that discipline.

--- a/content/what-is/what-is-secrets-management.md
+++ b/content/what-is/what-is-secrets-management.md
@@ -22,7 +22,7 @@ Secrets are often the gateway to accessing sensitive systems and data. With robu
 
 ### Maintaining Compliance with Security Regulations
 
-Many industries are governed by strict regulations that require the protection of sensitive data. Effective secrets management helps organizations comply with these regulations, such as GDPR, HIPAA, or PCI DSS, by ensuring that access to sensitive data is tightly controlled and monitored. Compliance not only avoids legal penalties but also builds trust with customers and partners.
+Many industries are governed by strict regulations that require the protection of sensitive data. Effective secrets management helps organizations comply with frameworks and regulations such as [SOC 2](/what-is/what-is-soc-2/), GDPR, HIPAA, or PCI DSS, by ensuring that access to sensitive data is tightly controlled and monitored. Compliance not only avoids legal penalties but also builds trust with customers and partners.
 
 ### Simplifying the Process of Rotating and Updating Secrets
 


### PR DESCRIPTION
A few small content updates in the what-is section:

- Add a cross-reference from the internal developer platform page to the platform engineering page, in the section that contrasts the two.
- Add a cross-reference from the secrets management page to the SOC 2 page in its compliance section, and adjust "regulations" to "frameworks and regulations" for accuracy (SOC 2 is an attestation, not a law).
- Add a short "Other NoSQL alternatives to DynamoDB" section to the DynamoDB vs Bigtable page (Cassandra/ScyllaDB, MongoDB/DocumentDB, Cosmos DB, Redis) and refresh its meta description.

No content removed; titles and URLs unchanged. Markdown lint and Prettier pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)