### PR TITLE
docs(esc): expand 1password-secrets provider page

### DIFF
--- a/content/docs/esc/providers/secrets/1password-secrets.md
+++ b/content/docs/esc/providers/secrets/1password-secrets.md
@@ -1,7 +1,7 @@
 ---
 title: 1password-secrets
 title_tag: 1password-secrets Pulumi ESC Provider
-meta_desc: The `1password-secrets` provider enables you to dynamically import Secrets from 1Password into your Pulum ESC environment.
+meta_desc: The `1password-secrets` provider enables you to dynamically import Secrets from 1Password into your Pulumi ESC environment.
 h1: 1password-secrets
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
@@ -16,13 +16,28 @@ aliases:
     - /docs/esc/concepts/providers/secrets/1password-secrets/
 ---
 
-The `1password-secrets` provider enables you to dynamically import Secrets from 1Password into your Environment. The provider will return a map of names to Secrets.
+The `1password-secrets` provider enables you to dynamically import secrets from 1Password into your environment. The provider returns a map of names to secret values, which you can then expose as configuration or environment variables. Secrets are fetched lazily at open time, so the values are never stored in the environment definition.
 
 {{% notes type="warning" %}}
-This provider is currently in **preview**.
+This provider is currently in **preview**. Its inputs and behavior may change in a future release.
+{{% /notes %}}
+
+## Prerequisites
+
+The provider authenticates to 1Password with a **Service Account token**. Before you can configure it, you need to create a Service Account and grant it access to the vaults that hold the secrets you want to import:
+
+1. In 1Password, create a Service Account and grant it **read** access to each vault that contains a referenced item. A Service Account can only read items in the vaults you explicitly share with it, so be sure to include every vault used in your `op://` references.
+1. Copy the generated token. Service Account tokens begin with the prefix `ops_`.
+
+For step-by-step instructions, see 1Password's [Get started with 1Password Service Accounts](https://developer.1password.com/docs/service-accounts/get-started/) documentation.
+
+{{% notes type="info" %}}
+The `1password-secrets` provider authenticates with Service Account tokens only. 1Password Connect is not currently supported.
 {{% /notes %}}
 
 ## Example
+
+The following environment imports four secrets from 1Password and exposes two of them as Pulumi configuration:
 
 ```yaml
 values:
@@ -31,24 +46,94 @@ values:
       fn::open::1password-secrets:
         login:
           serviceAccountToken:
-            fn::secret: "ops_123ABC"
+            fn::secret: ops_eyJzaWduSW5B...
         get:
-          email_section_example:
+          pagerduty_email:
             ref: "op://Management/PagerDuty/Admin/email"
-          anna_sans_section_example:
+          stripe_key:
             ref: "op://dev/Stripe/publishable-key"
-          olaf_attr_example:
+          github_otp:
             ref: "op://development/GitHub/Security/one-time password?attribute=otp"
-          sven_ssh_example:
+          deploy_ssh_key:
             ref: "op://Private/ssh keys/ssh key/private key?ssh-format=openssh"
-          nokk_whitespace_example:
-            ref: "op://development/aws/Access Keys/access_key_id"
-          gale_unique_id_example:
-            ref: "op://prod/yj3jfj2vzsbiwqabprflnl27lm/password"
   pulumiConfig:
-    email: ${1password.secrets.email_section_example}
-    stripeKey: ${1password.secrets.anna_sans_section_example}
+    email: ${1password.secrets.pagerduty_email}
+    stripeKey: ${1password.secrets.stripe_key}
 ```
