### PR TITLE
vale: enforce sentence-case H2+ headings (Pulumi.HeadingSentenceCase)

### DIFF
--- a/.claude/commands/docs-review/scripts/vale-findings-filter.py
+++ b/.claude/commands/docs-review/scripts/vale-findings-filter.py
@@ -63,6 +63,7 @@ RULE_CATEGORIES: dict[str, str] = {
     "Pulumi.LinkText": "vague link text",
     "Pulumi.EmptyAltText": "empty alt text",
     "Pulumi.CommandBackticks": "unbacked CLI command",
+    "Pulumi.HeadingSentenceCase": "heading capitalization",
     "Pulumi.Repetition": "repeated word",
     "Google.Acronyms": "acronym",
     "Google.Contractions": "contractions",

--- a/.vale.ini
+++ b/.vale.ini
@@ -19,7 +19,7 @@ TokenIgnores = ({{[%<].*?[%>]}}), \
                (\{\{[^}]+\}\})
 
 # Disable Google rules that conflict with Pulumi house style.
-Google.Headings = NO        # Pulumi uses Title Case for H1 (markdownlint covers H2+).
+Google.Headings = NO        # Replaced by Pulumi.HeadingSentenceCase, which scopes to H2+ only (Pulumi uses Title Case for the H1/page title). Nothing else enforced H2 case — markdownlint has no sentence-case rule.
 Google.WordList = NO        # Google product-name overrides don't match Pulumi terminology.
 Google.We = NO              # Documentation style allows first-person plural.
 Google.Will = NO            # Too noisy on declarative technical prose.
@@ -36,3 +36,6 @@ write-good.E-Prime = NO     # Banning all forms of "to be" is impractical for te
 # Per-path overrides. Vale merges sections; more-specific wins on conflicts.
 [content/blog/**/*.md]
 Google.FirstPerson = NO     # Blog posts are written in author voice; 'I'/'my'/'me' are the medium.
+
+[content/docs/iac/cli/commands/**/*.md]
+Pulumi.HeadingSentenceCase = NO  # Generated from `pulumi gen-docs`; the cobra `### SEE ALSO` headings are fixed boilerplate, not hand-authored prose.

--- a/styles/Pulumi/HeadingSentenceCase.yml
+++ b/styles/Pulumi/HeadingSentenceCase.yml
@@ -1,0 +1,196 @@
+extends: capitalization
+message: "Heading '%s' should use sentence case (capitalize only the first word and proper nouns)."
+link: STYLE-GUIDE.md
+level: warning
+# H2+ only. Pulumi convention is Title Case for the H1/page title and sentence
+# case for every subheading; Vale's per-level heading scopes let us enforce the
+# latter without touching H1. (Google.Headings is disabled in .vale.ini because
+# it has no level scope and would false-flag every Title-Case H1.)
+scope:
+  - heading.h2
+  - heading.h3
+  - heading.h4
+  - heading.h5
+  - heading.h6
+match: $sentence
+# Words allowed to stay capitalized mid-heading: proper nouns, products, clouds,
+# services, languages, and acronyms. Curated from a scan of all H2+ headings in
+# content/docs (the high-frequency capitalized mid-heading tokens) plus the
+# Pulumi product/term vocabulary. Deliberately EXCLUDES lowercase-by-convention
+# Pulumi concepts (stack, project, resource, provider, output, secret, config)
+# so the rule still flags those — see data/STYLE-GUIDE Nomenclature.
+exceptions:
+  # Pulumi products & terms
+  - Pulumi
+  - ESC
+  - Neo
+  - CrossGuard
+  - Deployments
+  - Insights
+  - Copilot
+  - IDP
+  # IaC ecosystem
+  - Terraform
+  - OpenTofu
+  - Crossplane
+  - CloudFormation
+  - CDK
+  - CDKTF
+  - Helm
+  - Kustomize
+  - Ansible
+  - Chef
+  - Puppet
+  - IaC
+  # Clouds & vendors
+  - AWS
+  - Azure
+  - GCP
+  - Google
+  - Microsoft
+  - Oracle
+  - DigitalOcean
+  - Cloudflare
+  - Cloud
+  - Alibaba
+  - Linode
+  - Vercel
+  - Netlify
+  - Heroku
+  # Cloud services / resources
+  - EKS
+  - ECS
+  - ECR
+  - EC2
+  - S3
+  - VPC
+  - IAM
+  - KMS
+  - RDS
+  - Lambda
+  - DynamoDB
+  - GKE
+  - AKS
+  - ACI
+  - ARM
+  - Fargate
+  - CloudWatch
+  - Route53
+  - GuardDuty
+  # Kubernetes & containers
+  - Kubernetes
+  - Docker
+  - Containerd
+  - Istio
+  - Knative
+  # Identity / auth
+  - OIDC
+  - OAuth
+  - SAML
+  - SCIM
+  - SSO
+  - RBAC
+  - MFA
+  - JWT
+  - Okta
+  - OneLogin
+  - JumpCloud
+  - Entra
+  - Auth0
+  - LDAP
+  - Active
+  - Directory
+  # Source control & CI/CD
+  - GitHub
+  - GitLab
+  - Git
+  - Bitbucket
+  - Jenkins
+  - Actions
+  - VCS
+  - CI/CD
+  - CD
+  # Data stores & SaaS
+  - Snowflake
+  - MongoDB
+  - MySQL
+  - PostgreSQL
+  - Postgres
+  - Redis
+  - Kafka
+  - Datadog
+  - PagerDuty
+  - Slack
+  - Teams
+  - Jira
+  - ServiceNow
+  - Twilio
+  - Stripe
+  - Vault
+  - Consul
+  # Languages, formats, runtimes
+  - Python
+  - TypeScript
+  - JavaScript
+  - Node.js
+  - Go
+  - Golang
+  - Java
+  - .NET
+  - C#
+  - F#
+  - YAML
+  - JSON
+  - TOML
+  - HCL
+  - SQL
+  - GraphQL
+  - Markdown
+  # Protocols & generic acronyms
+  - API
+  - APIs
+  - CLI
+  - SDK
+  - SDKs
+  - REST
+  - gRPC
+  - HTTP
+  - HTTPS
+  - URL
+  - URLs
+  - URI
+  - ID
+  - IDs
+  - UI
+  - CLI
+  - MCP
+  - DNS
+  - TLS
+  - SSL
+  - SSH
+  - SFTP
+  - CIDR
+  - ARN
+  - ARNs
+  - SQS
+  - SNS
+  - VM
+  - VMs
+  - OS
+  - CDN
+  - FAQ
+  - FAQs
+  # OSes & tooling
+  - Linux
+  - macOS
+  - Windows
+  - VS
+  - Visual
+  - Studio
+  - Cosmos
+  - Marketplace
+  - MongoDB
+  - REPL
+  - Emmet
+  - gRPC
+  - I


