### PR TITLE
docs(resources): fix datetime import in replacementTrigger Python examples

### DIFF
--- a/content/blog/triggering-resource-replacements/index.md
+++ b/content/blog/triggering-resource-replacements/index.md
@@ -53,6 +53,7 @@ const keyManager = new KeyManagerResource("key-manager", {}, {
 
 ```py
 ...
+from datetime import datetime
 
 today = datetime.now()
 trigger = f"{today.month}-{today.year}"

--- a/content/docs/iac/concepts/resources/options/replacementtrigger.md
+++ b/content/docs/iac/concepts/resources/options/replacementtrigger.md
@@ -37,7 +37,7 @@ const keyManager = new KeyManagerResource("key-manager", {}, {
 {{% choosable language python %}}
 
 ```py
-import datetime
+from datetime import datetime
 
 today = datetime.now()
 trigger = f"{today.month}-{today.year}"


### PR DESCRIPTION
The Python examples in two docs files used `import datetime` followed by `datetime.now()`, which raises `AttributeError: module 'datetime' has no attribute 'now'` at runtime. The `now()` method belongs to `datetime.datetime` (the class), not to the `datetime` module itself.

## Changes

**`content/docs/iac/concepts/resources/options/replacementtrigger.md`**

Changed `import datetime` to `from datetime import datetime`, making the existing `datetime.now()` call correct.

**`content/blog/triggering-resource-replacements/index.md`**

Added `from datetime import datetime` to the Python snippet so the `datetime.now()` call is unambiguously correct. The snippet previously used `...` to imply hidden imports; this makes the intent explicit.

## Testing

Verified the fix by running the corrected snippet locally:

```python
from datetime import datetime
today = datetime.now()
trigger = f"{today.month}-{today.year}"
# Output: '6-2026' — no AttributeError
```

Fixes #19454

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*
