### PR TITLE
Run content-review pipeline in the worker; allow bot dispatch; drop Slack

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -55,11 +55,17 @@ proposal — stale lane only, see below — use `content-review/retire-<slug>`
 instead.) If an open PR already exists for that branch name, skip the article
 entirely and note it in the results file: a previous run owns it.
 
-### 2. Pre-compute (deterministic floor)
+### 2. Pre-compute (deterministic floor) — the workflow runs this for you
 
-Generate a synthetic whole-file diff and run the docs-review pre-steps over
-it. Scripts live in `.claude/commands/docs-review/scripts/`; artifacts go in
-the repo root, exactly as the PR review workflow lays them out:
+The `content-review-article` workflow generates the synthetic whole-file diff
+and runs the docs-review pre-steps **before invoking you**, exactly as the PR
+review workflow does. The artifacts are already at the repo root when you
+start: `.fetched-urls.json`, `.candidate-claims.json`, `.verified-claims.json`,
+`.vale-findings.json`, `.frontmatter-validation.json`, and
+`.cross-sibling-discovery.json`. **Read them — do not regenerate them.**
+
+For reference (and for local runs outside CI), the exact pipeline the workflow
+executes — scripts live in `.claude/commands/docs-review/scripts/`:
 
 ```bash
 git diff --no-index /dev/null <path> > .synthetic.patch || true
@@ -95,9 +101,9 @@ python3 .claude/commands/docs-review/scripts/vale-findings-filter.py \
     --in .vale-raw.json --out .vale-findings.json || echo '[]' > .vale-findings.json
 ```
 
-If any pre-step fails, continue with the artifacts you
-have and say so in the PR description; never fabricate artifact contents.
-(Consult flag names with `--help` if a script rejects an invocation —
+If any artifact is missing or carries an `errors` field, continue with the
+artifacts you have and say so in the PR description; never fabricate artifact
+contents. (Consult flag names with `--help` if running a script by hand —
 do not guess alternate flags.)
 
 ### 3. Triage and fix — HIGH-CONFIDENCE ONLY

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -264,7 +264,7 @@ outcome **instead of** a fix PR, under a strict evidence standard:
 ## Output
 
 After all articles, write `.content-review-results.json` to the repo root
-for the workflow's review-dispatch and Slack steps:
+for the workflow's review-dispatch step:
 
 ```json
 {
@@ -284,6 +284,7 @@ for the workflow's review-dispatch and Slack steps:
 ```
 
 `head_sha` is each PR branch's final commit SHA (`git rev-parse HEAD` after
-the last push) — the review dispatch needs it. `skipped` lists articles
-abandoned mid-run (existing PR, unfixable build break) with a reason string.
-The `summary` line is posted to Slack verbatim; keep it to one line.
+the last push) — the review dispatch (which reads `.prs[]`) needs it.
+`skipped` lists articles abandoned mid-run (existing PR, unfixable build
+break) with a reason string. The `summary` line is a one-line run note for
+the workflow log; keep it to one line.

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -92,6 +92,64 @@ jobs:
           echo "--- queue ---"
           cat .content-review-queue.json
 
