### PR TITLE
content-review: capture selection signal in the ledger + reconstruct history

### DIFF
--- a/scripts/content-review/reconstruct-ledger-history.py
+++ b/scripts/content-review/reconstruct-ledger-history.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Reconstruct the full history of content-review actions from the S3 ledger.
+
+`record-review.py` writes one object per page slug and overwrites it each review,
+but the ledger bucket has versioning enabled (infrastructure/index.ts), so every
+overwrite is preserved as an immutable S3 object version. This walks those
+versions and assembles a single chronological timeline of every review the
+pipeline ever did — outcome AND selection signal (tier / score / monthly_visits)
+— so metrics are reconstructable from day one without depending on the ~90-day
+GitHub run logs.
+
+Resolve the bucket from the stack output (never hardcode it):
+
+    BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName --stack <stack>)
+    reconstruct-ledger-history.py --bucket "$BUCKET" --format csv --out history.csv
+
+Or point it at the same URI the workflow uses:
+
+    reconstruct-ledger-history.py --uri "s3://$BUCKET/ledger/" --format jsonl
+
+Needs the AWS CLI and read access to the bucket (the ContinuousDelivery role, or
+your own creds). Run `--self-test` to exercise the timeline assembly offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Flat columns for --format csv (the high-signal subset; --format jsonl keeps
+# every field plus the _version_* metadata).
+CSV_COLUMNS = [
+    "last_modified", "reviewed_at", "slug", "status", "tier", "score",
+    "monthly_visits", "traffic_available", "fixes", "skipped_findings",
+    "attempts", "clarity_flag", "retirement", "pr_number", "_version_id",
+]
+
+
+# ---- S3 access (thin wrappers; the testable core is build_timeline/emit) -----
+
+
+def parse_uri(uri: str) -> tuple[str, str]:
+    """s3://bucket/prefix/ -> (bucket, prefix)."""
+    rest = uri[len("s3://"):] if uri.startswith("s3://") else uri
+    bucket, _, prefix = rest.partition("/")
+    return bucket, prefix
+
+
+def list_versions(bucket: str, prefix: str) -> list[dict]:
+    """Every object version under the prefix (the AWS CLI auto-paginates)."""
+    out = subprocess.run(
+        ["aws", "s3api", "list-object-versions",
+         "--bucket", bucket, "--prefix", prefix, "--output", "json"],
+        capture_output=True, text=True, check=True,
+    )
+    data = json.loads(out.stdout or "{}")
+    return data.get("Versions", []) or []
+
+
+def fetch_body(bucket: str, key: str, version_id: str) -> dict | None:
+    """Fetch one object version's JSON body."""
+    with tempfile.NamedTemporaryFile(suffix=".json") as tmp:
+        r = subprocess.run(
+            ["aws", "s3api", "get-object", "--bucket", bucket, "--key", key,
+             "--version-id", version_id, tmp.name],
+            capture_output=True, text=True, check=False,
+        )
+        if r.returncode != 0:
+            print(f"reconstruct: get-object failed for {key}@{version_id}: {r.stderr.strip()}",
+                  file=sys.stderr)
+            return None
+        try:
+            return json.loads(Path(tmp.name).read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+
+
+# ---- assembly (pure; unit-tested) -------------------------------------------
+
+
+def build_timeline(versions: list[dict], bodies: dict[str, dict]) -> list[dict]:
+    """Merge version metadata with each fetched record, sorted oldest-first.
+
+    `versions` is the list-object-versions output (each: Key, VersionId,
+    LastModified, IsLatest). `bodies` maps VersionId -> the parsed record JSON.
+    Versions whose body is missing/unparseable are skipped. Ordering is by the
+    S3 LastModified timestamp (precise even when several reviews share a
+    reviewed_at date), with VersionId as a stable tiebreak.
+    """
+    rows: list[dict] = []
+    for v in versions:
+        body = bodies.get(v.get("VersionId"))
+        if not isinstance(body, dict):
+            continue
+        rows.append({
+            **body,
+            "_version_id": v.get("VersionId"),
+            "_last_modified": v.get("LastModified"),
+            "_is_latest": bool(v.get("IsLatest")),
+            "last_modified": v.get("LastModified"),
+        })
+    rows.sort(key=lambda r: (r.get("_last_modified") or "", r.get("_version_id") or ""))
+    return rows
+
+
+def to_jsonl(rows: list[dict]) -> str:
+    return "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows)
+
+
+def to_csv(rows: list[dict]) -> str:
+    import io
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+    w.writeheader()
+    for r in rows:
+        w.writerow({c: r.get(c) for c in CSV_COLUMNS})
+    return buf.getvalue()
+
+
+# ---- main -------------------------------------------------------------------
+
+
+def gather(bucket: str, prefix: str) -> list[dict]:
+    versions = list_versions(bucket, prefix)
+    bodies = {
+        v["VersionId"]: fetch_body(bucket, v["Key"], v["VersionId"])
+        for v in versions if v.get("VersionId") and v.get("Key")
+    }
+    return build_timeline(versions, bodies)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--uri", help="s3://bucket/prefix/ (e.g. the workflow's CONTENT_REVIEW_LEDGER_URI)")
+    ap.add_argument("--bucket", help="bucket name (resolve from the stack output, don't hardcode)")
+    ap.add_argument("--prefix", default="ledger/", help="key prefix (default: ledger/)")
+    ap.add_argument("--format", choices=["jsonl", "csv"], default="jsonl")
+    ap.add_argument("--out", help="output path (default: stdout)")
+    ap.add_argument("--self-test", action="store_true", help="run the offline assembly checks")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if args.uri:
+        bucket, prefix = parse_uri(args.uri)
+    elif args.bucket:
+        bucket, prefix = args.bucket, args.prefix
+    else:
+        ap.error("one of --uri or --bucket is required")
+
+    rows = gather(bucket, prefix)
+    body = to_csv(rows) if args.format == "csv" else to_jsonl(rows)
+    if args.out:
+        Path(args.out).write_text(body)
+        print(f"reconstruct: {len(rows)} event(s) → {args.out}", file=sys.stderr)
+    else:
+        sys.stdout.write(body)
+    print(f"reconstruct: {len(rows)} ledger event(s) across {len({r['slug'] for r in rows if r.get('slug')})} page(s)",
+          file=sys.stderr)
+    return 0
+
+
+def self_test() -> int:
+    failures = []
+
+    def check(name, cond):
+        print(("ok: " if cond else "FAIL: ") + name, file=sys.stderr if not cond else sys.stdout)
+        if not cond:
+            failures.append(name)
+
+    # Two pages, one reviewed twice — versions arrive unordered.
+    versions = [
+        {"Key": "ledger/a.json", "VersionId": "v2", "LastModified": "2026-06-20T10:00:00Z", "IsLatest": True},
+        {"Key": "ledger/a.json", "VersionId": "v1", "LastModified": "2026-06-18T10:00:00Z", "IsLatest": False},
+        {"Key": "ledger/b.json", "VersionId": "v3", "LastModified": "2026-06-19T10:00:00Z", "IsLatest": True},
+        {"Key": "ledger/c.json", "VersionId": "vX", "LastModified": "2026-06-21T10:00:00Z", "IsLatest": True},
+    ]
+    bodies = {
+        "v1": {"slug": "a", "status": "incomplete", "tier": 1, "score": 200.0, "monthly_visits": 50, "attempts": 1, "reviewed_at": "2026-06-18"},
+        "v2": {"slug": "a", "status": "reviewed", "tier": 1, "score": 210.0, "monthly_visits": 55, "fixes": 1, "pr_number": 19999, "reviewed_at": "2026-06-20"},
+        "v3": {"slug": "b", "status": "clean", "tier": 2, "score": 80.0, "monthly_visits": 12, "reviewed_at": "2026-06-19"},
+        "vX": None,  # unparseable body -> skipped
+    }
+    rows = build_timeline(versions, bodies)
+
+    check("drops versions with no body", len(rows) == 3)
+    check("sorted oldest-first by LastModified",
+          [r["_version_id"] for r in rows] == ["v1", "v3", "v2"])
+    check("carries selection signal through", rows[2]["tier"] == 1 and rows[2]["score"] == 210.0)
+    check("flags the current version", rows[2]["_is_latest"] is True and rows[0]["_is_latest"] is False)
+    check("two pages' history reconstructed",
+          {r["slug"] for r in rows} == {"a", "b"})
+    check("page a shows the incomplete→reviewed progression",
+          [r["status"] for r in rows if r["slug"] == "a"] == ["incomplete", "reviewed"])
+
+    csv_out = to_csv(rows)
+    check("csv has a header + one row per event", len(csv_out.strip().splitlines()) == 4)
+    check("csv header is the flat column set", csv_out.splitlines()[0] == ",".join(CSV_COLUMNS))
+
+    jsonl_out = to_jsonl(rows)
+    check("jsonl has one line per event", len(jsonl_out.strip().splitlines()) == 3)
+    check("uri parsing splits bucket/prefix", parse_uri("s3://my-bucket/ledger/") == ("my-bucket", "ledger/"))
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall reconstruct-ledger-history self-tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -28,7 +28,8 @@ genuinely "incomplete" and stays due for retry.
 
 Canonical record (every field always present):
   { path, slug, lane, status, pr, pr_number, head_sha, fixes,
-    skipped_findings, retirement, note, attempts, clarity_flag, reviewed_at }
+    skipped_findings, retirement, note, attempts, clarity_flag,
+    tier, score, monthly_visits, traffic_available, reviewed_at }
 
 The record is written locally (audit artifact) and, when CONTENT_REVIEW_LEDGER_URI
 is set, uploaded to <uri>/<slug>.json with reviewed_at stamped to today (UTC).
@@ -87,14 +88,30 @@ def warn(msg: str) -> None:
 # ---- inputs -----------------------------------------------------------------
 
 
+def _maybe_int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
 def load_queue_article(queue_path: Path) -> dict:
-    """Return the single article (path/slug/lane) from the worker queue."""
+    """Return the single article from the worker queue, with its selection signal.
+
+    Beyond the bookkeeping fields (path/slug/lane/attempts), this carries the
+    selection facts the dispatcher chose the page on — tier, score, monthly
+    visits, and whether the traffic snapshot was available that run. They're
+    persisted onto the ledger record so the versioned ledger is a complete,
+    self-contained metrics source (outcome AND why-it-was-picked), reconstructable
+    from S3 object versions without depending on the ~90-day run logs.
+    """
     data = json.loads(queue_path.read_text())
     articles = data.get("articles") or []
     if not articles:
         raise SystemExit(f"record-review: no articles in {queue_path}")
     a = articles[0]
     path = a["path"]
+    traffic = data.get("traffic") or {}
     return {
         "path": path,
         "slug": a.get("slug") or slugify(path),
@@ -102,6 +119,11 @@ def load_queue_article(queue_path: Path) -> dict:
         # Prior incomplete-retry count, carried from the ledger by the selector.
         # build_record increments it on another incomplete, resets it on success.
         "attempts": int(a.get("attempts") or 0),
+        # Selection signal (None when absent, e.g. a --paths manual dispatch).
+        "tier": _maybe_int(a.get("tier")),
+        "score": a.get("score"),
+        "monthly_visits": _maybe_int(a.get("monthly_visits")),
+        "traffic_available": bool(traffic.get("available")),
     }
 
 
@@ -247,6 +269,12 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         "note": None,
         "attempts": prior_attempts + 1,
         "clarity_flag": bool(verdict.get("clarity_flag")) if verdict else False,
+        # Selection signal (carried from the queue) — persisted so the versioned
+        # ledger captures why the page was picked, not just the outcome.
+        "tier": article.get("tier"),
+        "score": article.get("score"),
+        "monthly_visits": article.get("monthly_visits"),
+        "traffic_available": bool(article.get("traffic_available")),
         "reviewed_at": datetime.now(timezone.utc).date().isoformat(),
     }
 
