### PR TITLE
Scroll docs left nav to the active page and fix sidebar height

### DIFF
--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -81,7 +81,7 @@
             {{- with index site.Menus $menuName }}
             <li class="expandable expanded{{ if eq $currentSection $menuName }} expanded{{ end }}" data-menu-id="{{ $menuName }}-top">
                 <ul class="list-none">
-                    {{- partial "inline/menu/walk.html" (dict "page" $page "rootMenuID" $menuName "currentSection" $currentSection "menuEntries" . "allMenuEntries" . "forceTopLevelLabel" $label) }}
+                    {{- partial "inline/menu/walk.html" (dict "page" $page "rootMenuID" $menuName "currentSection" $currentSection "menuEntries" . "allMenuEntries" . "forceTopLevelLabel" $label "expandedIDs" $expandedIDs) }}
                 </ul>
             </li>
             {{- end }}
@@ -109,6 +109,47 @@
 
         </ul>
     </pulumi-docs-nav>
+
+    {{/* Scroll the active item into view. Runs inline — before first paint — so the
+         menu never visibly jumps. The expanded classes are rendered server-side above,
+         so the geometry is already final.
+
+         The menu's scroll position is carried across page loads via sessionStorage,
+         so navigating between pages whose nav items are already in view (e.g.,
+         siblings) doesn't move the nav at all. Only when the active item falls
+         outside the restored view is it scrolled (centered) into view. */}}
+    <script>
+        (function () {
+            var menu = document.currentScript.closest("nav").querySelector("pulumi-docs-nav");
+            var KEY = "docs-nav-scroll-position";
+
+            try {
+                var saved = sessionStorage.getItem(KEY);
+                if (saved !== null) {
+                    menu.scrollTop = parseInt(saved, 10) || 0;
+                }
+                window.addEventListener("pagehide", function () {
+                    sessionStorage.setItem(KEY, menu.scrollTop);
+                });
+            } catch (e) {
+                // Storage unavailable; fall through to centering below.
+            }
+
+            var active = menu.querySelector("a.active");
+            if (!active) {
+                return;
+            }
+            var menuRect = menu.getBoundingClientRect();
+            if (menuRect.height === 0) {
+                return;
+            }
+            var itemRect = active.getBoundingClientRect();
+            if (itemRect.top < menuRect.top || itemRect.bottom > menuRect.bottom) {
+                // Center the active item vertically within the menu.
+                menu.scrollTop += itemRect.top - menuRect.top - (menuRect.height - itemRect.height) / 2;
+            }
+        })();
+    </script>
 </nav>
 
 {{/*
@@ -153,6 +194,7 @@
     {{- $page := .page }}
     {{- $rootMenuID := .rootMenuID }}
     {{- $allMenuEntries := .allMenuEntries }}
+    {{- $expandedIDs := default slice .expandedIDs }}
 
     {{- range .menuEntries }}
         {{/* Skip Overview pages since we add them manually */}}
@@ -197,7 +239,11 @@
                 {{- $page.Scratch.Add "breadcrumbs" (dict "name" $currentMenuItem.Name "url" $currentMenuItem.URL) }}
             {{- end }}
 
-            <li {{ if (and .Children (ne .Identifier $rootMenuID)) }} class="expandable" {{ end }}
+            {{/* Render the expanded state server-side (ancestors of the current page, plus
+                 auto-expanded menu IDs) so the nav paints fully expanded — no flash of
+                 collapsed items while waiting for the pulumi-docs-nav component to load. */}}
+            {{- $isExpanded := or ($page.IsMenuCurrent .Menu .) ($page.HasMenuCurrent .Menu .) (and .Identifier (in $expandedIDs .Identifier)) }}
+            <li {{ if (and .Children (ne .Identifier $rootMenuID)) }} class="expandable{{ if $isExpanded }} expanded{{ end }}" {{ end }}
                 {{ if .Identifier }} data-menu-id="{{ .Identifier }}" {{ end }}
                 >
                 {{- if and .Children (ne .Identifier $rootMenuID) }}
@@ -247,7 +293,7 @@
                                 </li>
                             {{- end }}
                         {{- end }}
