### PR TITLE
Make self-hosted Pulumi Cloud a first-class, self-serve experience

### DIFF
--- a/content/docs/administration/self-hosting/_index.md
+++ b/content/docs/administration/self-hosting/_index.md
@@ -13,7 +13,7 @@ menu:
   administration:
     name: Self-Hosting
     parent: administration-home
-    weight: 40
+    weight: 25
     identifier: administration-self-hosting
 aliases:
   - /docs/guides/self-hosted/
@@ -32,6 +32,14 @@ sections:
     The self-hosted version provides all the same capabilities as the SaaS offering at [app.pulumi.com](https://app.pulumi.com/signin). You manage data backups, keep the service running, and maintain updates, while gaining full control over the deployment environment.
 
     Pulumi can be deployed in any on-premise or cloud environment and integrated with your preferred identity provider: GitHub Enterprise, GitLab Enterprise, SAML SSO, or email/password authentication.
+
+- type: button-cards
+  heading: Get started
+  cards:
+  - icon: rocket-launch
+    heading: Install Self-Hosted Pulumi Cloud
+    link: /docs/administration/self-hosting/install/
+    description: Pick your platform and install. Evaluate with Docker Compose in minutes, or deploy to production on AWS, Azure, Google Cloud, or Kubernetes.
 
 - type: button-cards
   heading: Deployment options

--- a/content/docs/administration/self-hosting/deployment-options/_index.md
+++ b/content/docs/administration/self-hosting/deployment-options/_index.md
@@ -14,9 +14,9 @@ aliases:
   - /docs/administration/self-hosting/pulumi-cloud/deployment-options/
   - /docs/pulumi-cloud/admin/self-hosted/deployment-options/
 ---
-Pulumi offers a number of deployment options for self-hosting the Pulumi Cloud.
+Pulumi offers a number of deployment options for self-hosting the Pulumi Cloud. To get started, see [Install Self-Hosted Pulumi Cloud](/docs/administration/self-hosting/install/), which walks you through each platform. Use Docker Compose to evaluate on a single host in minutes; the other options are production deployments.
 
-* [Docker Compose](quickstart-docker-compose/)
+* [Docker Compose](quickstart-docker-compose/) — evaluation and testing
 * [ECS](ecs-hosted/)
 * [EKS](eks-hosted/)
 * [AKS](aks-hosted/)

--- a/content/docs/administration/self-hosting/deployment-options/quickstart-docker-compose.md
+++ b/content/docs/administration/self-hosting/deployment-options/quickstart-docker-compose.md
@@ -1,8 +1,8 @@
 ---
-title_tag: Quickstart Docker Compose | Self-Hosting Pulumi 
-meta_desc: Quickstart Docker compose installer for testing of the self-hosted Pulumi Cloud.
+title_tag: Try Self-Hosted Pulumi Cloud with Docker Compose
+meta_desc: Evaluate self-hosted Pulumi Cloud in about ten minutes with the all-in-one Docker Compose stack.
 title: Docker Compose
-h1: Pulumi Cloud self-hosted Docker Compose install
+h1: Try Self-Hosted Pulumi Cloud with Docker Compose
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   administration:
@@ -16,49 +16,72 @@ aliases:
   - /docs/pulumi-cloud/admin/self-hosted/deployment-options/quickstart-docker-compose/
 ---
 
-The Pulumi Cloud Docker container images can be run using any OCI-compatible container orchestrator. We provide sample docker-compose files that can help you get started with your self-evaluation quickly.
+The fastest way to try self-hosted Pulumi Cloud is the all-in-one Docker Compose stack. It runs the API, the web Console, a migrated MySQL database, and OpenSearch on a single host with working defaults, so you can evaluate the full platform in about ten minutes. Use it for evaluation and testing; for production, see the [production deployment options](/docs/administration/self-hosting/deployment-options/).
 
-> **Note**: docker-compose is not required to run these containers. We recommend that you choose a container orchestrator with which your IT team has experience.
+## Prerequisites
 
-In addition to the environment variables that each container exposes, the following can be set when using either of the quickstart solutions below. These are used by the `run-ee.sh` script provided to you as part of the self-evaluation package. If any of these variables are not set when you run `run-ee.sh`, the default values will be used.
-
-`PULUMI_DATA_PATH`: The persistent path where the service should store the checkpoint objects. Default uses `/tmp/pulumi-ee/data`.
-
-`PULUMI_LOCAL_DATABASE_NAME`: The database instance’s hostname. Default is `pulumi-db`.
-
-`PULUMI_LOCAL_DATABASE_PORT`: The database instance’s port. Default is `3306`.
-
-For example, `PULUMI_DATA_PATH=/my/persistent/dir LOCAL_DATABASE_NAME=my-db LOCAL_DATABASE_PORT=3306 ./scripts/run-ee.sh`.
-
-Regardless of the quickstart option you choose below, `run-ee.sh` will be the way to start the necessary containers. There will be at most 3 containers (including the DB) for the system to be considered complete.
-
-## Quickstart Docker Compose Deployment Options
-
-The [Quickstart Docker Compose Installer](https://github.com/pulumi/pulumi-self-hosted-installers/tree/master/quickstart-docker-compose) is used to deploy a test system using Docker.
-
-### Option #1 - Using the all-in-one approach
-
-If you would like to use Pulumi’s all-in-one solution, you just need to run `run-ee.sh` like this: `run-ee.sh -f ./all-in-one/docker-compose.yml`. This will start all components using working defaults, including a DB container that is migrated using our DB scripts.
+- [Docker Engine](https://docs.docker.com/engine/install/) with the Docker Compose plugin (v2).
+- A host with at least 2 CPU cores, 8 GB of memory, and 20 GB of free disk.
+- Ports `3000` (Console), `8080` (API), and `9200`/`5601` (OpenSearch) available on the host.
+- A Pulumi license key.
 
 {{% notes "info" %}}
-Environment variables should be set in the `./all-in-one/docker-compose.yml` file.
+Self-hosted Pulumi Cloud requires a license key set in `PULUMI_LICENSE_KEY`. [Get an evaluation license](/product/self-hosted/#self-hosted-trial) to get started.
 {{% /notes %}}
 
-### Option #2 - Provide your own Database
+## Run the all-in-one stack
 
-The service is tested against a MySQL version 8.0 instance. It is assumed that you have a DB instance called `pulumi-db` running at port `3306` and accessible within a network called `pulumi-ee`.
+1. Clone the installer and change into the quickstart directory:
 
-{{% notes "info" %}}
-You will need the `migrations` folder downloaded locally, which contains the DB scripts that need to be applied against your DB instance.
-Your Pulumi sales contact should be able to provide you with this.
-{{% /notes %}}
+    ```bash
+    git clone https://github.com/pulumi/pulumi-self-hosted-installers.git
+    cd pulumi-self-hosted-installers/quickstart-docker-compose
+    ```
 
-## Quickstart Docker Compose System Management and Maintenance
+1. Set your license key:
 
-Since the quickstart option is meant to be used for testing purposes, there is no real maintenance or management needed other than perhaps updating the service containers with the latest versions.
+    ```bash
+    export PULUMI_LICENSE_KEY=<your-license-key>
+    ```
 
-### Updating the Pulumi Cloud Containers
+1. Start the stack:
 
-For testing purposes, it is recommended to use the `latest` image tag in the docker compose file and re-run the `run-ee.sh` script when there are newer versions of the service image pushed to docker hub.
+    ```bash
+    ./scripts/run-ee.sh -f ./all-in-one/docker-compose.yml
+    ```
 
-If you specified a specific image version in the docker compose file, then update the version tag and re-run the `run-ee.sh` script.
+    This starts every component with working defaults, including a MySQL container that is migrated automatically. Checkpoint data is stored under `$HOME/pulumi-self-hosted-installers/data` by default; override it with `PULUMI_DATA_PATH`.
+
+1. Open the Console at [http://localhost:3000](http://localhost:3000) and create the first account. The first user to register becomes an administrator.
+
+1. Point the CLI at your instance and follow the prompt to create an access token:
+
+    ```bash
+    pulumi login http://localhost:8080
+    ```
+
+1. Verify the connection:
+
+    ```bash
+    pulumi whoami
+    ```
+
+To stop the stack, press `Ctrl+C`, then remove the containers with `docker compose -f ./all-in-one/docker-compose.yml down`. Delete the data directory to discard evaluation state.
+
+## Advanced configuration
+
+The `run-ee.sh` script honors the following environment variables; unset variables fall back to working defaults:
+
+- `PULUMI_DATA_PATH`: persistent path for checkpoint objects. Defaults to `$HOME/pulumi-self-hosted-installers/data`.
+- `PULUMI_LOCAL_DATABASE_NAME`: the database hostname. Default is `pulumi-db`.
+- `PULUMI_LOCAL_DATABASE_PORT`: the database port. Default is `3306`.
+
+Other settings — identity providers, object storage, encryption keys — are configured in the `environment` blocks of `./all-in-one/docker-compose.yml`. See [Components](/docs/administration/self-hosting/components/) for the full set of variables each container accepts.
+
+### Bring your own database
+
+To run against an existing MySQL 8.0 instance instead of the bundled database, start the service with the base `docker-compose.yml` and point it at a database reachable as `pulumi-db:3306` on the `pulumi-ee` network. This path requires the `migrations` folder to apply the schema; contact [sales@pulumi.com](mailto:sales@pulumi.com) to obtain it.
+
+## Updating
+
+For evaluation, pin the `latest` image tag in the compose file and re-run `run-ee.sh` to pull newer service images. If you pinned a specific version, update the tag and re-run the script.

--- a/content/docs/administration/self-hosting/install/_index.md
+++ b/content/docs/administration/self-hosting/install/_index.md
@@ -1,0 +1,85 @@
+---
+title_tag: Install Self-Hosted Pulumi Cloud
+meta_desc: Install self-hosted Pulumi Cloud on your platform — evaluate in minutes with Docker Compose, or deploy to production on AWS, Azure, Google Cloud, or Kubernetes.
+title: Install
+h1: Install Self-Hosted Pulumi Cloud
+meta_image: /images/docs/meta-images/docs-meta.png
+weight: 1
+menu:
+  administration:
+    name: Install
+    parent: administration-self-hosting
+    weight: 0
+    identifier: administration-self-hosting-install
+aliases:
+  - /self-hosted/install/
+---
+
+Run the full Pulumi Cloud platform in your own cloud account or data center. Start with the all-in-one Docker Compose stack to evaluate in about ten minutes, then choose a production deployment for your platform.
+
+{{% notes "info" %}}
+You can evaluate self-hosted Pulumi Cloud yourself — the Docker Compose stack below runs on your own machine in about ten minutes. You'll need an evaluation license key; [get one here](/product/self-hosted/#self-hosted-trial). For production, self-hosted Pulumi Cloud is available with the [Business Critical edition](/pricing/).
+{{% /notes %}}
+
+## Choose your platform
+
+{{< chooser cloud "docker,kubernetes,aws,azure,gcp" >}}
+
+{{% choosable cloud docker %}}
+
+The all-in-one Docker Compose stack runs the API, Console, database, and search on a single host — the fastest way to try self-hosted Pulumi Cloud.
+
+```bash
+git clone https://github.com/pulumi/pulumi-self-hosted-installers.git
+cd pulumi-self-hosted-installers/quickstart-docker-compose
+export PULUMI_LICENSE_KEY=<your-license-key>
+./scripts/run-ee.sh -f ./all-in-one/docker-compose.yml
+```
+
+Then open the Console at [http://localhost:3000](http://localhost:3000), create the first account, and run `pulumi login http://localhost:8080`.
+
+See the [Docker Compose quickstart](/docs/administration/self-hosting/deployment-options/quickstart-docker-compose/) for prerequisites, first login, verification, and teardown.
+
+{{% /choosable %}}
+
+{{% choosable cloud kubernetes %}}
+
+Deploy to your own Kubernetes cluster with MySQL and S3-compatible object storage. This is the most flexible production option and works in any environment, including air-gapped networks.
+
+See [Bring your own infrastructure](/docs/administration/self-hosting/deployment-options/byo-infra-hosted/) for the Kubernetes deployment guide.
+
+{{% /choosable %}}
+
+{{% choosable cloud aws %}}
+
+Deploy a production system on AWS. Two managed options are available:
+
+- [Amazon EKS](/docs/administration/self-hosting/deployment-options/eks-hosted/) — Kubernetes-based, with RDS Aurora, S3, and CloudWatch.
+- [Amazon ECS](/docs/administration/self-hosting/deployment-options/ecs-hosted/) — ECS and Fargate, with RDS Aurora, S3, and an Application Load Balancer.
+
+{{% /choosable %}}
+
+{{% choosable cloud azure %}}
+
+Deploy a production system on [Azure Kubernetes Service](/docs/administration/self-hosting/deployment-options/aks-hosted/) with Azure Database for MySQL and Azure Blob Storage.
+
+{{% /choosable %}}
+
+{{% choosable cloud gcp %}}
+
+Deploy a production system on [Google Kubernetes Engine](/docs/administration/self-hosting/deployment-options/gke-hosted/) with Cloud SQL for MySQL and Cloud Storage.
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## Before you go to production
+
+The deployment guides stand up a working system. Before you run production workloads, review the [Operations guide](/docs/administration/self-hosting/operations/) for high availability, backup and recovery, monitoring, sizing, and security hardening, and the [Network requirements](/docs/administration/self-hosting/network/) for ingress, egress, and air-gapped configurations.
+
+## Next steps
+
+- [Docker Compose quickstart](/docs/administration/self-hosting/deployment-options/quickstart-docker-compose/)
+- [All deployment options](/docs/administration/self-hosting/deployment-options/)
+- [Components and configuration](/docs/administration/self-hosting/components/)
+- [Operations guide](/docs/administration/self-hosting/operations/)

--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -50,8 +50,9 @@ Terraform is an infrastructure as code tool created by HashiCorp (acquired by IB
 | Modularity and reuse | [Component Resources](/docs/iac/concepts/components/) authored in any supported language; [Pulumi Packages](/docs/iac/concepts/packages/) let a component written in one language be consumed from any Pulumi language; language-native package managers (npm, PyPI, NuGet, Maven, Go modules); and the [Pulumi Registry](/registry/) for publicly available packages | [Terraform modules](https://developer.hashicorp.com/terraform/language/modules) (HCL) and the [Terraform Registry](https://registry.terraform.io/) for public modules |
 | Import existing resources | [`pulumi import`](/docs/iac/guides/migration/import/) and the [`import` resource option](/docs/iac/concepts/resources/options/import/), both of which generate code in your language | [`terraform import`](https://developer.hashicorp.com/terraform/cli/commands/import) and [`import` blocks](https://developer.hashicorp.com/terraform/language/import); HCL must be hand-authored, though `terraform plan -generate-config-out` can emit a draft |
 | Policy as code | [Pulumi Policies](/docs/insights/policy/) — open source, with rules written in Python, TypeScript, or Open Policy Agent Rego; Pulumi Cloud commercial plans add centralized policy management plus [Pulumi-maintained policy packs](/docs/insights/policy/policy-packs/pre-built-packs/) for compliance frameworks like CIS, HITRUST, NIST, and PCI DSS | [Sentinel](https://developer.hashicorp.com/sentinel) (proprietary, HCP Terraform / Enterprise only) and Open Policy Agent |
+| Self-hosting and on-prem | [Self-hosted Pulumi Cloud](/product/self-hosted/) runs the entire platform — state, secrets, RBAC, policy, and deployments — in your own cloud account or data center, including air-gapped environments, with the same capabilities as the SaaS | [Terraform Enterprise](https://developer.hashicorp.com/terraform/enterprise) is HashiCorp's self-managed offering; Sentinel policy, run tasks, and no-code provisioning are gated to HCP Terraform and Enterprise tiers |
 | Open source | Yes — [Apache License 2.0](https://github.com/pulumi/pulumi/blob/master/LICENSE) | No — [Business Source License 1.1](https://github.com/hashicorp/terraform/blob/main/LICENSE) |
-| Commercial option | [Pulumi Cloud](/docs/iac/guides/basics/pulumi-cloud-vs-oss/) | HCP Terraform / Terraform Enterprise |
+| Commercial option | [Pulumi Cloud](/docs/iac/guides/basics/pulumi-cloud-vs-oss/) — SaaS or [self-hosted](/product/self-hosted/) | HCP Terraform (SaaS) / Terraform Enterprise (self-managed) |
 
 ## Key differences
 
@@ -66,6 +67,10 @@ Both tools have large provider ecosystems. Pulumi can use any provider published
 ### Execution and orchestration
 
 Both tools provide a CLI and a managed remote-run service: Pulumi Cloud Deployments for Pulumi, and HCP Terraform for Terraform. Pulumi additionally exposes the [Automation API](/docs/iac/concepts/automation-api/), a programmatic SDK that lets you drive `up`, `preview`, and `destroy` from inside another program — for example, to ship a CLI that wraps Pulumi, build a self-service portal for application teams, or orchestrate many stacks dynamically from a higher-level service. Terraform does not have a programmatic equivalent.
+
+### Self-hosting and data control
+
+Both platforms offer a self-managed deployment for teams that can't use SaaS. Terraform Enterprise is HashiCorp's self-managed product. [Self-hosted Pulumi Cloud](/product/self-hosted/) runs the complete platform — state, secrets, RBAC, policy enforcement, and deployments — inside your own cloud account or data center, including fully air-gapped networks with no egress to the public internet. Data lives in a database and object store you control, and you integrate your own identity provider (GitHub Enterprise, GitLab, SAML SSO, and others). The self-hosted edition tracks the same capabilities as the SaaS, so teams evaluate features once and choose the deployment topology that fits their compliance posture. See the [self-hosting docs](/docs/administration/self-hosting/) for deployment options across AWS, Azure, Google Cloud, Kubernetes, and Docker.
 
 ### Secrets handling
 
@@ -144,9 +149,14 @@ Yes. [Pulumi Cloud as a Terraform state backend](/docs/iac/get-started/terraform
 
 [`pulumi refresh`](/docs/iac/cli/commands/pulumi_refresh/) compares the state file to the actual state in the cloud and reports differences, and `pulumi preview --diff` shows what would change on the next update. Pulumi Cloud commercial plans add [scheduled drift detection and remediation](/docs/deployments/deployments/drift/) that runs on a configurable cadence and can auto-remediate.
 
+### Can I run Pulumi on-prem like Terraform Enterprise?
+
+Yes. [Self-hosted Pulumi Cloud](/product/self-hosted/) runs the full platform in your own cloud account or data center, including air-gapped environments, with the same state, secrets, RBAC, policy, and deployment capabilities as the SaaS. It's available with the Business Critical edition; see the [self-hosting documentation](/docs/administration/self-hosting/) for deployment options and requirements.
+
 ## Next steps
 
 - [Get started with Pulumi](/docs/iac/get-started/)
+- [Migrating from Terraform Enterprise to self-hosted Pulumi Cloud](/docs/iac/comparisons/terraform/from-terraform-enterprise/)
 - [Pulumi terms and command equivalents for Terraform users](/docs/iac/comparisons/terraform/terminology/)
 - [Pulumi vs. OpenTofu](/docs/iac/comparisons/opentofu/)
 - [OpenTofu vs. Terraform](/docs/iac/comparisons/terraform/opentofu/)

--- a/content/docs/iac/comparisons/terraform/from-terraform-enterprise.md
+++ b/content/docs/iac/comparisons/terraform/from-terraform-enterprise.md
@@ -1,0 +1,47 @@
+---
+title_tag: "Migrating from Terraform Enterprise to Pulumi"
+meta_desc: How teams running self-managed Terraform Enterprise move to self-hosted Pulumi Cloud — the same on-prem operating model, with a phased migration path.
+title: From Terraform Enterprise
+h1: Migrating from Terraform Enterprise to Self-Hosted Pulumi Cloud
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: From Terraform Enterprise
+        parent: iac-comparisons-terraform
+        weight: 3
+aliases:
+    - /docs/iac/comparisons/terraform/migrating-from-terraform-enterprise/
+---
+
+Terraform Enterprise teams run infrastructure as code on their own infrastructure for data control, network isolation, and compliance. [Self-hosted Pulumi Cloud](/product/self-hosted/) offers the same operating model: the complete Pulumi Cloud platform — state, secrets, RBAC, policy, and deployments — running in your own cloud account or data center, including fully air-gapped networks. This guide is for teams evaluating a move from Terraform Enterprise to Pulumi without giving up self-management.
+
+## What you get with self-hosted Pulumi Cloud
+
+Self-hosted Pulumi Cloud runs the same platform as the [SaaS](https://app.pulumi.com/), so teams evaluate features once and choose the deployment topology that fits their compliance posture:
+
+- **The full platform in your environment.** State management, secrets, role-based access control, [policy enforcement](/docs/insights/policy/), and [deployments](/docs/deployments/) all run on infrastructure you operate.
+- **Data you control.** State and secrets live in a MySQL database and an object store within your own network. Encryption keys can be managed locally or through AWS KMS or Azure Key Vault.
+- **Air-gapped operation.** Run with no egress to the public internet, including environments that require FedRAMP.
+- **Your identity provider.** Integrate GitHub Enterprise, GitLab, SAML SSO, and others.
+
+For a feature-by-feature comparison of the two tools, see [Pulumi vs. Terraform](/docs/iac/comparisons/terraform/).
+
+## How migration works
+
+You don't rewrite everything at once. Pulumi is designed to adopt incrementally, and these paths combine:
+
+1. **Run side by side.** Pulumi programs can [reference existing Terraform state](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/#referencing-terraform-state) and read its outputs, so you keep existing infrastructure in Terraform while adopting Pulumi for new work.
+1. **Store Terraform state in Pulumi.** [Pulumi Cloud can act as a Terraform state backend](/docs/iac/get-started/terraform/terraform-state-backend/), giving you encrypted state, history, locking, RBAC, and audit policies while you continue to run Terraform day-to-day.
+1. **Convert HCL.** [`pulumi convert --from terraform`](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/#converting-terraform-hcl-to-pulumi) translates Terraform HCL into a Pulumi program in the language of your choice, preserving names, modules, and structure where possible.
+1. **Import existing resources.** [`pulumi import`](/docs/iac/guides/migration/import/) brings already-provisioned resources under Pulumi management and generates the corresponding code.
+
+For a complete walkthrough including bulk conversion and state migration, see [Migrating from Terraform to Pulumi](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/).
+
+## Pricing
+
+Self-hosted Pulumi Cloud is available with the Business Critical edition. See [pricing](/pricing/) for what each edition includes, and [contact us](/contact/) to discuss licensing and an evaluation for your environment.
+
+## Get started
+
+1. [Install self-hosted Pulumi Cloud](/docs/administration/self-hosting/install/) and deploy it yourself — evaluate with Docker Compose in minutes, then go to production on AWS, Azure, Google Cloud, or Kubernetes.
+1. [Get an evaluation license](/product/self-hosted/#self-hosted-trial), or talk to us about a guided rollout.

--- a/content/docs/install/_index.md
+++ b/content/docs/install/_index.md
@@ -39,6 +39,8 @@ The latest version of Pulumi is **{{< latest-version >}}**. For previous version
 
 By default, the Pulumi CLI stores state in [Pulumi Cloud](/docs/iac/guides/basics/pulumi-cloud-vs-oss/), our free, hosted state-management backend. Pulumi Cloud is free for individuals and is the recommended backend when you're learning Pulumi — no credit card required. If you'd rather host state yourself (S3, Azure Blob, GCS, or local), see [self-managed state backends](/docs/iac/concepts/state-and-backends/).
 
+Organizations that need to keep everything in their own environment can run the full Pulumi Cloud platform self-hosted — the same managed experience as the SaaS, in your own cloud account or data center. See [self-hosted Pulumi Cloud](/product/self-hosted/) and the [self-hosting docs](/docs/administration/self-hosting/).
+
 {{% notes "info" %}}
 You don't need a Pulumi Cloud account to install the CLI. You'll be prompted to sign in (or to pick a self-managed backend) the first time you run `pulumi login`.
 {{% /notes %}}

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -732,7 +732,7 @@ faq:
         - question: Is Pulumi SOC 2 compliant?
           answer: Yes, Pulumi has completed the SOC 2 Type 2 compliance process. Pulumi is committed to operational excellence for our customers.
         - question: Can I host Pulumi Cloud in my cloud or datacenter?
-          answer: Yes, we offer a self-hosted Pulumi Cloud for companies that have specific data control requirements and want to maintain complete control over hosting Pulumi Cloud. This option is available in Business Critical Edition. You can [request a Proof of Concept (PoC)](/product/self-hosted/#self-hosted-trial) to get started.
+          answer: Yes, we offer a self-hosted Pulumi Cloud for companies that have specific data control requirements and want to maintain complete control over hosting Pulumi Cloud. This option is available in Business Critical Edition. You can [deploy it yourself](/docs/administration/self-hosting/install/) in minutes with an evaluation license, or [talk to us](/product/self-hosted/#self-hosted-trial) about a guided rollout.
         - question: How do I convince my boss?
           answer: |
             Do you want to use Pulumi in your organization, but aren't sure how to bring it up with your boss? We've created a sample email to help you explain its benefits. Feel free to use the full letter or pieces of it. We are always happy to meet to learn more about your needs and explain these benefits in person — just [contact us](/contact/?form=sales).

--- a/content/product/_index.md
+++ b/content/product/_index.md
@@ -141,6 +141,15 @@ sections:
           Drift detection, dependency management, and enterprise RBAC give you visibility and control across the full infrastructure lifecycle.
     anchor: idp
 
+  - type: section_header
+    tag_line: Deployment options
+    title: Run Pulumi Cloud anywhere
+    description: |
+      Use Pulumi Cloud as a fully managed SaaS, or run the same platform yourself in your own cloud account or data center. Self-hosted Pulumi Cloud gives you complete control over data, identity, and network isolation, including air-gapped environments, with the same IaC, secrets, insights, and governance capabilities.
+    cta_text: Explore self-hosted Pulumi Cloud
+    cta_link: /product/self-hosted/
+    anchor: self-hosted
+
   - type: two_column
     anchor: get-started
     highlight_first_card: true

--- a/content/product/infrastructure-as-code.md
+++ b/content/product/infrastructure-as-code.md
@@ -143,7 +143,7 @@ sections:
     title: Open source core.
     title_line_2: Pulumi Cloud built-in.
     description: |
-      Get started with Pulumi Cloud for free, state management and secrets included. Our [open source engine](https://github.com/pulumi/pulumi) powers everything underneath. Scale to enterprise features when you need them, or self-host if required.
+      Get started with Pulumi Cloud for free, state management and secrets included. Our [open source engine](https://github.com/pulumi/pulumi) powers everything underneath. Scale to enterprise features when you need them, and run the same platform [fully self-hosted](/product/self-hosted/) in your own cloud or data center.
     image: /images/product/infrastructure-as-code/pulumi-concentric-circles.svg
     image_alt: Open source core and Pulumi Cloud
     image_above: true
@@ -399,4 +399,8 @@ sections:
         title: Complete audit trail
         description: |
           Every action logged. Who changed what, when, and why. Export to SIEM. Compliance reports at your fingertips.
+      - icon: buildings
+        title: Self-host the whole platform
+        description: |
+          Run all of Pulumi Cloud in your own cloud account or data center. Full control over data, identity, and network, including air-gapped deployments. [Learn about self-hosting](/product/self-hosted/).
 ---

--- a/content/product/self-hosted.md
+++ b/content/product/self-hosted.md
@@ -2,21 +2,31 @@
 title: Self-Hosted Pulumi Cloud
 layout: self-hosted
 
-meta_desc: Learn how to operate Pulumi Cloud in your own cloud account or data center.
+meta_desc: Run Pulumi Cloud self-hosted in your own cloud or data center — the same IaC, secrets, and governance as the SaaS, with full control over your data and network.
+
+aliases:
+    - /self-hosted/
+    - /try-self-hosted/
 
 overview:
-    title: Try Self-Hosted Pulumi
+    title: Run Pulumi Cloud in your own environment
     descriptionTop: |
-        Maintain complete control over your hosting, network isolation, identity, and data ownership to satisfy compliance requirements.  [Request a Proof of Concept](#self-hosted-trial) to evaluate self-hosted Pulumi.
+        Run the complete Pulumi Cloud platform in your own cloud account or data center. You get the same IaC, secrets, insights, and governance capabilities as the SaaS, with full control over data, identity, network isolation, and air-gapped operation.
     descriptionBottom: |
-        Want Pulumi Cloud delivered as SaaS?  [Start Using Pulumi Cloud for free](https://app.pulumi.com/signin).
+        Deploy it yourself in about ten minutes with Docker Compose, then move to production on AWS, Azure, Google Cloud, or Kubernetes.
+    ctaPrimary:
+        label: Deploy it yourself
+        link: /docs/administration/self-hosting/install/
+    ctaSecondary:
+        label: Talk to us about a guided rollout
+        link: "#self-hosted-trial"
 trial:
-    title: Request a Proof of Concept
+    title: Want a guided rollout?
     description: |
-        Fill out the form to connect with a solutions architect and start your evaluation.
+        You can [deploy self-hosted Pulumi Cloud yourself](/docs/administration/self-hosting/install/) in minutes. If you'd prefer help planning a production deployment, connect with a solutions architect.
     hubspot_form_id: b6ff58c0-2b40-4202-9a7f-d6d8aca4414a
 capabilities:
-    title: Capabilities of Self-Hosted Pulumi
+    title: Capabilities of Self-Hosted Pulumi Cloud
     items:
         - title: Cloud Engineering Platform
           icon: rocketship
@@ -27,7 +37,7 @@ capabilities:
           icon: gear
           icon_color: violet
           description: |
-            All data in Self-Hosted Pulumi is stored in a MySQL database and an encrypted object store within your own network.
+            All data in Self-Hosted Pulumi Cloud is stored in a MySQL database and an encrypted object store within your own network.
         - title: Air-gapped Communications
           icon: abstract-shapes
           icon_color: blue
@@ -52,15 +62,15 @@ capabilities:
 deployment:
     title: Hosting Options
     descriptionTop: |
-        [Install Self-Hosted Pulumi Cloud](/docs/pulumi-cloud/self-hosted/) in any on-premises or cloud provider environment or run in air-gapped environments, including those requiring FedRAMP.
+        [Install Self-Hosted Pulumi Cloud](/docs/administration/self-hosting/install/) in any on-premises or cloud provider environment or run in air-gapped environments, including those requiring FedRAMP.
     descriptionBottom: |
         [Talk to a Pulumi team member](/contact/) if you don't see your desired deployment option.
 pricing:
     title: Pricing
     description: |
-        Self-Hosted Pulumi is available as an additional license for the Business Critical Edition of Pulumi and provided as part of a guided Proof of Concept.
+        Self-Hosted Pulumi Cloud is available with the Business Critical edition. Evaluate it yourself with an evaluation license, then move to production with a Business Critical license.
 questions:
     title: Talk to a Human
     description: |
-        If you have any questions about Self-Hosted Pulumi, please contact us or visit the self-hosted docs.
+        If you have any questions about Self-Hosted Pulumi Cloud, please contact us or visit the self-hosted docs.
 ---

--- a/data/header_nav.yaml
+++ b/data/header_nav.yaml
@@ -41,6 +41,11 @@ items:
             description: The fastest, most secure way to deliver cloud infrastructure
             icon: custom/pulumi-idp
             track: header-product-idp
+          - label: Self-hosted Pulumi Cloud
+            href: /product/self-hosted/
+            description: Run the full Pulumi Cloud platform in your own cloud account or data center
+            icon: buildings
+            track: header-product-self-hosted
 
   - label: For engineers
     wide: true
@@ -106,6 +111,11 @@ items:
             description: Security, compliance, and support for teams
             icon: buildings
             track: header-enterprise-solutions
+          - label: Self-hosted Pulumi Cloud
+            href: /product/self-hosted/
+            description: Full data control, air-gapped and on-prem deployment options
+            icon: shield-check
+            track: header-enterprise-self-hosted
           - label: Case studies
             href: /case-studies/
             description: How Snowflake, Mercedes-Benz, and others use Pulumi

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -72,6 +72,7 @@ If you are an AI agent or programmatic consumer, start with these endpoints. Eac
 This llms.txt covers www.pulumi.com, which includes:
 
 - [Product](https://www.pulumi.com/product/): Pulumi Cloud platform overview and capabilities
+- [Self-hosted Pulumi Cloud](https://www.pulumi.com/product/self-hosted/): Run the full Pulumi Cloud platform in your own cloud account or data center, including air-gapped environments
 - [Pricing](https://www.pulumi.com/pricing/): Plans and pricing for Pulumi Cloud (Individual, Team, Enterprise, Business Critical)
 - [Pulumi Registry](https://www.pulumi.com/registry/): Documentation for 150+ cloud providers and components, available at `https://www.pulumi.com/registry/packages/<name>/`
 - [Pulumi Neo](https://www.pulumi.com/neo/): Pulumi's AI agent for building and managing cloud infrastructure

--- a/layouts/product/self-hosted.html
+++ b/layouts/product/self-hosted.html
@@ -13,6 +13,12 @@
                     <p class="pb-4">{{ .descriptionTop | markdownify }}</p>
                     <p><i>{{ .descriptionBottom | markdownify }}</i></p>
                 </div>
+                {{ if .ctaPrimary }}
+                <div class="flex flex-col sm:flex-row gap-4 mt-10 justify-center">
+                    <a href="{{ .ctaPrimary.link }}" class="btn btn-primary btn-xl">{{ .ctaPrimary.label }}</a>
+                    {{ with .ctaSecondary }}<a href="{{ .link }}" class="btn btn-outline btn-xl">{{ .label }}</a>{{ end }}
+                </div>
+                {{ end }}
             {{ end }}
         </div>
     </section>
@@ -28,19 +34,19 @@
                 <div class="flex flex-col pb-8 sm:pb-0">
                     <img class="h-12" src="/logos/tech/aws.svg" alt="AWS" />
                     <h5 class="my-6">AWS</h5>
-                    <a href="/docs/pulumi-cloud/self-hosted/deployment-options/eks-hosted/" class="btn btn-outline btn-xl">AWS Docs</a>
+                    <a href="/docs/administration/self-hosting/deployment-options/eks-hosted/" class="btn btn-outline btn-xl">AWS Docs</a>
                 </div>
 
                 <div class="flex flex-col pb-8 sm:pb-0">
                     <img class="h-12" src="/logos/pkg/azure-native.svg" alt="Azure" />
                     <h5 class="my-6">Azure</h5>
-                    <a href="/docs/pulumi-cloud/self-hosted/deployment-options/aks-hosted/" class="btn btn-outline btn-xl">Azure Docs</a>
+                    <a href="/docs/administration/self-hosting/deployment-options/aks-hosted/" class="btn btn-outline btn-xl">Azure Docs</a>
                 </div>
 
                 <div class="flex flex-col pb-8 sm:pb-0">
                     <img class="h-12" src="/images/self-hosted/docker-whale.svg" alt="Docker" />
                     <h5 class="my-6">Docker</h5>
-                    <a href="/docs/pulumi-cloud/self-hosted/deployment-options/local-docker/" class="btn btn-outline btn-xl">Docker Docs</a>
+                    <a href="/docs/administration/self-hosting/deployment-options/local-docker/" class="btn btn-outline btn-xl">Docker Docs</a>
                 </div>
             </div>
             <div class="flex flex-col sm:flex-row sm:mt-16 justify-between w-full mb-28 lg:w-8/12">
@@ -49,7 +55,7 @@
                         <img class="h-12" src="/logos/tech/gcp-logo.svg" alt="Google Cloud" />
                     </div>
                     <h5 class="my-6">Google Cloud</h5>
-                    <a href="/docs/pulumi-cloud/self-hosted/deployment-options/gke-hosted/" class="btn btn-outline btn-xl">Google Docs</a>
+                    <a href="/docs/administration/self-hosting/deployment-options/gke-hosted/" class="btn btn-outline btn-xl">Google Docs</a>
                 </div>
 
                 <div class="flex flex-col pb-8 sm:pb-0">
@@ -57,7 +63,7 @@
                         <img class="h-12" src="/images/self-hosted/kubernetes-logo-only.svg" alt="Kubernetes" />
                     </div>
                     <h5 class="my-6">Kubernetes</h5>
-                    <a href="/docs/pulumi-cloud/self-hosted/deployment-options/byo-infra-hosted/" class="btn btn-outline btn-xl">Kubernetes Docs</a>
+                    <a href="/docs/administration/self-hosting/deployment-options/byo-infra-hosted/" class="btn btn-outline btn-xl">Kubernetes Docs</a>
                 </div>
 
                 <div class="flex flex-col pb-8 sm:pb-0">
@@ -137,7 +143,7 @@
                     <p class="text-white">{{ .description }}</p>
                     <div class="flex flex-col sm:flex-row mt-16 justify-between">
                         <a class="btn btn-outline btn-xl w-56" href="/contact/">Talk to a human</a>
-                        <a class="btn btn-primary btn-xl w-56" href="/docs/pulumi-cloud/self-hosted/">Self-Hosted Docs</a>
+                        <a class="btn btn-primary btn-xl w-56" href="/docs/administration/self-hosting/">Self-Hosted Docs</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Why

Self-hosted Pulumi Cloud has long read as a buried, sales-gated enterprise exception rather than a first-class way to run the product — a perception problem we control. With many HashiCorp migrations coming from on-prem Terraform Enterprise, self-hosting needs to look and feel first-class. This makes it discoverable, positions it as an equal deployment choice, and lets a visitor try it themselves.

## What changed

**A first-class install front door** — new `/docs/administration/self-hosting/install/` with a platform picker (Docker / Kubernetes / AWS / Azure / GCP) mirroring the CLI install page, routing to a real, installer-grounded Docker Compose quickstart (`run-ee.sh`, all-in-one compose, console `:3000` / API `:8080`). Memorable aliases: `/self-hosted/` and `/self-hosted/install/`.

**Self-service-forward positioning** — the product page hero leads with a **"Deploy it yourself"** primary CTA; the proof-of-concept form is demoted to "Want a guided rollout?". Dropped the "or self-host *if required*" hedging on the IaC page (added a first-class self-hosting card), and reframed the pricing FAQ and self-hosted page copy around self-service.

**Discoverability** — self-hosted added to the header nav (Product + For enterprises), a "Run Pulumi Cloud anywhere" section on the product overview, a pointer from the CLI install landing, a docs nav-weight bump, and an `llms.txt` entry.

**Terraform Enterprise wedge** — the Terraform comparison gains a self-hosting row, a reframed commercial-option row, a "Self-hosting and data control" section, and an on-prem FAQ; plus a new `from-terraform-enterprise.md` migration page (honest, value-based, reusing existing migration paths).

## Product dependency (please note)

The self-serve copy assumes an **evaluation license a user can obtain without a sales call**. That mechanism doesn't exist yet — `run-ee.sh` requires a `PULUMI_LICENSE_KEY` sourced through the eval form today — so "get an evaluation license" links point at the closest current path. The content is written to be ready for the packaging change; when a self-serve trial license ships, those links retarget with no rework. (This mirrors GitLab's current motion: a self-serve self-managed trial, not a free-forever edition.)

## Intentionally out of scope

Per discussion: sized **reference architectures** (GitLab's big credibility tool — a worthwhile future follow-up with real sizing data), a dedicated self-hosted hero diagram, and the self-serve license mechanism itself.

## Verification

Full Hugo build passes (`make ensure` + one-shot render): exit 0, zero errors, 3,554 aliases. All new pages render, aliases resolve, the platform picker renders (`pulumi-chooser type="cloud" options="docker,kubernetes,aws,azure,gcp"`), the nav entry and self-service CTA buttons render. Install commands verified against `pulumi/pulumi-self-hosted-installers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