+
+### Don't hardcode the Service Account token
+
+The example above wraps the token with `fn::secret`, which encrypts it at rest. That works for getting started, but it still commits a literal token to your environment definition. As a best practice, define the token once in a dedicated environment and import it wherever it's needed, so the secret lives in a single place you can rotate independently:
+
+```yaml
+# In a base environment, e.g. acme/onepassword/credentials
+values:
+  onepasswordToken:
+    fn::secret: ops_eyJzaWduSW5B...
+```
+
+```yaml
+# In the environment that imports secrets
+imports:
+  - onepassword/credentials
+values:
+  1password:
+    secrets:
+      fn::open::1password-secrets:
+        login:
+          serviceAccountToken: ${onepasswordToken}
+        # ...
+```
+
+Here, `onepasswordToken` is the value exported by the imported `onepassword/credentials` environment. You can use any secret store this way — for example, a token read from another `fn::open` provider.
+
+## Reference syntax
+
+Each entry under `get` reads a single field from a 1Password item using a **secret reference** of the form:
+
+```
+op://<vault-name>/<item-name>/[section-name/]<field-name>
+```
+
+- **Sectionless field** — most fields live directly on an item. For example, `op://dev/Stripe/publishable-key` reads the `publishable-key` field of the `Stripe` item in the `dev` vault.
+- **Sectioned field** — fields organized under a named section include the section in the path. For example, `op://Management/PagerDuty/Admin/email` reads the `email` field from the `Admin` section of the `PagerDuty` item.
+
+You can append a query-string modifier to change how a field is returned:
+
+- `?attribute=otp` returns the current one-time password generated from a one-time password (TOTP) field, rather than the secret itself.
+- `?ssh-format=openssh` returns an SSH private key in OpenSSH format.
+
+Vault, item, section, and field names may contain spaces (for example, `op://Private/ssh keys/ssh key/private key`). You can also reference items by their unique ID instead of their name. For the complete grammar, see 1Password's [secret reference syntax](https://developer.1password.com/docs/cli/secrets-reference-syntax) documentation.
+
+## Verifying your configuration
+
+Once you've saved your environment, validate that the provider resolves your secrets by running either of the following:
+
+- `esc open <org>/<project>/<environment>` command of the [Pulumi ESC CLI](/docs/esc-cli/)
+- `pulumi env open <org>/<project>/<environment>` command of the [Pulumi CLI](/docs/install/)
+
+Make sure to replace `<org>`, `<project>`, and `<environment>` with the values of your Pulumi organization and environment identifier respectively. You should see output similar to the following:
+
+```json
+{
+  "1password": {
+    "secrets": {
+      "pagerduty_email": "admin@example.com",
+      "stripe_key": "pk_live_...",
+      "github_otp": "123456",
+      "deploy_ssh_key": "-----BEGIN OPENSSH PRIVATE KEY-----\n..."
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Authentication fails when opening the environment | The Service Account token is missing, malformed, or has been revoked. | Confirm `serviceAccountToken` resolves to a valid token beginning with `ops_`. Generate a new token in 1Password if the old one was rotated or deleted. |
+| A reference returns an "access denied" or "not found" vault error | The Service Account does not have access to the vault named in the `op://` reference. | Grant the Service Account read access to that vault in 1Password, then re-open the environment. |
+| A reference returns an item or field "not found" error | The vault, item, section, or field name in the `op://` reference is misspelled, or the item lacks the named field. | Verify the reference against the item in 1Password, including spaces, section names, and the field name. |
 
 ## Inputs
 
@@ -61,13 +146,13 @@ values:
 
 | Property              | Type   | Description                                                                   |
 |-----------------------|--------|-------------------------------------------------------------------------------|
-| `serviceAccountToken` | string | The service account token to use for authentication.                         |
+| `serviceAccountToken` | string | The [1Password Service Account token](#prerequisites) to use for authentication. |
 
 ### 1PasswordSecretsGet
 
 | Property | Type   | Description                                  |
 |----------|--------|----------------------------------------------|
-| `ref`    | string | A [reference to a secret](https://developer.1password.com/docs/cli/secrets-reference-syntax) of the form `op://vault-name/item-name/[section-name/]field-name` to read from 1Password.  |
+| `ref`    | string | A [reference to a secret](#reference-syntax) of the form `op://vault-name/item-name/[section-name/]field-name` to read from 1Password.  |
 
 ### Outputs
 


### PR DESCRIPTION
## Summary

Rewrites the `1password-secrets` ESC provider page from a ~229-word near-stub into a complete setup guide. This provider is configured in ~11.8K environment revisions (high adoption among ESC secrets providers), but the page omitted the hardest step — creating a 1Password Service Account token.

Fixes #19459. Part of #19378 (Refresh ESC Docs).

## What changed

- **Prerequisites** — how to create a 1Password Service Account token and grant it vault access, linking 1Password's official setup docs.
- **Don't hardcode the token** — recommend referencing the token from an imported environment; show the `fn::secret` inline fallback.
- **Reference syntax** — prose explanation of `op://<vault>/<item>/[section/]<field>`, sectioned vs. sectionless fields, and the `?attribute=otp` / `?ssh-format=openssh` modifiers.
- **Verifying your configuration** — `esc open` / `pulumi env open` commands plus sample output, matching sibling provider pages.
- **Troubleshooting** — table for auth failures, vault access denied, and reference-not-found errors.
- Note that the provider supports **Service Accounts only** — 1Password Connect is not supported (the integration is built on the 1Password Go SDK).
- Fix `Pulum` → `Pulumi` typo in `meta_desc`.

## Notes

- No Connect coverage: the provider schema exposes only `serviceAccountToken`.
- Preview note kept general — no authoritative source for specific preview limitations.
- Sample JSON output is illustrative (modeled on sibling pages), not captured from a live run.

## Verification

- `make lint` — 0 errors, Prettier clean
- `make build` — succeeds; rendered page anchors and internal links (`/docs/esc-cli/`, `/docs/install/`, `#prerequisites`, `#reference-syntax`) all resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)