### PR TITLE
docs: move Deploy with Pulumi button and Backstage plugin to new IDP Integrations section

### DIFF
--- a/content/docs/deployments/_index.md
+++ b/content/docs/deployments/_index.md
@@ -32,10 +32,6 @@ sections:
     heading: Webhooks
     description: Trigger external systems and workflows in response to stack updates, deployments, drift detection, and policy violations. Integrates with Slack, Microsoft Teams, or custom webhooks.
     link: /docs/deployments/webhooks/
-  - icon: radio-button
-    heading: Deploy with Pulumi Button
-    description: Enable one-click infrastructure deployments from GitHub repositories, gists, or any web page using embeddable deployment buttons.
-    link: /docs/deployments/pulumi-button/
 
 - type: flat
   heading: Have questions?

--- a/content/docs/idp/_index.md
+++ b/content/docs/idp/_index.md
@@ -66,6 +66,11 @@ sections:
     link: /docs/idp/guides/
     description: Learn best practices, the Four Factors framework, and how to automate component publishing.
 
+  - icon: link
+    heading: Integrations
+    link: /docs/idp/integrations/
+    description: Surface self-service workflows in the tools your developers already use, like the Deploy with Pulumi button and the Backstage plugin.
+
 - type: flat
   heading: Have questions?
   description: <p>For questions or feedback, reach out on <a href="https://slack.pulumi.com" target="_blank">community Slack</a>, <a href="https://github.com/pulumi" target="_blank">GitHub</a>, or <a href="/support/">contact support</a>.</p>

--- a/content/docs/idp/concepts/_index.md
+++ b/content/docs/idp/concepts/_index.md
@@ -41,4 +41,4 @@ Learn more about [no-code workflows](/docs/idp/concepts/no-code-stacks/) and [Pu
 
 ## Custom IDP
 
-Pulumi's flexible building blocks can support organizations with bespoke needs who need to build their own IDP. You can integrate Pulumi with your existing developer portal using [Organization Templates](/docs/idp/concepts/organization-templates/), the [Pulumi Backstage Plugin](/docs/idp/concepts/backstage-plugin/), or by [publishing from GitHub Actions](/docs/idp/guides/publishing-from-github-actions/).
+Pulumi's flexible building blocks can support organizations with bespoke needs who need to build their own IDP. You can integrate Pulumi with your existing developer portal using [Organization Templates](/docs/idp/concepts/organization-templates/), the [Pulumi Backstage Plugin](/docs/idp/integrations/backstage-plugin/), or by [publishing from GitHub Actions](/docs/idp/guides/publishing-from-github-actions/).

--- a/content/docs/idp/integrations/_index.md
+++ b/content/docs/idp/integrations/_index.md
@@ -1,0 +1,23 @@
+---
+title: Integrations
+title_tag: Pulumi IDP Integrations
+h1: Pulumi IDP Integrations
+meta_desc: Integrate Pulumi IDP with developer portals and embed self-service deployment workflows in the tools your developers already use.
+menu:
+  idp:
+    parent: idp-home
+    identifier: idp-integrations
+    weight: 40
+---
+
+Pulumi IDP integrates with the tools your developers already use, letting you surface self-service golden paths wherever your teams work. These integrations build on the [New Project Wizard](/docs/idp/concepts/new-project-wizard/) and [organization templates](/docs/idp/concepts/organization-templates/) to provide point-and-click provisioning from external surfaces.
+
+## Available integrations
+
+### Deploy with Pulumi button
+
+Embed a [Deploy with Pulumi button](/docs/idp/integrations/pulumi-button/) in README files, blog posts, or any web page to let users create new Pulumi projects from the browser with a single click.
+
+### Pulumi Backstage plugin
+
+Use the [Pulumi Backstage plugin](/docs/idp/integrations/backstage-plugin/) to integrate Pulumi with your Backstage developer portal, surfacing stack activity and scaffolding actions directly in your internal developer portal.

--- a/content/docs/idp/integrations/backstage-plugin.md
+++ b/content/docs/idp/integrations/backstage-plugin.md
@@ -6,10 +6,11 @@ meta_desc: Learn about the Pulumi Backstage plugin for integrating Pulumi with y
 menu:
   idp:
     name: Pulumi Backstage plugin
-    parent: idp-concepts
-    weight: 60
-    identifier: idp-concepts-backstage-plugin
+    parent: idp-integrations
+    weight: 20
+    identifier: idp-integrations-backstage-plugin
 aliases:
+- /docs/idp/concepts/backstage-plugin/
 - /docs/idp/developer-portals/backstage/
 - /docs/pulumi-cloud/developer-platforms/backstage/
 - /docs/pulumi-cloud/developer-portals/backstage/

--- a/content/docs/idp/integrations/pulumi-button.md
+++ b/content/docs/idp/integrations/pulumi-button.md
@@ -5,12 +5,13 @@ title: Deploy with Pulumi button
 h1: Deploy with Pulumi button
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
-  deployments:
+  idp:
     name: Deploy with Pulumi button
-    parent: deployments-home
-    weight: 40
-    identifier: deployments-pulumi-button
+    parent: idp-integrations
+    weight: 10
+    identifier: idp-integrations-pulumi-button
 aliases:
+- /docs/deployments/pulumi-button/
 - /docs/pulumi-cloud/pulumi-button/
 - /docs/reference/service/pulumi-button/
 - /docs/console/extensions/pulumi-button/

--- a/content/product/internal-developer-platforms.md
+++ b/content/product/internal-developer-platforms.md
@@ -74,7 +74,7 @@ sections:
 
       - **Low-Code**: Simple YAML for standard patterns. Platform teams create the templates, engineers fill in the values.
 
-      - **No-Code**: Deploy through Pulumi's project wizard or integrate with [Backstage](/docs/idp/concepts/backstage-plugin/). Click to provision.
+      - **No-Code**: Deploy through Pulumi's project wizard or integrate with [Backstage](/docs/idp/integrations/backstage-plugin/). Click to provision.
 
       - **REST API**: Programmatic access for custom tools and workflows. Build your own interfaces.
     image: /images/product/internal-developer-platforms/idp-self-service.svg


### PR DESCRIPTION
Creates a new Integrations section under IDP and moves two pages into it.

## Changes
- New `Integrations` section under IDP (nav order: Concepts → Guides → Integrations)
- Moved **Deploy with Pulumi button** from Deployments → `/docs/idp/integrations/pulumi-button/`
- Moved **Backstage plugin** from IDP Concepts → `/docs/idp/integrations/backstage-plugin/`
- Added aliases for old URLs; updated internal links in docs and product pages

Fixes #19466

🤖 Generated with [Claude Code](https://claude.com/claude-code)