### PR TITLE
content-review: gate the screenshot, rendered, and build passes

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -198,19 +198,13 @@ rendered views), then check both:
    applied, and the PR description must flag them as multi-page
    ("also rendered on N other pages" — grep for other callers).
 
-**Markdown view** — `public/<url path>/index.md` (the LLM/agent-facing
-render; docs pages cascade `outputs: [HTML, markdown]`, and shortcodes
-render through their `layouts/shortcodes/*.markdown.md` templates):
-
-1. Read it and check for leaked shortcode syntax — literal `{{<` / `>}}`
-   or `{{%` / `%}}` fragments in the output are the signature of a
-   shortcode missing its markdown template.
-2. Spot-check that content present in the HTML view isn't silently absent
-   here (same missing-template failure, quieter symptom).
-3. Fixes here are usually a new/corrected `*.markdown.md` shortcode
-   template — shared-source again, same multi-page flagging rule. When the
-   right rendering is debatable, it's a Findings-not-applied entry, not a
-   fix.
+You do **not** check the markdown view (`index.md`) for leaked shortcode
+delimiters here. Whether a shortcode renders cleanly to markdown is a property of
+the shortcode, not the page, so it's covered once across the whole built corpus
+by `scripts/content-review/check-rendered-markdown.py` (run periodically / in CI),
+not re-paid per review. Content-*mangling* in the markdown output (a template
+that silently drops or rewrites content) is a rendering-pipeline bug for the
+templating owner, tracked separately — not something to fix in a content review.
 
 If this pass applied any fix, re-run `make build` and then `make lint` (as
 separate commands) before opening the PR.

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -155,24 +155,34 @@ Editing guardrails:
   them, but be defensive.
 - Never add the `automation/merge` label to anything.
 
-### 4. Screenshot / UI pass
+### 4. Screenshot / UI pass (only when the page has images)
 
-Follow `references/screenshot-verification.md` for every image the article
-references. Verified-stale screenshots are **flagged in the PR description**
-(Screenshot check section), never regenerated or deleted by you.
+This pass is **gated**: the workflow pre-fills the PR's "Screenshot check"
+section with "No images." when the source references no content images (a
+deterministic source check — the shared `meta_image` card doesn't count). Run
+this pass only when that section still carries a `<TODO>`. When you do, follow
+`references/screenshot-verification.md` for every image the article references.
+Verified-stale screenshots are **flagged in the PR description** (Screenshot
+check section), never regenerated or deleted by you.
 
-### 5. Validate and render
+### 5. Validate
 
-`make lint` and `make build` must pass on the branch. Fix what they surface;
-if you cannot, drop the offending change rather than shipping a broken
-build. The build also produces the rendered views the next step reads.
+`make lint` must pass on the branch. Fix what it surfaces; if you cannot, drop
+the offending change rather than shipping a lint failure. **Do not run `make
+build` here** — the full build is left to the PR's normal CI, and step 6 runs it
+only on the pages that actually need the rendered pass.
 
-### 6. Rendered content pass (the customer-facing views)
+### 6. Rendered content pass (only when the page assembles render-time content)
 
 Source review misses content the page assembles at render time — shared
-snippets from shortcodes, values from `data/` files, partial-driven
-sections. The customer sees the assembled page, so check both rendered
-views `make build` just produced:
+snippets from shortcodes, values from `data/` files, partial-driven sections.
+But most docs pages assemble nothing the source doesn't already show (plain
+prose, code tabs, callouts, stepper chrome), so this pass is **gated** too: the
+workflow pre-fills the "Rendered content" section with "Skipped" when the source
+uses no content-bearing shortcode/partial/include, and leaves a `<TODO>` only
+when one is present (it names the triggering shortcode). Run this pass only when
+that `<TODO>` is there. When you do, first run `make build` (it produces the
+rendered views), then check both:
 
 **HTML view** — `public/<url path>/index.html`:
 
@@ -202,8 +212,8 @@ render through their `layouts/shortcodes/*.markdown.md` templates):
    right rendering is debatable, it's a Findings-not-applied entry, not a
    fix.
 
