### PR TITLE
docs: fix typos and grammar across top-traffic docs pages

### DIFF
--- a/content/docs/esc/environments/working-with-environments.md
+++ b/content/docs/esc/environments/working-with-environments.md
@@ -50,7 +50,7 @@ $ esc env ls --organization myorg
 myorg/myproject/test
 ```
 
-You can filter this list to a particular project by passing it's name:
+You can filter this list to a particular project by passing its name:
 
 ```bash
 $ esc env ls -p myproject
@@ -481,7 +481,7 @@ values:
       fn::secret: sk_XemWAl12i4x3hZhp4vBKDEXAMPLE
 ```
 
-The application-specific `myapp/dev` environment then `imports` these two environments and use their settings to compose new values:
+The application-specific `myapp/dev` environment then `imports` these two environments and uses their settings to compose new values:
 
 ```yaml
 # myorg/myapp/dev
@@ -634,7 +634,7 @@ $ esc env diff myorg/myproject/test@3 myorg/myproject/test@2
 
 ### Tagging Versions
 
-You can tag your revisions with meaningful names like `prod`, `stable`, `v1.1.2`. Each environment has a built-in `latest` tag that always points to the environment’s most recent revision. Use `esc env version tag` to tag a revision. In the following example we are assign `prod` tag to revision 3 of environment `test`.
+You can tag your revisions with meaningful names like `prod`, `stable`, `v1.1.2`. Each environment has a built-in `latest` tag that always points to the environment’s most recent revision. Use `esc env version tag` to tag a revision. In the following example we assign `prod` tag to revision 3 of environment `test`.
 
 ```bash
 $ esc env version tag myorg/myproject/test@prod @3
@@ -745,15 +745,15 @@ To unset a value inherited from another environment, overwrite it with `null`.
 ## Setting up access to environments
 
 {{% notes "info" %}}
-Access controls and Teams are only available to organizations using Pulumi Enterprise Edition and Pulumi Business Critical Edition.To learn more about editions visit the [pricing page](/pricing/).
+Access controls and Teams are only available to organizations using Pulumi Enterprise Edition and Pulumi Business Critical Edition. To learn more about editions visit the [pricing page](/pricing/).
 {{% /notes %}}
 
 ### Organization-wide permissions
 
-Go to the `Access Management` page under Settings to set Organization-wide environment permissions. Members of the organization will receive these permissions. By default, the environment permissions for the organization is set to `write`. There are four options:
+Go to the `Access Management` page under Settings to set Organization-wide environment permissions. Members of the organization will receive these permissions. By default, the environment permissions for the organization are set to `write`. There are four options:
 
 * `none`: Members have access to none of the environments
-* `read`: Members can view only plaintext key values (i.e., the definition of the environment). They won’t be able to see the secret values in plaintext, run any provider configurations to retrieve credentials or run any functions. They cannot perform any Pulumi IaC operations such as `refresh`, `up`, `destroy` on stacks that imports the environment
+* `read`: Members can view only plaintext key values (i.e., the definition of the environment). They won’t be able to see the secret values in plaintext, run any provider configurations to retrieve credentials or run any functions. They cannot perform any Pulumi IaC operations such as `refresh`, `up`, `destroy` on stacks that import the environment
 * `open`: Members with ‘open’ permissions can decrypt secrets and see them in plaintext. Additionally, they can get dynamic credentials using provider configurations and evaluate functions defined in the environment. They can perform any Pulumi IaC operation on stacks that import an environment as long as they have ‘write’ access to the stack and ‘open’ access to the environment
 * `write`: Members will have permissions to `open` and `update` any environment
 
@@ -805,7 +805,7 @@ Cloning an environment takes various options that allow for configuring what is 
 | Preserve History          | Preserve all prior versions of the environment up until the cloned version |
 | Preserve Environment Tags | Preserve all environment tags on the source environment                    |
 | Preserve Revision Tags    | Preserve all revision tags on the versions being cloned                    |
-| Preserve Team Access      | Preserve any team access that he source environment had                    |
+| Preserve Team Access      | Preserve any team access that the source environment had                    |
 
 An example clone command might look like:
 

--- a/content/docs/iac/cli/environment-variables.md
+++ b/content/docs/iac/cli/environment-variables.md
@@ -21,7 +21,7 @@ aliases:
     </dt>
     <dd>
         <p>
-            Specifies the selected pulumi stack, overriding the stack selected with <a href="/docs/iac/cli/commands/pulumi_stack_select/"><code class="text-xs">pulumi stack select STACK</code></a>
+            Specifies the selected pulumi stack, overriding the stack selected with <a href="/docs/iac/cli/commands/pulumi_stack_select/"><code class="text-xs">pulumi stack select STACK</code></a>.
             The priority is as follows:
             <ol>
                 <li>The <code class="text-xs">--stack</code> command line flag</li>
@@ -342,7 +342,7 @@ aliases:
     </dt>
     <dd>
         <p>
-            Use legacy refresh diff behaviour, in which only output changes are
+            Use legacy refresh diff behavior, in which only output changes are
             reported and changes against the desired state are not calculated.
         </p>
         <pre><code class="text-xs">PULUMI_ENABLE_LEGACY_REFRESH_DIFF=true</code></pre>

--- a/content/docs/iac/comparisons/terraform/opentofu.md
+++ b/content/docs/iac/comparisons/terraform/opentofu.md
@@ -56,7 +56,7 @@ Here is a summary of the key differences between OpenTofu and Terraform:
 | [Embed within Application Code](#embedding) | No | No |
 | [Third-party CI/CD Tools Support](#cicd) | No | Yes |
 | [Policy as Code](#policy) | No | Yes |
-| [Secrets Management](#secrets) | No. Secrets can be stored in a 3rd party product. There is no way to encrypt them in the state file. | No. Secrets are stored in a  separate product (Vault). There is no way to encrypt them in the state file. |
+| [Secrets Management](#secrets) | No. Secrets can be stored in a 3rd party product. There is no way to encrypt them in the state file. | No. Secrets are stored in a separate product (Vault). There is no way to encrypt them in the state file. |
 | [Audit Capabilities](#auditing) | No | Limited |
 | [Adopt Existing Resources](#adopting) | Yes. No code generation capabilities. | Yes. No code generation capabilities. |
 | [Aliases](#aliases) | Limited | Limited |

--- a/content/docs/iac/concepts/config.md
+++ b/content/docs/iac/concepts/config.md
@@ -640,7 +640,7 @@ outputs:
 
 ## Project Level Configuration
 
-There are cases where configuration for more than one stack in a given project is the same. For example, `aws:region` may be the same across multiple or all stacks in a project. Project level configuration (also sometimes referred to as hieararchical configuration) allows setting configuration at the project level instead of having to repeat the configuration setting in each stack's configuration file.
+There are cases where configuration for more than one stack in a given project is the same. For example, `aws:region` may be the same across multiple or all stacks in a project. Project level configuration (also sometimes referred to as hierarchical configuration) allows setting configuration at the project level instead of having to repeat the configuration setting in each stack's configuration file.
 
 ### Setting Project Level Configuration
 

--- a/content/docs/iac/concepts/providers/_index.md
+++ b/content/docs/iac/concepts/providers/_index.md
@@ -141,7 +141,7 @@ The following table summarizes the differences between default and explicit prov
 | Best fit for          | Simpler use cases, where only a single provider is needed per cloud                                                                                         | Greater control, often required for deploying into multiple environments for the same cloud in the same Pulumi program (e.g. two or more AWS regions) |
 
 {{% notes type="info" %}}
-The choice (or necessity) to use explicit providers is on a per-cloud basis. For example, you may have a program that deploys primary and disaster recovery resources in the public cloud, which might require explicit providers, but the program also creates DNS entries in with your DNS vendor, which can use the default provider since there's only a single resource to update for DNS.
+The choice (or necessity) to use explicit providers is on a per-cloud basis. For example, you may have a program that deploys primary and disaster recovery resources in the public cloud, which might require explicit providers, but the program also creates DNS entries with your DNS vendor, which can use the default provider since there's only a single resource to update for DNS.
 {{% /notes %}}
 
 ### Default provider configuration

--- a/content/docs/iac/concepts/resources/_index.md
+++ b/content/docs/iac/concepts/resources/_index.md
@@ -122,7 +122,7 @@ All resources have a required [`name`](/docs/concepts/resources/names) argument,
 
 The `args` argument is an object with a set of named property input values that are used to initialize the resource. These can be normal raw values—such as strings, integers, lists, and maps—or [outputs](/docs/concepts/inputs-outputs/) from other resources. Each resource has a number of named input properties that control the behavior of the resulting infrastructure. To determine what arguments a resource supports, refer to that resource’s API documentation in the [Registry](/registry/).
 
-The [`options`](/docs/concepts/options) argument is optional, but lets you control certain aspects of the resource. For example, you can show explicit dependencies, use a custom provider configuration, or import an existing infrastructure.
+The [`options`](/docs/concepts/options) argument is optional, but lets you control certain aspects of the resource. For example, you can show explicit dependencies, use a custom provider configuration, or import existing infrastructure.
 
 ## Related topics
 

--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -358,7 +358,7 @@ The following expressions are supported in patterns:
 | config.key | Config value of key | ${config.region}_${name} |
 
 {{% notes type="warning" %}}
-When an update requires replacing the resource, Pulumi's default behavior is to create the new resource and then deleting the old resource. However, when using verbatim names or patterns without random components, resources that need to be replaced will be deleted before creating the new resource. This can lead to downtime.
+When an update requires replacing the resource, Pulumi's default behavior is to create the new resource and then delete the old resource. However, when using verbatim names or patterns without random components, resources that need to be replaced will be deleted before creating the new resource. This can lead to downtime.
 {{% /notes %}}
 
 ### Provider-Specific Configuration

--- a/content/docs/iac/get-started/terraform/terraform-providers.md
+++ b/content/docs/iac/get-started/terraform/terraform-providers.md
@@ -35,7 +35,7 @@ This command automatically:
 
 ## Example: Random Pet Names
 
-Let's see how this works first-hand, using the `random` Terraform provider. We'll import the Terraform provider then use it to put a load balander in a random availability zone.
+Let's see how this works first-hand, using the `random` Terraform provider. We'll import the Terraform provider then use it to put a load balancer in a random availability zone.
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 

--- a/content/docs/iac/guides/basics/organizing-projects-stacks/_index.md
+++ b/content/docs/iac/guides/basics/organizing-projects-stacks/_index.md
@@ -40,7 +40,7 @@ Each stack typically corresponds to a distinct _environment_ for that service, s
 testing and development instances. There might even be multiple environments within each of these dimensions, such as
 a production environment in each of the US east coast, west coast, Europe, and Asia.
 
-Most users will start a monolithic structure, for a few good reasons:
+Most users will start with a monolithic structure, for a few good reasons:
 
 * **Simplicity.** Having a single project and collection of stacks is the easiest thing you could
   possibly do. Pulumi diffs edits to your application and infrastructure code, and so this approach leaves the

--- a/content/docs/iac/guides/building-extending/components/build-a-component.md
+++ b/content/docs/iac/guides/building-extending/components/build-a-component.md
@@ -231,7 +231,7 @@ Inputs can be any basic type (e.g. `boolean`, `integer`, `string`) or an `array`
 
 {{% choosable language typescript %}}
 
-Now we can implement the component itself. Components should inherit from `pulumi.ComponentResource`, and should accept the arguments class we just defined in the constructor. All the work for our component happens in the constructor, and outputs are returned via class properties. At the end of the process a calling `self.registerOutputs` signals Pulumi that the process of creating the component resource has completed.
+Now we can implement the component itself. Components should inherit from `pulumi.ComponentResource`, and should accept the arguments class we just defined in the constructor. All the work for our component happens in the constructor, and outputs are returned via class properties. At the end of the process, calling `self.registerOutputs` signals Pulumi that the process of creating the component resource has completed.
 
 ***Example:** `StaticPage.ts` the Component implementation*
 
@@ -241,7 +241,7 @@ Now we can implement the component itself. Components should inherit from `pulum
 
 {{% choosable language python %}}
 