+      # Run the docs-review deterministic pre-computation as a REAL workflow
+      # step — not a model instruction. Build the synthetic whole-file diff and
+      # run the claim extraction + verification, Vale, frontmatter, and
+      # cross-sibling pre-steps (the SKILL's step 2, now owned here). Artifacts
+      # land in the repo root for the review step below to adjudicate. Each
+      # command degrades gracefully (`|| stub`) so one pre-step failure never
+      # blocks the run; the model notes any missing/errored artifact in the PR.
+      - name: Pre-compute review artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ARTICLE_PATH: ${{ github.event.inputs.path }}
+        run: |
+          set +e
+          S=.claude/commands/docs-review/scripts
+          git diff --no-index /dev/null "$ARTICLE_PATH" > .synthetic.patch || true
+
+          python3 $S/extract-urls-and-fetch.py \
+            --patch-file .synthetic.patch --out .fetched-urls.json \
+            || echo '[]' > .fetched-urls.json
+          python3 $S/extract-claims.py \
+            --patch-file .synthetic.patch --out .candidate-claims-regex.json \
+            || echo '{"schema_version": 1, "claims": [], "renames": [], "errors": ["extract-claims.py failed to start"], "stats": {"claims_count": 0, "files_scanned": 0, "by_type": {}}}' > .candidate-claims-regex.json
+          python3 $S/extract-claims-llm.py \
+            --patch-file .synthetic.patch --changed-files "$ARTICLE_PATH" \
+            --pass atomic --scrutiny standard --out .candidate-claims-llm-1.json \
+            || echo '{"schema_version": 1, "pass": "atomic", "model": "claude-sonnet-4-6", "claims": [], "errors": ["extract-claims-llm.py failed to start"], "meta": {"files": 0, "scrutiny": "unknown", "input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}}' > .candidate-claims-llm-1.json
+          python3 $S/extract-claims-llm.py \
+            --patch-file .synthetic.patch --changed-files "$ARTICLE_PATH" \
+            --pass holistic --scrutiny standard --out .candidate-claims-llm-2.json \
+            || echo '{"schema_version": 1, "pass": "holistic", "model": "claude-sonnet-4-6", "claims": [], "errors": ["extract-claims-llm.py failed to start"], "meta": {"files": 0, "scrutiny": "unknown", "input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}}' > .candidate-claims-llm-2.json
+          python3 $S/merge-claims.py \
+            --regex .candidate-claims-regex.json \
+            --llm .candidate-claims-llm-1.json --llm .candidate-claims-llm-2.json \
+            --out .candidate-claims.json \
+            || echo '{"schema_version": 1, "claims": [], "errors": ["merge-claims.py failed to start"], "meta": {"regex_claims": 0, "llm_claims": 0, "merged_claims": 0, "llm_input_tokens": 0, "llm_output_tokens": 0, "llm_cache_read_input_tokens": 0, "llm_cache_creation_input_tokens": 0}}' > .candidate-claims.json
+          python3 $S/verify-claims.py \
+            --in .candidate-claims.json --fetched-urls .fetched-urls.json \
+            --out .verified-claims.json \
+            || echo '{"schema_version": 1, "model": "claude-sonnet-4-6", "verdicts": [], "errors": ["verify-claims.py failed to start"], "meta": {"n_claims": 0, "n_pass1": 0, "n_pass2": 0, "n_pass3": 0, "input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}}' > .verified-claims.json
+          python3 $S/frontmatter-validate.py \
+            --changed-files "$ARTICLE_PATH" --out .frontmatter-validation.json \
+            || echo '{"files": [], "global_identifier_map_size": 0, "global_alias_map_size": 0}' > .frontmatter-validation.json
+          python3 $S/cross-sibling-discover.py \
+            --changed-files "$ARTICLE_PATH" --out .cross-sibling-discovery.json \
+            || echo '{"files": []}' > .cross-sibling-discovery.json
+
+          vale --no-exit --output=JSON "$ARTICLE_PATH" > .vale-raw.json 2>/dev/null \
+            || echo '{}' > .vale-raw.json
+          python3 $S/vale-findings-filter.py \
+            --in .vale-raw.json --out .vale-findings.json \
+            || echo '[]' > .vale-findings.json
+
+          echo "--- pre-compute artifacts ---"
+          ls -1 .fetched-urls.json .candidate-claims.json .verified-claims.json \
+            .vale-findings.json .frontmatter-validation.json \
+            .cross-sibling-discovery.json 2>/dev/null || true
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -99,17 +157,30 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Bot token so the PR/pushes trigger downstream workflows.
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          # This workflow is dispatched by the dispatcher via GITHUB_TOKEN, so
+          # the run's actor is a Bot, which claude-code-action@v1 rejects by
+          # default. Same allowance claude-code-review.yml makes for its
+          # bot-dispatched #new-review path.
+          allowed_bots: 'github-actions[bot]'
           prompt: |
             The existing-content review selected one article in
