### PR TITLE
docs(esc): fix aws-login creds typo breaking EKS auth in k8s guide

### DIFF
--- a/content/docs/esc/guides/kubernetes-cluster-access.md
+++ b/content/docs/esc/guides/kubernetes-cluster-access.md
@@ -22,13 +22,13 @@ such as `kubectl` and `helm`, and with Pulumi programs that use the
 
 ## Prerequisites
 
-To complete the steps in this tutorial, you will need to install the following prerequisites:
+To complete the steps in this guide, you will need to install the following prerequisites:
 
 - the [Pulumi CLI](/docs/iac/cli/commands/pulumi_env/)
 - a Kubernetes cluster
 - [kubectl](https://kubernetes.io/releases/download/#kubectl)
 
-## Access Kubernetes Clusters from Command Line Tools
+## Access Kubernetes clusters from command line tools
 
 ESC integrates with Kubernetes client tools by setting the `KUBECONFIG` environment variable to point to a
 generated [Kubernetes configuration file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
@@ -113,7 +113,7 @@ environment:
   - <your-project-name>/<your-environment-name>
 ```
 
-## Authenticate to a Kubernetes Cluster
+## Authenticate to a Kubernetes cluster
 
 ESC enables you to connect to your Kubernetes cluster using credentials obtained from an ESC provider. For example,
 to connect to an AWS EKS cluster using AWS OIDC credentials returned by the [aws-login](/docs/esc/providers/login/aws-login/) provider.
@@ -137,7 +137,7 @@ values:
           roleArn: arn:aws:iam::0123456789:role/cluster-admin
           sessionName: <your-project-name>/<your-environment-name>
   environmentVariables:
-    AWS_ACCESS_KEY_ID: ${aws.creds.keyId}
+    AWS_ACCESS_KEY_ID: ${aws.creds.accessKeyId}
     AWS_SECRET_ACCESS_KEY: ${aws.creds.secretAccessKey}
     AWS_SESSION_TOKEN: ${aws.creds.sessionToken}
 ```


### PR DESCRIPTION
## Summary

Fixes the credential-mapping typo in the ESC Kubernetes cluster access guide that silently broke AWS/EKS authentication (surfaced via docs page feedback: "Doesn't work. Spent hours trying everything documented here and elsewhere").

The guide mapped `AWS_ACCESS_KEY_ID` from a non-existent `aws-login` output `keyId`:

```yaml
AWS_ACCESS_KEY_ID: ${aws.creds.keyId}   # before
AWS_ACCESS_KEY_ID: ${aws.creds.accessKeyId}  # after
```

The `aws-login` provider's output property is `accessKeyId` (confirmed in `content/docs/esc/providers/login/aws-login.md` — Outputs table and canonical example). ESC interpolation of a missing field yields an empty value, so `AWS_ACCESS_KEY_ID` was blank and EKS auth via the `aws-iam-authenticator` exec plugin failed with opaque "unauthorized" errors and no hint of the typo. The neighboring `secretAccessKey`/`sessionToken` keys were already correct.

## Optional cleanups (from the issue)

- Sentence-cased two Title Case H2 headings to match repo style.
- Changed "tutorial" → "guide" to match how the page is framed.

Fixes #19796

🤖 Generated with [Claude Code](https://claude.com/claude-code)