-Now we can implement the component itself. Components should inherit from `pulumi.ComponentResource`, and should accept the arguments class we just defined in the constructor. All the work for our component happens in the constructor, and outputs are returned via class properties. At the end of the process a calling `self.register_outputs` signals Pulumi that the process of creating the component resource has completed.
+Now we can implement the component itself. Components should inherit from `pulumi.ComponentResource`, and should accept the arguments class we just defined in the constructor. All the work for our component happens in the constructor, and outputs are returned via class properties. At the end of the process, calling `self.register_outputs` signals Pulumi that the process of creating the component resource has completed.
 
 ***Example:** `static_page.py` the Component implementation*
 
@@ -260,7 +260,7 @@ Now we can implement the component itself. Component structs should include `pul
 
 {{% choosable language csharp %}}
 
-Now we can implement the component itself. Components should inherit from `Pulumi.ComponentResource`, and should accept the arguments class we just defined in the constructor. All the work for our component happens in the constructor, and outputs are returned via class properties. At the end of the process a calling `this.RegisterOutputs` signals Pulumi that the process of creating the component resource has completed.
+Now we can implement the component itself. Components should inherit from `Pulumi.ComponentResource`, and should accept the arguments class we just defined in the constructor. All the work for our component happens in the constructor, and outputs are returned via class properties. At the end of the process, calling `this.RegisterOutputs` signals Pulumi that the process of creating the component resource has completed.
 
 ***Example:** `StaticPage.cs` the Component implementation*
 
@@ -270,7 +270,7 @@ Now we can implement the component itself. Components should inherit from `Pulum
 
 {{% choosable language java %}}
 
