### PR TITLE
Make tables responsive with scroll wrapper and mobile card reflow

### DIFF
--- a/content/docs/esc/vs/doppler.md
+++ b/content/docs/esc/vs/doppler.md
@@ -13,17 +13,6 @@ menu:
 aliases:
 ---
 
-<style>
-    main table {
-        font-size: 0.94em;
-    }
-
-    main table th,
-    main table td {
-        width: 33.3%;
-    }
-</style>
-
 Choosing the right [secrets management](/what-is/what-is-secrets-management/) tool is important, and we want you to have as much information as possible to make the choice that best suits your needs. We’ve created this document to help you understand how Pulumi ESC compares with Doppler.
 
 ## What is Doppler?
@@ -40,6 +29,7 @@ There are a couple of fundamental differences between Doppler and Pulumi ESC. Do
 
 Here's a detailed comparison of the two:
 
+<div class="table-wrapper">
 <table>
     <tr>
         <th>Feature</th>
@@ -170,5 +160,6 @@ Here's a detailed comparison of the two:
         <td>No</td>
     </tr>
 </table>
+</div>
 
 {{< get-started-esc >}}

--- a/content/docs/esc/vs/infisical.md
+++ b/content/docs/esc/vs/infisical.md
@@ -13,17 +13,6 @@ menu:
 aliases:
 ---
 
-<style>
-    main table {
-        font-size: 0.94em;
-    }
-
-    main table th,
-    main table td {
-        width: 33.3%;
-    }
-</style>
-
 Choosing the right [secrets management](/what-is/what-is-secrets-management/) tool is important, and we want you to have as much information as possible to make the choice that best suits your needs. We’ve created this document to help you understand how Pulumi ESC compares with Infisical.
 
 ## What is Infisical?
@@ -40,6 +29,7 @@ There are a couple of fundamental differences between Infisical and Pulumi ESC. 
 
 Here's a detailed comparison of the two:
 
+<div class="table-wrapper">
 <table>
     <tr>
         <th>Feature</th>
@@ -170,5 +160,6 @@ Here's a detailed comparison of the two:
         <td>No</td>
     </tr>
 </table>
+</div>
 
 {{< get-started-esc >}}

--- a/content/docs/esc/vs/vault.md
+++ b/content/docs/esc/vs/vault.md
@@ -13,17 +13,6 @@ menu:
 aliases:
 ---
 
-<style>
-    main table {
-        font-size: 0.94em;
-    }
-
-    main table th,
-    main table td {
-        width: 33.3%;
-    }
-</style>
-
 Choosing the right [secrets management](/what-is/what-is-secrets-management/) tool is important, and we want you to have as much information as possible to make the choice that best suits your needs. We’ve created this document to help you understand how Pulumi ESC compares with HashiCorp Vault, and how ESC and Vault can be used together.
 
 ## What is HashiCorp Vault?
@@ -44,6 +33,7 @@ While there are differences and similarities between Pulumi ESC and Vault, they 
 
 Here is a summary of the key differences between Pulumi ESC and HashiCorp Vault:
 
+<div class="table-wrapper">
 <table>
     <tr>
         <th>Feature</th>
@@ -171,5 +161,6 @@ Here is a summary of the key differences between Pulumi ESC and HashiCorp Vault:
         <td>Limited, configuring Vault as an OIDC provider is only available from the CLI</td>
     </tr>
 </table>
+</div>
 
 {{< get-started-esc >}}

--- a/content/docs/iac/comparisons/terraform/opentofu.md
+++ b/content/docs/iac/comparisons/terraform/opentofu.md
@@ -18,17 +18,6 @@ aliases:
     - /docs/iac/concepts/vs/terraform/opentofu/
 ---
 
-<style>
-    main table {
-        font-size: 0.94em;
-    }
-
-    main table th,
-    main table td {
-        width: 33.3%;
-    }
-</style>
-
 OpenTofu and Terraform are both infrastructure as code technologies that have similarities but fundamental differences. They both provide infrastructure as code software for cloud service management with a consistent CLI workflow. They allow you to write, plan, and apply changes to deliver infrastructure as code. In this comprehensive guide, we'll explore their key differences and similarities to help you choose the right infrastructure as code platform to meet your needs.
 
 ## OpenTofu vs. Terraform: Similarities {#similarities}

--- a/content/docs/iac/comparisons/terraform/terminology.md
+++ b/content/docs/iac/comparisons/terraform/terminology.md
@@ -18,18 +18,6 @@ aliases:
 - /docs/iac/concepts/vs/terraform/terminology/
 ---
 
-<style>
-    main table {
-        font-size: 0.94em;
-        width: 100%;
-    }
-
-    main table th:first-child,
-    main table td:first-child {
-        width: 33%;
-    }
-</style>
-
 If you're already familiar with Terraform, learning Pulumi terminology and commands is simple. Many of the existing Terraform vocabulary and commands that you already know have direct equivalents in Pulumi. The table below lists common Terraform terms and CLI commands along with their Pulumi equivalents.
 
 ## Terminology

--- a/content/docs/install/versions.md
+++ b/content/docs/install/versions.md
@@ -29,16 +29,18 @@ aliases:
 
 The current stable version of Pulumi is **{{< latest-version >}}**.
 
+<div class="table-wrapper">
 <table>
     <thead>
         <tr>
             <th scope="col" width="20%">Version</th>
             <th scope="col" width="20%">Date</th>
             <th scope="col" colspan="3" width="40%">Downloads</th>
-            <th scope="col" width="20%">---</th>
+            <th scope="col" width="20%">Checksums</th>
         </tr>
     </thead>
     <tbody>
         {{< changelog-table-body >}}
     </tbody>
 </table>
+</div>

--- a/layouts/_default/_markup/render-table.html
+++ b/layouts/_default/_markup/render-table.html
@@ -1,0 +1,40 @@
+{{- /*
+  Table render hook: wraps every Markdown table in a horizontally
+  scrollable container (.table-wrapper) so wide tables scroll within
+  their own box instead of overflowing the docs grid. When the table
+  has a header row, each <td> also gets a data-label attribute (the
+  matching column header) so the table can reflow into stacked
+  "label: value" cards on narrow viewports. See theme/src/scss/_tables.scss.
+*/ -}}
+{{- $hasHead := gt (len .THead) 0 -}}
+{{- $headRow := slice -}}
+{{- if $hasHead -}}{{- $headRow = index .THead 0 -}}{{- end -}}
+<div class="table-wrapper{{ if $hasHead }} table-responsive{{ end }}">
+  <table
+    {{- range $k, $v := .Attributes }}
+      {{- if $v }}{{ printf " %s=%q" $k $v | safeHTMLAttr }}{{ end }}
+    {{- end }}>
+    {{- with .THead }}
+    <thead>
+      {{- range . }}
+      <tr>
+        {{- range . }}
+        <th{{ with .Alignment }} style="text-align: {{ . }};"{{ end }}>{{ .Text }}</th>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </thead>
+    {{- end }}
+    {{- with .TBody }}
+    <tbody>
+      {{- range . }}
+      <tr>
+        {{- range $i, $cell := . }}
+        <td{{ with $cell.Alignment }} style="text-align: {{ . }};"{{ end }}{{ if and $hasHead (lt $i (len $headRow)) }} data-label="{{ (index $headRow $i).Text | plainify }}"{{ end }}>{{ $cell.Text }}</td>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </tbody>
+    {{- end }}
+  </table>
+</div>

--- a/layouts/topics/serverless.html
+++ b/layouts/topics/serverless.html
@@ -40,52 +40,56 @@
                 minimal infrastructure concerns.
             </p>
 
+            <div class="table-wrapper table-responsive">
             <table>
                 <thead>
-                    <th>Building Block</th>
-                    <th>AWS</th>
-                    <th>Azure</th>
-                    <th>Google Cloud</th>
+                    <tr>
+                        <th>Building Block</th>
+                        <th>AWS</th>
+                        <th>Azure</th>
+                        <th>Google Cloud</th>
+                    </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td><a href="#code-api" class="link">API</a></td>
-                        <td>Lambda</td>
-                        <td>Functions</td>
-                        <td>Cloud Functions</td>
+                        <td data-label="Building Block"><a href="#code-api" class="link">API</a></td>
+                        <td data-label="AWS">Lambda</td>
+                        <td data-label="Azure">Functions</td>
+                        <td data-label="Google Cloud">Cloud Functions</td>
                     </tr>
                     <tr>
