### PR TITLE
docs: consolidate voice/writing-style guidance into the brand MCP

### DIFF
--- a/.claude/commands/docs-review/references/prose-patterns.md
+++ b/.claude/commands/docs-review/references/prose-patterns.md
@@ -5,6 +5,8 @@ description: Concrete prose patterns to flag in user-facing content. Quote-and-r
 
 # Prose Patterns
 
+> **Source of truth.** The prose patterns to avoid (nested clause stacks, contrastive frames, uniform rhythm, AI-drafting tells) are defined in the brand guide's [writing style](https://brand.pulumi.com/voice/writing-style/) "Natural voice" section (also exposed through the brand MCP server). This file is the *operational* layer the review runs: the detection thresholds, the per-file cap, and the quote-and-rewrite mandate. Keep the pattern list here in sync with the brand section; it's the authority on what counts as a pattern.
+
 Applied to prose-bearing content (docs and blogs). Concrete patterns only — every finding must quote the offending text and propose a rewrite. If you can't quote the construction or propose a fix, drop the finding. Abstract "this could be clearer" / "consider reorganizing" feedback isn't a review concern.
 
 **Cap structural-pattern findings at 10 per file.** Spelling and grammar render uncapped (see below). If a file has more than 10 structural findings, surface only the most impactful; don't render every instance.

--- a/.claude/commands/glow-up.md
+++ b/.claude/commands/glow-up.md
@@ -12,6 +12,10 @@ Performs deep analysis and improvement of a single file, acting as a professiona
 
 The `file-path` argument is optional. If not provided, the command will attempt to infer the target file from context (e.g., a file currently open in the IDE).
 
+## Requires the `pulumi-brand` MCP server
+
+This skill delegates **all** voice, tone, prose, terminology, grammar, and naming judgment to the Pulumi brand guide served by the **`pulumi-brand` MCP server** (`https://brand.pulumi.com/mcp`). It deliberately keeps no local copy of those rules. Before analyzing anything, confirm the server is reachable and load its voice and writing-style guidance. **If you can't reach it, stop and tell the user the brand guide is unavailable — do not fall back to your own notions of Pulumi style.**
+
 ---
 
 ## Process
@@ -41,63 +45,34 @@ Read the entire target file and perform comprehensive analysis.
 
 #### Text analysis
 
-**Style violations:**
+Judge the prose against the **brand guide's voice and writing-style sections** (brand.pulumi.com, also exposed through the brand MCP server) — the source of truth for voice and tone, marketing language and superlatives, inclusive language, terminology and product naming, heading case, link text, lists, paragraph length, and grammar. Consult them and flag anything that violates them, quoting the offending line. Don't re-derive those rules here.
 
-- Marketing language, superlatives, and filler words ("easy", "simple", "just", "very", "really", "obviously")
-- Ableist or unnecessarily gendered language
-- Violent/aggressive terms (e.g., "kill")
-- Vague qualifiers that judge difficulty
-- Passive voice constructions
-- Overly complex or run-on sentences
-- Spelling and grammar errors
+Then flag the file-specific issues the brand guide doesn't own:
 
-**Structural issues:**
+**Code blocks** (Hugo rendering mechanics — see `STYLE-GUIDE.md`; the code-sample *style* itself lives in the brand writing-style section):
 
-- Incorrect heading capitalization (H1 should be Title Case, H2+ should be Sentence case)
-- Long paragraphs (more than 3 sentences)
-- Missing blank lines around headings
-- Skipped heading levels (e.g., H2 directly to H4)
+- Indented code blocks that should be fenced
+- Missing or wrong language identifiers (e.g., `bash` vs `output`)
+- Code examples that look like they may not run correctly
 
-**Code formatting:**
+**Links and structure:**
 
-- Indented code blocks (should use fenced blocks with language identifiers)
-- Missing language identifiers on fenced blocks
-- Wrong language identifiers (e.g., `bash` vs `output`)
-- Code examples that don't follow best practices or may not run correctly
+- Broken or unresolved links, or links pointing to the wrong target (404s, incorrect paths)
+- Skipped heading levels (e.g., H2 directly to H4) and missing blank lines around headings
 
-**Terminology:**
+**Content accuracy and completeness:**
 
-- Incorrect capitalization of Pulumi terms (e.g., "Stack" instead of "stack")
-- "Click" instead of "select"
-- "Go to" instead of "navigate"
-- Directional terms ("above", "below") instead of direct links
-
-**Links and references:**
-
-- Vague link text ("click here", "here", "this link")
-- Missing cross-references to related documentation
-- Broken or outdated links
-- Links that don't resolve or point to wrong targets (404s, incorrect paths)
-
-**Content quality:**
-
-- Unclear explanations
-- Missing context for users
+- Unclear explanations or missing context for the reader
 - Unsourced claims or statistics
 - Outdated information
-- Missing code examples where helpful
+- Missing code examples where they'd help
 
 **Front matter:**
 
 - Missing or incomplete required fields (title, description, etc.)
-- Meta descriptions that are inappropriate length or missing
-- SEO issues with page titles or descriptions
+- Meta description missing or of inappropriate length
 
-**Content type considerations:**
-
-- Consider whether the content is Documentation or Blog/Marketing material
-- Apply appropriate style guidelines based on content type (see `docs-review:references:docs` for technical docs, `docs-review:references:blog` for blog/marketing)
-- Documentation should be clear and objective; blogs can be more engaging
+**Content type:** route the file to the right base criteria — `docs-review:references:docs` for technical docs, `docs-review:references:blog` for blog/marketing.
 
 #### Image and diagram analysis
 
@@ -160,9 +135,10 @@ These references represent current branding standards. Use them to:
 
 Before proposing changes, verify understanding of:
 
-- `STYLE-GUIDE.md` — Pulumi-specific style rules (headings, links, code blocks, terminology)
+- The brand guide's voice and writing-style sections (brand.pulumi.com, also exposed through the brand MCP server) — voice, prose, terminology, grammar, and naming (the source of truth)
+- `STYLE-GUIDE.md` — this site's Hugo/repo mechanics (shortcodes, links, code fences, navigation)
 - `AGENTS.md` — Repository conventions and build workflow