@@ -402,13 +430,20 @@ def self_test() -> int:
         d = Path(d)
         queue = d / "queue.json"
         queue.write_text(json.dumps({
+            "traffic": {"available": True},
             "articles": [{
                 "path": "content/docs/iac/concepts/converters.md",
                 "slug": "docs-iac-concepts-converters",
                 "lane": "priority",
+                "tier": 2,
+                "score": 137.5,
+                "monthly_visits": 842,
             }]
         }))
         article = load_queue_article(queue)
+        check("queue article carries the selection signal",
+              article["tier"] == 2 and article["score"] == 137.5
+              and article["monthly_visits"] == 842 and article["traffic_available"] is True)
 
         # No verdict, no signal -> incomplete (the conservative default).
         rec = build_record(article, None, None, article["slug"])
@@ -436,8 +471,12 @@ def self_test() -> int:
         check("all canonical fields present", set(rec) == {
             "path", "slug", "lane", "status", "pr", "pr_number", "head_sha",
             "fixes", "skipped_findings", "retirement", "note", "attempts",
-            "clarity_flag", "reviewed_at"})
+            "clarity_flag", "tier", "score", "monthly_visits",
+            "traffic_available", "reviewed_at"})
         check("no-verdict clarity_flag defaults False", rec["clarity_flag"] is False)