-If this pass applied any fix, re-run `make lint && make build` before
-opening the PR.
+If this pass applied any fix, re-run `make build` and then `make lint` (as
+separate commands) before opening the PR.
 
 ### 7. PR — only when you applied a fix, opened as a draft
 

--- a/.claude/commands/review-existing-content/references/pr-body-template.md
+++ b/.claude/commands/review-existing-content/references/pr-body-template.md
@@ -49,9 +49,9 @@ Gated — the composer pre-fills "Skipped" when the source uses no content-beari
 shortcode/partial/include (it names the triggering shortcode when one is
 present). Only when this section carries a `<TODO>` do you run `make build` and
 the rendered pass, then report its outcomes — residue claims checked in the HTML
-view, the markdown view's shortcode-template status, and any shared-source
-(shortcode / partial / data) findings with their page-reach
-("also rendered on N other pages").
+view and any shared-source (shortcode / partial / data) findings with their
+page-reach ("also rendered on N other pages"). Leaked-delimiter checks on the
+markdown output are covered site-wide by `check-rendered-markdown.py`, not here.
 
 ## Verification
 

--- a/.claude/commands/review-existing-content/references/pr-body-template.md
+++ b/.claude/commands/review-existing-content/references/pr-body-template.md
@@ -37,13 +37,19 @@ For the judgment-level items above, run `/glow-up <path>`.
 
 ## Screenshot check
 
-Per image: current / stale (what differs) / unverifiable. Note any aging
-reference screenshots (see `references/screenshot-verification.md`).
+Gated — the composer pre-fills "No images." when the source references no
+content images, and you leave it as-is. Only when this section carries a
+`<TODO>` (the page has images) do you run the pass and report per image:
+current / stale (what differs) / unverifiable, plus any aging reference
+screenshots (see `references/screenshot-verification.md`).
 
 ## Rendered content
 
-Outcomes of the rendered pass — residue claims checked in the HTML view, the
-markdown view's shortcode-template status, and any shared-source
+Gated — the composer pre-fills "Skipped" when the source uses no content-bearing
+shortcode/partial/include (it names the triggering shortcode when one is
+present). Only when this section carries a `<TODO>` do you run `make build` and
+the rendered pass, then report its outcomes — residue claims checked in the HTML
+view, the markdown view's shortcode-template status, and any shared-source
 (shortcode / partial / data) findings with their page-reach
 ("also rendered on N other pages").
 

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -261,12 +261,19 @@ jobs:
                description and continue with what you have.)
             3. Apply HIGH-CONFIDENCE fixes only; everything judgment-level
                goes in the PR description's "Findings not applied" section.
-            4. Run the screenshot/UI verification pass (flag-only).
-            5. Run `make lint` and `make build`; resolve anything they
-               surface or drop the offending change.
-            6. Run the rendered content pass over the built page — both
-               the HTML view and the customer-facing markdown view
-               (`public/<url>/index.html` and `index.md`) — per the skill.
+            4. The "Screenshot check" section of `.pr-body-draft.md` is
+               pre-filled when the page references no content images. Run the
+               screenshot/UI pass (flag-only) and fill the section ONLY if it
+               still contains a `<TODO>`; otherwise leave the composed text.
+            5. Run `make lint`; resolve anything it surfaces or drop the
+               offending change. Do NOT run `make build` here — build is left
+               to the PR's normal CI (step 6 runs it only when required).
+            6. The "Rendered content" section is pre-filled "Skipped" when the
+               page uses no content-bearing shortcode/partial/include. ONLY if
+               it still contains a `<TODO>`: run `make build`, then run the
+               rendered content pass over both the HTML and customer-facing
+               markdown views (`public/<url>/index.html` and `index.md`) per
+               the skill, and fill the section.
             7. If you applied any fix, open a **draft** PR whose body is
                `.pr-body-draft.md` (composed for you at the repo root — the
                assemble-then-judge model, like the pre-merge review). Open it as

