### PR TITLE
Add HCL templates to template pages

### DIFF
--- a/content/templates/_index.md
+++ b/content/templates/_index.md
@@ -1,6 +1,6 @@
 ---
 title_tag: 'Pulumi Templates: Deploy Infrastructure to AWS, Azure, & Google Cloud'
 title: Pulumi Templates
-description: Pulumi templates are starter projects for common cloud architectures on AWS, Azure, and Google Cloud, available in TypeScript, Python, Go, .NET/C#, and YAML.
+description: Pulumi templates are starter projects for common cloud architectures on AWS, Azure, and Google Cloud, available in TypeScript, Python, Go, .NET/C#, YAML, and HCL.
 meta_desc: Deploy container services, serverless applications, Kubernetes clusters, and more to AWS, Azure, and Google Cloud with Pulumi templates.
 ---

--- a/content/templates/container-service/aws/index.md
+++ b/content/templates/container-service/aws/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Container Service to AWS
 title: Container Service on AWS
 layout: template
 schema_type: howto
-meta_desc: Deploy a container service on AWS with Pulumi, Amazon ECS on Fargate, and Amazon ECR in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a container service on AWS with Pulumi, Amazon ECS on Fargate, and Amazon ECR in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a container service on AWS with Pulumi and Amazon ECS.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Amazon Web Services
   slug: aws
@@ -55,6 +56,8 @@ $ open $(pulumi stack output url)
 
 Projects created with the Container Service template expose the following [configuration](/docs/iac/concepts/config/) settings:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 container_port
 : Specifies the port mapping for the container. Defaults to port 80.
 
@@ -67,9 +70,32 @@ memory
 image
 : Specifies the location of the Dockerfile used to build the container image that is run. Defaults to the Dockerfile in the `app` folder.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+app_path
+: Specifies the path to the container application to deploy, used as the build context for the Dockerfile. Defaults to `./app`.
+
+image_name
+: Specifies the name to give the container image that is built. Defaults to `my-app`.
+
+container_port
+: Specifies the port mapping for the container. Defaults to `80`.
+
+cpu
+: Specifies the amount of CPU to use with each task or each container within a task. Defaults to `256`.
+
+memory
+: Specifies the amount of memory to use with each task or each container within a task. Defaults to `512`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
 
 ### Using your own container image
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 If you already have a container image you'd like to build your container service with, you can do so either by replacing the Dockerfile in the `app` folder or by configuring the stack to point to another folder on your computer with the `image` setting:
 
@@ -77,6 +103,19 @@ If you already have a container image you'd like to build your container service
 $ pulumi config set image ../my-existing-image
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+If you already have a container image you'd like to build your container service with, you can do so either by replacing the Dockerfile in the `app` folder or by configuring the stack to point to another folder on your computer (one containing a Dockerfile) with the `app_path` setting:
+
+```bash
+$ pulumi config set app_path ../my-existing-image
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ## Cleaning up
 

--- a/content/templates/container-service/aws/index.md
+++ b/content/templates/container-service/aws/index.md
@@ -74,20 +74,14 @@ image
 
 {{% choosable language hcl %}}
 
-app_path
-: Specifies the path to the container application to deploy, used as the build context for the Dockerfile. Defaults to `./app`.
-
-image_name
-: Specifies the name to give the container image that is built. Defaults to `my-app`.
-
 container_port
-: Specifies the port mapping for the container. Defaults to `80`.
+: Specifies the port mapping for the container. Defaults to port 80.
 
 cpu
-: Specifies the amount of CPU to use with each task or each container within a task. Defaults to `256`.
+: Specifies the amount of CPU to use with each task or each container within a task. Defaults to 512.
 
 memory
-: Specifies the amount of memory to use with each task or each container within a task. Defaults to `512`.
+: Specifies the amount of memory to use with each task or each container within a task. Defaults to 128.
 
 {{% /choosable %}}
 
@@ -108,12 +102,7 @@ $ pulumi up
 
 {{% choosable language hcl %}}
 
-If you already have a container image you'd like to build your container service with, you can do so either by replacing the Dockerfile in the `app` folder or by configuring the stack to point to another folder on your computer (one containing a Dockerfile) with the `app_path` setting:
-
-```bash
-$ pulumi config set app_path ../my-existing-image
-$ pulumi up
-```
+If you already have a container image you'd like to build your container service with, you can do so by replacing the Dockerfile and application code in the `app` folder, then redeploying with `pulumi up`.
 
 {{% /choosable %}}
 

--- a/content/templates/container-service/azure/index.md
+++ b/content/templates/container-service/azure/index.md
@@ -85,14 +85,14 @@ imageTag
 
 {{% choosable language hcl %}}
 
-location
-: The Azure region to deploy into. Defaults to `WestUS`.
-
 app_path
 : The path to the folder containing the application and Dockerfile. Defaults to `./app`, which contains a "Hello world" example.
 
 image_name
 : The name of the container image to be published to Azure Container Registry. Defaults to `my-app`.
+
+image_tag
+: The tag applied to published container images. Defaults to `latest`.
 
 container_port
 : The port to expose on the container. Defaults to `80`.

--- a/content/templates/container-service/azure/index.md
+++ b/content/templates/container-service/azure/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Container Service to Azure
 title: Container Service on Azure
 layout: template
 schema_type: howto
-meta_desc: Deploy a container service on Azure with Pulumi, Azure Container Instances, and Azure Container Registry in TypeScript, Python, Go, or C#.
+meta_desc: Deploy a container service on Azure with Pulumi, Azure Container Instances, and Azure Container Registry in TypeScript, Python, Go, C#, or HCL.
 meta_image: meta.png
 card_desc: Deploy a container service on Azure with Pulumi and Azure Container Instances.
 template:
@@ -14,6 +14,7 @@ template:
     - python
     - go
     - csharp
+    - hcl
 cloud:
   name: Microsoft Azure
   slug: azure
@@ -60,6 +61,8 @@ $ open $(pulumi stack output url)
 
 Projects created with the Container Service template expose the following [configuration](/docs/iac/concepts/config/) settings:
 
+{{% choosable language "typescript,python,go,csharp" %}}
+
 appPath
 : The path to the folder containing the application and Dockerfile. Defaults to `app`, which contains a "Hello world" example.
 
@@ -78,12 +81,49 @@ imageName
 imageTag
 : The tag applied to published container images. Defaults to `latest`.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+location
+: The Azure region to deploy into. Defaults to `WestUS`.
+
+app_path
+: The path to the folder containing the application and Dockerfile. Defaults to `./app`, which contains a "Hello world" example.
+
+image_name
+: The name of the container image to be published to Azure Container Registry. Defaults to `my-app`.
+
+container_port
+: The port to expose on the container. Defaults to `80`.
+
+cpu
+: The number of CPU cores to allocate on the container. Defaults to `1`.
+
+memory
+: The amount of memory, in GB, to allocate on the container. Defaults to `2`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
+
+{{% choosable language "typescript,python,go,csharp" %}}
 
 ```bash
 $ pulumi config set containerPort 8080
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set container_port 8080
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ## Cleaning up
 

