### PR TITLE
Fix syntax error in transforms.md

### DIFF
--- a/content/docs/iac/concepts/resources/options/transforms.md
+++ b/content/docs/iac/concepts/resources/options/transforms.md
@@ -133,7 +133,7 @@ pulumi.runtime.registerResourceTransform(args => {
         args.props["tags"] = Object.assign(args.props["tags"], autoTags);
         return { props: args.props, opts: args.opts };
     }
-};
+});
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
### Proposed changes

There was a missing closing parententis on an typescript example