### PR DESCRIPTION
A recent automated content-review sweep missed a Title-Case H2 (`## Referencing Existing Infrastructure State` in the Terraform get-started docs). Root cause: **nothing enforced sentence case on subheadings.** `.vale.ini` disabled `Google.Headings` with the comment "markdownlint covers H2+" — but markdownlint has no sentence-case rule, so Title-Case H2s pass `make lint`.

## The rule

New `styles/Pulumi/HeadingSentenceCase.yml` — Vale's `capitalization` extension, **scoped to H2–H6 only** so the Title-Case H1/page title is untouched (that level scope is exactly why `Google.Headings`, which has none, couldn't be reused).

**Exceptions are data-driven, not guessed.** I scanned all **5,520** H2+ headings in `content/docs` and tallied the capitalized mid-heading tokens. The genuine proper nouns / products / clouds / services / acronyms became exceptions (Pulumi, ESC, Terraform, AWS, OIDC, Kubernetes, GitHub, CLI, SDK, …); the lowercase-by-convention Pulumi concepts (stack, project, resource, provider, …) were deliberately **left out** so the rule still flags those.

## Calibration

- Catches the original miss (and reference-state's H2 specifically).
- Generated CLI command docs scoped out in `.vale.ini` — the cobra `### SEE ALSO` boilerplate was ~240 of the raw hits, pure noise.
- Corpus-wide: ~790 findings remain, sampled at roughly **80% precision** (genuine Title-Case violations). The residual false positives are inherent to sentence-case checking — acronym expansions ("ESC (Environments, Secrets, and Configuration)") and code-identifier headings in API/schema reference pages.

## Risk & rollout

- **Non-blocking.** Vale runs as `make lint-prose`, which nags and never blocks `make lint` or CI. The ~790 existing-doc findings surface as advisory warnings, chipped away gradually by the content-review sweep.
- **Flag-only in content-review.** Wired into `vale-findings-filter.py` as the `heading capitalization` category, and deliberately **left out** of the composer's high-confidence auto-fix set — so for now it's surfaced for a human/the model to confirm, not auto-applied. Easy to promote to auto-fix once it proves out.
- Exceptions are a plain list — trivially extended over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)