### PR TITLE
Add secondary contact CTA and embedded form to /gads landing pages

### DIFF
--- a/content/gads/gads-template.md
+++ b/content/gads/gads-template.md
@@ -6,6 +6,15 @@ block_external_search_index: true
 aliases:
     - /gads/gads-template
 
+# Optional: override the embedded contact form section (#contact-form) at the
+# bottom of the page. All values default to the ones shown below.
+# contact_form:
+#     headline: Talk to a Pulumi expert
+#     description: |
+#         Have questions about Pulumi, pricing, or migrating from another tool?
+#         Tell us about your use case and our team will get back to you within one business day.
+#     hubspot_form_id: 8381e562-5fdf-4736-bb10-86096705e4ee
+
 heading: "Competitor Alternative"
 subheading: |
     Pulumi is a free, open source infrastructure as code tool, and works best with Pulumi Cloud to

--- a/layouts/gads/gads-template.html
+++ b/layouts/gads/gads-template.html
@@ -14,8 +14,9 @@
                 {{ .Params.overview.description | markdownify }}
             </p>
         </div>
-        <div class="container mx-auto text-center pt-8 w-9/12">
+        <div class="container mx-auto pt-8 w-9/12 flex flex-col sm:flex-row items-center justify-center gap-4">
             {{ partial "cta-get-started" (dict) }}
+            {{ partial "gads/cta-contact.html" (dict) }}
         </div>
     </section>
 
@@ -63,6 +64,23 @@
 
     <section id="case-studies">
         {{ partial "gads/case-studies.html" .Params.case_studies }}
+    </section>
+
+    {{ $contact := .Params.contact_form | default dict }}
+    <section id="contact-form" class="py-16 px-4 mt-8 border-t border-gray-200 bg-gray-100">
+        <div class="container mx-auto max-w-2xl text-center">
+            <h2>{{ $contact.headline | default "Talk to a Pulumi expert" | markdownify }}</h2>
+            <p class="text-gray-700 max-w-xl mx-auto">
+                {{ $contact.description | default "Have questions about Pulumi, pricing, or migrating from another tool? Tell us about your use case and our team will get back to you within one business day." | markdownify }}
+            </p>
+        </div>
+        <div class="container mx-auto max-w-2xl mt-8">
+            <div class="card p-10 bg-white shadow-lg">
+                <div class="hs-form hs-form-fg-dark font-normal">
+                    <pulumi-hubspot-form form-id="{{ $contact.hubspot_form_id | default "8381e562-5fdf-4736-bb10-86096705e4ee" }}"></pulumi-hubspot-form>
+                </div>
+            </div>
+        </div>
     </section>
 
     <script>

--- a/layouts/gads/gads-template.html
+++ b/layouts/gads/gads-template.html
@@ -15,7 +15,7 @@
             </p>
         </div>
         <div class="container mx-auto pt-8 w-9/12 flex flex-col sm:flex-row items-center justify-center gap-4">
-            {{ partial "cta-get-started" (dict) }}
+            {{ partial "cta-get-started" (dict "label" "Try Pulumi") }}
             {{ partial "gads/cta-contact.html" (dict) }}
         </div>
     </section>

--- a/layouts/partials/cta-get-started.html
+++ b/layouts/partials/cta-get-started.html
@@ -14,11 +14,12 @@
   Parameters:
     - class: CSS class for the button (default: "btn btn-primary btn-xl")
     - style: Optional inline style
+    - label: Optional label override (default: site-wide CTA label)
 */}}
 
 {{ $class := .class | default "btn btn-primary btn-xl" }}
 {{ $style := .style | default "" }}
-{{ $label := site.Params.cta.primary.label | default "Get Started" }}
+{{ $label := .label | default (site.Params.cta.primary.label | default "Get Started") }}
 {{ $href := site.Params.cta.primary.href | default "/docs/get-started/" }}
 
 <a href="{{ $href }}" class="{{ $class }}" data-role="cta-get-started"{{ with $style }} style="{{ . }}"{{ end }}>{{ $label }}</a>

--- a/layouts/partials/gads/cta-contact.html
+++ b/layouts/partials/gads/cta-contact.html
@@ -10,10 +10,10 @@
 
   Parameters:
     - class: CSS class for the button (default: "btn btn-outline btn-xl")
-    - label: Button label (default: "Talk to an expert")
+    - label: Button label (default: "Get a demo")
 */}}
 
 {{ $class := .class | default "btn btn-outline btn-xl" }}
-{{ $label := .label | default "Talk to an expert" }}
+{{ $label := .label | default "Get a demo" }}
 
 <a href="#contact-form" class="{{ $class }}" data-track="gads-cta-contact">{{ $label }}</a>

--- a/layouts/partials/gads/cta-contact.html
+++ b/layouts/partials/gads/cta-contact.html
@@ -1,0 +1,19 @@
+{{/*
+  GADS Contact CTA Button Partial
+
+  Secondary CTA for Google Ads landing pages. Anchors to the embedded
+  contact form section (#contact-form) rendered by gads-template.html,
+  keeping the visitor (and their UTM attribution) on the landing page.
+
+  Usage:
+    {{ partial "gads/cta-contact.html" (dict) }}
+
+  Parameters:
+    - class: CSS class for the button (default: "btn btn-outline btn-xl")
+    - label: Button label (default: "Talk to an expert")
+*/}}
+
+{{ $class := .class | default "btn btn-outline btn-xl" }}
+{{ $label := .label | default "Talk to an expert" }}
+
+<a href="#contact-form" class="{{ $class }}" data-track="gads-cta-contact">{{ $label }}</a>

