### PR TITLE
Align style guide and image review with the Pulumi Brand MCP server

### DIFF
--- a/.claude/commands/_common/images/manifest.yaml
+++ b/.claude/commands/_common/images/manifest.yaml
@@ -14,7 +14,11 @@ images:
     owner: docs-team
   - file: pulumi-logo-current.png
     area: branding
-    description: Current Pulumi logo and color scheme.
+    # Cached convenience copy. The canonical, always-current logo is served by
+    # the Pulumi Brand service — prefer a live fetch (get_logo via the Brand MCP
+    # server, or https://brand.pulumi.com/media/...) for the branding-currency
+    # check so it never rides on a stale PNG. See screenshot-verification.md.
+    description: Current Pulumi logo and color scheme (cached; canonical source is the Pulumi Brand service).
     captured: 2026-05-29
-    source_url: https://www.pulumi.com/brand/
+    source_url: https://brand.pulumi.com/
     owner: docs-team

--- a/.claude/commands/_common/images/manifest.yaml
+++ b/.claude/commands/_common/images/manifest.yaml
@@ -14,11 +14,11 @@ images:
     owner: docs-team
   - file: pulumi-logo-current.png
     area: branding
-    # Cached convenience copy. The canonical, always-current logo is served by
-    # the Pulumi Brand service — prefer a live fetch (get_logo via the Brand MCP
-    # server, or https://brand.pulumi.com/media/...) for the branding-currency
-    # check so it never rides on a stale PNG. See screenshot-verification.md.
-    description: Current Pulumi logo and color scheme (cached; canonical source is the Pulumi Brand service).
+    # Cached convenience copy. The canonical, always-current logo is the brand
+    # asset API (https://brand.pulumi.com/api) — prefer a live fetch for the
+    # branding-currency check so it never rides on a stale PNG. See
+    # screenshot-verification.md.
+    description: Current Pulumi logo and color scheme (cached; canonical source is the brand asset API).
     captured: 2026-05-29
-    source_url: https://brand.pulumi.com/
+    source_url: https://brand.pulumi.com/api
     owner: docs-team

--- a/.claude/commands/docs-review/references/image-review.md
+++ b/.claude/commands/docs-review/references/image-review.md
@@ -41,7 +41,7 @@ Applied to images and diagrams in user-facing content (docs, blogs, customer sto
 
 These are brand-*compliance* checks (is the asset a correct, approved Pulumi asset?), distinct from the aesthetic critique excluded below.
 
-- **Logo integrity.** The Pulumi logo must be an approved, unaltered version. Flag a recolored, stretched, rotated, cropped, or effect-laden (drop shadow, gradient, glow, outline) logo, a logo boxed in a non-approved container, or a logo on a busy or low-contrast background. The canonical logo and the full rules come from the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp) (`get_logo`, or canonical URLs under `https://brand.pulumi.com/media/...`); the brand `logo` section is authoritative.
+- **Logo integrity.** The Pulumi logo must be an approved, unaltered version. Flag a recolored, stretched, rotated, cropped, or effect-laden (drop shadow, gradient, glow, outline) logo, a logo boxed in a non-approved container, or a logo on a busy or low-contrast background. The canonical logo comes from the self-describing brand asset API (`https://brand.pulumi.com/api`); the brand `logo` guidelines are authoritative.
 - **No AI-generated brand imagery.** Pulumi's visual language doesn't reproduce cleanly under image models and reads off-brand. Flag illustrations or photos that appear AI-generated as Pulumi brand imagery.
 - **No Pulumipus in new materials.** As of 2026-03-23 the mascot is being reworked; existing Pulumipus assets must not be used in new content, and the mascot must never be AI-generated or altered. Flag any Pulumipus usage in added images.
 

--- a/.claude/commands/docs-review/references/image-review.md
+++ b/.claude/commands/docs-review/references/image-review.md
@@ -37,6 +37,14 @@ Applied to images and diagrams in user-facing content (docs, blogs, customer sto
 - **Comparison screenshots use side-by-side images of the same view.** Before/after pairs must show the same UI region, not different parts of the screen. If a "before" shows the dashboard and "after" shows a settings page, that's not a comparison — flag.
 - **Current product UI.** Screenshots of stale product UI (old logos, old console layouts) hurt the post's credibility. Flag screenshots that visibly use deprecated UI elements.
 
+## Brand assets
+
+These are brand-*compliance* checks (is the asset a correct, approved Pulumi asset?), distinct from the aesthetic critique excluded below.
+
+- **Logo integrity.** The Pulumi logo must be an approved, unaltered version. Flag a recolored, stretched, rotated, cropped, or effect-laden (drop shadow, gradient, glow, outline) logo, a logo boxed in a non-approved container, or a logo on a busy or low-contrast background. The canonical logo and the full rules come from the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp) (`get_logo`, or canonical URLs under `https://brand.pulumi.com/media/...`); the brand `logo` section is authoritative.
+- **No AI-generated brand imagery.** Pulumi's visual language doesn't reproduce cleanly under image models and reads off-brand. Flag illustrations or photos that appear AI-generated as Pulumi brand imagery.
+- **No Pulumipus in new materials.** As of 2026-03-23 the mascot is being reworked; existing Pulumipus assets must not be used in new content, and the mascot must never be AI-generated or altered. Flag any Pulumipus usage in added images.
+
 ## Diagrams
 
 - **Mermaid preferred over ASCII art.** Hugo renders Mermaid natively. Flag ASCII diagrams in `<pre>` blocks as "consider Mermaid" findings.
