### PR TITLE
Fix YAML frontmatter indentation rejected by stricter parsers

### DIFF
--- a/content/blog/aws-cdk-on-pulumi-1.0/index.md
+++ b/content/blog/aws-cdk-on-pulumi-1.0/index.md
@@ -1,8 +1,7 @@
 ---
 title: "Announcing the 1.0 release of AWS CDK on Pulumi"
 date: 2024-12-02T08:00:00-07:00
-meta_desc: "Enhanced support of AWS CDK constructs from within Pulumi. Combine Pulumi and AWS CDK
-resources amd use Pulumi Cloud Platform to manage CDK"
+meta_desc: "Enhanced support of AWS CDK constructs from within Pulumi. Combine Pulumi and AWS CDK resources and use Pulumi Cloud Platform to manage CDK"
 meta_image: meta.png
 authors:
     - matt-jeffryes

--- a/content/blog/azure-native-v3/index.md
+++ b/content/blog/azure-native-v3/index.md
@@ -18,10 +18,10 @@ tags:
 social:
     twitter: "Announcing Azure Native V3: We've reduced SDK size by 75% while maintaining the expanded resource coverage of other IaC tools. The best solution for Azure infrastructure just got even better."
     linkedin: "Today we're announcing Pulumi Azure Native V3, delivering a remarkable 75% reduction in SDK size while maintaining our industry-leading coverage of Azure resources. With more resource and property coverage compared to alternatives, Azure Native continues to be the most comprehensive and now its the most performant infrastructure as code solution for Microsoft Azure. 
-    
-    V3 optimizes the SDK by focusing on default API versions while preserving access to explicit versions when needed. This balance between performance and flexibility came from our collaborative RFC process with the community, ensuring we addressed real-world needs while dramatically improving the developer experience.
-    
-    For teams building on Azure, V3 makes development faster and more efficient without compromising on access to the complete Azure ecosystem - truly the best of both worlds."
+
+        V3 optimizes the SDK by focusing on default API versions while preserving access to explicit versions when needed. This balance between performance and flexibility came from our collaborative RFC process with the community, ensuring we addressed real-world needs while dramatically improving the developer experience.
+
+        For teams building on Azure, V3 makes development faster and more efficient without compromising on access to the complete Azure ecosystem - truly the best of both worlds."
 ---
 
 Pulumi Azure Native V3 is the most comprehensive infrastructure as code (IaC) solution for Microsoft Azure, combining full resource coverage with dramatic improvements in performance and developer experience.

--- a/content/blog/copilot-in-vscode/index.md
+++ b/content/blog/copilot-in-vscode/index.md
@@ -44,7 +44,7 @@ social:
     twitter: "🎉 Pulumi Copilot is now available in Visual Studio Code! Offload tasks to Pulumi Copilot right in your IDE by typing @pulumi in Copilot Chat. Build, deploy, and manage cloud infrastructure more efficiently than ever."
     linkedin: "Exciting news! Pulumi Copilot is now available in Visual Studio Code Copilot, bringing AI-powered cloud infrastructure management directly to your IDE. Simply install the Pulumi extension and type @pulumi in Copilot Chat to access Pulumi's cloud intelligence and streamline your infrastructure workflows.
 
-    Learn how Pulumi Copilot is revolutionizing cloud development: [Link]"
+        Learn how Pulumi Copilot is revolutionizing cloud development: [Link]"
 
 ---
 

--- a/content/blog/faster-secrets-management/index.md
+++ b/content/blog/faster-secrets-management/index.md
@@ -13,8 +13,8 @@ tags:
     - performance
 social:
     twitter: "Faster. IaC. Secrets.
-    
-    We've optimized secrets management in Pulumi IaC to reduce deployment times while maintaining security. Stacks with many secrets can save up to 10 seconds per operation. Update to version 3.155.0 to experience these performance improvements."
+
+        We've optimized secrets management in Pulumi IaC to reduce deployment times while maintaining security. Stacks with many secrets can save up to 10 seconds per operation. Update to version 3.155.0 to experience these performance improvements."
     linkedin: "Pulumi Infrastructure as Code now processes stack secrets more efficiently, reducing deployment times while maintaining robust security. Our latest update optimizes encryption and decryption operations through intelligent batching and smart change detection, eliminating unnecessary processing during updates. For stacks with many secrets, these improvements can save up to 10 seconds per operation, which adds up to significant time savings across your deployment pipeline. Update to version 3.155.0 today to experience these performance improvements without any configuration changes required."
 ---
 

--- a/content/blog/java-1-0/index.md
+++ b/content/blog/java-1-0/index.md
@@ -17,8 +17,8 @@ tags:
 social:
     twitter: "☕ The Pulumi Java SDK is now Generally Available! Manage your infrastructure using the composable, strongly typed programming language you already know and love - now including the powerful Pulumi Automation API!"
     linkedin: "Java, the world’s most trusted enterprise programming language, is now generally available in Pulumi. You can now leverage Java’s familiar, expressive, and safe syntax to manage your infrastructure in a composable and scalable way.
-    
-    Learn more about automating everything you run in the cloud with Java: [Link]"
+
+        Learn more about automating everything you run in the cloud with Java: [Link]"
 ---
 
 One of Pulumi's core Infrastructure as Code (IaC) features is the ability to [model infrastructure](https://www.pulumi.com/docs/iac/concepts/) using well-traveled, familiar general-purpose programming languages. Today, we're thrilled to announce that Java, one of the world's most popular programming languages, is now generally available in Pulumi. This release joins our existing first-class support for TypeScript, Python, Go, YAML, and C#, enabling Java developers to manage cloud infrastructure using the language they know and trust.

