### PR TITLE
content-review: route PRs through the real triage instead of force-reviewing them

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -205,17 +205,19 @@ render through their `layouts/shortcodes/*.markdown.md` templates):
 If this pass applied any fix, re-run `make lint && make build` before
 opening the PR.
 
-### 7. PR — only when you applied a fix, ready (non-draft)
+### 7. PR — only when you applied a fix, opened as a draft
 
-Open a **ready** PR to `master`. You do **not** write the body from scratch: the
+Open a **draft** PR to `master`. You do **not** write the body from scratch: the
 workflow composed `.pr-body-draft.md` (via `compose-pr-body.py`, the
 assemble-then-judge model — the composer ASSEMBLES facts, you JUDGE) with every
 section present and each pre-found finding pre-bucketed under a `<TODO>`. **Edit
 that draft**, resolve every `<TODO>`, strip the HTML-comment hints, and create
-the PR with `gh pr create --body-file .pr-body-draft.md`. The workflow re-runs
-`make lint` on your branch (flipping the PR back to draft if it fails) and
-dispatches the automated docs review afterward; humans merge. The sections (each
-is checked for):
+the PR with `gh pr create --draft --body-file .pr-body-draft.md`. The workflow
+then re-runs `make lint` on your branch and **promotes the PR to ready only if
+lint passes** — that ready transition is what triggers triage and the docs
+review (a clean lint means it flows through the normal pipeline; a trivial fix is
+short-circuited there). A lint failure leaves the PR a draft with a comment for a
+human; humans merge. The sections (each is checked for):
 
 - **Why this page**: composed from the selection queue (lane, tier, traffic
   figure + period, last reviewed). **Leave verbatim** — do not re-narrate it.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -218,7 +218,15 @@ jobs:
               SKIP="trivial"
             elif [[ ",$LABELS_CSV," == *",review:frontmatter-only,"* ]]; then
               SKIP="frontmatter-only"
