### PR TITLE
Make the content-review ledger workflow-owned and harden the model contract

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -50,10 +50,12 @@ branch and PR before starting the next.
 
 ### 1. Branch
 
-From up-to-date `master`, create `content-review/<slug>`. (For a retirement
-proposal — stale lane only, see below — use `content-review/retire-<slug>`
-instead.) If an open PR already exists for that branch name, skip the article
-entirely and note it in the results file: a previous run owns it.
+From up-to-date `master`, create the branch with the **exact** name
+`content-review/<slug>` (the queue entry's `slug`). For a retirement proposal —
+stale lane only, see below — use `content-review/retire-<slug>` instead. The
+workflow derives the PR from this branch name, so it must match exactly. If an
+open PR already exists for that branch name, skip the article entirely and set
+`"verdict": "skipped"` in the sentinel (step 8): a previous run owns it.
 
 ### 2. Pre-compute (deterministic floor) — the workflow runs this for you
 
@@ -192,9 +194,12 @@ opening the PR.
 
 ### 7. PR — only when you applied a fix, ready (non-draft)
 
-Open a **ready** PR to `master`. The workflow dispatches the automated
-docs review over it afterward; humans merge. Description contract
-(auditability — model on fix-broken-links PRs):
+Open a **ready** PR to `master`. Build the body from
+`references/pr-body-template.md` — fill **every** section — and create the PR
+with `gh pr create --body-file`. The workflow re-runs `make lint` on your branch
+(flipping the PR back to draft if it fails) and dispatches the automated docs
+review over it afterward; humans merge. The template's sections (each one is
+checked for):
 
 - **Why this page**: lane, tier, traffic figure + report period, last
   reviewed (from the queue entry) — so the reviewer knows how it was chosen.
@@ -213,32 +218,38 @@ docs review over it afterward; humans merge. Description contract
 - **Verification**: confirm `make lint` + `make build` passed and which
   pre-step artifacts informed the review (note any pre-step that failed).
 
-A clean article (zero applicable fixes) skips the PR — record it in the
-`clean` list of `.content-review-results.json` and write its ledger record
-(next step) with `"clean": true`.
+Do **not** record `pr_number` or `head_sha` yourself — the workflow derives
+them from the branch. A clean article (zero applicable fixes) skips the PR —
+set `"verdict": "clean"` in the sentinel (next step).
 
-### 8. Ledger
+### 8. Verdict sentinel — your only structured output
 
-Write the article's ledger record to `.content-review-ledger.json` at the
-repo root — one record per page. A workflow step stamps `reviewed_at` and
-uploads it to the S3 ledger as `<slug>.json`:
+Write `.content-review-verdict.json` at the repo root. This is the **only**
+file you produce for the workflow — do not write a ledger or a results file.
+The workflow derives the PR facts (existence, number, head SHA) from your
+branch, builds the canonical ledger record, and uploads it to S3 keyed by slug.
 
 ```json
 {
-  "path": "content/docs/iac/concepts/stacks/_index.md",
-  "slug": "docs-iac-concepts-stacks",
-  "pr": "https://github.com/pulumi/docs/pull/19999",
-  "lane": "priority",
-  "clean": false,
+  "verdict": "fixed",
+  "reason": "",
   "fixes": 4,
-  "skipped_findings": 2
+  "skipped_findings": 2,
+  "retirement": false
 }
 ```
 