--- a/content/templates/container-service/gcp/index.md
+++ b/content/templates/container-service/gcp/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Container Service to Google Cloud
 title: Container Service on Google Cloud
 layout: template
 schema_type: howto
-meta_desc: Deploy a container service on Google Cloud with Pulumi, Cloud Run, and Artifact Registry in TypeScript, Python, Go, or C#.
+meta_desc: Deploy a container service on Google Cloud with Pulumi, Cloud Run, and Artifact Registry in TypeScript, Python, Go, C#, or HCL.
 meta_image: meta.png
 card_desc: Deploy a container service on Google Cloud with Pulumi and Google Cloud Run.
 template:
@@ -14,6 +14,7 @@ template:
     - python
     - go
     - csharp
+    - hcl
 cloud:
   name: Google Cloud
   slug: gcp
@@ -33,7 +34,17 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
+{{% choosable language "typescript,python,go,csharp" %}}
+
 You must supply an existing Google Cloud project ID and choose a region before deploying the container service. You can input both through the new-project wizard. Once the project is created, you can deploy it with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+The template deploys into your active Google Cloud project (read from your gcloud credentials) and defaults to the `us-central1` region, which you can change with the `region` setting. Once the new project is created, you can deploy it with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
+
+{{% /choosable %}}
 
 ```bash
 $ pulumi up
@@ -54,6 +65,8 @@ $ open $(pulumi stack output url)
 
 Projects created with the Container Service template expose the following [configuration](/docs/iac/concepts/config/) settings:
 
+{{% choosable language "typescript,python,go,csharp" %}}
+
 containerPort
 : The port mapping for the container service. Defaults to port `8080`.
 
@@ -72,12 +85,52 @@ imageName
 appPath
 : The location of the Dockerfile used to build the container image. Defaults to the `app` folder, which contains a "Hello World" example app.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+region
+: The Google Cloud region to deploy into. Defaults to `us-central1`.
+
+app_path
+: The location of the Dockerfile used to build the container image. Defaults to the `app` folder, which contains a "Hello World" example app.
+
+image_name
+: The name of the container image deployed to your Cloud Run service. Defaults to `my-app`.
+
+container_port
+: The port mapping for the container service. Defaults to port `8080`.
+
+cpu
+: The amount of CPU to allocate to each container instance. Defaults to `1` CPU.
+
+memory
+: The amount of memory to allocate to each container instance. Defaults to `1Gi`.
+
+concurrency
+: The maximum number of concurrent requests per container instance. Defaults to `80`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
+
+{{% choosable language "typescript,python,go,csharp" %}}
 
 ```bash
 $ pulumi config set containerPort 3000
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set container_port 3000
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ## Cleaning up
 

--- a/content/templates/container-service/gcp/index.md
+++ b/content/templates/container-service/gcp/index.md
@@ -92,11 +92,11 @@ appPath
 region
 : The Google Cloud region to deploy into. Defaults to `us-central1`.
 
-app_path
-: The location of the Dockerfile used to build the container image. Defaults to the `app` folder, which contains a "Hello World" example app.
-
 image_name
 : The name of the container image deployed to your Cloud Run service. Defaults to `my-app`.
+
+app_path
+: The location of the Dockerfile used to build the container image. Defaults to the `app` folder, which contains a "Hello World" example app.
 
 container_port
 : The port mapping for the container service. Defaults to port `8080`.

--- a/content/templates/kubernetes-application/helm-chart/index.md
+++ b/content/templates/kubernetes-application/helm-chart/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Helm Chart to a Kubernetes Cluster
 title: Helm Chart on Kubernetes
 layout: template
 schema_type: howto
-meta_desc: Deploy a Helm chart to an existing Kubernetes cluster with Pulumi in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a Helm chart to an existing Kubernetes cluster with Pulumi in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a Helm chart to a Kubernetes cluster with Pulumi.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Helm Chart
   slug: helm-chart
@@ -51,15 +52,39 @@ Output values like these are useful in many ways, most commonly as inputs for ot
 
 Projects created with the Helm Chart template expose the following [configuration](/docs/iac/concepts/config/) settings:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 k8sNamespace
 : The name of the namespace to be created in your existing cluster. Defaults to `nginx-ingress`.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+k8s_namespace
+: The name of the namespace to be created in your existing cluster. Defaults to `nginx-ingress`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ pulumi config set k8sNamespace my-namespace
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set k8s_namespace my-namespace
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 You can customize the Helm chart by passing values to it in your Pulumi code. An example of passing a few values to the chart is included in the template for reference.
 

--- a/content/templates/kubernetes-application/web-application/index.md
+++ b/content/templates/kubernetes-application/web-application/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Web Application to a Kubernetes Cluster
 title: Web Application on Kubernetes
 layout: template
 schema_type: howto
-meta_desc: Deploy a web application to an existing Kubernetes cluster with Pulumi in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a web application to an existing Kubernetes cluster with Pulumi in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a web application to a Kubernetes cluster with Pulumi.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Web Application
   slug: web-application
@@ -42,11 +43,25 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 deploymentName
 : The name of your new Kubernetes Deployment.
 
 serviceName
 : The name of your new Kubernetes Service.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+deployment_name
+: The name of your new Kubernetes Deployment.
+
+service_name
+: The name of your new Kubernetes Service.
+
+{{% /choosable %}}
 
 Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources.
 
@@ -54,18 +69,45 @@ Output values like these are useful in many ways, most commonly as inputs for ot
 
 Projects created with the Kubernetes Application template expose the following [configuration](/docs/iac/concepts/config/) settings:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 namespace
 : The name of the namespace to be created in your existing cluster. Defaults to `default`.
 
 replicas
 : The number of replicated Pods to be created in your new Deployment. Defaults to `1`.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+k8s_namespace
+: The name of the namespace to be created in your existing cluster. Defaults to `webapp`.
+
+num_replicas
+: The number of replicated Pods to be created in your new Deployment. Defaults to `1`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ pulumi config set replicas 3
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set num_replicas 3
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ## Cleaning up
 

--- a/content/templates/kubernetes/aws/index.md
+++ b/content/templates/kubernetes/aws/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Managed Kubernetes Cluster to AWS
 title: Kubernetes Cluster on AWS
 layout: template
 schema_type: howto