-            `.content-review-queue.json` at the repo root.
+            `.content-review-queue.json` at the repo root, and the workflow has
+            ALREADY run the deterministic pre-computation pipeline over it
+            (synthetic whole-file diff → claim extraction + verification, Vale,
+            frontmatter, cross-sibling). The artifacts are at the repo root:
+            `.candidate-claims.json`, `.verified-claims.json`,
+            `.vale-findings.json`, `.frontmatter-validation.json`,
+            `.cross-sibling-discovery.json`, `.fetched-urls.json`. Read them;
+            do NOT regenerate them.
 
-            Follow `.claude/commands/review-existing-content/SKILL.md`
-            exactly. In short, for the article in the queue:
+            Follow `.claude/commands/review-existing-content/SKILL.md` exactly,
+            but SKIP step 2 (Pre-compute) — the workflow already did it. For the
+            article in the queue:
 
             1. Branch `content-review/<slug>` off master.
-            2. Run the docs-review pre-computation pipeline over the whole
-               file via a synthetic diff (the skill lists the exact
-               commands).
+            2. (Done by the workflow — read the artifacts above. If one is
+               missing or carries an `errors` field, note it in the PR
+               description and continue with what you have.)
             3. Apply HIGH-CONFIDENCE fixes only; everything judgment-level
                goes in the PR description's "Findings not applied" section.
             4. Run the screenshot/UI verification pass (flag-only).
@@ -124,7 +195,7 @@ jobs:
                description the skill describes. A clean article gets a
                ledger-only PR instead.
             9. Write `.content-review-results.json` (the skill defines the
-               shape) — the review-dispatch and Slack steps consume it.
+               shape) — the review-dispatch step consumes it.
           claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(python3:*),Bash(vale:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(gh repo view:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(mkdir:*),Bash(curl:*)"'
 
       # Slop defense: bot-authored PRs are auto-skipped by the docs-review
@@ -148,22 +219,6 @@ jobs:
               -f force=true \
               || echo "::warning::review dispatch failed for PR #$NUMBER"
           done
-
-      # Post the article's PR link to #docs-ops. Gated on the results file so
-      # a failed run stays silent rather than posting an empty message.
-      - name: Post result to Slack
-        if: hashFiles('.content-review-results.json') != ''
-        env:
-          SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
-        run: |
-          TEXT=$(jq -r '.summary' .content-review-results.json)
-          LINKS=$(jq -r '[.prs[]?.pr, (.ledger_only_pr // empty)] | join("\n")' .content-review-results.json)
-          [ -n "$LINKS" ] && TEXT="$TEXT"$'\n'"$LINKS"
-          curl -s -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
-            -H "Content-type: application/json; charset=utf-8" \
-            --data "$(jq -n --arg ch "#docs-ops" --arg txt "$TEXT" \
-              '{channel: $ch, text: $txt, unfurl_links: true}')"
 
 env:
   ESC_ACTION_OIDC_AUTH: true

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -150,30 +150,15 @@ jobs:
               || echo "::warning::worker dispatch failed for $P"
           done
 
-      # Post the dispatch summary (paths dispatched, or the halted warning) to
-      # #docs-ops. Each worker posts its own PR link when it finishes; this is
-      # the run-level "what got dispatched today" note. Gated on having
-      # articles or a halt so a quiet/failed run stays silent.
-      - name: Post summary to Slack
-        if: >-
-          github.event.inputs.dry_run != 'true' &&
-          (steps.select.outputs.has_articles == 'true' || steps.select.outputs.halted != '')
+      # Surface a halted selection (max_open_prs / gh_unavailable) in the run
+      # log — the select step already prints the queue JSON, this just makes the
+      # halt reason unmissable on a quiet run.
+      - name: Report halt
+        if: steps.select.outputs.halted != ''
         env:
-          SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
           HALTED: ${{ steps.select.outputs.halted }}
-          COUNT: ${{ steps.select.outputs.count }}
         run: |
-          if [ -n "$HALTED" ]; then
-            TEXT=":warning: Existing-content review halted: ${HALTED} (no articles dispatched)"
-          else
-            PATHS=$(jq -r '.articles[].path' .content-review-queue.json)
-            TEXT="Existing-content review dispatched ${COUNT} article review(s):"$'\n'"$PATHS"
-          fi
-          curl -s -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
-            -H "Content-type: application/json; charset=utf-8" \
-            --data "$(jq -n --arg ch "#docs-ops" --arg txt "$TEXT" \
-              '{channel: $ch, text: $txt, unfurl_links: true}')"
+          echo "::warning::Existing-content selection halted: ${HALTED} (no articles dispatched)"
 
 env:
   ESC_ACTION_OIDC_AUTH: true

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,18 @@ _vendor/
 /.content-review-results.json
 /.traffic-snapshot
 /.synthetic.patch