--- a/scripts/content-review/check-rendered-markdown.py
+++ b/scripts/content-review/check-rendered-markdown.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Site-wide scan for shortcodes that leak into the rendered markdown output.
+
+Docs pages cascade `outputs: [HTML, markdown]`, rendering each shortcode through
+its `layouts/shortcodes/<name>.markdown.md` template. A shortcode missing that
+template can leave raw Hugo delimiters (`{{<`, `>}}`, `{{%`, `%}}`) in the
+built `.md` output. Whether a shortcode renders cleanly is a property of the
+SHORTCODE, not the page — so this is one pass over the whole built corpus
+(`public/**/*.md`), run once or in CI, instead of a per-page check re-paid on
+every content review (which the content-review worker therefore no longer does).
+
+Legitimate shortcode-syntax *examples* (docs that teach Hugo) live in fenced
+code blocks or inline code spans; those are stripped before scanning so the
+signal stays clean. A delimiter outside code formatting is a real leak.
+
+Scope note — this catches DELIMITER leaks only. It does NOT catch content
+*mangling*, where a shortcode's markdown template silently drops or rewrites
+content (e.g. stripped `<artifactId>` tags in Java blocks, or `[ -f` collapsing
+to `[-f` in Bash blocks). Those are rendering-pipeline bugs for the templating
+owner — tracked separately, not rediscoverable by a delimiter grep.
+
+Usage:
+    check-rendered-markdown.py [--public public] [--strict]
+    check-rendered-markdown.py --self-test
+
+`--strict` exits non-zero when any leak is found (for gating CI); the default is
+advisory (report and exit 0). Requires a built site (`make build`) for a real
+run; `--self-test` exercises the scan logic offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# An opening (`{{<`, `{{%`) or closing (`>}}`, `%}}`) Hugo shortcode delimiter.
+DELIM_RE = re.compile(r"\{\{[<%]|[>%]\}\}")
+# A markdown fenced-code-block marker (``` or ~~~), optionally indented / with a
+# language tag. Toggles in/out of a code block.
+FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+# An inline code span: `…`. Stripped so documented syntax doesn't false-positive.
+INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def scan_text(text: str) -> list[tuple[int, str]]:
+    """Return (line_number, line) for every leaked delimiter outside code."""
+    hits: list[tuple[int, str]] = []
+    in_fence = False
+    for i, line in enumerate(text.splitlines(), 1):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if DELIM_RE.search(INLINE_CODE_RE.sub("", line)):
+            hits.append((i, line.strip()))
+    return hits
+
+
+def scan_tree(public: Path) -> dict[str, list[tuple[int, str]]]:
+    """Scan every `*.md` under `public`, returning {relpath: hits} for leaks."""
+    found: dict[str, list[tuple[int, str]]] = {}
+    for md in sorted(public.rglob("*.md")):
+        try:
+            hits = scan_text(md.read_text(errors="replace"))
+        except OSError:
+            continue
+        if hits:
+            found[str(md.relative_to(public))] = hits
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--public", default="public", help="built-site root (default: public)")
+    ap.add_argument("--strict", action="store_true", help="exit non-zero if any leak is found")
+    ap.add_argument("--self-test", action="store_true", help="run offline scan-logic checks")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = Path(args.public)
+    if not root.is_dir():
+        print(f"check-rendered-markdown: no build found at {root}/ — run `make build` first",
+              file=sys.stderr)
+        return 2
+
+    found = scan_tree(root)
+    total = sum(len(h) for h in found.values())
+    if not found:
+        print(f"check-rendered-markdown: scanned {root}/ — no leaked shortcode delimiters")
+        return 0
+
+    for rel, hits in found.items():
+        for line_no, line in hits:
+            print(f"{rel}:{line_no}: {line}")
+    print(f"\ncheck-rendered-markdown: {total} leak(s) across {len(found)} page(s)",
+          file=sys.stderr)
+    return 1 if args.strict else 0
+
+
+def self_test() -> int:
+    failures = []
+
+    def check(name, cond):
+        print(("ok: " if cond else "FAIL: ") + name,
+              file=sys.stdout if cond else sys.stderr)
+        if not cond:
+            failures.append(name)
+
+    leak = scan_text("Intro prose.\n\nThis page uses {{< notes >}} without a template.\n")
+    check("leaked delimiter in prose is flagged", len(leak) == 1 and leak[0][0] == 3)
+
+    closing = scan_text("Some text >}} dangling.\n")
+    check("closing delimiter is flagged", len(closing) == 1)
+
+    pct = scan_text("A {{% choosable %}} fragment leaked.\n")
+    check("percent-delimiter is flagged", len(pct) == 1)
+
+    fenced = scan_text("Example:\n\n```go\n{{< chooser >}}\ncode\n{{< /chooser >}}\n```\n\nDone.\n")
+    check("delimiters inside a fenced block are ignored", fenced == [])
+
+    inline = scan_text("Use the `{{< notes >}}` shortcode to add a callout.\n")
+    check("delimiters inside inline code are ignored", inline == [])
+
+    clean = scan_text("# Title\n\nPlain prose, a `code` span, and a list.\n\n- one\n- two\n")
+    check("clean rendered markdown yields no hits", clean == [])
+
+    mixed = scan_text("```\n{{< safe >}}\n```\n\nBut {{< leaked >}} here.\n")
+    check("fence then a real leak: only the leak counts",
+          len(mixed) == 1 and mixed[0][0] == 5)
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall check-rendered-markdown self-tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/compose-pr-body.py
+++ b/scripts/content-review/compose-pr-body.py
@@ -274,8 +274,9 @@ def render_rendered_content(gates: dict | None) -> str:
     trig = ", ".join(f"`{s}`" for s in (gates or {}).get("nonchrome_shortcodes", [])[:8])
     hint = f" Content-bearing shortcode(s) requiring the pass: {trig}." if trig else ""
     return head + (
-        f"<TODO: run `make build`, then check the HTML view + customer-facing markdown view — "
-        f"note any leaked shortcode syntax or shared-source residue, or confirm clean.{hint}>"
+        f"<TODO: run `make build`, then check the HTML view for render-time content "
+        f"(shortcode/partial/`data`-sourced) and verify any checkable claims in that residue, "
+        f"or confirm clean.{hint}>"
     )
 
 

--- a/scripts/content-review/compose-pr-body.py
+++ b/scripts/content-review/compose-pr-body.py
@@ -25,8 +25,12 @@ What the composer renders (facts — never the model's to invent):
     the authoritative `make lint` result (so lint status is never self-reported).
 
 What stays the model's (left as `<TODO>`): which stub is a real fix, the
-correction prose, the one-line deferral reasons, and the screenshot / rendered
-observations.
+correction prose, and the one-line deferral reasons. The "Screenshot check" and
+"Rendered content" sections are filled deterministically (via render-gates) when
+the source provably has nothing to look at — no content images, and no
+content-bearing shortcode/partial/include — and otherwise left as a `<TODO>` for
+the model to run that pass. This is what lets the worker skip the screenshot
+pass and the `make build` + rendered pass on the pages that don't need them.
 
 Degrades gracefully: a missing or errored artifact renders its section in a
 degraded form with a note, never a crash. The draft always contains every
@@ -55,6 +59,12 @@ _spec = importlib.util.spec_from_file_location(
 )
 _rp = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_rp)
+
+# Reuse the render/screenshot gate logic (single source of truth for whether the
+# screenshot and rendered-content passes have anything to look at).
+_spec_g = importlib.util.spec_from_file_location("render_gates", HERE / "render-gates.py")
+_rg = importlib.util.module_from_spec(_spec_g)
+_spec_g.loader.exec_module(_rg)
 
 LINT_PLACEHOLDER = "<!-- LINT-RESULT -->"
 
@@ -219,6 +229,56 @@ def render_deferrals(findings: list[dict], path: str) -> str:
     return head + body + footer
 
 
+def render_screenshot(gates: dict | None) -> str:
+    """Pre-fill the section when the source has no content images; else a TODO.
+
+    Gates default-safe: a missing/None gate falls back to the model-run TODO.
+    """
+    head = "## Screenshot check\n\n"
+    if gates and not gates.get("has_images", True):
+        return head + (
+            "No images. The page source references no screenshots, diagrams, or other "
+            "content images (only the generic shared `meta_image` card, if any), so there "
+            "is nothing to verify. _(Determined from the source; the screenshot pass was "
+            "skipped.)_"
+        )
+    n = (gates or {}).get("image_count")
+    hint = f" {n} image reference(s) detected in source." if n else ""
+    return head + (
+        f"<TODO: per image — current / stale (what differs) / unverifiable; "
+        f'or "No images." if the page references none.{hint}>'
+    )
+
+
+def render_rendered_content(gates: dict | None) -> str:
+    """Pre-fill "Skipped" when the source has no content-bearing includes.
+
+    Plain prose, code tabs, callouts, and stepper chrome assemble no content the
+    source markdown doesn't already show, so there is no render-time residue to
+    check and no `make build` needed. A non-chrome shortcode (or a missing gate)
+    falls back to the model-run TODO.
+    """
+    head = "## Rendered content\n\n"
+    if gates and not gates.get("needs_render_pass", True):
+        sc = gates.get("shortcodes") or []
+        used = (
+            "only render-safe chrome (" + ", ".join(f"`{s}`" for s in sc) + ")"
+            if sc else "no shortcodes, partials, or includes"
+        )
+        return head + (
+            f"Skipped — the page source uses {used}, so the rendered HTML and markdown "
+            "carry no content beyond the source prose (nothing data-sourced or "
+            "partial-included to fact-check). No `make build` or rendered pass required. "
+            "_(Determined from the source.)_"
+        )
+    trig = ", ".join(f"`{s}`" for s in (gates or {}).get("nonchrome_shortcodes", [])[:8])
+    hint = f" Content-bearing shortcode(s) requiring the pass: {trig}." if trig else ""
+    return head + (
+        f"<TODO: run `make build`, then check the HTML view + customer-facing markdown view — "
+        f"note any leaked shortcode syntax or shared-source residue, or confirm clean.{hint}>"
+    )
+
+
 def render_verification(artifacts: dict, errors: list[str]) -> str:
     lines = ["## Verification\n\n"]
     # The re-lint gate swaps LINT_PLACEHOLDER for the authoritative result. The
@@ -269,7 +329,7 @@ def artifact_inventory(verified, vale, readthrough, frontmatter) -> dict:
     return inv
 
 
-def compose(queue: dict, verified, vale, readthrough, frontmatter) -> str:
+def compose(queue: dict, verified, vale, readthrough, frontmatter, gates=None) -> str:
     path = ((queue.get("articles") or [{}])[0]).get("path", "")
     findings, errors = collect(verified, vale, readthrough, frontmatter)
     inv = artifact_inventory(verified, vale, readthrough, frontmatter)
@@ -281,11 +341,9 @@ def compose(queue: dict, verified, vale, readthrough, frontmatter) -> str:
         "",
         render_deferrals(findings, path).rstrip(),
         "",
-        "## Screenshot check\n\n<TODO: per image — current / stale (what differs) / unverifiable; "
-        "or \"No images.\" if the page references none.>",
+        render_screenshot(gates).rstrip(),
         "",
-        "## Rendered content\n\n<TODO: HTML view + customer-facing markdown view — note any leaked "
-        "shortcode syntax or shared-source residue, or confirm clean.>",
+        render_rendered_content(gates).rstrip(),
         "",
         render_verification(inv, errors).rstrip(),
         "",
@@ -305,12 +363,31 @@ def main() -> int:
 
     root = Path(args.repo_root)
     queue = json.loads(Path(args.queue).read_text())
+
+    # Compute the screenshot/rendered gates from the article source. Default-safe:
+    # an unreadable source leaves gates=None, and the renderers fall back to the
+    # model-run TODO (both passes run) rather than skipping anything.
+    gates = None
+    src = (queue.get("articles") or [{}])[0].get("path", "")
+    try:
+        if src and (root / src).is_file():
+            gates = _rg.analyze((root / src).read_text())
+            print(
+                f"compose-pr-body: gates — has_images={gates['has_images']}, "
+                f"needs_render_pass={gates['needs_render_pass']} "
+                f"(shortcodes: {', '.join(gates['shortcodes']) or 'none'})",
+                file=sys.stderr,
+            )
+    except OSError:
+        gates = None
+
     body = compose(
         queue,
         read_json(root / args.verified_claims),
         read_json(root / args.vale_findings),
         read_json(root / args.readthrough),
         read_json(root / args.frontmatter),
+        gates,
     )
     if args.out:
         Path(args.out).write_text(body)

--- a/scripts/content-review/render-gates.py
+++ b/scripts/content-review/render-gates.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Deterministic gates for the content-review screenshot and rendered passes.
+
+The screenshot pass (skill step 4) and the rendered-content pass (skill step 6)
+are per-page Opus work that, across every content-review PR to date, has
+produced zero applied fixes: the docs pages reviewed reference no content
+images, and their render-time content is navigation chrome or the page's own
+authored prose, not data-sourced claims. Rather than run both passes (and the
+full `make build` the rendered pass depends on) on every article, this computes
+— by a cheap source grep — whether either pass has anything to look at. The
+composer fills the corresponding PR-body sections deterministically when a gate
+is off, and the worker runs the pass only when it is on.
+
+  * has_images — the source body references a content image (a markdown image,
+    an `<img>`, or an image-bearing shortcode like `figure`/`video`). The
+    generic shared `meta_image` frontmatter card is NOT a content image, so a
+    page carrying only that reads as has_images=false.
+  * needs_render_pass — the source uses a shortcode/partial/include that can
+    inject content the source markdown does not itself show, i.e. ANY shortcode
+    not on the render-safe allowlist below. Pages built from plain prose, code
+    tabs, callouts, and stepper chrome have no such residue.
+
+Both gates are DEFAULT-SAFE: an unrecognized shortcode trips needs_render_pass
+(the pass runs), and the caller treats a missing/unreadable source as "run both
+passes" — so the optimization can only ever skip work that is provably absent,
+never silently drop a page that might have something to check.
+
+Usage:
+    render-gates.py --path content/docs/.../_index.md        # JSON to stdout
+    render-gates.py --self-test                              # offline checks
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Hugo shortcodes that render the page's OWN authored content or pure
+# navigation chrome — never data/-sourced or partial-included prose that the
+# source markdown does not already contain. A page using ONLY these (or none)
+# has no render-time content residue, so the rendered-content pass has nothing
+# extra to verify.
+#
+# CONSERVATIVE BY DESIGN: any shortcode NOT listed here trips the gate, so a new
+# or content-bearing shortcode is never silently skipped. Add an entry only
+# after confirming it carries no external content. (Deliberately excluded:
+# `langfile` and `get-started-install-body`, which embed file/partial content
+# the source markdown does not show — exactly the residue the pass exists for.)
+RENDER_SAFE_SHORTCODES = {
+    "chooser", "choosable",     # language / code tabs — the page's own code
+    "notes", "note",            # callout boxes — the page's own text
+    "get-started-stepper",      # get-started prev/next navigation chrome
+    "tabs", "tab",              # tabbed display of the page's own content
+}
+
+# Opening or closing shortcode tag: `{{< name`, `{{% name`, `{{< /name`, etc.
+SHORTCODE_RE = re.compile(r"\{\{[<%]\s*/?\s*([A-Za-z0-9_-]+)")
+
+# A content image: markdown image, HTML <img>, or an image-bearing shortcode.
+# `meta_image:` frontmatter is intentionally not matched (it's the shared card).
+IMAGE_RE = re.compile(r"!\[|<img[\s/>]|\{\{[<%]\s*(?:figure|video|image|img)\b")
+
+
+def analyze(text: str) -> dict:
+    """Compute both gates from an article's raw source markdown."""
+    shortcodes = sorted(set(SHORTCODE_RE.findall(text)))
+    nonchrome = sorted(s for s in shortcodes if s not in RENDER_SAFE_SHORTCODES)
+    image_count = len(IMAGE_RE.findall(text))
+    return {
+        "shortcodes": shortcodes,
+        "nonchrome_shortcodes": nonchrome,
+        "needs_render_pass": bool(nonchrome),
+        "has_images": image_count > 0,
+        "image_count": image_count,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--path", help="article source markdown to analyze")
+    ap.add_argument("--self-test", action="store_true", help="run offline checks")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.path:
+        ap.error("--path is required (or use --self-test)")
+
+    text = Path(args.path).read_text()
+    json.dump(analyze(text), sys.stdout, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+def self_test() -> int:
+    failures = []
+
+    def check(name, cond):
+        print(("ok: " if cond else "FAIL: ") + name,
+              file=sys.stdout if cond else sys.stderr)
+        if not cond:
+            failures.append(name)
+
+    plain = analyze("# Title\n\nJust prose and a `code` span.\n\n```go\nx := 1\n```\n")
+    check("plain prose: no render pass", plain["needs_render_pass"] is False)
+    check("plain prose: no images", plain["has_images"] is False)
+    check("plain prose: no shortcodes", plain["shortcodes"] == [])
+
+    safe = analyze(
+        "{{< chooser language \"typescript\" >}}\n{{% choosable %}}\ncode\n{{% /choosable %}}\n"
+        "{{< /chooser >}}\n{{< notes >}}a note{{< /notes >}}\n{{< get-started-stepper >}}\n"
+    )
+    check("chrome-only: no render pass", safe["needs_render_pass"] is False)
+    check("chrome-only: closing tags add no phantom names",
+          safe["shortcodes"] == ["choosable", "chooser", "get-started-stepper", "notes"])
+
+    langfile = analyze("intro\n{{< langfile >}}\n{{< chooser >}}x{{< /chooser >}}\n")
+    check("langfile trips the gate", langfile["needs_render_pass"] is True)
+    check("langfile is the only non-chrome trigger", langfile["nonchrome_shortcodes"] == ["langfile"])
+
+    install = analyze("{{< get-started-install-body >}}\n")
+    check("get-started-install-body trips the gate", install["needs_render_pass"] is True)
+
+    md_img = analyze("Here is a diagram:\n\n![architecture](/images/arch.png)\n")
+    check("markdown image: has_images", md_img["has_images"] is True)
+    check("markdown image alone: no render pass", md_img["needs_render_pass"] is False)
+
+    html_img = analyze('<img src="/images/x.png" alt="x">\n')
+    check("html <img>: has_images", html_img["has_images"] is True)
+
+    figure = analyze("{{< figure src=\"/images/x.png\" >}}\n")
+    check("figure shortcode: has_images", figure["has_images"] is True)
+    check("figure shortcode: also trips render pass (not chrome)",
+          figure["needs_render_pass"] is True)
+
+    meta_only = analyze("---\ntitle: X\nmeta_image: /images/docs/meta-images/docs-meta.png\n---\n\nProse.\n")
+    check("meta_image only: not a content image", meta_only["has_images"] is False)
+
+    mixed = analyze("{{< notes >}}n{{< /notes >}}\n{{< langfile >}}\n{{< pulumi-examples >}}\n")
+    check("mixed safe+unsafe: only unsafe listed",
+          mixed["nonchrome_shortcodes"] == ["langfile", "pulumi-examples"])
+    check("mixed: image_count is zero", mixed["image_count"] == 0)
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall render-gates self-tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/test_compose_pr_body.py
+++ b/scripts/content-review/test_compose_pr_body.py
@@ -118,6 +118,44 @@ check("degraded inventory marks missing", ".verified-claims.json`: missing" in b
 errd = c.compose(QUEUE, {"verdicts": [], "errors": ["verify-claims failed"]}, [], {"ran": False, "findings": []}, {})
 check("errored artifact surfaced", "Artifacts that failed" in errd and "verified-claims" in errd)
 
+
+# ---- gated screenshot / rendered sections -----------------------------------
+#
+# When the source provably has nothing to look at, the composer fills these
+# sections deterministically (no <TODO>) so the worker skips the pass + build.
+
+def _between(text: str, start: str, end: str) -> str:
+    return text.split(start, 1)[1].split(end, 1)[0]
+
+# Skip case: no images, only render-safe chrome.
+skip = c.compose(QUEUE, None, None, None, None,
+                 {"has_images": False, "needs_render_pass": False,
+                  "shortcodes": ["notes"], "nonchrome_shortcodes": [], "image_count": 0})
+shot_skip = _between(skip, "## Screenshot check", "## Rendered content")
+rend_skip = _between(skip, "## Rendered content", "## Verification")
+check("gated screenshot states No images", "No images." in shot_skip)
+check("gated screenshot carries no <TODO>", "<TODO" not in shot_skip)
+check("gated rendered states Skipped", "Skipped —" in rend_skip)
+check("gated rendered names the safe shortcode", "`notes`" in rend_skip)
+check("gated rendered carries no <TODO>", "<TODO" not in rend_skip)
+
+# Run case: an image and a content-bearing shortcode -> both passes still TODO.
+run = c.compose(QUEUE, None, None, None, None,
+                {"has_images": True, "needs_render_pass": True,
+                 "shortcodes": ["chooser", "langfile"], "nonchrome_shortcodes": ["langfile"],
+                 "image_count": 2})
+shot_run = _between(run, "## Screenshot check", "## Rendered content")
+rend_run = _between(run, "## Rendered content", "## Verification")
+check("ungated screenshot keeps <TODO>", "<TODO" in shot_run)
+check("ungated screenshot hints image count", "2 image reference(s)" in shot_run)
+check("ungated rendered keeps <TODO>", "<TODO" in rend_run)
+check("ungated rendered names the trigger shortcode", "`langfile`" in rend_run)
+
+# Default-safe: no gate info -> both passes run (TODO), nothing silently skipped.
+nogate = c.compose(QUEUE, None, None, None, None, None)
+check("no gate -> screenshot TODO", "<TODO" in _between(nogate, "## Screenshot check", "## Rendered content"))
+check("no gate -> rendered TODO", "<TODO" in _between(nogate, "## Rendered content", "## Verification"))
+
 if failures:
     print(f"\n{len(failures)} failure(s)", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
## What

Gates three per-article passes in the content-review worker on a cheap, deterministic source check, and replaces a per-page markdown check with a site-wide scan:

- **Screenshot pass** (skill step 4) — skipped unless the source references a content image (markdown image, `<img>`, or an image-bearing shortcode; the shared `meta_image` card doesn't count).
- **Rendered-content pass** (step 6) **and the `make build` it depends on** — skipped unless the source uses a shortcode/partial/include that injects content the markdown doesn't itself show (any shortcode not on a conservative render-safe allowlist of chrome / code-tabs / callouts).
- **Markdown leaked-delimiter check** — pulled out of the per-page pass into `check-rendered-markdown.py`, one scan over the built `public/**/*.md` corpus (runnable now or in CI). Whether a shortcode renders cleanly to markdown is a property of the shortcode, not the page, so it doesn't belong in a per-page review.

The worker now runs `make lint` only; `make build` is gated into step 6 and otherwise left to the PR's normal CI (which already owns it — the re-lint gate never re-ran build).

## Why

Across **every content-review PR to date** (11 with visible sections + this week's clean sweep), these passes produced **zero applied fixes**: the docs pages reviewed reference no content images, and their render-time content is navigation chrome or the page's own authored prose, not data-sourced claims. The only two things the rendered pass ever surfaced were out-of-scope content-mangling quirks in the markdown output — now filed for the rendering-pipeline owner as #19872. `make build` was also a documented source of permission-denial churn (compound `make lint && make build` calls).

## How it's safe

`render-gates.py` is **default-safe**: an unrecognized shortcode trips the gate (the pass runs), and a missing/unreadable source runs both passes — the optimization can only skip work that's provably absent. The composer fills the Screenshot/Rendered sections deterministically when a gate is off (naming the safe/triggering shortcodes) and leaves a `<TODO>` otherwise. `check-rendered-markdown.py` strips fenced/inline code before scanning so documented shortcode syntax doesn't false-positive.

## Tests

- `render-gates.py --self-test` (16 checks), `check-rendered-markdown.py --self-test` (7 checks), `test_compose_pr_body.py` extended for gated + default-safe rendering.
- Verified against real pages: `stack-settings`/`command-line-completion`/`aws/_index` skip; `kubernetes/begin` (install-body) and `*/modify-program` (langfile) run.

Relates to #19872 (content-mangling quirks for the pipeline owner).

Drafted by Claude; reviewed by Cam.