### PR TITLE
content-review: stop the lint-line hint leaking into the PR body

### DIFF
--- a/scripts/content-review/compose-pr-body.py
+++ b/scripts/content-review/compose-pr-body.py
@@ -221,9 +221,12 @@ def render_deferrals(findings: list[dict], path: str) -> str:
 
 def render_verification(artifacts: dict, errors: list[str]) -> str:
     lines = ["## Verification\n\n"]
+    # The re-lint gate swaps LINT_PLACEHOLDER for the authoritative result. The
+    # "do not edit" hint rides in a trailing HTML comment so it guides the model
+    # but never renders in the published body; the label is `make lint` only —
+    # build isn't stamped here (it's left to the PR's normal CI).
     lines.append(
-        f"- `make lint` / `make build`: {LINT_PLACEHOLDER} "
-        "(stamped by the workflow re-lint gate — do not edit this line)\n"
+        f"- `make lint`: {LINT_PLACEHOLDER} <!-- stamped by the workflow re-lint gate; leave this line as-is -->\n"
     )
     lines.append("- Pre-step artifacts:\n")
     for name, summary in artifacts.items():

--- a/scripts/content-review/test_compose_pr_body.py
+++ b/scripts/content-review/test_compose_pr_body.py
@@ -96,6 +96,12 @@ check("fix rows carry <TODO>", "<TODO: correction" in out)
 check("deferrals carry <TODO>", "<TODO: why judgment-level>" in deferral_block)
 check("screenshot/rendered are <TODO>", out.count("<TODO") >= 4)
 check("lint result is a stamped placeholder", c.LINT_PLACEHOLDER in out)
+# The "do not edit" hint must live in an HTML comment, not leak to readers, and
+# the label is `make lint` only (build isn't stamped here).
+check("no reader-facing 'do not edit' instruction", "do not edit this line" not in out)
+lint_line = next(l for l in out.splitlines() if c.LINT_PLACEHOLDER in l)
+check("lint hint rides in an HTML comment", "<!--" in lint_line.split(c.LINT_PLACEHOLDER, 1)[1])
+check("lint label is make-lint-only (no make build)", "make build`:" not in lint_line)
 
 # Verification inventory is deterministic.
 check("inventory counts verdicts", "3 verdict(s); 1 contradicted/mismatch, 1 unverifiable" in out)


### PR DESCRIPTION
Cosmetic follow-up to #19853. The composer's Verification line read:

```
- `make lint` / `make build`: <!-- LINT-RESULT --> (stamped by the workflow re-lint gate — do not edit this line)
```

The re-lint gate replaces only the `<!-- LINT-RESULT -->` token, so the model-directed parenthetical leaked into the **published** PR body (visible in #19856 / #19857 / #19858):

> - `make lint` / `make build`: ✅ `make lint` re-verified by the workflow on `5cf2f352ab` **(stamped by the workflow re-lint gate — do not edit this line)**

Two fixes:
- Move the "leave this line as-is" hint into a trailing **HTML comment** — it still guides the model but never renders for readers, and survives the token swap.
- Label the line **`make lint`** only; build isn't stamped here (it's left to the PR's normal CI), so the old "/ `make build`" implied a verdict it didn't have.

Result:
```
- `make lint`: <!-- LINT-RESULT --> <!-- stamped by the workflow re-lint gate; leave this line as-is -->
```
→ renders as `- make lint: ✅ make lint re-verified by the workflow on <sha>`.

Test asserts no reader-facing "do not edit" text and a make-lint-only label. `record-review` marker guard unchanged (still keys on `<!-- LINT-RESULT -->`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)