### PR TITLE
docs(tutorials): define and link "project" in Understanding Stacks

### DIFF
--- a/content/tutorials/building-with-pulumi/understanding-stacks/index.md
+++ b/content/tutorials/building-with-pulumi/understanding-stacks/index.md
@@ -13,7 +13,7 @@ aliases:
 
 Every Pulumi program is deployed to a stack. A stack is an isolated, independently [configurable](/docs/concepts/config/) instance of a Pulumi program. Stacks are commonly used to denote different phases of development (such as `development`, `staging`, and `production`) or feature branches (such as `feature-x-dev`).
 
-A project can have as many stacks as you need. By default, as you've seen in previous tutorials, Pulumi creates one for you when you create a new project with `pulumi new`.
+A [project](/docs/iac/concepts/projects/) --- the directory containing your `Pulumi.yaml` and program --- can have as many stacks as you need. By default, Pulumi creates one for you when you create a new project with `pulumi new`.
 
 ## Create a stack
 


### PR DESCRIPTION
The "Understanding Stacks" tutorial used the term "project" without defining or linking it. This adds an inline gloss plus a link to the concept page on first use, and removes the unlinked "as you've seen in previous tutorials" hand-wave.

## Changes
- Glossed "project" and linked to /docs/iac/concepts/projects/ on first use
- Dropped the unlinked "as you've seen in previous tutorials" phrasing

Fixes #19797.