-- Google Developer Documentation Style Guide — For topics not covered in STYLE-GUIDE.md
+- Google Developer Documentation Style Guide — for topics covered by none of the above
 
 ### 5. Create improvement plan
 
@@ -283,7 +259,7 @@ Report verification results to the user, including any flagged images that need 
 - Be thorough in identifying issues
 - Preserve technical accuracy
 - Maintain the author's intended meaning
-- Follow STYLE-GUIDE.md strictly
+- Follow the brand guide (via the MCP) for style, and STYLE-GUIDE.md for this site's mechanics
 - Make the documentation more accessible and clear
 - Add helpful cross-references to related docs
 - View all images referenced in the document

--- a/.claude/commands/new-blog-post.md
+++ b/.claude/commands/new-blog-post.md
@@ -38,7 +38,7 @@ When this command is invoked, you should:
 
 **Blog Post Details:**
 
-- **Title**: The blog post title (will be Title Case in frontmatter). If the user doesn't have a title yet, ask for a working title or topic to generate a slug and suggested meta description/tags. Be clear that the user can update the title later before publishing.
+- **Title**: The blog post title (sentence case in frontmatter — the brand standard). If the user doesn't have a title yet, ask for a working title or topic to generate a slug and suggested meta description/tags. Be clear that the user can update the title later before publishing.
 - **Author ID**: The author's ID (e.g., "jane-doe"). Prepopulate with the suggested author ID from git config if detected.
 - **Summary**: Suggest a concise, one-sentence meta description based on the post title (50-160 characters, optimized for SEO and social media)
 - **Tags**: Suggest 1-3 relevant tags based on the post title and similar existing blog posts. Common tags include: features, product-launches, pulumi-cloud, aws, azure, kubernetes, tutorials, announcements
@@ -112,7 +112,7 @@ Inform the user if author information was auto-populated and give them a chance 
 
 ```markdown
 ---
-title: "Title in Title Case"
+title: "Title in sentence case"
 # If user selected "I don't know yet": Add TODO comment above date
 # TODO: Update this date before publishing! Currently set to far future to prevent premature publication.
 date: YYYY-MM-DD  # Use 2099-01-01 if "I don't know yet" was selected, otherwise use the chosen date
@@ -190,7 +190,7 @@ After creating the files, tell the user:
 - **Images**: All images go in the same directory as `index.md`
 - **Author array**: The `authors` field in frontmatter is an array. For multi-author posts, add additional author IDs to the array (e.g., `- jane-doe\n    - john-smith`)
 - **More marker**: The `<!--more-->` comment marks where the excerpt ends on listing pages
-- **Style guide**: Remind users to follow `STYLE-GUIDE.md` (Heading style: H1 = Title Case, H2+ = Sentence case)
+- **Style guide**: Remind users that voice and writing style live in the brand guide (brand.pulumi.com, also exposed through the brand MCP server) — headings are sentence case at every level — and that `STYLE-GUIDE.md` covers this site's Hugo mechanics
 
 ## Example Usage
 

--- a/.claude/commands/new-doc/SKILL.md
+++ b/.claude/commands/new-doc/SKILL.md
@@ -157,7 +157,7 @@ Gather all required metadata using AskUserQuestion with smart suggestions.
 
 **For regular pages**, follow all patterns in `new-doc:references:questions-regular`:
 
-1. Title (with Title Case suggestion)
+1. Title (with sentence-case suggestion)
 2. Title tag (with "| Pulumi Docs" format)
 3. Meta description (50-160 chars validation)
 4. Filename (kebab-case validation)

--- a/.claude/commands/new-doc/references/questions-regular.md
+++ b/.claude/commands/new-doc/references/questions-regular.md
@@ -8,18 +8,18 @@ Complete patterns for gathering metadata for regular documentation pages. Ask fo
 
 ## Field 1: Title
 
-Generate Title Case version from the user's description.
+Generate a sentence-case version from the user's description (the brand standard is sentence case at every heading level, the page title included).
 
 ```
 Question: "What should the page title be?"
 Options:
