### PR TITLE
Point docs header Get Started button to app signup

### DIFF
--- a/data/docs_nav.yaml
+++ b/data/docs_nav.yaml
@@ -39,5 +39,5 @@ cta:
   dashboard: { label: Dashboard,  href: https://app.pulumi.com,        track: header-dashboard             }
   getStarted:
     label: Get started
-    href: /docs/get-started/
+    href: https://app.pulumi.com/signup
     track: get-started-practitioner-nav


### PR DESCRIPTION
## What

Updates the **Get started** button in the docs top-nav header to link directly to `https://app.pulumi.com/signup` instead of the `/docs/get-started/` tutorial page.

## Why

A reader clicking "Get started" in the header is signaling intent to try Pulumi. Routing them straight to the app signup flow gets them into the product faster, and matches the behavior of the marketing-site header CTA (which already points to the signup URL via `site.Params.cta.primary.href`).

## Change

- `data/docs_nav.yaml`: `cta.getStarted.href` changed from `/docs/get-started/` to `https://app.pulumi.com/signup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)