### PR TITLE
Select production environment in content-review workflows so PULUMI_STACK_NAME resolves

### DIFF
--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -39,6 +39,10 @@ jobs:
   review:
     name: Review one article
     runs-on: ubuntu-latest
+    # PULUMI_STACK_NAME is an environment-scoped variable, so the job must
+    # select the environment to resolve it — otherwise `Resolve ledger bucket`
+    # runs with --stack "" and the S3 ledger write is silently skipped.
+    environment: production
     # Hard cost ceiling for a single-article review; a hung run dies rather
     # than burning API budget.
     timeout-minutes: 30

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -50,6 +50,10 @@ jobs:
   review:
     name: Review existing content
     runs-on: ubuntu-latest
+    # PULUMI_STACK_NAME is an environment-scoped variable, so the job must
+    # select the environment to resolve it — otherwise `Resolve ledger bucket`
+    # runs with --stack "" and the ledger fetch (cooldowns) is silently skipped.
+    environment: production
     # Hard cost ceiling: selection + up to `count` article reviews fit well
     # inside this; a hung run dies rather than burning API budget.
     timeout-minutes: 60


### PR DESCRIPTION
## What

Declare `environment: production` on the `review` job in both content-review workflows:

- `review-existing-content.yml` (dispatcher)
- `content-review-article.yml` (per-article worker)

## Why

Both workflows resolve the review-ledger bucket with:

```
pulumi -C infrastructure stack output contentReviewLedgerBucketName \
  --stack "${{ vars.PULUMI_STACK_NAME }}"
```

`PULUMI_STACK_NAME` is a GitHub **environment** variable (`production` → `pulumi/www-production`), not a repo variable. A job that doesn't select an environment sees it as empty, so the command ran with `--stack ""`, the lookup failed, `uri` stayed empty, and the `Write review ledger to S3` (and the dispatcher's ledger fetch) step was gated out. `continue-on-error` plus the graceful-degradation fallback masked it, so runs went green while writing nothing.

Observed in dispatcher run [27643633652](https://github.com/pulumi/docs/actions/runs/27643633652): all three workers logged `ledger bucket output unavailable; ledger write will be skipped`, and `s3://content-review-ledger-e8e6737/ledger/` is empty. With no ledger, clean articles never enter cooldown and are eligible for reselection every cycle.

This matches the pattern `schedule-social.yml` and `build-and-deploy.yml` already use — they declare `environment: production` alongside the same `vars.PULUMI_STACK_NAME` reference.

## Verification

The bucket and stack output resolve correctly (`content-review-ledger-e8e6737`); the only missing piece was the environment selection that populates `PULUMI_STACK_NAME`.