-                        <td><a href="#code-bucket" class="link">Storage</a></td>
-                        <td>S3</td>
-                        <td>Blob Storage</td>
-                        <td>Cloud Storage</td>
+                        <td data-label="Building Block"><a href="#code-bucket" class="link">Storage</a></td>
+                        <td data-label="AWS">S3</td>
+                        <td data-label="Azure">Blob Storage</td>
+                        <td data-label="Google Cloud">Cloud Storage</td>
                     </tr>
                     <tr>
-                        <td><a href="#code-table" class="link">Data Storage</a></td>
-                        <td>DynamoDB</td>
-                        <td>Cosmos DB</td>
-                        <td>Cloud Datatable</td>
+                        <td data-label="Building Block"><a href="#code-table" class="link">Data Storage</a></td>
+                        <td data-label="AWS">DynamoDB</td>
+                        <td data-label="Azure">Cosmos DB</td>
+                        <td data-label="Google Cloud">Cloud Datatable</td>
                     </tr>
                     <tr>
-                        <td><a href="#code-timer" class="link">Timer</a></td>
-                        <td>CloudWatch</td>
-                        <td>Monitor</td>
-                        <td>Stackdriver Monitoring</td>
+                        <td data-label="Building Block"><a href="#code-timer" class="link">Timer</a></td>
+                        <td data-label="AWS">CloudWatch</td>
+                        <td data-label="Azure">Monitor</td>
+                        <td data-label="Google Cloud">Stackdriver Monitoring</td>
                     </tr>
                     <tr>
-                        <td><a href="#code-queue" class="link">Queue</a></td>
-                        <td>SQS</td>
-                        <td>Queue Storage</td>
-                        <td>Cloud Pub/Sub</td>
+                        <td data-label="Building Block"><a href="#code-queue" class="link">Queue</a></td>
+                        <td data-label="AWS">SQS</td>
+                        <td data-label="Azure">Queue Storage</td>
+                        <td data-label="Google Cloud">Cloud Pub/Sub</td>
                     </tr>
                     <tr>
-                        <td><a href="#code-topic" class="link">Topic</a></td>
-                        <td>SNS</td>
-                        <td>Queue Storage</td>
-                        <td>Cloud Pub/Sub</td>
+                        <td data-label="Building Block"><a href="#code-topic" class="link">Topic</a></td>
+                        <td data-label="AWS">SNS</td>
+                        <td data-label="Azure">Queue Storage</td>
+                        <td data-label="Google Cloud">Cloud Pub/Sub</td>
                     </tr>
                 </tbody>
             </table>
+            </div>
             <p>Pulumi makes it simple to interact with serverless services available from the major cloud vendors, and with Kubernetes.</p>
         </div>
     </section>

