### PR TITLE
Move pulumi-stacks and terraform-state into a new ESC "IaC" providers category

### DIFF
--- a/content/docs/ai/integrations/cli/_index.md
+++ b/content/docs/ai/integrations/cli/_index.md
@@ -65,7 +65,7 @@ If you can't use OIDC (for example, while you're getting started), the same `*-l
 
 The [Kubernetes Cluster Access](/docs/esc/guides/kubernetes-cluster-access/) guide walks through both options:
 
-- **Stack-output kubeconfig (recommended for Pulumi-managed clusters).** Use the [`pulumi-stacks`](/docs/esc/providers/secrets/pulumi-stacks/) ESC provider to read the kubeconfig from an EKS, AKS, or GKE stack output, then materialize it through `files.KUBECONFIG`. This way the cluster Neo connects to is always the cluster Pulumi just deployed, with no manual config drift.
+- **Stack-output kubeconfig (recommended for Pulumi-managed clusters).** Use the [`pulumi-stacks`](/docs/esc/providers/iac/pulumi-stacks/) ESC provider to read the kubeconfig from an EKS, AKS, or GKE stack output, then materialize it through `files.KUBECONFIG`. This way the cluster Neo connects to is always the cluster Pulumi just deployed, with no manual config drift.
 - **Static kubeconfig.** Drop a kubeconfig directly into `files.KUBECONFIG` for clusters not managed by a Pulumi program.
 
 ## Setting up a CLI integration

--- a/content/docs/esc/guides/integrate-with-pulumi-iac.md
+++ b/content/docs/esc/guides/integrate-with-pulumi-iac.md
@@ -113,7 +113,7 @@ You can manage a stack's imported environments with [Automation API](/docs/iac/c
 
 ## Accessing Pulumi stack outputs
 
-You can read [outputs](/docs/iac/concepts/inputs-outputs/#outputs) from other [Pulumi stacks](/docs/iac/concepts/stacks/) into an ESC environment with the [`pulumi-stacks` provider](/docs/esc/providers/secrets/pulumi-stacks/).
+You can read [outputs](/docs/iac/concepts/inputs-outputs/#outputs) from other [Pulumi stacks](/docs/iac/concepts/stacks/) into an ESC environment with the [`pulumi-stacks` provider](/docs/esc/providers/iac/pulumi-stacks/).
 
 ## Next steps
 

--- a/content/docs/esc/guides/kubernetes-cluster-access.md
+++ b/content/docs/esc/guides/kubernetes-cluster-access.md
@@ -64,7 +64,7 @@ the `KUBECONFIG` environment variable to refer to the file, and then runs a `kub
 ### Use stack outputs to generate a kubeconfig file
 
 Instead of hardcoding a kubeconfig, you also have the option of using ESC providers to dynamically import
