### PR TITLE
Simplify content-review cooldown and broaden the worker allowlist

### DIFF
--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -241,7 +241,14 @@ jobs:
                "retirement": <bool>}`. The workflow derives the PR facts and
                records the S3 ledger from this; do NOT write a ledger or results
                file yourself.
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(make build:*),Bash(make lint:*),Bash(make ensure:*),Bash(python3:*),Bash(vale:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(gh repo view:*),Bash(git:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(test:*),Bash(mkdir:*),Bash(curl:*)"'
+          # Allow general Bash. The per-command allowlist rejected ~6-21 calls
+          # per run, and every observed rejection was a benign compound command
+          # (`for` loops, `cd x && …`, `a; b` chains) or an unlisted verb like
+          # `rm` — claude-code-action matches each call against a single prefix,
+          # so a chain can never match. This runs on an ephemeral runner; the
+          # residual risk is the scoped bot/AWS/Pulumi creds it holds vs.
+          # injected instructions in reviewed content, accepted for throughput.
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash"'
 
       # TEMPORARY DIAGNOSTIC: runs show a high permission_denials_count (the model
       # hitting the allowlist wall, often on compound commands like

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -13,8 +13,8 @@ Selection algorithm (two lanes):
 1. Enumerate `content/docs/**/*.md`; drop tier-0 (generated/synced) paths
    and `draft: true` pages.
 2. Hard filters: pages with an open `content-review/<slug>` bot PR; pages
-   inside the ledger cooldown (365 days after a review; 180 days after a
-   review whose PR was closed without merging).
+   inside the ledger cooldown (365 days after a review, or 3 days after an
+   `incomplete` review that recorded no real outcome).
 3. Runaway guardrail: if >= MAX_OPEN_PRS open `content-review/*` PRs exist,
    emit an empty queue with `"halted": "max_open_prs"` so the workflow
    warns instead of piling on.
@@ -76,7 +76,6 @@ CONTENT_DIR = "content/docs"
 BRANCH_PREFIX = "content-review/"
 MAX_OPEN_PRS = 9
 COOLDOWN_DAYS = 365
-CLOSED_PR_COOLDOWN_DAYS = 180
 # A review that ended without a real outcome (the worker exited before recording
 # a verdict, or claimed a fix with no PR) is recorded `status: "incomplete"`. It
 # should be retried soon — but not re-picked in the same dispatch batch — so it
@@ -517,13 +516,11 @@ def main() -> int:
         if entry:
             reviewed = parse_day(entry.get("reviewed_at"))
             if reviewed:
-                if entry.get("status") == "incomplete":
-                    cooldown = INCOMPLETE_COOLDOWN_DAYS
-                else:
-                    cooldown = COOLDOWN_DAYS
-                    state = pr_state(entry.get("pr", ""), use_gh) if entry.get("pr") else None
-                    if state and state.get("state") == "CLOSED" and not state.get("mergedAt"):
-                        cooldown = CLOSED_PR_COOLDOWN_DAYS
+                cooldown = (
+                    INCOMPLETE_COOLDOWN_DAYS
+                    if entry.get("status") == "incomplete"
+                    else COOLDOWN_DAYS
+                )
                 if (today - reviewed).days < cooldown:
                     continue
         candidates.append(path)


### PR DESCRIPTION
## What

Two related simplifications to the existing-content review.

### 1. Drop the closed-PR cooldown branch

Selection called `gh pr view` for **every** reviewed-with-PR ledger entry on every dispatch — an API-volume cost that grows with the ledger — purely to shorten a page's cooldown from 365 → 180 days when its review PR was closed unmerged. Not worth a per-entry API call (and the gate to avoid it was needless complication). Now a flat 365-day cooldown; `incomplete` reviews keep their 3-day retry.

- Removes `CLOSED_PR_COOLDOWN_DAYS` and the `pr_state` call from selection. `pr_state` stays for the manual `stats` command.

### 2. Broaden the worker `--allowed-tools` to general `Bash`

With the denial logger fixed (#19739), the latest run showed every rejected call was a **benign compound command** (`for` loops, `cd x && …`, `a; b` chains) or an unlisted verb like `rm`. claude-code-action matches each call against a single allowed prefix, so a chained command can never match — no per-command allowlist can fix that. Replace the long prefix list with `Bash`.

**Tradeoff (deliberate):** the worker is an ephemeral runner, but it holds scoped bot/AWS/Pulumi credentials and reviews untrusted page content, so general Bash widens the blast radius of a prompt-injection. Accepted for throughput; revisit if abuse appears.

## Verification

- `select-articles` test suite: 41 passing.
- Workflow YAML validated.