### PR TITLE
Instrument content-review worker tool denials (temporary diagnostic)

### DIFF
--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -243,6 +243,21 @@ jobs:
                file yourself.
           claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(python3:*),Bash(vale:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(gh repo view:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(mkdir:*),Bash(curl:*)"'
 
+      # TEMPORARY DIAGNOSTIC: runs show a high permission_denials_count (the model
+      # hitting the allowlist wall, often on compound commands like
+      # `make lint && make build`), but the GitHub log streams only the init and
+      # result events — not the rejected commands. Parse the full transcript
+      # (execution_file, which only exists on the runner) and print just the
+      # denied command strings to the step summary, so the allowlist can be sized
+      # from real data. Emits no tool *results* — safe for this public repo.
+      # Remove once the allowlist is tuned.
+      - name: Summarize tool denials
+        if: always() && steps.claude.outputs.execution_file != ''
+        continue-on-error: true
+        run: |
+          python3 scripts/content-review/summarize-denials.py \
+            "${{ steps.claude.outputs.execution_file }}"
+
       # Lint re-gate: don't trust the model's self-report that `make lint`
       # passed on the branch. For a fix verdict, check out the pushed branch and
       # re-run lint. On failure: flip the PR back to draft, comment the output,

--- a/scripts/content-review/summarize-denials.py
+++ b/scripts/content-review/summarize-denials.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Summarize permission-denied tool calls from a Claude Code execution log.
+
+TEMPORARY DIAGNOSTIC. The content-review worker runs the review model under a
+tight `--allowed-tools` allowlist, and runs show a high `permission_denials_count`
+(12-21 per run) with no record of *which* commands were rejected — the GitHub log
+streams only the init and result events. This reads the action's `execution_file`
+(the full stream-json transcript, which only exists on the runner) and prints the
+denied command strings so the allowlist can be sized from real data.
+
+Safe for a public repo: it emits only the model's own *attempted* (and therefore
+un-executed) command strings — never tool results, which can carry command output
+or secrets. It cross-checks its tally against the result event's
+`permission_denials_count` and notes any mismatch so the parse can be trusted.
+
+Usage: python3 summarize-denials.py <execution_file>
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import sys
+
+# Substrings that mark a tool-permission rejection in a tool_result. Kept broad
+# (matching is anchored on an `is_error` result) so a wording change upstream
+# doesn't silently drop denials.
+DENIAL_MARKERS = (
+    "haven't granted",
+    "hasn't been granted",
+    "requested permissions",
+    "permission to use",
+    "not allowed to use",
+    "permission denied",
+    "permission to run",
+)
+
+
+def load_events(path: str) -> list[dict]:
+    """Return the transcript events, tolerating a JSON array or JSONL."""
+    text = open(path, encoding="utf-8").read()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return data.get("messages", [data])
+    return []
+
+
+def content_blocks(event: dict) -> list:
+    """The content blocks of an event, whether nested under `message` or not."""
+    msg = event.get("message", event)
+    blocks = msg.get("content")
+    return blocks if isinstance(blocks, list) else []
+
+
+def block_text(content) -> str:
+    """Flatten a tool_result `content` (string or list of text blocks)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            b.get("text", "") for b in content if isinstance(b, dict)
+        )
+    return ""
+
+
+def describe(tool_use: dict) -> str:
+    """A short label for a tool_use: the Bash command, else the tool name."""
+    name = tool_use.get("name", "?")
+    inp = tool_use.get("input") or {}
+    detail = inp.get("command") or inp.get("file_path") or inp.get("path")
+    return f"{name}: {detail}" if detail else name
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("logfile")
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.logfile):
+        print(f"summarize-denials: no execution log at {args.logfile}")
+        return 0
+    try:
+        events = load_events(args.logfile)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"summarize-denials: could not parse execution log ({e})")
+        return 0
+
+    # Map each tool_use id to its label, then attribute denial results back to it.
+    labels: dict[str, str] = {}
+    reported_count = None
+    for ev in events:
+        for b in content_blocks(ev):
+            if b.get("type") == "tool_use":
+                labels[b.get("id")] = describe(b)
+        if ev.get("type") == "result":
+            reported_count = ev.get("permission_denials_count", reported_count)
+
+    denied: collections.Counter[str] = collections.Counter()
+    for ev in events:
+        for b in content_blocks(ev):
+            if b.get("type") != "tool_result" or not b.get("is_error"):
+                continue
+            text = block_text(b.get("content")).lower()
+            if any(m in text for m in DENIAL_MARKERS):
+                denied[labels.get(b.get("tool_use_id"), "<unknown tool>")] += 1
+
+    total = sum(denied.values())
+    lines = [f"## Tool permission denials ({total} matched)", ""]
+    if denied:
+        for label, n in denied.most_common():
+            lines.append(f"- ({n}×) `{label}`")
+    else:
+        lines.append("_No denial markers found in the transcript._")
+    if reported_count is not None and reported_count != total:
+        lines += [
+            "",
+            f"> Note: result reports {reported_count} denials but {total} were "
+            "matched here — the denial wording may have changed; widen "
+            "`DENIAL_MARKERS`.",
+        ]
+    report = "\n".join(lines)
+    print(report)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as f:
+            f.write(report + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a temporary diagnostic to the content-review worker that surfaces which tool calls the review model had denied by the `--allowed-tools` allowlist.

## Why

The recent `count=5` run showed a high `permission_denials_count` per article (12, 14, 17, 21), tracking turn count and cost — the model repeatedly hits the allowlist wall, most likely on **compound commands** (`make lint && make build`, `cd public && grep …`) that can't match a single allowed prefix. But the GitHub log streams only the `init` and `result` events, so *which* commands were rejected isn't recoverable, and the action's `show_full_output` isn't usable here — pulumi/docs is public and that dumps tool results that can carry secrets.

This parses the action's `execution_file` (the full transcript, which only exists on the runner) and prints the **denied command strings** — the model's own un-executed bash, never tool results — to the step summary, cross-checked against `permission_denials_count`. Safe to read on a public repo.

## Changes

- `scripts/content-review/summarize-denials.py` — parses the stream-json transcript (array or JSONL), attributes denial results back to their `tool_use` commands, prints a deduped tally, and flags any mismatch vs the reported count.
- `.github/workflows/content-review-article.yml` — an `if: always()` "Summarize tool denials" step after the Claude step.

## Lifecycle

Diagnostic only — once the next run gives us the real denied-command list, we size the allowlist from it and remove this step. Self-tested locally against synthetic array/JSONL transcripts.