-                        {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" . "rootMenuID" $rootMenuID "currentSection" $.currentSection "allMenuEntries" $allMenuEntries) }}
+                        {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" . "rootMenuID" $rootMenuID "currentSection" $.currentSection "allMenuEntries" $allMenuEntries "expandedIDs" $expandedIDs) }}
                     </ul>
                 {{- end }}
             </li>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -36,6 +36,27 @@
     <!-- Our CSS and JS bundles. -->
     {{ partial "assets" . }}
 
+    {{- /* Cross-document view transitions, docs section only. On same-origin
+           navigations, supporting browsers (Chrome 126+, Safari 18.2+) keep the
+           old page on screen until the new one is ready instead of flashing
+           white. Both the outgoing and incoming page must carry the rule, so
+           gating it here scopes transitions to docs <-> docs navigations.
+           Disabling the snapshot animations makes the swap instant (no
+           crossfade). This must be a page-gated inline style — the rule is a
+           document-level opt-in, so it can't live in the shared CSS bundle. */ -}}
+    {{ if eq .Section "docs" }}
+        <style>
+            @view-transition {
+                navigation: auto;
+            }
+
+            ::view-transition-old(root),
+            ::view-transition-new(root) {
+                animation: none;
+            }
+        </style>
+    {{ end }}
+
 
     <!-- Google Site Verification for Google Webmaster tools and YouTube. -->
     <meta name="google-site-verification" content="N-ezSTIu4P3bSc4TqidV4wWCkMzFiMN269ZgDYArGkk" />

--- a/theme/src/scss/docs/_docs-main.scss
+++ b/theme/src/scss/docs/_docs-main.scss
@@ -90,12 +90,11 @@ body.section-registry {
             border: none;
             display: flex;
             flex-direction: column;
-            padding-bottom: 24px;
             flex-shrink: 0;
             margin: 0;
             width: 32px;
             flex-basis: 32px;
-            height: calc(100vh - 38px);
+            height: calc(100vh - 64px); // Fallback; JS tracks the header's visible height on scroll.
             position: sticky;
             left: 0;
             top: 0;
@@ -127,6 +126,7 @@ body.section-registry {
                 overflow-y: auto;
                 flex: 1;
                 min-height: 0;
+                padding-bottom: 24px; // Breathing room below the last item, inside the scroll area.
             }
 
             h2,
@@ -246,15 +246,10 @@ body.section-registry {
             .docs-main-nav-wrapper .docs-main-nav {
                 width: 240px;
                 flex-basis: 240px;
-                height: calc(100vh);
                 padding-left: 16px;
                 background-color: #fff;
                 box-shadow: 6px 0px 36px rgba(0, 0, 0, 0.08);
                 justify-content: space-between;
-
-                @media (min-width: 768) {
-                    height: calc(100vh - 38px);
-                }
             }
 
             nav.main-nav {

--- a/theme/src/ts/docs-main.ts
+++ b/theme/src/ts/docs-main.ts
@@ -47,10 +47,18 @@ function setTableOfContentsVisibility() {
 
 function setMainNavHeight() {
     const docsMainNav = document.querySelector<HTMLElement>(".docs-main-nav");
-    const docsFooter = document.querySelector<HTMLElement>(".docs-footer");
-    if (docsMainNav && docsFooter) {
-        docsMainNav.style.height = (docsFooter.offsetHeight + window.innerHeight) + "px";
+    if (!docsMainNav) {
+        return;
     }
+
+    // Size the sticky sidebar to the viewport space below the site header.
+    // The header scrolls away on docs pages, so track its visible bottom edge:
+    // full header visible at the top of the page, full viewport once it has
+    // scrolled offscreen.
+    const header = document.querySelector<HTMLElement>("body > header");
+    const headerBottom = header ? Math.max(header.getBoundingClientRect().bottom, 0) : 0;
+    docsMainNav.style.top = headerBottom + "px";
+    docsMainNav.style.height = (window.innerHeight - headerBottom) + "px";
 }
 
 function handleResize() {
@@ -66,6 +74,7 @@ function onScroll() {
     requestAnimationFrame(() => {
         scrollRafPending = false;
         setDocsMainNavPosition();
+        setMainNavHeight();
     });
 }
 


### PR DESCRIPTION
Human Jeff: Fixes the docs sidebar nav not scrolling on load, and also fixes a couple another annoyances with it,: 1. the height overflowing the viewport and 2. the short flash when loading and navigating between pages (mostly?).

---

The docs left nav didn't scroll the current page into view on load, so on short screens the active item was often out of sight. Fixes #11547.

## Changes
- **Scroll to active item** (`menu.html`): a pre-paint inline script centers the active nav item when it's out of view, and preserves the menu's scroll position across navigations (sessionStorage) so moving between sibling pages doesn't shift the nav.
- **No-flash render** (`menu.html`): expanded ancestors of the current page are now rendered server-side instead of being expanded by JS after load.
- **Sidebar height** (`docs-main.ts`, `_docs-main.scss`): the sticky sidebar is sized to the viewport space below the header (100vh − 64px at top, 100vh once the header scrolls away), and the scrollable menu area now extends to the viewport bottom.
- **Instant page transitions** (`head.html`): docs ↔ docs navigations opt into cross-document view transitions (Chrome 126+, Safari 18.2+) with snapshot animations disabled — the old page holds on screen until the new one is ready, then swaps instantly, eliminating the blank flash between page loads. Other browsers ignore it and navigate normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)