### PR TITLE
content(blog): push Pablo's two posts out one week

### DIFF
--- a/content/blog/cloudflare-first-networking-with-pulumi/index.md
+++ b/content/blog/cloudflare-first-networking-with-pulumi/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Cloudflare-First Networking as Code with Pulumi"
-date: 2026-06-16
+date: 2026-06-23
 meta_desc: "Build a Cloudflare-first edge baseline with Pulumi, including DNS, WAF rules, Workers, Zero Trust Access policies, and repeatable validation."
 meta_image: meta.png
 feature_image: feature.png

--- a/content/blog/end-to-end-databricks-with-pulumi/index.md
+++ b/content/blog/end-to-end-databricks-with-pulumi/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Build a Governed Databricks Workspace with Pulumi"
-date: 2026-06-18
+date: 2026-06-25
 meta_desc: "Provision a governed Databricks workspace baseline with Pulumi, including cluster policies, notebooks, jobs, and promotion workflows."
 feature_image: feature.png
 meta_image: meta.png


### PR DESCRIPTION
Reschedules Pablo Seibelt's two upcoming blog posts back by one week.

| Post | Was | Now |
| --- | --- | --- |
| Cloudflare-First Networking as Code with Pulumi | Tue 2026-06-16 | Tue 2026-06-23 |
| Build a Governed Databricks Workspace with Pulumi | Thu 2026-06-18 | Thu 2026-06-25 |

Date-only change to frontmatter; no content edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)