### PR TITLE
Split content review into dispatcher + per-article worker

### DIFF
--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -1,0 +1,173 @@
+name: "Scheduled jobs: Review existing content (one article)"
+
+# Per-article worker for the existing-content review. The dispatcher
+# (review-existing-content.yml) does the deterministic selection and fans
+# out one workflow_dispatch of this workflow per selected article; each run
+# here reviews exactly ONE article and opens exactly ONE PR. Splitting the
+# old batch-of-N invocation into one-article-per-run decouples the articles
+# (a hung article no longer burns the whole batch's budget) and lets a
+# per-path concurrency group keep two runs off the same article.
+#
+# This is workflow_dispatch only — the dispatcher invokes it; it is not on a
+# schedule of its own.
+
+on:
+  workflow_dispatch:
+    inputs:
+      path:
+        description: 'One content file under content/docs/'
+        required: true
+      lane:
+        description: 'Selection lane (priority/stale/manual); stale enables retirement'
+        required: false
+        default: 'priority'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write # Required for ESC OIDC auth
+  actions: write # Required to dispatch claude-code-review.yml over the PR
+
+# One run per article: a second dispatch for the same path queues behind the
+# first rather than racing it onto the same branch.
+concurrency:
+  group: content-review-article-${{ github.event.inputs.path }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    name: Review one article
+    runs-on: ubuntu-latest
+    # Hard cost ceiling for a single-article review; a hung run dies rather
+    # than burning API budget.
+    timeout-minutes: 30
+    steps:
+      # ESC runs before checkout so the bot token can authenticate the
+      # checkout — the PR opened by claude-code-action later then goes out as
+      # pulumi-bot rather than github-actions[bot].
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          # The skill reads git history (synthetic diffs, staleness), so a
+          # shallow clone won't do.
+          fetch-depth: 0
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            infrastructure/yarn.lock
+            theme/yarn.lock
+            theme/stencil/yarn.lock
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.157.0'
+          extended: true
+      # Vale (and other mise-pinned tools) for the skill's whole-file
+      # prose-lint pre-step.
+      - name: Install mise-managed tools
+        uses: jdx/mise-action@v2
+        with:
+          cache: true
+      - name: Install Python deps
+        run: python3 -m pip install --quiet pyyaml
+
+      # Build a single-article queue for the dispatched path. --paths bypasses
+      # scoring/guardrails; --lane carries the dispatcher's lane through so the
+      # retirement path stays in scope only when lane=stale.
+      - name: Build single-article queue
+        run: |
+          python3 scripts/content-review/select-articles.py \
+            --paths "${{ github.event.inputs.path }}" \
+            --lane "${{ github.event.inputs.lane || 'priority' }}" \
+            --out .content-review-queue.json
+          echo "--- queue ---"
+          cat .content-review-queue.json
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Bot token so the PR/pushes trigger downstream workflows.
+          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          prompt: |
+            The existing-content review selected one article in
+            `.content-review-queue.json` at the repo root.
+
+            Follow `.claude/commands/review-existing-content/SKILL.md`
+            exactly. In short, for the article in the queue:
+
+            1. Branch `content-review/<slug>` off master.
+            2. Run the docs-review pre-computation pipeline over the whole
+               file via a synthetic diff (the skill lists the exact
+               commands).
+            3. Apply HIGH-CONFIDENCE fixes only; everything judgment-level
+               goes in the PR description's "Findings not applied" section.
+            4. Run the screenshot/UI verification pass (flag-only).
+            5. Run `make lint` and `make build`; resolve anything they
+               surface or drop the offending change.
+            6. Run the rendered content pass over the built page — both
+               the HTML view and the customer-facing markdown view
+               (`public/<url>/index.html` and `index.md`) — per the skill.
+            7. Write the article's ledger file under
+               `scripts/content-review/ledger/`.
+            8. Open a **ready** (non-draft) PR with the auditable
+               description the skill describes. A clean article gets a
+               ledger-only PR instead.
+            9. Write `.content-review-results.json` (the skill defines the
+               shape) — the review-dispatch and Slack steps consume it.
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(python3:*),Bash(vale:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(gh repo view:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(mkdir:*),Bash(curl:*)"'
+
+      # Slop defense: bot-authored PRs are auto-skipped by the docs-review
+      # pipeline (claude-code-review.yml sets skip_reason=bot-author), so the
+      # content PR gets its review via explicit force dispatch — the same
+      # pattern claude-new.yml uses for #new-review. One article ⇒ 0 or 1 PR;
+      # the loop handles both.
+      - name: Dispatch docs review over the PR
+        if: hashFiles('.content-review-results.json') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          jq -c '.prs[]?' .content-review-results.json | while read -r pr; do
+            NUMBER=$(echo "$pr" | jq -r '.pr_number')
+            HEAD_SHA=$(echo "$pr" | jq -r '.head_sha')
+            echo "dispatching review for PR #$NUMBER ($HEAD_SHA)"
+            gh workflow run claude-code-review.yml \
+              --repo "${{ github.repository }}" \
+              -f pr_number="$NUMBER" \
+              -f head_sha="$HEAD_SHA" \
+              -f force=true \
+              || echo "::warning::review dispatch failed for PR #$NUMBER"
+          done
+
+      # Post the article's PR link to #docs-ops. Gated on the results file so
+      # a failed run stays silent rather than posting an empty message.
+      - name: Post result to Slack
+        if: hashFiles('.content-review-results.json') != ''
+        env:
+          SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
+        run: |
+          TEXT=$(jq -r '.summary' .content-review-results.json)
+          LINKS=$(jq -r '[.prs[]?.pr, (.ledger_only_pr // empty)] | join("\n")' .content-review-results.json)
+          [ -n "$LINKS" ] && TEXT="$TEXT"$'\n'"$LINKS"
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data "$(jq -n --arg ch "#docs-ops" --arg txt "$TEXT" \
+              '{channel: $ch, text: $txt, unfurl_links: true}')"
+
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -1,25 +1,28 @@
-name: "Scheduled jobs: Review existing content"
+name: "Scheduled jobs: Review existing content (dispatcher)"
 
 # Daily (workdays) automated review of EXISTING docs pages — the
 # counterpart to the PR-triggered docs review, for content that nobody is
-# currently editing. The selection script picks the day's articles
-# (strategic tier x traffic x review age, plus one reserved stale slot),
-# the review-existing-content skill reviews each via the docs-review claim
-# pipeline and opens one ready PR per article, and this workflow then
-# force-dispatches claude-code-review.yml over each PR (bot-authored PRs
-# are auto-skipped by that pipeline, so the review must be requested
-# explicitly). Humans merge; nothing here is auto-merged.
+# currently editing. This workflow is the DISPATCHER: the selection script
+# picks the day's articles (strategic tier x traffic x review age, plus one
+# reserved stale slot), and this workflow then fans out one
+# content-review-article.yml run per selected article. Each of those worker
+# runs reviews exactly one article, opens one ready PR, and force-dispatches
+# claude-code-review.yml over it. Humans merge; nothing here is auto-merged.
 #
 # The whole job is inert until the CONTENT_REVIEW_ENABLED repo variable is
 # 'true' — scheduled workflows only run from the default branch, so this
 # can merge ahead of being switched on. workflow_dispatch always runs
 # (that's the testing path; see the dry_run / count / paths inputs).
+#
+# CRON IS DISABLED for now: the dispatcher is MANUAL-ONLY during rollout.
+# Re-enable the schedule below when the per-article worker has proven out.
 
 on:
-  schedule:
-    # Weekdays at 2:00PM UTC (one hour before check-links, so the two
-    # bot-PR producers don't contend).
-    - cron: '0 14 * * 1-5'
+  # Re-enable when ready (see note above):
+  # schedule:
+  #   # Weekdays at 2:00PM UTC (one hour before check-links, so the two
+  #   # bot-PR producers don't contend).
+  #   - cron: '0 14 * * 1-5'
   workflow_dispatch:
     inputs:
       count:
@@ -41,7 +44,7 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write # Required for ESC OIDC auth + AWS OIDC role
-  actions: write # Required to dispatch claude-code-review.yml over the PRs
+  actions: write # Required to dispatch content-review-article.yml per article
 
 jobs:
   review:
@@ -127,84 +130,44 @@ jobs:
           echo "--- queue ---"
           cat .content-review-queue.json
 
-      # On dry runs and quiet/halted days everything below is skipped, so
-      # those runs cost no API spend.
-      - name: Run Claude Code
+      # Fan out one content-review-article.yml run per selected article. Each
+      # worker run reviews its single article, opens one ready PR, and
+      # force-dispatches the docs review over it. On dry runs and quiet/halted
+      # days this is skipped, so those runs cost no API spend.
+      - name: Dispatch per-article workers
         if: steps.select.outputs.has_articles == 'true' && github.event.inputs.dry_run != 'true'
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Bot token so the PRs/pushes trigger downstream workflows.
-          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-          prompt: |
-            The daily existing-content review selected today's articles in
-            `.content-review-queue.json` at the repo root.
-
-            Follow `.claude/commands/review-existing-content/SKILL.md`
-            exactly. In short, for each article in the queue, sequentially:
-
-            1. Branch `content-review/<slug>` off master.
-            2. Run the docs-review pre-computation pipeline over the whole
-               file via a synthetic diff (the skill lists the exact
-               commands).
-            3. Apply HIGH-CONFIDENCE fixes only; everything judgment-level
-               goes in the PR description's "Findings not applied" section.
-            4. Run the screenshot/UI verification pass (flag-only).
-            5. Run `make lint` and `make build`; resolve anything they
-               surface or drop the offending change.
-            6. Run the rendered content pass over the built page — both
-               the HTML view and the customer-facing markdown view
-               (`public/<url>/index.html` and `index.md`) — per the skill.
-            7. Write the article's ledger file under
-               `scripts/content-review/ledger/`.
-            8. Open a **ready** (non-draft) PR per article with the
-               auditable description the skill describes. Clean articles
-               share one ledger-only PR instead.
-            9. Write `.content-review-results.json` (the skill defines the
-               shape) — the workflow's review-dispatch and Slack steps
-               consume it.
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(python3:*),Bash(vale:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(gh repo view:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(mkdir:*),Bash(curl:*)"'
-
-      # Slop defense: bot-authored PRs are auto-skipped by the docs-review
-      # pipeline (claude-code-review.yml sets skip_reason=bot-author), so
-      # each content PR gets its review via explicit force dispatch — the
-      # same pattern claude-new.yml uses for #new-review. Deterministic
-      # post-step rather than a skill instruction so it can't be forgotten.
-      - name: Dispatch docs review over each PR
-        if: steps.select.outputs.has_articles == 'true' && hashFiles('.content-review-results.json') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          jq -c '.prs[]?' .content-review-results.json | while read -r pr; do
-            NUMBER=$(echo "$pr" | jq -r '.pr_number')
-            HEAD_SHA=$(echo "$pr" | jq -r '.head_sha')
-            echo "dispatching review for PR #$NUMBER ($HEAD_SHA)"
-            gh workflow run claude-code-review.yml \
+          jq -c '.articles[]' .content-review-queue.json | while read -r a; do
+            P=$(echo "$a" | jq -r '.path')
+            L=$(echo "$a" | jq -r '.lane')
+            echo "dispatching worker for $P (lane=$L)"
+            gh workflow run content-review-article.yml \
               --repo "${{ github.repository }}" \
-              -f pr_number="$NUMBER" \
-              -f head_sha="$HEAD_SHA" \
-              -f force=true \
-              || echo "::warning::review dispatch failed for PR #$NUMBER"
+              -f path="$P" \
+              -f lane="$L" \
+              || echo "::warning::worker dispatch failed for $P"
           done
 
-      # Post the day's summary (PR links, clean pages, or the halted
-      # warning) to #docs-ops. Gated on the results file so a failed run
-      # stays silent rather than posting an empty message.
+      # Post the dispatch summary (paths dispatched, or the halted warning) to
+      # #docs-ops. Each worker posts its own PR link when it finishes; this is
+      # the run-level "what got dispatched today" note. Gated on having
+      # articles or a halt so a quiet/failed run stays silent.
       - name: Post summary to Slack
         if: >-
           github.event.inputs.dry_run != 'true' &&
-          (hashFiles('.content-review-results.json') != '' || steps.select.outputs.halted != '')
+          (steps.select.outputs.has_articles == 'true' || steps.select.outputs.halted != '')
         env:
           SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
           HALTED: ${{ steps.select.outputs.halted }}
+          COUNT: ${{ steps.select.outputs.count }}
         run: |
-          if [ -f .content-review-results.json ]; then
-            TEXT=$(jq -r '.summary' .content-review-results.json)
-            LINKS=$(jq -r '[.prs[]?.pr, (.ledger_only_pr // empty)] | join("\n")' .content-review-results.json)
-            [ -n "$LINKS" ] && TEXT="$TEXT"$'\n'"$LINKS"
+          if [ -n "$HALTED" ]; then
+            TEXT=":warning: Existing-content review halted: ${HALTED} (no articles dispatched)"
           else
-            TEXT=":warning: Existing-content review halted: ${HALTED} (no articles processed)"
+            PATHS=$(jq -r '.articles[].path' .content-review-queue.json)
+            TEXT="Existing-content review dispatched ${COUNT} article review(s):"$'\n'"$PATHS"
           fi
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -407,6 +407,7 @@ def main() -> int:
     p.add_argument("--ledger-dir", default=str(DEFAULT_LEDGER_DIR))
     p.add_argument("--repo-root", default=str(REPO_ROOT), help=argparse.SUPPRESS)
     p.add_argument("--paths", help="Comma-separated content paths; bypasses scoring (testing)")
+    p.add_argument("--lane", help="Override lane for --paths entries (default manual)")
     p.add_argument("--no-gh", action="store_true", help="Skip gh API calls (testing)")
     p.add_argument("--today", help="Override today's date YYYY-MM-DD (testing)")
     p.add_argument("--dry-run", action="store_true", help="Print queue, write nothing")
@@ -465,7 +466,10 @@ def main() -> int:
         }
 
     # --paths: explicit override, no scoring, no guardrails (testing path).
+    # The per-article worker passes --lane to carry the dispatcher's lane through
+    # (e.g. stale, so retirement stays in scope); without it entries are manual.
     if args.paths:
+        lane = args.lane or "manual"
         for raw in args.paths.split(","):
             path = raw.strip()
             if not path:
@@ -473,7 +477,7 @@ def main() -> int:
             if path not in known:
                 print(f"select-articles: --paths entry not found: {path}", file=sys.stderr)
                 return 1
-            queue["articles"].append(article(path, "manual", None))
+            queue["articles"].append(article(path, lane, None))
         return finish(queue, args)
 
     open_branches = open_review_branches(use_gh)

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -181,6 +181,11 @@ def main() -> int:
         check([a["path"] for a in q["articles"]] == ["content/docs/misc/two.md"], "explicit path honored")
         check(q["articles"][0]["lane"] == "manual", "manual lane tagged")
 
+        print("--lane overrides the lane for --paths entries")
+        q = run_select(repo, tiers, ledger, "--paths", "content/docs/misc/two.md", "--lane", "stale")
+        check([a["path"] for a in q["articles"]] == ["content/docs/misc/two.md"], "single explicit path")
+        check(q["articles"][0]["lane"] == "stale", "lane override honored")
+
         print("count=1 yields just the stale pick")
         q = run_select(repo, tiers, ledger, "--count", "1")
         check(len(q["articles"]) == 1 and q["articles"][0]["lane"] == "stale",


### PR DESCRIPTION
## What & why

Refactors the automated existing-content review from a single workflow that batches N articles into **one** Claude Code invocation into a **dispatcher → worker** model:

- The old design selected N articles, handed the whole queue to one model run (the `review-existing-content` skill iterates `articles[]`), then force-dispatched `claude-code-review.yml` over each resulting PR. Batching coupled the articles' fate (one hung article burned the whole run's budget) and made per-article concurrency impossible.
- Now: the **dispatcher** does the deterministic selection and fans out one `workflow_dispatch` per article; each **worker** run reviews exactly one article and opens exactly one PR.

## Changes

**New worker — `.github/workflows/content-review-article.yml`**
- `workflow_dispatch`-only. Inputs: `path` (required, one file under `content/docs/`) and `lane` (optional, default `priority`).
- Builds a single-article queue for `path` carrying `lane`, runs the existing SKILL over that one article → one ready PR, then force-dispatches `claude-code-review.yml` over it (`force=true`), and posts the PR link to Slack.
- `concurrency` group keyed on `path` so the same article can't be reviewed by two concurrent runs. `timeout-minutes: 30`. Same permissions as the dispatcher.

**Dispatcher — `review-existing-content.yml` (refactored)**
- Keeps: ESC, AWS creds, traffic-snapshot fetch, the "Select articles" step (with its open-PR dedup + max-open-PR halt), the enable-gate, and the Slack summary.
- Removes: the "Run Claude Code" step and the per-PR forced-review dispatch — both moved into the worker.
- After selection, loops the queue and runs `gh workflow run content-review-article.yml -f path=<path> -f lane=<lane>` per entry.
- Slack now reports the run-level dispatch summary (paths/count) or the halt warning.
- **Cron is commented out** (kept in the file with a re-enable note) — the dispatcher is **manual dispatch only** during rollout. `workflow_dispatch` and the enable-gate remain.

**`scripts/content-review/select-articles.py`**
- New `--lane` flag overrides the lane for `--paths` entries (default stays `manual`). The worker uses `--paths <path> --lane <lane>` so tier/no_retire/url/slug are still computed from the path while the lane carries through — the retirement path stays in scope only when `lane=stale`. Covered by a new test in `test_select_articles.py`.

Humans still merge; nothing auto-merges and no `automation/merge` label is added anywhere.

## Validation

- Both workflow YAMLs parse (`yaml.safe_load`).
- `python3 scripts/content-review/test_select_articles.py` → 35 passed, 0 failed (includes the new `--lane` override case).
- `select-articles.py --paths <real content/docs file> --lane stale --out /tmp/q.json` → exactly one entry with `lane: stale`.
- `make lint` passes.

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCiPz2bqf2vkAiH4M6GJ5Y)_