### PR TITLE
Improve discoverability of the LLM/Markdown widget in docs

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -47,6 +47,8 @@
                 {{ if .Params.openapi_schema }}
                     {{ partial "openapi/schema-component.html" . }}
                 {{ end }}
+
+                <pulumi-top-button></pulumi-top-button>
             </div>
             {{ if not .Params.norightnav }}
             <div class="docs-table-of-contents docs-toc-desktop">

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -52,6 +52,8 @@
                 {{ if .Params.openapi_schema }}
                     {{ partial "openapi/schema-component.html" . }}
                 {{ end }}
+
+                <pulumi-top-button></pulumi-top-button>
             </div>
 
             <div class="docs-table-of-contents docs-toc-desktop">

--- a/layouts/partials/docs/table-of-contents.html
+++ b/layouts/partials/docs/table-of-contents.html
@@ -1,3 +1,8 @@
+{{ if .File }}
+    <div class="docs-md-actions">
+        <pulumi-llm-menu page-url="{{ .Permalink }}" page-title="{{ .Title }}"></pulumi-llm-menu>
+    </div>
+{{ end }}
 {{ if not $.Page.Params.no_on_this_page }}
     <div class="table-of-contents">
         {{ if strings.Contains $.Page.Permalink "registry/packages" }}
@@ -51,32 +56,7 @@
     </div>
 {{ end }}
 <ul class="p-0 list-none table-of-contents-feedback">
-    <!-- Only show "Edit this Page" for pages that are not generated. -->
     {{ if .File }}
-        <li>
-            <pulumi-llm-menu
-                page-url="{{ .Permalink }}"
-                page-title="{{ .Title }}"
-            ></pulumi-llm-menu>
-        </li>
-        {{ $isCLICommand := hasPrefix .Path "docs/cli/commands" }}
-        {{ $isAPIDoc := and (hasPrefix .Path "docs/reference/pkg/") (ne .Path "docs/reference/pkg/_index.md") }}
-        {{ if not (or $isCLICommand $isAPIDoc $.Page.Params.no_edit_this_page) }}
-            {{ $repoURL := "https://github.com/pulumi/docs" }}
-            {{ if (hasPrefix .Path "registry/") }}
-                {{ $repoURL = "https://github.com/pulumi/registry" }}
-            {{ end }}
-            <li>
-                <a
-                    data-track="edit-page"
-                    class="text-gray-600 hover:text-gray-700 text-xs"
-                    href="{{ $repoURL }}/edit/{{ $.Site.Params.contentRepositoryBaseBranch }}/content/{{ .File.Path }}"
-                    target="_blank"
-                >
-                    {{ partial "icon.html" (dict "name" "pencil-simple" "class" "mr-2") }}Edit this Page
-                </a>
-            </li>
-        {{ end }}
         <li>
             <a
                 data-track="request-change"
@@ -89,4 +69,3 @@
         </li>
     {{ end }}
 </ul>
-<pulumi-top-button></pulumi-top-button>

--- a/theme/src/scss/_button.scss
+++ b/theme/src/scss/_button.scss
@@ -29,6 +29,19 @@
                             focus-visible:border-red-600/40 focus-visible:ring-red-600/20; }
 .btn-link          { @apply h-auto inline-block text-violet-primary font-semibold underline-offset-5 hover:underline decoration-violet-300 border-none min-h-0! p-0! [&_svg]:no-underline; }
 
+// Split button — joins a primary .btn and a caret-only .btn into one control
+// with a single seam between the segments. The -ml-px overlaps the borders into
+// one divider; relative + z-on-hover lifts the active segment so its full border
+// (including the seam edge) renders above its neighbor.
+.btn-split {
+    @apply inline-flex;
+
+    > .btn                                  { @apply relative; }
+    > .btn:hover, > .btn:focus-visible      { @apply z-10; }
+    > .btn:first-child                      { @apply rounded-r-none; }
+    > .btn:last-child                       { @apply rounded-l-none -ml-px px-2; }
+}
+
 // Sizes — override the base h-9 / px-2.5
 .btn-xs      { @apply h-6 py-0.75 px-2 text-xs gap-1; }
 .btn-sm      { @apply h-8 py-2 px-3 text-xs gap-1; }

--- a/theme/src/scss/_buttons.scss
+++ b/theme/src/scss/_buttons.scss
@@ -3,7 +3,6 @@
 //
 // Active consumers:
 //   .btn-download             - card-button-download.html, convert.tsx