+# docs-review pre-computation artifacts the worker generates before the
+# review (claim extraction/verification, Vale, frontmatter, cross-sibling).
+/.fetched-urls.json
+/.candidate-claims.json
+/.candidate-claims-regex.json
+/.candidate-claims-llm-1.json
+/.candidate-claims-llm-2.json
+/.verified-claims.json
+/.vale-raw.json
+/.vale-findings.json
+/.frontmatter-validation.json
+/.cross-sibling-discovery.json
 
 .doctrees/
 .buildinfo


### PR DESCRIPTION
Follow-up to #19678. Addresses three issues with the per-article content-review worker.

## 1. Worker couldn't be dispatched by a bot

The dispatcher fires the worker via `GITHUB_TOKEN`, so the run's actor is a Bot, and `claude-code-action@v1` rejected it:

```
Actor type: Bot
##[error]Workflow initiated by non-human actor: github-actions (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Fix: add `allowed_bots: 'github-actions[bot]'` to the worker's `claude-code-action` step — the same allowance `claude-code-review.yml` already makes for its bot-dispatched `#new-review` path.

## 2. Actually run the pipeline (don't just tell Claude to)

Previously the worker prompt told Claude to "run the docs-review pre-computation pipeline." That's an instruction, not an execution. Now the **workflow** runs the deterministic floor as a real step (`Pre-compute review artifacts`):

- builds the synthetic whole-file diff (`git diff --no-index /dev/null <path>`);
- runs claim extraction (regex + 2× LLM), `merge-claims`, claim **verification**, Vale, frontmatter validation, and cross-sibling discovery — the exact pipeline the SKILL's step 2 documented, using the scripts' `--patch-file`/`--changed-files` modes;
- writes the artifacts (`.candidate-claims.json`, `.verified-claims.json`, `.vale-findings.json`, `.frontmatter-validation.json`, `.cross-sibling-discovery.json`, `.fetched-urls.json`) to the repo root.

Claude then **adjudicates and fixes** from those artifacts (SKILL steps 3+) instead of regenerating them. Each pre-step degrades gracefully with a schema-valid stub, so one failure never blocks the run; the model notes any missing/errored artifact in the PR. SKILL step 2 is reframed as workflow-owned, and the new artifacts are gitignored so the worker's branch commit can't leak them.

Verified the deterministic pre-steps run against a real `content/docs` file via the documented interface (regex extraction → 72 claims, frontmatter, cross-sibling, merge all succeeded).

## 3. Drop the Slack notifications

Removed from both the worker (`Post result to Slack`) and the dispatcher (`Post summary to Slack`). A halted selection (`max_open_prs` / `gh_unavailable`) is now surfaced as a workflow `::warning::` instead.

## Validation

- Both workflow YAMLs parse.
- `select-articles` test suite: 35 passed.
- `make lint` passes.

Humans still merge; nothing auto-merges.

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCiPz2bqf2vkAiH4M6GJ5Y)_