-            elif [[ "$AUTHOR" == "pulumi-bot" || "$AUTHOR" == "dependabot[bot]" ]]; then
+            # Bot-authored PRs are slop-skipped — EXCEPT content-review/*, which
+            # are first-class automated docs fixes we want reviewed. Those fall
+            # through to the already-reviewed guard below (so they still can't
+            # re-review loop) and otherwise get a normal review. Triage already
+            # ran on them and applied any trivial / frontmatter-only short-circuit
+            # above — the point of this change: a trivial content-review PR skips
+            # there instead of being force-reviewed.
+            elif [[ ( "$AUTHOR" == "pulumi-bot" || "$AUTHOR" == "dependabot[bot]" ) \
+                    && "$HEAD_BRANCH" != content-review/* ]]; then
               SKIP="bot-author"
             # Auto-fire path (workflow_run from triage) on a PR that the
             # review pipeline has already touched: don't burn API on a

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -21,10 +21,17 @@ jobs:
     # their own labeling pipelines (label-dependabot.yml) and don't
     # carry secrets. `ready_for_review` always has `draft: false`, so
     # the draft guard is a no-op for that event.
+    #
+    # Exception: content-review/* PRs are bot-authored but are first-class
+    # automated docs fixes we DO want triaged and reviewed like any human PR
+    # (the worker opens them draft and promotes to ready on a clean re-lint, so
+    # triage fires on that ready transition). They flow through the normal
+    # triage → review chain instead of being force-dispatched.
     if: >-
       !github.event.pull_request.draft
-      && github.event.pull_request.user.login != 'pulumi-bot'
       && github.event.pull_request.user.login != 'dependabot[bot]'
+      && (github.event.pull_request.user.login != 'pulumi-bot'
+          || startsWith(github.event.pull_request.head.ref, 'content-review/'))
 
     concurrency:
       group: claude-triage-${{ github.event.pull_request.number }}

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -267,9 +267,12 @@ jobs:
             6. Run the rendered content pass over the built page — both
                the HTML view and the customer-facing markdown view
                (`public/<url>/index.html` and `index.md`) — per the skill.
-            7. If you applied any fix, open a **ready** (non-draft) PR whose
-               body is `.pr-body-draft.md` (composed for you at the repo root —
-               the assemble-then-judge model, like the pre-merge review). Do NOT
+            7. If you applied any fix, open a **draft** PR whose body is
+               `.pr-body-draft.md` (composed for you at the repo root — the
+               assemble-then-judge model, like the pre-merge review). Open it as
+               a DRAFT (`gh pr create --draft`): the workflow re-lints your branch
+               and promotes the PR to ready only if lint passes — that ready
+               transition is what triggers triage and the docs review. Do NOT
                write the body from scratch. EDIT the draft:
                - "Why this page" is rendered from the selection queue — leave it
                  verbatim, its facts are authoritative.
@@ -282,8 +285,8 @@ jobs:
                  hints before opening the PR.
                - Leave the `<!-- LINT-RESULT -->` line in "Verification" exactly
                  as-is; the workflow stamps it with the authoritative result.
-               Then `gh pr create --body-file .pr-body-draft.md`. A clean article
-               (zero fixes) opens no PR.
+               Then `gh pr create --draft --body-file .pr-body-draft.md`. A clean
+               article (zero fixes) opens no PR.
             8. Write `.content-review-verdict.json` at the repo root — your ONLY
                structured output. Shape:
                `{"verdict": "fixed|clean|skipped", "reason": "<one line; required
@@ -315,23 +318,23 @@ jobs:
           python3 scripts/content-review/summarize-denials.py \
             "${{ steps.claude.outputs.execution_file }}"
 
-      # Lint re-gate: don't trust the model's self-report that `make lint`
-      # passed on the branch. For a fix verdict, check out the pushed branch and
-      # re-run lint. The composer left a `<!-- LINT-RESULT -->` placeholder in the
-      # PR body's Verification section precisely so this gate — the authority on
-      # lint, not the model — stamps the real outcome there. On failure: flip the
-      # PR back to draft, comment the output, stamp a FAILED marker, and skip the
-      # docs-review dispatch (the `lint_ok` output gates it). The ledger still
-      # records `reviewed` — the draft PR stays for a human. Build is left to the
-      # PR's normal CI.
-      - name: Re-lint the fix branch
+      # Lint re-gate + ready promotion. The model opened the PR as a DRAFT and
+      # we don't trust its self-report that `make lint` passed: check out the
+      # pushed branch and re-run lint ourselves. On PASS, promote the PR to ready
+      # — that draft→ready transition is what fires triage and the docs review
+      # (content-review/* PRs flow through the normal triage → review chain; see
+      # claude-triage.yml / claude-code-review.yml). On FAIL, leave it draft (so
+      # triage never fires) and comment the output for a human. Either way, stamp
+      # the authoritative result into the PR body's `<!-- LINT-RESULT -->`
+      # placeholder — this gate is the authority on lint, not the model. The
+      # ledger still records `reviewed`. Build is left to the PR's normal CI.
+      - name: Re-lint and promote the fix branch
         id: lint
         if: hashFiles('.content-review-verdict.json') != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
         run: |
-          echo "ok=true" >> "$GITHUB_OUTPUT"
           VERDICT=$(jq -r '.verdict // empty' .content-review-verdict.json)
           [ "$VERDICT" = "fixed" ] || { echo "verdict=$VERDICT; no branch to re-lint"; exit 0; }
           RETIRE=$(jq -r 'if .retirement then "retire-" else "" end' .content-review-verdict.json)
@@ -347,15 +350,14 @@ jobs:
               --branch "$BRANCH" --result "$1" --sha "$(git rev-parse --short HEAD)" || true
           }
           if make lint > .lint.log 2>&1; then
-            echo "lint passed on $BRANCH"
+            echo "lint passed on $BRANCH; promoting draft → ready (fires triage → review)"
             stamp_body passed
+            gh pr ready "$BRANCH" || echo "::warning::could not promote $BRANCH to ready"
           else
-            echo "ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::make lint failed on $BRANCH; flipping PR to draft"
-            gh pr ready "$BRANCH" --undo || true
+            echo "::warning::make lint failed on $BRANCH; leaving PR as draft"
             stamp_body failed
             {
-              echo "Automated review note: \`make lint\` failed on this branch, so the PR was returned to draft and the docs review was not dispatched. Lint output:"
+              echo "Automated review note: \`make lint\` failed on this branch, so the PR was left as a draft and no review was triggered. Lint output:"
               echo ""
               echo '```'
               tail -c 4000 .lint.log
@@ -388,26 +390,12 @@ jobs:
             --verdict .content-review-verdict.json \
             --claude-outcome "${{ steps.claude.outcome }}"
 
-      # Slop defense: bot-authored PRs are auto-skipped by the docs-review
-      # pipeline (claude-code-review.yml sets skip_reason=bot-author), so the
-      # content PR gets its review via explicit force dispatch — the same
-      # pattern claude-new.yml uses for #new-review. Gated on a derived
-      # `reviewed` status AND a passing re-lint; PR number + head SHA come from
-      # the ledger record's gh-derived values, never the model's self-report.
-      - name: Dispatch docs review over the PR
-        if: steps.record.outputs.dispatch == 'true' && steps.lint.outputs.ok != 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          NUMBER='${{ steps.record.outputs.pr_number }}'
-          HEAD_SHA='${{ steps.record.outputs.head_sha }}'
-          echo "dispatching review for PR #$NUMBER ($HEAD_SHA)"
-          gh workflow run claude-code-review.yml \
-            --repo "${{ github.repository }}" \
-            -f pr_number="$NUMBER" \
-            -f head_sha="$HEAD_SHA" \
-            -f force=true \
-            || echo "::warning::review dispatch failed for PR #$NUMBER"
+      # No explicit review dispatch: a content-review PR that passes re-lint is
+      # promoted draft → ready in the step above, and that transition drives the
+      # normal triage → docs-review chain (claude-triage.yml is opened to
+      # content-review/* bot PRs; claude-code-review.yml reviews them honoring the
+      # trivial / frontmatter-only short-circuits). Trivial fixes are skipped
+      # there instead of being force-reviewed.
 
 env:
   ESC_ACTION_OIDC_AUTH: true


### PR DESCRIPTION
Content-review PRs were force-dispatched to the docs review with `force=true`, which bypasses the `trivial` / `frontmatter-only` short-circuits along with the `bot-author` skip it was actually reaching for. So a +1/−1 typo fix got the full heavyweight review, and the PRs never saw triage at all (triage skips `pulumi-bot`).

Rather than pile more special-casing on the workaround, this stops modeling content-review PRs as bot slop and makes them **first-class**: they flow through the same triage → review chain as any human PR, honoring the trivial / frontmatter-only short-circuits.

## Changes (all gated on the `content-review/*` branch prefix)

- **`claude-triage.yml`** — run triage on `content-review/*` bot PRs (every other `pulumi-bot` / `dependabot` PR is still skipped).
- **`claude-code-review.yml`** — exempt `content-review/*` from the `bot-author` skip; they fall through to the existing `already-reviewed` guard so they can't re-review loop, and otherwise get a normal review that respects any `trivial` / `frontmatter-only` label triage applied.
- **`content-review-article.yml`** — the worker opens the PR as a **draft** and the re-lint gate **promotes it to ready only when lint passes**. That draft→ready transition is what fires triage, which cleanly sidesteps the lint/draft race (a ready PR can't be triaged before our own lint gate clears it). The `force=true` dispatch step is gone.
- **SKILL** — open a draft PR; the workflow promotes on a clean lint.

## Why draft-then-promote
Previously the PR opened *ready* and flipped to draft on lint failure. With triage now firing on these PRs, that would race the re-lint gate. Inverting it — open draft, promote on pass — means triage only ever fires once the branch has cleared our lint gate. It's also just more correct: a PR shouldn't read as ready before it passes lint.

## Blast radius
Every exemption checks the `content-review/*` head-branch prefix, so non-content-review PRs (human or bot) are completely untouched. Verified the skip decision across the matrix:

| PR | result |
|---|---|
| content-review bot, `review:trivial` | **trivial** (short-circuit ✓) |
| content-review bot, no label | reviewed |
| content-review bot, `review:frontmatter-only` | frontmatter-only |
| other `pulumi-bot` PR (e.g. SDK regen) | bot-author (still skipped) |
| `dependabot` PR | bot-author |
| human PR | reviewed |

Dispatcher is still manual-only, so I'll run a sweep after merge and confirm the chain fires end to end (draft → lint pass → ready → triage → review) and that a trivial fix short-circuits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)