### PR TITLE
Fix redundant blog landing page title (Blog | Pulumi Blog → Blog | Pulumi)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -211,6 +211,12 @@
              add "Blog" to the title so that the titles no longer clash. -->
         {{ if and (eq .Type "blog") .IsPage }}
             <title>{{ $title }} | Pulumi Blog</title>
+        {{ else if and (eq .Type "blog") .IsSection }}
+            {{ if gt $.Paginator.PageNumber 1 }}
+                <title>{{ $title }} | Page {{$.Paginator.PageNumber}} | Pulumi</title>
+            {{ else }}
+                <title>{{ $title }} | Pulumi</title>
+            {{ end }}
         {{ else if eq .Type "blog" }}
             {{ if gt $.Paginator.PageNumber 1 }}
                 <title>{{ $title }} | Page {{$.Paginator.PageNumber}} | Pulumi Blog</title>


### PR DESCRIPTION
## What

The blog landing page (`/blog/`) renders its `<title>` as **Blog | Pulumi Blog**, which is redundant. This changes it to **Blog | Pulumi**.

## Why

The section page's title is already "Blog", and `layouts/partials/head.html` appended ` | Pulumi Blog` to every blog-type page, producing the doubled "Blog" wording on the landing page.

## How

Added a dedicated branch for the blog **section** landing page (`.IsSection`) that uses the ` | Pulumi` suffix, including its paginated pages. Individual blog posts and the tag/author taxonomy list pages keep the ` | Pulumi Blog` suffix, which still disambiguates them from clashing page titles elsewhere on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)