### PR TITLE
Add a Pulumi Design Guidelines guide for component authors

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -17,11 +17,11 @@ iac:
   - name: Providers
     parent: iac-guides-building-extending
     identifier: iac-guides-providers
-    weight: 3
+    weight: 4
   - name: Using Existing Tools
     parent: iac-guides-building-extending
     identifier: iac-guides-using-existing-tools
-    weight: 4
+    weight: 5
   - name: Migrating from...
     parent: iac-guides-migration
     identifier: iac-guides-migration-from

--- a/content/docs/iac/guides/building-extending/_index.md
+++ b/content/docs/iac/guides/building-extending/_index.md
@@ -30,6 +30,12 @@ Build reusable infrastructure components to encapsulate and share infrastructure
 
 **[Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/)** - Choose the right packaging approach for your components: native language package, source-based plugin package, or executable-based plugin package.
 
+## Design Guidelines
+
+Design components other people are glad to use — prescriptive guidance on abstraction, naming, inputs and outputs, multi-language ergonomics, and evolution.
+
+**[Pulumi Design Guidelines](/docs/iac/guides/building-extending/design-guidelines/)** - Choose the right level of abstraction, name things well, design inputs and outputs that hold up across languages, and evolve components without breaking the programs that depend on them.
+
 ## Packages
 
 Package and distribute your components and providers for use across teams and projects.

--- a/content/docs/iac/guides/building-extending/design-guidelines/_index.md
+++ b/content/docs/iac/guides/building-extending/design-guidelines/_index.md
@@ -1,0 +1,74 @@
+---
+title_tag: "Pulumi Design Guidelines | Building & Extending"
+meta_desc: Prescriptive guidelines for designing reusable Pulumi components — abstraction, naming, inputs and outputs, multi-language ergonomics, and evolution.
+title: Pulumi Design Guidelines
+h1: Pulumi Design Guidelines
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Design Guidelines
+        parent: iac-guides-building-extending
+        weight: 2
+        identifier: iac-guides-design-guidelines
+---
+
+These guidelines describe how to design Pulumi [components](/docs/iac/concepts/components/) and [packages](/docs/iac/concepts/packages/) that other people will be glad to use. They are about judgment, not mechanics: how to choose the right level of abstraction, how to name things, what to accept as input and expose as output, and how to evolve a component without breaking the programs that depend on it.
+
+A good component encapsulates hard-won expertise, so that everyone who consumes it inherits sound decisions for free: the author does the thinking once, and every consumer benefits. The guidance here is drawn from Pulumi's own component libraries — [AWSX](/registry/packages/awsx/), [Pulumi EKS](/registry/packages/eks/), and others — and from a generation of infrastructure tooling that grappled with the same problems.
+
+## Who should read this
+
+This guide is for anyone authoring abstractions that other people consume:
+
+- **Platform teams** building the components and packages that application teams self-serve.
+- **Package authors** publishing to the [Pulumi Registry](/registry) or a [private registry](/docs/idp/).
+- **Anyone** factoring repeated infrastructure in their own programs into a reusable component.
+
+It assumes you already know the mechanics of building a component. If you don't, start with [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/), then come back here to make it good. For distribution choices, see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/).
+
+## Why design matters
+
+A component is an abstraction, and the value of an abstraction is measured by what it lets the consumer stop thinking about. A well-designed `Vpc` component lets a developer provision a sound, secure network without knowing how subnets, route tables, NAT gateways, and flow logs fit together. That is the entire point: the component author understands those details so the consumer doesn't have to.
+
+Design decisions are also expensive to reverse. Once a component is published and adopted, its names, inputs, and outputs become a contract. Consumers write programs against that contract, and every stack they deploy depends on it. Renaming an input or changing a default is no longer a local edit — it is a breaking change that ripples out to every program and every stack. The cost of a careless decision is paid by everyone downstream, repeatedly, for as long as the component lives.
+
+The consumer experience is the product. A component that does the right thing but is confusing to call, awkward to configure, or surprising in its output will be worked around rather than adopted. These guidelines exist to help you get the contract right the first time.
+
+## How to read the guidelines
+
+Each recommendation is tagged with one of four terms — a convention borrowed from the [.NET Framework Design Guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/) — that convey how strongly it applies.
+
+{{% guideline type="do" %}}
+**DO** guidelines should almost always be followed. Deviating requires a genuinely unusual reason.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** guidelines should generally be followed, but the right call depends on context. Understand the guideline before deciding it doesn't apply to you.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** guidelines point to things that are usually a bad idea, though not always wrong.
+{{% /guideline %}}
+
+{{% guideline type="dont" %}}
+**DON'T** guidelines should almost never be violated.
+{{% /guideline %}}
+
+Guidelines are recommendations, not rules a compiler enforces. The goal is a consistent, high-quality experience across the whole ecosystem of Pulumi components, so that consumers can move between components and find that they behave the way they expect.
+
+## The guidelines
+
+1. **[Choosing the right abstraction](/docs/iac/guides/building-extending/design-guidelines/abstraction/)** — finding the "Goldilocks" altitude: high enough to add value, low enough to stay flexible, and knowing when not to build a component at all.
+1. **[Naming](/docs/iac/guides/building-extending/design-guidelines/naming/)** — type tokens, packages, properties, and child resources, with an eye toward a great experience in every language.
+1. **[Designing inputs and outputs](/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs/)** — argument shape, required versus optional, sensible and secure defaults, secrets, validation, and what to expose.
+1. **[Composition and resource structure](/docs/iac/guides/building-extending/design-guidelines/composition/)** — parent/child relationships, propagating resource options, and building components out of other components.
+1. **[Single- versus multi-cloud abstractions](/docs/iac/guides/building-extending/design-guidelines/single-vs-multi-cloud/)** — when a cloud-agnostic abstraction earns its keep and when it becomes a leaky lowest common denominator.
+1. **[Designing for multiple languages](/docs/iac/guides/building-extending/design-guidelines/designing-for-languages/)** — the type-system constraints of multi-language components and how to design for them from day one.
+1. **[Versioning and evolution](/docs/iac/guides/building-extending/design-guidelines/versioning-and-evolution/)** — semantic versioning, breaking versus non-breaking changes, deprecation, and migrating consumers safely.
+
+## See also
+
+- [Component resources](/docs/iac/concepts/components/) — the underlying concept
+- [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/) — the mechanics
+- [Abstraction and encapsulation](/docs/tutorials/abstraction-encapsulation/) — a hands-on tutorial
+- [Four factors of a platform](/docs/idp/guides/best-practices/four-factors/) — where components fit in platform engineering

--- a/content/docs/iac/guides/building-extending/design-guidelines/abstraction.md
+++ b/content/docs/iac/guides/building-extending/design-guidelines/abstraction.md
@@ -1,0 +1,198 @@
+---
+title_tag: "Choosing the Right Abstraction | Pulumi Design Guidelines"
+meta_desc: How to choose the right level of abstraction for a Pulumi component — high enough to add value, low enough to stay flexible — and when not to build one.
+title: Choosing the Right Abstraction
+h1: Choosing the Right Abstraction
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Choosing the right abstraction
+        parent: iac-guides-design-guidelines
+        weight: 10
+---
+
+The hardest decision in component design is how much to abstract. Set the level too low and the component is overhead that adds nothing; set it too high and it becomes a monolith nobody can adapt to their needs. Get it just right — the "Goldilocks" altitude — and the component captures something the consumer already thinks of as a single thing, makes the decisions an expert would make on their behalf, and leaves the rest in their hands.
+
+It helps to picture a spectrum. At the bottom sits a raw resource — a single `aws.ec2.Vpc`, fully configurable and entirely your problem to wire up. At the top sits a finished, opinionated solution that makes nearly every decision for you. A good component lands in between, usually higher than its author first expects. The layers are worth naming: raw resources, curated defaults, and opinionated patterns. The same gradient runs through Pulumi components, from a bare provider resource to an [AWSX](/registry/packages/awsx/) abstraction to a full application platform built from many components.
+
+## Add value, don't relabel
+
+A component earns its place by encapsulating decisions: the wiring between resources, sensible defaults, security posture, and the invariants that keep a configuration correct. A consumer who uses the component inherits all of that for free.
+
+{{% guideline type="do" %}}
+**DO** build a component when it encapsulates a composition or a set of decisions that a consumer would otherwise have to get right themselves.
+{{% /guideline %}}
+
+A [`StaticPage` component](/docs/iac/guides/building-extending/components/build-a-component/) is a good example. Behind one input, it wires up a bucket, a website configuration, an index object, a public-access block, and a bucket policy — and it gets the policy and access settings right so the consumer doesn't expose their account by accident.
+
+{{% guideline type="dont" %}}
+**DON'T** wrap a single resource one-to-one with no added defaults, wiring, validation, or policy. A component that only forwards its arguments to one underlying resource is indirection without value — the consumer would be better off using the resource directly.
+{{% /guideline %}}
+
+A legitimate exception exists: a component that wraps a single resource but applies an opinionated, secure-by-default configuration — a hardened bucket, a database with backups and encryption switched on — is adding value, even though it manages one resource.
+
+{{% guideline type="avoid" %}}
+**AVOID** abstractions whose inputs are merely the union of the underlying resources' inputs. If a consumer has to understand every low-level setting to use your component, the abstraction isn't doing its job.
+{{% /guideline %}}
+
+## Model one concept
+
+A component should represent one coherent concept that a consumer can name and reason about: a `Vpc`, a `StaticWebsite`, a `KubernetesCluster`. The name is a good test of whether the altitude is right.
+
+{{% guideline type="consider" %}}
+**CONSIDER** the name test: if you cannot give a component a clear, single-noun name, it is probably doing too much. `Vpc` is a concept; `NetworkingAndDatabaseAndMonitoring` is three.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** "god components" that bundle unrelated concerns behind dozens of flags. They are hard to learn, hard to evolve, and force a consumer to accept everything in order to get anything.
+{{% /guideline %}}
+
+A well-sized component asks for high-level inputs that match its altitude. A `Vpc` should take a CIDR block and a number of availability zones — not require the consumer to hand it fully formed subnet and route-table arguments.
+
+{{< chooser language "typescript,python,go,csharp,java" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+// High-level inputs that match the abstraction. The consumer says what they
+// want; the component decides how to lay out subnets, route tables, and gateways.
+const vpc = new Vpc("app", {
+    cidrBlock: "10.0.0.0/16",
+    numberOfAvailabilityZones: 3,
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+# High-level inputs that match the abstraction. The consumer says what they
+# want; the component decides how to lay out subnets, route tables, and gateways.
+vpc = Vpc("app", {
+    "cidr_block": "10.0.0.0/16",
+    "number_of_availability_zones": 3,
+})
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+// High-level inputs that match the abstraction. The consumer says what they
+// want; the component decides how to lay out subnets, route tables, and gateways.
+vpc, err := NewVpc(ctx, "app", &VpcArgs{
+    CidrBlock:                 pulumi.String("10.0.0.0/16"),
+    NumberOfAvailabilityZones: pulumi.Int(3),
+})
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+// High-level inputs that match the abstraction. The consumer says what they
+// want; the component decides how to lay out subnets, route tables, and gateways.
+var vpc = new Vpc("app", new VpcArgs {
+    CidrBlock = "10.0.0.0/16",
+    NumberOfAvailabilityZones = 3,
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+// High-level inputs that match the abstraction. The consumer says what they
+// want; the component decides how to lay out subnets, route tables, and gateways.
+var vpc = new Vpc("app", VpcArgs.builder()
+    .cidrBlock("10.0.0.0/16")
+    .numberOfAvailabilityZones(3)
+    .build());
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+Pulumi's own `awsx.ec2.Vpc` is built this way: you give it a CIDR block and a number of availability zones, and it lays out public and private subnets across those zones, choosing a NAT gateway strategy whose default balances cost against availability. The consumer states intent; the component supplies the expertise.
+
+## Prefer composition to monoliths
+
+When an abstraction grows large, factor it into smaller components and compose them, rather than adding modes and flags to one big component. A `Microservice` can compose a `Vpc`, a `Database`, and a `LoadBalancer`, each independently useful and independently testable.
+
+{{% guideline type="do" %}}
+**DO** factor large abstractions into smaller components that can be used on their own and combined. Composition keeps each piece focused and lets consumers adopt only what they need.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** whether a flag you are about to add is really a second concept trying to escape. Two flags that are only ever set together, or never together, are often a sign that two components are hiding inside one.
+{{% /guideline %}}
+
+For more on building components out of components, see [Composition and resource structure](/docs/iac/guides/building-extending/design-guidelines/composition/).
+
+## Don't strand the consumer
+
+No abstraction anticipates every need. When a consumer hits something the component doesn't expose, they should be able to reach past it rather than abandon it.
+
+Pulumi's [EKS](/registry/packages/eks/) component is a good model. Alongside the `kubeconfig` most consumers want, `eks.Cluster` exposes the underlying `eksCluster` resource, a ready-to-use Kubernetes `provider`, and its `core` building blocks, so a consumer who needs something the high-level API doesn't cover can drop down without leaving the component behind. These deliberate openings are escape hatches, and every abstraction that survives contact with real users grows them.
+
+{{% guideline type="consider" %}}
+**CONSIDER** exposing the underlying resources, or their key properties, as outputs so consumers can reference and extend them.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** accepting optional pass-through configuration for the settings consumers most commonly need to customize, with good defaults when they're omitted.
+{{% /guideline %}}
+
+{{% guideline type="dont" %}}
+**DON'T** make a component an all-or-nothing black box. A small escape hatch costs far less than forcing a consumer to rip out the component the first time it doesn't fit.
+{{% /guideline %}}
+
+This guidance sits in tension with the previous sections: every escape hatch you add lowers the altitude of the abstraction. Expose too much and the component becomes the same lowest-level soup it was meant to hide. Aim for an abstraction that handles the common case in full and offers a deliberate, documented path for the uncommon one.
+
+## Anticipate future needs
+
+The escape hatch handles needs you didn't foresee. Many needs, though, are foreseeable from the resource types a component creates, and designing for them up front is far cheaper than bolting them on after consumers have built workarounds.
+
+Tags are the textbook case. If a component creates taggable cloud resources, someone will want to tag them for cost allocation, ownership, or compliance. And they will want *every* resource tagged, not only the ones the component happened to expose. A component that threads a `tags` input through to all of its children answers that need before it is asked; one that doesn't forces each consumer to reach around the component for something every one of them will eventually want.
+
+{{% guideline type="do" %}}
+**DO** accept the pervasive, cross-cutting inputs your resources invite, starting with `tags`, and propagate them to every child the component manages.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** what each resource type predictably invites: taggable resources invite tags, named resources invite a naming prefix, encryptable resources invite a key. These needs are visible the day you choose the resources, long before anyone files an issue.
+{{% /guideline %}}
+
+Pulumi's own libraries learned this the hard way. Tag propagation across the resources a component creates was one of the most persistent requests against AWSX, asked for repeatedly and across many of its components over the years, and consumers who couldn't wait resorted to applying a stack [transformation](/docs/iac/concepts/resources/options/transforms/) that walked the tree and tagged everything by hand.
+
+That workaround is also a warning. A transformation is a legitimate escape hatch: a consumer can apply one to a component to adjust resources its API doesn't surface. But when consumers *routinely* need a transformation to use your component — to tag its resources, set a common property, or correct a default — the recurring transformation is telling you that a predictable need belongs in the API as a first-class input.
+
+{{% guideline type="dont" %}}
+**DON'T** make routine customization depend on transformations. When the same transform shows up across many consumers, promote what it does into a real input and propagate it yourself.
+{{% /guideline %}}
+
+Anticipation has a limit, and it is the same one the rest of this chapter draws. Designing in inputs nobody asks for is the over-configurability trap from [Model one concept](#model-one-concept). Anticipate the needs that are both predictable and pervasive, the ones every consumer will hit, and leave the genuinely rare ones to the escape hatch.
+
+## When not to build a component
+
+Not every repetition deserves a component. Abstracting too early is as costly as abstracting too much.
+
+{{% guideline type="avoid" %}}
+**AVOID** distilling a component from a single example. An abstraction drawn from one use case tends to bake in that example's accidents and break the moment a second consumer arrives. Wait until you have seen the pattern two or three times.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** whether a plain function, a [project template](/docs/iac/guides/building-extending/creating-templates/), or inline code is a better fit. Components shine for reusable, multi-instance, and especially multi-language abstractions; a one-off composition used in a single program may not need one.
+{{% /guideline %}}
+
+## See also
+
+- [Composition and resource structure](/docs/iac/guides/building-extending/design-guidelines/composition/)
+- [Designing inputs and outputs](/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs/)
+- [Organizing Pulumi projects and stacks](/docs/iac/guides/basics/organizing-projects-stacks/)
+- [Abstraction and encapsulation](/docs/tutorials/abstraction-encapsulation/)

--- a/content/docs/iac/guides/building-extending/design-guidelines/composition.md
+++ b/content/docs/iac/guides/building-extending/design-guidelines/composition.md
@@ -1,0 +1,230 @@
+---
+title_tag: "Composition and Resource Structure | Pulumi Design Guidelines"
+meta_desc: How to structure a Pulumi component's child resources — parent/child relationships, propagating resource options, and composing components.
+title: Composition and Resource Structure
+h1: Composition and Resource Structure
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Composition and resource structure
+        parent: iac-guides-design-guidelines
+        weight: 40
+---
+
+A component is more than the inputs and outputs on its surface. Internally it is a tree of child resources, and the shape of that tree is part of the experience you ship. It shows up in `pulumi up` previews, in state, and in the resource graph a consumer reads when something goes wrong. This chapter is about getting that internal structure right: how children attach to the component, which resource options flow down to them, and how to compose components without making the tree incoherent.
+
+## Parent every child
+
+A [component](/docs/iac/concepts/components/) becomes the parent of the resources it creates by passing the [`parent`](/docs/iac/concepts/resources/options/parent/) option to each one. The parent/child relationship is what makes the children nest under the component in state, group beneath it in previews, and inherit the options described below. A child created without `parent` is loose: it lands at the top of the stack's resource tree as if the consumer had written it themselves, defeating the encapsulation the component exists to provide.
+
+{{% guideline type="do" %}}
+**DO** set `parent` to the component on every child resource the component creates.
+{{% /guideline %}}
+
+{{< chooser language "typescript,python,go,csharp,java" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+export class StaticPage extends pulumi.ComponentResource {
+    constructor(name: string, args: StaticPageArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("sample-components:index:StaticPage", name, args, opts);
+
+        // Each child names itself off `name` and parents to `this`.
+        const bucket = new aws.s3.Bucket(`${name}-bucket`, {}, { parent: this });
+
+        const website = new aws.s3.BucketWebsiteConfiguration(`${name}-website`, {
+            bucket: bucket.bucket,
+            indexDocument: { suffix: "index.html" },
+        }, { parent: this });
+
+        this.registerOutputs({});
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+class StaticPage(pulumi.ComponentResource):
+    def __init__(self, name, args, opts=None):
+        super().__init__("sample-components:index:StaticPage", name, {}, opts)
+
+        # Each child names itself off `name` and parents to `self`.
+        bucket = s3.Bucket(f"{name}-bucket", opts=ResourceOptions(parent=self))
+
+        website = s3.BucketWebsiteConfiguration(f"{name}-website",
+            bucket=bucket.bucket,
+            index_document={"suffix": "index.html"},
+            opts=ResourceOptions(parent=self))
+
+        self.register_outputs({})
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+func NewStaticPage(ctx *pulumi.Context, name string, args *StaticPageArgs, opts ...pulumi.ResourceOption) (*StaticPage, error) {
+    comp := &StaticPage{}
+    if err := ctx.RegisterComponentResource("sample-components:index:StaticPage", name, comp, opts...); err != nil {
+        return nil, err
+    }
+
+    // Each child names itself off `name` and parents to `comp`.
+    bucket, err := s3.NewBucket(ctx, fmt.Sprintf("%s-bucket", name), &s3.BucketArgs{},
+        pulumi.Parent(comp))
+    if err != nil {
+        return nil, err
+    }
+
+    _, err = s3.NewBucketWebsiteConfiguration(ctx, fmt.Sprintf("%s-website", name), &s3.BucketWebsiteConfigurationArgs{
+        Bucket:        bucket.Bucket,
+        IndexDocument: s3.BucketWebsiteConfigurationIndexDocumentArgs{Suffix: pulumi.String("index.html")},
+    }, pulumi.Parent(comp))
+    if err != nil {
+        return nil, err
+    }
+
+    return comp, ctx.RegisterResourceOutputs(comp, pulumi.Map{})
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+class StaticPage : ComponentResource {
+    public StaticPage(string name, StaticPageArgs args, ComponentResourceOptions? opts = null)
+        : base("sample-components:index:StaticPage", name, args, opts)
+    {
+        // Each child names itself off `name` and parents to `this`.
+        var bucket = new Bucket($"{name}-bucket", new() { }, new() { Parent = this });
+
+        var website = new BucketWebsiteConfiguration($"{name}-website", new() {
+            Bucket = bucket.BucketName,
+            IndexDocument = new BucketWebsiteConfigurationIndexDocumentArgs { Suffix = "index.html" },
+        }, new() { Parent = this });
+
+        this.RegisterOutputs(new Dictionary<string, object?>());
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+class StaticPage extends ComponentResource {
+    public StaticPage(String name, StaticPageArgs args, ComponentResourceOptions opts) {
+        super("sample-components:index:StaticPage", name, null, opts);
+
+        // Each child names itself off `name` and parents to `this`.
+        var bucket = new Bucket(String.format("%s-bucket", name), null,
+            CustomResourceOptions.builder().parent(this).build());
+
+        var website = new BucketWebsiteConfiguration(String.format("%s-website", name),
+            BucketWebsiteConfigurationArgs.builder()
+                .bucket(bucket.bucket())
+                .indexDocument(BucketWebsiteConfigurationIndexDocumentArgs.builder()
+                    .suffix("index.html")
+                    .build())
+                .build(),
+            CustomResourceOptions.builder().parent(this).build());
+
+        this.registerOutputs(Map.of());
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+For the full mechanics of creating children, see [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/#creating-child-resources).
+
+## Register outputs at the end
+
+The last thing a component's constructor should do is call `registerOutputs` with the values it exposes. Beyond recording the outputs in state, this call marks the component as fully constructed — the engine treats it as the signal that no more children are coming. Calling it once, at the end, keeps that contract clear.
+
+{{% guideline type="do" %}}
+**DO** call `registerOutputs` once, as the final statement of the constructor, passing the component's outputs.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** creating child resources after `registerOutputs`. Children registered past that point race against the completion signal and can be missed in the component's reported state.
+{{% /guideline %}}
+
+Deciding *which* values belong in your outputs — and how to type them — is the subject of [Designing inputs and outputs](/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs/). For the registration mechanics, see [Registering component outputs](/docs/iac/guides/building-extending/components/build-a-component/#registering-component-outputs).
+
+## Propagate resource options to children
+
+Because children declare the component as their `parent`, several [resource options](/docs/iac/concepts/resources/options/) the consumer sets on the component instance flow down to every child automatically — you don't re-apply them yourself. The engine carries the value down the parent/child chain at registration time. The [inherited-options reference](/docs/iac/concepts/resources/options/#options-inherited-from-a-component-to-its-children) lists exactly which options propagate; the ones component authors most need to keep in mind are below.
+
+The most important is the provider. When a consumer points your component at a specific [`provider`](/docs/iac/concepts/resources/options/provider/) or [`providers`](/docs/iac/concepts/resources/options/providers/) — a particular AWS region, a named Kubernetes cluster, an account with specific credentials — that choice is inherited by the component's child custom resources. This is what lets one consumer deploy your `Vpc` into `us-east-1` and another into `eu-west-1` from the same component, without you threading a region input through by hand.
+
+{{% guideline type="do" %}}
+**DO** let children inherit the consumer's `provider`/`providers` by parenting them to the component, rather than constructing providers inside the component from your own inputs. The consumer owns where their infrastructure lands.
+{{% /guideline %}}
+
+[`protect`](/docs/iac/concepts/resources/options/protect/) and [`retainOnDelete`](/docs/iac/concepts/resources/options/retainOnDelete/) are also inherited. A consumer who protects your `Database` component protects every child under it as a unit, which is almost always what they intend — the whole abstraction is the thing they don't want deleted.
+
+{{% guideline type="consider" %}}
+**CONSIDER** the consequences of inherited `protect` and `retainOnDelete` when you decide what to make a child of the component. Anything parented to the component participates in the consumer's protection as a single unit.
+{{% /guideline %}}
+
+[`dependsOn`](/docs/iac/concepts/resources/options/dependson/) works the other way around. It isn't pushed down to children, but because the children sit under the component, a consumer who lists your component in another resource's `dependsOn` is depending on the entire subtree — the dependent resource waits for every child to finish. That is the right default, and it means a component composes cleanly into a consumer's ordering without exposing its internals.
+
+For options Pulumi does *not* inherit — `ignoreChanges`, `customTimeouts`, and others a child may need — set them directly on the child as you create it, or use [`transforms`](/docs/iac/concepts/resources/options/transforms/) on the component to inject the option into matching child registrations. See [Passing resource options to components](/docs/iac/guides/building-extending/components/build-a-component/#passing-resource-options-to-components) for how options reach the constructor in the first place.
+
+## Compose components from components
+
+A child of a component can itself be a component. A `Microservice` may create a `Vpc`, a `Database`, and a `LoadBalancer` as its children, each a component with children of its own. Set `parent` on the nested components exactly as you would on a leaf resource, and the whole tree stays coherent: the consumer sees `Microservice` at the top, the three sub-components beneath it, and their cloud resources below those.
+
+This is composition at work, and the reasoning is familiar: a flat tree of small, single-purpose components is easier to reason about and reuse than one deep monolith. The parent/child relationship is what makes that composition show up directly in the Pulumi resource graph rather than living only in your code.
+
+{{% guideline type="do" %}}
+**DO** compose larger components out of smaller ones, parenting each nested component so the resource tree mirrors the conceptual hierarchy.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** keeping each composed component independently useful. A `Vpc` that only works inside your `Microservice` is a missed opportunity; one that stands on its own can be reused, tested, and reasoned about in isolation. This is the composition guidance from [Choosing the right abstraction](/docs/iac/guides/building-extending/design-guidelines/abstraction/), applied to the resource tree.
+{{% /guideline %}}
+
+For a worked treatment of this pattern in a platform context, see [Components using other components](/docs/idp/guides/best-practices/patterns/components-using-other-components/).
+
+## Keep the resource tree meaningful
+
+The tree a consumer sees in `pulumi up` and in state is documentation they read whether or not you intended it as such. A well-shaped tree makes the component's structure legible at a glance; a poorly shaped one buries the structure in noise.
+
+{{% guideline type="avoid" %}}
+**AVOID** a flat pile of dozens of children directly under the component when a couple of intermediate components would group them into recognizable units. If your `Cluster` creates thirty resources, grouping the networking and the node pools into sub-components turns a wall of resources into a structure a reader can scan.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** nesting for its own sake. A sub-component that wraps a single resource, or a layer that exists only to add a level to the tree, adds depth without adding meaning. Introduce an intermediate component when it names something the consumer would recognize — not to satisfy a symmetry instinct.
+{{% /guideline %}}
+
+The test is the consumer's mental model. The tree should mirror how someone reasons about the system, so that the structure they see in state matches the structure they already hold in their head.
+
+## Restructure safely
+
+A resource's identity is its [URN](/docs/iac/concepts/resources/names/), and the URN is built from the resource's name and its parent chain. Renaming a child or reparenting it — including the reparenting that happens when you factor children into a new sub-component — changes the URN, and Pulumi treats a changed URN as a different resource: it deletes the old one and creates a new one. Inside an unreleased component that's harmless. In a released component, it means an internal refactor can replace live infrastructure in every consumer's stack.
+
+{{% guideline type="dont" %}}
+**DON'T** rename or reparent the children of a released component without [`aliases`](/docs/iac/concepts/resources/options/aliases/). The alias tells Pulumi the new URN is the same resource as the old one, preserving its identity across the refactor.
+{{% /guideline %}}
+
+This is the resource-tree facet of a larger topic; the full rules for evolving a component without breaking consumers live in [Versioning and evolution](/docs/iac/guides/building-extending/design-guidelines/versioning-and-evolution/).
+
+## See also
+
+- [Component resources](/docs/iac/concepts/components/) — the underlying concept
+- [Resource options inherited by children](/docs/iac/concepts/resources/options/#options-inherited-from-a-component-to-its-children) — exactly which options propagate
+- [Designing inputs and outputs](/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs/) — what to expose and how to type it
+- [Versioning and evolution](/docs/iac/guides/building-extending/design-guidelines/versioning-and-evolution/) — restructuring released components safely

--- a/content/docs/iac/guides/building-extending/design-guidelines/designing-for-languages.md
+++ b/content/docs/iac/guides/building-extending/design-guidelines/designing-for-languages.md
@@ -1,0 +1,238 @@
+---
+title_tag: "Designing for Multiple Languages | Pulumi Design Guidelines"
+meta_desc: Design multi-language Pulumi components — the serialization constraints of the plugin boundary, representable types, enums, and schema-driven docs.
+title: Designing for Multiple Languages
+h1: Designing for Multiple Languages
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Designing for multiple languages
+        parent: iac-guides-design-guidelines
+        weight: 60
+---
+
+A multi-language component is authored once and consumed from every Pulumi language. That reach is the whole appeal — a platform team writes a component in TypeScript and an application team uses it from Python, Go, C#, Java, or YAML — but it comes with a constraint that shapes the design from the start. The component's inputs and outputs cross a serialization boundary between the consumer's program and the plugin that implements the component, and only data that can survive that crossing belongs on the public surface.
+
+This constraint is not unique to Pulumi. Any system that projects a single API into multiple languages restricts that API to a comparable representable subset. Designing to a language-neutral surface is the price of write-once, consume-anywhere — and, handled well, it is a small price.
+
+## Decide early: multi-language or single-language
+
+Whether a component is multi-language is a packaging decision, and it changes what types you are allowed to use. A [native language package](/docs/iac/guides/building-extending/components/packaging-components/#native-language-packages) is an ordinary class in one language with no Pulumi plugin and no serialization boundary; its arguments can be any type the language supports, including ones that could never cross a wire. A [plugin package](/docs/iac/guides/building-extending/components/packaging-components/) — source-based or executable — is consumable from every language precisely because its surface is described by a schema and marshaled across the boundary.
+
+{{% guideline type="do" %}}
+**DO** decide up front whether you are building a multi-language plugin package or a single-language native package, because it determines which types you may put on inputs and outputs.
+{{% /guideline %}}
+
+The reason to decide early is that the choice is hard to reverse. If you ship a native package today and later want multi-language consumption, every input that relied on a non-representable type — a callback, a class instance, a union — becomes a breaking change to remove. Designing to the representable subset from the beginning costs little and keeps the door open. See [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) for the full trade-off.
+
+## Think in schema, not language objects
+
+A multi-language component's public surface is effectively a [schema](/docs/iac/guides/building-extending/packages/schema/): a language-neutral description of its inputs and outputs that Pulumi projects into each consuming language's SDK. The most reliable way to design that surface is to picture it as data rather than as objects in your authoring language.
+
+{{% guideline type="do" %}}
+**DO** design inputs and outputs as data — primitives, lists, maps, and nested typed objects — so the shape projects cleanly into every language.
+{{% /guideline %}}
+
+The constraint applies only to the public surface. Inside the constructor or factory function you are writing ordinary code in one language and may use any feature it offers: helper classes, closures, generics, third-party libraries. Only what crosses the boundary as an input or output is governed by what the schema can represent.
+
+## Use representable types
+
+The authoritative list of what can and cannot appear on a packaged component's arguments lives in [Component arguments and type requirements](/docs/iac/guides/building-extending/components/build-a-component/#component-arguments-and-type-requirements). In summary, the representable types are:
+
+1. Primitives — strings, numbers (integers and floats), and booleans.
+1. Lists of representable types.
+1. Maps with string keys and representable values.
+1. Nested object types whose properties are themselves representable.
+1. Enums (with one caveat for Go, noted below).
+1. [Assets and archives](/docs/iac/concepts/assets-archives/).
+1. Any of the above wrapped in an `Input`/`Output` so consumers can pass values that aren't known until deploy time.
+
+Types that do not serialize are not representable: functions and callbacks, arbitrary language classes and interfaces, and open-ended unions beyond optionality. The per-language section of the reference spells out the exact syntax and the edge cases for each.
+
+{{% guideline type="do" %}}
+**DO** keep every input and output within the representable set, and prefer a flat shape — deeply nested arguments are harder to construct in every language.
+{{% /guideline %}}
+
+Here is an argument type built entirely from representable types: primitives, a list, a map, a nested typed object, and an enum-modeled field. It defines the same contract in each authoring language.
+
+{{< chooser language "typescript,python,go,csharp,java" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+export interface TlsConfigArgs {
+    enabled: pulumi.Input<boolean>;
+    minimumProtocolVersion: pulumi.Input<string>;  // closed set: "TLSv1.2" | "TLSv1.3"
+}
+
+export interface WebServiceArgs {
+    image: pulumi.Input<string>;
+    replicas?: pulumi.Input<number>;
+    domains: pulumi.Input<pulumi.Input<string>[]>;
+    tags?: pulumi.Input<{ [key: string]: pulumi.Input<string> }>;
+    tls: pulumi.Input<TlsConfigArgs>;
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+class TlsConfigArgs(TypedDict):
+    enabled: pulumi.Input[bool]
+    minimum_protocol_version: pulumi.Input[str]  # closed set: "TLSv1.2" | "TLSv1.3"
+
+class WebServiceArgs(TypedDict):
+    image: pulumi.Input[str]
+    replicas: NotRequired[pulumi.Input[int]]
+    domains: pulumi.Input[Sequence[pulumi.Input[str]]]
+    tags: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+    tls: pulumi.Input[TlsConfigArgs]
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+type TlsConfigArgs struct {
+    Enabled                pulumi.BoolInput   `pulumi:"enabled"`
+    MinimumProtocolVersion pulumi.StringInput `pulumi:"minimumProtocolVersion"` // closed set: "TLSv1.2" | "TLSv1.3"
+}
+
+type WebServiceArgs struct {
+    Image    pulumi.StringInput    `pulumi:"image"`
+    Replicas pulumi.IntPtrInput    `pulumi:"replicas,optional"`
+    Domains  pulumi.StringArrayInput `pulumi:"domains"`
+    Tags     pulumi.StringMapInput `pulumi:"tags,optional"`
+    Tls      TlsConfigArgs         `pulumi:"tls"`
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+public class TlsConfigArgs : ResourceArgs
+{
+    [Input("enabled", required: true)]
+    public Input<bool> Enabled { get; set; } = null!;
+
+    [Input("minimumProtocolVersion", required: true)] // closed set: "TLSv1.2" | "TLSv1.3"
+    public Input<string> MinimumProtocolVersion { get; set; } = null!;
+}
+
+public class WebServiceArgs : ResourceArgs
+{
+    [Input("image", required: true)]
+    public Input<string> Image { get; set; } = null!;
+
+    [Input("replicas")]
+    public Input<int>? Replicas { get; set; }
+
+    [Input("domains", required: true)]
+    public InputList<string> Domains { get; set; } = null!;
+
+    [Input("tags")]
+    public InputMap<string> Tags { get; set; } = null!;
+
+    [Input("tls", required: true)]
+    public Input<TlsConfigArgs> Tls { get; set; } = null!;
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+public final class WebServiceArgs extends ResourceArgs {
+    @Import(name = "image", required = true)
+    private Output<String> image;
+
+    @Import(name = "replicas")
+    private @Nullable Output<Integer> replicas;
+
+    @Import(name = "domains", required = true)
+    private Output<List<String>> domains;
+
+    @Import(name = "tags")
+    private @Nullable Output<Map<String, String>> tags;
+
+    @Import(name = "tls", required = true)
+    private Output<TlsConfigArgs> tls;
+
+    // getters omitted for brevity
+}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+Property names are defined once in their canonical camelCase form and projected into each language's idiomatic casing automatically; you don't repeat the name per language. The [Naming](/docs/iac/guides/building-extending/design-guidelines/naming/) chapter covers that projection and how to choose names that survive it.
+
+## No callbacks across the boundary
+
+It is tempting in a single-language program to take a function as an argument — a transform applied to each resource, a predicate that decides a default, an inline policy. A function cannot be represented in the schema and cannot be marshaled to a consumer in another language, so it has no place on a multi-language component's surface.
+
+{{% guideline type="dont" %}}
+**DON'T** accept a function, lambda, or callback as a component input. It cannot cross the plugin boundary, and it cannot be expressed at all from YAML.
+{{% /guideline %}}
+
+Replace the callback with declarative configuration: a named mode, a policy object with explicit fields, or a closed set of options the component interprets internally. A `retryPolicy` object with `maxAttempts` and `backoffSeconds` says the same thing as a retry callback, works from every language, and reads cleanly in YAML.
+
+## Closed sets are enums
+
+When an input accepts one of a fixed set of values — a TLS version, a load-balancer scheme, a log level — model it as an enum rather than a free-form string. An enum projects into each language as a real type with named members, so consumers get autocomplete and compile-time checking instead of guessing at valid strings, and the allowed values are self-documenting in the generated SDK and the Registry.
+
+{{% guideline type="consider" %}}
+**CONSIDER** modeling a fixed set of choices as an enum. It projects into each language as a named type and documents the valid values without a separate note.
+{{% /guideline %}}
+
+{{% guideline type="do" %}}
+**DO** reach for an enum before adding a second boolean. Two booleans encode four states, not all of which may be valid; a single enum names exactly the states you intend.
+{{% /guideline %}}
+
+The booleans-versus-enums rationale is covered in [Designing inputs and outputs](/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs/); the multi-language point is that the enum's value is amplified across languages. One caveat: Go has no native enum type, and Pulumi's Go schema inference does not synthesize an enum from string constants. A Go-authored component therefore expresses such a field as a plain string — the `minimumProtocolVersion` field above keeps to a string for exactly this reason. If enums in the generated SDKs matter to you, authoring in a language with native enum support is the more direct route.
+
+## Watch the edges that differ by language
+
+Most representable types behave identically everywhere, but a few details are expressed differently across languages and are worth a moment of thought.
+
+{{% guideline type="consider" %}}
+**CONSIDER** how optionality and numeric precision read in each target language, and stay within widely supported types rather than relying on one language's exotic type.
+{{% /guideline %}}
+
+Optionality and nullability are spelled differently per language — `?` in TypeScript, `Optional` in Python and Java, the `,optional` struct tag in Go, the `[Input]` attribute in C# — and the reference documents the canonical form for each. Numbers are the other common edge: very large integers and high-precision values don't have a single universal representation, so a value that fits comfortably in one language's numeric type may not in another. When in doubt, keep to ordinary integers and floats and consult [Component arguments and type requirements](/docs/iac/guides/building-extending/components/build-a-component/#component-arguments-and-type-requirements) for the specifics.
+
+## Doc comments are your API docs
+
+For a plugin package, the doc comments you write on argument and output properties are more than code comments — they flow into the generated schema and become the rendered API documentation in every language, in editor autocomplete, and in the [Registry](/docs/iac/guides/building-extending/packages/source-based-plugin/) or Pulumi Cloud IDP gallery. A consumer who never sees your source still sees these descriptions.
+
+{{% guideline type="do" %}}
+**DO** write a doc comment on every input and output property. For plugin packages these become the API documentation a consumer reads in their own language.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** shipping an undocumented public surface. An input with no description forces every consumer to read the source or guess, in a language where they may not have the source at all.
+{{% /guideline %}}
+
+## YAML is a consumer too
+
+A multi-language component is consumable from YAML, and YAML is purely declarative — no `apply`, no loops, no glue code. It is the strictest consumer of your design, and a good check on whether the component is genuinely language-neutral.
+
+{{% guideline type="do" %}}
+**DO** sanity-check that your component is pleasant to use from YAML. If configuring it requires imperative glue, the design is leaning on features only one language offers.
+{{% /guideline %}}
+
+A component that reads naturally in YAML — declarative inputs, no callbacks, no values that only make sense after an `apply` — will read naturally everywhere. If you find yourself unable to express a sensible YAML usage, that is a signal to revisit the surface, not to exclude YAML.
+
+## See also
+
+- [Component arguments and type requirements](/docs/iac/guides/building-extending/components/build-a-component/#component-arguments-and-type-requirements) — the authoritative list of representable types
+- [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) — native versus plugin packages and what each allows
+- [Pulumi package schema](/docs/iac/guides/building-extending/packages/schema/) — the language-neutral surface a component projects from
+- [Naming](/docs/iac/guides/building-extending/design-guidelines/naming/) — one name, projected into every language

--- a/content/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs.md
+++ b/content/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs.md
@@ -1,0 +1,325 @@
+---
+title_tag: "Designing Inputs and Outputs | Pulumi Design Guidelines"
+meta_desc: How to design a Pulumi component's inputs and outputs — argument shape, required versus optional, secure defaults, secrets, validation, and what to expose.
+title: Designing Inputs and Outputs
+h1: Designing Inputs and Outputs
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Designing inputs and outputs
+        parent: iac-guides-design-guidelines
+        weight: 30
+---
+
+A component's inputs and outputs are its contract. The inputs are what a consumer must understand to use it; the outputs are what they get to build on. Both are projected into every Pulumi language and, once published, are expensive to change. This chapter is about shaping that contract so it is small, safe, and stable.
+
+## The args object
+
+Pulumi components take their inputs as a single arguments object — `StaticPageArgs`, `VpcArgs` — passed as the constructor's second parameter after the instance name. This object is the component's front door: it is the first thing a consumer sees in autocomplete and the thing they fill in to call you.
+
+{{% guideline type="do" %}}
+**DO** group a component's inputs into one args type named after the component, with the `Args` suffix.
+{{% /guideline %}}
+
+{{% guideline type="dont" %}}
+**DON'T** take a long list of positional parameters. Positional arguments have no names at the call site, can't be reordered or made optional without breaking callers, and read terribly once there are more than two of them. The args object solves all three problems and is the convention every Pulumi consumer expects.
+{{% /guideline %}}
+
+Each field on the args type carries the same weight as a top-level property: it is named once, projected into every language, and part of the contract. See [Naming](/docs/iac/guides/building-extending/design-guidelines/naming/) for how to name those fields well.
+
+## Required versus optional
+
+The required inputs are the ones a consumer cannot avoid thinking about. Every required input is a question you force them to answer before they can deploy anything at all.
+
+{{% guideline type="do" %}}
+**DO** make an input required only when there is no sensible default — when the component genuinely cannot proceed without the consumer's answer. Everything else should be optional.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** the number of required inputs as a measure of the abstraction's altitude. A component with one or two required inputs is asking the consumer for the essential decisions and handling the rest. A component with a dozen required inputs is asking them to configure the underlying resources by hand — a sign the abstraction is too low. See [Choosing the right abstraction](/docs/iac/guides/building-extending/design-guidelines/abstraction/).
+{{% /guideline %}}
+
+How each language expresses optionality is mechanical — `?` in TypeScript, `Optional` in Python, a pointer or zero value in Go, a nullable property in C#, an unset builder field in Java — but the design decision is the same everywhere: a consumer who supplies only the required inputs should still get a complete, working result.
+
+## Sensible, secure defaults
+
+A default is a decision you make on the consumer's behalf. The whole value of a component is that its author has the expertise to make those decisions well, so the defaults should be what a knowledgeable user would have chosen anyway.
+
+{{% guideline type="do" %}}
+**DO** choose defaults that are correct for the majority of consumers. A consumer who configures nothing optional should get a sound, production-reasonable result, not a starting point they have to harden.
+{{% /guideline %}}
+
+{{% guideline type="do" %}}
+**DO** default to the secure posture: encryption enabled, public access denied, least-privilege permissions, logging on. The safe configuration should be the one a consumer gets for free.
+{{% /guideline %}}
+
+{{% guideline type="dont" %}}
+**DON'T** default to an insecure or permissive setting because it is convenient or makes a demo shorter. A default that quietly exposes data or grants broad access turns every consumer who didn't override it into an incident. If a consumer needs the unsafe option, make them ask for it explicitly.
+{{% /guideline %}}
+
+This is the same principle behind the [`StaticPage` component](/docs/iac/guides/building-extending/components/build-a-component/): it deliberately configures the bucket policy and public-access block so the page is reachable without leaving the account exposed. The consumer inherits that judgment. Good defaults are what let a consumer supply only what is unique to their case and inherit a sound baseline for the rest.
+
+## Accept Input<T>
+
+A property value in a Pulumi program is frequently not a plain, resolved value — it is an [output](/docs/iac/concepts/inputs-outputs/) of another resource that won't be known until deployment. Component inputs must accept these. The `Input<T>` type (`pulumi.Input<string>`, `pulumi.StringInput`, `Input<string>`, depending on the language) is the wrapper that accepts both a plain value and an unresolved output of that value.
+
+{{% guideline type="do" %}}
+**DO** type every input as `Input<T>` rather than a plain `T`. This lets a consumer wire your component's inputs directly to other resources' outputs, which is the normal way Pulumi programs connect resources together.
+{{% /guideline %}}
+
+{{% guideline type="dont" %}}
+**DON'T** accept an already-resolved plain value where an `Input<T>` belongs. A plain `string` parameter forces the consumer to `apply` or `await` the upstream output before calling you, which defeats Pulumi's dependency tracking and is awkward in every language.
+{{% /guideline %}}
+
+The canonical args type is small: one or two `Input<T>` fields for the essential decisions, the rest optional with defaults.
+
+{{< chooser language "typescript,python,go,csharp,java" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+export interface StaticPageArgs {
+    // Required: no sensible default exists for the page's content.
+    indexContent: pulumi.Input<string>;
+    // Optional: defaults to "index.html" when omitted.
+    indexDocument?: pulumi.Input<string>;
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+class StaticPageArgs(TypedDict):
+    index_content: pulumi.Input[str]
+    """Required: no sensible default exists for the page's content."""
+    index_document: NotRequired[pulumi.Input[str]]
+    """Optional: defaults to "index.html" when omitted."""
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+type StaticPageArgs struct {
+    // Required: no sensible default exists for the page's content.
+    IndexContent pulumi.StringInput `pulumi:"indexContent"`
+    // Optional: defaults to "index.html" when omitted.
+    IndexDocument pulumi.StringPtrInput `pulumi:"indexDocument"`
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+public sealed class StaticPageArgs : ResourceArgs {
+    // Required: no sensible default exists for the page's content.
+    [Input("indexContent")]
+    public Input<string> IndexContent { get; set; } = null!;
+
+    // Optional: defaults to "index.html" when omitted.
+    [Input("indexDocument")]
+    public Input<string>? IndexDocument { get; set; }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+class StaticPageArgs extends ResourceArgs {
+    // Required: no sensible default exists for the page's content.
+    @Import(name = "indexContent", required = true)
+    private Output<String> indexContent;
+
+    // Optional: defaults to "index.html" when omitted.
+    @Import(name = "indexDocument")
+    private Output<String> indexDocument;
+}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## Validate early
+
+Inputs that violate the component's assumptions should be rejected where the mistake was made — at construction — with an error that names the offending input and what it expected. The alternative is a confusing failure deep inside a provider call, after the consumer has waited for a deployment to get there.
+
+{{% guideline type="do" %}}
+**DO** validate inputs at construction and fail with a clear, specific message. "`cidrBlock` must be a valid CIDR range" is worth far more than letting the cloud provider reject it ten resources later.
+{{% /guideline %}}
+
+What you can validate, and when, depends on how the component is packaged — a same-language component can run arbitrary validation logic, while a component consumed across languages goes through schema-level constraints. See [Designing for multiple languages](/docs/iac/guides/building-extending/design-guidelines/designing-for-languages/).
+
+## Group related inputs
+
+A cluster of settings that belong together should look like one thing, not a scattering of loose fields. Flat boolean and string inputs that all configure the same sub-concern are hard to discover, and nothing stops a consumer from setting them inconsistently.
+
+{{% guideline type="consider" %}}
+**CONSIDER** a nested typed object for a group of related settings — `logging: { enabled, retentionDays, bucket }` rather than three top-level `logging*` fields. The nesting documents the relationship and keeps the top-level args readable.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** "flag soup": a pile of mutually dependent booleans where only certain combinations are valid. When two flags are only ever set together, or never together, they are usually one decision wearing two names.
+{{% /guideline %}}
+
+{{% guideline type="do" %}}
+**DO** model a choice among named modes as an enum or string union — `tier: "standard" | "premium"` — rather than several mutually exclusive booleans like `isStandard` and `isPremium`. An enum makes the illegal combinations unrepresentable and projects cleanly into every language. See [Designing for multiple languages](/docs/iac/guides/building-extending/design-guidelines/designing-for-languages/).
+{{% /guideline %}}
+
+## Secrets
+
+Some inputs and outputs carry sensitive material — passwords, tokens, private keys, connection strings. Pulumi can [encrypt these in state and mask them in CLI output](/docs/iac/concepts/secrets/), but only if the component marks them as secret.
+
+{{% guideline type="do" %}}
+**DO** mark sensitive inputs and outputs as secret so Pulumi encrypts them in state and masks them in `pulumi up` output. A credential that lands in plaintext state is a credential leak.
+{{% /guideline %}}
+
+{{% guideline type="do" %}}
+**DO** propagate secretness from inputs into the outputs derived from them. If an output is computed from a secret input — or is itself a generated password — it must be secret too, or the encryption is undone the moment the value is exposed.
+{{% /guideline %}}
+
+## Designing outputs
+
+Outputs are what a consumer builds the rest of their program on. The ones that matter most are the values a consumer cannot easily reconstruct themselves: endpoints, ARNs, generated names, connection strings. These are the reason they reach for your output instead of recomputing it. `eks.Cluster` exposes `kubeconfig` for exactly this reason — the one output nearly every consumer needs and none can reconstruct by hand.
+
+{{% guideline type="do" %}}
+**DO** expose the values a consumer needs to use or reference the thing the component created — especially values that are generated, assigned by the cloud, or otherwise not knowable from the inputs.
+{{% /guideline %}}
+
+A component registers its outputs by assigning them to public fields and calling `registerOutputs`. The fields are the typed contract; `registerOutputs` records the values into Pulumi's state.
+
+{{< chooser language "typescript,python,go,csharp,java" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+export class StaticPage extends pulumi.ComponentResource {
+    // The output a consumer actually needs: the live URL.
+    public readonly endpoint: pulumi.Output<string>;
+
+    constructor(name: string, args: StaticPageArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("sample-components:index:StaticPage", name, args, opts);
+        // ... create children ...
+        this.endpoint = bucketWebsite.websiteEndpoint;
+        this.registerOutputs({
+            endpoint: this.endpoint,
+        });
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+class StaticPage(pulumi.ComponentResource):
+    endpoint: pulumi.Output[str]
+    """The output a consumer actually needs: the live URL."""
+
+    def __init__(self, name, args, opts=None):
+        super().__init__("sample-components:index:StaticPage", name, {}, opts)
+        # ... create children ...
+        self.endpoint = bucket_website.website_endpoint
+        self.register_outputs({
+            "endpoint": self.endpoint,
+        })
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+type StaticPage struct {
+    pulumi.ResourceState
+    // The output a consumer actually needs: the live URL.
+    Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+}
+
+func NewStaticPage(ctx *pulumi.Context, name string, args *StaticPageArgs, opts ...pulumi.ResourceOption) (*StaticPage, error) {
+    comp := &StaticPage{}
+    if err := ctx.RegisterComponentResource("sample-components:index:StaticPage", name, comp, opts...); err != nil {
+        return nil, err
+    }
+    // ... create children ...
+    comp.Endpoint = bucketWebsite.WebsiteEndpoint
+    return comp, ctx.RegisterResourceOutputs(comp, pulumi.Map{
+        "endpoint": comp.Endpoint,
+    })
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+class StaticPage : ComponentResource {
+    // The output a consumer actually needs: the live URL.
+    [Output("endpoint")]
+    public Output<string> Endpoint { get; set; }
+
+    public StaticPage(string name, StaticPageArgs args, ComponentResourceOptions? opts = null)
+        : base("sample-components:index:StaticPage", name, args, opts)
+    {
+        // ... create children ...
+        this.Endpoint = bucketWebsite.WebsiteEndpoint;
+        this.RegisterOutputs(new Dictionary<string, object?> {
+            ["endpoint"] = this.Endpoint,
+        });
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+class StaticPage extends ComponentResource {
+    // The output a consumer actually needs: the live URL.
+    @Export(name = "endpoint", refs = { String.class }, tree = "[0]")
+    public final Output<String> endpoint;
+
+    public StaticPage(String name, StaticPageArgs args, ComponentResourceOptions opts) {
+        super("sample-components:index:StaticPage", name, null, opts);
+        // ... create children ...
+        this.endpoint = bucketWebsite.websiteEndpoint();
+        this.registerOutputs(Map.of(
+            "endpoint", this.endpoint));
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## Keep the output contract stable and minimal
+
+Every output is a promise. Once a consumer references it, you cannot remove or retype it without a [breaking change](/docs/iac/guides/building-extending/design-guidelines/versioning-and-evolution/). The output surface should therefore be the meaningful one, not the exhaustive one.
+
+{{% guideline type="avoid" %}}
+**AVOID** dumping every property of every child resource as an output. A wide output surface locks your internal resource layout into the contract — you can no longer swap a child or change how it's wired without breaking someone — and it buries the few outputs that matter under dozens that don't.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** exposing a child resource itself (or its id or ARN) when consumers legitimately need to extend or reference it. This is the same escape hatch described in [Choosing the right abstraction](/docs/iac/guides/building-extending/design-guidelines/abstraction/): a deliberate, documented handle on one child is far better than a black box, and far better than reflexively exposing all of them. See [Composition and resource structure](/docs/iac/guides/building-extending/design-guidelines/composition/) for how children relate to the component.
+{{% /guideline %}}
+
+The discipline is the same on both sides of the contract. A small, well-chosen set of inputs and a small, well-chosen set of outputs are what let consumers adopt the component quickly and let you evolve it without breaking them.
+
+## See also
+
+- [Inputs and outputs](/docs/iac/concepts/inputs-outputs/) — the underlying concept
+- [Secrets](/docs/iac/concepts/secrets/) — marking and handling sensitive values
+- [Choosing the right abstraction](/docs/iac/guides/building-extending/design-guidelines/abstraction/) — required-input count and escape hatches
+- [Designing for multiple languages](/docs/iac/guides/building-extending/design-guidelines/designing-for-languages/) — validation and representable types

--- a/content/docs/iac/guides/building-extending/design-guidelines/naming.md
+++ b/content/docs/iac/guides/building-extending/design-guidelines/naming.md
@@ -1,0 +1,155 @@
+---
+title_tag: "Naming | Pulumi Design Guidelines"
+meta_desc: Naming guidelines for Pulumi components — type tokens, packages, properties, and child resources — designed for a great experience in every Pulumi language.
+title: Naming
+h1: Naming
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Naming
+        parent: iac-guides-design-guidelines
+        weight: 20
+---
+
+Names are the most visible part of a component and the most expensive to change. A consumer sees them in their editor's autocomplete, in `pulumi up` output, in state, and in the Registry. Once a component is published, its names are a contract: renaming anything is a [breaking change](/docs/iac/guides/building-extending/design-guidelines/versioning-and-evolution/). Good names are worth the time they take to get right.
+
+This is doubly true for [multi-language components](/docs/iac/concepts/components/), where a single name you choose is projected into every Pulumi language. A name that reads well in one language and awkwardly in another degrades the experience for everyone who isn't using your authoring language.
+
+## Type tokens
+
+Every component has a type token of the form `package:module:Name` — for example, `awsx:ec2:Vpc` or `sample-components:index:StaticPage`. This token is the component's public identity. It appears in state, in CLI output, and in the Registry.
+
+{{% guideline type="do" %}}
+**DO** name the component type with a PascalCase noun that describes the concept it models: `Vpc`, `StaticPage`, `KubernetesCluster`. The type name is a thing, not an action.
+{{% /guideline %}}
+
+{{% guideline type="do" %}}
+**DO** use a short, lowercase package name that identifies your library or platform — for example, `awsx` or your team's name. Use `index` as the module for top-level types, and introduce named modules only when a package is large enough that grouping helps.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** stutter in the token. `network:vpc:Vpc` repeats the same word three times. Prefer a distinct package, module, and type so the full token reads cleanly.
+{{% /guideline %}}
+
+## Properties: one name, every language
+
+You define a component's input and output property names once, in their canonical camelCase form. Pulumi projects each name into the idiomatic casing of every consuming language automatically — so a single, well-chosen name becomes natural everywhere.
+
+{{< chooser language "typescript,python,go,csharp,java" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+// Canonical name: numberOfAvailabilityZones → TypeScript camelCase.
+const vpc = new Vpc("app", {
+    numberOfAvailabilityZones: 3,
+});
+export const subnets = vpc.privateSubnetIds;
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+# Canonical name: numberOfAvailabilityZones → Python snake_case.
+vpc = Vpc("app", {
+    "number_of_availability_zones": 3,
+})
+pulumi.export("subnets", vpc.private_subnet_ids)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+// Canonical name: numberOfAvailabilityZones → Go PascalCase.
+vpc, _ := NewVpc(ctx, "app", &VpcArgs{
+    NumberOfAvailabilityZones: pulumi.Int(3),
+})
+ctx.Export("subnets", vpc.PrivateSubnetIds)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+// Canonical name: numberOfAvailabilityZones → C# PascalCase.
+var vpc = new Vpc("app", new VpcArgs {
+    NumberOfAvailabilityZones = 3,
+});
+this.Subnets = vpc.PrivateSubnetIds;
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+// Canonical name: numberOfAvailabilityZones → Java camelCase.
+var vpc = new Vpc("app", VpcArgs.builder()
+    .numberOfAvailabilityZones(3)
+    .build());
+ctx.export("subnets", vpc.privateSubnetIds());
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+Because the same name is reshaped per language, choose names that survive the trip:
+
+{{% guideline type="do" %}}
+**DO** spell names out. `numberOfAvailabilityZones` translates cleanly into every casing convention; `numAZs` becomes cryptic in all of them.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** names that collide with reserved words or built-ins in a target language — `class`, `type`, `object`, `lambda`, `import`. A name that is fine in your authoring language can force an awkward rename or escaping in another.
+{{% /guideline %}}
+
+{{% guideline type="do" %}}
+**DO** treat acronyms consistently. Pick one canonical form — `vpcId`, `apiKey`, `htmlContent` — and rely on the per-language projection to do the rest. Mixing `URL` and `Url` across properties reads as carelessness once projected.
+{{% /guideline %}}
+
+## Names that describe intent
+
+{{% guideline type="do" %}}
+**DO** name a property after what it means to the consumer, not after the underlying resource attribute it happens to map to. `domainName` is clearer than `route53RecordFqdn`.
+{{% /guideline %}}
+
+{{% guideline type="do" %}}
+**DO** phrase boolean inputs as positive assertions of the enabled state: `enableLogging`, `publiclyAccessible`. Negated names like `disableLogging` force the reader to untangle a double negative when they set them to `false`.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** matching the vocabulary of the domain you model. If a consumer thinks in terms of "availability zones" and "CIDR blocks," use those words. Familiar names make a component feel like a natural part of the platform.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** vague, overloaded names like `config`, `options`, `data`, or `settings` for a specific input. They tell the consumer nothing about what belongs there. See [Designing inputs and outputs](/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs/) for grouping related inputs well.
+{{% /guideline %}}
+
+## Naming child resources
+
+A component's children each need a name. Those names form the resources' [URNs](/docs/iac/concepts/resources/names/) and, with [auto-naming](/docs/iac/concepts/resources/names/#autonaming), often influence the physical names in the cloud.
+
+{{% guideline type="do" %}}
+**DO** derive child resource names from the component instance's name, typically by prefixing it: `` `${name}-bucket` ``, `` `${name}-policy` ``. This keeps children unique across multiple instances of the component and makes their origin obvious in state and CLI output.
+{{% /guideline %}}
+
+{{% guideline type="dont" %}}
+**DON'T** hard-code a fixed string as a child's name. Two instances of the component in the same stack would then collide. The component instance name is what disambiguates them.
+{{% /guideline %}}
+
+{{% guideline type="consider" %}}
+**CONSIDER** keeping child name suffixes stable over the life of the component. Changing a child's name suffix changes its URN, which Pulumi sees as a delete-and-replace. Use [`aliases`](/docs/iac/concepts/resources/options/aliases/) when you must rename one. See [Versioning and evolution](/docs/iac/guides/building-extending/design-guidelines/versioning-and-evolution/).
+{{% /guideline %}}
+
+## See also
+
+- [Resource names and auto-naming](/docs/iac/concepts/resources/names/)
+- [Designing inputs and outputs](/docs/iac/guides/building-extending/design-guidelines/inputs-and-outputs/)
+- [Designing for multiple languages](/docs/iac/guides/building-extending/design-guidelines/designing-for-languages/)
+- [Pulumi package schema](/docs/iac/guides/building-extending/packages/schema/)

--- a/content/docs/iac/guides/building-extending/design-guidelines/single-vs-multi-cloud.md
+++ b/content/docs/iac/guides/building-extending/design-guidelines/single-vs-multi-cloud.md
@@ -1,0 +1,185 @@
+---
+title_tag: "Single- vs. Multi-Cloud Abstractions | Pulumi Design Guidelines"
+meta_desc: When a cloud-agnostic Pulumi component earns its keep, and when it becomes a leaky lowest common denominator that hides what matters.
+title: Single- vs. Multi-Cloud Abstractions
+h1: Single- vs. Multi-Cloud Abstractions
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Single- vs. multi-cloud
+        parent: iac-guides-design-guidelines
+        weight: 50
+---
+
+A cloud-agnostic component is valuable only when the clouds underneath it differ in ways the consumer genuinely doesn't care about. When the value the consumer is paying for lives in cloud-specific features, hiding those features behind a portable interface throws away the reason they chose that cloud in the first place.
+
+## Decide whether portability is a real requirement
+
+The first question is not how to build a multi-cloud abstraction. It is whether you should build one at all.
+
+{{% guideline type="do" %}}
+**DO** ask whether portability is an actual requirement or an aesthetic preference. A cloud-agnostic interface is only worth its cost if something concrete depends on it.
+{{% /guideline %}}
+
+Most teams run on one primary cloud and will for the life of the component. A multi-cloud abstraction that never gets exercised on a second cloud is pure cost: more surface area to design, more concepts for the consumer to learn, and a wider gap between what the interface promises and what the platform actually does. Worse, the unused path is rarely even correct. An implementation for a second cloud that has never been deployed and tested there is a guess, not a feature — the first consumer who tries it inherits the bugs.
+
+"Portable" also has a real and limited meaning. Pulumi already gives you one kind of portability for free: the same program, written in the same language, deploys to any cloud, and a component is reusable across every stack. The question here is narrower — whether one component instance should be able to target more than one cloud provider behind a single interface.
+
+## The lowest-common-denominator trap
+
+The most common failure is an abstraction that exposes only what every target cloud has in common.
+
+{{% guideline type="avoid" %}}
+**AVOID** abstractions whose surface is the intersection of what every cloud supports. The intersection is small and bland, and it strips out the differentiated capabilities that justified picking a particular cloud.
+{{% /guideline %}}
+
+Object storage is a fair candidate for a portable concept. "A durable, addressable bucket of blobs" means nearly the same thing on Amazon S3, Azure Blob Storage, and Google Cloud Storage, and most consumers of a bucket want exactly that. A consumer who stores and retrieves objects rarely cares which of the three is underneath.
+
+A managed database or a serverless platform is usually a poor candidate. The reason a team chooses Amazon Aurora, Azure Cosmos DB, or Google Spanner is the specific behavior of that service — its consistency model, its scaling story, its query surface, its operational guarantees. An abstraction that flattens those into a generic `Database` keeps the part that is interchangeable (it stores rows) and discards the part the team actually paid for. The same is true of AWS Lambda versus Azure Functions versus Google Cloud Run: the triggers, execution model, and concurrency semantics differ in ways application code depends on. Hide them and you have an interface that compiles against three clouds and is genuinely useful on none.
+
+The test is to ask what the consumer would lose by going through your abstraction instead of the native resource. If the answer is "nothing they care about," portability is cheap. If the answer is "the features they chose this cloud for," the abstraction is taking away the value, not adding it.
+
+## When multi-cloud earns its keep
+
+Portability is worth building when two conditions hold at once: the concept is genuinely uniform across providers, and the organization has a real reason to span them.
+
+{{% guideline type="consider" %}}
+**CONSIDER** a cloud-agnostic component when the concept is genuinely uniform across providers — an object store, a DNS record, a container running somewhere — *and* a concrete portability requirement exists.
+{{% /guideline %}}
+
+Concepts that survive the trip are the ones where the clouds converged on the same model: object storage, DNS records, TLS certificates, a container image running behind an address. These are commodities, and the differences between providers are mostly billing and region names.
+
+The requirement side has to be every bit as real. Legitimate drivers include regulatory or sovereignty rules that mandate a specific cloud in a specific geography, an acquisition that left the company running two clouds it must support, a genuine multi-region strategy that spans providers, and — most commonly — selling software that customers deploy into *their own* cloud account, where you don't control which one. That last case is the strongest: the second cloud isn't hypothetical, it's a customer you already have.
+
+If neither condition holds, you are paying for portability you will never use. If only one holds — a uniform concept with no portability requirement, or a real requirement around a concept that isn't uniform — the abstraction is premature or doomed, respectively.
+
+## Designing a multi-cloud abstraction well
+
+Once you've decided to build one, the quality of the abstraction comes down to whether swapping clouds is actually real and whether the consumer can still get at cloud-specific power when they need it.
+
+{{% guideline type="do" %}}
+**DO** keep the public shape — inputs, outputs, and [naming](/docs/iac/guides/building-extending/design-guidelines/naming/) — identical across the cloud-specific implementations, so that switching providers is a one-line change and not a rewrite.
+{{% /guideline %}}
+
+If the AWS implementation calls an input `bucketName` and the Azure one calls it `containerName`, the abstraction isn't portable; it only looks portable until someone tries to switch. The shared shape is the contract, and it only means something if every implementation honors it identically.
+
+{{% guideline type="do" %}}
+**DO** provide a deliberate escape hatch to the underlying cloud-specific resource, for the consumer who needs a feature the portable interface doesn't expose.
+{{% /guideline %}}
+
+A multi-cloud abstraction will always lag the native services, and a consumer will eventually need something that lives below your interface. Exposing the underlying resource as an output lets them reach past the abstraction for that one feature without abandoning it. The general escape-hatch guidance — and the tension it creates with the altitude of the abstraction — is covered in [Choosing the right abstraction](/docs/iac/guides/building-extending/design-guidelines/abstraction/).
+
+Three structural patterns are common:
+
+1. One component that takes a cloud or provider selector and branches internally. Simplest for the consumer, but the component carries every cloud's logic and dependencies.
+1. Separate, identically shaped components per cloud — `AwsObjectStore`, `AzureObjectStore` — that the consumer picks between. More explicit; the shared shape lives in convention or a common interface.
+1. An interface or abstract base that per-cloud implementations satisfy, with the consumer programming against the interface. Cleanest for swapping, and the most work to set up.
+
+Whichever you choose, the consumer-facing experience should read the same. Here a consumer instantiates a cloud-agnostic `ObjectStore` and selects the backing cloud through one input:
+
+{{< chooser language "typescript,python,go,csharp,java" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+// One shape, one selector. The component picks the right cloud-specific
+// resources; the consumer's code is identical whichever cloud they target.
+const store = new ObjectStore("assets", {
+    cloud: "aws",
+    versioned: true,
+});
+export const url = store.url;
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+# One shape, one selector. The component picks the right cloud-specific
+# resources; the consumer's code is identical whichever cloud they target.
+store = ObjectStore("assets", {
+    "cloud": "aws",
+    "versioned": True,
+})
+pulumi.export("url", store.url)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+// One shape, one selector. The component picks the right cloud-specific
+// resources; the consumer's code is identical whichever cloud they target.
+store, err := NewObjectStore(ctx, "assets", &ObjectStoreArgs{
+    Cloud:     pulumi.String("aws"),
+    Versioned: pulumi.Bool(true),
+})
+ctx.Export("url", store.Url)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+// One shape, one selector. The component picks the right cloud-specific
+// resources; the consumer's code is identical whichever cloud they target.
+var store = new ObjectStore("assets", new ObjectStoreArgs {
+    Cloud = "aws",
+    Versioned = true,
+});
+this.Url = store.Url;
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+// One shape, one selector. The component picks the right cloud-specific
+// resources; the consumer's code is identical whichever cloud they target.
+var store = new ObjectStore("assets", ObjectStoreArgs.builder()
+    .cloud("aws")
+    .versioned(true)
+    .build());
+ctx.export("url", store.url());
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## Single-cloud, done deliberately
+
+A focused single-cloud component that fully exploits its platform is usually the better abstraction, and choosing it on purpose is not a compromise.
+
+The evidence points the same way across the industry. The most widely used infrastructure libraries are overwhelmingly single-provider, and Pulumi's own high-level libraries — AWSX, the EKS and Azure Native components — are each built for one cloud, precisely so they can use that cloud to its fullest.
+
+{{% guideline type="dont" %}}
+**DON'T** add multi-cloud indirection on speculation. It bakes the cost in now to hedge against a second cloud that may never arrive — and if it does arrive, the untested path probably won't work anyway.
+{{% /guideline %}}
+
+This is the same instinct as not [distilling an abstraction from a single example](/docs/iac/guides/building-extending/design-guidelines/abstraction/): an interface drawn from one real implementation and one imagined one tends to fit the real one and mislead about the rest. When a second cloud genuinely arrives, you can extract a portable interface from the working single-cloud component, informed by two real implementations instead of one and a guess.
+
+{{% guideline type="consider" %}}
+**CONSIDER** naming and structuring a single-cloud component so a portable layer could be lifted out later without a rewrite. A clean `bucketName` reads as well under a future `ObjectStore` as it does today; a leaky `s3BucketArn` in the public surface does not.
+{{% /guideline %}}
+
+## Don't pretend the clouds are the same
+
+The worst outcome is an abstraction that hides a real behavioral difference behind a name that implies sameness.
+
+{{% guideline type="dont" %}}
+**DON'T** paper over genuine semantic differences — consistency models, IAM and identity models, networking and VPC semantics — behind a uniform name that quietly lies about them.
+{{% /guideline %}}
+
+If `ObjectStore` is strongly consistent on one cloud and eventually consistent on another, a consumer who reads-after-write correctly on the first will write a subtle bug on the second, and the abstraction is what led them there. A leaky abstraction that conceals a difference the consumer must account for is worse than no abstraction at all, because it costs them the time to discover the lie on top of the time to handle the difference. When the semantics truly diverge, two honest cloud-specific components that each tell the truth about their platform serve the consumer better than one that flattens the distinction.
+
+## See also
+
+- [Choosing the right abstraction](/docs/iac/guides/building-extending/design-guidelines/abstraction/)
+- [Naming](/docs/iac/guides/building-extending/design-guidelines/naming/)
+- [Providers](/docs/iac/concepts/providers/)
+- [Components](/docs/iac/concepts/components/)

--- a/content/docs/iac/guides/building-extending/design-guidelines/versioning-and-evolution.md
+++ b/content/docs/iac/guides/building-extending/design-guidelines/versioning-and-evolution.md
@@ -1,0 +1,206 @@
+---
+title_tag: "Versioning and Evolution | Pulumi Design Guidelines"
+meta_desc: Evolve a Pulumi component without breaking consumers — semantic versioning, breaking changes, defaults as contract, deprecation, and aliases.
+title: Versioning and Evolution
+h1: Versioning and Evolution
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    iac:
+        name: Versioning and evolution
+        parent: iac-guides-design-guidelines
+        weight: 70
+---
+
+A component is never finished. You will add capabilities, fix bugs, and reshape its internals long after the first consumer adopts it — and every one of those changes lands in stacks you don't control. This chapter is about making a component evolve without forcing a flag day on everyone downstream: what a version number promises, which changes honor that promise and which break it, and the tools Pulumi gives you to refactor structure without churning live resources.
+
+## The package is the unit of versioning
+
+A component does not carry its own version. It ships inside a [package](/docs/iac/concepts/packages/), and the package's version is what consumers pin and upgrade. Bumping the package version versions every component in it at once, whether or not each one changed. That single fact drives how you group components: the version number is only meaningful if it tracks the evolution of the things it covers.
+
+{{% guideline type="do" %}}
+**DO** group components that evolve together into one package, so the version number actually describes what changed. Components that are used together and change together share a release cadence honestly.
+{{% /guideline %}}
+
+{{% guideline type="avoid" %}}
+**AVOID** bundling unrelated components in one package. An unrelated component's breaking change drags everything else to a new major version, even the components that didn't change. Consumers then can't read the version to tell whether the component they depend on actually moved.
+{{% /guideline %}}
+
+The decision of what belongs in a package is the same cohesion judgment that governs [composition](/docs/iac/guides/building-extending/design-guidelines/composition/). [Repository strategy for Pulumi packages](/docs/iac/guides/building-extending/packages/repository-strategy/) covers the mechanics — one package per repository, and what "cohesive" looks like in practice.
+
+## Use semantic versioning
+
+Consumers pin a version and decide when to move. Semantic versioning is the contract that lets them decide safely: the shape of the version bump tells them whether an upgrade is routine or requires work. Semver applied to versioned, pinnable units in a registry is the model module ecosystems have converged on, and Pulumi packages follow it.
+
+{{% guideline type="do" %}}
+**DO** follow semantic versioning. Increment the major version for a breaking change, the minor version for a backward-compatible addition, and the patch version for a fix that changes no contract.
+{{% /guideline %}}
+
+A consumer who sees a minor or patch bump should be able to upgrade without reading a migration guide. A major bump is your signal that they cannot. Breaking that correspondence — slipping a breaking change into a minor release — is worse than the breaking change itself, because it defeats the one mechanism consumers have for protecting themselves.
+
+## Know what's breaking
+
+Whether a change breaks consumers comes down to two questions: does it change the component's surface — its inputs, outputs, and type — or does it change the resources a consumer already has in state? Either one is breaking.
+
+Changes that break the surface:
+
+1. Removing or renaming an input or output property.
+1. Changing a property's type, including narrowing a union or tightening what values are accepted.
+1. Making an optional input required, which breaks every consumer who omitted it.
+
+Changes that break existing resources:
+
+1. Changing a child resource's name suffix or its parent. Both alter the child's [URN](/docs/iac/concepts/resources/names/#urns), which Pulumi treats as a delete-and-replace of a live resource.
+1. Changing a default in a way that alters the resources a consumer already deployed (see [Defaults are part of the contract](#defaults-are-part-of-the-contract)).
+
+{{% guideline type="dont" %}}
+**DON'T** rename or remove a public input, output, or type, change a property's type, or make an optional input required in anything but a major version. Each of these forces consumers to edit their programs before they can upgrade.
+{{% /guideline %}}
+
+By contrast, adding to the surface is safe. A new optional input with a sensible default leaves every existing program valid and every existing stack unchanged; a new output gives consumers something to reference without taking anything away.
+
+{{% guideline type="do" %}}
+**DO** prefer additive changes. A new optional input with a default and a new output are backward-compatible and ship in a minor version.
+{{% /guideline %}}
+
+Here is the additive case — a new `errorDocument` input that defaults to the existing behavior, so consumers who don't set it see no change:
+
+{{< chooser language "typescript,python,go,csharp,java" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+export interface StaticPageArgs {
+    indexContent: pulumi.Input<string>;
+    // Added in a minor release. Optional, with a default, so existing
+    // programs compile unchanged and existing stacks see no diff.
+    errorDocument?: pulumi.Input<string>;
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+class StaticPageArgs:
+    index_content: pulumi.Input[str]
+    # Added in a minor release. Optional, with a default, so existing
+    # programs run unchanged and existing stacks see no diff.
+    error_document: Optional[pulumi.Input[str]] = None
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+type StaticPageArgs struct {
+    IndexContent pulumi.StringInput `pulumi:"indexContent"`
+    // Added in a minor release. Optional, with a default, so existing
+    // programs compile unchanged and existing stacks see no diff.
+    ErrorDocument pulumi.StringPtrInput `pulumi:"errorDocument"`
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+public sealed class StaticPageArgs {
+    public Input<string> IndexContent { get; set; } = null!;
+
+    // Added in a minor release. Optional, with a default, so existing
+    // programs compile unchanged and existing stacks see no diff.
+    public Input<string>? ErrorDocument { get; set; }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+public final class StaticPageArgs {
+    private Output<String> indexContent;
+
+    // Added in a minor release. Optional, with a default, so existing
+    // programs compile unchanged and existing stacks see no diff.
+    private @Nullable Output<String> errorDocument;
+}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+## Defaults are part of the contract
+
+A default is not a private implementation detail. It is the value thousands of consumers are implicitly relying on, and it is baked into the resources sitting in their stacks. Change it and the new value re-runs for everyone on upgrade.
+
+{{% guideline type="dont" %}}
+**DON'T** change a default value casually. A consumer who never set the input gets the new value on the next `pulumi up`, which can show up as an unexpected diff — or, if the property forces replacement, as a destroyed and recreated resource in production.
+{{% /guideline %}}
+
+The safe path is to make the new behavior reachable without changing what existing consumers get. Add a new optional input that defaults to the old behavior; consumers opt in when they're ready. Flip the default to the new behavior only in a major version, where consumers expect to do migration work.
+
+{{% guideline type="consider" %}}
+**CONSIDER** introducing new behavior behind a new optional input that defaults to the existing behavior, and changing the default only at a major version boundary. This turns a breaking change into an opt-in for everyone who wants it and a no-op for everyone who doesn't.
+{{% /guideline %}}
+
+## Deprecate before removing
+
+When a public input, output, or whole component outlives its usefulness, retire it in two steps rather than one. Mark it deprecated and point to the replacement while keeping it working, then remove it only at the next major version. Consumers get a release where the old surface still functions and the warning tells them what to do.
+
+{{% guideline type="do" %}}
+**DO** deprecate a public input, output, or component before removing it: keep it working, mark it deprecated, and document the replacement. Remove it only in a major version.
+{{% /guideline %}}
+
+{{% guideline type="dont" %}}
+**DON'T** delete a public surface without a deprecation period. A consumer's first encounter with the change should be a warning on a working program, not a compile error or a failed deployment.
+{{% /guideline %}}
+
+The [package schema](/docs/iac/guides/building-extending/packages/schema/) carries a `deprecationMessage` on resources, functions, and individual properties. Setting it surfaces the deprecation in the generated SDKs and docs for every language, so consumers see the warning and the suggested replacement in their own editor.
+
+## Use aliases to refactor safely
+
+Renaming a component or restructuring its children changes URNs, and Pulumi reads a changed URN as a different resource — delete the old, create the new. For a live database or a stateful volume, that is exactly the outcome you must avoid. [Aliases](/docs/iac/concepts/resources/options/aliases/) are the tool that lets the identity survive the refactor.
+
+{{% guideline type="do" %}}
+**DO** add an alias when you rename a component or move a child to a new name or parent, so Pulumi maps the old URN to the new one and updates the resource in place instead of replacing it.
+{{% /guideline %}}
+
+Aliases are inherited through the parent/child tree: aliasing a renamed component automatically re-maps its children, including the name prefix they derive from the component's name. Adding `aliases: [{ name: "${name}-storage" }]` to a child you renamed from `${name}-storage` to `${name}-bucket`, for instance, lets the existing bucket keep its identity through the rename.
+
+{{% guideline type="consider" %}}
+**CONSIDER** the alias temporary. Once every stack has rolled forward to the new identity, remove the alias from the component so the declaration stays clean.
+{{% /guideline %}}
+
+The structural mechanics of parent/child relationships and child naming live in [composition](/docs/iac/guides/building-extending/design-guidelines/composition/) and [naming](/docs/iac/guides/building-extending/design-guidelines/naming/). This chapter is about when to reach for an alias instead of accepting a replacement.
+
+## Communicate changes
+
+Consumers can't act on a change they don't know about. The version number tells them a breaking change exists; release notes tell them what it is and what to do.
+
+{{% guideline type="do" %}}
+**DO** ship release notes for every version and a migration note for every breaking change. State what changed, why, and the exact steps to upgrade — including any aliases consumers must add to their own programs.
+{{% /guideline %}}
+
+For [published packages](/docs/iac/guides/building-extending/packages/publishing-packages/), lean on the generated reference docs. Pulumi produces per-language documentation from the [package schema](/docs/iac/guides/building-extending/packages/schema/), so every consumer sees current inputs, outputs, and deprecation messages in their own language without you maintaining five copies by hand.
+
+## Tighten the contract with policy
+
+A component's contract often tightens over time — a value that used to be acceptable becomes one you want to forbid. Encoding every such rule as a required input or a narrower type is a breaking change, and a blunt one. Policy lets you enforce the constraint without changing the component's surface.
+
+{{% guideline type="consider" %}}
+**CONSIDER** validating inputs and usage with policy as the contract tightens, rather than making inputs required or narrowing types in a breaking way. Policy can enforce new constraints across consumers without forcing a major version on the component itself.
+{{% /guideline %}}
+
+See [Validating component inputs using policy functions](/docs/idp/guides/best-practices/patterns/validating-component-inputs-using-policy-functions/) for sharing one validation routine between a policy pack and the component constructor.
+
+## See also
+
+- [Repository strategy for Pulumi packages](/docs/iac/guides/building-extending/packages/repository-strategy/) — what belongs in a package, the unit of versioning
+- [Resource option: aliases](/docs/iac/concepts/resources/options/aliases/) — preserving identity across renames and restructures
+- [Composition and resource structure](/docs/iac/guides/building-extending/design-guidelines/composition/) — parent/child structure and child naming
+- [Pulumi package schema](/docs/iac/guides/building-extending/packages/schema/) — deprecation messages and generated docs

--- a/content/docs/iac/guides/building-extending/packages/_index.md
+++ b/content/docs/iac/guides/building-extending/packages/_index.md
@@ -9,7 +9,7 @@ menu:
     name: Packages
     identifier: iac-guides-packages
     parent: iac-guides-building-extending
-    weight: 2
+    weight: 3
 ---
 
 A [Pulumi package](/docs/iac/concepts/packages/) bundles components or a provider with a plugin so Pulumi can generate an SDK for any supported language. Package authors choose between two distribution models — source-based and executable-based — which differ in consumer runtime requirements, registry support, and publishing overhead.

--- a/layouts/shortcodes/guideline.html
+++ b/layouts/shortcodes/guideline.html
@@ -1,0 +1,29 @@
+{{- /*
+guideline.html — DO / CONSIDER / AVOID / DON'T recommendation callout, in the
+style of the .NET Framework Design Guidelines. Reuses the .note container for
+layout and adds a color-coded variant and a per-type icon. The recommendation
+text itself leads with the bold DO/CONSIDER/AVOID/DON'T word.
+
+Usage (percent form, so inner content is markdownified):
+    {{% guideline type="do" %}}**DO** ...{{% /guideline %}}
+    type = do | consider | avoid | dont
+*/ -}}
+{{- $type := default "do" (.Get "type") -}}
+{{- $icon := "check-circle" -}}
+{{- if eq $type "consider" -}}
+    {{- $icon = "lightbulb" -}}
+{{- else if eq $type "avoid" -}}
+    {{- $icon = "warning" -}}
+{{- else if eq $type "dont" -}}
+    {{- $icon = "prohibit" -}}
+{{- end -}}
+
+<div class="note guideline guideline-{{ $type }}">
+    <div class="icon-and-line">
+        {{ partial "icon.html" (dict "name" $icon "weight" "fill") }}
+        <div class="line"></div>
+    </div>
+    <div class="content">
+        {{- .Inner | markdownify -}}
+    </div>
+</div>

--- a/theme/src/scss/_notes.scss
+++ b/theme/src/scss/_notes.scss
@@ -125,6 +125,97 @@
         }
     }
 
+    // Design-guidelines callouts (the `guideline` shortcode). DO / CONSIDER /
+    // AVOID / DON'T reuse the .note container, varying only color, icon, and the
+    // colored lead word that the recommendation text starts with.
+    &.guideline-do {
+        background: var(--color-green-background);
+
+        a,
+        i,
+        svg.ph-icon {
+            color: var(--color-green-primary);
+        }
+
+        div.line {
+            background-color: var(--color-green-muted);
+        }
+
+        code {
+            background-color: var(--color-green-muted);
+        }
+
+        div.content > p:first-child > strong:first-child {
+            color: var(--color-green-primary);
+        }
+    }
+
+    &.guideline-consider {
+        background: var(--color-violet-background);
+
+        a,
+        i,
+        svg.ph-icon {
+            color: var(--color-violet-primary);
+        }
+
+        div.line {
+            background-color: var(--color-violet-muted);
+        }
+
+        code {
+            background-color: var(--color-violet-muted);
+        }
+
+        div.content > p:first-child > strong:first-child {
+            color: var(--color-violet-primary);
+        }
+    }
+
+    &.guideline-avoid {
+        background: var(--color-orange-background);
+
+        a,
+        i,
+        svg.ph-icon {
+            color: var(--color-orange-primary);
+        }
+
+        div.line {
+            background-color: var(--color-orange-muted);
+        }
+
+        code {
+            background: var(--color-orange-muted);
+        }
+
+        div.content > p:first-child > strong:first-child {
+            color: var(--color-orange-primary);
+        }
+    }
+
+    &.guideline-dont {
+        background: var(--color-red-background);
+
+        a,
+        i,
+        svg.ph-icon {
+            color: var(--color-red-primary);
+        }
+
+        div.line {
+            background-color: var(--color-red-muted);
+        }
+
+        code {
+            background-color: var(--color-red-muted);
+        }
+
+        div.content > p:first-child > strong:first-child {
+            color: var(--color-red-primary);
+        }
+    }
+
     div.highlight div.copy-button-container button.copy-button i,
     div.highlight div.copy-button-container button.copy-button svg {
         color: #fff;


### PR DESCRIPTION
## What this adds

A new multi-page **Pulumi Design Guidelines** guide under **Building & Extending**, covering how to *design* components and packages well — as distinct from the *mechanics* of building them, which the existing component and packaging guides already cover. It is prescriptive rather than reference, organized around scannable **DO / CONSIDER / AVOID / DON'T** recommendations (a convention borrowed from the .NET Framework Design Guidelines).

Eight pages:

1. **Introduction** (`_index.md`) — philosophy, audience, how to read the conventions
1. **Choosing the right abstraction** — the Goldilocks altitude; when *not* to build a component
1. **Naming** — type tokens and properties projected across languages; child naming
1. **Designing inputs and outputs** — args shape, secure defaults, `Input<T>`, secrets, stable contracts
1. **Composition and resource structure** — `parent`, option propagation, components-of-components
1. **Single- vs. multi-cloud abstractions** — when portability earns its keep vs. lowest-common-denominator
1. **Designing for multiple languages** — the serialization boundary, representable types, enums, schema-driven docs
1. **Versioning and evolution** — semver, breaking changes, defaults-as-contract, deprecation, aliases

The guidance is grounded in how Pulumi's own component libraries are designed (AWSX's high-level VPC inputs and sensible defaults; EKS's exposed `kubeconfig` and escape hatches).

## Implementation notes

- **New `guideline` shortcode** (`layouts/shortcodes/guideline.html`) renders the four color-coded callouts. It reuses the existing `.note` container and adds per-type color + icon (`check-circle` / `lightbulb` / `warning` / `prohibit`); the recommendation text supplies the bold lead word, which the styles then color.
- **Styles live in the SCSS source** (`theme/src/scss/_notes.scss`), since the committed `assets/css/bundle.css` is a generated artifact. The red semantic color trio already existed in `_theme.scss`. Reviewers running `make serve`/`make build` will get the recompiled bundle automatically.
- **Nav**: Design Guidelines sits immediately after Components (the natural next step once you can build one); surrounding section weights shift by one.

## Verification

- `make lint` — 0 markdown errors, prettier clean
- `make lint-prose` (Vale) — 0 errors; only nag-level `write-good` warnings remain
- Hugo build — exit 0, no template errors; all 8 pages render; callouts produce correct classes/icons; choosers render; nav links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)