### PR TITLE
Fix and upgrade ESC rotator provider pages (#19691)

### DIFF
--- a/content/docs/esc/providers/rotators/aws-iam.md
+++ b/content/docs/esc/providers/rotators/aws-iam.md
@@ -64,6 +64,24 @@ values:
             fn::secret: <secret key>
 ```
 
+### Alternative: static credentials
+
+Instead of an OIDC login, you can supply static AWS credentials directly to the rotator's `login`. The managing credentials must have permission to rotate the target user's access keys:
+
+```yaml
+# my-org/rotators/key-rotator
+values:
+  iam:
+    fn::rotate::aws-iam:
+      inputs:
+        region: us-west-2
+        login:
+          accessKeyId: <access key>
+          secretAccessKey:
+            fn::secret: <secret key>
+        userArn: arn:aws:iam::<account id>:user/<username>
+```
+
 ## Configuring OIDC
 
 To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and AWS, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/aws/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
@@ -157,3 +175,20 @@ The minimum permissions required for the rotation role are:
 | `accessKeyId`     | string | The AWS access key ID                          |
 | `secretAccessKey` | string | The AWS secret access key, stored as a secret. |
 | `createdAt`       | string | Creation timestamp (in RFC3339 format)         |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Rotation fails with an access-denied error | The login identity lacks the IAM permissions required to manage the user's access keys. | Grant the rotation role the [minimum permissions](#permissions) for the target `userArn`, then rotate again. |
+| Rotation fails with a limit error when creating an access key | The IAM user already has the maximum of two access keys, none managed by ESC. | Delete an unused access key on the IAM user so the rotator can create a new one, or seed the existing keys via the `state` input. |
+| OIDC login fails when opening the environment | The trust policy or audience on the rotation role is misconfigured. | Verify the OIDC trust relationship per [Configuring OIDC for AWS](/docs/esc/guides/configuring-oidc/aws/). |
+
+<!-- TODO(SME): verify exact IAM error strings (e.g. LimitExceeded, AccessDenied) for the aws-iam rotator. -->
+
+## Related
+
+* [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
+* [aws-login](/docs/esc/providers/login/aws-login/) - Authenticate with AWS via OIDC or static credentials
+* [Configuring OIDC for AWS](/docs/esc/guides/configuring-oidc/aws/) - Set up OIDC between Pulumi Cloud and AWS
+* [Rotators reference](/docs/esc/providers/rotators/) - Catalog of all ESC rotators

--- a/content/docs/esc/providers/rotators/aws-iam.md
+++ b/content/docs/esc/providers/rotators/aws-iam.md
@@ -180,11 +180,9 @@ The minimum permissions required for the rotation role are:
 
 | Symptom | Likely cause | Resolution |
 |---------|--------------|------------|
-| Rotation fails with an access-denied error | The login identity lacks the IAM permissions required to manage the user's access keys. | Grant the rotation role the [minimum permissions](#permissions) for the target `userArn`, then rotate again. |
-| Rotation fails with a limit error when creating an access key | The IAM user already has the maximum of two access keys, none managed by ESC. | Delete an unused access key on the IAM user so the rotator can create a new one, or seed the existing keys via the `state` input. |
-| OIDC login fails when opening the environment | The trust policy or audience on the rotation role is misconfigured. | Verify the OIDC trust relationship per [Configuring OIDC for AWS](/docs/esc/guides/configuring-oidc/aws/). |
-
-<!-- TODO(SME): verify exact IAM error strings (e.g. LimitExceeded, AccessDenied) for the aws-iam rotator. -->
+| Rotation fails with a permissions error | The login identity may lack the IAM permissions required to manage the user's access keys. | Grant the rotation role the [minimum permissions](#permissions) for the target `userArn`, then rotate again. |
+| Rotation fails when creating a new access key | The IAM user may already have the maximum number of access keys AWS allows, none managed by ESC. | Delete an unused access key on the IAM user so the rotator can create a new one, or seed the existing keys via the `state` input. |
+| OIDC login fails when opening the environment | The trust policy or audience on the rotation role may be misconfigured. | Verify the OIDC trust relationship per [Configuring OIDC for AWS](/docs/esc/guides/configuring-oidc/aws/). |
 
 ## Related
 

--- a/content/docs/esc/providers/rotators/azure-app-secret.md
+++ b/content/docs/esc/providers/rotators/azure-app-secret.md
@@ -57,6 +57,26 @@ values:
             fn::secret: <secret-value>
 ```
 
+### Alternative: static credentials
+
+Instead of an OIDC login, you can authenticate with a client secret by supplying `clientSecret` to the rotator's `login`:
+
+```yaml
+# my-org/rotators/secret-rotator
+values:
+  appSecret:
+    fn::rotate::azure-app-secret:
+      inputs:
+        login:
+          clientId: <your-client-id>
+          tenantId: <your-tenant-id>
+          subscriptionId: <your-subscription-id>
+          clientSecret:
+            fn::secret: <your-client-secret>
+        clientId: <target-app-client-id>
+        lifetimeInDays: 180
+```
+
 ## Configuring OIDC
 
 To learn how to configure OpenID Connect (OIDC) between Pulumi Cloud and Azure, see the [OpenID Connect integration](/docs/esc/guides/configuring-oidc/azure/) documentation. Once you have completed these steps, you can validate that your configuration is working by running either of the following:
@@ -145,3 +165,20 @@ Owner access alone suffices only for **delegated** logins (a user identity). An 
 | `secretValue` | string | The client secret value, stored as a secret.                   |
 | `createdAt`   | string | [Optional] - The creation timestamp of the secret (RFC3339).   |
 | `expiresAt`   | string | [Optional] - The expiration timestamp of the secret (RFC3339). |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Rotation fails with an authorization or insufficient-privileges error | The login identity lacks `Application.ReadWrite.All` (or `Application.ReadWrite.OwnedBy`) or is not an Owner of the target app registration. | Grant the required [Microsoft Graph permissions](#permissions) with admin consent, or add the identity as an Owner of the target app. |
+| Rotation fails for an application-only (OIDC) login that owns the app | Owner access alone is insufficient for application-only tokens. | Also grant `Application.ReadWrite.OwnedBy` with admin consent, as described in the [permissions](#permissions) note. |
+| New secrets expire sooner than expected | `lifetimeInDays` is unset or shorter than intended. | Set `lifetimeInDays` to the desired validity (default 180, maximum 730). |
+
+<!-- TODO(SME): verify exact Microsoft Graph error strings for the azure-app-secret rotator. -->
+
+## Related
+
+* [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
+* [azure-login](/docs/esc/providers/login/azure-login/) - Authenticate with Azure via OIDC or a client secret
+* [Configuring OIDC for Azure](/docs/esc/guides/configuring-oidc/azure/) - Set up OIDC between Pulumi Cloud and Azure
+* [Rotators reference](/docs/esc/providers/rotators/) - Catalog of all ESC rotators

--- a/content/docs/esc/providers/rotators/azure-app-secret.md
+++ b/content/docs/esc/providers/rotators/azure-app-secret.md
@@ -170,11 +170,9 @@ Owner access alone suffices only for **delegated** logins (a user identity). An 
 
 | Symptom | Likely cause | Resolution |
 |---------|--------------|------------|
-| Rotation fails with an authorization or insufficient-privileges error | The login identity lacks `Application.ReadWrite.All` (or `Application.ReadWrite.OwnedBy`) or is not an Owner of the target app registration. | Grant the required [Microsoft Graph permissions](#permissions) with admin consent, or add the identity as an Owner of the target app. |
-| Rotation fails for an application-only (OIDC) login that owns the app | Owner access alone is insufficient for application-only tokens. | Also grant `Application.ReadWrite.OwnedBy` with admin consent, as described in the [permissions](#permissions) note. |
+| Rotation fails with a permissions error | The login identity may lack `Application.ReadWrite.All` (or `Application.ReadWrite.OwnedBy`), or may not be an Owner of the target app registration. | Grant the required [Microsoft Graph permissions](#permissions) with admin consent, or add the identity as an Owner of the target app. |
+| Rotation fails for an application-only (OIDC) login that owns the app | For application-only tokens, Owner access alone may not be sufficient. | Also grant `Application.ReadWrite.OwnedBy` with admin consent, as described in the [permissions](#permissions) note. |
 | New secrets expire sooner than expected | `lifetimeInDays` is unset or shorter than intended. | Set `lifetimeInDays` to the desired validity (default 180, maximum 730). |
-
-<!-- TODO(SME): verify exact Microsoft Graph error strings for the azure-app-secret rotator. -->
 
 ## Related
 

--- a/content/docs/esc/providers/rotators/external.md
+++ b/content/docs/esc/providers/rotators/external.md
@@ -1,7 +1,7 @@
 ---
 title: external
 title_tag: external Pulumi ESC Rotator
-meta_desc: The `external` rotator enables you to rotate credentials using a custom adapter service. 
+meta_desc: The `external` rotator enables you to rotate credentials using a custom adapter service.
 h1: external
 menu:
   esc:
@@ -236,7 +236,7 @@ import jwt
 from jwt import PyJWKClient
 
 # Configuration
-JWKS_URL = "https://api.pulumi.com/.well-known/jwks.json"
+JWKS_URL = "https://api.pulumi.com/oidc/.well-known/jwks"
 ADAPTER_URL = "https://my-adapter.example.com/rotate-credentials"
 PORT = 8443
 
@@ -406,3 +406,19 @@ If no state is provided, the rotator passes `"state": null` on the first rotatio
 | Property  | Type   | Description                                           |
 |-----------|--------|-------------------------------------------------------|
 | `current` | object | The JSON response from your adapter, marked as secret |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Rotation fails with a 401 from your adapter | The JWT token failed verification, or your adapter rejected the `Authorization` header. | Verify your adapter fetches keys from `https://api.pulumi.com/oidc/.well-known/jwks` and validates the `audience` against your adapter's URL. See [JWT Authentication](/docs/esc/providers/secrets/external/#jwt-authentication). |
+| Rotation fails with a body-hash mismatch | Your adapter modified or re-encoded the request body before hashing it. | Compute the SHA-256 hash over the raw request bytes and compare against the `body_hash` claim without altering the body. |
+| Applications fail after a rotation | The adapter rotated the in-use credential instead of an inactive one. | Implement the [dual-secret strategy](#recommended-dual-secret-strategy) so applications always read `current` while the inactive credential is rotated. |
+
+<!-- TODO(SME): verify exact JWT/body-hash error responses surfaced by the external rotator. -->
+
+## Related
+
+- [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
+- [external secrets provider](/docs/esc/providers/secrets/external/) - Import secrets from a custom adapter service
+- [Rotators reference](/docs/esc/providers/rotators/) - Catalog of all ESC rotators

--- a/content/docs/esc/providers/rotators/external.md
+++ b/content/docs/esc/providers/rotators/external.md
@@ -411,11 +411,9 @@ If no state is provided, the rotator passes `"state": null` on the first rotatio
 
 | Symptom | Likely cause | Resolution |
 |---------|--------------|------------|
-| Rotation fails with a 401 from your adapter | The JWT token failed verification, or your adapter rejected the `Authorization` header. | Verify your adapter fetches keys from `https://api.pulumi.com/oidc/.well-known/jwks` and validates the `audience` against your adapter's URL. See [JWT Authentication](/docs/esc/providers/secrets/external/#jwt-authentication). |
-| Rotation fails with a body-hash mismatch | Your adapter modified or re-encoded the request body before hashing it. | Compute the SHA-256 hash over the raw request bytes and compare against the `body_hash` claim without altering the body. |
-| Applications fail after a rotation | The adapter rotated the in-use credential instead of an inactive one. | Implement the [dual-secret strategy](#recommended-dual-secret-strategy) so applications always read `current` while the inactive credential is rotated. |
-
-<!-- TODO(SME): verify exact JWT/body-hash error responses surfaced by the external rotator. -->
+| Your adapter rejects the request as unauthorized | The JWT token may have failed verification, or your adapter may have rejected the `Authorization` header. | Verify your adapter fetches keys from `https://api.pulumi.com/oidc/.well-known/jwks` and validates the `audience` against your adapter's URL. See [JWT Authentication](/docs/esc/providers/secrets/external/#jwt-authentication). |
+| Your adapter reports a body-hash mismatch | Your adapter may have modified or re-encoded the request body before hashing it. | Compute the SHA-256 hash over the raw request bytes and compare against the `body_hash` claim without altering the body. |
+| Applications fail after a rotation | The adapter may have rotated the in-use credential instead of an inactive one. | Implement the [dual-secret strategy](#recommended-dual-secret-strategy) so applications always read `current` while the inactive credential is rotated. |
 
 ## Related
 

--- a/content/docs/esc/providers/rotators/mysql.md
+++ b/content/docs/esc/providers/rotators/mysql.md
@@ -173,10 +173,8 @@ When you open the environment after a rotation, you should see output similar to
 | Symptom | Likely cause | Resolution |
 |---------|--------------|------------|
 | Rotation fails to connect to the database | The `host` or `port` is wrong, or the database is in a private network without a connector. | Verify `host` and `port`. For databases in a private network, configure a [rotation connector](/docs/esc/operations/rotation/aws-lambda) and set `database.connector`. |
-| Rotation fails with a permission or authentication error | The `managingUser` lacks privileges to change the rotated users' passwords. | Grant the managing user the privileges described in [database user setup](/docs/esc/operations/rotation/db-user-setup), then rotate again. |
-| Applications fail to authenticate after a rotation | Apps are reading the `previous` credentials, or rotation runs more frequently than apps refresh their configuration. | Configure applications to read `current`, and ensure the rotation schedule is less frequent than the application configuration refresh interval. |
-
-<!-- TODO(SME): verify exact error strings and the minimum MySQL privileges required for the managing user. -->
+| Rotation fails with a permissions or authentication error | The `managingUser` may lack the privileges needed to change the rotated users' passwords. | Grant the managing user the privileges described in [database user setup](/docs/esc/operations/rotation/db-user-setup), then rotate again. |
+| Applications fail to authenticate after a rotation | Apps may be reading the `previous` credentials, or rotation may run more frequently than apps refresh their configuration. | Configure applications to read `current`, and ensure the rotation schedule is less frequent than the application configuration refresh interval. |
 
 ## Related
 

--- a/content/docs/esc/providers/rotators/mysql.md
+++ b/content/docs/esc/providers/rotators/mysql.md
@@ -93,7 +93,22 @@ state:
     username: user2
 ```
 
-## Setup
+When you open the environment after a rotation, you should see output similar to the following:
+
+```json
+{
+  "dbRotator": {
+    "current": {
+      "username": "user1",
+      "password": "[secret]"
+    },
+    "previous": {
+      "username": "user2",
+      "password": "[secret]"
+    }
+  }
+}
+```
 
 ## Inputs
 
@@ -152,3 +167,21 @@ state:
 |------------|--------|-----------------------------------|
 | `username` | string | Username of user in the database. |
 | `password` | string | Password of user in the database. |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Rotation fails to connect to the database | The `host` or `port` is wrong, or the database is in a private network without a connector. | Verify `host` and `port`. For databases in a private network, configure a [rotation connector](/docs/esc/operations/rotation/aws-lambda) and set `database.connector`. |
+| Rotation fails with a permission or authentication error | The `managingUser` lacks privileges to change the rotated users' passwords. | Grant the managing user the privileges described in [database user setup](/docs/esc/operations/rotation/db-user-setup), then rotate again. |
+| Applications fail to authenticate after a rotation | Apps are reading the `previous` credentials, or rotation runs more frequently than apps refresh their configuration. | Configure applications to read `current`, and ensure the rotation schedule is less frequent than the application configuration refresh interval. |
+
+<!-- TODO(SME): verify exact error strings and the minimum MySQL privileges required for the managing user. -->
+
+## Related
+
+- [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
+- [Rotation connectors](/docs/esc/operations/rotation/) - Reach databases in a private network
+- [Database user setup](/docs/esc/operations/rotation/db-user-setup) - Prepare database users for rotation
+- [postgres rotator](/docs/esc/providers/rotators/postgres/) - Rotate credentials for a PostgreSQL database
+- [aws-login](/docs/esc/providers/login/aws-login/) - Authenticate with AWS for connector-based rotation

--- a/content/docs/esc/providers/rotators/passphrase.md
+++ b/content/docs/esc/providers/rotators/passphrase.md
@@ -1,7 +1,7 @@
 ---
 title: passphrase
 title_tag: passphrase Pulumi ESC Rotator
-meta_desc: The `passphrase` rotator enables you to rotate any user defined key by generating memorable passphrases.
+meta_desc: The `passphrase` rotator enables you to rotate any user-defined key by generating memorable passphrases.
 h1: passphrase
 menu:
   esc:
@@ -13,7 +13,7 @@ aliases:
   - /docs/esc/concepts/providers/rotators/passphrase/
 ---
 
-The `passphrase` rotator enables you to any user defined key in your ESC environment generating memorable passphrases.
+The `passphrase` rotator enables you to rotate any user-defined key in your ESC environment by generating memorable passphrases.
 
 {{% notes "info" %}}
 If you want to generate _random passwords_ use the [password rotator](/docs/esc/providers/rotators/password/)
@@ -21,22 +21,66 @@ If you want to generate _random passwords_ use the [password rotator](/docs/esc/
 
 ## Inputs
 
-- **separator**: Specifies a single character to be used as word separator. (default: `-`)
-- **capitalize**: if `true` will capitalize each generated word. (default: `false`)
-- **length**: The number of words that the generated passphrase will contain. (default: `5`)
+| Property     | Type    | Description                                                                |
+|--------------|---------|---------------------------------------------------------------------------|
+| `separator`  | string  | A single character used as the word separator. (default: `-`)             |
+| `capitalize` | boolean | If `true`, each generated word is capitalized. (default: `false`)         |
+| `length`     | int     | The number of words the generated passphrase will contain. (default: `5`) |
 
 ## Example
 
-The `passphrase` rotator can be configured for any random user defined key.
+The `passphrase` rotator can be configured for any user-defined key.
 
 ```yaml
 values:
-   fn::rotate::passphrase:
+  mypassphrase:
+    fn::rotate::passphrase:
       inputs:
         separator: "%"
         capitalize: true
         length: 4
-
 ```
 
 This configuration will generate passphrases like `Mouth%Purebred%Headstone%Plausibly`.
+
+When you open the environment, you should see output similar to the following:
+
+```json
+{
+  "mypassphrase": {
+    "current": "[secret]",
+    "previous": "[secret]"
+  }
+}
+```
+
+<!-- TODO(SME): verify the passphrase rotator output schema — confirm the current/previous shape and whether the generated value is nested under a property. -->
+
+## State (Optional)
+
+| Property   | Type   | Description                                                                                    |
+|------------|--------|------------------------------------------------------------------------------------------------|
+| `current`  | string | Current generated passphrase. This is the newest and recommended value.                        |
+| `previous` | string | Previous generated passphrase. This value is still valid, but will be phased out next rotation. |
+
+## Outputs
+
+| Property   | Type   | Description                                                                                    |
+|------------|--------|------------------------------------------------------------------------------------------------|
+| `current`  | string | Current generated passphrase, stored as a secret.                                              |
+| `previous` | string | Previous generated passphrase, stored as a secret.                                             |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Rotation fails with an invalid input error | `length` is set below the minimum or `separator` is more than a single character. | Set `length` to a positive integer and `separator` to a single character, then rotate again. |
+| The generated passphrase is shorter or longer than expected | `length` counts words, not characters. | Adjust `length` to the desired number of words; the character count varies with the words chosen. |
+
+<!-- TODO(SME): verify exact validation error strings and input bounds for the passphrase rotator. -->
+
+## Related
+
+- [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
+- [password rotator](/docs/esc/providers/rotators/password/) - Generate random passwords instead of memorable passphrases
+- [Rotators reference](/docs/esc/providers/rotators/) - Catalog of all ESC rotators

--- a/content/docs/esc/providers/rotators/passphrase.md
+++ b/content/docs/esc/providers/rotators/passphrase.md
@@ -23,9 +23,9 @@ If you want to generate _random passwords_ use the [password rotator](/docs/esc/
 
 | Property     | Type    | Description                                                                |
 |--------------|---------|---------------------------------------------------------------------------|
-| `separator`  | string  | A single character used as the word separator. (default: `-`)             |
-| `capitalize` | boolean | If `true`, each generated word is capitalized. (default: `false`)         |
-| `length`     | int     | The number of words the generated passphrase will contain. (default: `5`) |
+| `separator`  | string  | A single character used as the word separator. (default: `-`)                  |
+| `capitalize` | boolean | Whether to capitalize each generated word. (default: `false`)                  |
+| `length`     | int     | The number of words in the generated passphrase (3–15). (default: `5`)         |
 
 ## Example
 
@@ -54,30 +54,26 @@ When you open the environment, you should see output similar to the following:
 }
 ```
 
-<!-- TODO(SME): verify the passphrase rotator output schema — confirm the current/previous shape and whether the generated value is nested under a property. -->
-
 ## State (Optional)
 
-| Property   | Type   | Description                                                                                    |
-|------------|--------|------------------------------------------------------------------------------------------------|
-| `current`  | string | Current generated passphrase. This is the newest and recommended value.                        |
-| `previous` | string | Previous generated passphrase. This value is still valid, but will be phased out next rotation. |
+| Property   | Type   | Description                              |
+|------------|--------|------------------------------------------|
+| `current`  | string | The most recently generated passphrase.  |
+| `previous` | string | The prior generated passphrase.          |
 
 ## Outputs
 
-| Property   | Type   | Description                                                                                    |
-|------------|--------|------------------------------------------------------------------------------------------------|
-| `current`  | string | Current generated passphrase, stored as a secret.                                              |
-| `previous` | string | Previous generated passphrase, stored as a secret.                                             |
+| Property   | Type   | Description                                              |
+|------------|--------|----------------------------------------------------------|
+| `current`  | string | The most recently generated passphrase, stored as a secret. |
+| `previous` | string | The prior generated passphrase, stored as a secret.      |
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Resolution |
 |---------|--------------|------------|
-| Rotation fails with an invalid input error | `length` is set below the minimum or `separator` is more than a single character. | Set `length` to a positive integer and `separator` to a single character, then rotate again. |
+| Rotation fails with an invalid input error | `length` is outside 3–15, or `separator` is not a single character. | Set `length` within range and `separator` to a single character, then rotate again. |
 | The generated passphrase is shorter or longer than expected | `length` counts words, not characters. | Adjust `length` to the desired number of words; the character count varies with the words chosen. |
-
-<!-- TODO(SME): verify exact validation error strings and input bounds for the passphrase rotator. -->
 
 ## Related
 

--- a/content/docs/esc/providers/rotators/password.md
+++ b/content/docs/esc/providers/rotators/password.md
@@ -1,7 +1,7 @@
 ---
 title: password
 title_tag: password Pulumi ESC Rotator
-meta_desc: The `password` rotator enables you to rotate any user defined key by generating random passwords.
+meta_desc: The `password` rotator enables you to rotate any user-defined key by generating random passwords.
 h1: password
 menu:
   esc:
@@ -13,7 +13,7 @@ aliases:
   - /docs/esc/concepts/providers/rotators/password/
 ---
 
-The `password` rotator enables you to rotate any user defined key by generating random passwords.
+The `password` rotator enables you to rotate any user-defined key by generating random passwords.
 
 {{% notes "info" %}}
 If you want to generate _memorable passphrases_ use the [passphrase rotator](/docs/esc/providers/rotators/passphrase/)
@@ -21,18 +21,20 @@ If you want to generate _memorable passphrases_ use the [passphrase rotator](/do
 
 ## Inputs
 
-- **length**: The length of the generated passwords. (default `16`)
-- **lower**: If `true` the generated passwords will contain lowercase characters. (default: `true`)
-- **upper**: If `true` the generated passwords will contain uppercase characters. (default: `true`)
-- **special**: If `true` the generated passwords will contain special  characters. (default: `true`)
-- **minUpper**: The minimum number of uppercase characters that the generated passwords will contain. (default: `0`)
-- **minLower**: The minimum number of lowercase characters that the generated passwords will contain. (default: `0`)
-- **minSpecial**: The minimum number of special characters that the generated passwords will contain. (default: `0`)
-- **overrideSpecial**: a string containing all the special characters that can be used to generate passwords. (default: `!@#$%&*()-_=+[]{}<>:?`)
+| Property          | Type    | Description                                                                                          |
+|-------------------|---------|-----------------------------------------------------------------------------------------------------|
+| `length`          | int     | The length of the generated passwords. (default: `16`)                                              |
+| `lower`           | boolean | If `true`, the generated passwords will contain lowercase characters. (default: `true`)             |
+| `upper`           | boolean | If `true`, the generated passwords will contain uppercase characters. (default: `true`)             |
+| `special`         | boolean | If `true`, the generated passwords will contain special characters. (default: `true`)               |
+| `minUpper`        | int     | The minimum number of uppercase characters the generated passwords will contain. (default: `0`)     |
+| `minLower`        | int     | The minimum number of lowercase characters the generated passwords will contain. (default: `0`)     |
+| `minSpecial`      | int     | The minimum number of special characters the generated passwords will contain. (default: `0`)       |
+| `overrideSpecial` | string  | The set of special characters that can be used to generate passwords. (default: `!@#$%&*()-_=+[]{}<>:?`) |
 
 ## Example
 
-The `password` rotator can be configured for any random user defined key.
+The `password` rotator can be configured for any user-defined key.
 
 ```yaml
 values:
@@ -47,3 +49,45 @@ values:
 ```
 
 The previous example will generate passwords like: `wn#ZQH}z$[H_&h*`
+
+When you open the environment, you should see output similar to the following:
+
+```json
+{
+  "mypassword": {
+    "current": "[secret]",
+    "previous": "[secret]"
+  }
+}
+```
+
+<!-- TODO(SME): verify the password rotator output schema — confirm the current/previous shape and whether the generated value is nested under a property. -->
+
+## State (Optional)
+
+| Property   | Type   | Description                                                                                   |
+|------------|--------|-----------------------------------------------------------------------------------------------|
+| `current`  | string | Current generated password. This is the newest and recommended value.                         |
+| `previous` | string | Previous generated password. This value is still valid, but will be phased out next rotation. |
+
+## Outputs
+
+| Property   | Type   | Description                                        |
+|------------|--------|----------------------------------------------------|
+| `current`  | string | Current generated password, stored as a secret.    |
+| `previous` | string | Previous generated password, stored as a secret.   |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Rotation fails with an invalid input error | The sum of `minLower`, `minUpper`, and `minSpecial` exceeds `length`. | Increase `length` or lower the minimum-count inputs so they fit within the password length. |
+| Generated passwords are missing a character class | The class is disabled (`lower`, `upper`, or `special` set to `false`) or its minimum is `0`. | Enable the character class and set its corresponding minimum to require at least one character. |
+
+<!-- TODO(SME): verify exact validation error strings and input bounds for the password rotator. -->
+
+## Related
+
+- [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
+- [passphrase rotator](/docs/esc/providers/rotators/passphrase/) - Generate memorable passphrases instead of random passwords
+- [Rotators reference](/docs/esc/providers/rotators/) - Catalog of all ESC rotators

--- a/content/docs/esc/providers/rotators/password.md
+++ b/content/docs/esc/providers/rotators/password.md
@@ -23,14 +23,16 @@ If you want to generate _memorable passphrases_ use the [passphrase rotator](/do
 
 | Property          | Type    | Description                                                                                          |
 |-------------------|---------|-----------------------------------------------------------------------------------------------------|
-| `length`          | int     | The length of the generated passwords. (default: `16`)                                              |
-| `lower`           | boolean | If `true`, the generated passwords will contain lowercase characters. (default: `true`)             |
-| `upper`           | boolean | If `true`, the generated passwords will contain uppercase characters. (default: `true`)             |
-| `special`         | boolean | If `true`, the generated passwords will contain special characters. (default: `true`)               |
-| `minUpper`        | int     | The minimum number of uppercase characters the generated passwords will contain. (default: `0`)     |
-| `minLower`        | int     | The minimum number of lowercase characters the generated passwords will contain. (default: `0`)     |
-| `minSpecial`      | int     | The minimum number of special characters the generated passwords will contain. (default: `0`)       |
-| `overrideSpecial` | string  | The set of special characters that can be used to generate passwords. (default: `!@#$%&*()-_=+[]{}<>:?`) |
+| `length`          | int     | The length of the generated password (8–100). (default: `16`)                                       |
+| `lower`           | boolean | Whether to include lowercase characters. (default: `true`)                                          |
+| `upper`           | boolean | Whether to include uppercase characters. (default: `true`)                                          |
+| `numeric`         | boolean | Whether to include numbers. (default: `true`)                                                       |
+| `special`         | boolean | Whether to include special characters. (default: `true`)                                            |
+| `minLower`        | int     | The minimum number of lowercase characters to include (0–100). (default: `0`)                       |
+| `minUpper`        | int     | The minimum number of uppercase characters to include (0–100). (default: `0`)                       |
+| `minNumeric`      | int     | The minimum number of numeric characters to include (0–100). (default: `0`)                         |
+| `minSpecial`      | int     | The minimum number of special characters to include (0–100). (default: `0`)                         |
+| `overrideSpecial` | string  | The set of special characters to choose from. (default: `!@#$%&*()-_=+[]{}<>:?`)                    |
 
 ## Example
 
@@ -61,30 +63,26 @@ When you open the environment, you should see output similar to the following:
 }
 ```
 
-<!-- TODO(SME): verify the password rotator output schema — confirm the current/previous shape and whether the generated value is nested under a property. -->
-
 ## State (Optional)
 
-| Property   | Type   | Description                                                                                   |
-|------------|--------|-----------------------------------------------------------------------------------------------|
-| `current`  | string | Current generated password. This is the newest and recommended value.                         |
-| `previous` | string | Previous generated password. This value is still valid, but will be phased out next rotation. |
+| Property   | Type   | Description                            |
+|------------|--------|----------------------------------------|
+| `current`  | string | The most recently generated password.  |
+| `previous` | string | The prior generated password.          |
 
 ## Outputs
 
-| Property   | Type   | Description                                        |
-|------------|--------|----------------------------------------------------|
-| `current`  | string | Current generated password, stored as a secret.    |
-| `previous` | string | Previous generated password, stored as a secret.   |
+| Property   | Type   | Description                                            |
+|------------|--------|--------------------------------------------------------|
+| `current`  | string | The most recently generated password, stored as a secret. |
+| `previous` | string | The prior generated password, stored as a secret.      |
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Resolution |
 |---------|--------------|------------|
-| Rotation fails with an invalid input error | The sum of `minLower`, `minUpper`, and `minSpecial` exceeds `length`. | Increase `length` or lower the minimum-count inputs so they fit within the password length. |
-| Generated passwords are missing a character class | The class is disabled (`lower`, `upper`, or `special` set to `false`) or its minimum is `0`. | Enable the character class and set its corresponding minimum to require at least one character. |
-
-<!-- TODO(SME): verify exact validation error strings and input bounds for the password rotator. -->
+| Rotation fails with an invalid input error | `length` is outside 8–100, or the sum of `minLower`, `minUpper`, `minNumeric`, and `minSpecial` exceeds `length`. | Set `length` within range and lower the minimum-count inputs so they fit within the password length. |
+| Generated passwords are missing a character class | The class is disabled (`lower`, `upper`, `numeric`, or `special` set to `false`) or its minimum is `0`. | Enable the character class and set its corresponding minimum to require at least one character. |
 
 ## Related
 

--- a/content/docs/esc/providers/rotators/postgres.md
+++ b/content/docs/esc/providers/rotators/postgres.md
@@ -65,7 +65,7 @@ values:
               login: ${environments.rotatorExample.managingCredentials.awsLogin} # An implicit import from the above environment (assuming it's called rotatorExample/managingCredentials)
               lambdaArn: arn:aws:lambda:aws-region:111111111111:function:PulumiEscSecretRotatorLambda-Function-xxxxxxx
           database: rotator_example_db
-          host: rotator-example-mysql.cluster-xxxxxxxxxxxx.aws-region.rds.amazonaws.com
+          host: rotator-example-postgres.cluster-xxxxxxxxxxxx.aws-region.rds.amazonaws.com
           port: 5432
           managingUser: ${environments.rotatorExample.managingCredentials.managingUser} # An implicit import from the above environment (assuming it's called rotatorExample/managingCredentials)
         rotateUsers:
@@ -93,7 +93,22 @@ state:
     username: user2
 ```
 
-## Setup
+When you open the environment after a rotation, you should see output similar to the following:
+
+```json
+{
+  "dbRotator": {
+    "current": {
+      "username": "user1",
+      "password": "[secret]"
+    },
+    "previous": {
+      "username": "user2",
+      "password": "[secret]"
+    }
+  }
+}
+```
 
 ## Inputs
 
@@ -152,3 +167,21 @@ state:
 |------------|--------|-----------------------------------|
 | `username` | string | Username of user in the database. |
 | `password` | string | Password of user in the database. |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Rotation fails to connect to the database | The `host` or `port` is wrong, or the database is in a private network without a connector. | Verify `host` and `port`. For databases in a private network, configure a [rotation connector](/docs/esc/operations/rotation/aws-lambda) and set `database.connector`. |
+| Rotation fails with a permission or authentication error | The `managingUser` lacks privileges to change the rotated users' passwords. | Grant the managing user the privileges described in [database user setup](/docs/esc/operations/rotation/db-user-setup), then rotate again. |
+| Applications fail to authenticate after a rotation | Apps are reading the `previous` credentials, or rotation runs more frequently than apps refresh their configuration. | Configure applications to read `current`, and ensure the rotation schedule is less frequent than the application configuration refresh interval. |
+
+<!-- TODO(SME): verify exact error strings and the minimum PostgreSQL privileges required for the managing user. -->
+
+## Related
+
+- [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
+- [Rotation connectors](/docs/esc/operations/rotation/) - Reach databases in a private network
+- [Database user setup](/docs/esc/operations/rotation/db-user-setup) - Prepare database users for rotation
+- [mysql rotator](/docs/esc/providers/rotators/mysql/) - Rotate credentials for a MySQL database
+- [aws-login](/docs/esc/providers/login/aws-login/) - Authenticate with AWS for connector-based rotation

--- a/content/docs/esc/providers/rotators/postgres.md
+++ b/content/docs/esc/providers/rotators/postgres.md
@@ -173,10 +173,8 @@ When you open the environment after a rotation, you should see output similar to
 | Symptom | Likely cause | Resolution |
 |---------|--------------|------------|
 | Rotation fails to connect to the database | The `host` or `port` is wrong, or the database is in a private network without a connector. | Verify `host` and `port`. For databases in a private network, configure a [rotation connector](/docs/esc/operations/rotation/aws-lambda) and set `database.connector`. |
-| Rotation fails with a permission or authentication error | The `managingUser` lacks privileges to change the rotated users' passwords. | Grant the managing user the privileges described in [database user setup](/docs/esc/operations/rotation/db-user-setup), then rotate again. |
-| Applications fail to authenticate after a rotation | Apps are reading the `previous` credentials, or rotation runs more frequently than apps refresh their configuration. | Configure applications to read `current`, and ensure the rotation schedule is less frequent than the application configuration refresh interval. |
-
-<!-- TODO(SME): verify exact error strings and the minimum PostgreSQL privileges required for the managing user. -->
+| Rotation fails with a permissions or authentication error | The `managingUser` may lack the privileges needed to change the rotated users' passwords. | Grant the managing user the privileges described in [database user setup](/docs/esc/operations/rotation/db-user-setup), then rotate again. |
+| Applications fail to authenticate after a rotation | Apps may be reading the `previous` credentials, or rotation may run more frequently than apps refresh their configuration. | Configure applications to read `current`, and ensure the rotation schedule is less frequent than the application configuration refresh interval. |
 
 ## Related
 

--- a/content/docs/esc/providers/rotators/snowflake-user.md
+++ b/content/docs/esc/providers/rotators/snowflake-user.md
@@ -219,5 +219,5 @@ And exactly one of:
 ## Related
 
 - [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
-- [snowflake-login](/docs/esc/providers/login/snowflake-login/) - Authenticate with Snowflake via OIDC or a key-pair
+- [snowflake-login](/docs/esc/providers/login/snowflake-login/) - Authenticate with Snowflake via OIDC
 - [Rotators reference](/docs/esc/providers/rotators/) - Catalog of all ESC rotators

--- a/content/docs/esc/providers/rotators/snowflake-user.md
+++ b/content/docs/esc/providers/rotators/snowflake-user.md
@@ -212,11 +212,9 @@ And exactly one of:
 
 | Symptom | Likely cause | Resolution |
 |---------|--------------|------------|
-| Rotation fails to authenticate to Snowflake | The OIDC security integration is misconfigured, or the rotation service user lacks access. | Verify the `EXTERNAL_OAUTH` security integration values (issuer, JWKS URL, audience, allowed roles) and confirm the service user maps to the expected `login_name`. See [snowflake-login](/docs/esc/providers/login/snowflake-login/). |
-| Rotation fails with an insufficient-privileges error | The rotator role does not own or cannot alter the target user. | Grant the rotator role ownership of the target user (`GRANT OWNERSHIP ON USER ... TO ROLE ESC_ROTATOR`) and grant the role to the rotation service user. |
-| Applications fail to authenticate after a rotation | Applications are still using the rotated-out public key (`RSA_PUBLIC_KEY_2`). | Update applications to the `current` private key; the previous key remains valid as `RSA_PUBLIC_KEY_2` until the next rotation. |
-
-<!-- TODO(SME): verify exact Snowflake error strings and the minimum grants required for the rotator role. -->
+| Rotation fails to authenticate to Snowflake | The OIDC security integration may be misconfigured, or the rotation service user may lack access. | Verify the `EXTERNAL_OAUTH` security integration values (issuer, JWKS URL, audience, allowed roles) and confirm the service user maps to the expected `login_name`. See [snowflake-login](/docs/esc/providers/login/snowflake-login/). |
+| Rotation fails with a permissions error | The rotator role may not be able to alter the target user. | Confirm the rotator role can alter the target user, following the grants in [Configuring Snowflake for Key Rotation](#configuring-snowflake-for-key-rotation). |
+| Applications fail to authenticate after a rotation | Applications may still be using the rotated-out public key (`RSA_PUBLIC_KEY_2`). | Update applications to the `current` private key; the previous key remains valid as `RSA_PUBLIC_KEY_2` until the next rotation. |
 
 ## Related
 

--- a/content/docs/esc/providers/rotators/snowflake-user.md
+++ b/content/docs/esc/providers/rotators/snowflake-user.md
@@ -81,7 +81,7 @@ CREATE SECURITY INTEGRATION pulumi_oidc
 
 Replace `<pulumi-org>` with your Pulumi organization name.
 
-## Step 5: Managing credentials
+### Step 5: Managing credentials
 
 Set up an environment with [Snowflake login credentials](/docs/esc/providers/login/snowflake-login/) for the rotation service user:
 
@@ -98,7 +98,7 @@ values:
           role: ESC_ROTATOR
 ```
 
-## Step 6: Rotated environment
+### Step 6: Rotated environment
 
 Then, create a separate environment for your rotated credentials:
 
@@ -130,6 +130,27 @@ values:
             MIIEvQIBADANBgkqhkiG9w0BAQE...
             -----END PRIVATE KEY-----
         createdAt: "2025-01-01T12:00:00Z"
+```
+
+### Alternative: authenticating with a private key
+
+Instead of an OIDC `token` from the [snowflake-login](/docs/esc/providers/login/snowflake-login/) provider, the `login` can authenticate directly with a key-pair by supplying a `privateKey`. Provide `account`, `user`, and exactly one of `privateKey` or `token`:
+
+```yaml
+# my-org/rotators/snowflake-keyrotator
+values:
+  user:
+    fn::rotate::snowflake-user:
+      inputs:
+        login:
+          account: myorganization-account
+          user: ESC_ROTATION_SERVICE_USER
+          privateKey:
+            fn::secret: |
+              -----BEGIN PRIVATE KEY-----
+              MIIEvQIBADANBgkqhkiG9w0BAQE...
+              -----END PRIVATE KEY-----
+        targetUser: ESC_ROTATION_DEMO_USER
 ```
 
 ## Validation
@@ -186,3 +207,19 @@ And exactly one of:
 | `user`      | string | The rotated user.                                                     |
 | `privateKey`| string | Private key in PEM format (stored as a secret).                       |
 | `rotatedAt` | string | When the keypair was generated, in RFC3339 format.                    |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---------|--------------|------------|
+| Rotation fails to authenticate to Snowflake | The OIDC security integration is misconfigured, or the rotation service user lacks access. | Verify the `EXTERNAL_OAUTH` security integration values (issuer, JWKS URL, audience, allowed roles) and confirm the service user maps to the expected `login_name`. See [snowflake-login](/docs/esc/providers/login/snowflake-login/). |
+| Rotation fails with an insufficient-privileges error | The rotator role does not own or cannot alter the target user. | Grant the rotator role ownership of the target user (`GRANT OWNERSHIP ON USER ... TO ROLE ESC_ROTATOR`) and grant the role to the rotation service user. |
+| Applications fail to authenticate after a rotation | Applications are still using the rotated-out public key (`RSA_PUBLIC_KEY_2`). | Update applications to the `current` private key; the previous key remains valid as `RSA_PUBLIC_KEY_2` until the next rotation. |
+
+<!-- TODO(SME): verify exact Snowflake error strings and the minimum grants required for the rotator role. -->
+
+## Related
+
+- [Rotators](/docs/esc/concepts/rotators/) - How credential rotation works in Pulumi ESC
+- [snowflake-login](/docs/esc/providers/login/snowflake-login/) - Authenticate with Snowflake via OIDC or a key-pair
+- [Rotators reference](/docs/esc/providers/rotators/) - Catalog of all ESC rotators


### PR DESCRIPTION
Fixes the rotator-specific bugs and template gaps tracked in #19691 (part of the Refresh ESC Docs epic #19378).

## Part A — concrete bug fixes

- **`passphrase.md`** — broken intro sentence ("enables you to **any** user defined key … generating") fixed to "enables you to **rotate** any user-defined key … **by** generating"; added the missing parent map key under `values:` in the YAML example; removed a stray blank line inside the code fence; hyphenated "user-defined".
- **`postgres.md`** — removed the empty `## Setup` stub heading; fixed the `-mysql` RDS hostname used in a postgres example.
- **`mysql.md`** — removed the empty `## Setup` stub heading.
- **`snowflake-user.md`** — normalized Steps 5–6 from `##` to `###` to match Steps 1–4.
- **`external.md`** — fixed the JWKS URL (`/.well-known/jwks.json` 404s → `/oidc/.well-known/jwks`, the form every other ESC page uses).

## Part B — template upgrades (all 8 rotator pages)

- **Troubleshooting** and **Related** cross-link sections on every page.
- **`esc open` sample output** added to `postgres`, `mysql`, `password`, `passphrase`.
- **Static-credential / alternate-login examples** added to `aws-iam`, `azure-app-secret`, `snowflake-user`.
- **State/Outputs reference tables** added to `password` and `passphrase`; their Inputs converted to tables for consistency.

## Schema accuracy — verified against the live REST API

Queried `GET /api/esc/rotators/{name}/schema` to confirm the schemas rather than infer them:

- `password`/`passphrase` `current`/`previous` state + output shapes confirmed.
- `password` gained the previously-undocumented `numeric` and `minNumeric` inputs, plus verified value bounds (length 8–100, mins 0–100).
- `passphrase` gained verified bounds (length 3–15, single-character separator).
- Static-credential `login` fields for `aws-iam`, `azure-app-secret`, and `snowflake-user` (including snowflake's `oneOf(privateKey, token)`) confirmed valid.

## Troubleshooting content

The troubleshooting tables originally carried `<!-- TODO(SME) -->` flags on inferred causes/remedies. Those have been **softened** so no row asserts an unverified fact (generic symptom phrasing + "may" hedging on the *Likely cause* column), while keeping the schema-verified facts and on-page setup references. All SME TODOs are removed — no flags remain in the diff. An SME pass is still welcome to tighten the remedies, but nothing in the tables now claims an unverified specific.

## Out of scope / follow-up

Schema-reference tables are kept hand-written. #19792 tracks driving them from a data source derived from the REST API docs (per maintainer direction).

## Verification

- `make lint` passes (markdownlint + prettier, 0 errors).
- `make lint-prose` surfaces only non-blocking Vale nags, consistent with existing page voice.
- Schemas verified against the live Pulumi Cloud REST API (see above).
- Not yet done: local `make serve` visual pass + dark-mode check on the 8 pages (recommended before marking ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #19691 