-`slug` is the queue entry's `slug` (it becomes the S3 object key); `pr` is the
-PR you just opened, or `null` for a clean article; `fixes` = applied changes;
-`skipped_findings` = Findings-not-applied count. Omit `reviewed_at` — the
-workflow sets it.
+- `verdict`: `"fixed"` (you opened a PR), `"clean"` (zero applicable fixes, no
+  PR), or `"skipped"` (a previous run already owns this page's PR).
+- `reason`: one line — **required** for `clean` and `skipped`; omit/empty for
+  `fixed`.
+- `fixes`: applied changes; `skipped_findings`: Findings-not-applied count.
+- `retirement`: `true` only for a stale-lane retirement PR (branch
+  `content-review/retire-<slug>`).
+
+If you exit without writing this file, the workflow records the page as
+`incomplete` (a short cooldown, retried soon) — so always write it, even for a
+clean or skipped verdict.
 
 ## Retirement proposals (stale lane only)
 
@@ -264,28 +275,6 @@ outcome **instead of** a fix PR, under a strict evidence standard:
 
 ## Output
 
-After all articles, write `.content-review-results.json` to the repo root
-for the workflow's review-dispatch step:
-
-```json
-{
-  "prs": [
-    { "path": "content/docs/iac/concepts/stacks/_index.md",
-      "pr": "https://github.com/pulumi/docs/pull/19999",
-      "pr_number": 19999,
-      "head_sha": "abc1234",
-      "fixes": 4,
-      "retirement": false }
-  ],
-  "clean": ["content/docs/esc/overview.md"],
-  "skipped": [],
-  "summary": ":mag: Reviewed 3 articles — 2 fix PRs, 1 clean (ledger to S3)"
-}
-```
-
-`head_sha` is each PR branch's final commit SHA (`git rev-parse HEAD` after
-the last push) — the review dispatch (which reads `.prs[]`) needs it. The
-ledger is a separate per-page file (step 8), not part of this results file.
-`skipped` lists articles abandoned mid-run (existing PR, unfixable build
-break) with a reason string. The `summary` line is a one-line run note for
-the workflow log; keep it to one line.
+The verdict sentinel (step 8) is your only output. The workflow records the
+ledger and dispatches the docs review from it and from the branch — there is no
+results file to write.

--- a/.claude/commands/review-existing-content/references/pr-body-template.md
+++ b/.claude/commands/review-existing-content/references/pr-body-template.md
@@ -1,0 +1,49 @@
+# Content-review PR body template
+
+Fill **every** section below and pass the result to `gh pr create --body-file`.
+The worker re-lints the branch and checks that each `##` heading here is present
+in the PR body; a missing section is flagged (non-blocking) on the PR. Keep the
+diff to high-confidence fixes — judgment-level items belong in *Findings not
+applied*, not in the diff.
+
+The template starts after this line — copy from the first `##` heading down.
+
+---
+
+## Why this page
+
+Lane, strategic tier, traffic figure + report period, and last-reviewed date
+(from the queue entry) — so a reviewer can see how this page was selected.
+
+## Fixes applied
+
+One row per change. If zero fixes were applied this section is empty and no PR
+should exist.
+
+| Claim / finding | Authoritative source | Correction |
+| --- | --- | --- |
+|  |  |  |
+
+## Findings not applied
+
+Every skipped finding with one line of reasoning (why it's judgment-level, not a
+high-confidence fix).
+
+For the judgment-level items above, run `/glow-up <path>`.
+
+## Screenshot check
+
+Per image: current / stale (what differs) / unverifiable. Note any aging
+reference screenshots (see `references/screenshot-verification.md`).
+
+## Rendered content
+
+Outcomes of the rendered pass — residue claims checked in the HTML view, the
+markdown view's shortcode-template status, and any shared-source
+(shortcode / partial / data) findings with their page-reach
+("also rendered on N other pages").
+
+## Verification
+
+Confirm `make lint` + `make build` passed, and which pre-step artifacts informed
+the review (note any pre-step that failed or was missing).

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -214,7 +214,10 @@ jobs:
             but SKIP step 2 (Pre-compute) — the workflow already did it. For the
             article in the queue:
 
