### PR TITLE
content(topics): add author byline to Why Is Python So Popular

### DIFF
--- a/content/topics/why-is-python-so-popular.md
+++ b/content/topics/why-is-python-so-popular.md
@@ -29,6 +29,7 @@ customer_logos:
       - webflow
       - supabase
       - ro
+authors: ["zack-chase"]
 ---
 
 Even those who are unfamiliar with coding have likely heard of Python. What began as a hobby project named after a British surreal comedy troupe, Python has grown across three decades to become one of the world’s foremost coding languages. According to a [Stack Overflow Developer Survey](https://insights.stackoverflow.com/survey/2021#most-loved-dreaded-and-wanted-language-love-dread), approximately 68% of software developers who have worked extensively with Python have expressed interest in continuing to develop with Python. The same survey also identified Python as the number-one most-wanted coding language among developers who are not currently using it.


### PR DESCRIPTION
## Summary

The author-byline pass in #19134 added an `authors` field to every page under `content/what-is/`, assigned from the first git committer of each file. It missed `content/topics/why-is-python-so-popular.md`, which renders through the same `type: what-is` layout but lives outside that directory, so it's the one what-is page with no byline in the hero.

This adds the same attribution here: the page was created by Zack Chase in #228, and his team data entry and avatar already exist, so the byline renders with no other changes.

## Changes

- `content/topics/why-is-python-so-popular.md`: add `authors: ["zack-chase"]` to the frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)