-cluster information from [stack outputs](/docs/iac/concepts/stacks/#outputs) of Pulumi IaC programs. The [`pulumi-stacks`](/docs/esc/providers/secrets/pulumi-stacks/) ESC provider allows you to read Pulumi IaC stack outputs (in this example, a kubeconfig for an EKS cluster) at runtime and map those values to environment variables, to temporary files, or directly to other Pulumi IaC programs as stack configuration values. Check out the [Getting Started](/docs/clouds/kubernetes/) guide if you need help setting up a Kubernetes cluster.
+cluster information from [stack outputs](/docs/iac/concepts/stacks/#outputs) of Pulumi IaC programs. The [`pulumi-stacks`](/docs/esc/providers/iac/pulumi-stacks/) ESC provider allows you to read Pulumi IaC stack outputs (in this example, a kubeconfig for an EKS cluster) at runtime and map those values to environment variables, to temporary files, or directly to other Pulumi IaC programs as stack configuration values. Check out the [Getting Started](/docs/clouds/kubernetes/) guide if you need help setting up a Kubernetes cluster.
 
 The following environment defines a kubeconfig file based on a stack output:
 

--- a/content/docs/esc/providers/_index.md
+++ b/content/docs/esc/providers/_index.md
@@ -43,6 +43,13 @@ Dynamically import values from an external system of record into your environmen
 | [gcp-secrets](/docs/esc/providers/secrets/gcp-secrets/) | Import secrets from Google Cloud Secret Manager. |
 | [infisical-secrets](/docs/esc/providers/secrets/infisical-secrets/) | Import secrets from Infisical. |
 | [vault-secrets](/docs/esc/providers/secrets/vault-secrets/) | Import secrets from HashiCorp Vault. |
-| [pulumi-stacks](/docs/esc/providers/secrets/pulumi-stacks/) | Import outputs from a Pulumi stack (includes Terraform state stored in Pulumi Cloud). |
-| [terraform-state](/docs/esc/providers/secrets/terraform-state/) | Import outputs from a Terraform state file in S3 or Terraform Cloud. |
 | [external](/docs/esc/providers/secrets/external/) | Import secrets from a custom service adapter. |
+
+## Infrastructure as code providers
+
+Import the outputs of an existing Pulumi stack or Terraform state file into your environment.
+
+| Provider | Description |
+|---|---|
+| [pulumi-stacks](/docs/esc/providers/iac/pulumi-stacks/) | Import outputs from a Pulumi stack (includes Terraform state stored in Pulumi Cloud). |
+| [terraform-state](/docs/esc/providers/iac/terraform-state/) | Import outputs from a Terraform state file in S3 or Terraform Cloud. |

--- a/content/docs/esc/providers/iac/_index.md
+++ b/content/docs/esc/providers/iac/_index.md
@@ -1,0 +1,23 @@
+---
+title: Infrastructure as Code providers
+title_tag: Pulumi ESC infrastructure as code providers
+h1: Infrastructure as Code providers
+meta_desc: Pulumi ESC infrastructure as code providers import Pulumi stack outputs and Terraform state outputs into your environment.
+menu:
+  esc:
+    name: IaC
+    identifier: esc-providers-iac
+    parent: esc-providers
+    weight: 3
+aliases:
+  - /docs/esc/integrations/infrastructure/
+---
+
+Infrastructure as code providers import the outputs of an existing infrastructure deployment — a Pulumi stack or a Terraform state file — into your environment. Each provider is invoked through `fn::open::<name>`, and the imported outputs can be mapped to `pulumiConfig` or `environmentVariables` and consumed by downstream stacks, programs, and tools.
+
+Use these providers to share foundational infrastructure (VPC IDs, subnet IDs, cluster endpoints, DNS zones) across stacks and teams without copying values by hand or wiring up additional credentials.
+
+| Provider | Description |
+|---|---|
+| [pulumi-stacks](/docs/esc/providers/iac/pulumi-stacks/) | Import outputs from a Pulumi stack (including Terraform state stored in Pulumi Cloud). |
+| [terraform-state](/docs/esc/providers/iac/terraform-state/) | Import outputs from a Terraform state file in S3 or Terraform Cloud. |

--- a/content/docs/esc/providers/iac/pulumi-stacks.md
+++ b/content/docs/esc/providers/iac/pulumi-stacks.md
@@ -6,9 +6,10 @@ h1: pulumi-stacks
 menu:
     esc:
         identifier: pulumi-stacks
-        parent: esc-providers-secrets
-        weight: 50
+        parent: esc-providers-iac
+        weight: 1
 aliases:
+    - /docs/esc/providers/secrets/pulumi-stacks/
     - /docs/pulumi-cloud/esc/providers/pulumi-stacks/
     - /docs/esc/providers/pulumi-stacks/
     - /docs/esc/integrations/infrastructure/pulumi-iac/pulumi-stacks/
@@ -20,6 +21,8 @@ The `pulumi-stacks` provider enables you to import stack outputs from Pulumi int
 
 ## Example
 
+### Pulumi stack
+
 ```yaml
 values:
   stackRefs:
@@ -28,9 +31,30 @@ values:
         vpcInfra:
           stack: vpc-infra/dev
   pulumiConfig:
+    # Consume the stack outputs as Pulumi stack configuration (inputs to your program)
     vpcId: ${stackRefs.vpcInfra.vpcId}
     publicSubnetIds: ${stackRefs.vpcInfra.publicSubnetIds}
     privateSubnetIds: ${stackRefs.vpcInfra.privateSubnetIds}
+```
+
+### Terraform state stored in Pulumi Cloud
+
+When a stack's [Terraform state is stored in Pulumi Cloud](/docs/iac/get-started/terraform/terraform-state-backend/), the Terraform root module outputs are exposed as stack outputs (using their original snake_case names) and read here with no additional tokens or credentials. You can then map those outputs to either `pulumiConfig`, to consume them as inputs to a Pulumi program, or `environmentVariables`, to feed them back into a downstream Terraform run:
+
+```yaml
+values:
+  tfStack:
+    fn::open::pulumi-stacks:
+      stacks:
+        network:
+          stack: network-tf/production
+  pulumiConfig:
+    # Consume the Terraform outputs as Pulumi stack configuration (inputs to your program)
+    vpcId: ${tfStack.network.vpc_id}
+    subnetIds: ${tfStack.network.subnet_ids}
+  environmentVariables:
+    # Expose the outputs as TF_VAR_* environment variables to feed a downstream Terraform run
+    TF_VAR_vpc_id: ${tfStack.network.vpc_id}
 ```
 
 ## Inputs

--- a/content/docs/esc/providers/iac/terraform-state.md
+++ b/content/docs/esc/providers/iac/terraform-state.md
@@ -6,9 +6,10 @@ h1: terraform-state
 menu:
   esc:
     identifier: terraform-state
-    parent: esc-providers-secrets
-    weight: 51
+    parent: esc-providers-iac
+    weight: 2
 aliases:
+  - /docs/esc/providers/secrets/terraform-state/
   - /docs/pulumi-cloud/esc/providers/terraform-state/
   - /docs/esc/providers/terraform-state/
   - /docs/esc/integrations/infrastructure/terraform/terraform-state/
@@ -16,7 +17,12 @@ aliases:
   - /docs/esc/concepts/providers/secrets/terraform-state/
 ---
 
-The `terraform-state` provider enables you to read outputs from Terraform state files stored in S3 or Terraform Cloud.
+The `terraform-state` provider enables you to read outputs from Terraform state files stored in S3 or Terraform Cloud. By importing those outputs into your environment, you can seamlessly consume Terraform-managed infrastructure as inputs to your Pulumi programs — referencing values such as VPC IDs, subnet IDs, and cluster endpoints directly, without copying them by hand or rewriting your Terraform in Pulumi. This bridges the two tools, so you can adopt Pulumi incrementally alongside an existing Terraform footprint.
+
+Imported outputs are available under the `outputs` key (for example, `${terraform.outputs.vpc_id}`) and can be mapped to either of the following:
+
+- `pulumiConfig` — to consume them as [stack configuration](/docs/iac/concepts/config/) (that is, as inputs to your Pulumi program).
+- `environmentVariables` — to expose them as environment variables for the Pulumi CLI, a downstream Terraform run, or any other tooling.
 
 ## Example
 
@@ -37,8 +43,12 @@ values:
           key: path/to/terraform.tfstate
           region: us-west-2
   pulumiConfig:
+    # Consume the Terraform outputs as Pulumi stack configuration (inputs to your program)
     vpcId: ${terraform.outputs.vpc_id}
     subnetIds: ${terraform.outputs.subnet_ids}
+  environmentVariables:
+    # Expose the outputs as TF_VAR_* environment variables to feed a downstream Terraform run
+    TF_VAR_vpc_id: ${terraform.outputs.vpc_id}
 ```
 
 ### Terraform Cloud backend
@@ -54,8 +64,12 @@ values:
           token:
             fn::secret: tfc-token-value
   pulumiConfig:
+    # Consume the Terraform outputs as Pulumi stack configuration (inputs to your program)
     vpcId: ${terraform.outputs.vpc_id}
     subnetIds: ${terraform.outputs.subnet_ids}
+  environmentVariables:
+    # Expose the outputs as TF_VAR_* environment variables to feed a downstream Terraform run
+    TF_VAR_vpc_id: ${terraform.outputs.vpc_id}
 ```
 
 ## Inputs

--- a/content/docs/esc/providers/secrets/_index.md
+++ b/content/docs/esc/providers/secrets/_index.md
@@ -2,7 +2,7 @@
 title: Secrets and configuration providers
 title_tag: Pulumi ESC secrets and configuration providers
 h1: Secrets and configuration providers
-meta_desc: Pulumi ESC providers dynamically import secrets, configuration, Pulumi stack outputs, and Terraform state values into your environment.
+meta_desc: Pulumi ESC secrets and configuration providers dynamically import secrets and configuration from external systems of record into your environment.
 menu:
   esc:
     name: Secrets & config
@@ -29,6 +29,6 @@ Secrets and configuration providers dynamically import values from an external s
 | [gcp-secrets](/docs/esc/providers/secrets/gcp-secrets/) | Import secrets from Google Cloud Secret Manager. |
 | [infisical-secrets](/docs/esc/providers/secrets/infisical-secrets/) | Import secrets from Infisical. |
 | [vault-secrets](/docs/esc/providers/secrets/vault-secrets/) | Import secrets from HashiCorp Vault. |
-| [pulumi-stacks](/docs/esc/providers/secrets/pulumi-stacks/) | Import outputs from a Pulumi stack (including Terraform state stored in Pulumi Cloud). |
-| [terraform-state](/docs/esc/providers/secrets/terraform-state/) | Import outputs from a Terraform state file in S3 or Terraform Cloud. |
 | [external](/docs/esc/providers/secrets/external/) | Import secrets from a custom service adapter. |
+
+To import outputs from a Pulumi stack or a Terraform state file, see the [infrastructure as code providers](/docs/esc/providers/iac/).

--- a/content/docs/iac/concepts/config.md
+++ b/content/docs/iac/concepts/config.md
@@ -782,7 +782,7 @@ Stack tags applied by Pulumi CLI are listed in the `Tags` section of the Overvie
 
 Often there is common configuration and secrets you do not want to duplicate in various stack configuration files. Pulumi ESC can help with that!
 
-Once you have an [environment](/docs/esc/concepts/) set up and you are [projecting pulumi configuration](/docs/esc/concepts/outputs/#pulumiconfig), you can [import that environment](/docs/esc/providers/secrets/pulumi-stacks/) (or multiple environments) into your Pulumi stack.
+Once you have an [environment](/docs/esc/concepts/) set up and you are [projecting pulumi configuration](/docs/esc/concepts/outputs/#pulumiconfig), you can [import that environment](/docs/esc/providers/iac/pulumi-stacks/) (or multiple environments) into your Pulumi stack.
 
 ```yaml
 # import the test environment and all of its configuration

--- a/content/docs/iac/get-started/terraform/terraform-state-backend.md
+++ b/content/docs/iac/get-started/terraform/terraform-state-backend.md
@@ -25,7 +25,7 @@ If you are managing Terraform state in S3, Azure Blob Storage, or another DIY ba
 - **Automatic state locking** — prevents concurrent operations from corrupting state
 - **Role-based access control** — control who can read or modify each stack with [teams and RBAC](/docs/administration/access-identity/rbac/)
 - **Unified resource visibility** — view Terraform-managed resources alongside Pulumi-managed resources in [Resource Search](/docs/pulumi-cloud/insights/search/)
-- **Platform integration** — root module outputs become Pulumi stack outputs, accessible via [stack references](/docs/iac/concepts/stacks/#stackreferences) from other Pulumi stacks or via the [`pulumi-stacks` ESC provider](/docs/esc/providers/secrets/pulumi-stacks/) with no extra tokens or credentials required
+- **Platform integration** — root module outputs become Pulumi stack outputs, accessible via [stack references](/docs/iac/concepts/stacks/#stackreferences) from other Pulumi stacks or via the [`pulumi-stacks` ESC provider](/docs/esc/providers/iac/pulumi-stacks/) with no extra tokens or credentials required
 
 ## How it works
 
@@ -240,7 +240,7 @@ When Terraform state is stored in Pulumi Cloud, each Terraform resource is conve
 
 This "mechanical" mapping preserves the Terraform resource structure (attribute names, IDs, dependencies) without transforming it to Pulumi provider schemas. Resource properties use Terraform naming conventions, so practitioners can search for resources in Resource Search using the attribute names they are already familiar with. Sensitive values marked in your Terraform state are encrypted.
 
-Terraform root module outputs are mapped to Pulumi [stack outputs](/docs/iac/concepts/stacks/#outputs), making them available for [stack references](/docs/iac/concepts/stacks/#stackreferences) and the [`pulumi-stacks` ESC provider](/docs/esc/providers/secrets/pulumi-stacks/). This means your Pulumi stacks can directly reference Terraform outputs — useful for sharing foundational infrastructure like VPC IDs or DNS zones, and for incremental migrations where legacy infrastructure can stay in Terraform while new stacks are written in Pulumi.
+Terraform root module outputs are mapped to Pulumi [stack outputs](/docs/iac/concepts/stacks/#outputs), making them available for [stack references](/docs/iac/concepts/stacks/#stackreferences) and the [`pulumi-stacks` ESC provider](/docs/esc/providers/iac/pulumi-stacks/). This means your Pulumi stacks can directly reference Terraform outputs — useful for sharing foundational infrastructure like VPC IDs or DNS zones, and for incremental migrations where legacy infrastructure can stay in Terraform while new stacks are written in Pulumi.
 
 ### Audit policies
 

--- a/content/docs/support/faq/secrets-config.md
+++ b/content/docs/support/faq/secrets-config.md
@@ -28,7 +28,7 @@ See our [pricing page](https://www.pulumi.com/pricing/) for details.
 
 Secrets include [static secrets](/docs/esc/operations/managing-secrets/), [dynamic login credentials](/docs/esc/providers/login/) and [dynamic secrets](/docs/esc/providers/secrets/).
 
-In other words, when using Pulumi ESC's document editor, each definition of `fn::secret` and `fn::open::*` (except with the [pulumi-stacks provider](/docs/esc/providers/secrets/pulumi-stacks/)) is counted as a secret.
+In other words, when using Pulumi ESC's document editor, each definition of `fn::secret` and `fn::open::*` (except with the [pulumi-stacks provider](/docs/esc/providers/iac/pulumi-stacks/)) is counted as a secret.
 
 Only the secrets from the latest environment revision are counted towards your bill.
 


### PR DESCRIPTION
Groups the `pulumi-stacks` and `terraform-state` providers under a dedicated Infrastructure as Code section in the ESC providers reference, alongside Login & OIDC and Secrets & config. Part of #19690.

## Changes
- New `iac/_index.md` section landing page; nav label "IaC" (weight 3)
- `git mv`'d both pages into `providers/iac/`, with the old `/secrets/…` URLs added as aliases (redirects preserved)
- Updated the providers and secrets index tables, plus 6 cross-doc internal links
- Expanded the `terraform-state` and `pulumi-stacks` examples to map Terraform outputs to both `pulumiConfig` and `TF_VAR_*` environment variables

> Scoped to the IaC-category ask only. The schema-header consistency item (also in #19690) is intentionally excluded — it overlaps PR #19696's edits and should be folded into that branch.

Fixes #19458 