### PR TITLE
Resolve content-review ledger bucket from stack output, drop repo variable

### DIFF
--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -93,6 +93,26 @@ jobs:
           role-session-name: content-review-article
           aws-region: us-west-2
 
+      # Resolve the ledger bucket from our Pulumi stack output rather than a
+      # hand-maintained repo variable (same pattern as schedule-social.yml).
+      # Degrades gracefully: if the output isn't there, `uri` stays empty and
+      # the ledger-write step at the end is skipped.
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+      - name: Resolve ledger bucket
+        id: ledger-bucket
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName \
+            --stack "${{ vars.PULUMI_STACK_NAME }}" 2>/dev/null || true)
+          if [ -n "$BUCKET" ]; then
+            echo "uri=s3://$BUCKET/ledger/" >> "$GITHUB_OUTPUT"
+          else
+            echo "ledger bucket output unavailable; ledger write will be skipped"
+          fi
+
       # Build a single-article queue for the dispatched path. --paths bypasses
       # scoring/guardrails; --lane carries the dispatcher's lane through so the
       # retirement path stays in scope only when lane=stale.
@@ -241,10 +261,10 @@ jobs:
       # never collide. Runs for both fix and clean pages, so a clean page goes
       # into cooldown with no PR.
       - name: Write review ledger to S3
-        if: vars.CONTENT_REVIEW_LEDGER_S3_URI != '' && hashFiles('.content-review-ledger.json') != ''
+        if: steps.ledger-bucket.outputs.uri != '' && hashFiles('.content-review-ledger.json') != ''
         continue-on-error: true
         env:
-          LEDGER_URI: ${{ vars.CONTENT_REVIEW_LEDGER_S3_URI }}
+          LEDGER_URI: ${{ steps.ledger-bucket.outputs.uri }}
         run: |
           SLUG=$(jq -r '.slug // empty' .content-review-ledger.json)
           if [ -z "$SLUG" ]; then

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -111,17 +111,39 @@ jobs:
           aws s3 cp "${{ vars.CONTENT_REVIEW_TRAFFIC_S3_URI }}" .traffic-snapshot --quiet \
             || echo "traffic snapshot unavailable; selection proceeds without it"
 
+      # The ledger bucket is a resource of our own Pulumi stack, so resolve its
+      # name from the stack output rather than a hand-maintained repo variable —
+      # the same pattern schedule-social.yml uses for socialStateBucketName. This
+      # can't drift if the (auto-named) bucket is ever replaced. Degrades
+      # gracefully: if the output isn't there, `uri` stays empty and the ledger
+      # fetch below is skipped, leaving selection on tier + age.
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+      - name: Resolve ledger bucket
+        id: ledger-bucket
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName \
+            --stack "${{ vars.PULUMI_STACK_NAME }}" 2>/dev/null || true)
+          if [ -n "$BUCKET" ]; then
+            echo "uri=s3://$BUCKET/ledger/" >> "$GITHUB_OUTPUT"
+          else
+            echo "ledger bucket output unavailable; selection proceeds without cooldowns"
+          fi
+
       # The review ledger (one JSON object per page, key = slug) lives in S3, not
       # the repo — so the daily bookkeeping never round-trips through a PR. Sync
       # it down to a local cache that select-articles.py reads via --ledger-dir.
       # Degrades gracefully like the traffic fetch: an empty/absent ledger just
       # means selection falls back to tier + age with nothing in cooldown.
       - name: Fetch review ledger from S3
-        if: vars.CONTENT_REVIEW_LEDGER_S3_URI != ''
+        if: steps.ledger-bucket.outputs.uri != ''
         continue-on-error: true
         run: |
           mkdir -p .ledger-cache
-          aws s3 sync "${{ vars.CONTENT_REVIEW_LEDGER_S3_URI }}" .ledger-cache/ --quiet \
+          aws s3 sync "${{ steps.ledger-bucket.outputs.uri }}" .ledger-cache/ --quiet \
             || echo "review ledger unavailable; selection proceeds without cooldowns"
 
       # Deterministic selection: the model never chooses what to review.


### PR DESCRIPTION
## Why

Follow-up to #19721, which moved the content-review ledger to S3. That PR located the bucket via a hand-set `CONTENT_REVIEW_LEDGER_S3_URI` repo variable (modeled on the traffic-snapshot variable). But the traffic snapshot is a data-team export at an arbitrary path, whereas the **ledger bucket is a resource of our own Pulumi stack** — already exported as `contentReviewLedgerBucketName`. So its location is knowable from infra, and a separate repo variable is both redundant and a **drift hazard**: the bucket is auto-named (`content-review-ledger-<suffix>`), so if it's ever replaced the variable would silently point at a dead bucket.

## What

Resolve the bucket at runtime from the stack output — exactly the pattern the sibling `schedule-social.yml` already uses for `socialStateBucketName` (`schedule-social.yml:66`):

```bash
BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName --stack "$PULUMI_STACK_NAME")
```

Both workflows gain a `pulumi/actions@v7` step and a **Resolve ledger bucket** step that derives `s3://<bucket>/ledger/` and feeds it to the existing ledger sync (dispatcher) and write (worker) steps via a step output:

- `.github/workflows/review-existing-content.yml` — resolve → `aws s3 sync` the ledger down.
- `.github/workflows/content-review-article.yml` — resolve → `aws s3 cp` the page's record up.

The resolve step is `continue-on-error`, so a missing/unreadable output leaves the URI empty and the ledger steps skip — **the same graceful degradation** the variable approach had (selection falls back to tier + age, no cooldowns, no ledger write). Uses the existing `PULUMI_STACK_NAME` var and the `PULUMI_ACCESS_TOKEN` already available via ESC.

## Net effect

No repo variable to set or keep in sync — the bucket name flows straight from infra and can't go stale. The now-removed `CONTENT_REVIEW_LEDGER_S3_URI` has no remaining references in the repo.

## Verification

- Both workflow YAMLs parse.
- Resolve logic simulated both ways: bucket present → `uri=s3://<bucket>/ledger/`; bucket absent → empty `uri`, ledger steps skipped.
- End-to-end (post-merge, once deployed): manual `count=1` worker dispatch on a known page ⇒ the Resolve step logs the bucket, a `<slug>.json` object lands under `s3://<bucket>/ledger/`, and a re-run of selection drops that page into cooldown.

> Note: `pulumi stack output` reads deployed stack state via `PULUMI_ACCESS_TOKEN` and does not require installing the infra program's deps — same as `schedule-social.yml`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MdpFjbwppAcxsKyMYnNhve

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdpFjbwppAcxsKyMYnNhve)_