### PR TITLE
Fix white-on-white definition-list table in docs dark mode

### DIFF
--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -239,6 +239,30 @@ html[data-theme="dark"] body.section-docs {
         }
     }
 
+    // --- Definition-list "table" (dl.tabular) — e.g. the CLI environment-
+    // variables page. Same flip as the <table> above: the dl + dt carry the
+    // gray surface, dd is the white value cell. <p> inside dd is already
+    // force-flipped to --docs-fg by the base rule, so without the dd background
+    // flip the description text renders white-on-white.
+    dl.tabular {
+        background-color: var(--docs-surface);
+        border-color: var(--docs-border);
+        color: var(--docs-fg);
+
+        dt {
+            color: var(--docs-fg);
+        }
+
+        dd {
+            background-color: var(--docs-bg);
+        }
+
+        dt,
+        dd {
+            border-color: var(--docs-border);
+        }
+    }
+
     @media (max-width: 767.98px) {
         .table-wrapper.table-responsive {
             tr {


### PR DESCRIPTION
> [!TIP]
> [Preview link HERE!](http://www-testing-pulumi-docs-origin-pr-19830-a1ebec1f.s3-website.us-west-2.amazonaws.com/docs/iac/cli/environment-variables/)

> [!NOTE]
> I did look at converting this table to markdown, but there was no way to do it without really refactoring all the information in the table. Instead, I just added the missing classes. Verified against the Pulumi Brand MCP.
>
> Set to auto-merge.


## Problem

In dark mode, [`/docs/iac/cli/environment-variables/`](https://www.pulumi.com/docs/iac/cli/environment-variables/) renders its variable reference unreadably — the description column shows **white text on a white background**.

## Root cause

That page isn't an HTML `<table>`; it's a `<dl class="tabular">` definition list (the site's two-column reference idiom, styled in `theme/src/scss/_lists.scss`). Its cells use literal Tailwind utilities — `bg-gray-100` on the container, `bg-white` on each `<dd>`, `text-gray-700`.

The docs dark theme (`theme/src/scss/docs/_docs-theme.scss`) **deliberately removed per-utility color flips** (see the comment near line 489), so `bg-white` / `bg-gray-100` stay light in dark mode. But the base rule **does** force-flip `<p>` text to `--docs-fg` (white). Net result inside each `<dd>`: white `<p>` text on an un-flipped white background → invisible. (The `<dt>` names live in a `<span>`, so they keep `text-gray-700` and stay faintly visible — matching the reported symptom.)

The existing `<table>` dark override in the same file (~line 228) already solves the identical problem for real tables; `dl.tabular` was simply never given the analogous treatment.

## Fix

Add a dark-mode override for `dl.tabular` that mirrors the `<table>` block, using the semantic `--docs-*` tokens:

- container + `dt` → `--docs-surface`
- `dd` → `--docs-bg`
- text → `--docs-fg`, borders → `--docs-border`

No content changes — `environment-variables.md` is untouched.

## Why not convert it to Markdown / a real table?

The value cells contain block-level content — ~50 `<pre><code>` examples, an ordered list (`PULUMI_STACK`), multi-paragraph entries (`PULUMI_CONFIG`) — which Markdown table cells (inline-only) cannot hold without regression. Converting to a raw HTML `<table>` would change the visual design and is a ~540-line rewrite. The CSS override fixes the bug with **no visual change** to the table.

## Scope / blast radius

Double-gated on `html[data-theme="dark"]` **and** `body.section-docs`:

- **Light mode:** zero impact anywhere (the entire rule lives inside the dark block).
- **Non-docs sections** (blog, marketing, templates, …): zero impact (and they have no dark mode).
- **Docs + dark mode:** `dl.tabular` matches exactly one page — the environment-variables page — which is currently broken, so the only possible effect is the fix.

## Accessibility (APCA, Pulumi brand tokens)

| Foreground / background | Lc | Result |
|---|---|---|
| white on `#1F1B21` (value cells) | −106 | exceeds preferred body text ✅ |
| white on `#46434c` (label cells) | −97 | exceeds preferred body text ✅ |

## Testing

- Visual check: toggle dark mode on the environment-variables page — value text legible on dark cells; light mode unchanged.
- Local theme asset build (webpack) + CI.