--- a/theme/src/scss/_tables.scss
+++ b/theme/src/scss/_tables.scss
@@ -1,5 +1,20 @@
+// Tier 1: every Markdown table is wrapped in .table-wrapper by the table
+// render hook (layouts/_default/_markup/render-table.html). The wrapper
+// scrolls horizontally so wide tables stay inside the docs grid instead
+// of spilling into adjacent columns.
+.table-wrapper {
+    @apply block w-full max-w-full overflow-x-auto mb-4;
+    -webkit-overflow-scrolling: touch;
+
+    table {
+        @apply mb-0;
+    }
+}
+
 table {
-    @apply border-separate rounded bg-gray-200;
+    // Gridlines are the gray-200 background showing through the cell gaps.
+    // border-spacing-px (1px) makes them 1px thick instead of the 2px default.
+    @apply border-separate border-spacing-px rounded bg-gray-200;
 
     th,
     td {
@@ -7,10 +22,71 @@ table {
     }
 
     th {
-        @apply text-left text-sm text-gray-600 font-normal bg-gray-100;
+        @apply text-left text-sm text-gray-700 font-semibold bg-gray-100;
     }
 
     td {
         @apply bg-white;
+    }
+}
+
+// Tier 2: on narrow viewports, tables that carry column headers (and
+// therefore data-label attributes) reflow into stacked cards — one card
+// per row, each cell shown as a "label: value" pair, EUI-style.
+// Below the `md` breakpoint (768px) used by _mixins.scss screen-md.
+@media (max-width: 767.98px) {
+    .table-wrapper.table-responsive {
+        @apply overflow-x-visible;
+
+        table {
+            @apply block w-full bg-transparent rounded-none;
+        }
+
+        thead {
+            @apply sr-only;
+        }
+
+        tbody {
+            @apply block;
+        }
+
+        tr {
+            @apply block w-full mb-4 rounded border border-gray-300 overflow-hidden bg-white;
+
+            &:last-child {
+                @apply mb-0;
+            }
+        }
+
+        // Force full-width cells so any page-level column width (e.g. inline
+        // `width: 33.3%` styles on comparison pages) can't shrink the stacked
+        // cards. The class selectors here outrank element-level page rules.
+        th,
+        td {
+            @apply w-auto;
+        }
+
+        td {
+            @apply block text-left border-t border-gray-200;
+            // Break long, unbreakable tokens (e.g. inline <code>) instead of
+            // letting them overflow the card.
+            overflow-wrap: anywhere;
+
+            &:first-child {
+                @apply border-t-0;
+            }
+
+            // Stack the column header as a label above the value so wide
+            // content wraps naturally within the card.
+            &[data-label]::before {
+                content: attr(data-label);
+                @apply block mb-1 text-sm font-semibold text-gray-700;
+            }
+
+            // Empty headers (e.g. an icon-only column) get no label.
+            &[data-label=""]::before {
+                content: none;
+            }
+        }
     }
 }


### PR DESCRIPTION
Hello from human Jeff and his AI sidekick in the world of tomorrow! This adds responsive tables to resolve the issue from 2022. Also some minor style updates to tables: darker and semibold table headers plus thinner borders.

---

## What

Tables across the site weren't responsive — wide ones overflowed sideways or spilled out of the docs grid, and a few hand-rolled HTML tables forced cramped fixed-width columns (#11719).

This adds:

- **A table render hook** (`layouts/_default/_markup/render-table.html`) that wraps every Markdown table in a horizontally scrollable `.table-wrapper` and stamps each `<td>` with a `data-label` from its column header. No per-page edits — it applies site-wide.
- **Two tiers of CSS** in `theme/src/scss/_tables.scss`:
  - *Tier 1:* the wrapper scrolls horizontally so wide tables stay inside the grid.
  - *Tier 2:* below the `md` (768px) breakpoint, header-bearing tables reflow into stacked label/value cards. Cells are `display: block` with the label stacked above the value, so inline `<code>` and long text wrap cleanly instead of overflowing.
- **Raw-HTML table fixes:** the serverless topic table gets the full card reflow (and its malformed `<thead>` is fixed); the `esc/vs` comparisons and the CLI versions table get the scroll wrapper.
- **Cleanup:** removed the inline `width: 33.3%` `<style>` hacks on the `esc/vs` and Terraform comparison pages (the cause of the cramped columns), hardened the reflow CSS so stray page-level column widths can't shrink the mobile cards, and made the table gridlines 1px.

Blog and legal pages with raw HTML tables were intentionally left untouched.

## Test URLs

> Preview domain TBD — paths below. Narrow the window below ~768px to see the mobile card reflow.

**Full card reflow (Markdown tables + serverless):**
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/serverless/
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/iac/cli/environment-variables/
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/iac/comparisons/terraform/terminology/
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/iac/comparisons/terraform/opentofu/
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/iac/comparisons/opentofu/
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/esc/concepts/builtin-functions/fn-to-json/ _(inline `<code>` in cells)_

**Scroll wrapper (raw-HTML tables):**
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/esc/vs/vault/
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/esc/vs/infisical/
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/esc/vs/doppler/
- http://www-testing-pulumi-docs-origin-pr-19644-1a81392f.s3-website.us-west-2.amazonaws.com/docs/install/versions/

Fixes #11719

🤖 Generated with [Claude Code](https://claude.com/claude-code)