--- a/content/blog/pulumi-release-notes-114/index.md
+++ b/content/blog/pulumi-release-notes-114/index.md
@@ -12,13 +12,13 @@ social:
   twitter: "🚀 From IaC enhancements to expanded ESC capabilities, Pulumi Insights 2.0 and key AI innovations - walk through the product release notes for a summary of what's been shipped this year"
   linkedin: "As we wrap up 2024, let's look back at the significant features and improvements Pulumi has delivered- from Infrastructure as Code enhancements to expanded Pulumi ESC capabilities to the launch of Pulumi Insights 2.0 and key AI innovations, here's what's new in Pulumi:
 
-Key highlights include:
-• Visual Studio Code Extension
-• Pulumi ESC General Availability
-• Pulumi Insights 2.0 with Resource Explorer
-• Enhanced Kubernetes support with Auto Mode & Operator 2.0
+    Key highlights include:
+    • Visual Studio Code Extension
+    • Pulumi ESC General Availability
+    • Pulumi Insights 2.0 with Resource Explorer
+    • Enhanced Kubernetes support with Auto Mode & Operator 2.0
 
-Check out all the new features empowering teams to build better cloud infrastructure."
+    Check out all the new features empowering teams to build better cloud infrastructure."
 ---
 
 {{< notes type="info" >}}

--- a/content/blog/python-uv-toolchain/index.md
+++ b/content/blog/python-uv-toolchain/index.md
@@ -14,9 +14,9 @@ social:
     twitter: "Pulumi + uv: Announcing fast Python package management with uv, now fully integrated with Pulumi. See Adam and Julien discuss the new functionality in this video, or read our blog: www.pulumi.com//blog/python-uv-toolchain"
     linkedin: "We're thrilled to announce built-in support for uv in Pulumi! 
 
-    uv is an ultra-fast Python package manager written in Rust that can install dependencies up to 100x faster than traditional tools. Now fully integrated with Pulumi, it provides one of the fastest ways to manage your Python dependencies and virtual environments.
+        uv is an ultra-fast Python package manager written in Rust that can install dependencies up to 100x faster than traditional tools. Now fully integrated with Pulumi, it provides one of the fastest ways to manage your Python dependencies and virtual environments.
 
-    Learn more in our blog post: www.pulumi.com//blog/python-uv-toolchain"
+        Learn more in our blog post: www.pulumi.com//blog/python-uv-toolchain"
 
 ---
 Continuing our work to bring [the best of modern Python to Infrastructure as Code](/blog/pulumi-loves-python/), we are excited to announce built-in support for [uv](https://docs.astral.sh/uv/) in Pulumi. uv is an extremely fast Python package manager that can install dependencies up to 100x faster than traditional tools, providing one of the fastest ways to manage your Python dependencies and virtual environments.

--- a/content/testimonials/_index.md
+++ b/content/testimonials/_index.md
@@ -162,14 +162,14 @@ messages:
       featured: true
     -
       message: "I have been working on AWS for quite some time, but I never used IaC.
-      Pulumi is my first IaC framework and I am loving it."
+        Pulumi is my first IaC framework and I am loving it."
       author: Vidit
       link: joe user email
       source: email
     -
       message: "I find Pulumi to be quite enjoyable to use. As a developer who is new to Infrastructure as Code (IAC), my team wanted me to learn IAC so that we can move our entire infrastructure to code. After considering AWS CloudFormation and Terraform, we ultimately opted for Pulumi.
 
-      The only criticism I have is that I hadn't come across your platform before. Perhaps there's an opportunity to enhance your marketing efforts."
+        The only criticism I have is that I hadn't come across your platform before. Perhaps there's an opportunity to enhance your marketing efforts."
       author: Nabil
       link: joe user email
       source: email


### PR DESCRIPTION
## Problem

Eight content files have multi-line double-quoted YAML scalars in their front matter whose continuation lines are indented at (or below) the level of their key. The js-yaml version currently in the lockfile tolerates this, but newer/stricter parsers reject it as `deficient indentation`. When that happens, the markdown linter (`scripts/lint/lint-markdown.js`) — which parses every file's front matter with `js-yaml` — throws on these files and fails `make lint`.

This is what's blocking the Dependabot `js-yaml` 4.2.0 → 5.0.0 bump (#19803), but the affected files are technically malformed YAML regardless of the bump.

## Fix

Re-indent each continuation line so it sits deeper than its key, making the front matter valid under strict YAML. Because YAML strips leading whitespace from double-quoted multi-line scalars, the parsed string values are **unchanged** (verified by parsing every file before and after and diffing the result).

Affected files:

- `content/testimonials/_index.md`
- `content/blog/aws-cdk-on-pulumi-1.0/index.md`
- `content/blog/azure-native-v3/index.md`
- `content/blog/copilot-in-vscode/index.md`
- `content/blog/faster-secrets-management/index.md`
- `content/blog/java-1-0/index.md`
- `content/blog/pulumi-release-notes-114/index.md`
- `content/blog/python-uv-toolchain/index.md`

Two small extras in `aws-cdk-on-pulumi-1.0`: the `meta_desc` (which was the broken multi-line value) is collapsed to a single line, and an `amd` → `and` typo in it is corrected.