### PR TITLE
content-review: compose the PR body deterministically (provenance + findings + lint) and derive outcome from state

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -214,8 +214,9 @@ with `gh pr create --body-file`. The workflow re-runs `make lint` on your branch
 review over it afterward; humans merge. The template's sections (each one is
 checked for):
 
-- **Why this page**: lane, tier, traffic figure + report period, last
-  reviewed (from the queue entry) — so the reviewer knows how it was chosen.
+- **Why this page**: paste `.provenance.md` (composed for you at the repo root)
+  verbatim — lane, tier, traffic figure + report period, last reviewed,
+  rendered deterministically from the selection queue. Do not re-narrate it.
 - **Fixes applied**: table of claim/finding → authoritative source →
   correction, one row per change.
 - **Findings not applied**: every skipped finding with one line of reasoning.

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -207,21 +207,23 @@ opening the PR.
 
 ### 7. PR — only when you applied a fix, ready (non-draft)
 
-Open a **ready** PR to `master`. Build the body from
-`references/pr-body-template.md` — fill **every** section — and create the PR
-with `gh pr create --body-file`. The workflow re-runs `make lint` on your branch
-(flipping the PR back to draft if it fails) and dispatches the automated docs
-review over it afterward; humans merge. The template's sections (each one is
-checked for):
+Open a **ready** PR to `master`. You do **not** write the body from scratch: the
+workflow composed `.pr-body-draft.md` (via `compose-pr-body.py`, the
+assemble-then-judge model — the composer ASSEMBLES facts, you JUDGE) with every
+section present and each pre-found finding pre-bucketed under a `<TODO>`. **Edit
+that draft**, resolve every `<TODO>`, strip the HTML-comment hints, and create
+the PR with `gh pr create --body-file .pr-body-draft.md`. The workflow re-runs
+`make lint` on your branch (flipping the PR back to draft if it fails) and
+dispatches the automated docs review afterward; humans merge. The sections (each
+is checked for):
 
-- **Why this page**: paste `.provenance.md` (composed for you at the repo root)
-  verbatim — lane, tier, traffic figure + report period, last reviewed,
-  rendered deterministically from the selection queue. Do not re-narrate it.
-- **Fixes applied**: table of claim/finding → authoritative source →
-  correction, one row per change.
-- **Findings not applied**: every skipped finding with one line of reasoning.
-  End the section with: "For the judgment-level items above, run
-  `/glow-up <path>`."
+- **Why this page**: composed from the selection queue (lane, tier, traffic
+  figure + period, last reviewed). **Leave verbatim** — do not re-narrate it.
+- **Fixes applied**: pre-stubbed one row per high-confidence finding. Keep a row
+  only for a fix you actually applied (fill its Correction); move the rest down.
+- **Findings not applied**: pre-stubbed with the lower-confidence findings, plus
+  any row you moved down. One line of reasoning each. End the section with: "For
+  the judgment-level items above, run `/glow-up <path>`."
 - **Screenshot check**: per image — current / stale (what differs) /
   unverifiable; note any aging reference screenshots (see
   `references/screenshot-verification.md`).
@@ -229,8 +231,9 @@ checked for):
   checked in the HTML view, the markdown view's shortcode-template status,
   and any shared-source (shortcode/partial/data) findings with their
   page-reach ("also rendered on N other pages").
-- **Verification**: confirm `make lint` + `make build` passed and which
-  pre-step artifacts informed the review (note any pre-step that failed).
+- **Verification**: the composer renders the pre-step artifact inventory; the
+  `make lint` result is stamped by the re-lint gate — leave the
+  `<!-- LINT-RESULT -->` line untouched. Note any pre-step that failed.
 
 Do **not** record `pr_number` or `head_sha` yourself — the workflow derives
 them from the branch. A clean article (zero applicable fixes) skips the PR —

--- a/.claude/commands/review-existing-content/references/pr-body-template.md
+++ b/.claude/commands/review-existing-content/references/pr-body-template.md
@@ -12,8 +12,10 @@ The template starts after this line — copy from the first `##` heading down.
 
 ## Why this page
 
-Lane, strategic tier, traffic figure + report period, and last-reviewed date
-(from the queue entry) — so a reviewer can see how this page was selected.
+Paste the contents of `.provenance.md` here **verbatim**. The workflow composes
+that block deterministically from the selection queue (lane, strategic tier,
+traffic figure + report period, last-reviewed date) — do not rewrite or
+re-narrate it; its figures are authoritative.
 
 ## Fixes applied
 

--- a/.claude/commands/review-existing-content/references/pr-body-template.md
+++ b/.claude/commands/review-existing-content/references/pr-body-template.md
@@ -1,26 +1,27 @@
 # Content-review PR body template
 
-Fill **every** section below and pass the result to `gh pr create --body-file`.
-The worker re-lints the branch and checks that each `##` heading here is present
-in the PR body; a missing section is flagged (non-blocking) on the PR. Keep the
-diff to high-confidence fixes — judgment-level items belong in *Findings not
-applied*, not in the diff.
+You do **not** author this body from scratch. The workflow composes
+`.pr-body-draft.md` (via `compose-pr-body.py`) — every section present, the
+facts rendered, each pre-found finding pre-bucketed with a `<TODO>`. **Edit that
+draft** and pass it to `gh pr create --body-file .pr-body-draft.md`. This file is
+the reference for what each section must contain; the re-lint gate checks that
+every `##` heading survives. Keep the diff to high-confidence fixes —
+judgment-level items belong in *Findings not applied*, not in the diff.
 
-The template starts after this line — copy from the first `##` heading down.
-
----
+The sections, and what's yours vs. the composer's:
 
 ## Why this page
 
-Paste the contents of `.provenance.md` here **verbatim**. The workflow composes
-that block deterministically from the selection queue (lane, strategic tier,
-traffic figure + report period, last-reviewed date) — do not rewrite or
-re-narrate it; its figures are authoritative.
+Rendered by the composer from the selection queue (lane, strategic tier, traffic
+figure + report period, last-reviewed). **Leave verbatim** — its figures are
+authoritative; do not re-narrate it.
 
 ## Fixes applied
 
-One row per change. If zero fixes were applied this section is empty and no PR
-should exist.
+Pre-stubbed by the composer with one row per high-confidence finding. Keep a row
+ONLY for a fix you actually applied (fill its Correction); move the rest to
+*Findings not applied*. If zero fixes were applied this section is empty and no
+PR should exist.
 
 | Claim / finding | Authoritative source | Correction |
 | --- | --- | --- |
@@ -28,7 +29,8 @@ should exist.
 
 ## Findings not applied
 