-meta_desc: Deploy a managed Kubernetes cluster on AWS with Pulumi and Amazon EKS in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a managed Kubernetes cluster on AWS with Pulumi and Amazon EKS in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a Kubernetes cluster on AWS with Pulumi and Amazon EKS.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Amazon Web Services
   slug: aws
@@ -42,17 +43,36 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 kubeconfig
 : The cluster's kubeconfig file, which you can use with `kubectl` to access and communicate with your cluster.
 
 vpcId
 : The ID of the VPC that your cluster is running in.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+cluster_name
+: The name of the EKS cluster.
+
+vpc_id
+: The ID of the VPC that your cluster is running in.
+
+kubeconfig
+: The cluster's kubeconfig file, which you can use with `kubectl` to access and communicate with your cluster.
+
+{{% /choosable %}}
+
 Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources.
 
 ## Customizing the project
 
 Projects created with the Kubernetes template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 minClusterSize
 : The minimum number of nodes to allow in the cluster. Defaults to `3`.
@@ -64,10 +84,31 @@ desiredClusterSize
 : The desired number of nodes in the cluster. Defaults to `3`.
 
 eksNodeInstanceType
-: The EC2 instance type to use for the nodes. Defaults to `t2.medium`.
+: The EC2 instance type to use for the nodes. Defaults to `t3.medium`.
 
 vpcNetworkCidr
 : The network CIDR to use for the VPC. Defaults to `10.0.0.0/16`.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+min_cluster_size
+: The minimum number of nodes to allow in the cluster. Defaults to `3`.
+
+max_cluster_size
+: The maximum number of nodes to allow in the cluster. Defaults to `6`.
+
+desired_cluster_size
+: The desired number of nodes in the cluster. Defaults to `3`.
+
+node_instance_type
+: The EC2 instance type to use for the nodes. Defaults to `t3.medium`.
+
+vpc_network_cidr
+: The network CIDR to use for the VPC. Defaults to `10.0.0.0/16`.
+
+{{% /choosable %}}
 
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set).
 

--- a/content/templates/kubernetes/aws/index.md
+++ b/content/templates/kubernetes/aws/index.md
@@ -55,9 +55,6 @@ vpcId
 
 {{% choosable language hcl %}}
 
-cluster_name
-: The name of the EKS cluster.
-
 vpc_id
 : The ID of the VPC that your cluster is running in.
 

--- a/content/templates/kubernetes/azure/index.md
+++ b/content/templates/kubernetes/azure/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Managed Kubernetes Cluster to Azure
 title: Kubernetes Cluster on Azure
 layout: template
 schema_type: howto
-meta_desc: Deploy a managed Kubernetes cluster on Azure with Pulumi and Azure Kubernetes Service (AKS) in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a managed Kubernetes cluster on Azure with Pulumi and Azure Kubernetes Service (AKS) in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a Kubernetes cluster on Azure with Pulumi and Azure Kubernetes Service (AKS).
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Microsoft Azure
   slug: azure
@@ -34,6 +35,8 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 You must supply two values to deploy the cluster. You can input both through the new-project wizard:
 
 mgmtGroupId
@@ -44,11 +47,21 @@ sshPubKey
 
 Once the project is created, you can deploy it with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
+
+{{% /choosable %}}
+
 ```bash
 $ pulumi up
 ```
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 rgname
 : The name of the Azure Resource Group containing the Kubernetes cluster resources.
@@ -62,11 +75,25 @@ clusterName
 kubeconfig
 : The cluster's kubeconfig file, which you can use with `kubectl` to access and communicate with your cluster.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+cluster_name
+: The name of the AKS cluster.
+
+kubeconfig
+: The cluster's kubeconfig file, which you can use with `kubectl` to access and communicate with your cluster.
+
+{{% /choosable %}}
+
 Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources.
 
 ## Customizing the project
 
 Projects created with the Kubernetes Cluster template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 numWorkerNodes
 : The number of nodes in your cluster. Defaults to `3`.
@@ -80,12 +107,43 @@ prefixForDns
 nodeVmSize
 : The VM instance type used to run your nodes. Defaults to `Standard_DS2_v2`.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+location
+: The Azure region to deploy into. Defaults to `westus2`.
+
+node_count
+: The number of worker nodes in the cluster. Defaults to `3`.
+
+dns_prefix
+: The unique DNS prefix to use for the cluster. Defaults to `pulumi`.
+
+node_vm_size
+: The VM size to use for worker nodes. Defaults to `Standard_DS2_v2`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ pulumi config set numWorkerNodes 5
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set node_count 5
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ## Cleaning up
 

--- a/content/templates/kubernetes/azure/index.md
+++ b/content/templates/kubernetes/azure/index.md
@@ -111,9 +111,6 @@ nodeVmSize
 
 {{% choosable language hcl %}}
 
-location
-: The Azure region to deploy into. Defaults to `westus2`.
-
 node_count
 : The number of worker nodes in the cluster. Defaults to `3`.
 

--- a/content/templates/kubernetes/gcp/index.md
+++ b/content/templates/kubernetes/gcp/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Managed Kubernetes Cluster to Google Cloud
 title: Kubernetes Cluster on Google Cloud
 layout: template
 schema_type: howto
-meta_desc: Deploy a managed Kubernetes cluster on Google Cloud with Pulumi and Google Kubernetes Engine (GKE) in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a managed Kubernetes cluster on Google Cloud with Pulumi and Google Kubernetes Engine (GKE) in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a Kubernetes cluster on Google Cloud with Pulumi and Google Kubernetes Engine (GKE).
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Google Cloud
   slug: gcp
@@ -34,13 +35,25 @@ Follow the prompts to complete the new-project wizard. When it's done, you'll ha
 
 ## Deploying the project
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 You must supply an existing Google Cloud project ID to deploy the cluster. You can input it through the new-project wizard. Once the project is created, you can deploy it with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+The template deploys into your active Google Cloud project (read from your gcloud credentials) and defaults to the `us-central1` region, which you can change with the `region` setting. Once the new project is created, you can deploy it with [`pulumi up`](/docs/iac/cli/commands/pulumi_up):
+
+{{% /choosable %}}
 
 ```bash
 $ pulumi up
 ```
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 networkName
 : The name of the VPC network containing the Kubernetes cluster resources.
@@ -57,11 +70,28 @@ clusterId
 kubeconfig
 : The cluster's kubeconfig file, which you can use with `kubectl` to access and communicate with your cluster.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+network_name
