### PR TITLE
content-review: log traffic URI resolution and snapshot fetch

### DIFF
--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -145,6 +145,10 @@ jobs:
           URI=$(pulumi stack output docsTrafficPageviewsLatestS3Uri \
             --stack pulumi/dwh-workflows-orchestrate-airflow/production 2>/dev/null || true)
           if [ -n "$URI" ]; then
+            # The URI is an s3:// path, not a secret — log it so a glance at the
+            # run confirms the cross-stack read resolved (silent success would be
+            # indistinguishable from a skip).
+            echo "resolved docs-traffic export URI: $URI"
             echo "uri=$URI" >> "$GITHUB_OUTPUT"
           else
             echo "docs-traffic export output unavailable; selection proceeds on tier + age alone"
@@ -153,8 +157,11 @@ jobs:
         if: steps.traffic-uri.outputs.uri != ''
         continue-on-error: true
         run: |
-          aws s3 cp "${{ steps.traffic-uri.outputs.uri }}" .traffic-snapshot --quiet \
-            || echo "traffic snapshot unavailable; selection proceeds without it"
+          if aws s3 cp "${{ steps.traffic-uri.outputs.uri }}" .traffic-snapshot --quiet; then
+            echo "fetched traffic snapshot: $(wc -c < .traffic-snapshot) bytes"
+          else
+            echo "traffic snapshot unavailable; selection proceeds without it"
+          fi
 
       # The review ledger (one JSON object per page, key = slug) lives in S3, not
       # the repo — so the daily bookkeeping never round-trips through a PR. Sync


### PR DESCRIPTION
Follow-up to #19801. That PR wired the docs-traffic export in, but the two new steps were silent on success: the resolve step wrote the URI only to `$GITHUB_OUTPUT` (never echoed), and the fetch used `aws s3 cp --quiet`. A successful cross-stack read was therefore indistinguishable from a skip in the run log — the only confirmation lived in the later queue-JSON dump (`traffic.available` / `pages_matched`).

This adds a line of output to each step so the first live run plainly shows the external data flowed:

- **Resolve traffic snapshot URI** — echoes the resolved `s3://` URI (a path, not a secret) before writing it to the step output.
- **Fetch traffic snapshot from S3** — prints the fetched byte count on success.

No behavior change; the fallback messages and graceful degradation are unchanged. This matters because the cross-stack output read against the data team's Airflow stack is unverified until a real run, and these lines make that run self-evidently working or not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)