### PR TITLE
docs(esc): document value precedence rules (#14131)

### DIFF
--- a/content/docs/esc/concepts/outputs.md
+++ b/content/docs/esc/concepts/outputs.md
@@ -180,7 +180,7 @@ aws:region                    us-west-2
 greeting                      Hola
 ```
 
-For object values, the environment and stack configurations are deep-merged using [JSON merge patch](https://datatracker.ietf.org/doc/html/rfc7396) semantics: the two objects are combined key by key, and the stack's value wins for any key defined in both.
+For object values, the environment and stack configurations are deep-merged using [JSON merge patch](https://datatracker.ietf.org/doc/html/rfc7396) semantics: the two objects are combined key by key, and the stack's value wins for any key defined in both. This deep-merge behavior is specific to `pulumiConfig`. It differs from how an object value declared as a project-level default in `Pulumi.yaml` combines with a stack-level value in `Pulumi.<stack-name>.yaml`: there the stack value _replaces_ the project default outright rather than merging into it.
 
 {{< notes type="info" >}}
 This is the opposite of how [`environmentVariables`](#precedence) resolve against your local environment, where the value from the environment wins. The two rules are distinct.

--- a/content/docs/esc/concepts/outputs.md
+++ b/content/docs/esc/concepts/outputs.md
@@ -63,6 +63,21 @@ $ esc run default/greet -- sh -c '${GREETING}, ${USER}!'
 Hello, user!
 ```
 
+### Precedence
+
+When an ESC consumer such as [`esc run`](/docs/esc/cli/commands/esc_run) runs a command, the values in `environmentVariables` are layered on top of the variables already present in your local (OS) environment. If a variable is defined in both places, **the value from the environment takes precedence** over the inherited local value.
+
+For example, the `default/greet` environment above sets `GREETING: Hello`. Even if `GREETING` is already set in your shell, the environment's value is used:
+
+```console
+$ GREETING=from-shell esc run default/greet -- printenv GREETING
+Hello
+```
+
+{{< notes type="info" >}}
+This is the opposite of how [`pulumiConfig`](#precedence-1) resolves against explicit stack configuration: there, the explicit stack value wins. Keep the two rules distinct.
+{{< /notes >}}
+
 ## files
 
 The `files` reserved property contains values that should be written to temporary files. For example, [`esc run`](/docs/esc/cli/commands/esc_run) writes the contents of each property in the `files` property to a temporary file and exports the file's path in the named environment variable that is accessible to the command to run.
@@ -142,6 +157,36 @@ KEY                           VALUE
 aws:region                    us-west-2
 greeting                      Hello
 ```
+
+### Precedence
+
+When a configuration key is defined both in an environment's `pulumiConfig` and explicitly in a stack's own configuration, **the explicit stack configuration value takes precedence**. Explicit stack configuration includes:
+
+- Values written directly to `Pulumi.<stack-name>.yaml` under the `config:` block.
+- Values set with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set/), which writes to that same stack configuration file.
+
+For example, given the environment above (which sets `greeting: Hello`), if the stack also sets the key explicitly:
+
+```console
+$ pulumi config set greeting Hola
+```
+
+then the explicit value wins:
+
+```console
+$ pulumi config
+KEY                           VALUE
+aws:region                    us-west-2
+greeting                      Hola
+```
+
+For object values, the environment and stack configurations are deep-merged using [JSON merge patch](https://datatracker.ietf.org/doc/html/rfc7386) semantics: the two objects are combined key by key, and the stack's value wins for any key defined in both.
+
+{{< notes type="info" >}}
+This is the opposite of how [`environmentVariables`](#precedence) resolve against your local environment, where the value from the environment wins. The two rules are distinct.
+{{< /notes >}}
+
+This precedence is separate from the rule that applies _among_ multiple imported environments, where the last imported environment wins. See [Imports](/docs/esc/concepts/imports/) for details.
 
 ## policyConfig
 

--- a/content/docs/esc/concepts/outputs.md
+++ b/content/docs/esc/concepts/outputs.md
@@ -180,7 +180,7 @@ aws:region                    us-west-2
 greeting                      Hola
 ```
 
-For object values, the environment and stack configurations are deep-merged using [JSON merge patch](https://datatracker.ietf.org/doc/html/rfc7386) semantics: the two objects are combined key by key, and the stack's value wins for any key defined in both.
+For object values, the environment and stack configurations are deep-merged using [JSON merge patch](https://datatracker.ietf.org/doc/html/rfc7396) semantics: the two objects are combined key by key, and the stack's value wins for any key defined in both.
 
 {{< notes type="info" >}}
 This is the opposite of how [`environmentVariables`](#precedence) resolve against your local environment, where the value from the environment wins. The two rules are distinct.

--- a/content/docs/esc/guides/integrate-with-pulumi-iac.md
+++ b/content/docs/esc/guides/integrate-with-pulumi-iac.md
@@ -93,6 +93,10 @@ values:
 
 Learn more in [Importing environments](/docs/esc/concepts/imports/).
 
+{{< notes type="info" >}}
+When a key is set both in an environment's `pulumiConfig` and explicitly in your stack configuration, the explicit stack value takes precedence. See [Precedence](/docs/esc/concepts/outputs/#precedence-1) for the full rules.
+{{< /notes >}}
+
 ## Convert existing stack config to an ESC environment
 
 To convert your existing stack config to a new ESC environment, use the Pulumi CLI:

--- a/content/docs/iac/concepts/config.md
+++ b/content/docs/iac/concepts/config.md
@@ -791,3 +791,5 @@ environment:
 config:
     # normal pulumi config
 ```
+
+When a key is set both by an imported environment and explicitly in your stack configuration, the explicit stack value takes precedence. See [Precedence](/docs/esc/concepts/outputs/#precedence-1) for the full rules.


### PR DESCRIPTION
Documents the previously-undocumented ESC value precedence rules from #14131, where a community user had to write code to discover the behavior. Behavior was confirmed from pulumi/pulumi and pulumi/esc source, and verified empirically in a sample program/environment.

## Rules documented (they point in opposite directions)
- `pulumiConfig` vs. explicit stack config — explicit stack config wins (`Pulumi.<stack>.yaml` and `pulumi config set`); objects deep-merge via JSON merge patch with stack keys winning.
- `environmentVariables` vs. local OS env vars — the ESC value wins (e.g. `esc run`).

## Object-merge contrast (#16148)
`pulumiConfig` object values deep-merge with explicit stack config. This is called out as distinct from how a project-level object default in `Pulumi.yaml` combines with a stack-level value in `Pulumi.<stack>.yaml`, where the stack value **replaces** the project default outright. Both behaviors verified empirically:
- ESC `pulumiConfig` `{fromEnv, shared:env}` + stack `{fromStack, shared:stack}` → `{fromEnv, fromStack, shared:stack}` (deep-merge, stack wins per key).
- `Pulumi.yaml` default `{fromProject, shared:project}` + `Pulumi.dev.yaml` `{fromStack, shared:stack}` → `{fromStack, shared:stack}` (replace; `fromProject` dropped).

## Changes
- `esc/concepts/outputs.md` — two new `### Precedence` subsections (cross-linked); pulumiConfig section also contrasts deep-merge vs. project/stack replace
- `esc/guides/integrate-with-pulumi-iac.md` — precedence note
- `iac/concepts/config.md` — cross-link from the ESC-from-stack-config section

Fixes #14131
Fixes #16148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