+        check("selection signal persisted on the record",
+              rec["tier"] == 2 and rec["score"] == 137.5
+              and rec["monthly_visits"] == 842 and rec["traffic_available"] is True)
 
         # Repeated incomplete accrues against the prior count the selector carried.
         retried = {**article, "attempts": 2}


### PR DESCRIPTION
Makes the automated content-review pipeline fully auditable **from day one, with no dependency on the data team** for a metrics destination — everything lands in our own versioned ledger bucket.

## Why now
Before flipping the dispatcher cron on: the ledger bucket already has S3 **versioning enabled** (`infrastructure/index.ts`), so every per-slug overwrite is preserved as an immutable version — that's a complete audit trail of *outcomes*. The gap was that the ledger record omitted the **selection signal** (tier / score / monthly_visits), which was only durable for pages that opened a PR (in the PR body) and otherwise lived only in the ~90-day GitHub run logs. You can't backfill that after the logs age out, so it has to land before go-live.

## Changes

**1. Enrich the ledger record (`record-review.py`)** — persist `tier`, `score`, `monthly_visits`, and `traffic_available` on every record (they were already in the queue it reads; just dropped). Now the versioned ledger is a self-contained metrics source: outcome *and* why-the-page-was-picked, for every review.

**2. Reconstruction script (`reconstruct-ledger-history.py`)** — walks the ledger bucket's S3 object versions, fetches each, and emits a single chronological timeline (JSONL or CSV) of every review the pipeline ever did:

```
BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName --stack <stack>)
reconstruct-ledger-history.py --bucket "$BUCKET" --format csv --out history.csv
```

Resolves the bucket from the stack output (never hardcoded). Sorts by the S3 version timestamp (precise even when several reviews share a `reviewed_at` date), flags the current version, and skips unparseable bodies.

## Tests
- `record-review.py --self-test` — covers the new fields end to end (queue → record).
- `reconstruct-ledger-history.py --self-test` — exercises the timeline assembly offline (ordering, current-version flagging, CSV/JSONL shape, and an `incomplete → reviewed` progression — the real terraform/_index case).
- Selector suite unchanged (44 passing).

The reconstruction script's S3 walk can't be integration-tested without bucket creds locally, so its assembly logic is fully unit-tested and the AWS calls are thin CLI wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)