### PR TITLE
docs(deployments): strengthen ESC guidance and tidy OIDC guides

### DIFF
--- a/content/docs/deployments/deployments/cloud-credentials.md
+++ b/content/docs/deployments/deployments/cloud-credentials.md
@@ -16,12 +16,14 @@ menu:
 
 In order for a Pulumi IaC operation like `update` or `preview` work, the Pulumi CLI must be able to access credentials that will allow it to perform the necessary CRUD operations on the resources in your stack. In order for Pulumi Deployments to access the necessary cloud credentials to run your Pulumi operation there are two common approaches you can take:
 
-1. **Use [Pulumi Deployments' OIDC integration](/docs/deployments/deployments/oidc/)** where possible (we support [AWS](/docs/deployments/deployments/oidc/aws/), [Azure](/docs/deployments/deployments/oidc/azure/), and [Google Cloud](/docs/deployments/deployments/oidc/gcp/)), and store any remaining required secrets or configuration in [Pulumi Deployments Environment Variables](/docs/deployments/deployments/reference/#deployment-settings).
-2. **Use [Pulumi ESC](/docs/esc/)** to define an Environment (or Environments), and [import the environment(s) into your stack](/docs/esc/guides/integrate-with-pulumi-iac/).
+1. **Use [Pulumi ESC](/docs/esc/)** (recommended) to define an Environment (or Environments), and [import the environment(s) into your stack](/docs/esc/guides/integrate-with-pulumi-iac/).
+2. **Use [Pulumi Deployments' OIDC integration](/docs/deployments/deployments/oidc/)** where possible (we support [AWS](/docs/deployments/deployments/oidc/aws/), [Azure](/docs/deployments/deployments/oidc/azure/), and [Google Cloud](/docs/deployments/deployments/oidc/gcp/)), and store any remaining required secrets or configuration in [Pulumi Deployments Environment Variables](/docs/deployments/deployments/reference/#deployment-settings).
+
+Pulumi recommends Pulumi ESC for most users. See [Choosing between Pulumi ESC Environments and Pulumi Deployments OIDC](#choosing-between-pulumi-esc-environments-and-pulumi-deployments-oidc) below for details.
 
 ## Choosing between Pulumi ESC Environments and Pulumi Deployments OIDC
 
-Pulumi recommends using ESC Environments over Deployments OIDC for the following reasons:
+Deployments OIDC predates Pulumi ESC and was originally the only way to use OIDC with Deployments, which is why it remains a common default. It's still a good fit for some scenarios — for example, [customer-managed agents](/docs/deployments/deployments/runs/customer-managed-agents/) that can't reach Pulumi Cloud over the network to use ESC. For most users, though, Pulumi recommends using ESC Environments over Deployments OIDC for the following reasons:
 
 - Pulumi ESC Environments are more portable compared to Deployments OIDC: Ignoring any locally stored credentials, e.g., environment variables set in your command shell, you can have greater confidence that a Pulumi Deployments operation will succeed if it succeeds on your local machine.
 - Pulumi ESC Environments are more modular compared to Deployments OIDC: Deployments settings are applied on a per-stack basis, which means that the OIDC configuration must be repeated for every stack that is using Deployments OIDC. In comparison, Pulumi ESC Environments are centrally defined and may be imported into any number of Pulumi stacks.

--- a/content/docs/deployments/deployments/oidc/_index.md
+++ b/content/docs/deployments/deployments/oidc/_index.md
@@ -21,9 +21,7 @@ aliases:
 
 Pulumi Deployments supports OpenID Connect (OIDC) integration with popular cloud providers. In order for a Pulumi IaC operation like `update` or `preview` to work, the Pulumi CLI must be able to access credentials that will allow it to perform the necessary CRUD operations on the resources in your stack. Pulumi Deployments' OIDC integrations allow your deployments to use dynamic, short-lived cloud credentials for supported clouds instead of static credentials which are less secure and difficult to rotate. This page explains how to set up OIDC for Pulumi Deployments to access resources in your cloud provider accounts.
 
-{{% notes type="info" %}}
-There are multiple approaches for supplying cloud credentials to Pulumi Deployments. For guidance on choosing between Deployments OIDC and Pulumi ESC, see [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/deployments/cloud-credentials/).
-{{% /notes %}}
+{{< esc-recommendation >}}
 
 ## Overview
 

--- a/content/docs/deployments/deployments/oidc/aws.md
+++ b/content/docs/deployments/deployments/oidc/aws.md
@@ -21,51 +21,60 @@ aliases:
   - /docs/pulumi-cloud/oidc/provider/aws/
 ---
 
-{{% notes type="info" %}}
-There are multiple approaches for supplying cloud credentials to Pulumi Deployments. For guidance on choosing between Deployments OIDC and Pulumi ESC, see [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/deployments/cloud-credentials/).
-{{% /notes %}}
+{{< esc-recommendation >}}
 
 This document outlines the steps required to configure Pulumi Deployments to use OpenID Connect to authenticate with AWS. OIDC in AWS uses a web identity provider to assume an IAM role. Access to the IAM role is authorized using a trust policy that validates the contents of the OIDC token issued by Pulumi Cloud.
 
-## Create the identity provider
+Configuring OIDC for AWS involves two sides:
+
+1. **AWS** — register Pulumi Cloud as an OIDC identity provider and create an IAM role that trusts it. You can do this in the [AWS console](#using-the-aws-console) or [programmatically](#using-infrastructure-as-code).
+1. **Pulumi Deployments** — enable the AWS OIDC integration for your stack so that each deployment exchanges its OIDC token for credentials from that role. You can do this in the [Pulumi Cloud console](#using-the-pulumi-cloud-console) or [programmatically with the Pulumi Service provider](#using-infrastructure-as-code-1).
+
+## Configure AWS
+
+{{% notes type="info" %}}
+Deployments must authenticate against an OIDC provider in **each** AWS account it deploys to, and AWS allows only **one** OIDC provider per URL in an account. Register the `https://api.pulumi.com/oidc` provider once per account. If it already exists — for example, because you also use it with [Pulumi ESC](/docs/esc/guides/configuring-oidc/aws/) or configured Deployments OIDC previously — don't create a second one. Instead, add only an IAM role that trusts the existing provider, and confirm your Pulumi organization is listed among the provider's audiences (adding one if needed, as described [below](#using-infrastructure-as-code)).
+{{% /notes %}}
+
+### Using the AWS console
+
+#### Create the identity provider
 
 1. In the navigation pane of the [IAM console](https://console.aws.amazon.com/iam/), choose **Identity providers**, and then choose **Add provider**.
-  {{< video title="Starting the Create Identity Provider wizard" src="https://www.pulumi.com/uploads/create-idp-start.mp4" autoplay="true" loop="true" >}}
-2. In the **Provider type** section, click the radio button next to **OpenID Connect**.
-3. For the **Provider URL**, provide the following URL: `https://api.pulumi.com/oidc`
-4. For the **Audience** field, enter the name of your Pulumi organization. Then select **Add provider**.
+1. In the **Provider type** section, click the radio button next to **OpenID Connect**.
+1. For the **Provider URL**, provide the following URL: `https://api.pulumi.com/oidc`
+1. For the **Audience** field, enter the name of your Pulumi organization. Then select **Add provider**.
 
-## Configure the IAM role and trust policy
+{{% notes type="info" %}}
+The audience must exactly match your Pulumi organization name, which is always lowercase (the value shown in the Pulumi Console URL, `app.pulumi.com/<org>`). AWS compares the token's `aud` claim using a case-sensitive `StringEquals` condition — on both the provider's registered audience and the role's trust policy — so entering it with different casing (for example, a capitalized display name) causes the credential exchange to fail with no obvious error.
+{{% /notes %}}
+
+#### Configure the IAM role and trust policy
 
 Once you have created the identity provider, you will see a notification at the top of your screen prompting you to assign an IAM role.
 
 1. Select the **Assign role** button.
-2. Select the **Create a new role** option, then select **Next**.
-  {{< video title="Prompt for assigning IAM role" src="https://www.pulumi.com/uploads/assign-iam-role-prompt.mp4" autoplay="true" loop="true" >}}
-3. On the IAM **Create role** page, ensure the **Web identity** radio button is selected.
-4. In the **Web identity** section:
+1. Select the **Create a new role** option, then select **Next**.
+1. On the IAM **Create role** page, ensure the **Web identity** radio button is selected.
+1. In the **Web identity** section:
     * Select `api.pulumi.com/oidc` under **Identity provider**.
     * Select the name of your Pulumi organization under **Audience**. Then select **Next**.
-  {{< video title="Create IAM role wizard" src="https://www.pulumi.com/uploads/create-role-wizard.mp4" autoplay="true" loop="true" >}}
-5. On the **Add permissions** page, select the permissions that you want to grant to your Pulumi deployments. Then select **Next**.
+1. On the **Add permissions** page, select the permissions that you want to grant to your Pulumi deployments. Then select **Next**.
+1. Provide a name and optional description for the IAM role. Then select **Create role**.
 
-    {{% notes type="info" %}}
-Many Pulumi programs create IAM roles, policies, or instance profiles (e.g., for Lambda, ECS, or EKS), which require IAM permissions. While `AdministratorAccess` is the simplest policy that covers all services including IAM, it is broader than most workloads need. For better security, consider one of these alternatives:
+Make a note of the IAM role's ARN; it will be necessary to enable OIDC for your deployment.
+
+{{% notes type="info" %}}
+When choosing permissions on the **Add permissions** step above, keep in mind that many Pulumi programs create IAM roles, policies, or instance profiles (e.g., for Lambda, ECS, or EKS), which require IAM permissions. While `AdministratorAccess` is the simplest policy that covers all services including IAM, it is broader than most workloads need. For better security, consider one of these alternatives:
 
 * **PowerUserAccess + IAMFullAccess** — provides broad service access with IAM permissions but excludes AWS Organizations management.
 * **Custom least-privilege policy** — scoped to only the AWS services and IAM actions your Pulumi program uses (e.g., `ec2:*`, `s3:*`, `iam:CreateRole`, `iam:AttachRolePolicy`, `iam:PassRole`).
 * **Permissions boundary** — use a broader role policy but attach an [IAM permissions boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) to cap the privileges of any IAM entities that Pulumi creates, preventing privilege escalation.
 
 You can also further constrain the assumed role session using the **Policy ARNs** field in the Pulumi Deployments OIDC configuration.
-    {{% /notes %}}
+{{% /notes %}}
 
-  {{< video title="Adding S3 permissions to IAM role" src="https://www.pulumi.com/uploads/create-role-add-perms.mp4" autoplay="true" loop="true" >}}
-6. Provide a name and optional description for the IAM role. Then select **Create role**.
-  {{< video title="Adding name and description to role then creating it" src="https://www.pulumi.com/uploads/create-role.mp4" autoplay="true" loop="true" >}}
-
-Make a note of the IAM role's ARN; it will be necessary to enable OIDC for your deployment.
-
-### Restricting role assumption to Pulumi Cloud scopes
+##### Restricting role assumption to Pulumi Cloud scopes
 
 The following restricts to any deployment in your organization:
 
@@ -95,21 +104,97 @@ The following restricts to any stack within a specific project:
 
 The subject claim also includes the stack name and operation, so you can restrict further. See the [full subject format and custom claims](/docs/deployments/deployments/oidc/#custom-claims) for details.
 
-## Configure OIDC via the Pulumi console
+### Using infrastructure as code
 
-{{% notes type="info" %}}
-In addition to the Pulumi Console, deployment settings including OIDC can be configured for a stack using the [pulumiservice.DeploymentSettings](https://www.pulumi.com/registry/packages/pulumiservice/api-docs/deploymentsettings/) resource or via the [REST API](/docs/deployments/deployments/api/#patchsettings).
+You can register the identity provider and create the IAM role with a Pulumi program instead of the console. The following example uses TypeScript and the [AWS provider](/registry/packages/aws/); the same resources are available in every Pulumi language.
+
+```typescript
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const org = "<your-org-name>";
+
+// Register Pulumi Cloud as an OIDC identity provider. The audience (clientIdLists)
+// is your Pulumi organization name.
+const provider = new aws.iam.OpenIdConnectProvider("pulumi-deployments-oidc", {
+    url: "https://api.pulumi.com/oidc",
+    clientIdLists: [org],
+});
+
+// Create the IAM role that deployments will assume, trusting the provider above.
+const role = new aws.iam.Role("pulumi-deployments-oidc", {
+    assumeRolePolicy: pulumi.jsonStringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Effect: "Allow",
+            Principal: { Federated: provider.arn },
+            Action: "sts:AssumeRoleWithWebIdentity",
+            Condition: {
+                StringEquals: { "api.pulumi.com/oidc:aud": org },
+                StringLike: { "api.pulumi.com/oidc:sub": `pulumi:deploy:org:${org}:*` },
+            },
+        }],
+    }),
+});
+
+// Attach the permissions your deployments need. Scope this down for production.
+new aws.iam.RolePolicyAttachment("pulumi-deployments-oidc", {
+    role: role.name,
+    policyArn: "arn:aws:iam::aws:policy/AdministratorAccess",
+});
+
+export const roleArn = role.arn;
+```
+
+{{% notes type="warning" %}}
+AWS allows only **one** OIDC identity provider per URL per account, and there is no standalone resource for managing a provider's audiences. If `https://api.pulumi.com/oidc` is already registered in your account — for example, because you also use it with [Pulumi ESC](/docs/esc/guides/configuring-oidc/aws/) — recreating it with Pulumi will conflict. To add your organization as an additional audience on the existing provider, use the AWS CLI:
+
+```bash
+aws iam add-client-id-to-open-id-connect-provider \
+  --open-id-connect-provider-arn arn:aws:iam::<account-id>:oidc-provider/api.pulumi.com/oidc \
+  --client-id <your-org-name>
+```
+
 {{% /notes %}}
 
+## Configure Pulumi Deployments
+
+### Using the Pulumi Cloud console
+
 1. Navigate to your stack in the Pulumi Console.
-2. Open the stack's "Settings" tab.
-3. Choose the "Deploy" panel.
-4. Under the "OpenID Connect" header, toggle "Enable AWS Integration".
-5. Enter the ARN of the IAM role created above in the "Role ARN" field.
-6. Enter a name for the assumed role session in the "Session Name" field. See [Session name](#session-name) for the supported template variables.
-7. If you would like to use additional policies to further constrain the session's capabilities, enter the policies' ARNs separated by commas in the "Policy ARNs" field.
-8. If you would like to constrain the duration of the assumed role session, enter a duration in the form "XhYmZs" in the "Session Duration" field.
-9. Select the "Save deployment configuration" button.
+1. Open the stack's "Settings" tab.
+1. Choose the "Deploy" panel.
+1. Under the "OpenID Connect" header, toggle "Enable AWS Integration".
+1. Enter the ARN of the IAM role created above in the "Role ARN" field.
+1. Enter a name for the assumed role session in the "Session Name" field. See [Session name](#session-name) for the supported template variables.
+1. If you would like to use additional policies to further constrain the session's capabilities, enter the policies' ARNs separated by commas in the "Policy ARNs" field.
+1. If you would like to constrain the duration of the assumed role session, enter a duration in the form "XhYmZs" in the "Session Duration" field.
+1. Select the "Save deployment configuration" button.
+
+### Using infrastructure as code
+
+You can manage the same deployment settings in source control with the [`pulumiservice.DeploymentSettings`](/registry/packages/pulumiservice/api-docs/deploymentsettings/) resource (the OIDC configuration is set under `operationContext.oidc.aws`). Deployment settings can also be configured via the [REST API](/docs/deployments/deployments/api/#patchsettings).
+
+```typescript
+import * as pulumiservice from "@pulumi/pulumiservice";
+
+new pulumiservice.DeploymentSettings("deployment-settings", {
+    organization: "<your-org-name>",
+    project: "<your-project-name>",
+    stack: "<your-stack-name>",
+    operationContext: {
+        oidc: {
+            aws: {
+                roleARN: "<your-oidc-iam-role-arn>",
+                sessionName: "pulumi-deployments",
+                // Optional: further constrain the session.
+                // policyARNs: ["arn:aws:iam::aws:policy/ReadOnlyAccess"],
+                // duration: "1h",
+            },
+        },
+    },
+});
+```
 
 With this configuration, each deployment of this stack will attempt to exchange the deployment's OIDC token for AWS credentials using the specified IAM role prior to running any pre-commands or Pulumi operations. The fetched credentials are published in the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` environment variables. The raw OIDC token is also available for advanced scenarios in the `PULUMI_OIDC_TOKEN` environment variable and the `/mnt/pulumi/pulumi.oidc` file.
 

--- a/content/docs/deployments/deployments/oidc/azure.md
+++ b/content/docs/deployments/deployments/oidc/azure.md
@@ -21,11 +21,14 @@ aliases:
   - /docs/pulumi-cloud/oidc/provider/azure/
 ---
 
-{{% notes type="info" %}}
-There are multiple approaches for supplying cloud credentials to Pulumi Deployments. For guidance on choosing between Deployments OIDC and Pulumi ESC, see [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/deployments/cloud-credentials/).
-{{% /notes %}}
+{{< esc-recommendation >}}
 
 This document outlines the steps required to configure Pulumi Deployments to use OpenID Connect to authenticate with Azure. OIDC in Azure uses [workload identity federation](https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation) to access Azure resources via a Microsoft Entra App. Access to the temporary credentials is authorized using federated credentials that validate the contents of the OIDC token issued by Pulumi Cloud.
+
+Configuring OIDC for Azure involves two sides:
+
+1. **Azure** — register a Microsoft Entra application with federated credentials that trust Pulumi Cloud, and grant its service principal access to your resources. You can do this in the [Azure portal](#using-the-azure-portal) or [programmatically](#using-infrastructure-as-code).
+1. **Pulumi Deployments** — enable the Azure OIDC integration for your stack so that each deployment exchanges its OIDC token for credentials from that application. You can do this in the [Pulumi Cloud console](#using-the-pulumi-cloud-console) or [programmatically with the Pulumi Service provider](#using-infrastructure-as-code-1).
 
 ## Prerequisites
 
@@ -35,14 +38,18 @@ This document outlines the steps required to configure Pulumi Deployments to use
 Please note that this guide provides step-by-step instructions based on the official provider documentation which is subject to change. For the most current and precise information, always refer to the [official Azure documentation](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal).
 {{< /notes >}}
 
-## Create a Microsoft Entra application
+## Configure Azure
+
+### Using the Azure portal
+
+#### Create a Microsoft Entra application
 
 In the navigation pane of the [Microsoft Entra console](https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Overview):
 
 1. Select **App registrations** and then click **New registration**.
-2. Provide a name for your application (ex: `pulumi-deployments-oidc-app`).
-3. In the **Supported account types** section, select **Accounts in this organizational directory only**.
-4. Click **Register**.
+1. Provide a name for your application (ex: `pulumi-deployments-oidc-app`).
+1. In the **Supported account types** section, select **Accounts in this organizational directory only**.
+1. Click **Register**.
 
 After the Microsoft Entra application has been created, take note of the following details:
 
@@ -52,21 +59,21 @@ After the Microsoft Entra application has been created, take note of the followi
 
 These values will be necessary when enabling OIDC for your service.
 
-## Add federated credentials
+#### Add federated credentials
 
 Once you have created your new application registration, you will be redirected to the application's **Overview** page. In the left navigation menu:
 
 1. Navigate to the **Certificates & secrets** pane.
-2. Select the **Federated credentials** tab.
-3. Click on the **Add credential** button. This will start the "Add a credential" wizard.
-4. In the wizard, select **Other Issuer** as the **Federated credential scenario**.
-5. Fill in the remaining form fields as follows:
+1. Select the **Federated credentials** tab.
+1. Click on the **Add credential** button. This will start the "Add a credential" wizard.
+1. In the wizard, select **Other Issuer** as the **Federated credential scenario**.
+1. Fill in the remaining form fields as follows:
     * **Issuer:** `https://api.pulumi.com/oidc`
     * **Subject Identifier:** must be a valid subject claim (see examples at the end of this section).
     * **Name:** An arbitrary name for the credential, e.g. "pulumi-oidc-credentials".
     * **Audience:** Enter the name of your Pulumi organization.
 
-### Subject claim examples
+##### Subject claim examples
 
 Because Azure's federated credentials require that the subject identifier exactly matches an OIDC token's subject claim, this process must be repeated for each permutation of the subject claim that is possible for a stack. For example, in order to enable all of the valid operations on a stack named `dev` of the `core` project in the `contoso` organization, you would need to create credentials for each of the following subject identifiers:
 
@@ -75,34 +82,108 @@ Because Azure's federated credentials require that the subject identifier exactl
 * `pulumi:deploy:org:contoso:project:core:stack:dev:operation:refresh:scope:write`
 * `pulumi:deploy:org:contoso:project:core:stack:dev:operation:destroy:scope:write`
 
-## Create a service principal
+#### Create a service principal
 
 To provide Pulumi services the ability to deploy, manage, and interact with Azure resources, you need to associate your Microsoft Entra application with your Subscription or Resource Group.
 
 1. Navigate to the [Subscriptions](https://portal.azure.com/#view/Microsoft_Azure_Billing/SubscriptionsBladeV1) page of the Azure portal.
-2. Select the subscription to create the service principal in.
+1. Select the subscription to create the service principal in.
     * If you want to limit access to a specific resource group, go to the [Resource Groups](https://portal.azure.com/#view/HubsExtension/BrowseResourceGroups) page instead and select the desired resource group.
-3. In the left navigation menu, select **Access control (IAM)**.
-4. Click **Add** > **Add role assignment** to be taken to the **Add role assignment** wizard.
-5. Under the **Job function roles** tab, select the desired role from the list, then click **Next**.
-6. Select **User, group, or service principal**, then click **Select members**
-7. Enter the name of the application you created in a previous step, select it from the list, then click **Select**.
-8. Click **Next** and then **Review + assign**.
+1. In the left navigation menu, select **Access control (IAM)**.
+1. Click **Add** > **Add role assignment** to be taken to the **Add role assignment** wizard.
+1. Under the **Job function roles** tab, select the desired role from the list, then click **Next**.
+1. Select **User, group, or service principal**, then click **Select members**
+1. Enter the name of the application you created in a previous step, select it from the list, then click **Select**.
+1. Click **Next** and then **Review + assign**.
 
-## Configure OIDC in the Pulumi console
+### Using infrastructure as code
 
-{{% notes "info" %}}
-In addition to the Pulumi Console, deployment settings including OIDC can be configured for a stack using the [pulumiservice.DeploymentSettings](https://www.pulumi.com/registry/packages/pulumiservice/api-docs/deploymentsettings/) resource or via the [REST API](/docs/deployments/deployments/api/#patchsettings).
-{{% /notes %}}
+You can create the Entra application, federated credentials, service principal, and role assignment with a Pulumi program instead of the portal. The following example uses TypeScript with the [Azure AD provider](/registry/packages/azuread/) and the [Azure Native provider](/registry/packages/azure-native/); the same resources are available in every Pulumi language.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as azuread from "@pulumi/azuread";
+import * as authorization from "@pulumi/azure-native/authorization";
+
+const org = "contoso";
+const project = "core";
+const stack = "dev";
+
+const current = authorization.getClientConfigOutput();
+
+// Register an Entra application and a matching service principal.
+const app = new azuread.Application("pulumi-deployments-oidc", {
+    displayName: "pulumi-deployments-oidc",
+});
+
+const servicePrincipal = new azuread.ServicePrincipal("pulumi-deployments-oidc", {
+    clientId: app.clientId,
+});
+
+// Grant the service principal access to your subscription. "Contributor" is shown
+// here; scope this down for production.
+const contributorRoleId = "b24988ac-6180-42a0-ab88-20f7382dd24c";
+const subscriptionScope = pulumi.interpolate`/subscriptions/${current.subscriptionId}`;
+
+new authorization.RoleAssignment("pulumi-deployments-contributor", {
+    principalId: servicePrincipal.id,
+    principalType: "ServicePrincipal",
+    roleDefinitionId: pulumi.interpolate`${subscriptionScope}/providers/Microsoft.Authorization/roleDefinitions/${contributorRoleId}`,
+    scope: subscriptionScope,
+});
+
+// Azure federated credentials require an exact subject match (no wildcards), so add
+// one credential per operation.
+for (const operation of ["preview", "update", "refresh", "destroy"]) {
+    new azuread.ApplicationFederatedIdentityCredential(`cred-${operation}`, {
+        applicationId: app.id,
+        displayName: operation,
+        issuer: "https://api.pulumi.com/oidc",
+        audiences: [org],
+        subject: `pulumi:deploy:org:${org}:project:${project}:stack:${stack}:operation:${operation}:scope:write`,
+    });
+}
+
+export const clientId = app.clientId;
+export const tenantId = current.tenantId;
+export const subscriptionId = current.subscriptionId;
+```
+
+## Configure Pulumi Deployments
+
+### Using the Pulumi Cloud console
 
 1. Navigate to your stack in the [Pulumi Console](https://app.pulumi.com/signin).
-2. Open the stack's **Settings** tab.
-3. Choose the **Deploy** panel.
-4. Under the **OpenID Connect** header, toggle **Enable Azure Integration**.
-5. Enter the client and tenant IDs for the app registration created above in the **Client ID** and **Tenant ID** fields, respectively.
-6. Enter the ID of the subscription you want to use in the **Subscription ID** field.
-7. Click the **Save deployment configuration** button.
+1. Open the stack's **Settings** tab.
+1. Choose the **Deploy** panel.
+1. Under the **OpenID Connect** header, toggle **Enable Azure Integration**.
+1. Enter the client and tenant IDs for the app registration created above in the **Client ID** and **Tenant ID** fields, respectively.
+1. Enter the ID of the subscription you want to use in the **Subscription ID** field.
+1. Click the **Save deployment configuration** button.
+
+### Using infrastructure as code
+
+You can manage the same deployment settings in source control with the [`pulumiservice.DeploymentSettings`](/registry/packages/pulumiservice/api-docs/deploymentsettings/) resource (the OIDC configuration is set under `operationContext.oidc.azure`). Deployment settings can also be configured via the [REST API](/docs/deployments/deployments/api/#patchsettings).
+
+```typescript
+import * as pulumiservice from "@pulumi/pulumiservice";
+
+new pulumiservice.DeploymentSettings("deployment-settings", {
+    organization: "contoso",
+    project: "core",
+    stack: "dev",
+    operationContext: {
+        oidc: {
+            azure: {
+                clientId: "<application-client-id>",
+                tenantId: "<directory-tenant-id>",
+                subscriptionId: "<subscription-id>",
+            },
+        },
+    },
+});
+```
 
 With this configuration, each deployment of this stack will attempt to exchange the deployment's OIDC token for Azure credentials using the specified AAD App prior to running any pre-commands or Pulumi operations. The fetched credentials are published in the `ARM_CLIENT_ID`, `ARM_TENANT_ID`,  and `ARM_SUBSCRIPTION_ID` environment variables. The raw OIDC token is also available for advanced scenarios in the `PULUMI_OIDC_TOKEN` environment variable and the `/mnt/pulumi/pulumi.oidc` file.
 
-If you want an example of how to automate the configuration of OIDC for Pulumi Deployments with Azure, you can refer to [this TypeScript example](https://github.com/pulumi/workshops/blob/main/az-pulumi-deployments/az-oidc-setup/index.ts).
+For a full end-to-end example that configures both sides together, see [this TypeScript example](https://github.com/pulumi/workshops/blob/main/az-pulumi-deployments/az-oidc-setup/index.ts).

--- a/content/docs/deployments/deployments/oidc/gcp.md
+++ b/content/docs/deployments/deployments/oidc/gcp.md
@@ -21,11 +21,14 @@ aliases:
   - /docs/pulumi-cloud/oidc/provider/gcp/
 ---
 
-{{% notes type="info" %}}
-There are multiple approaches for supplying cloud credentials to Pulumi Deployments. For guidance on choosing between Deployments OIDC and Pulumi ESC, see [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/deployments/cloud-credentials/).
-{{% /notes %}}
+{{< esc-recommendation >}}
 
 This document outlines the steps required to configure Pulumi Deployments to use OpenID Connect to authenticate with Google Cloud. OIDC in Google Cloud uses [workload identity federation](https://cloud.google.com/iam/docs/workload-identity-federation) to allow access to resources. Access to the resources is authorized using attribute conditions that validate the contents of the OIDC token issued by Pulumi Cloud.
+
+Configuring OIDC for Google Cloud involves two sides:
+
+1. **Google Cloud** — create a workload identity pool and OIDC provider that trust Pulumi Cloud, and a service account your deployments can impersonate. You can do this in the [Google Cloud console](#using-the-google-cloud-console) or [programmatically](#using-infrastructure-as-code).
+1. **Pulumi Deployments** — enable the Google Cloud OIDC integration for your stack so that each deployment exchanges its OIDC token for credentials from that service account. You can do this in the [Pulumi Cloud console](#using-the-pulumi-cloud-console) or [programmatically with the Pulumi Service provider](#using-infrastructure-as-code-1).
 
 ## Prerequisites
 
@@ -35,43 +38,47 @@ This document outlines the steps required to configure Pulumi Deployments to use
 Please note that this guide provides step-by-step instructions based on the official provider documentation which is subject to change. For the most current and precise information, always refer to the official [Google Cloud documentation](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers).
 {{< /notes >}}
 
-## Create a Workload Identity Pool and Provider
+## Configure Google Cloud
+
+### Using the Google Cloud console
+
+#### Create a workload identity pool and provider
 
 1. Navigate to the [Workload Identity Pools page](https://console.cloud.google.com/projectselector2/iam-admin/workload-identity-pools) in the Google Cloud console.
-2. Select your Google Cloud project.
-3. Click the **Create Pool** button.
-4. Provide a name and an optional description, then click **Continue**
-5. In the **Add a provider to pool** dropdown, select **OpenID Connect (OIDC)**.
-6. Provide a name for the provider.
-7. In the **Issuer** field, enter `https://api.pulumi.com/oidc`.
-8. In the **Audiences** section, select the **Allowed audiences** radio button. Enter the name of your Pulumi organization. Then click **Continue**.
-9. In the **Configure provider attributes** section, provide the value of `assertion.sub` in the **OIDC 1** field. Then click **Save**.
+1. Select your Google Cloud project.
+1. Click the **Create Pool** button.
+1. Provide a name and an optional description, then click **Continue**
+1. In the **Add a provider to pool** dropdown, select **OpenID Connect (OIDC)**.
+1. Provide a name for the provider.
+1. In the **Issuer** field, enter `https://api.pulumi.com/oidc`.
+1. In the **Audiences** section, select the **Allowed audiences** radio button. Enter the name of your Pulumi organization. Then click **Continue**.
+1. In the **Configure provider attributes** section, provide the value of `assertion.sub` in the **OIDC 1** field. Then click **Save**.
 
-## Configure a Service Account
+#### Configure a service account
 
-Once you have created your workload identity pool and provider, you will be directed to the pool details page. If you already have an appropriate service account created, skip ahead to the steps found in the [Grant access to the service account](/docs/pulumi-cloud/oidc/provider/gcp/#grant-access-to-the-service-account) section. Otherwise, continue through the steps below to create a new one.
+Once you have created your workload identity pool and provider, you will be directed to the pool details page. If you already have an appropriate service account created, skip ahead to the steps found in the [Grant access to the service account](#grant-access-to-the-service-account) section. Otherwise, continue through the steps below to create a new one.
 
-### Create a new service account
+##### Create a new service account
 
 1. Navigate to the [Service Accounts](https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts) page.
-2. Select your Google Cloud project.
-3. Click "Create Service Account".
-4. Enter a value for the **Service account name** field. Then click **Create And Continue**
+1. Select your Google Cloud project.
+1. Click "Create Service Account".
+1. Enter a value for the **Service account name** field. Then click **Create And Continue**
     * The **Service account ID** field will auto-populate based on this value.
-5. In the **Grant this service account access to project** section, select the role(s) that provides the relevant access to your Pulumi service. Then click **Continue**.
-6. Leave the values in the next section blank and click **Done**.
+1. In the **Grant this service account access to project** section, select the role(s) that provides the relevant access to your Pulumi service. Then click **Continue**.
+1. Leave the values in the next section blank and click **Done**.
 
-### Grant access to the service account
+##### Grant access to the service account
 
 1. In your workload identity pool's details page, click the **Grant Access** button.
-2. In the **Select service account** dropdown, select the desired service account to associate with the pool.
-3. Under the **Select principals** section, click the **Only identities matching the filter** radio button.
-4. In the **Attribute name** dropdown, select **Subject**.
-5. In the **Attribute value** field, provide a valid subject claim (see examples at the end of this section). Then click **Save**.
+1. In the **Select service account** dropdown, select the desired service account to associate with the pool.
+1. Under the **Select principals** section, click the **Only identities matching the filter** radio button.
+1. In the **Attribute name** dropdown, select **Subject**.
+1. In the **Attribute value** field, provide a valid subject claim (see examples at the end of this section). Then click **Save**.
 
 Make a note of the project number, workload identity pool ID, provider ID, and service account email address from the previous steps. These will be necessary to enable OIDC for your service.
 
-### Subject claim examples
+##### Subject claim examples
 
 To enable valid operations on a specific stack, Google federated credentials require an exact match on the OIDC token subject claim. Unfortunately, the subject identifier does *not* currently allow wildcards. Therefore, you must create credentials for each permutation of the subject claim that is possible for the stack.
 
@@ -82,20 +89,103 @@ For example, to enable all of the valid operations on a stack named `dev` of the
 * `pulumi:deploy:org:contoso:project:core:stack:dev:operation:refresh:scope:write`
 * `pulumi:deploy:org:contoso:project:core:stack:dev:operation:destroy:scope:write`
 
-## Configure OIDC in the Pulumi Console
+### Using infrastructure as code
 
-{{% notes "info" %}}
-In addition to the Pulumi Console, deployment settings including OIDC can be configured for a stack using the [pulumiservice.DeploymentSettings](https://www.pulumi.com/registry/packages/pulumiservice/api-docs/deploymentsettings/) resource or via the [REST API](/docs/deployments/deployments/api/#patchsettings).
-{{% /notes %}}
+You can create the workload identity pool, provider, and service account with a Pulumi program instead of the console. The following example uses TypeScript and the [Google Cloud provider](/registry/packages/gcp/); the same resources are available in every Pulumi language.
+
+```typescript
+import * as gcp from "@pulumi/gcp";
+import * as pulumi from "@pulumi/pulumi";
+
+const org = "contoso";
+const project = "core";
+const stack = "dev";
+
+const gcpProjectId = "<your-gcp-project-id>";         // e.g. "my-project"
+const gcpProjectNumber = "<your-gcp-project-number>"; // e.g. "123456789012"
+
+// Create a workload identity pool and an OIDC provider that trusts Pulumi Cloud.
+const pool = new gcp.iam.WorkloadIdentityPool("pulumi-deployments", {
+    workloadIdentityPoolId: "pulumi-deployments",
+});
+
+const poolProvider = new gcp.iam.WorkloadIdentityPoolProvider("pulumi-deployments", {
+    workloadIdentityPoolId: pool.workloadIdentityPoolId,
+    workloadIdentityPoolProviderId: "pulumi-deployments",
+    attributeMapping: {
+        "google.subject": "assertion.sub",
+    },
+    oidc: {
+        issuerUri: "https://api.pulumi.com/oidc",
+        allowedAudiences: [org],
+    },
+});
+
+// Create a service account with the permissions your deployments need.
+const account = new gcp.serviceaccount.Account("pulumi-deployments", {
+    accountId: "pulumi-deployments",
+    displayName: "Pulumi Deployments OIDC",
+});
+
+new gcp.projects.IAMMember("pulumi-deployments-editor", {
+    project: gcpProjectId,
+    role: "roles/editor",
+    member: pulumi.interpolate`serviceAccount:${account.email}`,
+});
+
+// Google federated credentials require an exact subject match (no wildcards), so bind
+// one principal per operation to let it impersonate the service account.
+for (const operation of ["preview", "update", "refresh", "destroy"]) {
+    const subject = `pulumi:deploy:org:${org}:project:${project}:stack:${stack}:operation:${operation}:scope:write`;
+    new gcp.serviceaccount.IAMMember(`wif-${operation}`, {
+        serviceAccountId: account.name,
+        role: "roles/iam.workloadIdentityUser",
+        member: pulumi.interpolate`principal://iam.googleapis.com/projects/${gcpProjectNumber}/locations/global/workloadIdentityPools/${pool.workloadIdentityPoolId}/subject/${subject}`,
+    });
+}
+
+export const workloadPoolId = pool.workloadIdentityPoolId;
+export const providerId = poolProvider.workloadIdentityPoolProviderId;
+export const serviceAccountEmail = account.email;
+```
+
+## Configure Pulumi Deployments
+
+### Using the Pulumi Cloud console
 
 1. Navigate to your stack in the Pulumi Console.
-2. Open the stack's "Settings" tab.
-3. Choose the "Deploy" panel.
-4. Under the "OpenID Connect" header, toggle "Enable Google Cloud Integration".
-5. Enter the numerical ID of your Google Cloud project in the "Project Number" field.
-6. Enter the workload pool ID, identity provider ID, and service account email address in the "Workload Pool ID", "Identity Provider ID", and "Service Account Email Address" fields.
-7. If desired, enter the stack's Google Cloud region in the "Region" field. This is typically unnecessary.
-8. If you would like to constrain the duration of the temporary Google Cloud credentials, enter a duration in the form "XhYmZs" in the "Session Duration" field.
-9. Click the "Save deployment configuration" button.
+1. Open the stack's "Settings" tab.
+1. Choose the "Deploy" panel.
+1. Under the "OpenID Connect" header, toggle "Enable Google Cloud Integration".
+1. Enter the numerical ID of your Google Cloud project in the "Project Number" field.
+1. Enter the workload pool ID, identity provider ID, and service account email address in the "Workload Pool ID", "Identity Provider ID", and "Service Account Email Address" fields.
+1. If desired, enter the stack's Google Cloud region in the "Region" field. This is typically unnecessary.
+1. If you would like to constrain the duration of the temporary Google Cloud credentials, enter a duration in the form "XhYmZs" in the "Session Duration" field.
+1. Click the "Save deployment configuration" button.
+
+### Using infrastructure as code
+
+You can manage the same deployment settings in source control with the [`pulumiservice.DeploymentSettings`](/registry/packages/pulumiservice/api-docs/deploymentsettings/) resource (the OIDC configuration is set under `operationContext.oidc.gcp`). Deployment settings can also be configured via the [REST API](/docs/deployments/deployments/api/#patchsettings).
+
+```typescript
+import * as pulumiservice from "@pulumi/pulumiservice";
+
+new pulumiservice.DeploymentSettings("deployment-settings", {
+    organization: "contoso",
+    project: "core",
+    stack: "dev",
+    operationContext: {
+        oidc: {
+            gcp: {
+                projectId: "<your-gcp-project-number>", // the numerical project ID
+                workloadPoolId: "pulumi-deployments",
+                providerId: "pulumi-deployments",
+                serviceAccount: "<service-account-email>",
+                // Optional: region, tokenLifetime
+            },
+        },
+    },
+});
+```
 
 With this configuration, each deployment of this stack will attempt to exchange the deployment's OIDC token for Google Cloud credentials using the specified federated identity prior to running any pre-commands or Pulumi operations. The fetched credentials are published as a credential configuration in the `GOOGLE_CREDENTIALS` environment variable. The raw OIDC token is also available for advanced scenarios in the `PULUMI_OIDC_TOKEN` environment variable and the `/mnt/pulumi/pulumi.oidc` file.

--- a/content/docs/deployments/deployments/runs/customer-managed-agents.md
+++ b/content/docs/deployments/deployments/runs/customer-managed-agents.md
@@ -112,9 +112,13 @@ The workflow runner will attempt to read the `oidc_token_file` for a fresh OIDC 
 
 ## Providing credentials to workflow runners
 
+{{% notes type="info" %}}
+For most users, Pulumi recommends [Pulumi ESC](/docs/esc/) for supplying cloud credentials to Deployments. However, if your customer-managed agents can't reach Pulumi Cloud over the network to use ESC, [Pulumi Deployments OIDC](/docs/deployments/deployments/oidc/) is an appropriate solution. For a comparison, see [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/deployments/cloud-credentials/).
+{{% /notes %}}
+
 There are two methods to provide cloud provider credentials to the workflow runners:
 
-1. Use [OpenID Connect (OIDC) to generate credentials](/docs/pulumi-cloud/oidc)
+1. Use [OpenID Connect (OIDC) to generate credentials](/docs/deployments/deployments/oidc/)
 2. Directly provide credentials to workflow runners through environment variables configured in the host, or passing the environment variables when invoking the binary. Example:
 
    ```bash

--- a/content/docs/deployments/deployments/using/settings.md
+++ b/content/docs/deployments/deployments/using/settings.md
@@ -202,9 +202,7 @@ For guidance on choosing between a pre-run install hook and a custom image, buil
 
 Pulumi Deployments supports OIDC for authenticating with cloud providers. This enables your deployments to access your cloud resources without storing static credentials in Pulumi Cloud.
 
-{{% notes type="info" %}}
-There are multiple approaches for supplying cloud credentials to Pulumi Deployments. For guidance on choosing between Deployments OIDC and Pulumi ESC, see [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/deployments/cloud-credentials/).
-{{% /notes %}}
+{{< esc-recommendation >}}
 
 For details on supported clouds see [OIDC Setup for Pulumi Deployments](/docs/deployments/deployments/oidc/).
 

--- a/layouts/shortcodes/esc-recommendation.html
+++ b/layouts/shortcodes/esc-recommendation.html
@@ -1,0 +1,10 @@
+<div class="note note-info">
+    <div class="icon-and-line">
+        {{ partial "icon.html" (dict "name" "info" "weight" "fill") }}
+        <div class="line"></div>
+    </div>
+    <div class="content">
+        {{ $body := `**Pulumi ESC is the recommended way to supply cloud credentials to Pulumi Deployments.** Deployments OIDC predates Pulumi ESC and was originally the only way to use OIDC with Deployments. It still works, but for most users ESC is the better choice. For a comparison and guidance on when each is appropriate, see [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/deployments/cloud-credentials/).` }}
+        {{- $body | markdownify -}}
+    </div>
+</div>


### PR DESCRIPTION
Strengthens the recommendation to use Pulumi ESC everywhere Deployments OIDC is discussed, and reorganizes the per-cloud OIDC guides. Closes #19634.

## Changes
- New `esc-recommendation` shortcode; applied to the four Deployments OIDC pages and the deployment settings page (replaces the old neutral callout)
- Strengthened ESC messaging on `cloud-credentials.md`; added a Deployments-OIDC-when-agents-can't-reach-Pulumi-Cloud note to `customer-managed-agents.md`
- Restructured the AWS/Azure/GCP guides into two sides (cloud + Deployments), each with console and infrastructure-as-code paths
- Added AWS one-provider-per-account + audience-casing guidance
- Removed CDN-hosted screencast videos (hard to keep current)