### PR TITLE
content-review: weighted-fair-queuing staleness selector

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -37,9 +37,9 @@ Read `.content-review-queue.json` from the repo root (written by
 }
 ```
 
-- `lane` — `priority` (scored pick), `stale` (longest-unreviewed reserve
-  slot), or `manual` (workflow_dispatch override).
+- `lane` — `priority` (scored pick) or `manual` (workflow_dispatch override).
 - `no_retire` — when true, retirement must never be proposed for this page.
+  This is the **hard veto** on retirement — honor it regardless of evidence.
 - If `articles` is empty or `halted` is set, do nothing (the workflow won't
   invoke you in that case, but be defensive).
 
@@ -51,8 +51,8 @@ branch and PR before starting the next.
 ### 1. Branch
 
 From up-to-date `master`, create the branch with the **exact** name
-`content-review/<slug>` (the queue entry's `slug`). For a retirement proposal —
-stale lane only, see below — use `content-review/retire-<slug>` instead. The
+`content-review/<slug>` (the queue entry's `slug`). For a retirement proposal
+(see below) use `content-review/retire-<slug>` instead. The
 workflow derives the PR from this branch name, so it must match exactly. If an
 open PR already exists for that branch name, skip the article entirely and set
 `"verdict": "skipped"` in the sentinel (step 8): a previous run owns it.
@@ -244,17 +244,23 @@ branch, builds the canonical ledger record, and uploads it to S3 keyed by slug.
 - `reason`: one line — **required** for `clean` and `skipped`; omit/empty for
   `fixed`.
 - `fixes`: applied changes; `skipped_findings`: Findings-not-applied count.
-- `retirement`: `true` only for a stale-lane retirement PR (branch
+- `retirement`: `true` only for a retirement PR (branch
   `content-review/retire-<slug>`).
 
 If you exit without writing this file, the workflow records the page as
-`incomplete` (a short cooldown, retried soon) — so always write it, even for a
-clean or skipped verdict.
+`incomplete`. An incomplete outcome does **not** advance the staleness clock, so
+the page stays due and is retried on a later sweep — up to an attempt cap, after
+which it backs off for a human. Always write the sentinel, even for a clean or
+skipped verdict.
 
-## Retirement proposals (stale lane only)
+## Retirement proposals
 
-For a `stale`-lane article with `"no_retire": false`, retirement is a valid
-outcome **instead of** a fix PR, under a strict evidence standard:
+For any article with `"no_retire": false`, retirement is a valid outcome
+**instead of** a fix PR when the strict evidence standard below is met.
+`no_retire: true` is the primary guardrail and an absolute veto — never propose
+retiring such a page no matter how strong the evidence. Retirement is no longer
+restricted to a particular lane; it can be proposed on any review that clears
+the bar, with the full reasoning documented in the PR.
 
 - **Evidence required (two-sided):** the page appears in the traffic report
   with near-zero views (absence from the report is NOT evidence — the page

--- a/.claude/commands/review-existing-content/references/strategic-tiers.yaml
+++ b/.claude/commands/review-existing-content/references/strategic-tiers.yaml
@@ -13,11 +13,13 @@
 #                 0 = EXCLUDED: generated or upstream-synced content. The
 #                     review bot must never touch these — the generators own
 #                     them and will overwrite or fight any hand edit.
-#   no_retire — the retirement lane may never propose retiring a matching
-#               page. Tier 1 implies no_retire; set it explicitly on lower
-#               tiers that are SEO-critical or contractually required. Once
-#               GSC data is flowing, high-impression entries can be
-#               regenerated from thresholds; hand-curated entries stay.
+#   no_retire — hard veto: review must never propose retiring a matching page,
+#               regardless of evidence. This is the PRIMARY retirement
+#               guardrail (retirement is no longer gated to a lane). Tier 1
+#               implies no_retire; set it explicitly on lower tiers that are
+#               SEO-critical or contractually required. Once GSC data is
+#               flowing, high-impression entries can be regenerated from
+#               thresholds; hand-curated entries stay.
 #
 # Matching is LONGEST PREFIX WINS (so a deeper, more specific entry overrides
 # a broader one). Prefixes are repo paths, not URLs.

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -18,7 +18,7 @@ on:
         description: 'One content file under content/docs/'
         required: true
       lane:
-        description: 'Selection lane (priority/stale/manual); stale enables retirement'
+        description: 'Selection lane (priority/manual); informational — retirement is gated by the evidence bar + no_retire, not the lane'
         required: false
         default: 'priority'
 
@@ -118,8 +118,8 @@ jobs:
           fi
 
       # Build a single-article queue for the dispatched path. --paths bypasses
-      # scoring/guardrails; --lane carries the dispatcher's lane through so the
-      # retirement path stays in scope only when lane=stale.
+      # scoring/guardrails; --lane just tags the queue entry (informational —
+      # retirement is gated by the evidence bar + no_retire, not the lane).
       - name: Build single-article queue
         run: |
           python3 scripts/content-review/select-articles.py \
@@ -216,7 +216,7 @@ jobs:
 
             1. Branch off master with the EXACT name `content-review/<slug>`
                (the queue entry's `slug`), or `content-review/retire-<slug>`
-               for a stale-lane retirement. The workflow derives the PR from
+               for a retirement proposal. The workflow derives the PR from
                this branch name, so it must match exactly.
             2. (Done by the workflow — read the artifacts above. If one is
                missing or carries an `errors` field, note it in the PR
@@ -305,10 +305,12 @@ jobs:
 
       # Record the page's outcome to the S3 ledger as one object keyed by slug.
       # Runs `if: always()` so a model that exits without output still lands an
-      # `incomplete` record (short cooldown, retried soon) rather than silently
-      # looping. record-review.py builds the canonical record, derives the PR
-      # facts from `gh`, stamps reviewed_at, uploads, and emits the dispatch
-      # signal. One article per run ⇒ one object, so writes never collide.
+      # `incomplete` record. An incomplete outcome does not advance the
+      # staleness clock (the page stays due, retried next sweep up to the
+      # attempt cap) rather than silently looping. record-review.py builds the
+      # canonical record, derives the PR facts from `gh`, stamps reviewed_at,
+      # increments attempts, uploads, and emits the dispatch signal. One article
+      # per run ⇒ one object, so writes never collide.
       - name: Record review ledger
         id: record
         if: always() && steps.ledger-bucket.outputs.uri != ''

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -3,8 +3,9 @@ name: "Scheduled jobs: Review existing content (dispatcher)"
 # Daily (workdays) automated review of EXISTING docs pages — the
 # counterpart to the PR-triggered docs review, for content that nobody is
 # currently editing. This workflow is the DISPATCHER: the selection script
-# picks the day's articles (strategic tier x traffic x review age, plus one
-# reserved stale slot), and this workflow then fans out one
+# picks the day's articles by weighted fair queuing — score = importance
+# (strategic tier x traffic) x staleness (days since the page's effective last
+# review) — and this workflow then fans out one
 # content-review-article.yml run per selected article. Each of those worker
 # runs reviews exactly one article, opens one ready PR, and force-dispatches
 # claude-code-review.yml over it. Humans merge; nothing here is auto-merged.
@@ -52,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     # PULUMI_STACK_NAME is an environment-scoped variable, so the job must
     # select the environment to resolve it — otherwise `Resolve ledger bucket`
-    # runs with --stack "" and the ledger fetch (cooldowns) is silently skipped.
+    # runs with --stack "" and the ledger fetch (review history) is silently skipped.
     environment: production
     # Hard cost ceiling: selection + up to `count` article reviews fit well
     # inside this; a hung run dies rather than burning API budget.
@@ -69,8 +70,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-          # Selection reads git history (staleness ordering, recent-human-
-          # edit penalty), so a shallow clone won't do.
+          # Selection reads git history (staleness clock: creation date and
+          # newest non-bot edit per page), so a shallow clone won't do.
           fetch-depth: 0
       - name: Install Node
         uses: actions/setup-node@v6
@@ -134,21 +135,22 @@ jobs:
           if [ -n "$BUCKET" ]; then
             echo "uri=s3://$BUCKET/ledger/" >> "$GITHUB_OUTPUT"
           else
-            echo "ledger bucket output unavailable; selection proceeds without cooldowns"
+            echo "ledger bucket output unavailable; selection proceeds on git staleness alone"
           fi
 
       # The review ledger (one JSON object per page, key = slug) lives in S3, not
       # the repo — so the daily bookkeeping never round-trips through a PR. Sync
       # it down to a local cache that select-articles.py reads via --ledger-dir.
       # Degrades gracefully like the traffic fetch: an empty/absent ledger just
-      # means selection falls back to tier + age with nothing in cooldown.
+      # means every page's staleness clock falls back to its git history
+      # (creation date / newest non-bot edit), with no prior reviews to apply.
       - name: Fetch review ledger from S3
         if: steps.ledger-bucket.outputs.uri != ''
         continue-on-error: true
         run: |
           mkdir -p .ledger-cache
           aws s3 sync "${{ steps.ledger-bucket.outputs.uri }}" .ledger-cache/ --quiet \
-            || echo "review ledger unavailable; selection proceeds without cooldowns"
+            || echo "review ledger unavailable; selection proceeds on git staleness alone"
 
       # Deterministic selection: the model never chooses what to review.
       # Writes has_articles= / halted= / count= to $GITHUB_OUTPUT for the

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -91,6 +91,9 @@ def load_queue_article(queue_path: Path) -> dict:
         "path": path,
         "slug": a.get("slug") or slugify(path),
         "lane": a.get("lane") or "priority",
+        # Prior incomplete-retry count, carried from the ledger by the selector.
+        # build_record increments it on another incomplete, resets it on success.
+        "attempts": int(a.get("attempts") or 0),
     }
 
 
@@ -175,7 +178,15 @@ def check_pr_body(body: str | None) -> list[str]:
 
 def build_record(article: dict, verdict: dict | None, pr: dict | None,
                  slug: str) -> dict:
-    """Build the canonical ledger record from the queue, verdict, and PR state."""
+    """Build the canonical ledger record from the queue, verdict, and PR state.
+
+    `attempts` accrues the consecutive `incomplete` retries: it starts from the
+    prior count the selector carried in (`article["attempts"]`), is incremented
+    by one on another incomplete outcome, and is reset to 0 the moment the page
+    reaches any completed status. The selector backs a page off once it hits
+    ATTEMPT_CAP, so this counter is the loop guard.
+    """
+    prior_attempts = int(article.get("attempts") or 0)
     rec = {
         "path": article["path"],
         "slug": slug,
@@ -188,6 +199,7 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         "skipped_findings": 0,
         "retirement": bool(verdict.get("retirement")) if verdict else False,
         "note": None,
+        "attempts": prior_attempts + 1,
         "reviewed_at": datetime.now(timezone.utc).date().isoformat(),
     }
 
@@ -202,15 +214,18 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
     if v == "clean":
         rec["status"] = "clean"
         rec["note"] = verdict.get("reason")
+        rec["attempts"] = 0
     elif v == "skipped":
         rec["status"] = "skipped"
         rec["note"] = verdict.get("reason") or "skipped by reviewer"
+        rec["attempts"] = 0
     elif v == "fixed":
         if pr:
             rec["status"] = "reviewed"
             rec["pr"] = pr.get("url")
             rec["pr_number"] = int(pr.get("number") or 0)
             rec["head_sha"] = pr.get("headRefOid") or ""
+            rec["attempts"] = 0
         else:
             rec["status"] = "incomplete"
             rec["note"] = f"verdict 'fixed' but no PR on {branch_for(slug, rec['retirement'])}"
@@ -328,14 +343,22 @@ def self_test() -> int:
         rec = build_record(article, None, None, article["slug"])
         check("no-verdict -> incomplete", rec["status"] == "incomplete")
         check("incomplete has reviewed_at", bool(rec["reviewed_at"]))
+        check("incomplete bumps attempts from 0 -> 1", rec["attempts"] == 1)
         check("all canonical fields present", set(rec) == {
             "path", "slug", "lane", "status", "pr", "pr_number", "head_sha",
-            "fixes", "skipped_findings", "retirement", "note", "reviewed_at"})
+            "fixes", "skipped_findings", "retirement", "note", "attempts",
+            "reviewed_at"})
 
-        # Clean verdict.
-        rec = build_record(article, {"verdict": "clean", "reason": "accurate"},
+        # Repeated incomplete accrues against the prior count the selector carried.
+        retried = {**article, "attempts": 2}
+        rec = build_record(retried, {"verdict": "fixed"}, None, article["slug"])
+        check("incomplete accrues prior attempts (2 -> 3)", rec["attempts"] == 3)
+
+        # Clean verdict resets the retry counter.
+        rec = build_record(retried, {"verdict": "clean", "reason": "accurate"},
                            None, article["slug"])
         check("clean verdict -> clean", rec["status"] == "clean" and rec["pr"] is None)
+        check("clean resets attempts to 0", rec["attempts"] == 0)
 
         # Fixed + PR -> reviewed with derived facts.
         pr = {"number": 19731, "state": "OPEN",
@@ -347,6 +370,7 @@ def self_test() -> int:
         check("derived pr_number", rec["pr_number"] == 19731)
         check("derived head_sha", rec["head_sha"].startswith("5344e12"))
         check("fixes carried", rec["fixes"] == 1)
+        check("reviewed resets attempts to 0", rec["attempts"] == 0)
 
         # Fixed + no PR -> incomplete.
         rec = build_record(article, {"verdict": "fixed"}, None, article["slug"])

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -8,30 +8,35 @@ the day's review queue as JSON. The model never chooses what to review —
 this script does, so the selection is auditable and reproducible from its
 inputs.
 
-Selection algorithm (two lanes):
+Selection algorithm (weighted fair queuing by staleness):
 
 1. Enumerate `content/docs/**/*.md`; drop tier-0 (generated/synced) paths
    and `draft: true` pages.
 2. Hard filters: pages with an open `content-review/<slug>` bot PR; pages
-   inside the ledger cooldown (365 days after a review, or 3 days after an
-   `incomplete` review that recorded no real outcome).
+   whose `incomplete` review has already burned ATTEMPT_CAP retries (they
+   back off and are surfaced for a human instead of looping forever).
 3. Runaway guardrail: if >= MAX_OPEN_PRS open `content-review/*` PRs exist,
    emit an empty queue with `"halted": "max_open_prs"` so the workflow
    warns instead of piling on.
-4. Reserve ONE slot for the stale lane: the longest-unreviewed page —
-   never-reviewed pages first (oldest last-modified in git first), then
-   oldest `reviewed_at`. This guarantees the whole corpus is eventually
-   swept regardless of how the priority weights are tuned.
-5. Fill the remaining slots from the priority score:
+4. Score every remaining page and take the top `count`. No threshold, no
+   reserved lane — staleness self-corrects starvation (the longer a page
+   goes unreviewed the higher it climbs, so the whole corpus is swept):
 
-       score = 0.40*tier_w + 0.35*traffic_n + 0.25*age_n
+       score = importance * staleness
 
-   tier_w    = {1: 1.0, 2: 0.6, 3: 0.3}
-   traffic_n = log1p(visits) / log1p(max_visits); pages missing from the
-               report impute the median; if the traffic file is absent the
-               traffic term is dropped and the remaining weights renormalize
-   age_n     = min(days_since_review / 365, 1.0); never reviewed -> 1.0
-   penalty   = x0.5 when a non-bot commit touched the file < 30 days ago
+   importance = tier_w * (0.5 + 0.5*traffic_n)   with a traffic snapshot
+              = tier_w                            tier-only when absent
+   tier_w     = {1: 1.0, 2: 0.6, 3: 0.3}
+   traffic_n  = log1p(visits) / log1p(max_visits); pages missing from the
+                report impute the median
+   staleness  = (today - effective_last_review).days, floored at 0
+   effective_last_review = max(bot_reviewed_at, last_non-bot_commit_date)
+                where bot_reviewed_at counts only for a *completed* review
+                (an `incomplete` outcome never advances the clock, so the
+                page stays due). Never-bot-reviewed pages fall back to their
+                git creation date: a brand-new page sorts to the back, an
+                ancient never-reviewed page to the front. A human (non-bot)
+                edit fully resets the clock.
 
    Ties break on path ascending, so runs are reproducible.
 
@@ -75,19 +80,19 @@ CONTENT_DIR = "content/docs"
 
 BRANCH_PREFIX = "content-review/"
 MAX_OPEN_PRS = 9
-COOLDOWN_DAYS = 365
-# A review that ended without a real outcome (the worker exited before recording
-# a verdict, or claimed a fix with no PR) is recorded `status: "incomplete"`. It
-# should be retried soon — but not re-picked in the same dispatch batch — so it
-# gets a short cooldown instead of the full year.
-INCOMPLETE_COOLDOWN_DAYS = 3
-RECENT_EDIT_DAYS = 30
-RECENT_EDIT_PENALTY = 0.5
+# An `incomplete` review (worker exited before recording a verdict, or claimed
+# a fix with no PR) never advances the staleness clock, so the page stays due
+# and is retried next sweep. This caps the retries: once a page has burned
+# ATTEMPT_CAP incomplete runs it backs off (is excluded and surfaced) instead
+# of looping forever on whatever keeps breaking it.
+ATTEMPT_CAP = 3
 
-WEIGHT_TIER = 0.40
-WEIGHT_TRAFFIC = 0.35
-WEIGHT_AGE = 0.25
 TIER_WEIGHTS = {1: 1.0, 2: 0.6, 3: 0.3}
+
+# Statuses a ledger entry can carry (set by record-review.py). Any status other
+# than "incomplete" is a completed review whose date advances the clock; legacy
+# entries predating the field have no `status` and are treated as completed.
+INCOMPLETE_STATUS = "incomplete"
 
 BOT_AUTHORS = {"pulumi-bot", "dependabot[bot]", "github-actions[bot]"}
 
@@ -227,41 +232,39 @@ def load_ledger(ledger_dir: Path) -> dict[str, dict]:
 # ---- Git signals (single-pass, no per-file subprocess fan-out) ---------------
 
 
-def recent_human_edits(repo: Path, days: int = RECENT_EDIT_DAYS) -> set[str]:
-    """Files under content/docs touched by a non-bot author in the last N days."""
-    out = run_git(
-        repo,
-        ["log", f"--since={days} days ago", "--name-only", "--format=%x01%an", "--", CONTENT_DIR],
-    )
-    touched: set[str] = set()
+def git_history_signals(repo: Path) -> tuple[dict[str, int], dict[str, int]]:
+    """Per-path git timestamps for content/docs, from one history pass.
+
+    Walks history newest-first and returns two maps of unix commit times:
+
+      newest_non_bot : the most recent commit by a *non-bot* author that
+                       touched the path (a human edit — resets the staleness
+                       clock). Absent for pages only ever touched by bots.
+      created        : the oldest commit that touched the path (its creation),
+                       the fallback clock for never-bot-reviewed pages.
+    """
+    out = run_git(repo, ["log", "--name-only", "--format=%x01%ct%x01%an", "--", CONTENT_DIR])
+    newest_non_bot: dict[str, int] = {}
+    created: dict[str, int] = {}
+    current_ct = 0
     author_is_bot = True
     for line in out.splitlines():
         if line.startswith("\x01"):
-            author_is_bot = line[1:].strip() in BOT_AUTHORS
-        elif line.strip() and not author_is_bot:
-            touched.add(line.strip())
-    return touched
-
-
-def last_modified_times(repo: Path) -> dict[str, int]:
-    """{path: newest commit unix time} for content/docs, from one git pass.
-
-    Walks history newest-first; the first time a path appears is its last
-    modification. Used to order never-reviewed pages in the stale lane
-    (longest-untouched first).
-    """
-    out = run_git(repo, ["log", "--name-only", "--format=%x01%ct", "--", CONTENT_DIR])
-    times: dict[str, int] = {}
-    current = 0
-    for line in out.splitlines():
-        if line.startswith("\x01"):
+            # Header line is "\x01<commit-time>\x01<author-name>".
+            parts = line.split("\x01")
+            ct = parts[1] if len(parts) > 1 else ""
+            an = parts[2] if len(parts) > 2 else ""
             try:
-                current = int(line[1:].strip())
+                current_ct = int(ct.strip())
             except ValueError:
-                current = 0
-        elif line.strip() and line.strip() not in times:
-            times[line.strip()] = current
-    return times
+                current_ct = 0
+            author_is_bot = an.strip() in BOT_AUTHORS
+        elif line.strip():
+            path = line.strip()
+            created[path] = current_ct  # last write wins -> oldest commit
+            if not author_is_bot and path not in newest_non_bot:
+                newest_non_bot[path] = current_ct
+    return newest_non_bot, created
 
 
 def run_git(repo: Path, args: list[str]) -> str:
@@ -319,35 +322,64 @@ def parse_day(s: str | None) -> date | None:
             return None
 
 
+def _ts_to_day(ts: int | None) -> date | None:
+    if not ts:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).date()
+
+
+def effective_last_review(
+    path: str,
+    entry: dict | None,
+    newest_non_bot: dict[str, int],
+    created: dict[str, int],
+) -> date | None:
+    """The date the staleness clock is measured from.
+
+    max(completed bot review, newest human edit); an `incomplete` review does
+    not count, so the page stays due. Never-bot-reviewed pages fall back to the
+    git creation date. None only when the page has no git history at all.
+    """
+    cands: list[date] = []
+    if entry:
+        reviewed = parse_day(entry.get("reviewed_at"))
+        if reviewed and entry.get("status") != INCOMPLETE_STATUS:
+            cands.append(reviewed)
+    human = _ts_to_day(newest_non_bot.get(path))
+    if human:
+        cands.append(human)
+    if cands:
+        return max(cands)
+    return _ts_to_day(created.get(path))
+
+
+def importance(
+    tier: int,
+    visits: int | None,
+    max_visits: int,
+    median_visits: int,
+    have_traffic: bool,
+) -> float:
+    """Strategic weight, modulated by traffic when a snapshot is available."""
+    tier_w = TIER_WEIGHTS.get(tier, TIER_WEIGHTS[3])
+    if have_traffic and max_visits > 0:
+        v = visits if visits is not None else median_visits
+        traffic_n = math.log1p(v) / math.log1p(max_visits)
+        return tier_w * (0.5 + 0.5 * traffic_n)
+    return tier_w
+
+
 def score_page(
     tier: int,
     visits: int | None,
     max_visits: int,
     median_visits: int,
-    last_reviewed: date | None,
+    last_review: date | None,
     today: date,
-    recently_edited: bool,
     have_traffic: bool,
 ) -> float:
-    tier_w = TIER_WEIGHTS.get(tier, TIER_WEIGHTS[3])
-
-    if last_reviewed is None:
-        age_n = 1.0
-    else:
-        age_n = min((today - last_reviewed).days / 365.0, 1.0)
-
-    if have_traffic and max_visits > 0:
-        v = visits if visits is not None else median_visits
-        traffic_n = math.log1p(v) / math.log1p(max_visits)
-        score = WEIGHT_TIER * tier_w + WEIGHT_TRAFFIC * traffic_n + WEIGHT_AGE * age_n
-    else:
-        # No traffic data at all: drop the term, renormalize the rest.
-        rest = WEIGHT_TIER + WEIGHT_AGE
-        score = (WEIGHT_TIER / rest) * tier_w + (WEIGHT_AGE / rest) * age_n
-
-    if recently_edited:
-        score *= RECENT_EDIT_PENALTY
-    return round(score, 4)
+    staleness = max((today - last_review).days, 0) if last_review else 0
+    return round(importance(tier, visits, max_visits, median_visits, have_traffic) * staleness, 4)
 
 
 # ---- Subcommands ---------------------------------------------------------------
@@ -355,13 +387,16 @@ def score_page(
 
 def cmd_stats(ledger_dir: Path, use_gh: bool) -> int:
     entries = load_ledger(ledger_dir)
-    counts = {"merged": 0, "closed": 0, "open": 0, "clean": 0, "incomplete": 0, "unknown": 0}
+    counts = {"merged": 0, "closed": 0, "open": 0, "clean": 0,
+              "incomplete": 0, "capped": 0, "unknown": 0}
     by_lane: dict[str, int] = {}
     for path, entry in sorted(entries.items()):
         by_lane[entry.get("lane", "priority")] = by_lane.get(entry.get("lane", "priority"), 0) + 1
         status = entry.get("status")
-        if status == "incomplete":
+        if status == INCOMPLETE_STATUS:
             counts["incomplete"] += 1
+            if int(entry.get("attempts", 0)) >= ATTEMPT_CAP:
+                counts["capped"] += 1
             continue
         # `status == "clean"` is the canonical form; `clean: true` is the legacy
         # pre-standardization field still present on older ledger objects.
@@ -472,12 +507,13 @@ def main() -> int:
             "no_retire": no_retire,
             "monthly_visits": traffic.get(path),
             "last_reviewed": entry.get("reviewed_at"),
+            "attempts": int(entry.get("attempts", 0)),
             "score": score,
         }
 
     # --paths: explicit override, no scoring, no guardrails (testing path).
-    # The per-article worker passes --lane to carry the dispatcher's lane through
-    # (e.g. stale, so retirement stays in scope); without it entries are manual.
+    # The per-article worker passes --lane to carry the dispatcher's lane
+    # through; without it entries are manual.
     if args.paths:
         lane = args.lane or "manual"
         for raw in args.paths.split(","):
@@ -500,10 +536,10 @@ def main() -> int:
         return finish(queue, args)
     open_slugs = {b[len(BRANCH_PREFIX):].removeprefix("retire-") for b in open_branches}
 
-    recently_edited = recent_human_edits(repo)
-    modified_times = last_modified_times(repo)
+    newest_non_bot, created = git_history_signals(repo)
 
     candidates: list[str] = []
+    capped: list[str] = []
     for path in all_paths:
         tier, _ = tier_for(path, tier_rules)
         if tier == 0:
@@ -513,31 +549,19 @@ def main() -> int:
         if is_draft(repo / path):
             continue
         entry = ledger.get(path)
-        if entry:
-            reviewed = parse_day(entry.get("reviewed_at"))
-            if reviewed:
-                cooldown = (
-                    INCOMPLETE_COOLDOWN_DAYS
-                    if entry.get("status") == "incomplete"
-                    else COOLDOWN_DAYS
-                )
-                if (today - reviewed).days < cooldown:
-                    continue
+        if entry and entry.get("status") == INCOMPLETE_STATUS \
+                and int(entry.get("attempts", 0)) >= ATTEMPT_CAP:
+            capped.append(path)
+            continue
         candidates.append(path)
 
-    # Stale lane: one reserved slot for the longest-unreviewed page.
-    def stale_key(path: str):
-        entry = ledger.get(path)
-        reviewed = parse_day(entry.get("reviewed_at")) if entry else None
-        never = reviewed is None
-        return (
-            0 if never else 1,                                   # never-reviewed first
-            modified_times.get(path, 0) if never else 0,          # longest-untouched first
-            reviewed.toordinal() if reviewed else 0,              # then oldest review
-            path,
+    if capped:
+        print(
+            f"select-articles: {len(capped)} page(s) backed off at the "
+            f"{ATTEMPT_CAP}-attempt cap (need a human): " + ", ".join(sorted(capped)[:10])
+            + (" ..." if len(capped) > 10 else ""),
+            file=sys.stderr,
         )
-
-    stale_pick: str | None = min(candidates, key=stale_key) if candidates else None
 
     scored = sorted(
         (
@@ -547,23 +571,19 @@ def main() -> int:
                     traffic.get(path),
                     max_visits,
                     median_visits,
-                    parse_day(ledger.get(path, {}).get("reviewed_at")),
+                    effective_last_review(path, ledger.get(path), newest_non_bot, created),
                     today,
-                    path in recently_edited,
                     have_traffic,
                 ),
                 path,
             )
             for path in candidates
-            if path != stale_pick
         ),
         key=lambda t: (-t[0], t[1]),
     )
 
-    for score, path in scored[: max(args.count - (1 if stale_pick else 0), 0)]:
+    for score, path in scored[: max(args.count, 0)]:
         queue["articles"].append(article(path, "priority", score))
-    if stale_pick and args.count > 0:
-        queue["articles"].append(article(stale_pick, "stale", None))
 
     return finish(queue, args)
 

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -2,9 +2,20 @@
 """Tests for select-articles.py.
 
 Self-contained — run with `python3 test_select_articles.py` (no pytest dep).
-Builds a throwaway git repo with a miniature content/docs tree, fixture
-tiers/ledger/traffic files, and shells out to the script with `--no-gh`
-(no GitHub API) and `--today` (frozen clock), asserting on the queue JSON.
+Builds a throwaway git repo with a miniature content/docs tree committed at
+controlled dates by human and bot authors, plus fixture tiers/ledger/traffic
+files, and shells out to the script with `--no-gh` (no GitHub API) and
+`--today` (frozen clock), asserting on the queue JSON.
+
+The selector scores every page by `importance * staleness` and takes the top N.
+`staleness` is measured from `effective_last_review = max(completed bot review,
+newest non-bot commit)`, falling back to the git creation date — so the fixture
+commits are dated deliberately:
+
+  created 2024-01-01 (human)  -> ~893 days stale at the 2026-06-12 clock
+  edited  2026-06-10 (human)  -> ~2 days stale  (a human edit resets the clock)
+  edited  2026-06-10 (bot)    -> still ~893     (a bot edit does NOT reset)
+  created 2026-06-01 (human)  -> ~11 days stale (a brand-new page sorts to back)
 """
 
 from __future__ import annotations
@@ -22,6 +33,8 @@ REPO_TIERS = (
     HERE.parents[1]
     / ".claude/commands/review-existing-content/references/strategic-tiers.yaml"
 )
+
+TODAY = "2026-06-12"
 
 _failures: list[str] = []
 _passes = 0
@@ -52,35 +65,60 @@ tiers:
     no_retire: true
 """
 
-FILES = [
-    "content/docs/concepts/_index.md",
-    "content/docs/concepts/stacks.md",
-    "content/docs/esc/overview.md",
-    "content/docs/misc/one.md",
-    "content/docs/misc/two.md",
-    "content/docs/misc/protected/keep.md",
-    "content/docs/generated/cli.md",
+# Created long ago (2024-01-01) by a human, so all share the same high staleness
+# and ordering among them is driven purely by tier (and traffic, when present).
+BASE_FILES = [
+    "content/docs/concepts/_index.md",   # tier 1
+    "content/docs/concepts/stacks.md",   # tier 1 — later human-edited (reset)
+    "content/docs/esc/overview.md",      # tier 2
+    "content/docs/misc/one.md",          # tier 3 — later bot-edited (no reset)
+    "content/docs/misc/two.md",          # tier 3
+    "content/docs/misc/protected/keep.md",  # tier 3, no_retire
+    "content/docs/generated/cli.md",     # tier 0 (excluded)
 ]
+
+
+def git(repo: Path, *args: str, date: str | None = None,
+        name: str = "Human Author", email: str = "human@example.com") -> None:
+    env = {**os.environ, "GIT_AUTHOR_NAME": name, "GIT_AUTHOR_EMAIL": email,
+           "GIT_COMMITTER_NAME": name, "GIT_COMMITTER_EMAIL": email}
+    if date:
+        env["GIT_AUTHOR_DATE"] = date
+        env["GIT_COMMITTER_DATE"] = date
+    subprocess.run(["git", "-C", str(repo), *args], check=True, env=env,
+                   capture_output=True)
 
 
 def make_repo(tmp: Path) -> Path:
     repo = tmp / "repo"
-    for rel in FILES:
+    repo.mkdir()
+    git(repo, "init", "-q")
+    git(repo, "config", "commit.gpgsign", "false")
+
+    # C1 — the base corpus, created long ago by a human.
+    for rel in BASE_FILES:
         f = repo / rel
         f.parent.mkdir(parents=True, exist_ok=True)
         f.write_text(PAGE)
     (repo / "content/docs/misc/draft.md").write_text(DRAFT)
-    env = {**os.environ, "GIT_AUTHOR_DATE": "2026-01-01T00:00:00Z",
-           "GIT_COMMITTER_DATE": "2026-01-01T00:00:00Z"}
-    for cmd in (
-        ["git", "init", "-q"],
-        ["git", "config", "user.email", "t@example.com"],
-        ["git", "config", "user.name", "Human Author"],
-        ["git", "config", "commit.gpgsign", "false"],
-        ["git", "add", "."],
-        ["git", "commit", "-q", "-m", "seed"],
-    ):
-        subprocess.run(cmd, cwd=repo, check=True, env=env)
+    git(repo, "add", ".")
+    git(repo, "commit", "-q", "-m", "seed", date="2024-01-01T00:00:00Z")
+
+    # C2 — a brand-new page, recently created by a human.
+    (repo / "content/docs/misc/newpage.md").write_text(PAGE)
+    git(repo, "add", ".")
+    git(repo, "commit", "-q", "-m", "new page", date="2026-06-01T00:00:00Z")
+
+    # C3 — a human edit to concepts/stacks: resets its staleness clock.
+    (repo / "content/docs/concepts/stacks.md").write_text(PAGE + "\nEdited.\n")
+    git(repo, "add", ".")
+    git(repo, "commit", "-q", "-m", "human edit", date="2026-06-10T00:00:00Z")
+
+    # C4 — a bot edit to misc/one: must NOT reset its clock.
+    (repo / "content/docs/misc/one.md").write_text(PAGE + "\nBot touch.\n")
+    git(repo, "add", ".")
+    git(repo, "commit", "-q", "-m", "bot edit", date="2026-06-10T00:00:00Z",
+        name="pulumi-bot", email="bot@pulumi.com")
     return repo
 
 
@@ -88,7 +126,7 @@ def run_select(repo: Path, tiers: Path, ledger: Path, *extra: str) -> dict:
     out = repo / ".queue.json"
     env = {k: v for k, v in os.environ.items() if k != "GITHUB_OUTPUT"}
     proc = subprocess.run(
-        [sys.executable, str(SCRIPT), "--no-gh", "--today", "2026-06-12",
+        [sys.executable, str(SCRIPT), "--no-gh", "--today", TODAY,
          "--repo-root", str(repo), "--tiers", str(tiers),
          "--ledger-dir", str(ledger), "--out", str(out), *extra],
         capture_output=True, text=True, env=env,
@@ -97,12 +135,25 @@ def run_select(repo: Path, tiers: Path, ledger: Path, *extra: str) -> dict:
     return json.loads(out.read_text()) if out.is_file() else {}
 
 
+def scores(q: dict) -> dict[str, float]:
+    return {a["path"]: a["score"] for a in q["articles"]}
+
+
 def write_ledger(ledger: Path, path: str, reviewed_at: str, **kw) -> None:
     ledger.mkdir(parents=True, exist_ok=True)
     slug = path.removeprefix("content/").removesuffix("/_index.md").removesuffix(".md").replace("/", "-")
     entry = {"path": path, "reviewed_at": reviewed_at, "pr": "", "lane": "priority",
-             "clean": False, "fixes": 0, "skipped_findings": 0, **kw}
+             "status": "reviewed", "fixes": 0, "skipped_findings": 0, "attempts": 0, **kw}
     (ledger / f"{slug}.json").write_text(json.dumps(entry, indent=2) + "\n")
+
+
+C = "content/docs/concepts/_index.md"
+STACKS = "content/docs/concepts/stacks.md"
+OVERVIEW = "content/docs/esc/overview.md"
+ONE = "content/docs/misc/one.md"
+TWO = "content/docs/misc/two.md"
+KEEP = "content/docs/misc/protected/keep.md"
+NEWPAGE = "content/docs/misc/newpage.md"
 
 
 def main() -> int:
@@ -111,115 +162,100 @@ def main() -> int:
         repo = make_repo(tmp)
         tiers = tmp / "tiers.yaml"
         tiers.write_text(TIERS)
-        ledger = tmp / "ledger"
+        empty = tmp / "ledger-empty"
         traffic = tmp / "traffic.json"
 
-        print("tier-0, drafts excluded; deterministic ordering")
-        q = run_select(repo, tiers, ledger)
+        print("exclusions, lanes, and staleness ordering (no traffic, no ledger)")
+        q = run_select(repo, tiers, empty, "--count", "3")
         paths = [a["path"] for a in q["articles"]]
         check(len(paths) == 3, f"3 picks (got {paths})")
         check("content/docs/generated/cli.md" not in paths, "tier-0 excluded")
         check("content/docs/misc/draft.md" not in paths, "draft excluded")
-        check(q["articles"][-1]["lane"] == "stale", "last slot is the stale lane")
-        check(all(a["lane"] == "priority" for a in q["articles"][:-1]), "other slots priority")
-        q2 = run_select(repo, tiers, ledger)
+        check(all(a["lane"] == "priority" for a in q["articles"]), "all picks priority lane")
+        check(paths[0] == C, f"most-stale tier-1 tops the queue (got {paths[0]})")
+        check(paths[1] == OVERVIEW, f"stale tier-2 outranks stale tier-3 (got {paths[1]})")
+        check(STACKS not in paths, "freshly human-edited tier-1 is NOT in the top picks")
+        q2 = run_select(repo, tiers, empty, "--count", "3")
         check([a["path"] for a in q2["articles"]] == paths, "selection is deterministic")
 
-        print("no traffic file: tier dominates (renormalized weights)")
-        # All never-reviewed (age_n=1.0). The stale lane claims the path-first
-        # never-reviewed page (concepts/_index.md); the priority slots should
-        # then rank tier 1 > 2 > 3.
-        check(q["articles"][-1]["path"] == "content/docs/concepts/_index.md", "stale slot takes path-first never-reviewed")
-        check(paths[0] == "content/docs/concepts/stacks.md", f"tier-1 tops priority lane (got {paths[0]})")
-        check(paths[1] == "content/docs/esc/overview.md", "tier-2 second in priority lane")
+        print("human edit resets the clock; a bot edit does not")
+        full = run_select(repo, tiers, empty, "--count", "20")
+        s = scores(full)
+        check(s[STACKS] < s[C], "human-edited tier-1 scores far below the never-edited tier-1")
+        check(s[STACKS] < s[KEEP], "freshly human-edited page falls below stale tier-3 pages")
+        check(s[ONE] == s[TWO], "bot-edited page scores identically to its never-edited tier-3 sibling")
+        check(s[ONE] > s[STACKS], "bot edit left the page stale (unlike the human-edited one)")
 
-        print("traffic ranking: high-traffic tier-3 outranks low-traffic tier-2")
+        print("multiplicative score: stale tier-2 beats a fresh tier-1")
+        check(s[OVERVIEW] > s[STACKS], "importance*staleness lets a very stale tier-2 outrank a fresh tier-1")
+
+        print("creation-date fallback: a brand-new page sorts behind an ancient one")
+        check(s[TWO] > s[NEWPAGE], "older-created tier-3 outranks the just-created tier-3")
+        check(s[NEWPAGE] > 0, "brand-new page still scores nonzero")
+
+        print("traffic ranking: within a tier, the busier page outranks the quieter")
         traffic.write_text(json.dumps({
             "period": "2026-05", "source": "test",
-            "pages": {"/docs/misc/one/": 50000, "/docs/esc/overview/": 3},
+            "pages": {"/docs/misc/one/": 50000, "/docs/misc/two/": 5},
         }))
-        q = run_select(repo, tiers, ledger, "--traffic-file", str(traffic))
-        prio = [a["path"] for a in q["articles"] if a["lane"] == "priority"]
-        check(prio.index("content/docs/misc/one.md") < prio.index("content/docs/esc/overview.md")
-              if "content/docs/esc/overview.md" in prio
-              else "content/docs/misc/one.md" in prio,
-              "traffic term lifts the busy tier-3 page")
-        one = next(a for a in q["articles"] if a["path"] == "content/docs/misc/one.md")
-        check(one["monthly_visits"] == 50000, "visits recorded on the queue entry")
-        check(q["traffic"]["available"] is True, "traffic marked available")
-        check(q["traffic"]["pages_matched"] == 2, "URL→path normalization matched both")
-
-        print("median imputation: missing pages don't zero out")
-        two = next((a for a in q["articles"] if a["path"] == "content/docs/misc/two.md"), None)
-        if two is not None and two["lane"] == "priority":
-            check(two["score"] > 0, "imputed page scores nonzero")
+        qt = run_select(repo, tiers, empty, "--count", "20", "--traffic-file", str(traffic))
+        st = scores(qt)
+        check(st[ONE] > st[TWO], "traffic lifts the busy tier-3 page above the quiet one")
+        check(qt["traffic"]["available"] is True, "traffic marked available")
+        check(qt["traffic"]["pages_matched"] == 2, "URL→path normalization matched both")
+        one_art = next(a for a in qt["articles"] if a["path"] == ONE)
+        check(one_art["monthly_visits"] == 50000, "visits recorded on the queue entry")
 
         print("CSV traffic parses")
         csvf = tmp / "traffic.csv"
         csvf.write_text("path,views\n/docs/misc/one/,1234\n")
-        q = run_select(repo, tiers, ledger, "--traffic-file", str(csvf))
-        check(q["traffic"]["pages_matched"] == 1, "CSV snapshot parsed")
+        qc = run_select(repo, tiers, empty, "--count", "20", "--traffic-file", str(csvf))
+        check(qc["traffic"]["pages_matched"] == 1, "CSV snapshot parsed")
 
-        print("cooldown: recently reviewed pages are skipped")
-        write_ledger(ledger, "content/docs/concepts/_index.md", "2026-05-01")
-        q = run_select(repo, tiers, ledger)
-        paths = [a["path"] for a in q["articles"]]
-        check("content/docs/concepts/_index.md" not in paths, "365d cooldown respected")
+        print("incomplete review keeps a page due (its reviewed_at is ignored)")
+        led_inc = tmp / "ledger-incomplete"
+        write_ledger(led_inc, OVERVIEW, "2026-06-11", status="incomplete", attempts=1)
+        qi = run_select(repo, tiers, led_inc, "--count", "20")
+        si = scores(qi)
+        check(OVERVIEW in si, "incomplete page stays in the queue despite a fresh reviewed_at")
+        check(si[OVERVIEW] == s[OVERVIEW], "incomplete reviewed_at does not advance the staleness clock")
 
-        print("cooldown expiry: old review re-enters the pool")
-        write_ledger(ledger, "content/docs/concepts/_index.md", "2024-01-01")
-        q = run_select(repo, tiers, ledger)
-        paths = [a["path"] for a in q["articles"]]
-        check("content/docs/concepts/_index.md" in paths, "page back after cooldown")
+        print("attempt cap backs a perpetually-failing page off")
+        led_cap = tmp / "ledger-capped"
+        write_ledger(led_cap, TWO, "2026-06-11", status="incomplete", attempts=3)
+        qcap = run_select(repo, tiers, led_cap, "--count", "20")
+        check(TWO not in scores(qcap), "page at the attempt cap is excluded entirely")
+        check(ONE in scores(qcap), "non-capped pages still selected")
 
-        print("stale lane prefers never-reviewed over oldest-reviewed")
-        stale = next(a for a in q["articles"] if a["lane"] == "stale")
-        check(stale["last_reviewed"] is None, "stale pick is never-reviewed")
+        print("completed review advances the clock (page is deprioritized)")
+        led_done = tmp / "ledger-done"
+        write_ledger(led_done, C, "2026-06-05", status="reviewed")
+        qd = run_select(repo, tiers, led_done, "--count", "3")
+        dpaths = [a["path"] for a in qd["articles"]]
+        check(dpaths[0] == OVERVIEW, "after a fresh completed review the tier-1 page drops below the stale tier-2")
+        check(C not in dpaths, "just-reviewed tier-1 leaves the top picks")
 
         print("--paths override bypasses scoring")
-        q = run_select(repo, tiers, ledger, "--paths", "content/docs/misc/two.md")
-        check([a["path"] for a in q["articles"]] == ["content/docs/misc/two.md"], "explicit path honored")
+        q = run_select(repo, tiers, empty, "--paths", TWO)
+        check([a["path"] for a in q["articles"]] == [TWO], "explicit path honored")
         check(q["articles"][0]["lane"] == "manual", "manual lane tagged")
 
         print("--lane overrides the lane for --paths entries")
-        q = run_select(repo, tiers, ledger, "--paths", "content/docs/misc/two.md", "--lane", "stale")
-        check([a["path"] for a in q["articles"]] == ["content/docs/misc/two.md"], "single explicit path")
+        q = run_select(repo, tiers, empty, "--paths", TWO, "--lane", "stale")
         check(q["articles"][0]["lane"] == "stale", "lane override honored")
 
-        print("count=1 yields just the stale pick")
-        q = run_select(repo, tiers, ledger, "--count", "1")
-        check(len(q["articles"]) == 1 and q["articles"][0]["lane"] == "stale",
-              "reserved stale slot survives count=1")
-
         print("no_retire flags propagate")
-        q = run_select(repo, tiers, ledger, "--paths",
-                       "content/docs/misc/protected/keep.md,content/docs/concepts/stacks.md")
+        q = run_select(repo, tiers, empty, "--paths", f"{KEEP},{STACKS}")
         flags = {a["path"]: a["no_retire"] for a in q["articles"]}
-        check(flags["content/docs/misc/protected/keep.md"] is True, "explicit no_retire")
-        check(flags["content/docs/concepts/stacks.md"] is True, "tier 1 implies no_retire")
+        check(flags[KEEP] is True, "explicit no_retire")
+        check(flags[STACKS] is True, "tier 1 implies no_retire")
 
-        print("incomplete status: short cooldown, unlike a real review")
-        inc = tmp / "ledger_inc"
-        target = "content/docs/concepts/stacks.md"
-        # A real review 4 days ago is still inside the 365-day cooldown.
-        write_ledger(inc, target, "2026-06-08")
-        q = run_select(repo, tiers, inc, "--count", "5")
-        check(target not in [a["path"] for a in q["articles"]],
-              "real review 4d ago stays in the 365d cooldown")
-        # Same age, but an incomplete review only cools down for 3 days -> eligible.
-        write_ledger(inc, target, "2026-06-08", status="incomplete")
-        q = run_select(repo, tiers, inc, "--count", "5")
-        check(target in [a["path"] for a in q["articles"]],
-              "incomplete review past the 3d window is eligible again")
-        # An incomplete review 1 day ago is still inside the short window.
-        write_ledger(inc, target, "2026-06-11", status="incomplete")
-        q = run_select(repo, tiers, inc, "--count", "5")
-        check(target not in [a["path"] for a in q["articles"]],
-              "incomplete review 1d ago still cooling down")
+        print("attempts surfaced on queue entries")
+        check(all("attempts" in a for a in full["articles"]), "every queue entry carries attempts")
 
         print("repo strategic-tiers.yaml parses and excludes generated trees")
         proc = subprocess.run(
-            [sys.executable, str(SCRIPT), "--no-gh", "--today", "2026-06-12",
+            [sys.executable, str(SCRIPT), "--no-gh", "--today", TODAY,
              "--tiers", str(REPO_TIERS), "--ledger-dir", str(tmp / "empty"),
              "--paths", "content/docs/iac/cli/commands/pulumi.md", "--dry-run"],
             capture_output=True, text=True,
@@ -228,7 +264,6 @@ def main() -> int:
             entry = json.loads(proc.stdout)["articles"][0]
             check(entry["tier"] == 0, "real tiers file marks CLI commands tier 0")
         else:
-            # Page may not exist in a sparse checkout; the parse still ran.
             check("tiers" not in proc.stderr.lower(), "real tiers file parses")
 
     print(f"\n{_passes} passed, {len(_failures)} failed")


### PR DESCRIPTION
Workstream 1 of the existing-content review pipeline: replace the page selector's fixed cooldowns + additive score + reserved stale lane with a weighted-fair-queuing staleness model.

## What changed

**`select-articles.py`** — `score = importance × staleness`, top-N, no threshold, no reserved lane (staleness self-corrects starvation).
- `importance = tier_weight × (0.5 + 0.5 × traffic_norm)`, degrading to tier-only when no traffic snapshot is present.
- `staleness` = days since `effective_last_review = max(completed bot review, newest non-bot commit)`, falling back to git creation date. A human (non-bot) edit fully resets the clock; a bot edit does not; an `incomplete` review never advances it, so the page stays due.
- One git-history pass derives the non-bot/creation timestamps. Open-PR dedup, tier-0/draft exclusion, and halt guards are unchanged.
- `ATTEMPT_CAP` backs a perpetually-failing `incomplete` page off (excluded and surfaced) instead of looping.

**`record-review.py`** — carries and increments `attempts`, resetting to 0 on any completed outcome.

**Retirement** is no longer gated to the (removed) stale lane: allowed on any review that clears the strict evidence bar, with `no_retire` promoted to the primary hard veto. SKILL, `strategic-tiers.yaml`, and both workflow YAMLs updated to match (workflow changes are comment/description-only).

## Cadence (730-day sim over the real corpus, 578 reviewable pages)

Full coverage, 0 idle days, no starvation. Median re-review cadence grades cleanly by importance (~1 : 1.9 : 4.0 for t1:t2:t3 with real trailing-6-month pageviews; ~1 : 1.7 : 3.5 tier-only). Within a tier, busy pages get ~15–20% tighter cadence than quiet ones, and traffic reorders within a tier without ever jumping tiers.

## Tests

- `test_select_articles.py` rewritten — 44 pass (date/author-varied git fixtures).
- `record-review.py --self-test` passes.
- `make lint` clean.