### PR TITLE
Clarify where GitLab troubleshooting steps occur

### DIFF
--- a/content/docs/integrations/version-control/gitlab.md
+++ b/content/docs/integrations/version-control/gitlab.md
@@ -140,9 +140,9 @@ Use GitLab repositories as template sources for [Pulumi IDP](/docs/idp/concepts/
 
 If comments aren't appearing on your merge requests, verify that:
 
-1. The GitLab integration is connected and shows a valid status under **Management** > **Version control**.
-1. The webhook exists on your GitLab group. Navigate to your group's **Settings** > **Webhooks** and look for the `https://api.pulumi.com/workflow/gitlab` endpoint.
-1. The stack is associated with the correct GitLab repository and branch.
+1. In the [Pulumi Cloud console](https://app.pulumi.com), the GitLab integration is connected and shows a valid status under **Management** > **Version control**.
+1. In the GitLab console, the webhook exists on your GitLab group. Navigate to your group's **Settings** > **Webhooks** and look for the `https://api.pulumi.com/workflow/gitlab` endpoint.
+1. In the Pulumi Cloud console, the stack is associated with the correct GitLab repository and branch.
 
 ### Integration shows as disconnected
 


### PR DESCRIPTION
Clarifies the "Merge request comments not appearing" troubleshooting steps to make explicit where each verification happens.

## Changes
- Steps 1 & 3 now specify the Pulumi Cloud console (with a link to app.pulumi.com)
- Step 2 now specifies the GitLab console for the group webhook

Fixes #19670