### PR TITLE
schema: add foundingLocation to Organization structured data

### DIFF
--- a/layouts/partials/schema/graph-builder.html
+++ b/layouts/partials/schema/graph-builder.html
@@ -63,6 +63,10 @@
       (dict "@type" "Person" "name" "Joe Duffy")
       (dict "@type" "Person" "name" "Eric Rudder")
     )
+    "foundingLocation" (dict
+      "@type" "Place"
+      "name" "Seattle, Washington, United States"
+    )
     "address" (dict
       "@type" "PostalAddress"
       "streetAddress" "601 Union St Suite 1415"


### PR DESCRIPTION
Adds `foundingLocation` (Seattle, Washington, United States) to the homepage Organization schema in `graph-builder.html`, next to the existing `foundingDate` and `founders` fields.

Small, accurate enrichment of the company entity's structured data. Validated with a local Hugo render (`hugo --renderToMemory`) — template compiles and the homepage builds without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)