-//   .btn-scroll-top           - top-button.tsx
 //   .card-cta-contained-btn   - card-button-download.html
 
 .btn-download {
@@ -22,14 +21,6 @@
 
 .btn-download:hover {
     color: var(--color-violet-800);
-}
-
-.btn-scroll-top {
-    @apply text-white text-center opacity-75 rounded-sm bg-gray-800 mt-2 w-4 h-4 inline-flex items-center justify-center;
-
-    svg {
-        @apply w-3 h-3;
-    }
 }
 
 .card .card-cta-contained-btn {

--- a/theme/src/scss/components/_llm-menu.scss
+++ b/theme/src/scss/components/_llm-menu.scss
@@ -1,22 +1,15 @@
 .llm-menu-container {
     position: relative;
-    display: block;
-}
-
-.llm-menu-trigger {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    background: none;
-    border: none;
-    padding: 0;
-    margin: 0;
-    cursor: pointer;
-    text-decoration: none;
-    transition: color 0.2s ease;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 
-    i:first-child {
-        width: 14px;
-        margin-right: 0.5rem;
+    // Hold a fixed width on the primary "Copy page" segment so the control
+    // doesn't shrink when its label swaps to the shorter "Copied!".
+    .btn-split > .btn:first-child {
+        min-width: 7.5rem;
+        justify-content: start;
     }
 }
 

--- a/theme/src/scss/docs/_docs-main.scss
+++ b/theme/src/scss/docs/_docs-main.scss
@@ -318,6 +318,26 @@ body.section-registry {
             padding-bottom: 24px;
             min-height: 100vh;
 
+            // Scroll-to-top button: sticks 1rem above the viewport bottom and,
+            // because it lives at the end of (and is bounded by) this column,
+            // right-aligns to the content's right edge. JS toggles .visible /
+            // .hidden on the inner <a> to reveal it after scrolling.
+            > pulumi-top-button {
+                position: sticky;
+                bottom: 1rem;
+                z-index: 10;
+                display: block;
+                width: fit-content;
+                margin-left: auto;
+
+                // It floats over content, so keep an opaque surface (the dark
+                // outline variant is otherwise transparent and would let text
+                // bleed through).
+                .btn {
+                    background-color: var(--docs-bg, var(--color-white));
+                }
+            }
+
             @media (min-width: 1024px) {
                 max-width: 1200px;
                 flex-direction: column;
@@ -398,6 +418,10 @@ body.section-registry {
 
         .docs-toc-mobile {
             display: flex;
+            // Stack the markdown actions and the "On this page" accordion in their
+            // own full-width rows instead of cramming them side by side.
+            flex-direction: column;
+            align-items: stretch;
 
             div.table-of-contents {
                 display: flex;
@@ -410,6 +434,14 @@ body.section-registry {
         .docs-marketing-ad,
         .docs-toc-desktop {
             display: none;
+        }
+
+        // Markdown / LLM actions show at every breakpoint. Only the slot for the
+        // current width is visible (mobile slot < 1280px, desktop slot ≥ 1280px),
+        // so the widget never renders twice.
+        .docs-md-actions {
+            display: block;
+            margin-bottom: 16px;
         }
 
 
@@ -435,13 +467,18 @@ body.section-registry {
                 display: block;
             }
 
+            // Desktop right-rail spacing (visibility handled by the base rule).
+            .docs-md-actions {
+                margin-bottom:1.5rem;
+            }
+
             .docs-table-of-contents {
-                margin-top: 1rem;
+                margin-top: 2.5rem;
                 padding: 1rem 0;
                 overflow-y: auto;
-                height: 90vh;
+                height: 100vh;
                 position: sticky;
-                top: 3.5rem;
+                top: 0;
                 display: block;
                 margin-right: 10px;
 
@@ -636,7 +673,11 @@ body.section-registry {
                 font-family: 'Inter';
                 font-weight: 600;
                 font-size: 12px;
-                color: #8e8f97;
+                // Full-strength foreground token; flips automatically in docs
+                // dark mode (near-black in light, white in dark). Registry pages
+                // aren't body.section-docs (the token is undefined there), so the
+                // fallback keeps them at their original muted gray.
+                color: var(--docs-fg, #8e8f97);
                 margin: 0 !important;
             }
         }
@@ -702,13 +743,16 @@ body.section-registry {
         }
 
         .heading:hover {
+            // Resting heading is full-strength --docs-fg, so hover softens to the
+            // muted token (lighter in light mode, dimmer in dark) for feedback.
+            // Fallback keeps registry (non-docs) pages at their original hover.
             div.icon {
-                background-color: var(--color-gray-900);
+                background-color: var(--docs-fg-muted, var(--color-gray-900));
             }
 
             .icon-heading-wrapper {
                 h2 {
-                    color: var(--color-gray-900);
+                    color: var(--docs-fg-muted, var(--color-gray-900));
                 }
             }
         }

--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -320,10 +320,9 @@ html[data-theme="dark"] body.section-docs {
     // --- Right-rail table of contents (shared selectors w/ registry; the
     //     section-docs gate keeps registry light) -----------------------------
     div.table-of-contents {
-        div.heading h2 {
-            color: var(--docs-fg-muted);
-        }
-
+        // Heading h2 and the :hover state now resolve their --docs-* tokens
+        // directly in the base rules (_docs-main.scss), so they flip here
+        // automatically — no override needed.
         ul li a {
             color: var(--docs-link);
         }
@@ -603,15 +602,9 @@ html[data-theme="dark"] body.section-docs {
 // "Copy page" / LLM menu dropdown in the right-rail TOC (_llm-menu.scss — all
 // hardcoded light slate grays). Not a detached overlay, so plain section-docs scope.
 html[data-theme="dark"] body.section-docs {
-    // Trigger button (utilities: text-gray-600 hover:text-gray-700).
-    .llm-menu-trigger {
-        color: var(--docs-fg-muted);
-
-        &:hover {
-            color: var(--docs-fg);
-        }
-    }
-
+    // The split "Copy page" button + "View as Markdown" button use .btn-outline,
+    // which already has a shared dark skin above (matching the header nav). Only
+    // the dropdown below needs its own overrides.
     .llm-menu-dropdown {
         background: var(--color-gray-950);
         border-color: var(--docs-border);

--- a/theme/src/ts/misc.ts
+++ b/theme/src/ts/misc.ts
@@ -140,11 +140,17 @@ export function generateOnThisPage() {
 
         let tocRafPending = false;
         const setActiveItem = () => {
-            let active = null;
+            // Active = the last heading scrolled above a line 80px below the
+            // viewport top (just past the headings' 60px scroll-margin-top, so the
+            // heading you click registers instead of the next). Uses viewport-
+            // relative coords; offsetTop would be wrong here (positioned ancestor).
+            let active = headingItems[0];
             for (const heading of headingItems) {
-                if (!active && heading.element.offsetTop >= window.scrollY) {
+                if (heading.element.getBoundingClientRect().top <= 80) {
                     active = heading;
                 }
+            }
+            for (const heading of headingItems) {
                 heading.listItems.forEach(li => li.classList.toggle("active", heading === active));
             }
         };

--- a/theme/stencil/src/components/llm-menu/llm-menu.tsx
+++ b/theme/stencil/src/components/llm-menu/llm-menu.tsx
@@ -65,11 +65,6 @@ export class LlmMenu {
         }
     }
 
-    private viewMarkdown() {
-        window.open(this.getMarkdownUrl(), "_blank");
-        this.trackEvent("view-markdown");
-    }
-
     private showCopied(type: string) {
         this.copied = type;
         setTimeout(() => (this.copied = ""), 2000);
@@ -119,17 +114,6 @@ export class LlmMenu {
             </svg>
         );
 
-        const markdownIcon = (
-            <svg class="llm-menu-icon" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path
-                    d="M14 3a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h12zM2 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H2z"
-                />
-                <path
-                    d="M9.146 8.146a.5.5 0 0 1 .708 0L11.5 9.793l1.646-1.647a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 0-.708zM11.5 5a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-1 0v-4a.5.5 0 0 1 .5-.5zM3.56 11V5.01h1.44L6.5 7.98 8 5.01h1.44V11H8.2V6.57L6.5 9.56l-1.7-2.99V11H3.56z"
-                />
-            </svg>
-        );
-
         const chatGptLogo = (
             <svg class="llm-menu-icon" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -148,35 +132,40 @@ export class LlmMenu {
             </svg>
         );
 
+        const copyIcon = (
+            <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--regular" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
+                <path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/>
+            </svg>
+        );
+
         return (
             <Host>
                 <div class="llm-menu-container">
-                    <button class="llm-menu-trigger text-gray-600 hover:text-gray-700 text-xs" onClick={() => (this.isOpen = !this.isOpen)}>
-                        <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--regular mr-2" fill="currentColor" viewBox="0 0 256 256" style={{ width: "14px", height: "14px" }} aria-hidden="true" focusable="false">
-                            <path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/>
-                        </svg>
-                        Copy Page
-                        {this.isOpen ? (
-                            <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--bold" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
-                                <path d="M216.49,168.49a12,12,0,0,1-17,0L128,97,56.49,168.49a12,12,0,0,1-17-17l80-80a12,12,0,0,1,17,0l80,80A12,12,0,0,1,216.49,168.49Z"/>
-                            </svg>
-                        ) : (
-                            <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--bold" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
-                                <path d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"/>
-                            </svg>
-                        )}
-                    </button>
+                    <div class="btn-split">
+                        <button class="btn btn-outline" onClick={() => this.copyPage()}>
+                            {copyIcon}
+                            {this.copied === "page" ? "Copied!" : "Copy page"}
+                        </button>
+                        <button class="btn btn-outline" aria-haspopup="menu" aria-expanded={this.isOpen ? "true" : "false"} aria-label="More copy options" onClick={() => (this.isOpen = !this.isOpen)}>
+                            {this.isOpen ? (
+                                <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--bold" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
+                                    <path d="M216.49,168.49a12,12,0,0,1-17,0L128,97,56.49,168.49a12,12,0,0,1-17-17l80-80a12,12,0,0,1,17,0l80,80A12,12,0,0,1,216.49,168.49Z"/>
+                                </svg>
+                            ) : (
+                                <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--bold" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
+                                    <path d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"/>
+                                </svg>
+                            )}
+                        </button>
+                    </div>
+
+                    <a class="btn btn-outline" href={this.getMarkdownUrl()} target="_blank" rel="noopener" onClick={() => this.trackEvent("view-markdown")}>
+                        View as Markdown
+                    </a>
 
                     {this.isOpen && (
                         <div class="llm-menu-dropdown">
                             <div>
-                                <button class="llm-menu-item" onClick={() => this.copyUrl()}>
-                                    {linkIcon}
-                                    <div class="llm-menu-text">
-                                        <div class="llm-menu-title">{this.copied === "url" ? "Copied!" : "Copy URL"}</div>
-                                        <div class="llm-menu-subtitle">Copy page link to share</div>
-                                    </div>
-                                </button>
                                 <button class="llm-menu-item" onClick={() => this.copyPage()}>
                                     <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--regular llm-menu-icon" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
                                         <path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/>
@@ -186,15 +175,12 @@ export class LlmMenu {
                                         <div class="llm-menu-subtitle">Copy page for LLMs</div>
                                     </div>
                                 </button>
-                                <button class="llm-menu-item" onClick={() => this.viewMarkdown()}>
-                                    {markdownIcon}
+                                <button class="llm-menu-item" onClick={() => this.copyUrl()}>
+                                    {linkIcon}
                                     <div class="llm-menu-text">
-                                        <div class="llm-menu-title">View as Markdown</div>
-                                        <div class="llm-menu-subtitle">Open Markdown in new tab</div>
+                                        <div class="llm-menu-title">{this.copied === "url" ? "Copied!" : "Copy URL"}</div>
+                                        <div class="llm-menu-subtitle">Copy page link to share</div>
                                     </div>
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--regular llm-menu-external" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
-                                        <path d="M224,104a8,8,0,0,1-16,0V59.32l-66.33,66.34a8,8,0,0,1-11.32-11.32L196.68,48H152a8,8,0,0,1,0-16h64a8,8,0,0,1,8,8Zm-40,24a8,8,0,0,0-8,8v72H48V80h72a8,8,0,0,0,0-16H48A16,16,0,0,0,32,80V208a16,16,0,0,0,16,16H176a16,16,0,0,0,16-16V136A8,8,0,0,0,184,128Z"/>
-                                    </svg>
                                 </button>
                                 <hr />
                                 <button class="llm-menu-item" onClick={() => this.openInChatGPT()}>

--- a/theme/stencil/src/components/top-button/top-button.tsx
+++ b/theme/stencil/src/components/top-button/top-button.tsx
@@ -20,11 +20,11 @@ export class TopButton {
     }
 
     render() {
-        let buttonClass = `btn-scroll-top ${this.visible}`;
+        let buttonClass = `btn btn-outline btn-icon-lg ${this.visible}`;
         return (
             <a class={buttonClass} title="Scroll to top" href="#">
                 <svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--bold" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
-                    <path d="M213.66,165.66a8,8,0,0,1-11.32,0L128,91.31,53.66,165.66a8,8,0,0,1-11.32-11.32l80-80a8,8,0,0,1,11.32,0l80,80A8,8,0,0,1,213.66,165.66Z"/>
+                    <path d="M216.49,168.49a12,12,0,0,1-17,0L128,97,56.49,168.49a12,12,0,0,1-17-17l80-80a12,12,0,0,1,17,0l80,80A12,12,0,0,1,216.49,168.49Z"/>
                 </svg>
             </a>
         );


### PR DESCRIPTION
Adjusted some other things while I was in there, some colors and the scroll to top button.
Also removed the 'Edit this page' link, but left 'Request changes'.

---

### Proposed changes

Reworks the docs right-rail LLM/Markdown actions to make them more discoverable: the single "Copy Page" dropdown trigger becomes a split **Copy page** button (with a caret for the remaining LLM options) alongside a standalone **View as Markdown** button, both moved above the table of contents. Adds a reusable `.btn-split` style, restyles the scroll-to-top button as a sticky `.btn-outline` icon button anchored to the content column, and wires up dark-mode tokens for the affected headings. Also removes the legacy "Edit this Page" link and the now-unused `.btn-scroll-top` style.

### Related issues

Closes #17557