### PR TITLE
docs(esc): move rotator best practices under Operations

### DIFF
--- a/content/docs/esc/concepts/builtin-functions/_index.md
+++ b/content/docs/esc/concepts/builtin-functions/_index.md
@@ -20,6 +20,7 @@ All function invocations take the form of an object with a single key that names
 
 ## Functions
 
+- [`fn::secret`](/docs/esc/concepts/builtin-functions/fn-secret/)
 - [`fn::concat`](/docs/esc/concepts/builtin-functions/fn-concat/)
 - [`fn::final`](/docs/esc/concepts/builtin-functions/fn-final/)
 - [`fn::fromBase64`](/docs/esc/concepts/builtin-functions/fn-from-base64/)
@@ -27,7 +28,6 @@ All function invocations take the form of an object with a single key that names
 - [`fn::join`](/docs/esc/concepts/builtin-functions/fn-join/)
 - [`fn::open`](/docs/esc/concepts/builtin-functions/fn-open/)
 - [`fn::rotate`](/docs/esc/concepts/builtin-functions/fn-rotate/)
-- [`fn::secret`](/docs/esc/concepts/builtin-functions/fn-secret/)
 - [`fn::split`](/docs/esc/concepts/builtin-functions/fn-split/)
 - [`fn::toBase64`](/docs/esc/concepts/builtin-functions/fn-to-base64/)
 - [`fn::toJSON`](/docs/esc/concepts/builtin-functions/fn-to-json/)

--- a/content/docs/esc/concepts/builtin-functions/fn-secret.md
+++ b/content/docs/esc/concepts/builtin-functions/fn-secret.md
@@ -11,12 +11,54 @@ menu:
   esc:
     parent: esc-syntax-builtin-functions
     identifier: esc-syntax-fn-secret
-    weight: 8
+    weight: 0
 ---
 
 The `fn::secret` built-in function decrypts a ciphertext literal into a secret string value.
 
 In addition to its evaluation-time behavior, `fn::secret` has additional behavior at update time. When an environment is saved, any `fn::secret` invocations with plaintext arguments are transformed by encrypting the plaintext and replacing it with a ciphertext literal.
+
+## Storing secrets
+
+To store a secret, add an `fn::secret` value to an environment. ESC encrypts it when the environment is saved, so plaintext is never persisted.
+
+### Via the CLI
+
+Add a secret using the `--secret` flag:
+
+```bash
+esc env set <org>/<project>/<env-name> apiKey my-secret-value --secret
+```
+
+### Via the Pulumi Cloud console
+
+In the environment editor, wrap a value in `fn::secret` and select **Save**:
+
+```yaml
+values:
+  apiKey:
+    fn::secret: my-secret-value
+```
+
+### Multi-line secrets
+
+For multi-line values such as private keys, TLS certificates, or SSH keys, use a YAML block scalar:
+
+```yaml
+values:
+  tlsCert:
+    fn::secret: |
+      -----BEGIN CERTIFICATE-----
+      MIIDXTCCAkWgAwIBAgIJAMqBbsYRO...
+      -----END CERTIFICATE-----
+  privateKey:
+    fn::secret: |
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIEowIBAAKCAQEA0Z3VS5JJcds3...
+      -----END RSA PRIVATE KEY-----
+```
+
+The `|` character tells YAML to preserve newlines, which is required for PEM-formatted values. Using `esc env set` for multi-line secrets is not recommended — use the console editor or edit the environment YAML directly.
 
 ## Declaration
 

--- a/content/docs/esc/concepts/rotators.md
+++ b/content/docs/esc/concepts/rotators.md
@@ -106,42 +106,4 @@ Once you determined that you need one, follow the links below to learn how to se
 
 ## Best practices
 
