### PR TITLE
docs(esc): add subjectAttributes example and consolidate OIDC subject docs

### DIFF
--- a/content/docs/esc/guides/configuring-oidc/_index.md
+++ b/content/docs/esc/guides/configuring-oidc/_index.md
@@ -46,15 +46,11 @@ To configure OIDC for your cloud provider, refer to one of our guides:
 * [Configuring OIDC for Infisical](/docs/esc/guides/configuring-oidc/infisical/)
 * [Configuring OIDC for Vault](/docs/esc/guides/configuring-oidc/vault/)
 
-## Customizing OIDC claims
-
-To securely exchange OIDC tokens for cloud provider credentials, Pulumi ESC must present claims that match the provider’s trust policy. In many cases, the default claims are sufficient. But if you need to restrict access more precisely, such as limiting credentials to a specific environment, user, or project you can customize the subject and other claims.
-
 ## Configuring trust relationships
 
 Cloud providers use [OIDC token's claims](https://openid.net/specs/openid-connect-core-1_0.html#Claims) to determine whether to trust and issue credentials. While the exact configuration varies by provider, most rely on core claims like **Audience**, **Subject**, and **Issuer**. Pulumi ESC includes these by default, along with additional custom claims that mirror the subject structure.
 
-If you need to define fine-grained trust policies—such as allowing only a specific environment or user to assume a role—you can customize the subject format or reference custom claims. This gives you more control over how access is granted and ensures that only the right entities can request credentials.
+If you need to define fine-grained trust policies (such as allowing only a specific environment or user to assume a role), you can customize the subject format or reference custom claims. This gives you more control over how access is granted and ensures that only the right entities can request credentials.
 
 The following claims are commonly used when configuring trust relationships:
 
@@ -78,20 +74,64 @@ Pulumi ESC's default issued OIDC tokens include the following claims:
 
 ## Custom token claim
 
-To tailor token claims for more granular control, you can modify the default subject claim format by using the `subjectAttributes` property. This allows you to reference specific attributes in your cloud provider’s trust policy. This is especially useful if you plan to reference subject claims within your cloud provider’s trust policy.
+To securely exchange OIDC tokens for cloud provider credentials, Pulumi ESC must present claims that match the provider's trust policy. In many cases the default claims are sufficient, but if you need to restrict access more precisely (for example, limiting credentials to a specific environment, user, or project), you can modify the subject claim format by using the `subjectAttributes` property. This is especially useful when you plan to reference the subject within your cloud provider's trust policy to restrict which environments, users, or organizations may request credentials.
 
-Default subject claim format:
+By default (when `subjectAttributes` is not set), the subject claim has the format:
 
-`pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}`
+`pulumi:environments:org:<organization name>:env:<project name>/<environment name>`
 
-Additional options for customization include:
+When you set `subjectAttributes`, the subject instead begins with the fixed prefix `pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}`, and each configured attribute is appended to it as a `:<attribute>:<value>` pair, in the order listed.
+
+The following attributes are available:
 
 * `rootEnvironment.name`: the name of the environment that is opened first. This root environment in turn opens other imported environments
-* `currentEnvironment.name`: the name of the environment where the ESC login provider and `subjectAttributes` are defined
+* `currentEnvironment.name`: the full name (including the project) of the environment where the ESC login provider and `subjectAttributes` are defined
 * `pulumi.user.login`: the login identifier of the user opening the environment
 * `pulumi.organization.login`: the login identifier of the organization
 
-Consider the following example definitions for two environments, `Project/Environment-A` and `Project/Environment-B`:
+{{< notes type="info" >}}
+
+The set of attributes that may be encoded into the subject claim is deliberately restricted to this fixed list. Because the subject is consumed by the cloud provider's trust policy to make authorization decisions, only values that are determined and attested by the Pulumi platform (rather than supplied by the requesting caller) are permitted. Admitting arbitrary or user-controllable values would allow a caller to forge a subject that satisfies a trust policy and thereby obtain credentials they are not entitled to. Each supported attribute therefore reflects a non-spoofable, platform-derived identity or environment value; attributes that a caller could influence are intentionally excluded.
+
+{{< /notes >}}
+
+### Example
+
+Consider the `project/development` environment, opened by the user `personA` in the `contoso` organization, with the following login configuration:
+
+```yaml
+values:
+  aws:
+    login:
+      fn::open::aws-login:
+        oidc:
+          roleArn: arn:aws:iam::123456789123:role/aws-role
+          sessionName: esc-${context.pulumi.user.login}
+          subjectAttributes:
+            - currentEnvironment.name
+            - pulumi.user.login
+```
+
+The resulting subject claim is:
+
+`pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:project/development:pulumi.user.login:personA`
+
+To restrict a role to this environment and user, configure your cloud provider's trust policy so that its subject (`sub`) condition matches this value exactly. The syntax for expressing that condition is provider-specific. See the corresponding provider guide for a complete trust-policy example, such as [Configuring OIDC for AWS](/docs/esc/guides/configuring-oidc/aws/#subject-claim-example).
+
+{{< notes type="warning" >}}
+
+For environments within the legacy `default` project, the project is **not** present in the subject, to preserve backwards compatibility. This affects the subject claim in two ways:
+
+* When `subjectAttributes` is not set, the default subject claim omits the project: `pulumi:environments:org:<organization name>:env:<environment name>` (rather than the usual `pulumi:environments:org:<organization name>:env:<project name>/<environment name>`).
+* When `subjectAttributes` is set, the `currentEnvironment.name` attribute resolves to only the environment name (for example, `development`) rather than the usual `project/development`. So for an environment named `development` opened by `personA`, the subject is `pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:development:pulumi.user.login:personA`.
+
+For this reason, we recommend moving your environments out of the `default` project for best security practices.
+
+{{< /notes >}}
+
+### How attributes resolve across imported environments
+
+The `rootEnvironment.name` and `currentEnvironment.name` attributes resolve relative to the environment that opens the chain. `currentEnvironment.name` resolves to the environment in which it is defined, while `rootEnvironment.name` resolves to the top-level environment that was opened. Consider the following definitions for two environments, `Project/Environment-A` and `Project/Environment-B`:
 
 ```yaml
 #Project/Environment-A
@@ -101,23 +141,23 @@ values:
 
 #Project/Environment-B
 imports:
-- Project/EnvironmentA
+- Project/Environment-A
 values:
   envb-rootEnv: ${context.rootEnvironment.name}
   envb-currentEnv: ${context.currentEnvironment.name}
 ```
 
-When you open `Project/Environment-B`, the output would be:
+When you open `Project/Environment-B`, the output is:
 
-```
+```json
 {
-  "enva-currentEnv-name": "Project/Environment-A",
-  "enva-rootEnv-name": "Project/Environment-B",
+  "enva-currentEnv": "Project/Environment-A",
+  "enva-rootEnv": "Project/Environment-B",
   "envb-currentEnv": "Project/Environment-B",
   "envb-rootEnv": "Project/Environment-B"
 }
 ```
 
-Notice how `enva-rootEnv-name` is resolved to `Project/Environment-B`. That's because Project/Environment-A is opened from Project/Environment-B which is the root, i.e. the top-level environment to be opened.
+Notice how `enva-rootEnv` resolves to `Project/Environment-B`. That's because `Project/Environment-A` is opened from `Project/Environment-B`, which is the root (the top-level environment to be opened).
 
-When importing multiple environments into Pulumi IaC Stack Config, each environment is resolved separately. For example, if you import multiple environments into your Pulumi Stack with `rootEnvironment.name` attribute defined in all of them, then each `rootEnvironment.name` will resolve to the environment name where it is defined.
+When importing multiple environments into Pulumi IaC stack config, each environment is resolved separately. For example, if you import multiple environments into your Pulumi stack with the `rootEnvironment.name` attribute defined in all of them, then each `rootEnvironment.name` resolves to the environment name where it is defined.

--- a/content/docs/esc/guides/configuring-oidc/aws.md
+++ b/content/docs/esc/guides/configuring-oidc/aws.md
@@ -75,7 +75,7 @@ Next, select the **trust relationships** tab, which is where the trust policy of
 }
 ```
 
-This definition allows any Pulumi ESC environment in your organization to assume this role. The `sub` condition uses a wildcard to permit any environment within your org. You can make the policy more granular by restricting access to a specific environment. For more detailed configuration, see the [customizing claims documentation](/docs/esc/environments/configuring-oidc/#customizing-oidc-claims).
+This definition allows any Pulumi ESC environment in your organization to assume this role. The `sub` condition uses a wildcard to permit any environment within your org. You can make the policy more granular by restricting access to a specific environment. For more detailed configuration, see [Custom token claim](/docs/esc/guides/configuring-oidc/#custom-token-claim).
 
 Before you log out of the AWS console, make sure to make a note of your role’s ARN value as you will need it in the next step.
 
@@ -133,21 +133,7 @@ Make sure to replace `<your-org>`, `<your-project>`, and `<your-environment>` wi
 
 ## Subject claim customization
 
-You can [customize](/docs/esc/environments/configuring-oidc/#customizing-oidc-claims) the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given IAM role. This allows for more granular access control than the default organization-level permissions.
-
-By default, the subject claim has the following format:
-
-`pulumi:environments:org:<organization name>:env:<project name>/<environment name>`
-
-To customize the subject, use the `subjectAttributes` property in your environment configuration. This produces a subject with the prefix:
-
-`pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}`
-
-{{< notes type="warning" >}}
-
-For environments within the legacy `default` project, the project will **not** be present in the subject to preserve backwards compatibility. The format of the subject claim when `subjectAttributes` are not set is `pulumi:environments:org:<organization name>:env:<environment name>`. If `currentEnvironment.name` is used as a custom subject attribute it will resolve to only the environment name (e.g. `pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:development:pulumi.user.login:personA`). Due to this it is recommended to move your environments out of the `default` project for best security practices.
-
-{{< /notes >}}
+You can customize the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given IAM role. This allows for more granular access control than the default organization-level permissions. Use the `subjectAttributes` property in your login configuration; see [Custom token claim](/docs/esc/guides/configuring-oidc/#custom-token-claim) for the full list of available attributes and how the subject is composed.
 
 ## Subject claim example
 
@@ -175,15 +161,6 @@ The OIDC subject claim for this environment would be `pulumi:environments:pulumi
   }
 }
 ```
-
-The subject always contains the prefix `pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}` and every key configured will be appended to this prefix. The list of all possible options for `subjectAttributes` are:
-
-* `rootEnvironment.name`: the name of the environment that is opened first. This root environment in turn opens other imported environments
-* `currentEnvironment.name`: the full name (including the project) of the environment where the ESC login provider and `subjectAttributes` are defined
-* `pulumi.user.login`: the login identifier of the user opening the environment
-* `pulumi.organization.login`: the login identifier of the organization
-
-When importing multiple environments into Pulumi IaC Stack Config, each environment is resolved separately. For example, if you import multiple environments into your Pulumi Stack with `rootEnvironment.name` attribute defined in all of them, then each `rootEnvironment.name` will resolve to the environment name where it is defined.
 
 {{< notes type="info" >}}
 

--- a/content/docs/esc/guides/configuring-oidc/azure.md
+++ b/content/docs/esc/guides/configuring-oidc/azure.md
@@ -137,16 +137,9 @@ To learn more about how to set up and use the various providers in Pulumi ESC, p
 
 ## Subject claim customization
 
-You can [customize](/docs/esc/environments/configuring-oidc/#customizing-oidc-claims) the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given IAM role. This allows for more granular access control than the default organization-level permissions
+You can customize the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given role. This allows for more granular access control than the default organization-level permissions. Use the `subjectAttributes` property in your login configuration; see [Custom token claim](/docs/esc/guides/configuring-oidc/#custom-token-claim) for the full list of available attributes and how the subject is composed.
 
-This is done by configuring the `subjectAttributes` setting. It expects an array of keys to include in it:
-
-* `rootEnvironment.name`: the name of the environment that is opened first. This root environment in turn opens other imported environments
-* `currentEnvironment.name`: the full name (including the project) of the environment where the ESC login provider and `subjectAttributes` are defined
-* `pulumi.user.login`: the login identifier of the user opening the environment
-* `pulumi.organization.login`: the login identifier of the organization
-
-The subject always contains the following prefix `pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}` and every key configured will be appended to this prefix. For example, consider the following environment:
+For example, consider the following environment:
 
 ```yaml
 values:
@@ -161,19 +154,7 @@ values:
 
 The subject will be `pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:project/development:pulumi.user.login:userLogin`. Note how the keys and values are appended along with the prefix.
 
-{{< notes type="warning" >}}
-
-For environments within the legacy `default` project, the project will **not** be present in the subject to preserve backwards compatibility. The format of the subject claim when `subjectAttributes` are not set is `pulumi:environments:org:<organization name>:env:<environment name>`. If `currentEnvironment.name` is used as a custom subject attribute it will resolve to only the environment name (e.g. `pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:development:pulumi.user.login:personA`). Due to this it is recommended to move your environments out of the `default` project for best security practices.
-
-{{< /notes >}}
-
 ## Subject claim example
-
-Here is an example of a valid subject claim for the `project/development` environment of the `contoso` organization:
-
-* `pulumi:environments:org:contoso:env:project/development`
-
-The default format of the subject claim when `subjectAttributes` are not used is `pulumi:environments:org:<organization name>:env:<project name>/<environment name>`
 
 {{< notes type="warning" >}}
 

--- a/content/docs/esc/guides/configuring-oidc/doppler.md
+++ b/content/docs/esc/guides/configuring-oidc/doppler.md
@@ -111,21 +111,9 @@ the [relevant Pulumi documentation](/docs/esc/integrations/)
 
 ## Subject claim customization
 
-You can [customize](/docs/esc/environments/configuring-oidc/#customizing-oidc-claims) the subject claim in the OIDC token to control
-which Pulumi environments or users are allowed to assume a given identity. This allows for more granular access control
-than the default organization-level permissions.
+You can customize the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given identity. This allows for more granular access control than the default organization-level permissions. Use the `subjectAttributes` property in your login configuration; see [Custom token claim](/docs/esc/guides/configuring-oidc/#custom-token-claim) for the full list of available attributes and how the subject is composed.
 
-This is done by configuring the `subjectAttributes` setting. It expects an array of keys to include in it:
-
-* `rootEnvironment.name`: the name of the environment that is opened first. This root environment in turn opens other
-  imported environments
-* `currentEnvironment.name`: the full name (including the project) of the environment where the ESC login provider and
-  `subjectAttributes` are defined
-* `pulumi.user.login`: the login identifier of the user opening the environment
-* `pulumi.organization.login`: the login identifier of the organization
-
-The subject always contains the following prefix `pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}` and
-every key configured will be appended to this prefix. For example, consider the following environment:
+For example, consider the following environment:
 
 ```yaml
 values:
@@ -143,31 +131,7 @@ The subject will be
 `pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:project/development:pulumi.user.login:userLogin`.
 Note how the keys and values are appended along with the prefix.
 
-{{< notes type="warning" >}}
-
-If not customized, the subject claim has the following format by default:
-
-`pulumi:environments:org:<organization name>:env:<project name>/<environment name>`
-
-{{< /notes >}}
-
-{{< notes type="warning" >}}
-
-For environments within the legacy `default` project, the project will **not** be present in the subject to preserve
-backwards compatibility. The format of the subject claim when `subjectAttributes` are not set is
-`pulumi:environments:org:<organization name>:env:<environment name>`. If `currentEnvironment.name` is used as a custom
-subject attribute it will resolve to only the environment name (e.g.
-`pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:development:pulumi.user.login:personA`).
-Due to this it is recommended to move your environments out of the `default` project for best security practices.
-
-{{< /notes >}}
-
 ## Subject claim example
-
-Here is an example of a valid, not customized subject claim for the `project/development` environment of the `contoso`
-organization:
-
-* `pulumi:environments:org:contoso:env:project/development`
 
 {{< notes type="warning" >}}
 

--- a/content/docs/esc/guides/configuring-oidc/gcp.md
+++ b/content/docs/esc/guides/configuring-oidc/gcp.md
@@ -154,16 +154,9 @@ For more details about the `region` field, see the [gcp-login provider documenta
 
 ## Subject claim customization
 
-You can [customize](/docs/esc/environments/configuring-oidc/#customizing-oidc-claims) the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given IAM role. This allows for more granular access control than the default organization-level permissions.
+You can customize the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given role. This allows for more granular access control than the default organization-level permissions. Use the `subjectAttributes` property in your login configuration; see [Custom token claim](/docs/esc/guides/configuring-oidc/#custom-token-claim) for the full list of available attributes and how the subject is composed.
 
-You can do so by configuring the `subjectAttributes` setting. It expects an array of keys to include in it:
-
-* `rootEnvironment.name`: the name of the environment that is opened first. This root environment in turn opens other imported environments
-* `currentEnvironment.name`: the full name (including the project) of the environment where the ESC login provider and `subjectAttributes` are defined
-* `pulumi.user.login`: the login identifier of the user opening the environment
-* `pulumi.organization.login`: the login identifier of the organization
-
-The subject always contains the following prefix `pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}` and every key configured will be appended to this prefix. For example, consider the following environment:
+For example, consider the following environment:
 
 ```yaml
 values:
@@ -179,23 +172,11 @@ values:
 
 The subject will be `pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:project/development:pulumi.user.login:userLogin`. Note how the keys and values are appended along with the prefix.
 
-{{< notes type="warning" >}}
-
-For environments within the legacy `default` project, the project will **not** be present in the subject to preserve backwards compatibility. The format of the subject claim when `subjectAttributes` are not set is `pulumi:environments:org:<organization name>:env:<environment name>`. If `currentEnvironment.name` is used as a custom subject attribute it will resolve to only the environment name (e.g. `pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:development:pulumi.user.login:personA`). Due to this it is recommended to move your environments out of the `default` project for best security practices.
-
-{{< /notes >}}
-
 ### Subject claim examples
 
-Below is an example of a valid subject claim for the `project/development` environment of the `contoso` organization:
-
-* `pulumi:environments:org:contoso:env:project/development`
-
-The default format of the subject claim when `subjectAttributes` are not used is `pulumi:environments:org:<organization name>:env:<project name>/<environment name>`
-
 {{< notes type="warning" >}}
 
-If you are integrating Pulumi ESC with Pulumi IaC, the default subject identifier of the ESC environment will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the subject identifier's value sent to Azure from Pulumi.
+If you are integrating Pulumi ESC with Pulumi IaC, the default subject identifier of the ESC environment will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the subject identifier's value sent to Google Cloud from Pulumi.
 
 Use 'subjectAttributes' to customize the subject identifier to work with Pulumi IaC. Alternatively, you can use this syntax: `pulumi:environments:org:contoso:env:<yaml>` when configuring the subject claim in your cloud provider account. Make sure to replace `contoso` with the name of your Pulumi organization and use the literal value of `<yaml>` as shown.
 

--- a/content/docs/esc/guides/configuring-oidc/infisical.md
+++ b/content/docs/esc/guides/configuring-oidc/infisical.md
@@ -112,21 +112,9 @@ the [relevant Pulumi documentation](/docs/esc/integrations/)
 
 ## Subject claim customization
 
-You can [customize](/docs/esc/environments/configuring-oidc/#customizing-oidc-claims) the subject claim in the OIDC token to control
-which Pulumi environments or users are allowed to assume a given identity. This allows for more granular access control
-than the default organization-level permissions.
+You can customize the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given identity. This allows for more granular access control than the default organization-level permissions. Use the `subjectAttributes` property in your login configuration; see [Custom token claim](/docs/esc/guides/configuring-oidc/#custom-token-claim) for the full list of available attributes and how the subject is composed.
 
-This is done by configuring the `subjectAttributes` setting. It expects an array of keys to include in it:
-
-* `rootEnvironment.name`: the name of the environment that is opened first. This root environment in turn opens other
-  imported environments
-* `currentEnvironment.name`: the full name (including the project) of the environment where the ESC login provider and
-  `subjectAttributes` are defined
-* `pulumi.user.login`: the login identifier of the user opening the environment
-* `pulumi.organization.login`: the login identifier of the organization
-
-The subject always contains the following prefix `pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}` and
-every key configured will be appended to this prefix. For example, consider the following environment:
+For example, consider the following environment:
 
 ```yaml
 values:
@@ -144,31 +132,7 @@ The subject will be
 `pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:project/development:pulumi.user.login:userLogin`.
 Note how the keys and values are appended along with the prefix.
 
-{{< notes type="warning" >}}
-
-If not customized, the subject claim has the following format by default:
-
-`pulumi:environments:org:<organization name>:env:<project name>/<environment name>`
-
-{{< /notes >}}
-
-{{< notes type="warning" >}}
-
-For environments within the legacy `default` project, the project will **not** be present in the subject to preserve
-backwards compatibility. The format of the subject claim when `subjectAttributes` are not set is
-`pulumi:environments:org:<organization name>:env:<environment name>`. If `currentEnvironment.name` is used as a custom
-subject attribute it will resolve to only the environment name (e.g.
-`pulumi:environments:pulumi.organization.login:contoso:currentEnvironment.name:development:pulumi.user.login:personA`).
-Due to this it is recommended to move your environments out of the `default` project for best security practices.
-
-{{< /notes >}}
-
 ## Subject claim example
-
-Here is an example of a valid, not customized subject claim for the `project/development` environment of the `contoso`
-organization:
-
-* `pulumi:environments:org:contoso:env:project/development`
 
 {{< notes type="warning" >}}
 

--- a/content/docs/esc/guides/configuring-oidc/vault.md
+++ b/content/docs/esc/guides/configuring-oidc/vault.md
@@ -209,16 +209,9 @@ To learn more about how to set up and use the various providers in Pulumi ESC, p
 
 ## Subject claim customization
 
-You can [customize](/docs/esc/environments/configuring-oidc/#customizing-oidc-claims) the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given IAM role. This allows for more granular access control than the default organization-level permissions.
+You can customize the subject claim in the OIDC token to control which Pulumi environments or users are allowed to assume a given role. This allows for more granular access control than the default organization-level permissions. Use the `subjectAttributes` property in your login configuration; see [Custom token claim](/docs/esc/guides/configuring-oidc/#custom-token-claim) for the full list of available attributes and how the subject is composed.
 
-You do so by configuring the `subjectAttributes` setting. It expects an array of keys to include in it:
-
-* `rootEnvironment.name`: the name of the root environment being evaluated
-* `currentEnvironment.name`: the name of the current environment being evaluated
-* `pulumi.user.login`: the login identifier of the user opening the environment
-* `pulumi.organization.login`: the login identifier of the organization
-
-The subject always contains the following prefix `pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}` and every key configured will be appended to this prefix. For example, consider the following environment:
+For example, consider the following environment:
 
 ```yaml
 values:


### PR DESCRIPTION
Fixes #19814.

The ESC OIDC guide's "Custom token claim" section introduced `subjectAttributes` but never showed an example and trailed off into an unheaded topic. This adds a worked example and tightens the section, then consolidates the duplicated explanation that was copy-pasted across all six provider guides.

## Changes
- Add a worked `subjectAttributes` example + resulting subject claim, and a security rationale (the attribute allowlist is restricted to non-spoofable, platform-attested values) to the canonical `#custom-token-claim` section
- Give the import-resolution example its own heading and fix its bugs
- Merge the floating "Customizing OIDC claims" section into "Custom token claim"
- De-duplicate the identical subject-customization content from aws/azure/doppler/gcp/infisical/vault guides — they now link to the canonical section
- Fix a gcp.md copy-paste bug ("value sent to Azure" → "Google Cloud")