-Every skipped finding with one line of reasoning (why it's judgment-level, not a
+Pre-stubbed with the lower-confidence findings; add any row you moved down from
+*Fixes applied*. One line of reasoning each (why it's judgment-level, not a
 high-confidence fix).
 
 For the judgment-level items above, run `/glow-up <path>`.
@@ -47,5 +49,7 @@ markdown view's shortcode-template status, and any shared-source
 
 ## Verification
 
-Confirm `make lint` + `make build` passed, and which pre-step artifacts informed
-the review (note any pre-step that failed or was missing).
+The composer renders the pre-step artifact inventory here. The `make lint`
+result is **not** yours to assert: leave the `<!-- LINT-RESULT -->` line
+untouched — the workflow's re-lint gate stamps it with the authoritative
+outcome. Note any pre-step that failed or was missing.

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -21,6 +21,10 @@ on:
         description: 'Selection lane (priority/manual); informational — retirement is gated by the evidence bar + no_retire, not the lane'
         required: false
         default: 'priority'
+      queue_json:
+        description: 'Single-article queue JSON from the dispatcher (carries traffic/score/tier for deterministic provenance). Empty on manual dispatch — the worker falls back to rebuilding a traffic-blind queue from `path`.'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -117,17 +121,42 @@ jobs:
             echo "ledger bucket output unavailable; ledger write will be skipped"
           fi
 
-      # Build a single-article queue for the dispatched path. --paths bypasses
-      # scoring/guardrails; --lane just tags the queue entry (informational —
-      # retirement is gated by the evidence bar + no_retire, not the lane).
+      # Establish the single-article queue. Preferred: use the queue the
+      # dispatcher handed us verbatim — it carries the selection facts (traffic,
+      # score, tier, last-reviewed) this page was actually chosen on. Fallback
+      # (manual dispatch with no queue_json): rebuild from --paths, which bypasses
+      # scoring/guardrails and is necessarily traffic-blind.
       - name: Build single-article queue
+        env:
+          QUEUE_JSON: ${{ github.event.inputs.queue_json }}
         run: |
-          python3 scripts/content-review/select-articles.py \
-            --paths "${{ github.event.inputs.path }}" \
-            --lane "${{ github.event.inputs.lane || 'priority' }}" \
-            --out .content-review-queue.json
+          if [ -n "$QUEUE_JSON" ]; then
+            printf '%s' "$QUEUE_JSON" > .content-review-queue.json
+            python3 -c "import json,sys; json.load(open('.content-review-queue.json'))" \
+              && echo "using dispatcher-provided queue" \
+              || { echo "::warning::queue_json was not valid JSON; rebuilding"; rm -f .content-review-queue.json; }
+          fi
+          if [ ! -f .content-review-queue.json ]; then
+            python3 scripts/content-review/select-articles.py \
+              --paths "${{ github.event.inputs.path }}" \
+              --lane "${{ github.event.inputs.lane || 'priority' }}" \
+              --out .content-review-queue.json
+          fi
           echo "--- queue ---"
           cat .content-review-queue.json
+
+      # Compose the PR body's "Why this page" provenance block deterministically
+      # from that queue (facts → code, judgment → model), so the review never
+      # narrates the selection facts from a partial view. The model pastes
+      # .provenance.md in verbatim. Degrades to an empty file so a render hiccup
+      # never blocks the run.
+      - name: Render provenance block
+        run: |
+          python3 scripts/content-review/render-provenance.py \
+            --queue .content-review-queue.json --out .provenance.md \
+            || printf '## Why this page\n\n_Provenance render failed; see the queue JSON in the run log._\n' > .provenance.md
+          echo "--- provenance ---"
+          cat .provenance.md
 
       # Run the docs-review deterministic pre-computation as a REAL workflow
       # step — not a model instruction. Build the synthetic whole-file diff and
@@ -241,7 +270,10 @@ jobs:
                its body from
                `.claude/commands/review-existing-content/references/pr-body-template.md`
                (fill every section) and pass it with `gh pr create --body-file`.
-               A clean article (zero fixes) opens no PR.
+               For the **"Why this page"** section, paste the contents of
+               `.provenance.md` (composed for you at the repo root) **verbatim** —
+               do NOT write or edit that section yourself; its facts are
+               authoritative. A clean article (zero fixes) opens no PR.
             8. Write `.content-review-verdict.json` at the repo root — your ONLY
                structured output. Shape:
                `{"verdict": "fixed|clean|skipped", "reason": "<one line; required
@@ -312,13 +344,15 @@ jobs:
           git checkout - || true
 
       # Record the page's outcome to the S3 ledger as one object keyed by slug.
-      # Runs `if: always()` so a model that exits without output still lands an
-      # `incomplete` record. An incomplete outcome does not advance the
-      # staleness clock (the page stays due, retried next sweep up to the
-      # attempt cap) rather than silently looping. record-review.py builds the
-      # canonical record, derives the PR facts from `gh`, stamps reviewed_at,
-      # increments attempts, uploads, and emits the dispatch signal. One article
-      # per run ⇒ one object, so writes never collide.
+      # Runs `if: always()` so a model that exits without output still lands a
+      # record. With no sentinel the status is derived from observable state
+      # (`--claude-outcome` + whether a content-review/<slug> branch was pushed):
+      # a successful run that changed nothing is "clean" and advances the
+      # staleness clock; a failed run or a stranded branch is "incomplete" and
+      # stays due (retried next sweep up to the attempt cap). record-review.py
+      # builds the canonical record, derives the PR facts from `gh`, stamps
+      # reviewed_at, increments attempts, uploads, and emits the dispatch signal.
+      # One article per run ⇒ one object, so writes never collide.
       - name: Record review ledger
         id: record
         if: always() && steps.ledger-bucket.outputs.uri != ''
@@ -329,7 +363,8 @@ jobs:
         run: |
           python3 scripts/content-review/record-review.py \
             --queue .content-review-queue.json \
-            --verdict .content-review-verdict.json
+            --verdict .content-review-verdict.json \
+            --claude-outcome "${{ steps.claude.outcome }}"
 
       # Slop defense: bot-authored PRs are auto-skipped by the docs-review
       # pipeline (claude-code-review.yml sets skip_reason=bot-author), so the

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -145,19 +145,6 @@ jobs:
           echo "--- queue ---"
           cat .content-review-queue.json
 
-      # Compose the PR body's "Why this page" provenance block deterministically
-      # from that queue (facts → code, judgment → model), so the review never
-      # narrates the selection facts from a partial view. The model pastes
-      # .provenance.md in verbatim. Degrades to an empty file so a render hiccup
-      # never blocks the run.
-      - name: Render provenance block
-        run: |
-          python3 scripts/content-review/render-provenance.py \
-            --queue .content-review-queue.json --out .provenance.md \
-            || printf '## Why this page\n\n_Provenance render failed; see the queue JSON in the run log._\n' > .provenance.md
-          echo "--- provenance ---"
-          cat .provenance.md
-
       # Run the docs-review deterministic pre-computation as a REAL workflow
       # step — not a model instruction. Build the synthetic whole-file diff and
       # run the claim extraction + verification, Vale, frontmatter, and
@@ -224,6 +211,20 @@ jobs:
             .vale-findings.json .frontmatter-validation.json \
             .cross-sibling-discovery.json .readthrough-findings.json 2>/dev/null || true
 
+      # Assemble the ~80%-done PR body from the queue + pre-step artifacts
+      # (facts → code, judgment → model), mirroring docs-review's compose-review.
+      # The model EDITS .pr-body-draft.md rather than authoring the body from a
+      # bare template: provenance and the finding inventory are rendered for it,
+      # each finding pre-bucketed into Fixes/Findings-not-applied with a <TODO>.
+      # Degrades to a minimal valid draft so a compose hiccup never blocks the run.
+      - name: Compose PR body draft
+        run: |
+          python3 scripts/content-review/compose-pr-body.py \
+            --queue .content-review-queue.json --out .pr-body-draft.md \
+            || printf '## Why this page\n\n_Draft composition failed; build the body from the template and the run log._\n\n## Fixes applied\n\n## Findings not applied\n\n## Screenshot check\n\n## Rendered content\n\n## Verification\n' > .pr-body-draft.md
+          echo "--- pr body draft ---"
+          cat .pr-body-draft.md
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -266,14 +267,23 @@ jobs:
             6. Run the rendered content pass over the built page — both
                the HTML view and the customer-facing markdown view
                (`public/<url>/index.html` and `index.md`) — per the skill.
-            7. If you applied any fix, open a **ready** (non-draft) PR. Build
-               its body from
-               `.claude/commands/review-existing-content/references/pr-body-template.md`
-               (fill every section) and pass it with `gh pr create --body-file`.
-               For the **"Why this page"** section, paste the contents of
-               `.provenance.md` (composed for you at the repo root) **verbatim** —
-               do NOT write or edit that section yourself; its facts are
-               authoritative. A clean article (zero fixes) opens no PR.
+            7. If you applied any fix, open a **ready** (non-draft) PR whose
+               body is `.pr-body-draft.md` (composed for you at the repo root —
+               the assemble-then-judge model, like the pre-merge review). Do NOT
+               write the body from scratch. EDIT the draft:
+               - "Why this page" is rendered from the selection queue — leave it
+                 verbatim, its facts are authoritative.
+               - "Fixes applied" is pre-stubbed with one row per high-confidence
+                 finding. Keep a row ONLY for a fix you actually applied and fill
+                 its Correction; move every row you did not apply down to
+                 "Findings not applied" with a one-line reason.
+               - Fill each `<TODO>` (deferral reasons, the screenshot and rendered
+                 observations). Resolve every `<TODO>` and strip the HTML comment
+                 hints before opening the PR.
+               - Leave the `<!-- LINT-RESULT -->` line in "Verification" exactly
+                 as-is; the workflow stamps it with the authoritative result.
+               Then `gh pr create --body-file .pr-body-draft.md`. A clean article
+               (zero fixes) opens no PR.
             8. Write `.content-review-verdict.json` at the repo root — your ONLY
                structured output. Shape:
                `{"verdict": "fixed|clean|skipped", "reason": "<one line; required
@@ -307,10 +317,13 @@ jobs:
 
       # Lint re-gate: don't trust the model's self-report that `make lint`
       # passed on the branch. For a fix verdict, check out the pushed branch and
-      # re-run lint. On failure: flip the PR back to draft, comment the output,
-      # and skip the docs-review dispatch (the `lint_ok` output gates it). The
-      # ledger still records `reviewed` — the draft PR stays for a human. Build
-      # is left to the PR's normal CI.
+      # re-run lint. The composer left a `<!-- LINT-RESULT -->` placeholder in the
+      # PR body's Verification section precisely so this gate — the authority on
+      # lint, not the model — stamps the real outcome there. On failure: flip the
+      # PR back to draft, comment the output, stamp a FAILED marker, and skip the
+      # docs-review dispatch (the `lint_ok` output gates it). The ledger still
+      # records `reviewed` — the draft PR stays for a human. Build is left to the
+      # PR's normal CI.
       - name: Re-lint the fix branch
         id: lint
         if: hashFiles('.content-review-verdict.json') != ''
@@ -326,12 +339,21 @@ jobs:
           BRANCH="content-review/${RETIRE}${SLUG}"
           git fetch origin "$BRANCH" || { echo "::warning::branch $BRANCH not found"; exit 0; }
           git checkout "$BRANCH"
+          # Stamp the authoritative lint result into the PR body's Verification
+          # section, replacing the composer's placeholder (idempotent: only acts
+          # if the placeholder is still present, so a re-run can't double-stamp).
+          stamp_body() {
+            python3 scripts/content-review/stamp-lint-result.py \
+              --branch "$BRANCH" --result "$1" --sha "$(git rev-parse --short HEAD)" || true
+          }
           if make lint > .lint.log 2>&1; then
             echo "lint passed on $BRANCH"
+            stamp_body passed
           else
             echo "ok=false" >> "$GITHUB_OUTPUT"
             echo "::warning::make lint failed on $BRANCH; flipping PR to draft"
             gh pr ready "$BRANCH" --undo || true
+            stamp_body failed
             {
               echo "Automated review note: \`make lint\` failed on this branch, so the PR was returned to draft and the docs review was not dispatched. Lint output:"
               echo ""

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -208,14 +208,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Hand each worker its OWN single-article queue, carrying the
+          # selection facts this dispatcher computed (traffic, score, tier,
+          # last-reviewed). The worker renders the PR's "Why this page" block
+          # from these deterministically rather than re-deriving a traffic-blind
+          # queue and narrating it — facts composed by code, the same split the
+          # pre-merge review uses. `path`/`lane` are still passed for the
+          # concurrency group and the --paths fallback.
+          TRAFFIC=$(jq -c '.traffic' .content-review-queue.json)
+          GEN=$(jq -r '.generated' .content-review-queue.json)
           jq -c '.articles[]' .content-review-queue.json | while read -r a; do
             P=$(echo "$a" | jq -r '.path')
             L=$(echo "$a" | jq -r '.lane')
+            Q=$(jq -nc --argjson art "$a" --argjson traffic "$TRAFFIC" --arg gen "$GEN" \
+              '{generated: $gen, count: 1, traffic: $traffic, articles: [$art]}')
             echo "dispatching worker for $P (lane=$L)"
             gh workflow run content-review-article.yml \
               --repo "${{ github.repository }}" \
               -f path="$P" \
               -f lane="$L" \
+              -f queue_json="$Q" \
               || echo "::warning::worker dispatch failed for $P"
           done
 

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ _vendor/
 /.frontmatter-validation.json
 /.cross-sibling-discovery.json
 /.readthrough-findings.json
+/.provenance.md
 
 .doctrees/
 .buildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,7 @@ _vendor/
 /.frontmatter-validation.json
 /.cross-sibling-discovery.json
 /.readthrough-findings.json
-/.provenance.md
+/.pr-body-draft.md
 
 .doctrees/
 .buildinfo

--- a/.prettierignore
+++ b/.prettierignore
@@ -76,6 +76,6 @@ static/js
 /.vale-raw.json
 /.vale-findings.json
 /.content-review-*.json
-/.provenance.md
+/.pr-body-draft.md
 /.lint.log
 /.lint-comment.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -76,5 +76,6 @@ static/js
 /.vale-raw.json
 /.vale-findings.json
 /.content-review-*.json
+/.provenance.md
 /.lint.log
 /.lint-comment.md

--- a/scripts/content-review/compose-pr-body.py
+++ b/scripts/content-review/compose-pr-body.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Assemble an ~80%-done content-review PR body from the pre-step artifacts.
+
+The content-review counterpart to docs-review's `compose-review.py`, and the
+same design frame: **the composer ASSEMBLES, the model JUDGES.** Instead of
+letting the review model free-write the whole PR body from a bare template (it
+narrated provenance it couldn't see and re-listed findings it might omit or
+mis-source), this runs as a workflow step after the pre-computation pipeline and
+writes `.pr-body-draft.md` — a structurally complete body with every section
+present, the factual parts rendered verbatim, and one stub bullet per pre-found
+finding carrying a `<TODO>` marker. The model then EDITS the draft: it keeps the
+fix rows it actually applied (filling the correction), moves the rest to
+"Findings not applied" with a reason, and fills the `<TODO>` observations.
+
+What the composer renders (facts — never the model's to invent):
+
+  * "Why this page" — verbatim from the selection queue (via render-provenance).
+  * "Fixes applied" / "Findings not applied" — one stub per pre-found finding
+    from `.verified-claims.json` (contradicted/mismatch/unverifiable claims),
+    `.vale-findings.json`, `.readthrough-findings.json`, and
+    `.frontmatter-validation.json`, pre-bucketed by a conservative
+    high-confidence rule. The model re-buckets and writes the prose.
+  * "Verification" — a deterministic pre-step artifact inventory, plus a
+    `<!-- LINT-RESULT -->` placeholder the workflow's re-lint gate stamps with
+    the authoritative `make lint` result (so lint status is never self-reported).
+
+What stays the model's (left as `<TODO>`): which stub is a real fix, the
+correction prose, the one-line deferral reasons, and the screenshot / rendered
+observations.
+
+Degrades gracefully: a missing or errored artifact renders its section in a
+degraded form with a note, never a crash. The draft always contains every
+required `##` heading so the downstream section check passes.
+
+Usage:
+    compose-pr-body.py --queue .content-review-queue.json --out .pr-body-draft.md
+        [--verified-claims .verified-claims.json] [--vale-findings .vale-findings.json]
+        [--readthrough .readthrough-findings.json] [--frontmatter .frontmatter-validation.json]
+        [--repo-root .]
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+# Reuse the provenance renderer (single source of truth for "Why this page").
+_spec = importlib.util.spec_from_file_location(
+    "render_provenance", HERE / "render-provenance.py"
+)
+_rp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_rp)
+
+LINT_PLACEHOLDER = "<!-- LINT-RESULT -->"
+
+# Vale categories whose fix has exactly one correct form and preserves meaning —
+# safe to pre-bucket as a fix candidate. Everything else (passive voice,
+# wordiness, hedging, em-dash density, tone, punctuation style …) starts as a
+# deferral; the model promotes any it decides to apply.
+HIGH_CONF_VALE = {
+    "spelling", "nomenclature", "substitution", "inclusive language",
+    "repeated word", "spacing", "agreement", "plurals", "difficulty qualifier",
+}
+
+
+def read_json(path: Path | None):
+    if not path or not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# ---- finding collection -----------------------------------------------------
+#
+# Each finding becomes a dict {label, source, detail, fix}: `label` names it,
+# `source` is the authoritative pointer for the Fixes table, `detail` is a short
+# context line for the deferral list, `fix` is True when it is pre-bucketed as a
+# high-confidence fix candidate. `errors` accumulates artifacts that failed.
+
+
+def _truncate(s: str, n: int = 160) -> str:
+    s = " ".join((s or "").split())
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def collect(verified, vale, readthrough, frontmatter) -> tuple[list[dict], list[str]]:
+    findings: list[dict] = []
+    errors: list[str] = []
+
+    # Verified claims: contradicted/mismatch @ high confidence -> fix candidate;
+    # contradicted/mismatch @ lower confidence or unverifiable -> deferral.
+    if isinstance(verified, dict):
+        if verified.get("errors"):
+            errors.append("verified-claims")
+        for v in verified.get("verdicts") or []:
+            verdict = (v.get("verdict") or "").lower()
+            conf = (v.get("confidence") or "").lower()
+            if verdict in ("contradicted", "mismatch"):
+                loc = v.get("line_range") or ""
+                findings.append({
+                    "label": f"Claim ({v.get('claim_id', '?')}{', ' + loc if loc else ''}): "
+                             f"{_truncate(v.get('text', ''))}",
+                    "source": _truncate(v.get("source", ""), 200) or "(no source pointer)",
+                    "detail": _truncate(v.get("evidence", "")),
+                    "fix": conf == "high",
+                })
+            elif verdict == "unverifiable":
+                findings.append({
+                    "label": f"Claim ({v.get('claim_id', '?')}): {_truncate(v.get('text', ''))} — unverifiable",
+                    "source": _truncate(v.get("source", ""), 200) or "(verifier did not converge)",
+                    "detail": _truncate(v.get("evidence", "")) or "verification did not converge",
+                    "fix": False,
+                })
+    elif verified is not None:
+        errors.append("verified-claims (unexpected shape)")
+
+    # Vale: high-confidence mechanical categories -> fix candidate; style -> deferral.
+    if isinstance(vale, list):
+        for f in vale:
+            cat = (f.get("category") or "style").lower()
+            line = f.get("line")
+            loc = f"L{line}" if line else ""
+            findings.append({
+                "label": f"Vale {cat}{' (' + loc + ')' if loc else ''}: {_truncate(f.get('message', ''))}",
+                "source": "`STYLE-GUIDE.md` (Vale)",
+                "detail": _truncate(f.get("message", "")),
+                "fix": cat in HIGH_CONF_VALE,
+            })
+    elif vale is not None:
+        errors.append("vale-findings (unexpected shape)")
+
+    # Readthrough: local_repair -> fix candidate; reconception -> deferral (flag only).
+    if isinstance(readthrough, dict):
+        if readthrough.get("errors"):
+            errors.append("readthrough")
+        for f in readthrough.get("findings") or []:
+            fix_class = (f.get("fix_class") or "reconception").lower()
+            loc = f.get("line_range") or ""
+            findings.append({
+                "label": f"Readthrough {f.get('failure_mode', 'finding')}"
+                         f"{' (' + loc + ')' if loc else ''}: \"{_truncate(f.get('anchor_quote', ''), 100)}\"",
+                "source": "readthrough coherence pass",
+                "detail": _truncate(f.get("proposed_fix", "")),
+                "fix": fix_class == "local_repair",
+            })
+    elif readthrough is not None:
+        errors.append("readthrough (unexpected shape)")
+
+    # Frontmatter: alias collisions are real violations (fix); menu-parent gaps
+    # are usually legacy patterns (defer for a human).
+    if isinstance(frontmatter, dict):
+        for ffile in frontmatter.get("files") or []:
+            for col in ffile.get("alias_collisions") or []:
+                findings.append({
+                    "label": f"Frontmatter alias collision: `{col.get('alias', '?')}`",
+                    "source": "`.frontmatter-validation.json`",
+                    "detail": _truncate(json.dumps(col)),
+                    "fix": True,
+                })
+            for mp in ffile.get("menu_parents") or []:
+                if mp.get("parent_exists_in_menu") is False:
+                    findings.append({
+                        "label": f"Frontmatter menu parent `{mp.get('parent', '?')}`"
+                                 f" (menu `{mp.get('menu_name', '?')}`) not found",
+                        "source": "`.frontmatter-validation.json`",
+                        "detail": "parent_exists_in_menu: false — often a legacy secondary-menu pattern; verify before changing",
+                        "fix": False,
+                    })
+
+    return findings, errors
+
+
+# ---- section rendering ------------------------------------------------------
+
+
+def render_fixes(findings: list[dict]) -> str:
+    fixes = [f for f in findings if f["fix"]]
+    head = (
+        "## Fixes applied\n\n"
+        "<!-- Pre-stubbed from high-confidence pre-step findings. Keep a row ONLY\n"
+        "     for a fix you actually applied and fill its Correction; move every\n"
+        "     row you did not apply down to \"Findings not applied\" with a reason. -->\n\n"
+        "| Claim / finding | Authoritative source | Correction |\n"
+        "| --- | --- | --- |\n"
+    )
+    if not fixes:
+        return head + "| _No high-confidence fix candidates pre-stubbed._ | | |\n"
+    rows = "".join(
+        f"| {f['label']} | {f['source']} | <TODO: correction, or move to Findings not applied> |\n"
+        for f in fixes
+    )
+    return head + rows
+
+
+def render_deferrals(findings: list[dict], path: str) -> str:
+    deferrals = [f for f in findings if not f["fix"]]
+    head = (
+        "## Findings not applied\n\n"
+        "<!-- One line of reasoning each (why it's judgment-level, not a\n"
+        "     high-confidence fix). Add any rows you moved down from above. -->\n\n"
+    )
+    if deferrals:
+        body = "".join(
+            f"- **{f['label']}** — <TODO: why judgment-level>"
+            + (f" _(context: {f['detail']})_" if f["detail"] else "")
+            + "\n"
+            for f in deferrals
+        )
+    else:
+        body = "- _Nothing judgment-level was pre-found. Add any finding you chose not to apply._\n"
+    footer = f"\nFor the judgment-level items above, run `/glow-up {path}`.\n"
+    return head + body + footer
+
+
+def render_verification(artifacts: dict, errors: list[str]) -> str:
+    lines = ["## Verification\n\n"]
+    lines.append(
+        f"- `make lint` / `make build`: {LINT_PLACEHOLDER} "
+        "(stamped by the workflow re-lint gate — do not edit this line)\n"
+    )
+    lines.append("- Pre-step artifacts:\n")
+    for name, summary in artifacts.items():
+        lines.append(f"  - `{name}`: {summary}\n")
+    if errors:
+        lines.append(
+            f"- ⚠️ Artifacts that failed or had an `errors` field: {', '.join(sorted(set(errors)))}. "
+            "Note the gap and review with what's available.\n"
+        )
+    return "".join(lines)
+
+
+def artifact_inventory(verified, vale, readthrough, frontmatter) -> dict:
+    inv: dict[str, str] = {}
+
+    if isinstance(verified, dict):
+        vs = verified.get("verdicts") or []
+        contra = sum(1 for v in vs if (v.get("verdict") or "").lower() in ("contradicted", "mismatch"))
+        unver = sum(1 for v in vs if (v.get("verdict") or "").lower() == "unverifiable")
+        inv[".verified-claims.json"] = f"{len(vs)} verdict(s); {contra} contradicted/mismatch, {unver} unverifiable"
+    else:
+        inv[".verified-claims.json"] = "missing"
+
+    inv[".vale-findings.json"] = f"{len(vale)} finding(s)" if isinstance(vale, list) else "missing"
+
+    if isinstance(readthrough, dict):
+        fnd = readthrough.get("findings") or []
+        ran = readthrough.get("ran")
+        inv[".readthrough-findings.json"] = f"ran={ran}, {len(fnd)} finding(s)"
+    else:
+        inv[".readthrough-findings.json"] = "missing"
+
+    if isinstance(frontmatter, dict):
+        files = frontmatter.get("files") or []
+        cols = sum(len(f.get("alias_collisions") or []) for f in files)
+        inv[".frontmatter-validation.json"] = f"{len(files)} file(s); {cols} alias collision(s)"
+    else:
+        inv[".frontmatter-validation.json"] = "missing"
+
+    return inv
+
+
+def compose(queue: dict, verified, vale, readthrough, frontmatter) -> str:
+    path = ((queue.get("articles") or [{}])[0]).get("path", "")
+    findings, errors = collect(verified, vale, readthrough, frontmatter)
+    inv = artifact_inventory(verified, vale, readthrough, frontmatter)
+
+    return "\n".join([
+        _rp.render(queue).rstrip(),
+        "",
+        render_fixes(findings).rstrip(),
+        "",
+        render_deferrals(findings, path).rstrip(),
+        "",
+        "## Screenshot check\n\n<TODO: per image — current / stale (what differs) / unverifiable; "
+        "or \"No images.\" if the page references none.>",
+        "",
+        "## Rendered content\n\n<TODO: HTML view + customer-facing markdown view — note any leaked "
+        "shortcode syntax or shared-source residue, or confirm clean.>",
+        "",
+        render_verification(inv, errors).rstrip(),
+        "",
+    ])
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--queue", required=True)
+    p.add_argument("--out", help="output path (default: stdout)")
+    p.add_argument("--verified-claims", default=".verified-claims.json")
+    p.add_argument("--vale-findings", default=".vale-findings.json")
+    p.add_argument("--readthrough", default=".readthrough-findings.json")
+    p.add_argument("--frontmatter", default=".frontmatter-validation.json")
+    p.add_argument("--repo-root", default=".")
+    args = p.parse_args()
+
+    root = Path(args.repo_root)
+    queue = json.loads(Path(args.queue).read_text())
+    body = compose(
+        queue,
+        read_json(root / args.verified_claims),
+        read_json(root / args.vale_findings),
+        read_json(root / args.readthrough),
+        read_json(root / args.frontmatter),
+    )
+    if args.out:
+        Path(args.out).write_text(body)
+        print(f"compose-pr-body: wrote {args.out}", file=sys.stderr)
+    else:
+        sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -181,6 +181,18 @@ def check_pr_body(body: str | None) -> list[str]:
     return [s for s in REQUIRED_PR_SECTIONS if s.lower() not in text]
 
 
+def unresolved_draft_markers(body: str | None) -> int:
+    """Count composer scaffolding the model should have resolved before publish.
+
+    The composer seeds the draft with `<TODO>` markers and `<!-- LINT-RESULT -->`
+    (the latter stamped by the re-lint gate, which runs before this). Either left
+    in a published body means the model shipped the scaffold — worth a
+    non-blocking nudge, mirroring the pre-merge `no-todo-tokens` guard.
+    """
+    text = body or ""
+    return text.count("<TODO") + text.count("<!-- LINT-RESULT -->")
+
+
 def canonical_branch_pushed(slug: str) -> bool:
     """True if either canonical review branch was pushed to origin.
 
@@ -355,6 +367,10 @@ def run(args) -> int:
                      f"following required sections: {', '.join(missing)}."],
                     check=False,
                 )
+        leftover = unresolved_draft_markers(pr.get("body"))
+        if leftover:
+            warn(f"PR #{record['pr_number']} body still has {leftover} unresolved "
+                 "draft marker(s) (<TODO> / unstamped lint placeholder)")
 
     out_path = Path(args.out)
     out_path.write_text(json.dumps(record, indent=2) + "\n")
@@ -466,6 +482,12 @@ def self_test() -> int:
                "Rendered content"})
         check("section check passes complete body",
               check_pr_body("\n".join(f"## {s}" for s in REQUIRED_PR_SECTIONS)) == [])
+
+        # Unresolved-draft-marker guard (non-blocking parity with no-todo-tokens).
+        check("counts leftover TODO + lint placeholder",
+              unresolved_draft_markers("a <TODO: fix> b <!-- LINT-RESULT --> c") == 2)
+        check("clean published body has zero markers",
+              unresolved_draft_markers("## Why this page\nall resolved") == 0)
 
     if failures:
         print(f"\n{len(failures)} failure(s)", file=sys.stderr)

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -16,7 +16,15 @@ Outcome derivation:
   * verdict "clean"                                      -> status "clean"
   * verdict "skipped"                                    -> status "skipped"
   * verdict "fixed"  + no PR on the canonical branch     -> status "incomplete"
-  * sentinel absent / unparseable                        -> status "incomplete"
+  * sentinel absent, run succeeded, no branch pushed     -> status "clean"
+  * sentinel absent, run failed OR a branch exists       -> status "incomplete"
+
+The last two cases extend the file's "derive facts from observable state, not
+self-report" principle to the verdict itself: a model that completes its turn
+and pushes no `content-review/<slug>` branch reviewed the page and changed
+nothing — that is "clean", regardless of whether it remembered to write the
+sentinel. A branch with no PR (a half-applied fix) or a failed/timed-out run is
+genuinely "incomplete" and stays due for retry.
 
 Canonical record (every field always present):
   { path, slug, lane, status, pr, pr_number, head_sha, fixes,
@@ -173,11 +181,31 @@ def check_pr_body(body: str | None) -> list[str]:
     return [s for s in REQUIRED_PR_SECTIONS if s.lower() not in text]
 
 
+def canonical_branch_pushed(slug: str) -> bool:
+    """True if either canonical review branch was pushed to origin.
+
+    Used only when the sentinel is absent, to tell a clean review (no branch)
+    from a half-applied fix (branch, no PR). Best-effort: a probe failure
+    returns False, biasing an unknowable case toward clean rather than a
+    perpetual incomplete retry.
+    """
+    refs = [f"refs/heads/{branch_for(slug, r)}" for r in (False, True)]
+    try:
+        out = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", *refs],
+            capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        return False
+    return out.returncode == 0 and bool(out.stdout.strip())
+
+
 # ---- derivation -------------------------------------------------------------
 
 
 def build_record(article: dict, verdict: dict | None, pr: dict | None,
-                 slug: str) -> dict:
+                 slug: str, claude_succeeded: bool = False,
+                 branch_exists: bool = False) -> dict:
     """Build the canonical ledger record from the queue, verdict, and PR state.
 
     `attempts` accrues the consecutive `incomplete` retries: it starts from the
@@ -185,6 +213,12 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
     by one on another incomplete outcome, and is reset to 0 the moment the page
     reaches any completed status. The selector backs a page off once it hits
     ATTEMPT_CAP, so this counter is the loop guard.
+
+    When the sentinel is absent the status is derived from observable state
+    rather than defaulted to incomplete: a run that succeeded and pushed no
+    canonical branch (`claude_succeeded and not branch_exists`) is recorded
+    "clean"; a failed run, or one that left a branch behind without a PR, is
+    "incomplete" and stays due.
     """
     prior_attempts = int(article.get("attempts") or 0)
     rec = {
@@ -205,7 +239,15 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
     }
 
     if verdict is None:
-        rec["note"] = "worker produced no verdict"
+        if claude_succeeded and not branch_exists:
+            # Successful review that produced no branch == clean, even though the
+            # model skipped the sentinel. Advance the clock instead of looping.
+            rec["status"] = "clean"
+            rec["note"] = "no verdict sentinel; run succeeded with no changes (derived clean)"
+            rec["attempts"] = 0
+        else:
+            why = "run did not succeed" if not claude_succeeded else "a branch exists without a PR"
+            rec["note"] = f"worker produced no verdict ({why})"
         return rec
 
     rec["fixes"] = int(verdict.get("fixes") or 0)
@@ -287,7 +329,19 @@ def run(args) -> int:
     if want_pr and not pr and args.pr_json is None:
         scan_misnamed_sibling(slug)
 
-    record = build_record(article, verdict, pr, slug)
+    # Only needed when the sentinel is absent: distinguish a clean review (no
+    # branch) from a half-applied fix (branch, no PR). Skip the probe otherwise.
+    claude_succeeded = (args.claude_outcome or "").strip().lower() == "success"
+    branch_exists = False
+    if verdict is None:
+        branch_exists = (
+            args.branch_exists == "true" if args.branch_exists is not None
+            else canonical_branch_pushed(slug)
+        )
+
+    record = build_record(article, verdict, pr, slug,
+                          claude_succeeded=claude_succeeded,
+                          branch_exists=branch_exists)
 
     # PR-body section check (non-blocking) for fix PRs.
     if record["status"] == "reviewed" and pr is not None:
@@ -340,11 +394,29 @@ def self_test() -> int:
         }))
         article = load_queue_article(queue)
 
-        # No verdict -> incomplete.
+        # No verdict, no signal -> incomplete (the conservative default).
         rec = build_record(article, None, None, article["slug"])
-        check("no-verdict -> incomplete", rec["status"] == "incomplete")
+        check("no-verdict (no signal) -> incomplete", rec["status"] == "incomplete")
         check("incomplete has reviewed_at", bool(rec["reviewed_at"]))
         check("incomplete bumps attempts from 0 -> 1", rec["attempts"] == 1)
+
+        # No verdict, but the run succeeded and pushed no branch -> derived clean.
+        rec = build_record(article, None, None, article["slug"],
+                           claude_succeeded=True, branch_exists=False)
+        check("no-verdict + success + no branch -> clean", rec["status"] == "clean")
+        check("derived-clean resets attempts to 0", rec["attempts"] == 0)
+        check("derived-clean notes the derivation",
+              "derived clean" in (rec["note"] or ""))
+
+        # No verdict + success but a branch was left behind -> incomplete (half fix).
+        rec = build_record(article, None, None, article["slug"],
+                           claude_succeeded=True, branch_exists=True)
+        check("no-verdict + success + branch -> incomplete", rec["status"] == "incomplete")
+
+        # No verdict + run failed -> incomplete even with no branch.
+        rec = build_record(article, None, None, article["slug"],
+                           claude_succeeded=False, branch_exists=False)
+        check("no-verdict + failed run -> incomplete", rec["status"] == "incomplete")
         check("all canonical fields present", set(rec) == {
             "path", "slug", "lane", "status", "pr", "pr_number", "head_sha",
             "fixes", "skipped_findings", "retirement", "note", "attempts",
@@ -407,6 +479,11 @@ def main() -> int:
     p.add_argument("--queue", help="single-article queue JSON (.content-review-queue.json)")
     p.add_argument("--verdict", help="model verdict sentinel (.content-review-verdict.json)")
     p.add_argument("--pr-json", help="inject gh PR JSON (file path or '-' for stdin); for tests")
+    p.add_argument("--claude-outcome",
+                   help="GitHub step outcome of the review run (success/failure/cancelled). "
+                        "With no sentinel, 'success' + no pushed branch => clean; anything else => incomplete.")
+    p.add_argument("--branch-exists", choices=["true", "false"],
+                   help="inject canonical-branch existence (tests); omit to probe origin via git ls-remote")
     p.add_argument("--out", default=".content-review-ledger.json",
                    help="local ledger artifact path")
     p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")

--- a/scripts/content-review/render-provenance.py
+++ b/scripts/content-review/render-provenance.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Render the content-review PR body's "Why this page" section deterministically.
+
+The per-article worker (`.github/workflows/content-review-article.yml`) used to
+let the review model narrate this provenance block from its local queue. That
+queue was rebuilt traffic-blind, so the model wrote "traffic unavailable" even
+when the dispatcher had selected the page using live traffic — the facts were
+self-reported, not composed. This script composes them from the dispatcher's
+queue entry instead (the same split the pre-merge review uses via
+`compose-review.py`): code emits the facts, the model only writes judgment.
+
+Input is the single-article queue the dispatcher handed the worker
+(`.content-review-queue.json`): a `traffic` meta block plus one `articles[0]`
+entry carrying `monthly_visits`, `tier`, `no_retire`, `last_reviewed`,
+`attempts`, and `score`. Output is the exact `## Why this page` Markdown the
+worker pastes verbatim into the PR body.
+
+Usage:
+    render-provenance.py --queue .content-review-queue.json --out .provenance.md
+    render-provenance.py --queue .content-review-queue.json   # to stdout
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _fmt_int(n) -> str:
+    try:
+        return f"{int(n):,}"
+    except (TypeError, ValueError):
+        return str(n)
+
+
+def _period_str(traffic: dict) -> str | None:
+    """Normalize the traffic period (a string, or a {start,end} object)."""
+    period = traffic.get("period")
+    if isinstance(period, dict):
+        start, end = period.get("start"), period.get("end")
+        if start and end:
+            return f"{start} to {end}"
+        return start or end
+    return period or traffic.get("generated")
+
+
+def render(queue: dict) -> str:
+    articles = queue.get("articles") or []
+    if not articles:
+        raise SystemExit("render-provenance: no articles in queue")
+    a = articles[0]
+    traffic = queue.get("traffic") or {}
+
+    path = a.get("path", "")
+    url = a.get("url") or ""
+    lane = a.get("lane") or "priority"
+    tier = a.get("tier")
+    no_retire = bool(a.get("no_retire"))
+    visits = a.get("monthly_visits")
+    last_reviewed = a.get("last_reviewed")
+    attempts = int(a.get("attempts") or 0)
+    score = a.get("score")
+
+    # Traffic line: a real per-page figure when the snapshot resolved and the
+    # page appeared in it; otherwise say so plainly (selection fell back to
+    # tier + age). `available` is the queue-level snapshot-presence flag.
+    if traffic.get("available") and visits is not None:
+        period = _period_str(traffic)
+        source = traffic.get("source")
+        suffix = []
+        if period:
+            suffix.append(f"period {period}")
+        if source:
+            suffix.append(f"source `{source}`")
+        tail = f" ({'; '.join(suffix)})" if suffix else ""
+        traffic_line = f"{_fmt_int(visits)} monthly visits{tail}"
+    elif traffic.get("available"):
+        traffic_line = "not in the traffic snapshot this run (selected on tier + age)"
+    else:
+        traffic_line = "snapshot unavailable this run (selected on tier + age)"
+
+    reviewed_line = (
+        f"{last_reviewed} (`attempts: {attempts}`)"
+        if last_reviewed
+        else f"never (`attempts: {attempts}`)"
+    )
+
+    tier_line = f"{tier}" if tier is not None else "unclassified"
+    tier_line += f" (`no_retire: {'true' if no_retire else 'false'}`)"
+
+    score_line = f"{score}" if score is not None else "n/a (explicit dispatch)"
+
+    page_line = f"`{path}`" + (f" → [{url}]({url})" if url else "")
+
+    return (
+        "## Why this page\n\n"
+        f"- **Page:** {page_line}\n"
+        f"- **Lane:** {lane}\n"
+        f"- **Strategic tier:** {tier_line}\n"
+        f"- **Traffic:** {traffic_line}\n"
+        f"- **Last reviewed:** {reviewed_line}\n"
+        f"- **Selection score:** {score_line}\n"
+        "\n_This section is composed deterministically from the selection queue;"
+        " do not edit it._\n"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--queue", required=True, help="single-article queue JSON")
+    p.add_argument("--out", help="output Markdown path (default: stdout)")
+    args = p.parse_args()
+
+    queue = json.loads(Path(args.queue).read_text())
+    body = render(queue)
+    if args.out:
+        Path(args.out).write_text(body)
+        print(f"render-provenance: wrote {args.out}", file=sys.stderr)
+    else:
+        sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/stamp-lint-result.py
+++ b/scripts/content-review/stamp-lint-result.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Stamp the authoritative `make lint` result into a content-review PR body.
+
+The composer (`compose-pr-body.py`) leaves a `<!-- LINT-RESULT -->` placeholder
+in the PR body's Verification section. The worker's re-lint gate — which re-runs
+`make lint` on the pushed branch and is the authority on lint status, not the
+review model — calls this to replace that placeholder with the real outcome. So
+"lint passed" in the body is never the model's self-report.
+
+Idempotent: it only edits when the placeholder is still present, so a re-run
+can't double-stamp or clobber a human's later edit.
+
+Usage:
+    stamp-lint-result.py --branch content-review/<slug> --result passed|failed --sha <short-sha>
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+PLACEHOLDER = "<!-- LINT-RESULT -->"
+
+
+def _gh(args: list[str]) -> tuple[int, str]:
+    try:
+        p = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        print("stamp-lint-result: gh not available", file=sys.stderr)
+        return 1, ""
+    if p.returncode != 0:
+        print(f"stamp-lint-result: gh {' '.join(args[:3])}… failed: {p.stderr.strip()}", file=sys.stderr)
+    return p.returncode, p.stdout
+
+
+def marker(result: str, sha: str) -> str:
+    if result == "passed":
+        return f"✅ `make lint` re-verified by the workflow on `{sha}`"
+    return (
+        f"❌ `make lint` FAILED on `{sha}` — PR returned to draft; "
+        "see the automated lint comment on this PR"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--branch", required=True)
+    ap.add_argument("--result", required=True, choices=["passed", "failed"])
+    ap.add_argument("--sha", default="")
+    args = ap.parse_args()
+
+    rc, body = _gh(["pr", "view", args.branch, "--json", "body", "--jq", ".body"])
+    if rc != 0:
+        return 0  # best-effort; the re-lint step already wraps this in || true
+    if PLACEHOLDER not in body:
+        print("stamp-lint-result: placeholder absent; nothing to stamp", file=sys.stderr)
+        return 0
+
+    updated = body.replace(PLACEHOLDER, marker(args.result, args.sha))
+    # gh pr edit reads --body-file from a path or '-'; pass the new body on stdin.
+    try:
+        p = subprocess.run(
+            ["gh", "pr", "edit", args.branch, "--body-file", "-"],
+            input=updated, text=True, capture_output=True, check=False,
+        )
+    except FileNotFoundError:
+        return 0
+    if p.returncode != 0:
+        print(f"stamp-lint-result: gh pr edit failed: {p.stderr.strip()}", file=sys.stderr)
+        return 0
+    print(f"stamp-lint-result: stamped lint={args.result} into {args.branch} body")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/test_compose_pr_body.py
+++ b/scripts/content-review/test_compose_pr_body.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Tests for compose-pr-body.py (assemble-then-judge PR-body draft)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "compose_pr_body", Path(__file__).resolve().parent / "compose-pr-body.py"
+)
+c = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(c)
+
+failures: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if cond:
+        print(f"ok: {name}")
+    else:
+        failures.append(name)
+        print(f"FAIL: {name}", file=sys.stderr)
+
+
+QUEUE = {
+    "traffic": {"available": True, "period": "2026-06", "source": "CLICKSTREAM.FCT_PAGEVIEWS"},
+    "articles": [{
+        "path": "content/docs/iac/concepts/functions/resource-methods.md",
+        "url": "/docs/iac/concepts/functions/resource-methods/",
+        "lane": "priority", "tier": 1, "no_retire": True,
+        "monthly_visits": 384, "last_reviewed": None, "attempts": 0, "score": 278.3,
+    }],
+}
+
+# A contradicted high-confidence claim (-> fix), an unverifiable claim (-> defer).
+VERIFIED = {
+    "verdicts": [
+        {"claim_id": "c3", "line_range": "L34", "text": "C# signature GetKubeconfig(Cluster.GetKubeconfigArgs? args)",
+         "verdict": "contradicted", "confidence": "high",
+         "evidence": "dotnet SDK defines flat ClusterGetKubeconfigArgs", "source": "pulumi/pulumi-eks: sdk/dotnet/Cluster.cs"},
+        {"claim_id": "c5", "line_range": "L52", "text": "Python signature includes profile_name",
+         "verdict": "unverifiable", "confidence": "low",
+         "evidence": "verifier did not converge", "source": "(no source pointer)"},
+        {"claim_id": "c2", "text": "TS signature", "verdict": "verified", "confidence": "high",
+         "evidence": "matches", "source": "sdk/nodejs/cluster.ts"},
+    ],
+}
+# One mechanical Vale (difficulty qualifier -> fix), one style (passive -> defer).
+VALE = [
+    {"file": "x.md", "line": 67, "rule": "Pulumi.Difficulty", "category": "difficulty qualifier",
+     "severity": "warning", "message": "'Simple' judges difficulty for the reader"},
+    {"file": "x.md", "line": 12, "rule": "Google.Passive", "category": "passive voice",
+     "severity": "suggestion", "message": "consider active voice"},
+]
+# One local_repair (-> fix), one reconception (-> defer).
+READTHROUGH = {
+    "ran": True,
+    "findings": [
+        {"line_range": "L40", "failure_mode": "missing-step", "anchor_quote": "run pulumi up",
+         "fix_class": "local_repair", "proposed_fix": "add a login step before L40"},
+        {"line_range": "L1-90", "failure_mode": "purpose-mismatch", "anchor_quote": "Configure access",
+         "fix_class": "reconception", "proposed_fix": "split architecture half into its own page"},
+    ],
+}
+FRONTMATTER = {"files": [{"path": "x.md",
+    "alias_collisions": [{"alias": "/docs/dupe/"}],
+    "menu_parents": [{"menu_name": "concepts", "parent": "functions", "parent_exists_in_menu": False}]}]}
+
+out = c.compose(QUEUE, VERIFIED, VALE, READTHROUGH, FRONTMATTER)
+
+# All six required sections present (record-review's check_pr_body expects these).
+for sec in ["Why this page", "Fixes applied", "Findings not applied",
+            "Screenshot check", "Rendered content", "Verification"]:
+    check(f"section present: {sec}", f"## {sec}" in out)
+
+# Provenance composed (real visits, not narrated).
+check("provenance shows real visits", "384 monthly visits" in out)
+
+# High-confidence findings land as fix stubs.
+check("contradicted high-confidence claim -> fix row", "c3" in out.split("## Findings not applied")[0])
+check("mechanical Vale -> fix row", "difficulty qualifier" in out.split("## Findings not applied")[0])
+check("local_repair readthrough -> fix row", "missing-step" in out.split("## Findings not applied")[0])
+check("alias collision -> fix row", "alias collision" in out.split("## Findings not applied")[0])
+
+# Judgment-level findings land as deferral stubs.
+deferral_block = out.split("## Findings not applied")[1].split("## Screenshot")[0]
+check("unverifiable claim -> deferral", "c5" in deferral_block)
+check("style Vale -> deferral", "passive voice" in deferral_block)
+check("reconception readthrough -> deferral", "purpose-mismatch" in deferral_block)
+check("legacy menu parent -> deferral", "menu parent" in deferral_block)
+
+# TODO markers for the model to fill; lint placeholder for the gate to stamp.
+check("fix rows carry <TODO>", "<TODO: correction" in out)
+check("deferrals carry <TODO>", "<TODO: why judgment-level>" in deferral_block)
+check("screenshot/rendered are <TODO>", out.count("<TODO") >= 4)
+check("lint result is a stamped placeholder", c.LINT_PLACEHOLDER in out)
+
+# Verification inventory is deterministic.
+check("inventory counts verdicts", "3 verdict(s); 1 contradicted/mismatch, 1 unverifiable" in out)
+
+# Graceful degradation: all artifacts missing still yields a valid full draft.
+bare = c.compose(QUEUE, None, None, None, None)
+for sec in ["Why this page", "Fixes applied", "Findings not applied",
+            "Screenshot check", "Rendered content", "Verification"]:
+    check(f"degraded draft still has {sec}", f"## {sec}" in bare)
+check("degraded fixes section notes no stubs", "No high-confidence fix candidates" in bare)
+check("degraded inventory marks missing", ".verified-claims.json`: missing" in bare)
+
+# Errored artifact is surfaced in Verification.
+errd = c.compose(QUEUE, {"verdicts": [], "errors": ["verify-claims failed"]}, [], {"ran": False, "findings": []}, {})
+check("errored artifact surfaced", "Artifacts that failed" in errd and "verified-claims" in errd)
+
+if failures:
+    print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+    sys.exit(1)
+print("\nall compose-pr-body tests passed")

--- a/scripts/content-review/test_render_provenance.py
+++ b/scripts/content-review/test_render_provenance.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Tests for render-provenance.py (deterministic "Why this page" block)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "render_provenance", Path(__file__).resolve().parent / "render-provenance.py"
+)
+rp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rp)
+
+failures: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if cond:
+        print(f"ok: {name}")
+    else:
+        failures.append(name)
+        print(f"FAIL: {name}", file=sys.stderr)
+
+
+def _entry(**over):
+    base = {
+        "path": "content/docs/iac/concepts/projects/stack-settings-file.md",
+        "url": "/docs/iac/concepts/projects/stack-settings-file/",
+        "slug": "docs-iac-concepts-projects-stack-settings-file",
+        "lane": "priority",
+        "tier": 1,
+        "no_retire": True,
+        "monthly_visits": 1639,
+        "last_reviewed": None,
+        "attempts": 0,
+        "score": 294.9144,
+    }
+    base.update(over)
+    return base
+
+
+# Traffic available + page has a visit figure -> real number, not "unavailable".
+q = {
+    "traffic": {
+        "source": "CLICKSTREAM.FCT_PAGEVIEWS",
+        "period": {"start": "2025-12-22", "end": "2026-06-22"},
+        "available": True,
+    },
+    "articles": [_entry()],
+}
+out = rp.render(q)
+check("renders the canonical heading", out.startswith("## Why this page"))
+check("formats visits with a thousands separator", "1,639 monthly visits" in out)
+check("includes the report period", "2025-12-22 to 2026-06-22" in out)
+check("never narrates 'unavailable' when traffic is present", "unavailable" not in out)
+check("surfaces tier + no_retire", "**Strategic tier:** 1 (`no_retire: true`)" in out)
+check("surfaces the score", "294.9144" in out)
+check("marks the block machine-composed", "composed deterministically" in out)
+
+# Snapshot present but this page absent from it -> distinct from snapshot-missing.
+q_missing_page = {
+    "traffic": {"available": True, "period": "2026-06"},
+    "articles": [_entry(monthly_visits=None)],
+}
+check(
+    "page absent from snapshot reads distinctly",
+    "not in the traffic snapshot" in rp.render(q_missing_page),
+)
+
+# No snapshot at all (worker --paths fallback) -> says so, doesn't invent a number.
+q_no_traffic = {
+    "traffic": {"available": False},
+    "articles": [_entry(monthly_visits=None, last_reviewed="2026-05-01", attempts=1, score=None)],
+}
+out2 = rp.render(q_no_traffic)
+check("snapshot-unavailable stated plainly", "snapshot unavailable this run" in out2)
+check("last_reviewed date rendered when present", "2026-05-01 (`attempts: 1`)" in out2)
+check("missing score degrades gracefully", "n/a (explicit dispatch)" in out2)
+
+if failures:
+    print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+    sys.exit(1)
+print("\nall render-provenance tests passed")


### PR DESCRIPTION
Closes the gap that surfaced in the first live-traffic sweep ([dispatcher run](https://github.com/pulumi/docs/actions/runs/28122823605); PRs #19849, #19850): the content-review worker let the model **free-write the entire PR body**, so it narrated provenance it couldn't see ("traffic unavailable" when selection used live traffic) and self-reported facts the workflow already knew. This moves the whole body onto the **assemble-then-judge** model that pre-merge review uses via `compose-review.py` — *the composer assembles facts, the model judges* — plus a related outcome-recording fix.

### 1. Compose the whole PR body (`compose-pr-body.py`)

Runs after the pre-compute pipeline and writes `.pr-body-draft.md`: every section present, the factual parts rendered, and one stub bullet per pre-found finding carrying a `<TODO>`. The model **edits** the draft instead of authoring it.

| Section | Composed from | Owner |
|---|---|---|
| Why this page | selection queue (the dispatcher now passes each worker its real entry: traffic, score, tier, last-reviewed) | **code** |
| Fixes applied | `.verified-claims.json` (contradicted/mismatch @ high conf) + mechanical Vale + readthrough `local_repair` + frontmatter collisions | code stubs; **model** fills the correction / keeps only what it applied |
| Findings not applied | the lower-confidence remainder (unverifiable claims, style Vale, `reconception`, legacy menu parents) | code stubs; **model** writes the one-line reasons |
| Verification | deterministic pre-step artifact inventory | **code** |
| Screenshot / Rendered | — | **model** |

### 2. Lint status is no longer self-reported

The composer leaves a `<!-- LINT-RESULT -->` placeholder in Verification; the re-lint gate — the authority on lint, not the model — stamps it with the real outcome (`stamp-lint-result.py`). `record-review.py` also warns (non-blocking) on any `<TODO>`/placeholder left behind, mirroring pre-merge's `no-todo-tokens` guard.

### 3. Outcome derived from observable state (the original bug #2)

When the model finishes successfully but skips the verdict sentinel (the Terraform page this run), `record-review.py` now derives the status from run-outcome + branch existence — success + no branch ⇒ **clean** (advances the staleness clock) rather than a false `incomplete` that re-runs forever.

## What stays the model's
Which stub is a real fix, the correction prose, the deferral reasons, screenshot/rendered observations — exactly the `<TODO>` set pre-merge leaves to Opus.

## Tests
- `compose-pr-body.py` — new suite: correct bucketing of all four artifact types, degraded (all-missing) and errored-artifact paths, every required heading present.
- `record-review.py --self-test` — state-derivation cases + the unresolved-marker guard.
- `render-provenance.py` (now the provenance module the composer imports) and `test_select_articles.py` — unchanged, all passing.
- Both workflows validate; `.pr-body-draft.md` added to git/prettier ignores.

Safe to merge ahead of go-live — the dispatcher is still manual-only. Next manual sweep produces PR bodies assembled from the artifacts, with correct traffic figures, a workflow-stamped lint line, and no false `incomplete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)