-Now we can implement the component itself. Components should inherit from `Pulumi.ComponentResource`, and should accept the arguments class we just defined in the constructor. All the work for our component happens in the constructor, and outputs are returned via class properties. At the end of the process a calling `this.registerOutputs` signals Pulumi that the process of creating the component resource has completed.
+Now we can implement the component itself. Components should inherit from `Pulumi.ComponentResource`, and should accept the arguments class we just defined in the constructor. All the work for our component happens in the constructor, and outputs are returned via class properties. At the end of the process, calling `this.registerOutputs` signals Pulumi that the process of creating the component resource has completed.
 
 ***Example:** `StaticPage.java` the Component implementation*
 

--- a/content/docs/iac/guides/building-extending/providers/build-a-provider.md
+++ b/content/docs/iac/guides/building-extending/providers/build-a-provider.md
@@ -359,7 +359,7 @@ $ cd use-file-provider
 $ pulumi new yaml
 ```
 
-This will initiatize a minimal YAML program. Let's modify the default YAML file:
+This will initialize a minimal YAML program. Let's modify the default YAML file:
 
 ***Example:** The `Pulumi.yaml` file*
 
@@ -519,7 +519,7 @@ Here's where the business logic of the resource operations happens. In this exam
 
 The `Create` operation handles the logic of determining if the resource exists or not, and if not, it creates it using the provided argument context. In many providers this is where you would interact with external cloud APIs, databases, and other systems. In this example, we're going to interact with our local filesystem using calls to Go's `os` library.
 
-First, we check to see if the user configured the `force` option. We can access that through the `req.Inputs` collection, which is will be an instance of `FileArgs`. If `force` is true, we don't need to check to see if the file exists, otherwise, use `os.Stat` and `os.IsNotExist` to see if the specified directory and filename already exist. If it does, we exit early with an error. This will let Pulumi know that the create operation failed, and it will be propagated up to the end user via the console/log output.
+First, we check to see if the user configured the `force` option. We can access that through the `req.Inputs` collection, which will be an instance of `FileArgs`. If `force` is true, we don't need to check to see if the file exists, otherwise, use `os.Stat` and `os.IsNotExist` to see if the specified directory and filename already exist. If it does, we exit early with an error. This will let Pulumi know that the create operation failed, and it will be propagated up to the end user via the console/log output.
 
 To return an error, we return a null `CreateResponse` instance with an error string. The Provider SDK functions use a request and response pattern for each operation, parameterized by the argument and state types. The next piece of logic checks `req.DryRun` to see if we are in a *preview* mode or an *update* mode. If we are in preview mode, don't take any actions that would mutate the state and just return early.
 
@@ -567,7 +567,7 @@ func (File) Create(ctx context.Context, req infer.CreateRequest[FileArgs]) (resp
 
 The `Delete` operation removes a resource safely. This operation follows a similar pattern to `Create`, but instead of a `CreateRequest`/`CreateResponse` we have `DeleteRequest`/`DeleteResponse`.
 
-One new concept inroduced in this example function is the use of the Pulumi logger. Calling `p.GetLogger(ctx)` gets you a logger with a familiar interface. This is how you might pass informational messages and warnings to the user without throwing an error.
+One new concept introduced in this example function is the use of the Pulumi logger. Calling `p.GetLogger(ctx)` gets you a logger with a familiar interface. This is how you might pass informational messages and warnings to the user without throwing an error.
 
 ```go
 func (File) Delete(ctx context.Context, req infer.DeleteRequest[FileState]) (infer.DeleteResponse, error) {
@@ -600,7 +600,7 @@ func (File) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckRespo
 
 ##### The `Update` operation
 
-The `Update` operation modifies the resource with new values. After checking to see if we are in a preview mode of not, we overwrite the file with the new contents. Note that it's not necessary to check if the input contents are different than current state of the content, as this logic is handled by the `Diff` operation.
+The `Update` operation modifies the resource with new values. After checking to see if we are in a preview mode or not, we overwrite the file with the new contents. Note that it's not necessary to check if the input contents are different than current state of the content, as this logic is handled by the `Diff` operation.
 
 ```go
 func (File) Update(ctx context.Context, req infer.UpdateRequest[FileArgs, FileState]) (infer.UpdateResponse[FileState], error) {

--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -941,4 +941,4 @@ Current limitations include:
 
 ## Conclusion
 
-Using Terraform modules directly in Pulumi allows you to leverage the vast ecosystem of Terraform modules and your existing investments into custom modules, while maintaining all the benefits of Pulumi's rich programming model. This approach enables the two products to coexist, allowing teams continue to collaborate while using the best tools for their specific needs, and enables a gradual migration path from Terraform to Pulumi.
+Using Terraform modules directly in Pulumi allows you to leverage the vast ecosystem of Terraform modules and your existing investments into custom modules, while maintaining all the benefits of Pulumi's rich programming model. This approach enables the two products to coexist, allowing teams to continue to collaborate while using the best tools for their specific needs, and enables a gradual migration path from Terraform to Pulumi.

--- a/content/docs/iac/guides/testing/_index.md
+++ b/content/docs/iac/guides/testing/_index.md
@@ -51,7 +51,7 @@ Because cloud resources are not created, you can't write a test that would evalu
 
 ## Property Testing
 
-Property tests are based on [Policy as Code](/docs/insights/policy/), Pulumi's offering to set guardrails and enforce compliance for cloud resources. In addition to authoring company-wide policies, Pulumi Policies enables another type of infrastructure testing. Each policy becomes a property, an invariant, that a test evaluates and asserts.
+Property tests are based on [Policy as Code](/docs/insights/policy/), Pulumi's offering to set guardrails and enforce compliance for cloud resources. In addition to authoring company-wide policies, Pulumi Policies enable another type of infrastructure testing. Each policy becomes a property, an invariant, that a test evaluates and asserts.
 
 Property tests run inside the Pulumi CLI before and after infrastructure provisioning. In contrast to "black-box" integration testing, policy rules have access to all input and output values of all cloud resources in the stack. As opposed to unit testing, property tests can evaluate real values returned from the cloud provider instead of the mocked ones.
 
@@ -61,11 +61,11 @@ Property tests can run against any cloud environment: it can be a persistent "ac
 
 ## Integration Testing
 
-Integration testing takes a different approach of unit tests: the tests deploy cloud resources and validate their actual **behavior**.
+Integration testing takes a different approach from unit tests: the tests deploy cloud resources and validate their actual **behavior**.
 
 An integration test invokes the Pulumi command-line interface (CLI) to deploy infrastructure to an [ephemeral environment](https://about.gitlab.com/blog/2020/01/27/kubecon-na-2019-are-you-about-to-break-prod/). When the resources are deployed, the test retrieves endpoints of the infrastructure from the stack outputs: usually, a URL or a public IP address. The test verifies that the infrastructure behaves as expected; for example, it expects a valid HTML document from a health-check endpoint or runs a suite of application-level tests against the public API. When the tests finish, the infrastructure is destroyed.
 
-The great advantage of integration tests is the ability to test the actual cloud infrastructure and its real properties. However, compared to unit tests, integrations tests take more time to execute.
+The great advantage of integration tests is the ability to test the actual cloud infrastructure and its real properties. However, compared to unit tests, integration tests take more time to execute.
 
 Depending on the type of resources and frequency of testing, even short-lived ephemeral environments may incur notable charges from the cloud provider. Be sure to plan accordingly and measure frequently.
 

--- a/content/docs/iac/guides/testing/unit.md
+++ b/content/docs/iac/guides/testing/unit.md
@@ -1084,7 +1084,7 @@ $ go test
 
 {{% /choosable %}}
 {{% choosable language "csharp" %}}
-Run the following command to execute your Python tests:
+Run the following command to execute your C# tests:
 
 ```bash
 $ dotnet test

--- a/content/docs/iac/languages-sdks/go/_index.md
+++ b/content/docs/iac/languages-sdks/go/_index.md
@@ -140,5 +140,3 @@ For more information on when and how to use dev builds, see [Using dev builds fo
 
 - [Unit testing](/docs/iac/concepts/testing/unit/): Test your infrastructure code in isolation
 - [Integration testing](/docs/iac/concepts/testing/integration/): Test your infrastructure deployments end-to-end
-</content>
-</invoke>

--- a/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
+++ b/content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
@@ -29,7 +29,7 @@ Pulumi supports programs written in YAML or JSON.  In both cases, the programs (
 | `outputs` | map[string]Expression | No | Yes | Outputs specifies the [Pulumi stack outputs](/docs/concepts/stack#outputs) of the program and how they are computed from the `resources` is a value of the appropriate type for the template to use if no value is specified. |
 | `pulumi` | map[string]Expression | No | No | Configuration of the Pulumi CLI |
 
-In many locations within this schema, values may be expressions which computed a value based on the `config`, `variables`, or outputs of `resources`.  These expressions can be provided in two ways:
+In many locations within this schema, values may be expressions which compute a value based on the `config`, `variables`, or outputs of `resources`.  These expressions can be provided in two ways:
 
 * If an object is provided as a value, and has a key that has the prefix `fn::`, the object is treated as an expression, and the expression will be resolved to a new value that will be used in place of the object.
 * Any string value is interpreted as an interpolation, with `${...}` being replaced by evaluating the expression in the `...`.
@@ -109,7 +109,7 @@ Config values are set using `pulumi config set` for scalar types, `pulumi config
 
 ### Resources
 
-The value of `resources` is an object whose keys are logical resource names by which the resource will be referenced in expressions within the program, and whose values which are elements of the schema below.  Each item in this object represents a resource which will be managed by the Pulumi program.
+The value of `resources` is an object whose keys are logical resource names by which the resource will be referenced in expressions within the program, and whose values are elements of the schema below.  Each item in this object represents a resource which will be managed by the Pulumi program.
 
 | Property  |  Type | Required | Expressions | Description |
 |- | - | - | - | - |
@@ -216,7 +216,7 @@ resources:
       version: 5.1.0
 ```
 
-The provider instance can than be used as described in section [Resource Options](#resource-options) by setting the `provider` option:
+The provider instance can then be used as described in section [Resource Options](#resource-options) by setting the `provider` option:
 
 ```yaml
 resources:
@@ -505,7 +505,7 @@ The  `parent` and `provider` values permit expressions which must use interpolat
 | `parent` | Expression | Parent specifies a parent for the resource |
 | `provider` | Expression | Provider specifies an explicitly configured provider, instead of using the default global provider |
 | `version` | string | Version specifies a provider plugin version that should be used when operating on a resource |
-| `pluginDownloadURL` | string | Version specifies a URL that should be used when to download the provider plugin |
+| `pluginDownloadURL` | string | Version specifies a URL that should be used to download the provider plugin |
 
 ##### `fn::join`
 
@@ -554,7 +554,7 @@ The expression `${policyVersion}` will have the value `v1.1`.
 
 ##### `fn::*Asset` and `fn::*Archive`
 
-[Assets and Archives](/docs/concepts/assets-archives/) are intrinsic types to Pulumi, like strings and numbers, and some resources may take these as inputs or return them as outputs. The built-ins create each kind of asset or archive. Each takes all take a single string value.
+[Assets and Archives](/docs/concepts/assets-archives/) are intrinsic types to Pulumi, like strings and numbers, and some resources may take these as inputs or return them as outputs. The built-ins create each kind of asset or archive. Each takes a single string value.
 
 | Built-In | Argument Type | Description |
 | - | - | - |

--- a/content/docs/install/_index.md
+++ b/content/docs/install/_index.md
@@ -316,7 +316,7 @@ You can install Pulumi using elevated permissions through the [Chocolatey packag
    <pre class="chroma"><code class="language-bash" data-lang="powershell" data-track="install-pulumi-windows-choco">&gt; choco install pulumi</code></pre>
 </div>
 
-This will install the `pulumi` CLI to the usual place (often `$($env:ChocolateyInstall)\lib\pulumi`) and generate the [shims](https://docs.chocolatey.org/en-us/features/shim) (usually `$($env:ChocolateyInstall)\bin`) to add Pulumi your path.
+This will install the `pulumi` CLI to the usual place (often `$($env:ChocolateyInstall)\lib\pulumi`) and generate the [shims](https://docs.chocolatey.org/en-us/features/shim) (usually `$($env:ChocolateyInstall)\bin`) to add Pulumi to your path.
 
 Subsequent updates can be installed in the usual way:
 
@@ -634,7 +634,7 @@ Please see https://github.com/pulumi/pulumi-benchmarking where we have a benchma
 The results from this benchmark were 10% CPU utilization on a Apple M1 Pro for the apply and 20% CPU utilization for the destroy.
 The memory usage for both was 1.5GB.
 
-So the following recommendations were made to add some headroom for the typical pulumi actions, espciailly for larger projects.
+So the following recommendations were made to add some headroom for the typical pulumi actions, especially for larger projects.
 -->
 
 The following are general recommendations for minimum system requirements when using Pulumi. Actual performance may vary based on the SDK runtime, providers used, operating system and the size and complexity of your infrastructure deployments. However, the following requirements should be considered a minimum to account for typical usage.

--- a/content/docs/install/versions.md
+++ b/content/docs/install/versions.md
@@ -1,6 +1,6 @@
 ---
 title: Pulumi CLI versions
-meta_desc: This page provides an list of available versions of the Pulumi CLI.
+meta_desc: This page provides a list of available versions of the Pulumi CLI.
 menu:
   iac:
     name: Available versions


### PR DESCRIPTION
## What & why

A proofreading pass over our **highest-traffic documentation pages** to fix typos and grammatical errors. Scope was intentionally narrow: **spelling and grammar only — no stylistic rewrites, rewording, or tone changes.**

## How pages were selected

- **Source:** Google Search Console (`sc-domain:pulumi.com`), ranked by organic-search **clicks**.
- **Window:** 2026-03-01 → 2026-06-08 (last ~3 months).
- **Set:** top 100 `/docs/` pages by clicks.
- **Excluded (26):** auto-generated pages where hand-edits don't persist — `pulumi_*` CLI command references, `reference/pkg/*` SDK API docs, and the Cloud REST API reference. URLs were mapped to source files via path matching + frontmatter `aliases` (the site uses Hugo aliases/rewrites, so URLs don't map 1:1 to files).
- **Reviewed:** the remaining **74 editable source pages**; **18 had genuine issues.**

Top of the traffic list for reference: `iac/comparisons/terraform`, `get-started/download-install`, `iac/concepts/state-and-backends`, `iac/concepts/secrets`, the docs home, `iac/concepts/stacks`, and `iac/concepts/config`.

## Highlights

- **Spelling:** `load balander`→`load balancer`, `initiatize`→`initialize`, `inroduced`→`introduced`, `hieararchical`→`hierarchical`, `espciailly`→`especially`
- **Grammar / agreement:** subject-verb agreement, missing articles and words, `it's`→`its`, `than`→`then`, `of not`→`or not`, faulty parallelism
- **Copy-paste fix:** the C# tab in the unit-testing guide told readers to "execute your Python tests"
- **Stray markup:** removed leftover `</content></invoke>` tags rendering at the bottom of the Go SDK page

<details>
<summary>Pages changed (18)</summary>

- content/docs/esc/environments/working-with-environments.md
- content/docs/iac/cli/environment-variables.md
- content/docs/iac/comparisons/terraform/opentofu.md
- content/docs/iac/concepts/config.md
- content/docs/iac/concepts/providers/_index.md
- content/docs/iac/concepts/resources/_index.md
- content/docs/iac/concepts/resources/names.md
- content/docs/iac/get-started/terraform/terraform-providers.md
- content/docs/iac/guides/basics/organizing-projects-stacks/_index.md
- content/docs/iac/guides/building-extending/components/build-a-component.md
- content/docs/iac/guides/building-extending/providers/build-a-provider.md
- content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
- content/docs/iac/guides/testing/_index.md
- content/docs/iac/guides/testing/unit.md
- content/docs/iac/languages-sdks/go/_index.md
- content/docs/iac/languages-sdks/yaml/yaml-language-reference.md
- content/docs/install/_index.md
- content/docs/install/versions.md

</details>

## Verification

- `make lint` → markdown lint passes (0 errors across 1785 files)
- `prettier --check` on all changed files → clean
- Every edit reviewed to confirm it sits in prose, not inside code blocks, shortcodes, or frontmatter keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)