+: The name of the VPC network containing the Kubernetes cluster resources.
+
+cluster_name
+: The name of the GKE cluster.
+
+kubeconfig
+: The cluster's kubeconfig file, which you can use with `kubectl` to access and communicate with your cluster.
+
+{{% /choosable %}}
+
 Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources.
 
 ## Customizing the project
 
 Projects created with the Kubernetes Cluster template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 gcp:project
 : The Google Cloud project ID to deploy into.
@@ -72,12 +102,37 @@ gcp:region
 nodesPerZone
 : The desired number of nodes per zone in the node pool. Defaults to `1`.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+region
+: The Google Cloud region to deploy into. Defaults to `us-central1`.
+
+nodes_per_zone
+: The desired number of nodes per zone in the node pool. Defaults to `1`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ pulumi config set nodesPerZone 2
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set nodes_per_zone 2
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ## Cleaning up
 

--- a/content/templates/serverless-application/aws/index.md
+++ b/content/templates/serverless-application/aws/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Serverless Application to AWS
 title: AWS Serverless Application
 layout: template
 schema_type: howto
-meta_desc: Deploy a serverless application on AWS with Pulumi, AWS Lambda, and Amazon API Gateway in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a serverless application on AWS with Pulumi, AWS Lambda, and Amazon API Gateway in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a serverless application on AWS with Pulumi, AWS Lambda, and Amazon API Gateway.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Amazon Web Services
   slug: aws
@@ -42,8 +43,22 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 url
 : The HTTP URL for the application.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+site_url
+: The HTTP URL for the website.
+
+api_url
+: The HTTP URL for the API endpoint.
+
+{{% /choosable %}}
 
 Stack outputs are useful in a number of ways, most commonly as inputs to other stacks or cloud resources.
 
@@ -51,11 +66,25 @@ Stack outputs are useful in a number of ways, most commonly as inputs to other s
 
 Projects created with the AWS Serverless template expose the following [configuration](/docs/iac/concepts/config/) settings:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 path
 : The path to the folder containing the files of the website. Defaults to `www`, which is the folder included with the template. The `/date` path is a GET endpoint that retrieves the current time from the Lambda function.
 
 code
 : The path to the folder containing the Lambda function code. Defaults to the `function` folder included with the template.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+site_path
+: The path to the folder containing the files of the website. Defaults to `./www`, which is the folder included with the template. The `/date` path is a GET endpoint that retrieves the current time from the Lambda function.
+
+app_path
+: The path to the folder containing the Lambda function code. Defaults to the `./function` folder included with the template.
+
+{{% /choosable %}}
 
 None of these settings is required; by default, the template deploys the website and function using the files in the `www` and `function` folders bundled with the template.
 
@@ -63,12 +92,25 @@ None of these settings is required; by default, the template deploys the website
 
 If you already have a website you'd like to deploy, you can do so by replacing the contents of the `www` folder and redeploying with `pulumi up`.
 
-Alternatively, you can configure the stack to deploy from another folder on your machine by using [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) to change the value of the `path` setting:
+Alternatively, you can configure the stack to deploy from another folder on your machine by using [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) to change the value of the website path setting:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ pulumi config set path ../my-website/dist
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set site_path ../my-website/dist
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ### Customizing the application's functionality
 

--- a/content/templates/serverless-application/aws/index.md
+++ b/content/templates/serverless-application/aws/index.md
@@ -43,30 +43,16 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
-{{% choosable language "typescript,python,go,csharp,yaml" %}}
-
 url
 : The HTTP URL for the application.
-
-{{% /choosable %}}
-
-{{% choosable language hcl %}}
-
-site_url
-: The HTTP URL for the website.
-
-api_url
-: The HTTP URL for the API endpoint.
-
-{{% /choosable %}}
 
 Stack outputs are useful in a number of ways, most commonly as inputs to other stacks or cloud resources.
 
 ## Customizing the project
 
-Projects created with the AWS Serverless template expose the following [configuration](/docs/iac/concepts/config/) settings:
-
 {{% choosable language "typescript,python,go,csharp,yaml" %}}
+
+Projects created with the AWS Serverless template expose the following [configuration](/docs/iac/concepts/config/) settings:
 
 path
 : The path to the folder containing the files of the website. Defaults to `www`, which is the folder included with the template. The `/date` path is a GET endpoint that retrieves the current time from the Lambda function.
@@ -74,39 +60,26 @@ path
 code
 : The path to the folder containing the Lambda function code. Defaults to the `function` folder included with the template.
 
+None of these settings is required; by default, the template deploys the website and function using the files in the `www` and `function` folders bundled with the template.
+
 {{% /choosable %}}
 
 {{% choosable language hcl %}}
 
-site_path
-: The path to the folder containing the files of the website. Defaults to `./www`, which is the folder included with the template. The `/date` path is a GET endpoint that retrieves the current time from the Lambda function.
-
-app_path
-: The path to the folder containing the Lambda function code. Defaults to the `./function` folder included with the template.
+The HCL version of this template exposes no [configuration](/docs/iac/concepts/config/) settings. It deploys the website and function using the files in the `www` and `function` folders bundled with the template.
 
 {{% /choosable %}}
-
-None of these settings is required; by default, the template deploys the website and function using the files in the `www` and `function` folders bundled with the template.
 
 ### Using your own web content
 
 If you already have a website you'd like to deploy, you can do so by replacing the contents of the `www` folder and redeploying with `pulumi up`.
 
-Alternatively, you can configure the stack to deploy from another folder on your machine by using [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) to change the value of the website path setting:
-
 {{% choosable language "typescript,python,go,csharp,yaml" %}}
+
+Alternatively, you can configure the stack to deploy from another folder on your machine by using [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set) to change the value of the website path setting:
 
 ```bash
 $ pulumi config set path ../my-website/dist
-$ pulumi up
-```
-
-{{% /choosable %}}
-
-{{% choosable language hcl %}}
-
-```bash
-$ pulumi config set site_path ../my-website/dist
 $ pulumi up
 ```
 

--- a/content/templates/serverless-application/azure/index.md
+++ b/content/templates/serverless-application/azure/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Serverless Application to Azure
 title: Azure Serverless Application
 layout: template
 schema_type: howto
-meta_desc: Deploy a serverless application on Azure with Pulumi, Azure Functions, and Azure Blob Storage in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a serverless application on Azure with Pulumi, Azure Functions, and Azure Blob Storage in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a serverless application on Azure with Pulumi, Azure Functions, and Azure Blob Storage.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Microsoft Azure
   slug: azure
@@ -42,21 +43,49 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 siteURL
 : The HTTP URL of the static website.
 
 apiURL
 : The HTTP URL of the serverless function endpoint.
 
-Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `siteURL`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+site_url
+: The HTTP URL of the static website.
+
+api_url
+: The HTTP URL of the serverless function endpoint.
+
+{{% /choosable %}}
+
+Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed website URL, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ open $(pulumi stack output siteURL)
 ```
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ open $(pulumi stack output site_url)
+```
+
+{{% /choosable %}}
+
 ## Customizing the project
 
 Projects created with the Serverless Application template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 sitePath
 : The path to the folder containing the files of the website. Defaults to `www`, which is the folder included with the template.
@@ -70,12 +99,46 @@ indexDocument
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+location
+: The Azure region to deploy into. Defaults to `WestUS`.
+
+site_path
+: The path to the folder containing the files of the website. Defaults to `./www`, which is the folder included with the template.
+
+app_path
+: The path to the folder containing the serverless functions to be deployed. Defaults to `./app`, which is also included with the template.
+
+index_document
+: The file to use for top-level pages. Defaults to `index.html`.
+
+error_document
+: The file to use for error pages. Defaults to `error.html`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ pulumi config set sitePath ../my-existing-website/build
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set site_path ../my-existing-website/build
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ## Cleaning up
 

--- a/content/templates/serverless-application/azure/index.md
+++ b/content/templates/serverless-application/azure/index.md
@@ -55,7 +55,7 @@ apiURL
 
 {{% choosable language hcl %}}
 
-site_url
+origin_url
 : The HTTP URL of the static website.
 
 api_url
@@ -76,7 +76,7 @@ $ open $(pulumi stack output siteURL)
 {{% choosable language hcl %}}
 
 ```bash
-$ open $(pulumi stack output site_url)
+$ open $(pulumi stack output origin_url)
 ```
 
 {{% /choosable %}}
@@ -102,9 +102,6 @@ errorDocument
 {{% /choosable %}}
 
 {{% choosable language hcl %}}
-
-location
-: The Azure region to deploy into. Defaults to `WestUS`.
 
 site_path
 : The path to the folder containing the files of the website. Defaults to `./www`, which is the folder included with the template.

--- a/content/templates/serverless-application/gcp/index.md
+++ b/content/templates/serverless-application/gcp/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Serverless Application to Google Cloud
 title: Google Cloud Serverless Application
 layout: template
 schema_type: howto
-meta_desc: Deploy a serverless application on Google Cloud with Pulumi, Cloud Functions (Gen 2), and Cloud Storage in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a serverless application on Google Cloud with Pulumi, Cloud Functions (Gen 2), and Cloud Storage in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a serverless application on Google Cloud with Pulumi, Cloud Functions, and Cloud Storage.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Google Cloud Platform
   slug: gcp
@@ -46,21 +47,49 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 siteURL
 : The HTTP URL of the static website.
 
 apiURL
 : The HTTP URL of the serverless function endpoint.
 
-Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `siteURL`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+site_url
+: The HTTP URL of the static website.
+
+api_url
+: The HTTP URL of the serverless function endpoint.
+
+{{% /choosable %}}
+
+Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed site URL, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ open $(pulumi stack output siteURL)
 ```
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ open $(pulumi stack output site_url)
+```
+
+{{% /choosable %}}
+
 ## Customizing the project
 
 Projects created with the serverless template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 sitePath
 : The path to the folder containing the files of the website. Defaults to `www`, which is the name (and relative path) of the folder included with the template.