@@ -44,6 +52,6 @@ Applied to images and diagrams in user-facing content (docs, blogs, customer sto
 
 ## Do not flag
 
-- **Image composition or visual design.** Colors, layout, typography, and aesthetic critique are out of scope. Flag *technical* issues (missing alt, wrong format, oversized file), not editorial design preferences.
+- **Image composition or visual design.** Colors, layout, typography, and aesthetic critique are out of scope. Flag *technical* issues (missing alt, wrong format, oversized file) and brand-*compliance* issues (see [Brand assets](#brand-assets) — logo misuse, AI-generated brand imagery, deprecated mascot), not editorial design preferences.
 - **Stock photography choice.** If the post uses a hero image, "you should use a different photo" is editorial. Flag a placeholder image that wasn't replaced; don't critique a real image.
 - **Image redundancy.** "This screenshot doesn't add much" is editorial. Flag broken or stale screenshots, not whether the post needs them.

--- a/.claude/commands/review-existing-content/references/screenshot-verification.md
+++ b/.claude/commands/review-existing-content/references/screenshot-verification.md
@@ -4,7 +4,7 @@ description: Screenshot and UI verification pass for the automated existing-cont
 
 # Screenshot Verification
 
-Base image criteria (alt text, borders, format, size) come from
+Base image criteria (alt text, borders, format, size, brand-asset compliance) come from
 `docs-review:references:image-review` — apply those first. This reference
 adds the **currency** checks: is the UI an article's screenshots show still
 the UI the product ships?
@@ -25,25 +25,20 @@ For each image the article references:
    a third-party console), record it as `n/a — not Pulumi UI` and move on.
 2. Read the matching reference image(s) from the manifest (`area:
    console-overview` for Pulumi Cloud Console UI, `branding` for logos). For
-   branding, the manifest PNG is a cached convenience — the Pulumi Brand
-   service is the canonical, always-current source (see the Branding bullet).
+   branding, the manifest PNG is a cached convenience; the canonical logo is
+   the brand asset API (see the Branding bullet).
 3. Compare deliberately, not impressionistically:
    - **Left navigation** — section names, order, presence/absence of
      products. This is the highest-signal staleness indicator.
    - **Terminology** — product names and labels visible in the UI vs. what
      the article's prose calls them.
-   - **Branding** — compare any Pulumi logo in the image against the
-     *canonical* logo from the Pulumi Brand service, not just the cached
-     `branding` reference PNG (which can lag the live brand). Download a PNG of
-     the current mark and Read it for the comparison, e.g. `curl -sL
-     "https://brand.pulumi.com/api/logo?lockup=horizontal&background=white&format=png&width=1200"
-     -o /tmp/pulumi-logo.png` (or use the Brand MCP server's `get_logo` if it's
-     configured); the brand `logo` rules are authoritative. Beyond shape, flag
-     brand-asset *misuse* — a recolored, stretched, rotated, cropped, or
-     effect-laden logo, or one on a busy/low-contrast background — and flag any
-     **AI-generated brand imagery** or any **Pulumipus** mascot usage
-     (deprecated for new materials as of 2026-03-23). These are compliance
-     flags, not aesthetic critique.
+   - **Branding** — compare any Pulumi logo against the *canonical* mark, not
+     just the cached `branding` PNG (which can lag). Fetch the current logo and
+     Read it:
+     `curl -sL "https://brand.pulumi.com/api/logo?lockup=horizontal&background=white&format=png&width=1200" -o /tmp/pulumi-logo.png`.
+     Then apply the brand-asset compliance checks from
+     `docs-review:references:image-review` (logo misuse, AI-generated imagery,
+     deprecated Pulumipus).
    - **Structure** — header layout, major panels.
 4. Record a verdict per image: `current`, `stale` (name the specific
    differences — "left nav shows 'Pulumi Insights' where current UI has
@@ -54,9 +49,6 @@ Also check the manifest's `captured` dates: if a reference you used is older
 than 180 days, add an aging note to the Screenshot check section ("reference
 `pulumi-cloud-console-current.png` captured YYYY-MM-DD — refresh needed; owner:
 docs-team"). Keep flagging it on every run until the reference is refreshed.
-For the `branding` reference specifically, prefer the live brand-service fetch
-above over the cached PNG, so logo currency never silently rides on a stale
-reference image.
 
 ## Lane 2 — product source verification (when accessible)
 

--- a/.claude/commands/review-existing-content/references/screenshot-verification.md
+++ b/.claude/commands/review-existing-content/references/screenshot-verification.md
@@ -24,13 +24,26 @@ For each image the article references:
    product UI or branding (e.g. an architecture diagram, a terminal capture,
    a third-party console), record it as `n/a — not Pulumi UI` and move on.
 2. Read the matching reference image(s) from the manifest (`area:
-   console-overview` for Pulumi Cloud Console UI, `branding` for logos).
+   console-overview` for Pulumi Cloud Console UI, `branding` for logos). For
+   branding, the manifest PNG is a cached convenience — the Pulumi Brand
+   service is the canonical, always-current source (see the Branding bullet).
 3. Compare deliberately, not impressionistically:
    - **Left navigation** — section names, order, presence/absence of
      products. This is the highest-signal staleness indicator.
    - **Terminology** — product names and labels visible in the UI vs. what
      the article's prose calls them.
-   - **Branding** — logo shape and colors against the branding reference.
+   - **Branding** — compare any Pulumi logo in the image against the
+     *canonical* logo from the Pulumi Brand service, not just the cached
+     `branding` reference PNG (which can lag the live brand). Download a PNG of
+     the current mark and Read it for the comparison, e.g. `curl -sL
+     "https://brand.pulumi.com/api/logo?lockup=horizontal&background=white&format=png&width=1200"
+     -o /tmp/pulumi-logo.png` (or use the Brand MCP server's `get_logo` if it's
+     configured); the brand `logo` rules are authoritative. Beyond shape, flag
+     brand-asset *misuse* — a recolored, stretched, rotated, cropped, or
+     effect-laden logo, or one on a busy/low-contrast background — and flag any
+     **AI-generated brand imagery** or any **Pulumipus** mascot usage
+     (deprecated for new materials as of 2026-03-23). These are compliance
+     flags, not aesthetic critique.
    - **Structure** — header layout, major panels.
 4. Record a verdict per image: `current`, `stale` (name the specific
    differences — "left nav shows 'Pulumi Insights' where current UI has
@@ -41,6 +54,9 @@ Also check the manifest's `captured` dates: if a reference you used is older
 than 180 days, add an aging note to the Screenshot check section ("reference
 `pulumi-cloud-console-current.png` captured YYYY-MM-DD — refresh needed; owner:
 docs-team"). Keep flagging it on every run until the reference is refreshed.
+For the `branding` reference specifically, prefer the live brand-service fetch
+above over the cached PNG, so logo currency never silently rides on a stale
+reference image.
 
 ## Lane 2 — product source verification (when accessible)
 

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,7 +1,7 @@
 # Pulumi Documentation Style Guide
 
 This guide defines Pulumi-specific style rules for our documentation.  
-For topics not addressed here, refer to the [Google Developer Documentation Style Guide](https://developers.google.com/style).
+It's the repo-specific layer. For brand-level voice, writing style, and visual conventions, the [Pulumi brand guidelines](https://brand.pulumi.com/) are authoritative — query them directly through the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp) (see [Brand guidelines and the Brand MCP server](#brand-guidelines-and-the-brand-mcp-server) below). For anything none of these covers, fall back to the [Google Developer Documentation Style Guide](https://developers.google.com/style).
 
 ---
 
@@ -16,6 +16,22 @@ The following exceptions are specifically excluded from this style guide:
 
 ---
 
+## Brand guidelines and the Brand MCP server
+
+Pulumi's brand-level conventions — voice and tone, writing style (grammar, punctuation, product names), typography, logo and visual usage, and color — live in the [Pulumi brand guidelines](https://brand.pulumi.com/), served programmatically by the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp). That server is the source of truth for brand questions this guide doesn't answer.
+
+Precedence, highest first:
+
+1. **This style guide** — repo-specific conventions for the Hugo content in this repository.
+1. **Pulumi brand guidelines (Brand MCP server)** — brand-wide voice, writing style, and visual rules.
+1. **[Google Developer Documentation Style Guide](https://developers.google.com/style)** — anything neither of the above covers.
+
+Where this guide and the brand guidelines diverge, this guide wins for this repository — but the divergence should be deliberate and documented here (see [Headings](#headings) for the one current example). Don't invent a third convention; reconcile with the brand guidelines or note the exception.
+
+Agents with the Brand MCP server configured can pull the full text of any section on demand (for example, `get_guidelines({ section: "writing-style" })`) and should prefer it to guessing. The same server provides approved logo assets (`get_logo`), the brand color palette and semantic tokens, and an APCA contrast checker. Use those when **creating** brand assets — blog meta images, diagrams, slide decks — not for second-guessing the colors in a product screenshot.
+
+---
+
 ## Inclusive Language
 
 Pulumi strives to use language that is clear, inclusive, and respectful.  
@@ -26,7 +42,7 @@ Pulumi strives to use language that is clear, inclusive, and respectful.
 - Avoid unnecessarily gendered language (e.g., use _folks_, _everyone_).  
 - Avoid violent or aggressive terms (e.g., avoid _kill_).  
 - Avoid pop-culture references that may not be globally understood.  
-- Instead of "click," use "select."  
+- Instead of "click," use "select" (or "choose").  
 - Instead of "go to," use "navigate."  
 - Avoid directional terms (e.g., "see above"); link directly.  
 - Avoid words like "easy" or "simple." These judge difficulty and may alienate readers.
@@ -42,6 +58,8 @@ Pulumi strives to use language that is clear, inclusive, and respectful.
 - Use capitalization only for proper nouns. For example, use "stack" not "Stack."
 - Do not end headings with punctuation, with one exception: headings in a "Frequently asked questions" section may end with `?` so the site's FAQPage JSON-LD auto-collector (`layouts/partials/schema/collectors/faq-entity.html`) detects them as questions.
 - Headings should be surrounded by blank lines.
+
+> **Brand divergence (intentional).** The [Pulumi brand writing-style guidelines](https://brand.pulumi.com/) call for sentence case on *all* headings. This repository keeps **Title Case for the page title (H1) only** — it's rendered from front-matter `title` and styled Title Case site-wide, consistent with the Title Case used for navigation menu items. H2 and deeper follow the brand's sentence-case rule. Don't "fix" existing H1s to sentence case.
 
 **Navigation menu items**: Use **Title Case** for frontmatter menu fields (`menu.name`, `menu.title`). Navigation items are UI labels, not prose headings, and follow Title Case conventions consistent with industry standards.
 
@@ -110,8 +128,11 @@ If the page also links to related child pages, use standard markdown (lists, tab
 ## Images and Media
 
 - Use root-relative paths for all image references (see [Links](#links) above).
-- Provide descriptive alt text for all images.
+- Provide descriptive alt text for all images. Describe the image's content or function in a few words, and omit lead-ins like "image of" or "screenshot of" — screen readers already announce those.
+- Name image files descriptively (helps accessibility and SEO); avoid generic names like `screenshot-1.png`.
 - For partial screenshots where the image may be hard to distinguish from the page background, add a 1px gray #999999 border.
+
+**Brand assets.** For logos, illustrations, and other brand imagery, use the approved assets from the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp) (`get_logo`, or the canonical URLs under `https://brand.pulumi.com/media/...`). Don't recolor, distort, add effects to, or otherwise alter the logo, and never use generative AI to create Pulumi brand imagery or the Pulumipus mascot. See the brand `logo`, `visuals`, and `guidelines` sections for the full rules.
 
 ---
 
@@ -154,6 +175,17 @@ Both syntaxes work for plain text content, but use percent signs for shortcodes 
 - Separate paragraphs with a blank line.  
 - Do not use line breaks within paragraphs. Let text wrap naturally.  
 - Keep paragraphs short (ideally ≤3 sentences).
+
+---
+
+## Grammar and punctuation
+
+- Use the Oxford (serial) comma: "build, deploy, and manage," not "build, deploy and manage."
+- Contractions are fine — preferred, even — in docs. They read more naturally.
+- Put commas and periods outside closing quotation marks unless they belong to the quoted text — e.g., write `"us-west-2"`, with the comma outside.
+- Em-dashes are fine when you write them yourself, but revise away the em-dashes, three-item series, and filler phrasings that LLMs tend to emit — they read as unedited machine output.
+
+For dates, times, numbers, point of view (*you* vs. *we*), and other mechanics this guide doesn't specify, defer to the brand `writing-style` guidance via the [Brand MCP server](https://brand.pulumi.com/mcp).
 
 ---
 
@@ -285,7 +317,9 @@ See [Hugo diagrams docs](https://gohugo.io/content-management/diagrams/) and [Me
   - Pulumi ESC (Environments, Secrets, and Configuration)  
   - Pulumi IDP (Internal Developer Platform)  
   - Pulumi Insights  
-  - Pulumi Cloud
+  - Pulumi Cloud (also Pulumi console / Pulumi Cloud console — but not "Pulumi UI")
+  - Pulumi Deployments
+  - Pulumi Neo
   - Pulumi Policies  
 - Expand product acronyms at first mention. Use just the product name after.  
 - For non-Pulumi acronyms: spell out on first use, then use the acronym.  

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,7 +1,7 @@
 # Pulumi Documentation Style Guide
 
 This guide defines Pulumi-specific style rules for our documentation.  
-It's the repo-specific layer. For brand-level voice, writing style, and visual conventions, the [Pulumi brand guidelines](https://brand.pulumi.com/) are authoritative — query them directly through the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp) (see [Brand guidelines and the Brand MCP server](#brand-guidelines-and-the-brand-mcp-server) below). For anything none of these covers, fall back to the [Google Developer Documentation Style Guide](https://developers.google.com/style).
+It's the repo-specific layer. For brand-level conventions, defer to the [Pulumi brand guidelines](https://brand.pulumi.com/) (see [Brand guidelines](#brand-guidelines) below); for anything neither covers, fall back to the [Google Developer Documentation Style Guide](https://developers.google.com/style).
 
 ---
 
@@ -16,19 +16,17 @@ The following exceptions are specifically excluded from this style guide:
 
 ---
 
-## Brand guidelines and the Brand MCP server
+## Brand guidelines
 
-Pulumi's brand-level conventions — voice and tone, writing style (grammar, punctuation, product names), typography, logo and visual usage, and color — live in the [Pulumi brand guidelines](https://brand.pulumi.com/), served programmatically by the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp). That server is the source of truth for brand questions this guide doesn't answer.
+Brand-level conventions — voice and tone, writing style, typography, logo and visual usage, and color — live in the [Pulumi brand guidelines](https://brand.pulumi.com/). Precedence, highest first:
 
-Precedence, highest first:
+1. **This style guide** — repo-specific conventions for this repository's Hugo content.
+1. **Pulumi brand guidelines** — brand-wide voice, writing style, and visual rules.
+1. **[Google Developer Documentation Style Guide](https://developers.google.com/style)** — anything neither covers.
 
-1. **This style guide** — repo-specific conventions for the Hugo content in this repository.
-1. **Pulumi brand guidelines (Brand MCP server)** — brand-wide voice, writing style, and visual rules.
-1. **[Google Developer Documentation Style Guide](https://developers.google.com/style)** — anything neither of the above covers.
+When this guide and the brand guidelines diverge, this guide wins here — but flag the divergence rather than inventing a third convention.
 
-Where this guide and the brand guidelines diverge, this guide wins for this repository — but any divergence should be deliberate and documented here. Don't invent a third convention; reconcile with the brand guidelines or note the exception.
-
-Agents with the Brand MCP server configured can pull the full text of any section on demand (for example, `get_guidelines({ section: "writing-style" })`) and should prefer it to guessing. The same server provides approved logo assets (`get_logo`), the brand color palette and semantic tokens, and an APCA contrast checker. Use those when **creating** brand assets — blog meta images, diagrams, slide decks — not for second-guessing the colors in a product screenshot.
+Approved logos and other brand assets come from the self-describing brand asset API (`https://brand.pulumi.com/api`) — no setup, just fetch the URL. Working in an interactive agent or editor? Installing the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp) puts the full guidelines, logos, palette, and a contrast checker inline.
 
 ---
 
@@ -132,7 +130,7 @@ If the page also links to related child pages, use standard markdown (lists, tab
 - Name image files descriptively (helps accessibility and SEO); avoid generic names like `screenshot-1.png`.
 - For partial screenshots where the image may be hard to distinguish from the page background, add a 1px gray #999999 border.
 
-**Brand assets.** For logos, illustrations, and other brand imagery, use the approved assets from the [Pulumi Brand MCP server](https://brand.pulumi.com/mcp) (`get_logo`, or the canonical URLs under `https://brand.pulumi.com/media/...`). Don't recolor, distort, add effects to, or otherwise alter the logo, and never use generative AI to create Pulumi brand imagery or the Pulumipus mascot. See the brand `logo`, `visuals`, and `guidelines` sections for the full rules.
+**Brand assets.** Use approved logos from the brand asset API (`https://brand.pulumi.com/api`); don't recolor, distort, or otherwise alter the logo, and never AI-generate Pulumi brand imagery or the Pulumipus mascot.
 
 ---
 
@@ -185,7 +183,7 @@ Both syntaxes work for plain text content, but use percent signs for shortcodes 
 - Put commas and periods outside closing quotation marks unless they belong to the quoted text — e.g., write `"us-west-2"`, with the comma outside.
 - Em-dashes are fine when you write them yourself, but revise away the em-dashes, three-item series, and filler phrasings that LLMs tend to emit — they read as unedited machine output.
 
-For dates, times, numbers, point of view (*you* vs. *we*), and other mechanics this guide doesn't specify, defer to the brand `writing-style` guidance via the [Brand MCP server](https://brand.pulumi.com/mcp).
+For dates, times, numbers, point of view (*you* vs. *we*), and anything else this guide doesn't specify, defer to the brand `writing-style` guidelines.
 
 ---
 

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -26,7 +26,7 @@ Precedence, highest first:
 1. **Pulumi brand guidelines (Brand MCP server)** — brand-wide voice, writing style, and visual rules.
 1. **[Google Developer Documentation Style Guide](https://developers.google.com/style)** — anything neither of the above covers.
 
-Where this guide and the brand guidelines diverge, this guide wins for this repository — but the divergence should be deliberate and documented here (see [Headings](#headings) for the one current example). Don't invent a third convention; reconcile with the brand guidelines or note the exception.
+Where this guide and the brand guidelines diverge, this guide wins for this repository — but any divergence should be deliberate and documented here. Don't invent a third convention; reconcile with the brand guidelines or note the exception.
 
 Agents with the Brand MCP server configured can pull the full text of any section on demand (for example, `get_guidelines({ section: "writing-style" })`) and should prefer it to guessing. The same server provides approved logo assets (`get_logo`), the brand color palette and semantic tokens, and an APCA contrast checker. Use those when **creating** brand assets — blog meta images, diagrams, slide decks — not for second-guessing the colors in a product screenshot.
 
@@ -59,7 +59,7 @@ Pulumi strives to use language that is clear, inclusive, and respectful.
 - Do not end headings with punctuation, with one exception: headings in a "Frequently asked questions" section may end with `?` so the site's FAQPage JSON-LD auto-collector (`layouts/partials/schema/collectors/faq-entity.html`) detects them as questions.
 - Headings should be surrounded by blank lines.
 
-> **Brand divergence (intentional).** The [Pulumi brand writing-style guidelines](https://brand.pulumi.com/) call for sentence case on *all* headings. This repository keeps **Title Case for the page title (H1) only** — it's rendered from front-matter `title` and styled Title Case site-wide, consistent with the Title Case used for navigation menu items. H2 and deeper follow the brand's sentence-case rule. Don't "fix" existing H1s to sentence case.
+> **Title vs. headings.** The brand guide's sentence-case rule governs *headings*, and it treats the H1 as the page **title**, not a heading. Title Case for the H1 — rendered from front-matter `title`, consistent with the Title Case used for navigation menu items — is therefore in keeping with the [Pulumi brand writing-style guidelines](https://brand.pulumi.com/), not an exception to them. Sentence case applies to H2 and deeper. Don't "fix" existing H1s to sentence case.
 
 **Navigation menu items**: Use **Title Case** for frontmatter menu fields (`menu.name`, `menu.title`). Navigation items are UI labels, not prose headings, and follow Title Case conventions consistent with industry standards.
 


### PR DESCRIPTION
## What & why

Two asks, both driven by the Pulumi Brand MCP server (`get_guidelines`, `get_logo`, color/contrast tools):

1. **Reconcile `STYLE-GUIDE.md` with the brand guidance** — find and resolve conflicts.
2. **Find a place for the brand service in the automated review / content-freshness workflows, especially around images** — and wire it in only where there's a real advantage.

## `STYLE-GUIDE.md`

- **New "Brand guidelines and the Brand MCP server" section** establishing precedence (this guide → brand guidelines/MCP → Google) and pointing agents at the server for the full brand text, logos, palette, and APCA contrast checks.
- **Title vs. headings, clarified (not a divergence):** the brand guide's sentence-case rule governs *headings* and treats the H1 as the page **title**, so this repo's Title Case for H1 (front-matter `title`) is in keeping with the brand guide. Sentence case applies to H2 and deeper. The Headings note now says this explicitly so it isn't mistaken for a conflict.
- **Factual gaps in the product-name list closed:** added Pulumi Deployments, Pulumi Neo, and the *Pulumi console / Pulumi Cloud console (not "Pulumi UI")* guidance from the brand list.
- **New "Grammar and punctuation" section** (Oxford comma, contractions, quote/comma placement, em-dash & LLM-tell guidance) — the guide had none — plus a small `click → "select" (or "choose")` broadening to match the brand wording.
- **Images and Media strengthened:** alt-text wording ("omit 'image of'/'screenshot of'"), descriptive filenames, and a **brand-assets** note (approved logos only; never AI-generate brand imagery or the Pulumipus).

> Net result: no remaining conflicts between the style guide and the brand guidance.

## Workflows — where the brand service helps (and where it doesn't)

- **PR pre-merge review (`claude-code-review.yml`): unchanged.** It's diff-only and does no image review (`ci.md` never touches images); most doc images are product screenshots the brand service can't evaluate; and `image-review.md` deliberately excludes color/aesthetic critique. No significant advantage, so no change.
- **Content-freshness worker (`content-review-article.yml`): improved via its criteria.** It already runs a branding/screenshot pass and already has `WebFetch`/`curl`, so the win lands in the reference files it executes — **no YAML/MCP plumbing change required**:
  - `screenshot-verification.md` — compare logos against the **canonical logo fetched live from the brand service** instead of a curated PNG the system itself flags as stale after 180 days; flag logo misuse, AI-generated brand imagery, and deprecated-Pulumipus usage as **compliance** findings.
  - `image-review.md` — new **Brand assets** section (logo integrity, no AI brand imagery, no Pulumipus in new materials) with a tight carve-out from the existing "don't critique aesthetics" rule. This also reaches the interactive `/docs-review`.
  - `manifest.yaml` — branding PNG marked a cached convenience; canonical source now points at the brand service.

## Notes for the reviewer

- **Live MCP tools in CI were deliberately *not* wired in.** The in-scope image check only needs the canonical logo + published rules, both reachable over plain HTTPS the worker already allows. Pulling in the structured color tools would reopen the color/aesthetic critique the repo intentionally excludes. The brand MCP's color/contrast/`get_logo` tools are better suited to the **authoring** skills (blog meta images, figma-to-template, etc.) — happy to wire those up as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGdqWHa92cN3VPT9BpRh2i