### PR TITLE
head: add article OpenGraph metadata for authored pages

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -116,6 +116,21 @@
         {{ end }}
     {{ end }}
 
+    {{ with .Params.authors }}
+        {{ range $authorName := . }}
+            {{ with index site.Data.team.team $authorName }}
+                <meta property="article:author" content="{{ .name }}" />
+                <meta name="author" content="{{ .name }}" />
+            {{ end }}
+        {{ end }}
+        {{ if not $.PublishDate.IsZero }}
+            <meta property="article:published_time" content="{{ $.PublishDate.Format "2006-01-02T15:04:05Z07:00" }}" />
+        {{ end }}
+        {{ if not $.Lastmod.IsZero }}
+            <meta property="article:modified_time" content="{{ $.Lastmod.Format "2006-01-02T15:04:05Z07:00" }}" />
+        {{ end }}
+    {{ end }}
+
     {{ if .Params.meta_title }}
         <meta property="og:title" content="{{ .Params.meta_title }}" />
     {{ else if .Params.title }}


### PR DESCRIPTION
## What

Emit OpenGraph `article:*` metadata on pages that declare authors (what-is pages and blog posts), driven by the existing `authors` front-matter and `data/team` records:

- `article:author` (one per author)
- `article:published_time`
- `article:modified_time`
- a generic `<meta name="author">` tag

## Why

These pages already set `og:type` = `article` but never emitted the article-level metadata to match. Populating it improves how the pages are represented by crawlers that consume these tags (LinkedIn, Facebook, SEO/AEO).

Note: Slack's link unfurl does **not** render `article:author`, so the Slack card appearance is unchanged — this is for the crawlers that do read these tags.

## Notes

- Gated on `.Params.authors`, so pages without authors are unaffected.
- Zero-date guards (`IsZero`) mean pages without a resolvable publish/modified date simply omit those tags rather than emitting empty/garbage values.

Verified on `/what-is/what-is-platform-engineering/`:

\`\`\`html
<meta property="article:author" content="Christian Nunciato">
<meta name="author" content="Christian Nunciato">
<meta property="article:published_time" content="2026-05-11T00:00:00Z">
<meta property="article:modified_time" content="2026-05-20T12:56:50-04:00">
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)