-            1. Branch `content-review/<slug>` off master.
+            1. Branch off master with the EXACT name `content-review/<slug>`
+               (the queue entry's `slug`), or `content-review/retire-<slug>`
+               for a stale-lane retirement. The workflow derives the PR from
+               this branch name, so it must match exactly.
             2. (Done by the workflow — read the artifacts above. If one is
                missing or carries an `errors` field, note it in the PR
                description and continue with what you have.)
@@ -226,58 +229,96 @@ jobs:
             6. Run the rendered content pass over the built page — both
                the HTML view and the customer-facing markdown view
                (`public/<url>/index.html` and `index.md`) — per the skill.
-            7. If you applied any fix, open a **ready** (non-draft) PR with
-               the auditable description the skill describes. A clean article
-               (zero fixes) opens no PR.
-            8. Write the page's ledger record to `.content-review-ledger.json`
-               (the skill defines the shape) — the workflow uploads it to the
-               S3 ledger.
-            9. Write `.content-review-results.json` (the skill defines the
-               shape) — the review-dispatch step consumes it.
+            7. If you applied any fix, open a **ready** (non-draft) PR. Build
+               its body from
+               `.claude/commands/review-existing-content/references/pr-body-template.md`
+               (fill every section) and pass it with `gh pr create --body-file`.
+               A clean article (zero fixes) opens no PR.
+            8. Write `.content-review-verdict.json` at the repo root — your ONLY
+               structured output. Shape:
+               `{"verdict": "fixed|clean|skipped", "reason": "<one line; required
+               for clean/skipped>", "fixes": <int>, "skipped_findings": <int>,
+               "retirement": <bool>}`. The workflow derives the PR facts and
+               records the S3 ledger from this; do NOT write a ledger or results
+               file yourself.
           claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(python3:*),Bash(vale:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(gh repo view:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(mkdir:*),Bash(curl:*)"'
+
+      # Lint re-gate: don't trust the model's self-report that `make lint`
+      # passed on the branch. For a fix verdict, check out the pushed branch and
+      # re-run lint. On failure: flip the PR back to draft, comment the output,
+      # and skip the docs-review dispatch (the `lint_ok` output gates it). The
+      # ledger still records `reviewed` — the draft PR stays for a human. Build
+      # is left to the PR's normal CI.
+      - name: Re-lint the fix branch
+        id: lint
+        if: hashFiles('.content-review-verdict.json') != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+        run: |
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+          VERDICT=$(jq -r '.verdict // empty' .content-review-verdict.json)
+          [ "$VERDICT" = "fixed" ] || { echo "verdict=$VERDICT; no branch to re-lint"; exit 0; }
+          RETIRE=$(jq -r 'if .retirement then "retire-" else "" end' .content-review-verdict.json)
+          SLUG=$(jq -r '.articles[0].slug' .content-review-queue.json)
+          BRANCH="content-review/${RETIRE}${SLUG}"
+          git fetch origin "$BRANCH" || { echo "::warning::branch $BRANCH not found"; exit 0; }
+          git checkout "$BRANCH"
+          if make lint > .lint.log 2>&1; then
+            echo "lint passed on $BRANCH"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::make lint failed on $BRANCH; flipping PR to draft"
+            gh pr ready "$BRANCH" --undo || true
+            {
+              echo "Automated review note: \`make lint\` failed on this branch, so the PR was returned to draft and the docs review was not dispatched. Lint output:"
+              echo ""
+              echo '```'
+              tail -c 4000 .lint.log
+              echo '```'
+            } > .lint-comment.md
+            gh pr comment "$BRANCH" --body-file .lint-comment.md || true
+          fi
+          git checkout - || true
+
+      # Record the page's outcome to the S3 ledger as one object keyed by slug.
+      # Runs `if: always()` so a model that exits without output still lands an
+      # `incomplete` record (short cooldown, retried soon) rather than silently
+      # looping. record-review.py builds the canonical record, derives the PR
+      # facts from `gh`, stamps reviewed_at, uploads, and emits the dispatch
+      # signal. One article per run ⇒ one object, so writes never collide.
+      - name: Record review ledger
+        id: record
+        if: always() && steps.ledger-bucket.outputs.uri != ''
+        continue-on-error: true
+        env:
+          CONTENT_REVIEW_LEDGER_URI: ${{ steps.ledger-bucket.outputs.uri }}
+          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+        run: |
+          python3 scripts/content-review/record-review.py \
+            --queue .content-review-queue.json \
+            --verdict .content-review-verdict.json
 
       # Slop defense: bot-authored PRs are auto-skipped by the docs-review
       # pipeline (claude-code-review.yml sets skip_reason=bot-author), so the
       # content PR gets its review via explicit force dispatch — the same
-      # pattern claude-new.yml uses for #new-review. One article ⇒ 0 or 1 PR;
-      # the loop handles both.
+      # pattern claude-new.yml uses for #new-review. Gated on a derived
+      # `reviewed` status AND a passing re-lint; PR number + head SHA come from
+      # the ledger record's gh-derived values, never the model's self-report.
       - name: Dispatch docs review over the PR
-        if: hashFiles('.content-review-results.json') != ''
+        if: steps.record.outputs.dispatch == 'true' && steps.lint.outputs.ok != 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          jq -c '.prs[]?' .content-review-results.json | while read -r pr; do
-            NUMBER=$(echo "$pr" | jq -r '.pr_number')
-            HEAD_SHA=$(echo "$pr" | jq -r '.head_sha')
-            echo "dispatching review for PR #$NUMBER ($HEAD_SHA)"
-            gh workflow run claude-code-review.yml \
-              --repo "${{ github.repository }}" \
-              -f pr_number="$NUMBER" \
-              -f head_sha="$HEAD_SHA" \
-              -f force=true \
-              || echo "::warning::review dispatch failed for PR #$NUMBER"
-          done
-
-      # Persist the page's review record to the S3 ledger as one object keyed by
-      # slug — instead of committing it through a PR. The model wrote the record
-      # to `.content-review-ledger.json`; this step stamps an authoritative
-      # reviewed_at and uploads it. One article per run ⇒ one object, so writes
-      # never collide. Runs for both fix and clean pages, so a clean page goes
-      # into cooldown with no PR.
-      - name: Write review ledger to S3
-        if: steps.ledger-bucket.outputs.uri != '' && hashFiles('.content-review-ledger.json') != ''
-        continue-on-error: true
-        env:
-          LEDGER_URI: ${{ steps.ledger-bucket.outputs.uri }}
-        run: |
-          SLUG=$(jq -r '.slug // empty' .content-review-ledger.json)
-          if [ -z "$SLUG" ]; then
-            echo "::warning::ledger record missing slug; not written"
-            exit 0
-          fi
-          jq --arg d "$(date -u +%F)" '.reviewed_at = $d' .content-review-ledger.json \
-            | aws s3 cp - "${LEDGER_URI%/}/${SLUG}.json" \
-            || echo "::warning::ledger write failed for $SLUG"
+          NUMBER='${{ steps.record.outputs.pr_number }}'
+          HEAD_SHA='${{ steps.record.outputs.head_sha }}'
+          echo "dispatching review for PR #$NUMBER ($HEAD_SHA)"
+          gh workflow run claude-code-review.yml \
+            --repo "${{ github.repository }}" \
+            -f pr_number="$NUMBER" \
+            -f head_sha="$HEAD_SHA" \
+            -f force=true \
+            || echo "::warning::review dispatch failed for PR #$NUMBER"
 
 env:
   ESC_ACTION_OIDC_AUTH: true

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Record one content-review article's outcome to the S3 ledger.
+
+This is the single source of truth for the ledger record shape and its upload.
+The per-article worker (`.github/workflows/content-review-article.yml`) runs it
+once after the review model finishes, with `if: always()`, so every dispatched
+article lands exactly one canonical ledger object — even when the model exits
+without producing any output.
+
+The model's only structured output is a tiny verdict sentinel
+(`.content-review-verdict.json`); everything authoritative about the PR
+(existence, number, head SHA) is derived here from `gh`, not self-reported.
+
+Outcome derivation:
+  * verdict "fixed"  + PR on content-review/<slug>      -> status "reviewed"
+  * verdict "clean"                                      -> status "clean"
+  * verdict "skipped"                                    -> status "skipped"
+  * verdict "fixed"  + no PR on the canonical branch     -> status "incomplete"
+  * sentinel absent / unparseable                        -> status "incomplete"
+
+Canonical record (every field always present):
+  { path, slug, lane, status, pr, pr_number, head_sha, fixes,
+    skipped_findings, retirement, note, reviewed_at }
+
+The record is written locally (audit artifact) and, when CONTENT_REVIEW_LEDGER_URI
+is set, uploaded to <uri>/<slug>.json with reviewed_at stamped to today (UTC).
+A `dispatch` / `pr_number` / `head_sha` signal is emitted to $GITHUB_OUTPUT for
+the workflow's review-dispatch step. Degrades gracefully: a missing bucket URI
+skips the upload (the page reappears next cycle) rather than failing the run.
+
+Self-contained — run the smoke checks with `python3 record-review.py --self-test`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+# Reuse slugify + the branch prefix from select-articles.py (single source of
+# truth). Its filename is hyphenated, so import it by path; its main() is guarded
+# under __main__, so importing has no side effects.
+_spec = importlib.util.spec_from_file_location(
+    "select_articles", HERE / "select-articles.py"
+)
+_select = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_select)
+slugify = _select.slugify
+BRANCH_PREFIX = _select.BRANCH_PREFIX
+
+# PR-body sections the review skill mandates; the post-create check warns (never
+# blocks) when a fix PR's body is missing one.
+REQUIRED_PR_SECTIONS = [
+    "Why this page",
+    "Fixes applied",
+    "Findings not applied",
+    "Screenshot check",
+    "Rendered content",
+    "Verification",
+]
+
+
+def log(msg: str) -> None:
+    print(f"record-review: {msg}", file=sys.stderr)
+
+
+def warn(msg: str) -> None:
+    # `::warning::` surfaces in the GitHub Actions run summary.
+    print(f"::warning::record-review: {msg}", file=sys.stderr)
+
+
+# ---- inputs -----------------------------------------------------------------
+
+
+def load_queue_article(queue_path: Path) -> dict:
+    """Return the single article (path/slug/lane) from the worker queue."""
+    data = json.loads(queue_path.read_text())
+    articles = data.get("articles") or []
+    if not articles:
+        raise SystemExit(f"record-review: no articles in {queue_path}")
+    a = articles[0]
+    path = a["path"]
+    return {
+        "path": path,
+        "slug": a.get("slug") or slugify(path),
+        "lane": a.get("lane") or "priority",
+    }
+
+
+def load_verdict(verdict_path: Path | None) -> dict | None:
+    """Return the model's verdict sentinel, or None if absent/unparseable."""
+    if not verdict_path or not verdict_path.is_file():
+        return None
+    try:
+        return json.loads(verdict_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        warn(f"verdict sentinel unreadable ({e}); treating as incomplete")
+        return None
+
+
+def branch_for(slug: str, retirement: bool) -> str:
+    return f"{BRANCH_PREFIX}{'retire-' if retirement else ''}{slug}"
+
+
+def fetch_pr(branch: str, pr_json: str | None) -> dict | None:
+    """PR for the given head branch, or None.
+
+    `pr_json` (a file path, or '-' for stdin) injects the gh response for tests;
+    otherwise we shell out to `gh pr view <branch>`.
+    """
+    if pr_json is not None:
+        raw = sys.stdin.read() if pr_json == "-" else Path(pr_json).read_text()
+        raw = raw.strip()
+        if not raw:
+            return None
+        pr = json.loads(raw)
+        return pr or None
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", branch, "--json", "number,state,headRefOid,url,body"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        warn("gh not available; cannot derive PR facts")
+        return None
+    if out.returncode != 0:
+        return None  # no PR for this branch
+    try:
+        return json.loads(out.stdout) or None
+    except json.JSONDecodeError:
+        return None
+
+
+def scan_misnamed_sibling(slug: str) -> None:
+    """Best-effort warning when a fix PR exists under a non-canonical branch."""
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--limit", "100",
+             "--json", "number,headRefName,url"],
+            capture_output=True, text=True, check=False,
+        )
+        if out.returncode != 0:
+            return
+        for pr in json.loads(out.stdout or "[]"):
+            head = pr.get("headRefName", "")
+            if not head.startswith(BRANCH_PREFIX):
+                continue
+            head_slug = head[len(BRANCH_PREFIX):].removeprefix("retire-")
+            if head_slug == slug:
+                warn(
+                    f"PR #{pr.get('number')} ({pr.get('url')}) reviews this page "
+                    f"under non-canonical branch '{head}' — recording incomplete"
+                )
+    except (OSError, json.JSONDecodeError):
+        pass
+
+
+def check_pr_body(body: str | None) -> list[str]:
+    """Return the required section headings missing from a fix PR's body."""
+    text = (body or "").lower()
+    return [s for s in REQUIRED_PR_SECTIONS if s.lower() not in text]
+
+
+# ---- derivation -------------------------------------------------------------
+
+
+def build_record(article: dict, verdict: dict | None, pr: dict | None,
+                 slug: str) -> dict:
+    """Build the canonical ledger record from the queue, verdict, and PR state."""
+    rec = {
+        "path": article["path"],
+        "slug": slug,
+        "lane": article["lane"],
+        "status": "incomplete",
+        "pr": None,
+        "pr_number": 0,
+        "head_sha": "",
+        "fixes": 0,
+        "skipped_findings": 0,
+        "retirement": bool(verdict.get("retirement")) if verdict else False,
+        "note": None,
+        "reviewed_at": datetime.now(timezone.utc).date().isoformat(),
+    }
+
+    if verdict is None:
+        rec["note"] = "worker produced no verdict"
+        return rec
+
+    rec["fixes"] = int(verdict.get("fixes") or 0)
+    rec["skipped_findings"] = int(verdict.get("skipped_findings") or 0)
+    v = verdict.get("verdict")
+
+    if v == "clean":
+        rec["status"] = "clean"
+        rec["note"] = verdict.get("reason")
+    elif v == "skipped":
+        rec["status"] = "skipped"
+        rec["note"] = verdict.get("reason") or "skipped by reviewer"
+    elif v == "fixed":
+        if pr:
+            rec["status"] = "reviewed"
+            rec["pr"] = pr.get("url")
+            rec["pr_number"] = int(pr.get("number") or 0)
+            rec["head_sha"] = pr.get("headRefOid") or ""
+        else:
+            rec["status"] = "incomplete"
+            rec["note"] = f"verdict 'fixed' but no PR on {branch_for(slug, rec['retirement'])}"
+    else:
+        rec["note"] = f"unrecognized verdict {v!r}"
+
+    return rec
+
+
+# ---- outputs ----------------------------------------------------------------
+
+
+def upload(record: dict, slug: str, uri: str) -> None:
+    """Upload the record to <uri>/<slug>.json via the aws CLI (stdin)."""
+    key = f"{uri.rstrip('/')}/{slug}.json"
+    try:
+        subprocess.run(
+            ["aws", "s3", "cp", "-", key],
+            input=json.dumps(record, indent=2) + "\n",
+            text=True, check=True,
+        )
+        log(f"uploaded ledger record to {key}")
+    except FileNotFoundError:
+        warn("aws CLI not available; ledger record not uploaded")
+    except subprocess.CalledProcessError as e:
+        warn(f"ledger upload failed for {slug} ({e})")
+
+
+def emit_outputs(record: dict) -> None:
+    """Write dispatch/pr_number/head_sha to $GITHUB_OUTPUT (or stdout)."""
+    dispatch = "true" if record["status"] == "reviewed" else "false"
+    lines = [
+        f"dispatch={dispatch}",
+        f"pr_number={record['pr_number']}",
+        f"head_sha={record['head_sha']}",
+        f"status={record['status']}",
+    ]
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if out_path:
+        with open(out_path, "a") as f:
+            f.write("\n".join(lines) + "\n")
+    for line in lines:
+        print(line)
+
+
+# ---- main -------------------------------------------------------------------
+
+
+def run(args) -> int:
+    article = load_queue_article(Path(args.queue))
+    slug = article["slug"]
+    verdict = load_verdict(Path(args.verdict) if args.verdict else None)
+    retirement = bool(verdict.get("retirement")) if verdict else False
+    branch = branch_for(slug, retirement)
+
+    want_pr = bool(verdict) and verdict.get("verdict") == "fixed"
+    pr = fetch_pr(branch, args.pr_json) if want_pr else None
+    if want_pr and not pr and args.pr_json is None:
+        scan_misnamed_sibling(slug)
+
+    record = build_record(article, verdict, pr, slug)
+
+    # PR-body section check (non-blocking) for fix PRs.
+    if record["status"] == "reviewed" and pr is not None:
+        missing = check_pr_body(pr.get("body"))
+        if missing:
+            warn(f"PR #{record['pr_number']} body missing sections: {', '.join(missing)}")
+            if args.pr_json is None:
+                subprocess.run(
+                    ["gh", "pr", "comment", str(record["pr_number"]), "--body",
+                     "Automated review note: this PR's description is missing the "
+                     f"following required sections: {', '.join(missing)}."],
+                    check=False,
+                )
+
+    out_path = Path(args.out)
+    out_path.write_text(json.dumps(record, indent=2) + "\n")
+    log(f"status={record['status']} slug={slug} -> {out_path}")
+
+    uri = os.environ.get("CONTENT_REVIEW_LEDGER_URI", "").strip()
+    if uri:
+        upload(record, slug, uri)
+    else:
+        warn("CONTENT_REVIEW_LEDGER_URI unset; ledger record written locally only")
+
+    emit_outputs(record)
+    return 0
+
+
+def self_test() -> int:
+    import tempfile
+
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+            print(f"FAIL: {name}", file=sys.stderr)
+        else:
+            print(f"ok: {name}")
+
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        queue = d / "queue.json"
+        queue.write_text(json.dumps({
+            "articles": [{
+                "path": "content/docs/iac/concepts/converters.md",
+                "slug": "docs-iac-concepts-converters",
+                "lane": "priority",
+            }]
+        }))
+        article = load_queue_article(queue)
+
+        # No verdict -> incomplete.
+        rec = build_record(article, None, None, article["slug"])
+        check("no-verdict -> incomplete", rec["status"] == "incomplete")
+        check("incomplete has reviewed_at", bool(rec["reviewed_at"]))
+        check("all canonical fields present", set(rec) == {
+            "path", "slug", "lane", "status", "pr", "pr_number", "head_sha",
+            "fixes", "skipped_findings", "retirement", "note", "reviewed_at"})
+
+        # Clean verdict.
+        rec = build_record(article, {"verdict": "clean", "reason": "accurate"},
+                           None, article["slug"])
+        check("clean verdict -> clean", rec["status"] == "clean" and rec["pr"] is None)
+
+        # Fixed + PR -> reviewed with derived facts.
+        pr = {"number": 19731, "state": "OPEN",
+              "headRefOid": "5344e12aa5f08646ead32d92be3b76ca9f6a0302",
+              "url": "https://github.com/pulumi/docs/pull/19731", "body": ""}
+        rec = build_record(article, {"verdict": "fixed", "fixes": 1}, pr,
+                           article["slug"])
+        check("fixed+PR -> reviewed", rec["status"] == "reviewed")
+        check("derived pr_number", rec["pr_number"] == 19731)
+        check("derived head_sha", rec["head_sha"].startswith("5344e12"))
+        check("fixes carried", rec["fixes"] == 1)
+
+        # Fixed + no PR -> incomplete.
+        rec = build_record(article, {"verdict": "fixed"}, None, article["slug"])
+        check("fixed+no-PR -> incomplete", rec["status"] == "incomplete")
+
+        # Section check.
+        check("section check flags missing",
+              set(check_pr_body("## Why this page\n## Verification")) ==
+              {"Fixes applied", "Findings not applied", "Screenshot check",
+               "Rendered content"})
+        check("section check passes complete body",
+              check_pr_body("\n".join(f"## {s}" for s in REQUIRED_PR_SECTIONS)) == [])
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall record-review self-tests passed")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Record a content-review outcome to the S3 ledger.")
+    p.add_argument("--queue", help="single-article queue JSON (.content-review-queue.json)")
+    p.add_argument("--verdict", help="model verdict sentinel (.content-review-verdict.json)")
+    p.add_argument("--pr-json", help="inject gh PR JSON (file path or '-' for stdin); for tests")
+    p.add_argument("--out", default=".content-review-ledger.json",
+                   help="local ledger artifact path")
+    p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.queue:
+        p.error("--queue is required")
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -77,6 +77,11 @@ BRANCH_PREFIX = "content-review/"
 MAX_OPEN_PRS = 9
 COOLDOWN_DAYS = 365
 CLOSED_PR_COOLDOWN_DAYS = 180
