### PR TITLE
docs(secrets): document that resource id can't be made secret in state

### DIFF
--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -466,6 +466,10 @@ Unlike the logical name (which you choose) or the URN (which Pulumi derives), th
 
 Because `id` is an output, it is wrapped in Pulumi's `Output<T>` type and is not known until the resource has been created or updated. You access it just like any other output — by passing it directly to another resource's input or by using `.apply()` when you need to transform the value in code.
 
+{{% notes type="info" %}}
+The physical ID is always stored in plain text in the state file and cannot be encrypted, even with [`additionalSecretOutputs`](/docs/iac/concepts/resources/options/additionalsecretoutputs/). If a resource places a sensitive value in its ID, see [The resource ID cannot be made secret](/docs/concepts/secrets/#the-resource-id-cannot-be-made-secret).
+{{% /notes %}}
+
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 
 {{% choosable language typescript %}}

--- a/content/docs/iac/concepts/resources/options/additionalsecretoutputs.md
+++ b/content/docs/iac/concepts/resources/options/additionalsecretoutputs.md
@@ -82,3 +82,7 @@ resources:
 {{< /chooser >}}
 
 Only top-level resource properties can be designated secret. If sensitive data is nested inside of a property, you must mark the entire top-level output property as secret.
+
+{{% notes "warning" %}}
+A resource's [physical ID](/docs/iac/concepts/resources/names/#physicalid) (the `id` output property) cannot be included in `additionalSecretOutputs`. The `id` is a special property, not a regular output, so it is always stored in plain text in the state file. See [The resource ID cannot be made secret](/docs/concepts/secrets/#the-resource-id-cannot-be-made-secret) for the implications and a workaround.
+{{% /notes %}}

--- a/content/docs/iac/concepts/secrets/_index.md
+++ b/content/docs/iac/concepts/secrets/_index.md
@@ -194,6 +194,23 @@ Be careful that you do not pass this plain-text value to code that might expose 
 
 It is possible to mark resource outputs as containing secrets. In this case, Pulumi will automatically treat those outputs as secrets and encrypt them in the state file and anywhere they flow to. To do so, use the [`additional secret outputs`](/docs/concepts/resources#additionalsecretoutputs) option.
 
+### The resource ID cannot be made secret
+
+A resource's [physical ID](/docs/iac/concepts/resources/names/#physicalid) — the `id` output property assigned by the provider — is always stored in plain text in the state file and cannot be encrypted. Adding `id` to [`additionalSecretOutputs`](/docs/iac/concepts/resources/options/additionalsecretoutputs/) has no effect, because `id` is a special property rather than a regular output.
+
+{{% notes "warning" %}}
+This matters when a resource places a sensitive, generated value in its ID. For example, the `result` of `random.RandomString` is also exposed as the resource's `id`, so the generated string ends up unencrypted in state even if you mark `result` as secret.
+
+To keep a generated secret out of plain-text state, use a resource that exposes the sensitive value only as a normal output. For instance, `random.RandomPassword` returns the generated value in its `result` output (its `id` is not the secret), so marking `result` secret encrypts it everywhere it is stored:
+
+```typescript
+const password = new random.RandomPassword("password", {
+    length: 16,
+}, { additionalSecretOutputs: ["result"] });
+```
+
+{{% /notes %}}
+
 ## Encrypted secrets in configuration data {#secrets}
 
 Some configuration data is sensitive, such as database passwords or service tokens. For such cases, passing the `--secret` flag to the `config set` command encrypts the data and stores the resulting ciphertext instead of plain text.


### PR DESCRIPTION
## Summary

Documents the known limitation from [pulumi/pulumi#8946](https://github.com/pulumi/pulumi/issues/8946): a resource's physical ID (the `id` output property) is always serialized in **plain text** in the state file and cannot be encrypted. Adding `id` to `additionalSecretOutputs` has no effect, because `id` is a special property rather than a regular output.

This matters when a resource places a generated, sensitive value in its ID (e.g. `random.RandomString`, whose `result` is also its `id`). The docs now point users to the workaround: use a resource that exposes the secret only as a normal output (e.g. `random.RandomPassword`'s `result`) and mark that output secret.

## Changes

- **Secrets page** (`secrets/_index.md`) — new "The resource ID cannot be made secret" subsection with a warning callout and the `RandomPassword` workaround (primary, most discoverable location).
- **`additionalSecretOutputs` option page** — scoped warning note where users naturally try `additionalSecretOutputs: ["id"]`.
- **Physical IDs section** (`resources/names.md`) — brief cross-reference info note.

All three cross-link to each other.

## Test plan

- [x] `make lint` passes (markdown + prettier)
- [ ] Reviewer: verify callouts render and anchors resolve on the three pages

Fixes #11716

🤖 Generated with [Claude Code](https://claude.com/claude-code)