-### Least privilege
-
-It is recommended to follow the principle of least privilege when defining the permissions for the user or role that will be used to rotate the secret. The user or role should have only the necessary permissions to perform the rotation action, and no more.
-
-The minimum required permissions for each rotation function are documented in the [rotator reference](/docs/esc/providers/rotators/).
-
-### Separation of concerns
-
-It is recommended that the login credentials required to perform the rotation action are stored in a separate environment, and imported via an [implicit import](/docs/esc/concepts/imports/#implicit-imports). This ensures that the credentials are not exposed to users who are unable to open the managing environment.
-
-### Composition
-
-It is a best practice to define a separate environment for your rotated functions, and import them into the environments that require the rotated credentials. This allows you to manage the rotation logic in a single place, and allows for the rotated environment to be versioned separately from the rest of your configuration. Specifically, since a new revision is created on every rotation, you may want to always import the latest version of the rotated environment to ensure that the latest rotated credentials are always used.
-
-Another reason to keep your rotated functions in a separate environment is that an environment containing a rotation function *cannot be rolled back*, since the rotated secrets have been deactivated. By keeping your rotation functions separate, you can ensure that the rest of your configuration can be rolled back to a previous revision if needed.
-
-### Organization
-
-There are a few options for how you might organize your rotated environments.
-
-You may want to organize your rotated environment by rotation schedule. Since a single environment can only have one rotation schedule, you can group your rotated environments by the frequency at which they need to be rotated. For example, you may have a `daily` environment, a `weekly` environment, and a `monthly` environment, each with their own rotation schedule.
-
-Alternatively, you may want to keep a separate environment for each rotated secret. This avoids the potential for partial failures, described in more detail below.
-
-### Handling partial failures
-
-If multiple rotation functions are defined in a single environment, it is possible that some fail while others succeed. In these cases, a partial failure will be reported.
-
-To handle partial failures, failed keys can be individually retried using the `esc env rotate [envName] [path(s)-to-rotate]` command. This will allow you to retry the rotation of a specific key without affecting the rotation of other keys in the environment.
-
-```bash
-esc env rotate rotators/pulumi-ci credentials.bot.aws
-Environment 'rotators/pulumi-ci' rotated.
-New revision '23' was created.
-```
-
-{{% notes type="warning" %}}
-**WARNING** Beware of double rotation in the case of partial failures. If a key is rotated twice, the first rotation will be invalidated and the second rotation will be active. This can lead to unexpected behavior if not handled correctly, for example if the rotated secret has not been updated at the consumer.
-{{% /notes %}}
+For operational guidance on organizing rotated environments and handling failures, see [Best practices](/docs/esc/operations/rotation/best-practices/).

--- a/content/docs/esc/operations/_index.md
+++ b/content/docs/esc/operations/_index.md
@@ -21,7 +21,7 @@ If you are looking for *what* ESC is rather than *how to run it*, start with [Co
 
 ## Rotation
 
-- [Rotation connectors](/docs/esc/operations/rotation/) — deploy connectors so rotators can reach databases and services in private networks.
+- [Rotating secrets](/docs/esc/operations/rotation/) — best practices for rotation, and deploying connectors so rotators can reach databases and services in private networks.
 
 ## CI/CD
 

--- a/content/docs/esc/operations/managing-secrets.md
+++ b/content/docs/esc/operations/managing-secrets.md
@@ -16,92 +16,24 @@ aliases:
 
 This guide shows you how to store and retrieve secrets in Pulumi ESC environments. Secrets are encrypted values that ESC stores securely and hides from view by default.
 
-## Prerequisites
-
-- [ESC CLI](/docs/install/esc/) installed
-- [Pulumi account](https://app.pulumi.com/signup) created
-- An ESC environment (create one with `esc env init <org>/<project>/<env-name>`)
+New to ESC? Start with [Get Started](/docs/esc/get-started/) for a five-minute walkthrough, then return here for the full secret-management workflow.
 
 ## Understanding ESC values
 
-ESC environments store configuration as key-value pairs in YAML format. All values are defined under a top-level `values` key:
+ESC environments store configuration as key-value pairs in YAML under a top-level `values` key. Any value wrapped in `fn::secret` is encrypted at rest and masked in output:
 
 ```yaml
 values:
-  apiEndpoint: https://api.example.com
-  region: us-west-2
+  region: us-west-2 # plaintext configuration
   apiKey:
-    fn::secret: my-secret-value
+    fn::secret: my-secret-value # encrypted secret
 ```
 
-Values can be:
-
-- **Plain text** - Regular configuration values (region, endpoint URLs)
-- **Secrets** - Encrypted values marked with `fn::secret`
-- **Structured data** - Objects and arrays
-- **Dynamic values** - Generated from providers (covered in other guides)
+For the full breakdown of static, secret, and dynamic value types, see [Environments](/docs/esc/concepts/environments/).
 
 ## Storing secrets
 
-### Via the CLI
-
-Add a secret to your environment using the `--secret` flag:
-
-```bash
-esc env set <org>/<project>/<env-name> apiKey my-secret-value --secret
-```
-
-For example:
-
-```bash
-esc env set my-org/my-project/dev apiKey demo-secret-123 --secret
-```
-
-This encrypts the value before storing it.
-
-### Via the Pulumi Cloud console
-
-1. Navigate to [Pulumi Cloud](https://app.pulumi.com/signin)
-1. Select **Environments** in the left navigation
-1. Select your environment
-1. In the editor, add your secret using the `fn::secret` function:
-
-```yaml
-values:
-  apiKey:
-    fn::secret: my-secret-value
-```
-
-1. Select **Save**
-
-The console will encrypt the secret and replace the plaintext value with a ciphertext reference:
-
-```yaml
-values:
-  apiKey:
-    fn::secret:
-      ciphertext: ZXNjeAA...
-```
-
-### Multi-line secrets
-
-For multi-line values such as private keys, TLS certificates, or SSH keys, use a YAML block scalar with `fn::secret`:
-
-```yaml
-values:
-  tlsCert:
-    fn::secret: |
-      -----BEGIN CERTIFICATE-----
-      MIIDXTCCAkWgAwIBAgIJAMqBbsYRO...
-      -----END CERTIFICATE-----
-  privateKey:
-    fn::secret: |
-      -----BEGIN RSA PRIVATE KEY-----
-      MIIEowIBAAKCAQEA0Z3VS5JJcds3...
-      -----END RSA PRIVATE KEY-----
-```
-
-The `|` character tells YAML to preserve newlines, which is required for PEM-formatted values. Using `esc env set` for multi-line secrets is not recommended — use the console editor or edit the environment YAML directly.
+To store a secret, add an [`fn::secret`](/docs/esc/concepts/builtin-functions/fn-secret/) value to your environment — using the CLI (`esc env set --secret`), the Pulumi Cloud console, or by editing the environment YAML directly. See [`fn::secret`](/docs/esc/concepts/builtin-functions/fn-secret/#storing-secrets) for the full reference and examples, including multi-line secrets such as PEM-formatted keys and certificates.
 
 ## Retrieving secrets
 
@@ -175,37 +107,9 @@ Each environment can have different RBAC permissions, ensuring production secret
 
 ## Best practices
 
-### Use secrets for sensitive data
-
-Mark these values as secrets:
-
-- API keys and tokens
-- Database passwords
-- Private keys and certificates
-- OAuth client secrets
-
-### Use plain text for non-sensitive data
-
-These can be plain text:
-
-- Region names
-- Public endpoints
-- Feature flags
-- Port numbers
-
 ### Rotate secrets regularly
 
-ESC supports two approaches to secret rotation:
-
-**Manual update** — Replace a secret value by setting a new one:
-
-```bash
-esc env set my-org/my-project/prod apiKey new-secret-value --secret
-```
-
-ESC versions every change, so you can audit the history or roll back if needed.
-
-**Automated rotation** — For supported secret types (database passwords, AWS IAM keys, and others), ESC can [automatically rotate credentials on a schedule](/docs/esc/environments/rotation/) using `fn::rotate`. If the rotation target lives in a private network, a [rotation connector](/docs/esc/operations/rotation/) runs the rotation on Pulumi Cloud's behalf. This is the recommended approach over manual updates, as it eliminates manual steps and reduces exposure windows.
+You can replace a secret manually with `esc env set ... --secret` (ESC versions every change, so you can audit or roll back). For supported secret types, ESC can also [rotate credentials automatically on a schedule](/docs/esc/concepts/rotators/) — the recommended approach. See [Rotating secrets](/docs/esc/operations/rotation/) for operational guidance and [best practices](/docs/esc/operations/rotation/best-practices/).
 
 ### Control access with RBAC
 

--- a/content/docs/esc/operations/rotation/_index.md
+++ b/content/docs/esc/operations/rotation/_index.md
@@ -1,8 +1,8 @@
 ---
-title: Rotation connectors
-title_tag: Pulumi ESC rotation connectors
-h1: Rotation connectors
-meta_desc: Deploy Pulumi ESC rotation connectors so rotators can reach databases and services that live in private networks.
+title: Rotating secrets
+title_tag: Pulumi ESC rotating secrets
+h1: Rotating secrets
+meta_desc: Operational guidance for rotating secrets with Pulumi ESC — best practices and deploying rotation connectors for private networks.
 menu:
   esc:
     identifier: esc-operations-rotation
@@ -10,16 +10,22 @@ menu:
     weight: 1
 ---
 
+Operational guidance for rotating secrets with Pulumi ESC. For background on what rotation is and how the `fn::rotate::*` syntax works, see [Rotators](/docs/esc/concepts/rotators/).
+
+## Best practices
+
+See [Best practices](/docs/esc/operations/rotation/best-practices/) for guidance on least privilege, separation of concerns, composing rotated environments, and handling partial failures.
+
+## Rotation connectors
+
 Some [rotators](/docs/esc/providers/rotators/) need to reach the credential they're rotating — for example, the `mysql` and `postgres` rotators must connect to the database to change a user's password. When the target lives in a private network that Pulumi Cloud can't reach directly, a **rotation connector** runs the rotation inside that network on Pulumi Cloud's behalf.
 
-For background on what rotation is and how the `fn::rotate::*` syntax works, see [Rotation](/docs/esc/concepts/rotators/).
-
-## Available connectors
+### Available connectors
 
 | Connector | Runtime | Used by |
 |---|---|---|
 | [AWS Lambda](/docs/esc/operations/rotation/aws-lambda/) | AWS Lambda inside a VPC | `mysql`, `postgres` |
 
-## Setup checklists
+### Setup checklists
 
 - [Database user setup](/docs/esc/operations/rotation/db-user-setup/) — pre-create the database user (and grant the right permissions) that a rotator will manage.

--- a/content/docs/esc/operations/rotation/aws-lambda.md
+++ b/content/docs/esc/operations/rotation/aws-lambda.md
@@ -7,7 +7,7 @@ menu:
   esc:
     identifier: aws-lambda
     parent: esc-operations-rotation
-    weight: 1
+    weight: 2
 aliases:
   - /docs/esc/environments/rotation/aws-lambda/
 ---

--- a/content/docs/esc/operations/rotation/best-practices.md
+++ b/content/docs/esc/operations/rotation/best-practices.md
@@ -1,0 +1,53 @@
+---
+title: Best practices
+title_tag: Pulumi ESC rotation best practices
+h1: Best practices
+meta_desc: Best practices for rotating secrets with Pulumi ESC — least privilege, separation of concerns, composing rotated environments, and handling partial failures.
+menu:
+  esc:
+    identifier: esc-operations-rotation-best-practices
+    parent: esc-operations-rotation
+    weight: 1
+---
+
+Recommendations for rotating secrets safely and reliably with Pulumi ESC. For conceptual background on what rotators are and how the `fn::rotate::*` syntax works, see [Rotators](/docs/esc/concepts/rotators/).
+
+## Least privilege
+
+It is recommended to follow the principle of least privilege when defining the permissions for the user or role that will be used to rotate the secret. The user or role should have only the necessary permissions to perform the rotation action, and no more.
+
+The minimum required permissions for each rotation function are documented in the [rotator reference](/docs/esc/providers/rotators/).
+
+## Separation of concerns
+
+It is recommended that the login credentials required to perform the rotation action are stored in a separate environment, and imported via an [implicit import](/docs/esc/concepts/imports/#implicit-imports). This ensures that the credentials are not exposed to users who are unable to open the managing environment.
+
+## Composition
+
+It is a best practice to define a separate environment for your rotated functions, and import them into the environments that require the rotated credentials. This allows you to manage the rotation logic in a single place, and allows for the rotated environment to be versioned separately from the rest of your configuration. Specifically, since a new revision is created on every rotation, you may want to always import the latest version of the rotated environment to ensure that the latest rotated credentials are always used.
+
+Another reason to keep your rotated functions in a separate environment is that an environment containing a rotation function *cannot be rolled back*, since the rotated secrets have been deactivated. By keeping your rotation functions separate, you can ensure that the rest of your configuration can be rolled back to a previous revision if needed.
+
+## Organization
+
+There are a few options for how you might organize your rotated environments.
+
+You may want to organize your rotated environment by rotation schedule. Since a single environment can only have one rotation schedule, you can group your rotated environments by the frequency at which they need to be rotated. For example, you may have a `daily` environment, a `weekly` environment, and a `monthly` environment, each with their own rotation schedule.
+
+Alternatively, you may want to keep a separate environment for each rotated secret. This avoids the potential for partial failures, described in more detail below.
+
+## Handling partial failures
+
+If multiple rotation functions are defined in a single environment, it is possible that some fail while others succeed. In these cases, a partial failure will be reported.
+
+To handle partial failures, failed keys can be individually retried using the `esc env rotate [envName] [path(s)-to-rotate]` command. This will allow you to retry the rotation of a specific key without affecting the rotation of other keys in the environment.
+
+```bash
+esc env rotate rotators/pulumi-ci credentials.bot.aws
+Environment 'rotators/pulumi-ci' rotated.
+New revision '23' was created.
+```
+
+{{% notes type="warning" %}}
+**WARNING** Beware of double rotation in the case of partial failures. If a key is rotated twice, the first rotation will be invalidated and the second rotation will be active. This can lead to unexpected behavior if not handled correctly, for example if the rotated secret has not been updated at the consumer.
+{{% /notes %}}

--- a/content/docs/esc/operations/rotation/db-user-setup.md
+++ b/content/docs/esc/operations/rotation/db-user-setup.md
@@ -7,7 +7,7 @@ menu:
   esc:
     identifier: db-user-setup
     parent: esc-operations-rotation
-    weight: 1
+    weight: 3
 aliases:
   - /docs/esc/environments/rotation/db-user-setup/
 ---

--- a/content/docs/esc/providers/login/gh-login.md
+++ b/content/docs/esc/providers/login/gh-login.md
@@ -50,7 +50,7 @@ for instructions on how to generate a private key (in PEM format) and download t
 
 Private keys do not expire and need to be manually revoked. You must keep private keys for GitHub Apps secure.
 Store the private key as a secret by using the `fn::secret` function.
-See "[Managing Secrets](/docs/esc/operations/managing-secrets/#storing-secrets)".
+See "[`fn::secret`](/docs/esc/concepts/builtin-functions/fn-secret/#storing-secrets)".
 
 ```yaml
 appId: 123456


### PR DESCRIPTION
Moves rotator best practices out of the concept page and into Operations, and tidies up where ESC secret content lives. Fixes #19618.

## Changes
- Rename the Operations "Rotation connectors" section to "Rotating secrets"
- Add a dedicated `rotation/best-practices.md` page (moved from the rotators concept page)
- Consolidate secret-storing guidance (CLI, console, multi-line) onto the `fn::secret` page; list it first under Built-in Functions
- Trim `managing-secrets.md` to retrieval and organization, pointing to canonical sources
- Update inbound links (gh-login, operations index)