### PR TITLE
Fix bugs and document output consumption across ESC provider pages

### DIFF
--- a/content/docs/esc/providers/login/doppler-login.md
+++ b/content/docs/esc/providers/login/doppler-login.md
@@ -30,6 +30,9 @@ values:
       fn::open::doppler-login:
         oidc:
           identityId: 00000000-0000-0000-0000-000000000000
+  environmentVariables:
+    # Consumed by the Doppler CLI for authentication
+    DOPPLER_TOKEN: ${doppler.login.accessToken}
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/providers/login/gh-login.md
+++ b/content/docs/esc/providers/login/gh-login.md
@@ -52,6 +52,8 @@ Private keys do not expire and need to be manually revoked. You must keep privat
 Store the private key as a secret by using the `fn::secret` function.
 See "[Managing Secrets](/docs/esc/operations/managing-secrets/#storing-secrets)".
 
+Because the PEM-formatted private key spans multiple lines, wrap it in a YAML block scalar (`|`) so the newlines are preserved. See "[Multi-line secrets](/docs/esc/operations/managing-secrets/#multi-line-secrets)".
+
 ```yaml
 appId: 123456
 privateKey:

--- a/content/docs/esc/providers/login/infisical-login.md
+++ b/content/docs/esc/providers/login/infisical-login.md
@@ -30,6 +30,9 @@ values:
       fn::open::infisical-login:
         oidc:
           identityId: aaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+  environmentVariables:
+    # Consumed by the Infisical CLI for authentication
+    INFISICAL_TOKEN: ${infisical.login.accessToken}
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/providers/login/vault-login.md
+++ b/content/docs/esc/providers/login/vault-login.md
@@ -28,6 +28,10 @@ values:
         address: https://127.0.0.1:8200/
         jwt:
           role: example-role
+  environmentVariables:
+    # Consumed by the Vault CLI and the Pulumi Vault provider
+    VAULT_ADDR: ${vault.login.address}
+    VAULT_TOKEN: ${vault.login.token}
 ```
 
 ```yaml
@@ -42,6 +46,11 @@ values:
           token:
             fn::secret: redacted
           policies: [kv-read]
+  environmentVariables:
+    # Consumed by the Vault CLI and the Pulumi Vault provider
+    VAULT_ADDR: ${vault.login.address}
+    VAULT_TOKEN: ${vault.login.token}
+    VAULT_NAMESPACE: ${vault.login.namespace}
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/providers/secrets/1password-secrets.md
+++ b/content/docs/esc/providers/secrets/1password-secrets.md
@@ -45,6 +45,9 @@ values:
             ref: "op://development/aws/Access Keys/access_key_id"
           gale_unique_id_example:
             ref: "op://prod/yj3jfj2vzsbiwqabprflnl27lm/password"
+  pulumiConfig:
+    email: ${1password.secrets.email_section_example}
+    stripeKey: ${1password.secrets.anna_sans_section_example}
 ```
 
 ## Inputs

--- a/content/docs/esc/providers/secrets/aws-parameter-store.md
+++ b/content/docs/esc/providers/secrets/aws-parameter-store.md
@@ -43,6 +43,9 @@ values:
             decrypt: true
           myList:
             name: /myNamespace/myList
+  pulumiConfig:
+    myKey: ${aws.params.myKey}
+    secureKey: ${aws.params.secureKey}
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/providers/secrets/aws-secrets.md
+++ b/content/docs/esc/providers/secrets/aws-secrets.md
@@ -39,6 +39,9 @@ values:
             secretId: api-key
           app-secret:
             secretId: app-secret
+  pulumiConfig:
+    apiKey: ${aws.secrets.api-key}
+    appSecret: ${aws.secrets.app-secret}
 ```
 
 ## Example: Key/Value Pair Secrets
@@ -62,7 +65,7 @@ values:
             secretId: prod-db
     secrets-unpacked:
       db-creds:
-        fn::fromJSON: ${aws.secrets.my-secret}
+        fn::fromJSON: ${aws.secrets.db-creds}
   pulumiConfig:
     dbUserName: ${aws.secrets-unpacked.db-creds.userName}
     dbPassword: ${aws.secrets-unpacked.db-creds.password}

--- a/content/docs/esc/providers/secrets/azure-secrets.md
+++ b/content/docs/esc/providers/secrets/azure-secrets.md
@@ -37,6 +37,9 @@ values:
             name: api-key
           app-secret:
             name: app-secret
+  pulumiConfig:
+    apiKey: ${azure.secrets.api-key}
+    appSecret: ${azure.secrets.app-secret}
 ```
 
 ## Configuring OIDC
@@ -98,7 +101,7 @@ Make sure to replace `<org>`, `<project>`, and `<environment>` with the values o
 | `name`         | string | The name of the secret to import.                 |
 | `version`      | string | [Optional] - The version of the secret to import. |
 
-### Outputs
+## Outputs
 
 | Property | Type   | Description                         |
 |----------|--------|-------------------------------------|

--- a/content/docs/esc/providers/secrets/doppler-secrets.md
+++ b/content/docs/esc/providers/secrets/doppler-secrets.md
@@ -37,6 +37,9 @@ values:
             name: API_KEY
           app-secret:
             name: APP_SECRET