-- "{Suggested Title in Title Case} (Recommended)"
+- "{Suggested title in sentence case} (Recommended)"
 - "Enter a different title"
 ```
 
 **Logic:**
 
-- Convert user's description to Title Case (capitalize major words)
+- Convert user's description to sentence case (capitalize only the first word and proper nouns)
 - Present as recommended option
 - If user selects "Enter different", prompt for text input
 - Store result as `{title}`
@@ -87,6 +87,6 @@ Options:
 - Always provide smart suggestions based on context
 - Make recommended option first choice
 - Validate input when user enters custom values
-- Use Title Case for page titles (Field 1)
+- Use sentence case for page titles (Field 1)
 - Keep meta descriptions concise and descriptive (Field 3)
 - Ensure filenames follow kebab-case convention (Field 4)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -820,18 +820,10 @@ jobs:
           # own access checks, so opening this door doesn't widen the
           # trust surface.
           allowed_bots: 'github-actions[bot]'
-          # Public Pulumi brand MCP server — source of truth for voice and
-          # writing-style guidance. The docs-review skills consult it instead
-          # of carrying their own copies of those rules. No auth: public.
-          mcp_config: |
-            {
-              "mcpServers": {
-                "pulumi-brand": {
-                  "type": "http",
-                  "url": "https://brand.pulumi.com/mcp"
-                }
-              }
-            }
+          # The public Pulumi brand MCP server (voice/writing-style source of
+          # truth) is wired below via `claude_args --mcp-config` — v1 has no
+          # `mcp_config` input. Its tools are added to --allowed-tools. The
+          # config merges with the action's built-in GitHub MCP server. No auth.
           # Initial review uses Opus; re-entrant updates (via @claude mentions)
           # use Sonnet — see .github/workflows/claude.yml.
           # The CI prompt lives at .claude/commands/docs-review/ci.md and is
@@ -892,7 +884,10 @@ jobs:
             When the editorial pass is done, save `.review-draft.md` and **exit**. Do not post the comment yourself; do not call `pinned-comment.sh` or `validate-pinned.py`. The workflow runs validation, deterministic surgical fixes, and the GitHub upsert as separate steps after this one. Every `<TODO:` placeholder must be replaced before you exit — `validate-pinned.py`'s `no-todo-tokens` rule fails the body otherwise.
 
             Post-run review-state labels (`review:outstanding-issues` / `review:no-blockers` / `review:stale` / `review:error`) are applied by separate workflow steps based on the published body's 🚨 Outstanding count. Do not apply them yourself.
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,mcp__pulumi-brand__get_guidelines,mcp__pulumi-brand__search_guidelines,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr list:*),Bash(gh api:*),Bash(gh search:*),Bash(gh release:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh repo view:*),Bash(gh repo list:*),Bash(python3 -c:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(file:*),Bash(stat:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(tr:*),Bash(cut:*),Bash(paste:*),Bash(sort:*),Bash(uniq:*),Bash(diff:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(true:*),Bash(false:*),Bash(test:*),Bash(which:*),Bash(command:*),Bash(curl:*),Bash(wget:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git blame:*),Bash(git status:*),Bash(git remote:*),Bash(git ls-files:*),Bash(git rev-parse:*),Bash(git rev-list:*)"'
+          claude_args: |
+            --model claude-opus-4-8
+            --mcp-config '{"mcpServers": {"pulumi-brand": {"type": "http", "url": "https://brand.pulumi.com/mcp"}}}'
+            --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,mcp__pulumi-brand__get_guidelines,mcp__pulumi-brand__search_guidelines,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr list:*),Bash(gh api:*),Bash(gh search:*),Bash(gh release:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh repo view:*),Bash(gh repo list:*),Bash(python3 -c:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(file:*),Bash(stat:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(tr:*),Bash(cut:*),Bash(paste:*),Bash(sort:*),Bash(uniq:*),Bash(diff:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(true:*),Bash(false:*),Bash(test:*),Bash(which:*),Bash(command:*),Bash(curl:*),Bash(wget:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git blame:*),Bash(git status:*),Bash(git remote:*),Bash(git ls-files:*),Bash(git rev-parse:*),Bash(git rev-list:*)"
 
       # ---- post-edit validate / splice / re-validate / upsert chain ----
       # The editorial pass step (above) exits after editing .review-draft.md.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1033,7 +1033,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: claude-execution-pr${{ steps.pr-context.outputs.pr_number }}-run${{ github.run_id }}
-          path: /home/runner/work/_temp/claude-execution-output.json
+          # claude-code-action@v1 writes the stream-JSON log to a temp path it
+          # exposes via the `execution_file` output (the old hardcoded
+          # /home/runner/work/_temp/claude-execution-output.json no longer
+          # exists, so this silently uploaded nothing). The log's system/init
+          # message lists mcp_servers + their connection status, which is how
+          # we confirm the brand MCP connected.
+          path: ${{ steps.claude-review.outputs.execution_file }}
           retention-days: 90
           if-no-files-found: ignore
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1033,13 +1033,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: claude-execution-pr${{ steps.pr-context.outputs.pr_number }}-run${{ github.run_id }}
-          # claude-code-action@v1 writes the stream-JSON log to a temp path it
-          # exposes via the `execution_file` output (the old hardcoded
-          # /home/runner/work/_temp/claude-execution-output.json no longer
-          # exists, so this silently uploaded nothing). The log's system/init
-          # message lists mcp_servers + their connection status, which is how
-          # we confirm the brand MCP connected.
-          path: ${{ steps.claude-review.outputs.execution_file }}
+          # NOTE: this hardcoded path is stale under claude-code-action@v1 (the
+          # action exposes the log via its `execution_file` output instead), so
+          # this currently uploads nothing — but that output rendered empty in
+          # testing, and an empty `path` makes upload-artifact fail. Restoring
+          # the original harmless no-op; wiring up real execution-log
+          # observability is a separate follow-up.
+          path: /home/runner/work/_temp/claude-execution-output.json
           retention-days: 90
           if-no-files-found: ignore
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -820,6 +820,18 @@ jobs:
           # own access checks, so opening this door doesn't widen the
           # trust surface.
           allowed_bots: 'github-actions[bot]'
+          # Public Pulumi brand MCP server — source of truth for voice and
+          # writing-style guidance. The docs-review skills consult it instead
+          # of carrying their own copies of those rules. No auth: public.
+          mcp_config: |
+            {
+              "mcpServers": {
+                "pulumi-brand": {
+                  "type": "http",
+                  "url": "https://brand.pulumi.com/mcp"
+                }
+              }
+            }
           # Initial review uses Opus; re-entrant updates (via @claude mentions)
           # use Sonnet — see .github/workflows/claude.yml.
           # The CI prompt lives at .claude/commands/docs-review/ci.md and is
@@ -880,7 +892,7 @@ jobs:
             When the editorial pass is done, save `.review-draft.md` and **exit**. Do not post the comment yourself; do not call `pinned-comment.sh` or `validate-pinned.py`. The workflow runs validation, deterministic surgical fixes, and the GitHub upsert as separate steps after this one. Every `<TODO:` placeholder must be replaced before you exit — `validate-pinned.py`'s `no-todo-tokens` rule fails the body otherwise.
 
             Post-run review-state labels (`review:outstanding-issues` / `review:no-blockers` / `review:stale` / `review:error`) are applied by separate workflow steps based on the published body's 🚨 Outstanding count. Do not apply them yourself.
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr list:*),Bash(gh api:*),Bash(gh search:*),Bash(gh release:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh repo view:*),Bash(gh repo list:*),Bash(python3 -c:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(file:*),Bash(stat:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(tr:*),Bash(cut:*),Bash(paste:*),Bash(sort:*),Bash(uniq:*),Bash(diff:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(true:*),Bash(false:*),Bash(test:*),Bash(which:*),Bash(command:*),Bash(curl:*),Bash(wget:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git blame:*),Bash(git status:*),Bash(git remote:*),Bash(git ls-files:*),Bash(git rev-parse:*),Bash(git rev-list:*)"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,mcp__pulumi-brand__get_guidelines,mcp__pulumi-brand__search_guidelines,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr list:*),Bash(gh api:*),Bash(gh search:*),Bash(gh release:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh repo view:*),Bash(gh repo list:*),Bash(python3 -c:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(file:*),Bash(stat:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(tr:*),Bash(cut:*),Bash(paste:*),Bash(sort:*),Bash(uniq:*),Bash(diff:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(true:*),Bash(false:*),Bash(test:*),Bash(which:*),Bash(command:*),Bash(curl:*),Bash(wget:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git blame:*),Bash(git status:*),Bash(git remote:*),Bash(git ls-files:*),Bash(git rev-parse:*),Bash(git rev-list:*)"'
 
       # ---- post-edit validate / splice / re-validate / upsert chain ----
       # The editorial pass step (above) exits after editing .review-draft.md.

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -207,6 +207,18 @@ jobs:
           # default. Same allowance claude-code-review.yml makes for its
           # bot-dispatched #new-review path.
           allowed_bots: 'github-actions[bot]'
+          # Public Pulumi brand MCP — source of truth for voice and
+          # writing-style. The review skills consult it instead of carrying
+          # their own copies. No auth: the server is public.
+          mcp_config: |
+            {
+              "mcpServers": {
+                "pulumi-brand": {
+                  "type": "http",
+                  "url": "https://brand.pulumi.com/mcp"
+                }
+              }
+            }
           prompt: |
             The existing-content review selected one article in
             `.content-review-queue.json` at the repo root, and the workflow has
@@ -256,7 +268,7 @@ jobs:
           # so a chain can never match. This runs on an ephemeral runner; the
           # residual risk is the scoped bot/AWS/Pulumi creds it holds vs.
           # injected instructions in reviewed content, accepted for throughput.
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,mcp__pulumi-brand__get_guidelines,mcp__pulumi-brand__search_guidelines,Bash"'
 
       # TEMPORARY DIAGNOSTIC: runs show a high permission_denials_count (the model
       # hitting the allowlist wall, often on compound commands like

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -207,18 +207,9 @@ jobs:
           # default. Same allowance claude-code-review.yml makes for its
           # bot-dispatched #new-review path.
           allowed_bots: 'github-actions[bot]'
-          # Public Pulumi brand MCP — source of truth for voice and
-          # writing-style. The review skills consult it instead of carrying
-          # their own copies. No auth: the server is public.
-          mcp_config: |
-            {
-              "mcpServers": {
-                "pulumi-brand": {
-                  "type": "http",
-                  "url": "https://brand.pulumi.com/mcp"
-                }
-              }
-            }
+          # The public Pulumi brand MCP server (voice/writing-style source of
+          # truth) is wired below via `claude_args --mcp-config` — v1 has no
+          # `mcp_config` input. Its tools are added to --allowed-tools. No auth.
           prompt: |
             The existing-content review selected one article in
             `.content-review-queue.json` at the repo root, and the workflow has
@@ -268,7 +259,10 @@ jobs:
           # so a chain can never match. This runs on an ephemeral runner; the
           # residual risk is the scoped bot/AWS/Pulumi creds it holds vs.
           # injected instructions in reviewed content, accepted for throughput.
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,mcp__pulumi-brand__get_guidelines,mcp__pulumi-brand__search_guidelines,Bash"'
+          claude_args: |
+            --model claude-opus-4-8
+            --mcp-config '{"mcpServers": {"pulumi-brand": {"type": "http", "url": "https://brand.pulumi.com/mcp"}}}'
+            --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,mcp__pulumi-brand__get_guidelines,mcp__pulumi-brand__search_guidelines,Bash"
 
       # TEMPORARY DIAGNOSTIC: runs show a high permission_denials_count (the model
       # hitting the allowlist wall, often on compound commands like

--- a/.vale.ini
+++ b/.vale.ini
@@ -18,8 +18,10 @@ BlockIgnores = (?s) *({{[%<].*?[%>]}}.*?{{[%<] */[a-zA-Z][a-zA-Z0-9_-]* *[%>]}})
 TokenIgnores = ({{[%<].*?[%>]}}), \
                (\{\{[^}]+\}\})
 
-# Disable Google rules that conflict with Pulumi house style.
-Google.Headings = NO        # Pulumi uses Title Case for H1 (markdownlint covers H2+).
+# Disable Google rules that conflict with Pulumi house style (brand.pulumi.com
+# is the source of truth; these mirror its writing-style/voice sections offline).
+Google.Headings = NO        # Brand standard is sentence case at every level; left off to avoid flagging the large backlog of existing Title Case headings during migration.
+Google.Quotes = NO          # Brand puts commas/periods OUTSIDE closing quotes (logical style); Google's rule forces them inside.
 Google.WordList = NO        # Google product-name overrides don't match Pulumi terminology.
 Google.We = NO              # Documentation style allows first-person plural.
 Google.Will = NO            # Too noisy on declarative technical prose.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,16 +30,16 @@ Do not substitute other tools or commands, or change `package.json` to use pnpm 
 
 ## Code & Content Rules
 
-For all content files, follow `STYLE-GUIDE.md`. If a rule is not covered there, fall back to the [Google Developer Documentation Style Guide](https://developers.google.com/style). Do not invent new style conventions; ask for clarification if something is ambiguous.
+For all content files, Pulumi's **voice, tone, prose, product naming, and grammar** are defined in the **Pulumi brand guide** ([brand.pulumi.com](https://brand.pulumi.com/)), which is also exposed to agents through the public **brand MCP server**. Consult the relevant section (voice or writing style) before writing or reviewing. `STYLE-GUIDE.md` covers only this site's Hugo/repo mechanics (shortcodes, links, navigation, code fences, etc.) and points to the brand guide for each topic it doesn't own. If a rule is in neither, fall back to the [Google Developer Documentation Style Guide](https://developers.google.com/style). Do not invent new style conventions; ask for clarification if something is ambiguous.
+
+**Precedence:** wherever the brand guide overlaps with anything in this repo — these conventions, `STYLE-GUIDE.md`, or any skill (including the social, SEO, and AEO guidance that still lives in this repo), the brand guide takes priority. That specialized guidance stays in the repo for now; if the brand guide later grows its own, the brand guide's version wins.
 
 Meta files like this one, `BUILD-AND-DEPLOY.md`, and agent instruction/skill files (e.g., `.claude/commands/*.md`) are exempt from formatting rules (heading case, trailing newlines, etc.).
 
 For all content files (docs, blogs, tutorials, etc.):
 
 - **Markdown**: Must always end with a newline.
-- **Headings**:  
-  - H1 = Title Case  
-  - H2+ = Sentence case
+- **Headings**: Sentence case at every level (H1 included), and sentence case for nav menu labels. See the brand guide's [writing style](https://brand.pulumi.com/voice/writing-style/) section. Hugo heading mechanics (one H1, FAQ `?` exception) live in `STYLE-GUIDE.md`.
 - **TypeScript/JavaScript**: Must follow `tsconfig.json` settings. No comments unless explicitly requested.
 - **TypeScript program files** (`static/programs/`): Use hand-written constructor style — resource name and opening `{` on the same line, `}, {` inline when an opts argument follows:
   ```typescript

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,98 +1,88 @@
 # Pulumi Documentation Style Guide
 
-This guide defines Pulumi-specific style rules for our documentation.  
-For topics not addressed here, refer to the [Google Developer Documentation Style Guide](https://developers.google.com/style).
+Pulumi's **voice, tone, prose, product naming, grammar, and punctuation** guidance lives in the **Pulumi brand guide** at [brand.pulumi.com](https://brand.pulumi.com/), and is consumable programmatically through the **brand MCP server**. That guide is the single source of truth for how Pulumi content reads. Do not restate or fork those rules here.
+
+**Precedence:** wherever the brand guide overlaps with anything in this repo — these mechanics, the skills under `.claude/commands/`, or any social, SEO, or AEO guidance that still lives here — **the brand guide wins.** Some specialized guidance (e.g. social copy, SEO/AEO) currently lives only in this repo's skills; if and when the brand guide grows its own version, the brand guide's version takes priority.
+
+This file covers only the **Hugo- and repo-specific mechanics** that the brand guide doesn't — how content is structured, linked, and rendered in *this* site.
+
+For anything not covered in either place, fall back to the [Google Developer Documentation Style Guide](https://developers.google.com/style).
+
+---
+
+## Where the style rules live
+
+Pulumi's voice and writing rules live in the brand guide, published at [brand.pulumi.com](https://brand.pulumi.com/) and exposed to agents through the public **brand MCP server** (see [brand.pulumi.com/mcp-server](https://brand.pulumi.com/mcp-server/)). Consult the relevant section before writing or reviewing:
+
+| For… | See |
+| ---- | --- |
+| Voice and tone | [Voice & tone](https://brand.pulumi.com/voice/voice-and-tone/) |
+| Grammar, punctuation, product names, headings, links, lists, code-sample style | [Writing style](https://brand.pulumi.com/voice/writing-style/) |
+
+An agent with the brand MCP server configured can pull any of these on its own — the server's instructions route it to the right section.
+
+Key rules the brand guide owns (so you know what *not* to look for here): inclusive language; the Oxford comma; sentence case for headings; Pulumi product-name capitalization; "public preview" over "public beta"; punctuation outside quotation marks; descriptive link text and alt text; and the prose patterns to avoid. The offline [Vale](https://vale.sh) rules in `styles/Pulumi/` mirror the mechanically enforceable subset of these (see [Automated checks](#automated-checks)).
 
 ---
 
 ## Scope
 
-This style guide applies to all Hugo content files in this repository.
+These mechanics apply to all Hugo content files in this repository.
 
-The following exceptions are specifically excluded from this style guide:
-
-- Non-content files (scripts, configuration, etc.) should follow general best practices for that file type.
-- Meta Markdown files (e.g., `README.md`, `AGENTS.md`) may use different conventions as appropriate.
-
----
-
-## Inclusive Language
-
-Pulumi strives to use language that is clear, inclusive, and respectful.  
-
-- Avoid ableist terms.  
-  - Instead of _crazy_, use _wild_.  
-  - Instead of _dummy_, use _placeholder_.  
-- Avoid unnecessarily gendered language (e.g., use _folks_, _everyone_).  
-- Avoid violent or aggressive terms (e.g., avoid _kill_).  
-- Avoid pop-culture references that may not be globally understood.  
-- Instead of "click," use "select."  
-- Instead of "go to," use "navigate."  
-- Avoid directional terms (e.g., "see above"); link directly.  
-- Avoid words like "easy" or "simple." These judge difficulty and may alienate readers.
+- Non-content files (scripts, configuration, etc.) follow general best practices for their type.
+- Meta Markdown files (`README.md`, `AGENTS.md`, `BUILD-AND-DEPLOY.md`, skill files) are exempt from these formatting rules.
 
 ---
 
 ## Headings
 
-- Exactly one H1 (`#`) per page, set in front matter `title`.
-- H1: **Title Case**.
-- H2 and deeper: **Sentence case**.
-- Only increment one heading level at a time (no skipping levels).
-- Use capitalization only for proper nouns. For example, use "stack" not "Stack."
-- Do not end headings with punctuation, with one exception: headings in a "Frequently asked questions" section may end with `?` so the site's FAQPage JSON-LD auto-collector (`layouts/partials/schema/collectors/faq-entity.html`) detects them as questions.
-- Headings should be surrounded by blank lines.
+Heading **case is sentence case** for all levels — see the brand guide's [writing style](https://brand.pulumi.com/voice/writing-style/). The rest is Hugo mechanics:
 
-**Navigation menu items**: Use **Title Case** for frontmatter menu fields (`menu.name`, `menu.title`). Navigation items are UI labels, not prose headings, and follow Title Case conventions consistent with industry standards.
+- Exactly one H1 (`#`) per page, set in front matter `title`.
+- Only increment one heading level at a time (no skipping levels).
+- Do not end headings with punctuation, with one exception: headings in a "Frequently asked questions" section may end with `?` so the site's FAQPage JSON-LD auto-collector (`layouts/partials/schema/collectors/faq-entity.html`) detects them as questions.
+- Surround headings with blank lines.
+
+**Navigation menu items** (`menu.name`, `menu.title`): sentence case, consistent with headings.
 
 ---
 
 ## Links
 
-- **Internal and external links**: use normal Markdown syntax.
-  - `[Link text](/path/to/file)`
-  - `[Link text](https://example.com)`
-- Link text must be descriptive. Avoid vague text like _here_ or _click here_.
-- When changing the URL of an existing page, add a redirect with a [Hugo alias](https://gohugo.io/content-management/urls/#yaml-front-matter).
-- **Always use root-relative paths** (beginning with `/`) for all internal links and image references — never page-relative paths like `./image.png`, `../other-page`, or bare relative paths like `some-page`. Page-relative paths are ambiguous because Hugo content files are sometimes named `.md` files rather than `_index.md` files in a folder, making the meaning of `./` differ between the file's location on disk and the URL the page is served from. Root-relative paths are unambiguous, portable, and don't silently break when files move.
+The brand guide owns link *text* (descriptive, no "here"/"click here"). This site adds path mechanics:
+
+- **Always use root-relative paths** (beginning with `/`) for internal links and image references — never page-relative paths like `./image.png`, `../other-page`, or bare `some-page`. Hugo content is sometimes a `.md` file and sometimes an `_index.md` in a folder, so `./` is ambiguous; root-relative paths are unambiguous and don't break when files move.
   - Correct: `[stacks](/docs/iac/concepts/stacks/)`, `![diagram](/blog/my-post/diagram.png)`
   - Incorrect: `[stacks](./stacks/)`, `![diagram](./diagram.png)`, `[stacks](../stacks/)`
+- When changing the URL of an existing page, add a redirect with a [Hugo alias](https://gohugo.io/content-management/urls/#yaml-front-matter).
 
-### External Link Indicator
+### External link indicator
 
-Links that navigate users to a different UI/experience (different from the main docs site) should include the ↗ (U+2197 North East Arrow) symbol to indicate this transition when linking from navigation menus or landing page cards.
+Links that take users to a different UI/experience should include the ↗ (U+2197 North East Arrow) symbol when they appear in navigation menus or landing-page cards.
 
-**When to use ↗:**
-- Links to generated API documentation (`/docs/reference/pkg/*`)
-- Links to external sites (e.g., pkg.go.dev)
-- Links to Tutorials (different UI)
-- Any link that takes users away from the main docs experience
+**When to use ↗:** links to generated API docs (`/docs/reference/pkg/*`), external sites (e.g. pkg.go.dev), Tutorials (different UI), or anything that leaves the main docs experience.
 
 **Placement:**
-- In menu configurations (`config/_default/menus.yml`): append to the `name` field with a space
-  - Example: `name: SDK docs ↗`
-- In landing page cards: append to the `heading` field with a space
-  - Example: `heading: Python ↗`
+- In menu configs (`config/_default/menus.yml`): append to the `name` field with a space — `name: SDK docs ↗`
+- In landing-page cards: append to the `heading` field with a space — `heading: Python ↗`
 
-The symbol is not needed in regular in-text links within documentation pages.
-
-**Rationale:** The ↗ symbol is the web-standard indicator for external links and helps users understand they're navigating to a different UI, preventing surprise when the page appearance changes.
+Not needed for regular in-text links within documentation pages.
 
 ---
 
 ## Navigation patterns
 
-Every section has an `_index.md` that the sidebar automatically injects as the first item of the section's submenu. The label it receives — **"Overview"** or **"Introduction"** — depends on the page's role.
+Every section has an `_index.md` that the sidebar injects as the first item of the section's submenu. The label it receives — **"Overview"** or **"Introduction"** — depends on the page's role.
 
 ### Overview pages
 
-Use **"Overview"** for section indexes whose primary purpose is routing readers to child pages, with little or no prose of their own. Add `docs_home: true` to the frontmatter to mark the page as an overview and enable the section home template.
+Use **"Overview"** for section indexes whose primary purpose is routing readers to child pages, with little or no prose of their own. Add `docs_home: true` to enable the section home template.
 
 Required frontmatter:
 
 - `docs_home: true`
 - `notitle: true` — suppresses the duplicate H1 (the template renders it from `h1:`)
-- `norightnav: true` — hides the right-hand table of contents (unused on overview pages)
+- `norightnav: true` — hides the right-hand table of contents
 - `h1:` — displayed in the page banner
 - `description:` — short paragraph rendered in the banner (HTML string)
 - `sections:` — list of section blocks using `type: cards-logo-label-link`, `type: button-cards`, or `type: flat`
@@ -107,23 +97,23 @@ If the page also links to related child pages, use standard markdown (lists, tab
 
 ---
 
-## Images and Media
+## Images and media
 
-- Use root-relative paths for all image references (see [Links](#links) above).
-- Provide descriptive alt text for all images.
-- For partial screenshots where the image may be hard to distinguish from the page background, add a 1px gray #999999 border.
+The brand guide owns **alt text** (its [writing style](https://brand.pulumi.com/voice/writing-style/) section). This site adds:
+
+- Use root-relative paths for all image references (see [Links](#links)).
+- For partial screenshots where the image may be hard to distinguish from the page background, add a 1px gray #999999 border (the `/add-borders` skill does this).
+- Images on template-driven pages go under `assets/fingerprinted/` (see `AGENTS.md`).
 
 ---
 
-## Notes / Callouts
+## Notes / callouts
 
 Use the `{{ notes }}` shortcode sparingly. Supported levels:
 
-- `info` — general information  
-- `tip` — helpful hints  
-- `warning` — important cautions  
-
-**Example:**
+- `info` — general information
+- `tip` — helpful hints
+- `warning` — important cautions
 
 ```go
 {{% notes type="tip" %}}
@@ -137,55 +127,26 @@ This is a useful suggestion.
 
 Hugo supports two shortcode notations:
 
-- **`{{% shortcode %}}`** (percent signs) - Use for shortcodes that process Markdown content. Hugo processes these before Markdown rendering
-  - Examples: `notes`, `choosable`, `details`
+- **`{{% shortcode %}}`** (percent signs) — for shortcodes that process Markdown content. Hugo processes these *before* Markdown rendering. Examples: `notes`, `choosable`, `details`.
+- **`{{< shortcode >}}`** (angle brackets) — for shortcodes that output pre-formatted content. Hugo processes these *after* Markdown rendering. Examples: `cleanup`, `example`.
 
-- **`{{< shortcode >}}`** (angle brackets) - Use for shortcodes that output pre-formatted content. Hugo processes these after Markdown rendering
-  - Examples: `cleanup`, `example`
-
-**Rule of thumb:** If the shortcode uses `markdownify` internally (check `layouts/shortcodes/`), use percent signs. Otherwise, use angle brackets.
-
-Both syntaxes work for plain text content, but use percent signs for shortcodes with nested Markdown like lists or headings.
+**Rule of thumb:** if the shortcode uses `markdownify` internally (check `layouts/shortcodes/`), use percent signs. Otherwise, use angle brackets. Use percent signs for shortcodes with nested Markdown like lists or headings.
 
 ---
 
-## Paragraphs and Line Breaks
+## Code blocks and console output
 
-- Separate paragraphs with a blank line.  
-- Do not use line breaks within paragraphs. Let text wrap naturally.  
-- Keep paragraphs short (ideally ≤3 sentences).
+The brand guide owns **code-sample style** — indentation, quoting, comments, line-splitting (its [writing style](https://brand.pulumi.com/voice/writing-style/) "Code samples" section). This site adds the Hugo rendering mechanics:
 
----
-
-## Lists
-
-- Use ordered lists for steps.
-- All items should begin with `1.` (Markdown will auto-number).
-
-Example:
-
-```markdown
-1. First step
-1. Second step
-1. Third step
-```
-
----
-
-## Code Blocks and Console Output
-
-### Code Fences
+### Code fences
 
 Use fenced code blocks (triple backticks) for all code and console output.
 
-**Supported languages for syntax highlighting:**
-- Language-specific: `typescript`, `python`, `go`, `java`, `csharp`, `yaml`, etc.
-- Shell commands: `bash`, `sh`
-- Console output: `output`
+**Supported languages for syntax highlighting:** language-specific (`typescript`, `python`, `go`, `java`, `csharp`, `yaml`, etc.), shell commands (`bash`, `sh`), and console output (`output`).
 
-### Console Output
+### Console output
 
-**Do not use indentation** (4 spaces) to denote console output. While technically valid Markdown, indented blocks are difficult for both humans and AI assistants to parse and maintain.
+**Do not use indentation** (4 spaces) to denote console output. While valid Markdown, indented blocks are hard for humans and AI assistants to parse and maintain.
 
 **Wrong:**
 
@@ -203,12 +164,10 @@ output line 2
 ```
 ````
 
-### Shell Commands vs Output
+### Shell commands vs. output
 
-- Use `bash` or `sh` for commands the user should type
-- Use `output` for the resulting console output
-
-**Example:**
+- Use `bash` or `sh` for commands the user should type.
+- Use `output` for the resulting console output.
 
 ```bash
 pulumi up
@@ -219,13 +178,9 @@ Updating (dev)
 ...
 ```
 
-**Rationale:** Fenced code blocks are explicit, easy to identify, and support syntax highlighting. Indented blocks can be confused with nested lists or quotes, especially when editing.
-
 ### Line highlighting
 
-Use the `hl_lines` parameter on fenced code blocks to highlight specific lines with a purple background. This draws attention to the most important lines in a code sample, such as newly added or changed lines.
-
-**Single lines and ranges:**
+Use the `hl_lines` parameter on fenced code blocks to highlight specific lines with a purple background — useful for newly added or changed lines.
 
 ````markdown
 ```typescript {hl_lines=[3]}
@@ -245,7 +200,7 @@ import pulumi_aws as aws
 ```
 ````
 
-**Combined with line numbers:**
+Combined with line numbers:
 
 ````markdown
 ```typescript {.line-numbers hl_lines=[5,"14-19"]}
@@ -253,94 +208,70 @@ import pulumi_aws as aws
 ```
 ````
 
-Use line highlighting when a code block is long but only a few lines are new or noteworthy. Do not highlight every line — if the entire block matters equally, no highlighting is needed.
-
----
-
-## Blockquotes
-
-- Use blockquotes only for direct quotations.
-
-Example:
-
-> This is something a person said.
+Highlight only the few lines that are new or noteworthy. If the entire block matters equally, no highlighting is needed.
 
 ---
 
 ## Diagrams
 
-We support two formats:
+Two formats are supported:
 
-- **GoAT (ASCII diagrams)** — good for simple flows.  
-- **Mermaid** — supports flowcharts, sequence diagrams, class diagrams, etc.  
+- **Mermaid** — flowcharts, sequence diagrams, class diagrams, etc. Rendered natively via the Hugo code block hook (`layouts/_default/_markup/render-codeblock-mermaid.html`). Use ` ```mermaid ` fenced blocks. Preferred.
+- **GoAT (ASCII diagrams)** — good for simple flows.
 
 See [Hugo diagrams docs](https://gohugo.io/content-management/diagrams/) and [Mermaid docs](https://mermaid.js.org/).
 
 ---
 
-## Product Names and Acronyms
+## Ordered lists
 
-- Always capitalize Pulumi product names correctly.  
-  - Pulumi IaC (Infrastructure as Code)  
-  - Pulumi ESC (Environments, Secrets, and Configuration)  
-  - Pulumi IDP (Internal Developer Platform)  
-  - Pulumi Insights  
-  - Pulumi Cloud
-  - Pulumi Policies  
-- Expand product acronyms at first mention. Use just the product name after.  
-- For non-Pulumi acronyms: spell out on first use, then use the acronym.  
-  - Example: Virtual Private Cloud (VPC), then VPC.  
-- Widely known acronyms (API, HTTP, REST) don’t need expansion.
-- *Pulumi Policies* is the product name, so it's a singular proper noun (like "United States" or "Brooks Brothers").
-  - Always refer to it in the singular form (e.g., "Pulumi Policies enforces compliance").
-  - Never refer to it in the plural (e.g., avoid "Pulumi Policies enforce compliance").
-- Use **"public preview"** for pre-GA features, not "public beta." This aligns with Pulumi's release terminology.
+To minimize diff noise, every item in an ordered list begins with `1.` (Markdown auto-numbers):
+
+```markdown
+1. First step
+1. Second step
+1. Third step
+```
+
+(For list *grammar* — parallelism, when to use a list at all — see the brand guide.)
 
 ---
 
 ## Glossary
 
-The [Pulumi glossary](/docs/iac/concepts/glossary/) defines common terms and concepts used throughout the documentation.
+The [Pulumi glossary](/docs/iac/concepts/glossary/) defines common terms used throughout the documentation.
 
-- When introducing a new concept or Pulumi-specific term in documentation, consider adding it to the glossary.
-- The glossary helps users (both human and AI agents) quickly understand Pulumi terminology.
-- To add or update glossary terms, edit `data/glossary.toml`.
-- Link to specific glossary terms using anchor links: `/docs/iac/concepts/glossary/#term-name`
+- When introducing a new concept or Pulumi-specific term, consider adding it to the glossary.
+- The glossary helps both human and AI readers understand Pulumi terminology.
+- To add or update terms, edit `data/glossary.toml`.
+- Link to specific terms using anchor links: `/docs/iac/concepts/glossary/#term-name`.
 
 ### Preferred terminology
 
-The following terms have precise meanings in Pulumi documentation. Use them consistently and prefer them over informal or ambiguous alternatives:
+These terms have precise meanings in Pulumi documentation. Use them consistently:
 
 | Term | Definition |
 | ---- | ---------- |
 | **Native language package** | A component published to a language-specific registry (npm, PyPI, NuGet, Maven, etc.) without a Pulumi plugin. Consumable only in the language in which it was authored. |
 | **Pulumi package** | A component or provider packaged with a Pulumi plugin so Pulumi can generate SDKs for any supported language. Consumable in all Pulumi languages. |
 
-Use **"Pulumi package"** (not "cross-language package") when referring to components or providers distributed with a Pulumi plugin. Use **"native language package"** (not "single-language package" or "language-native package") when referring to components distributed as standard language packages without a Pulumi plugin.
-
----
-
-## References to Commands or UI
-
-- CLI commands: wrap in backticks (e.g., `pulumi up`).  
-- UI elements: use **bold** (e.g., “Go to the **Account** page”).  
-- Navigation: use arrows (e.g., **Settings** → **API Keys**).
+Use **"Pulumi package"** (not "cross-language package") for components or providers distributed with a Pulumi plugin. Use **"native language package"** (not "single-language package" or "language-native package") for components distributed as standard language packages without a Pulumi plugin.
 
 ---
 
 ## Tutorials
 
-- If the tutorial is followed by another, end with a **Next steps** section.  
+- If the tutorial is followed by another, end with a **Next steps** section.
 - If pointing to references or further reading, end with a **Learn more** section.
 
 ---
 
-## Blog Posts
+## Blog posts
 
-See [BLOGGING.md](BLOGGING.md) for guidance on writing Pulumi blog posts.
+See [BLOGGING.md](BLOGGING.md) for the repo mechanics of writing Pulumi blog posts. For blog voice, see the brand guide's voice and writing-style sections via the MCP server.
 
 ---
 
 ## Automated checks
 
-The rules in this guide are enforced — where mechanically possible — by [Vale](https://vale.sh) via `.vale.ini` at the repo root. Custom rules live under `styles/Pulumi/` and layer on top of the Google Developer Style Guide and write-good packages. Run locally with `make lint-prose`. Vale findings also surface in the pinned PR review under ⚠️ Low-confidence and never block merges.
+Where mechanically possible, the brand guide's rules are enforced by [Vale](https://vale.sh) via `.vale.ini`. Custom rules under `styles/Pulumi/` (product-name casing, inclusive language, substitutions, AI-drafting tells) layer on top of the Google Developer Style Guide and write-good packages. **Vale runs offline in CI and can't call the MCP, so these rules are a local mirror of the brand guidance — keep them in sync with it, treating the brand guide as the source of truth.** Run locally with `make lint-prose`. Vale findings surface in the pinned PR review under ⚠️ Low-confidence and never block merges.


### PR DESCRIPTION
**Draft** — opened primarily to verify the brand MCP server connection in CI.

## What this does

Makes the Pulumi brand guide (public **`pulumi-brand`** MCP server at `https://brand.pulumi.com/mcp`) the source of truth for general **voice + writing-style**, and has the docs `STYLE-GUIDE.md` and content skills consult it rather than restating it. Adds a **precedence rule**: wherever the brand guide overlaps anything in this repo, the brand guide wins.

## Verifying the MCP connection

The brand MCP is wired into `claude-code-review.yml` and `content-review-article.yml` via `mcp_config`, pointing at the already-live public server (no auth). Note: the auto-review fires via `workflow_run`, which uses **master's** copy of the workflow — so this PR's new `mcp_config` is exercised by **manually dispatching the review on this branch**, not by the auto-trigger.

## Out of scope

SEO/AEO and social-copy skills stay in this repo untouched for now; they'll be handled in the brand guide separately. The brand-side changes (voice/writing-style enrichments) are a separate `pulumi/marketing-web` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)