--- a/layouts/partials/gads/feature-section.html
+++ b/layouts/partials/gads/feature-section.html
@@ -40,8 +40,9 @@
 
     {{ partial "gads/feature-grid.html" (dict "items" $item.features) }}
 
-    <div class="pt-8 text-center">
+    <div class="pt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
         <a href="{{ $ctaLink }}" class="btn btn-primary btn-lg" data-role="cta-get-started">{{ $ctaLabel }}</a>
+        {{ partial "gads/cta-contact.html" (dict "class" "btn btn-outline btn-lg") }}
     </div>
 </div>
 {{ end }}

--- a/layouts/partials/gads/feature-section.html
+++ b/layouts/partials/gads/feature-section.html
@@ -17,7 +17,7 @@
 */}}
 
 {{ $ctaLink := site.Params.cta.primary.href }}
-{{ $ctaLabel := site.Params.cta.primary.label }}
+{{ $ctaLabel := "Try Pulumi" }}
 
 {{ range $item := .items }}
 <div class="border-t p-8 md:p-16 lg:p-32 relative">

--- a/layouts/partials/gads/header.html
+++ b/layouts/partials/gads/header.html
@@ -14,7 +14,7 @@
                 <!-- Sign Up CTA plus secondary contact CTA -->
                 <div class="cta-container flex items-center gap-2">
                     {{ partial "gads/cta-contact.html" (dict "class" "btn btn-ghost") }}
-                    {{ partial "cta-get-started" (dict) }}
+                    {{ partial "cta-get-started" (dict "label" "Try Pulumi") }}
                 </div>
             </div>
         </header>

--- a/layouts/partials/gads/header.html
+++ b/layouts/partials/gads/header.html
@@ -11,8 +11,9 @@
                     </a>
                 </div>
                 
-                <!-- Keep only Sign Up CTA -->
-                <div class="cta-container">
+                <!-- Sign Up CTA plus secondary contact CTA -->
+                <div class="cta-container flex items-center gap-2">
+                    {{ partial "gads/cta-contact.html" (dict "class" "btn btn-ghost") }}
                     {{ partial "cta-get-started" (dict) }}
                 </div>
             </div>

--- a/layouts/partials/gads/hero.html
+++ b/layouts/partials/gads/hero.html
@@ -28,7 +28,7 @@
         <p class="body-xl text-gray-700 max-w-3xl mt-4">{{ $subheading | markdownify }}</p>
         {{ end }}
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mt-8">
-            {{ partial "cta-get-started" (dict) }}
+            {{ partial "cta-get-started" (dict "label" "Try Pulumi") }}
             {{ partial "gads/cta-contact.html" (dict) }}
         </div>
     </div>

--- a/layouts/partials/gads/hero.html
+++ b/layouts/partials/gads/hero.html
@@ -27,5 +27,9 @@
         {{ if $subheading }}
         <p class="body-xl text-gray-700 max-w-3xl mt-4">{{ $subheading | markdownify }}</p>
         {{ end }}
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mt-8">
+            {{ partial "cta-get-started" (dict) }}
+            {{ partial "gads/cta-contact.html" (dict) }}
+        </div>
     </div>
 </header>


### PR DESCRIPTION
## Summary

Improves the paid ads landing pages under `/gads/`.

### What changed

- **New partial** `layouts/partials/gads/cta-contact.html` — outline-style "Get a demo" button linking to `#contact-form` (with `data-track="gads-cta-contact"` for analytics).
- **Secondary CTA placed alongside every primary button**: header (ghost style), hero, overview section, and the bottom of each feature section.
- **Primary CTA relabeled "Try Pulumi"** on gads pages only, via a new optional `label` parameter on the site-wide `cta-get-started` partial (default behavior everywhere else is unchanged).
- **New `#contact-form` section** at the bottom of `gads-template.html` — headline, supporting copy, and the existing sales HubSpot form (`8381e562-…`, the same form used on `/contact/?form=sales` and the migrate pages) in a card.
- **Frontmatter-overridable with defaults**: pages can optionally set `contact_form.headline`, `contact_form.description`, and `contact_form.hubspot_form_id`; with no changes, all 32 existing `/gads/` pages get the section automatically. Documented in `content/gads/gads-template.md`.

### Why on-page instead of linking to /contact/

Keeping the form on the landing page preserves the `utm_*`/`gclid` querystring through to the HubSpot submission (HubSpot reads the page URL/tracking cookie), so paid attribution isn't lost on a navigation — same reason the existing template forwards querystrings to app.pulumi.com links.

### Verification

- Served locally; `/gads/aws/` renders 6 "Try Pulumi" + 6 "Get a demo" CTAs plus the form section, and the HubSpot form loads and renders its fields (screenshot-verified).
- `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)