### PR TITLE
content(pricing): show token-based pricing for Pulumi Neo

### DIFF
--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -564,11 +564,11 @@ comparison_table:
               - title: Pulumi Neo
                 link: /docs/ai/neo/
                 items:
-                  - content: 15m tokens/mo
+                  - content: 15M tokens/mo
                     subtext: free
-                  - content: $3/1m tokens
-                  - content: $3/1m tokens
-                  - content: $3/1m tokens
+                  - content: $3/M tokens
+                  - content: $3/M tokens
+                  - content: $3/M tokens
           ## Pulumi Workflow table
           - header: Internal Developer Platform
             icon: custom/pulumi-idp

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -564,10 +564,11 @@ comparison_table:
               - title: Pulumi Neo
                 link: /docs/ai/neo/
                 items:
-                  - content: _blank
-                  - content: _check
-                  - content: _check
-                  - content: _check
+                  - content: 15m tokens/mo
+                    subtext: free
+                  - content: $3/1m tokens
+                  - content: $3/1m tokens
+                  - content: $3/1m tokens
           ## Pulumi Workflow table
           - header: Internal Developer Platform
             icon: custom/pulumi-idp


### PR DESCRIPTION
## Summary

Updates the **Pulumi Neo** row in the pricing comparison table (Infrastructure AI section) to show token-based pricing instead of generic check/blank icons.

| Tier | Before | After |
|------|--------|-------|
| Individual | — (blank) | `15m tokens/mo` (free) |
| Team | ✓ | `$3/1m tokens` |
| Enterprise | ✓ | `$3/1m tokens` |
| Business Critical | ✓ | `$3/1m tokens` |

Display-only change to `content/pricing/_index.md` front matter; no billing logic is wired up here.

## Open question

The Individual column now advertises a free monthly token allotment (`15m tokens/mo`). Confirming that Neo is actually offered on the free Individual plan before this goes ready for review.