@@ -74,12 +103,46 @@ indexDocument
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+region
+: The Google Cloud region to deploy into. Defaults to `us-central1`.
+
+site_path
+: The path to the folder containing the files of the website. Defaults to `./www`, which is the relative path of the folder included with the template.
+
+app_path
+: The path to the folder containing the serverless functions to be deployed. Defaults to `./app`, which is also included with the template.
+
+index_document
+: The file to use for top-level pages. Defaults to `index.html`.
+
+error_document
+: The file to use for error pages. Defaults to `error.html`.
+
+{{% /choosable %}}
+
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ pulumi config set sitePath ../my-existing-website/build
 $ pulumi up
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ pulumi config set site_path ../my-existing-website/build
+$ pulumi up
+```
+
+{{% /choosable %}}
 
 ## Cleaning up
 

--- a/content/templates/static-website/aws/index.md
+++ b/content/templates/static-website/aws/index.md
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Amazon Web Services
   slug: aws
@@ -42,21 +43,49 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 cdnHostname
 : The provider-assigned hostname of the CloudFront CDN. Useful for creating `CNAME` records to associate custom domains.
 
 cdnURL
 : The fully-qualified HTTPS URL of the CloudFront CDN.
 
-Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `cdnURL`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+cdn_url
+: The fully-qualified HTTPS URL of the CloudFront CDN.
+
+cdn_hostname
+: The provider-assigned hostname of the CloudFront CDN. Useful for creating `CNAME` records to associate custom domains.
+
+{{% /choosable %}}
+
+Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed CDN URL, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ open $(pulumi stack output cdnURL)
 ```
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ open $(pulumi stack output cdn_url)
+```
+
+{{% /choosable %}}
+
 ## Customizing the project
 
 Projects created with the Static Website template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 path
 : The path to the folder containing the files of the website. Defaults to `www`, which is the name (and relative path) of the folder included with the template.
@@ -66,6 +95,21 @@ indexDocument
 
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+path
+: The path to the folder containing the files of the website. Defaults to `./www`, which is the name (and relative path) of the folder included with the template.
+
+index_document
+: The file to use for top-level pages. Defaults to `index.html`.
+
+error_document
+: The file to use for error pages. Defaults to `error.html`.
+
+{{% /choosable %}}
 
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
 
@@ -82,7 +126,7 @@ $ pulumi up
 
 By default, the generated program configures the CloudFront CDN to cache files for 600 seconds (10 minutes), which may or may not be the best fit for your project or stack. You can adjust these settings by changing the code in {{< langfile >}}:
 
-{{% chooser language "typescript,python,go,csharp,yaml" / %}}
+{{% chooser language "typescript,python,go,csharp,yaml,hcl" / %}}
 
 {{% choosable language typescript %}}
 
@@ -163,6 +207,21 @@ cdn:
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```diff
+resource "aws_cloudfront_distribution" "cdn" {
+  default_cache_behavior {
+-   default_ttl = 600
+-   max_ttl     = 600
+-   min_ttl     = 600
++   default_ttl = 3600
++   max_ttl     = 3600
++   min_ttl     = 3600
+```
+
+{{% /choosable %}}
+
 Alternatively, and perhaps better, you could make these settings configurable as well, which would allow them to vary between other stacks in your project.
 
 ## Next steps
@@ -184,9 +243,19 @@ $ pulumi config set domain example.com
 $ pulumi config set subdomain www
 ```
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 Then, in your editor of choice, open {{< langfile >}} and add the following lines to the configuration section at the top of the program to import the new settings and capture the domain as a reusable value:
 
-{{< chooser language "typescript,python,go,csharp,yaml" / >}}
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+Then, in your editor of choice, open {{< langfile >}} and add the following lines to the top of the program to declare the new variables and capture the domain as a reusable value:
+
+{{% /choosable %}}
+
+{{< chooser language "typescript,python,go,csharp,yaml,hcl" / >}}
 
 {{% choosable language typescript %}}
 
@@ -244,9 +313,37 @@ variables:
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+variable "domain" {
+  type = string
+}
+
+variable "subdomain" {
+  type = string
+}
+
+locals {
+  domain_name = "${var.subdomain}.${var.domain}"
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 Next, just above the `aws.cloudfront.Distribution` declaration, add these lines to provision and validate a new SSL/TLS certificate with [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) (ACM):
 
-{{< chooser language "typescript,python,go,csharp,yaml" / >}}
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+Next, just above the `aws_cloudfront_distribution` resource, add these lines to provision and validate a new SSL/TLS certificate with [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) (ACM):
+
+{{% /choosable %}}
+
+{{< chooser language "typescript,python,go,csharp,yaml,hcl" / >}}
 
 {{% choosable language typescript %}}
 
@@ -449,9 +546,60 @@ resources:
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+# Look up your existing Route 53 hosted zone.
+data "aws_route53_zone" "zone" {
+  name = var.domain
+}
+
+# ACM certificates for CloudFront must be created in the us-east-1 region.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+# Provision a new ACM certificate.
+resource "aws_acm_certificate" "certificate" {
+  provider          = aws.us_east_1
+  domain_name       = local.domain_name
+  validation_method = "DNS"
+}
+
+# Validate the ACM certificate with DNS.
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for option in aws_acm_certificate.certificate.domain_validation_options : option.domain_name => {
+      name   = option.resource_record_name
+      type   = option.resource_record_type
+      record = option.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 Extend the CloudFront configuration to handle requests for the new domain by adding an `aliases` argument to the CDN configuration and adjusting  `viewerCertificate` to use the newly provisioned ACM certificate:
 
-{{< chooser language "typescript,python,go,csharp,yaml" / >}}
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+Extend the CloudFront configuration to handle requests for the new domain by adding an `aliases` argument to the CDN configuration and adjusting the `viewer_certificate` block to use the newly provisioned ACM certificate:
+
+{{% /choosable %}}
+
+{{< chooser language "typescript,python,go,csharp,yaml,hcl" / >}}
 
 {{% choosable language typescript %}}
 
@@ -546,9 +694,26 @@ cdn:
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+resource "aws_cloudfront_distribution" "cdn" {
+  # ...
+  aliases = [local.domain_name]
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    acm_certificate_arn            = aws_acm_certificate.certificate.arn
+    ssl_support_method             = "sni-only"
+  }
+}
+```
+
+{{% /choosable %}}
+
 Below that, add a Route 53 `A` record to create a DNS record pointing to the CloudFront CDN:
 
-{{< chooser language "typescript,python,go,csharp,yaml" / >}}
+{{< chooser language "typescript,python,go,csharp,yaml,hcl" / >}}
 
 {{% choosable language typescript %}}
 
@@ -666,9 +831,30 @@ resources:
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+# Create a DNS A record to point to the CDN.
+resource "aws_route53_record" "domain" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = var.subdomain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [aws_acm_certificate.certificate]
+}
+```
+
+{{% /choosable %}}
+
 And finally, complete the program by exporting the new URL as a Pulumi stack output:
 
-{{< chooser language "typescript,python,go,csharp,yaml" / >}}
+{{< chooser language "typescript,python,go,csharp,yaml,hcl" / >}}
 
 {{% choosable language typescript %}}
 
@@ -712,6 +898,16 @@ outputs:
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+output "domain_url" {
+  value = "https://${local.domain_name}"
+}
+```
+
+{{% /choosable %}}
+
 Save your changes, then preview and deploy with another `pulumi up`:
 
 ```bash
@@ -720,17 +916,43 @@ $ pulumi up
 
 In a few moments, you should be able to browse to your website using the custom domain:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 ```bash
 $ open $(pulumi stack output domainURL)
 ```
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ open $(pulumi stack output domain_url)
+```
+
+{{% /choosable %}}
+
 #### Using a third-party DNS service
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 If the domain you'd like to use is being managed by a third-party DNS service, you can generally use the exported `cdnHostname` to create a `CNAME` record with your DNS provider. You can obtain this value with `pulumi stack output`:
 
 ```bash
 $ pulumi stack output cdnHostname
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+If the domain you'd like to use is being managed by a third-party DNS service, you can generally use the exported `cdn_hostname` to create a `CNAME` record with your DNS provider. You can obtain this value with `pulumi stack output`:
+
+```bash
+$ pulumi stack output cdn_hostname
+```
+
+{{% /choosable %}}
 
 Pulumi supports many third-party DNS providers, all of which are available in the [Pulumi Registry](/registry/) and accompanied by examples, including:
 

--- a/content/templates/static-website/azure/index.md
+++ b/content/templates/static-website/azure/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Static Website to Azure
 title: Azure Static Website
 layout: template
 schema_type: howto
-meta_desc: Deploy a static website on Azure with Pulumi, Azure Blob Storage, and Azure CDN in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a static website on Azure with Pulumi, Azure Blob Storage, and Azure CDN in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a static website on Azure with Pulumi, Azure Blob Storage, and Azure CDN.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
     name: Microsoft Azure
     slug: azure
@@ -42,6 +43,8 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 originHostname
 : The provider-assigned hostname of the Azure Blob Storage container.
 
@@ -54,15 +57,47 @@ cdnHostname
 cdnURL
 : The fully-qualified HTTPS URL of the Azure CDN.
 
-Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `cdnURL`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+origin_url
+: The fully-qualified HTTP URL of the storage container endpoint.
+
+origin_hostname
+: The provider-assigned hostname of the Azure Blob Storage container.
+
+cdn_url
+: The fully-qualified HTTPS URL of the Azure CDN.
+
+cdn_hostname
+: The provider-assigned hostname of the Azure CDN. Useful for creating `CNAME` records to associate custom domains.
+
+{{% /choosable %}}
+
+Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed CDN URL, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ open $(pulumi stack output cdnURL)
 ```
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ open $(pulumi stack output cdn_url)
+```
+
+{{% /choosable %}}
+
 ## Customizing the project
 
 Projects created with the Static Website template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 path
 : The path to the folder containing the files of the website. Defaults to `www`, which is the name (and relative path) of the folder included with the template.
@@ -72,6 +107,24 @@ indexDocument
 
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+location
+: The Azure region to deploy into. Defaults to `WestUS`.
+
+path
+: The path to the folder containing the files of the website. Defaults to `./www`, which is the name (and relative path) of the folder included with the template.
+
+index_document
+: The file to use for top-level pages. Defaults to `index.html`.
+
+error_document
+: The file to use for error pages. Defaults to `error.html`.
+
+{{% /choosable %}}
 
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
 

--- a/content/templates/static-website/azure/index.md
+++ b/content/templates/static-website/azure/index.md
@@ -67,15 +67,9 @@ origin_url
 origin_hostname
 : The provider-assigned hostname of the Azure Blob Storage container.
 
-cdn_url
-: The fully-qualified HTTPS URL of the Azure CDN.
-
-cdn_hostname
-: The provider-assigned hostname of the Azure CDN. Useful for creating `CNAME` records to associate custom domains.
-
 {{% /choosable %}}
 
-Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed CDN URL, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed URL of the deployed site, for example, can be used from the command line to open it in your favorite web browser:
 
 {{% choosable language "typescript,python,go,csharp,yaml" %}}
 
@@ -88,7 +82,7 @@ $ open $(pulumi stack output cdnURL)
 {{% choosable language hcl %}}
 
 ```bash
-$ open $(pulumi stack output cdn_url)
+$ open $(pulumi stack output origin_url)
 ```
 
 {{% /choosable %}}
@@ -111,9 +105,6 @@ errorDocument
 {{% /choosable %}}
 
 {{% choosable language hcl %}}
-
-location
-: The Azure region to deploy into. Defaults to `WestUS`.
 
 path
 : The path to the folder containing the files of the website. Defaults to `./www`, which is the name (and relative path) of the folder included with the template.

--- a/content/templates/static-website/gcp/index.md
+++ b/content/templates/static-website/gcp/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Static Website to Google Cloud
 title: Google Cloud Static Website
 layout: template
 schema_type: howto
-meta_desc: Deploy a static website on Google Cloud with Pulumi, Cloud Storage, and Cloud CDN in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a static website on Google Cloud with Pulumi, Cloud Storage, and Cloud CDN in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a static website on Google Cloud with Pulumi, Cloud Storage, and Cloud CDN.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
     name: Google Cloud
     slug: gcp
@@ -42,6 +43,8 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 originHostname
 : The provider-assigned hostname of the Google Cloud Storage bucket.
 
@@ -54,15 +57,47 @@ cdnHostname
 cdnURL
 : The fully-qualified HTTPS URL of the Google Cloud CDN.
 
-Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `cdnURL`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+origin_url
+: The fully-qualified HTTP URL of the storage bucket endpoint.
+
+origin_hostname
+: The provider-assigned hostname of the Google Cloud Storage bucket.
+
+cdn_url
+: The fully-qualified HTTPS URL of the Google Cloud CDN.
+
+cdn_hostname
+: The provider-assigned hostname of the Google Cloud CDN. Useful for creating `CNAME` records to associate custom domains.
+
+{{% /choosable %}}
+
+Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed CDN URL, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 ```bash
 $ open $(pulumi stack output cdnURL)
 ```
 
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ open $(pulumi stack output cdn_url)
+```
+
+{{% /choosable %}}
+
 ## Customizing the project
 
 Projects created with the Static Website template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 path
 : The path to the folder containing the files of the website. Defaults to `www`, which is the name (and relative path) of the folder included with the template.
@@ -72,6 +107,21 @@ indexDocument
 
 errorDocument
 : The file to use for error pages. Defaults to `error.html`.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+path
+: The path to the folder containing the files of the website. Defaults to `./www`, which is the relative path of the folder included with the template.
+
+index_document
+: The file to use for top-level pages. Defaults to `index.html`.
+
+error_document
+: The file to use for error pages. Defaults to `error.html`.
+
+{{% /choosable %}}
 
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
 

--- a/content/templates/virtual-machine/aws/index.md
+++ b/content/templates/virtual-machine/aws/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Virtual Machine to AWS
 title: Virtual Machine on AWS
 layout: template
 schema_type: howto
-meta_desc: Deploy an Amazon EC2 virtual machine on AWS running Amazon Linux 2023 with Pulumi in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy an Amazon EC2 virtual machine on AWS running Amazon Linux 2023 with Pulumi in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a virtual machine on AWS with Pulumi and Amazon EC2.
 template:
@@ -15,6 +15,7 @@ template:
       - go
       - csharp
       - yaml
+      - hcl
 cloud:
   name: Amazon Web Services
   slug: aws
@@ -61,11 +62,28 @@ $ open $(pulumi stack output url)
 
 Projects created with the Virtual Machine template expose the following [configuration](/docs/iac/concepts/config/) settings:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 instanceType
 : The EC2 instance type to use for the VM. Defaults to `t3.micro`.
 
 vpcNetworkCidr
 : The network CIDR to use for the VPC. Defaults to `10.0.0.0/16`.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+instance_type
+: The EC2 instance type to use for the VM. Defaults to `t3.micro`.
+
+vpc_network_cidr
+: The network CIDR to use for the VPC. Defaults to `10.0.0.0/16`.
+
+service_port
+: The HTTP service port to expose on the VM. Defaults to `80`.
+
+{{% /choosable %}}
 
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
 

--- a/content/templates/virtual-machine/azure/index.md
+++ b/content/templates/virtual-machine/azure/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Virtual Machine to Azure
 title: Virtual Machine on Azure
 layout: template
 schema_type: howto
-meta_desc: Deploy an Azure virtual machine with Pulumi and Azure Virtual Machines in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy an Azure virtual machine with Pulumi and Azure Virtual Machines in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a virtual machine on Azure with Pulumi and Azure Virtual Machines.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Microsoft Azure
   slug: azure
@@ -42,6 +43,8 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 ip
 : The IP address of the virtual machine.
 
@@ -50,6 +53,24 @@ hostname
 
 url
 : The fully-qualified HTTP URL of the HTTP server running on the virtual machine.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+ip
+: The IP address of the virtual machine.
+
+hostname
+: The provider-assigned hostname of the virtual machine.
+
+url
+: The fully-qualified HTTP URL of the HTTP server running on the virtual machine.
+
+private_key
+: The PEM-encoded private key for SSH access to the VM. This value is a secret.
+
+{{% /choosable %}}
 
 Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `url`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
 
@@ -60,6 +81,8 @@ $ open $(pulumi stack output url)
 ## Customizing the project
 
 Projects created with the Virtual Machine template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 adminUsername
 : The user account to create on the VM. Defaults to `pulumiuser`.
@@ -78,6 +101,30 @@ servicePort
 
 sshPublicKey
 : The public key data to use for SSH authentication.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+location
+: The Azure location to deploy into. Defaults to `WestUS2`.
+
+admin_username
+: The user account to create on the VM. Defaults to `pulumiuser`.
+
+vm_name
+: The DNS hostname prefix to use for the VM. Defaults to `my-server`.
+
+vm_size
+: The machine size to use for the VM. Defaults to `Standard_A1_v2`.
+
+os_image
+: The Azure image reference (publisher:offer:sku:version) to use for the VM. Defaults to `Debian:debian-11:11:latest`.
+
+service_port
+: The HTTP service port to expose on the VM. Defaults to `80`.
+
+{{% /choosable %}}
 
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
 

--- a/content/templates/virtual-machine/azure/index.md
+++ b/content/templates/virtual-machine/azure/index.md
@@ -106,9 +106,6 @@ sshPublicKey
 
 {{% choosable language hcl %}}
 
-location
-: The Azure location to deploy into. Defaults to `WestUS2`.
-
 admin_username
 : The user account to create on the VM. Defaults to `pulumiuser`.
 

--- a/content/templates/virtual-machine/gcp/index.md
+++ b/content/templates/virtual-machine/gcp/index.md
@@ -3,7 +3,7 @@ title_tag: Deploy a Virtual Machine to Google Cloud
 title: Virtual Machine on Google Cloud
 layout: template
 schema_type: howto
-meta_desc: Deploy a Google Cloud virtual machine with Pulumi and Compute Engine in TypeScript, Python, Go, C#, or YAML.
+meta_desc: Deploy a Google Cloud virtual machine with Pulumi and Compute Engine in TypeScript, Python, Go, C#, YAML, or HCL.
 meta_image: meta.png
 card_desc: Deploy a virtual machine on Google Cloud with Pulumi and Google Compute Engine.
 template:
@@ -15,6 +15,7 @@ template:
     - go
     - csharp
     - yaml
+    - hcl
 cloud:
   name: Google Cloud
   slug: gcp
@@ -42,6 +43,8 @@ $ pulumi up
 
 When the deployment completes, Pulumi exports the following [stack output](/docs/iac/concepts/stacks/#outputs) values:
 
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
+
 ip
 : The IP address of the virtual machine.
 
@@ -50,6 +53,21 @@ hostname
 
 url
 : The fully-qualified HTTP URL of the HTTP server running on the virtual machine.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+name
+: The name of the virtual machine instance.
+
+ip
+: The IP address of the virtual machine.
+
+url
+: The fully-qualified HTTP URL of the HTTP server running on the virtual machine.
+
+{{% /choosable %}}
 
 Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `url`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
 
@@ -60,6 +78,8 @@ $ open $(pulumi stack output url)
 ## Customizing the project
 
 Projects created with the Virtual Machine template expose the following [configuration](/docs/iac/concepts/config/) settings:
+
+{{% choosable language "typescript,python,go,csharp,yaml" %}}
 
 machineType
 : The Compute Engine machine type to use for the VM. Defaults to `e2-micro`.
@@ -72,6 +92,24 @@ instanceTag
 
 servicePort
 : The HTTP service port to expose on the VM. Defaults to `80`.
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+machine_type
+: The Compute Engine machine type to use for the VM. Defaults to `e2-micro`.
+
+os_image
+: The OS image type to use for the VM. Defaults to `debian-11`.
+
+instance_tag
+: The tag to apply to the VM instance. Defaults to `webserver`.
+
+service_port
+: The HTTP service port to expose on the VM. Defaults to `80`.
+
+{{% /choosable %}}
 
 All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/iac/cli/commands/pulumi_config_set):
 

--- a/layouts/partials/templates/languages.html
+++ b/layouts/partials/templates/languages.html
@@ -17,6 +17,7 @@
     "visualbasic" "Visual Basic"
     "java" "Java"
     "yaml" "YAML"
+    "hcl" "HCL"
     "bun" "Bun"
 -}}
 {{- $items := slice -}}

--- a/layouts/shortcodes/langfile.html
+++ b/layouts/shortcodes/langfile.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific filename based on the chosen language. */ -}}
-<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,fsharp,visualbasic,java,yaml" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,fsharp,visualbasic,java,yaml,hcl" option-style="none" class="inline">
     <pulumi-choosable type="language" value="javascript"><code>index.js</code></pulumi-choosable>
     <pulumi-choosable type="language" value="typescript"><code>index.ts</code></pulumi-choosable>
     <pulumi-choosable type="language" value="python"><code>__main__.py</code></pulumi-choosable>
@@ -9,4 +9,5 @@
     <pulumi-choosable type="language" value="visualbasic"><code>Program.vb</code></pulumi-choosable>
     <pulumi-choosable type="language" value="java"><code>App.java</code></pulumi-choosable>
     <pulumi-choosable type="language" value="yaml"><code>Pulumi.yaml</code></pulumi-choosable>
+    <pulumi-choosable type="language" value="hcl"><code>main.tf</code></pulumi-choosable>
 </pulumi-chooser>

--- a/layouts/shortcodes/langfile.markdown.md
+++ b/layouts/shortcodes/langfile.markdown.md
@@ -27,4 +27,7 @@
 <!-- option: yaml -->
 `Pulumi.yaml`
 <!-- /option -->
+<!-- option: hcl -->
+`main.tf`
+<!-- /option -->
 <!-- /chooser -->


### PR DESCRIPTION
Adds **HCL** as a selectable language across the architecture template pages, paired with the new HCL templates in pulumi/templates#1141.

- Adds `hcl` as an option to the language chooser and partials
- Adds `- hcl` to each page's `template.languages` and to the `meta_desc`/index copy.
- Makes the config/outputsections HCL-aware: HCL templates use snake_case names with some different defaults, extra/dropped variables, and different outputs, so each diverging definition list, example command, and intro is wrapped in language choosables — non-HCL readers are unchanged.
- Adds an HCL walkthrough for the static-website/aws "Adding a custom domain" example and a cache-settings snippet.
- Corrects the kubernetes/aws `eksNodeInstanceType` default (`t2.medium` → `t3.medium`) to match the actual templates.

⚠️ **Do not merge before pulumi/templates#1141 merges.** The HCL templates these pages reference (`<prefix>-hcl`) won't exist in `pulumi/templates` until that PR lands.

Closes https://github.com/pulumi/marketing/issues/1771.