+# A review that ended without a real outcome (the worker exited before recording
+# a verdict, or claimed a fix with no PR) is recorded `status: "incomplete"`. It
+# should be retried soon — but not re-picked in the same dispatch batch — so it
+# gets a short cooldown instead of the full year.
+INCOMPLETE_COOLDOWN_DAYS = 3
 RECENT_EDIT_DAYS = 30
 RECENT_EDIT_PENALTY = 0.5
 
@@ -351,11 +356,17 @@ def score_page(
 
 def cmd_stats(ledger_dir: Path, use_gh: bool) -> int:
     entries = load_ledger(ledger_dir)
-    counts = {"merged": 0, "closed": 0, "open": 0, "clean": 0, "unknown": 0}
+    counts = {"merged": 0, "closed": 0, "open": 0, "clean": 0, "incomplete": 0, "unknown": 0}
     by_lane: dict[str, int] = {}
     for path, entry in sorted(entries.items()):
         by_lane[entry.get("lane", "priority")] = by_lane.get(entry.get("lane", "priority"), 0) + 1
-        if entry.get("clean"):
+        status = entry.get("status")
+        if status == "incomplete":
+            counts["incomplete"] += 1
+            continue
+        # `status == "clean"` is the canonical form; `clean: true` is the legacy
+        # pre-standardization field still present on older ledger objects.
+        if status == "clean" or entry.get("clean"):
             counts["clean"] += 1
             continue
         state = pr_state(entry.get("pr", ""), use_gh)
@@ -506,10 +517,13 @@ def main() -> int:
         if entry:
             reviewed = parse_day(entry.get("reviewed_at"))
             if reviewed:
-                cooldown = COOLDOWN_DAYS
-                state = pr_state(entry.get("pr", ""), use_gh) if entry.get("pr") else None
-                if state and state.get("state") == "CLOSED" and not state.get("mergedAt"):
-                    cooldown = CLOSED_PR_COOLDOWN_DAYS
+                if entry.get("status") == "incomplete":
+                    cooldown = INCOMPLETE_COOLDOWN_DAYS
+                else:
+                    cooldown = COOLDOWN_DAYS
+                    state = pr_state(entry.get("pr", ""), use_gh) if entry.get("pr") else None
+                    if state and state.get("state") == "CLOSED" and not state.get("mergedAt"):
+                        cooldown = CLOSED_PR_COOLDOWN_DAYS
                 if (today - reviewed).days < cooldown:
                     continue
         candidates.append(path)

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -198,6 +198,25 @@ def main() -> int:
         check(flags["content/docs/misc/protected/keep.md"] is True, "explicit no_retire")
         check(flags["content/docs/concepts/stacks.md"] is True, "tier 1 implies no_retire")
 
+        print("incomplete status: short cooldown, unlike a real review")
+        inc = tmp / "ledger_inc"
+        target = "content/docs/concepts/stacks.md"
+        # A real review 4 days ago is still inside the 365-day cooldown.
+        write_ledger(inc, target, "2026-06-08")
+        q = run_select(repo, tiers, inc, "--count", "5")
+        check(target not in [a["path"] for a in q["articles"]],
+              "real review 4d ago stays in the 365d cooldown")
+        # Same age, but an incomplete review only cools down for 3 days -> eligible.
+        write_ledger(inc, target, "2026-06-08", status="incomplete")
+        q = run_select(repo, tiers, inc, "--count", "5")
+        check(target in [a["path"] for a in q["articles"]],
+              "incomplete review past the 3d window is eligible again")
+        # An incomplete review 1 day ago is still inside the short window.
+        write_ledger(inc, target, "2026-06-11", status="incomplete")
+        q = run_select(repo, tiers, inc, "--count", "5")
+        check(target not in [a["path"] for a in q["articles"]],
+              "incomplete review 1d ago still cooling down")
+
         print("repo strategic-tiers.yaml parses and excludes generated trees")
         proc = subprocess.run(
             [sys.executable, str(SCRIPT), "--no-gh", "--today", "2026-06-12",


### PR DESCRIPTION
## What

Reworks the existing-content review so the S3 ledger is written by the workflow, not the model, and shrinks the model's contract to a single verdict sentinel.

## Why

Dispatcher run [27646387680](https://github.com/pulumi/docs/actions/runs/27646387680) exposed two defects:

1. **Lost reviews.** The `get-started/_index.md` worker exited cleanly (~19 min, $4.17) without writing `.content-review-ledger.json`; the guarded upload step was silently skipped, so the page got no ledger entry, no cooldown, and would be re-selected (and re-spent) next cycle.
2. **Schema drift + self-reported PR facts.** Hand-authored records diverged in shape, and `results.json` carried `head_sha`/`pr_number` the model typed by hand — `head_sha` goes stale if the model pushes again after capturing it, sending the downstream review at the wrong commit.

## Changes

- **`scripts/content-review/record-review.py`** (new) — single source of truth for the canonical ledger record. Derives the outcome from the verdict sentinel + the PR state read from `gh` (`number`, `headRefOid`, `url`), stamps `reviewed_at`, uploads to S3, and emits `dispatch`/`pr_number`/`head_sha` outputs. Reuses `slugify` from `select-articles.py`. Has `--self-test`.
- **`.github/workflows/content-review-article.yml`** — the ledger-write step becomes an `if: always()` **Record review ledger** step (a no-output exit now lands an `incomplete` record); a **Re-lint the fix branch** step re-runs `make lint` on the pushed branch and flips a failing PR back to draft + skips dispatch; the dispatch step consumes the gh-derived PR facts. The model's prompt now writes only the verdict sentinel.
- **`.claude/commands/review-existing-content/SKILL.md`** — model writes only `.content-review-verdict.json`; ledger/results authorship and `git rev-parse HEAD` removed; PR body comes from the new template; branch name must be exact.
- **`.claude/commands/review-existing-content/references/pr-body-template.md`** (new) — checked PR-body structure.
- **`scripts/content-review/select-articles.py`** — `status:"incomplete"` → 3-day cooldown (vs 365) so a failed review retries soon without looping; `cmd_stats` honors the canonical `status` while keeping the legacy `clean` field.

## Verification

- `python3 scripts/content-review/record-review.py --self-test` — passes (incomplete / clean / fixed+PR / fixed+no-PR derivation, section check).
- `python3 scripts/content-review/test_select_articles.py` — 41 passing, including new incomplete-cooldown cases.
- Workflow YAML validated; `py_compile` clean. `make lint` scope (content/ markdown + prettier, which ignores `*.md`/`.github`) does not cover these files.

After merge: dispatch one worker against a known-clean page to confirm a canonical object lands in `s3://content-review-ledger-e8e6737/ledger/`, then re-run the dispatcher with `count=5` and confirm 5/5 ledger objects.