+  pulumiConfig:
+    apiKey: ${doppler.secrets.api-key}
+    appSecret: ${doppler.secrets.app-secret}
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/providers/secrets/external.md
+++ b/content/docs/esc/providers/secrets/external.md
@@ -44,6 +44,9 @@ values:
         environment: production
         secretType: api-keys
       secret: true  # Optional, defaults to true
+  pulumiConfig:
+    apiKey: ${customSecrets.response.apiKey}
+    apiSecret: ${customSecrets.response.apiSecret}
 ```
 
 ### Request Payload

--- a/content/docs/esc/providers/secrets/gcp-secrets.md
+++ b/content/docs/esc/providers/secrets/gcp-secrets.md
@@ -38,6 +38,9 @@ values:
             name: api-key
           app-secret:
             name: app-secret
+  pulumiConfig:
+    apiKey: ${gcp.secrets.api-key}
+    appSecret: ${gcp.secrets.app-secret}
 ```
 
 ## Configuring OIDC
@@ -51,20 +54,17 @@ Make sure to replace `<org>`, `<project>`, and `<environment>` with the values o
 
 ```json
 {
-  "environmentVariables": {
-    "GOOGLE_PROJECT": 111111111111
-    "CLOUDSDK_AUTH_ACCESS_TOKEN": "ya29...."
-  },
   "gcp": {
     "login": {
       "accessToken": "ya29.....",
       "expiry": "2023-11-09T11:12:41Z",
-      "project": 111111111111,
+      "project": 123456789,
       "tokenType": "Bearer"
+    },
+    "secrets": {
+      "api-key": "my-api-key",
+      "app-secret": "my-app-secret"
     }
-  },
-  "pulumiConfig": {
-    "gcp:accessToken": "ya29...."
   }
 }
 ```
@@ -85,14 +85,14 @@ Make sure to replace `<org>`, `<project>`, and `<environment>` with the values o
 | `tokenType`   | string | The type of the access token.                                                    |
 | `expiry`      | string | [Optional] - The access token's expiry time.                                     |
 
-#### GCPSecretsAccess
+### GCPSecretsAccess
 
 | Property       | Type   | Description                                       |
 |----------------|--------|---------------------------------------------------|
 | `name`         | string | The name of the secret to import.                 |
 | `version`      | string | [Optional] - The version of the secret to import. |
 
-### Outputs
+## Outputs
 
 | Property | Type   | Description                         |
 |----------|--------|-------------------------------------|

--- a/content/docs/esc/providers/secrets/infisical-secrets.md
+++ b/content/docs/esc/providers/secrets/infisical-secrets.md
@@ -39,6 +39,9 @@ values:
             projectId: xxxxxxx-bbbb-cccc-dddd-eeeeeeeeeeee
             environment: dev
             secretKey: app-secret
+  pulumiConfig:
+    apiKey: ${infisical.secrets.api-key}
+    appSecret: ${infisical.secrets.app-secret}
 ```
 
 ## Configuring OIDC

--- a/content/docs/esc/providers/secrets/vault-secrets.md
+++ b/content/docs/esc/providers/secrets/vault-secrets.md
@@ -33,8 +33,14 @@ values:
         read:
           api-key:
             path: api-key
+            # Read a single field so the output is a scalar value
+            field: value
           app-secret:
             path: app-secret
+            field: value
+  pulumiConfig:
+    apiKey: ${vault.secrets.api-key}
+    appSecret: ${vault.secrets.app-secret}
 ```
 
 ## Configuring OIDC
@@ -87,7 +93,7 @@ Make sure to replace `<org>`, `<project>`, and `<environment>` with the values o
 | `namespace` | string | [Optional] The namespace to use for the session.                              |
 | `token`     | string | The token to use for authentication.                                          |
 
-#### VaultSecretsRead
+### VaultSecretsRead
 
 | Property | Type   | Description                                  |
 |----------|--------|----------------------------------------------|


### PR DESCRIPTION
Improves the ESC provider documentation pages. Part of #19463.

## Bug fixes (secrets pages)
- `gcp-secrets`: fix invalid sample JSON (missing comma) that also showed login output instead of the secrets map; normalize heading levels
- `azure-secrets`: Outputs H3 → H2
- `vault-secrets`: VaultSecretsRead H4 → H3
- `aws-secrets`: fix dangling `${aws.secrets.my-secret}` → `${aws.secrets.db-creds}`

## Output-consumption examples
- Login pages (`doppler`, `infisical`, `vault`): show login outputs exported as the env vars the corresponding CLI/provider consumes
- `gh-login`: call out multi-line-secrets guidance for the PEM private key
- Secrets pages: map imported secrets to `pulumiConfig` (`aws-secrets`, `aws-parameter-store`, `azure`, `gcp`, `doppler`, `infisical`, `vault`, `external`, `1password`)

## Follow-ups for SME verification
- [ ] `vault-secrets` uses `field` to flatten a read to a scalar — confirm the output shape against the ESC provider source
- [ ] Confirm ESC interpolation resolves the digit-leading `1password` key (`${1password.secrets.*}`)