### PR TITLE
Track docs choice selections in Segment

### DIFF
--- a/theme/src/ts/chooser.ts
+++ b/theme/src/ts/chooser.ts
@@ -7,6 +7,11 @@ function getElemClasses(e: Element) {
 function selectChoice(kind, choice, extra?) {
     document.cookie = "pulumi_" + kind + "=" + choice + "; max-age=31536000; path=/";
 
+    const analytics = (window as any).analytics;
+    if (analytics && analytics.track && typeof analytics.track === "function") {
+        analytics.track("docs-choice-selected", { kind: kind, choice: choice });
+    }
+
     var choiceTabs = 0;
     document.querySelectorAll<HTMLElement>("a." + kind + "-tab").forEach(e => {
         choiceTabs++;


### PR DESCRIPTION
Fire a Segment analytics event in `selectChoice()` whenever the user selects a language, OS, cloud, or k8s-language tab. Mirrors the pattern already used in `neo-mode.ts`.

Event: `docs-choice-selected` with payload `{ kind, choice }`

Collects the data required for #16563

Generated with [Claude Code](https://claude.ai/code)