### PR TITLE
Fix code-block mangling in docs markdown (.md) output

### DIFF
--- a/layouts/partials/docs/markdown-pipeline.md
+++ b/layouts/partials/docs/markdown-pipeline.md
@@ -1,57 +1,75 @@
 {{- $content := . -}}
-{{- /* Phase 1: Convert Chroma syntax-highlighted HTML to fenced code blocks */ -}}
+{{- /* Phase 1: Convert Chroma syntax-highlighted HTML to fenced code blocks.
+       MUST run globally and FIRST: it establishes the ``` fence structure that the
+       split below depends on. */ -}}
 {{- $content = replaceRE `<div[^>]*>\s*<pre[^>]*><code class="language-([^"]*)"[^>]*>` "```$1\n" $content -}}
 {{- $content = replaceRE `</code></pre>\s*</div>` "\n```\n\n" $content -}}
 {{- $content = replaceRE `<pre[^>]*><code>` "```\n" $content -}}
 {{- $content = replaceRE `</code></pre>` "\n```\n\n" $content -}}
-{{- /* Phase 1b: Strip script, style, and iframe elements (content and all) */ -}}
+{{- /* Phase 1b: Strip script, style, and iframe elements (content and all). Global and
+       before the split: their (?s).*? bodies could contain ```, so removing them first
+       keeps the fence count balanced. */ -}}
 {{- $content = replaceRE `(?s)<script[^>]*>.*?</script>` "" $content -}}
 {{- $content = replaceRE `(?s)<style[^>]*>.*?</style>` "" $content -}}
 {{- $content = replaceRE `<iframe[^>]*/?>` "" $content -}}
-{{- /* Phase 2: Strip all block-level and decorative tags in consolidated passes */ -}}
-{{- $content = replaceRE `</?(?:span|label|div|p|blockquote|ol|ul|li|pre|section|table|thead|tbody|tr|td|th|dl|dt|dd|details|summary)[^>]*>` "" $content -}}
-{{- $content = replaceRE `(?:<i[^>]*></i>|<input[^>]*>)` "" $content -}}
-{{- $content = replaceRE `<!--\s*markdownlint[^>]*-->` "" $content -}}
-{{- /* Phase 3: Strip deep leading whitespace left by HTML tag removal, preserving
-       indentation inside fenced code blocks. Split on ``` boundaries: even-indexed
-       segments are prose (strip 4+ leading spaces), odd-indexed are code (keep). */ -}}
+{{- /* Phases 2-6 are PROSE-ONLY and must never touch fenced code (doing so stripped
+       <artifactId> tags and collapsed `[ -f` to `[-f`; see issue #19872). Split on ```
+       fence boundaries: even-indexed segments are prose, odd-indexed are code. Prose gets
+       the full transform set; code gets ONLY Chroma <span> stripping (the sole inline
+       cleanup legitimate inside a fence — entities are decoded globally in Phase 8). We
+       rejoin with the literal ``` we split on. This generalizes the fence-aware pattern
+       the old Phase 3 already used for whitespace. */ -}}
 {{- $segments := split $content "```" -}}
 {{- $cleaned := "" -}}
 {{- range $i, $seg := $segments -}}
   {{- if eq (mod $i 2) 0 -}}
-    {{- $cleaned = printf "%s%s" $cleaned (replaceRE `(?m)^[ \t]{4,}` "" $seg) -}}
+    {{- /* ---- PROSE branch ---- */ -}}
+    {{- /* Phase 2: Strip block-level and decorative tags in consolidated passes */ -}}
+    {{- $seg = replaceRE `</?(?:span|label|div|p|blockquote|ol|ul|li|pre|section|table|thead|tbody|tr|td|th|dl|dt|dd|details|summary)[^>]*>` "" $seg -}}
+    {{- $seg = replaceRE `(?:<i[^>]*></i>|<input[^>]*>)` "" $seg -}}
+    {{- $seg = replaceRE `<!--\s*markdownlint[^>]*-->` "" $seg -}}
+    {{- /* Phase 3: Strip deep leading whitespace left by HTML tag removal. Prose only;
+           code indentation lives in the odd segments and is preserved. */ -}}
+    {{- $seg = replaceRE `(?m)^[ \t]{4,}` "" $seg -}}
+    {{- /* Phase 4: Normalize blank runs so inline conversions can match cleanly */ -}}
+    {{- $seg = replaceRE `\n{3,}` "\n\n" $seg -}}
+    {{- /* Phase 5: Convert inline HTML to markdown */ -}}
+    {{- $seg = replaceRE `<a[^>]*href="([^"]*)"[^>]*>([^<]*)</a>` "[$2]($1)" $seg -}}
+    {{- /* Collapse whitespace inside markdown link brackets (from multi-line <a> tags) */ -}}
+    {{- $seg = replaceRE `\[\s+` "[" $seg -}}
+    {{- $seg = replaceRE `\s+\]\(` "](" $seg -}}
+    {{- $seg = replaceRE `<code[^>]*>([^<]*)</code>` "`$1`" $seg -}}
+    {{- $seg = replaceRE `<strong>([^<]*)</strong>` "**$1**" $seg -}}
+    {{- $seg = replaceRE `<em>([^<]*)</em>` "*$1*" $seg -}}
+    {{- $seg = replaceRE `<img[^>]*src="([^"]*)"[^>]*alt="([^"]*)"[^>]*/?>` "![$2]($1)" $seg -}}
+    {{- $seg = replaceRE `<img[^>]*alt="([^"]*)"[^>]*src="([^"]*)"[^>]*/?>` "![$1]($2)" $seg -}}
+    {{- $seg = replaceRE `<img[^>]*/?>` "" $seg -}}
+    {{- /* Phase 6: Convert heading tags to markdown headings */ -}}
+    {{- $seg = replaceRE `<h1[^>]*>([^<]*)</h1>` "\n# $1\n" $seg -}}
+    {{- $seg = replaceRE `<h2[^>]*>([^<]*)</h2>` "\n## $1\n" $seg -}}
+    {{- $seg = replaceRE `<h3[^>]*>([^<]*)</h3>` "\n### $1\n" $seg -}}
+    {{- $seg = replaceRE `<h4[^>]*>([^<]*)</h4>` "\n#### $1\n" $seg -}}
+    {{- $seg = replaceRE `<h5[^>]*>([^<]*)</h5>` "\n##### $1\n" $seg -}}
+    {{- $seg = replaceRE `<h6[^>]*>([^<]*)</h6>` "\n###### $1\n" $seg -}}
+    {{- /* Strip remaining anchor tags. Tightened from `</?a[^>]*>` so it matches ONLY real
+           anchors (<a>, <a …attrs>, </a>) and never <artifactId>-style tags. RE2 has no
+           lookahead, so require either `>` or whitespace immediately after the name `a`. */ -}}
+    {{- $seg = replaceRE `</?a(?:\s[^>]*)?>` "" $seg -}}
+    {{- /* Strip lone +/- lines left from accordion toggle spans */ -}}
+    {{- $seg = replaceRE `(?m)^[+\-]\n` "" $seg -}}
+    {{- /* Strip auto-generated cobra footer */ -}}
+    {{- $seg = replaceRE `(?m)^###### Auto generated by spf13/cobra.*$` "" $seg -}}
+    {{- $cleaned = printf "%s%s" $cleaned $seg -}}
   {{- else -}}
+    {{- /* ---- CODE branch ---- only legitimate in-fence cleanup is Chroma <span> stripping */ -}}
+    {{- $seg = replaceRE `</?span[^>]*>` "" $seg -}}
     {{- $cleaned = printf "%s```%s```" $cleaned $seg -}}
   {{- end -}}
 {{- end -}}
 {{- $content = $cleaned -}}
-{{- /* Phase 4: Normalize whitespace so inline conversions can match cleanly */ -}}
-{{- $content = replaceRE `\n{3,}` "\n\n" $content -}}
-{{- /* Phase 5: Convert inline HTML to markdown */ -}}
-{{- $content = replaceRE `<a[^>]*href="([^"]*)"[^>]*>([^<]*)</a>` "[$2]($1)" $content -}}
-{{- /* Collapse whitespace inside markdown link brackets (from multi-line <a> tags) */ -}}
-{{- $content = replaceRE `\[\s+` "[" $content -}}
-{{- $content = replaceRE `\s+\]\(` "](" $content -}}
-{{- $content = replaceRE `<code[^>]*>([^<]*)</code>` "`$1`" $content -}}
-{{- $content = replaceRE `<strong>([^<]*)</strong>` "**$1**" $content -}}
-{{- $content = replaceRE `<em>([^<]*)</em>` "*$1*" $content -}}
-{{- $content = replaceRE `<img[^>]*src="([^"]*)"[^>]*alt="([^"]*)"[^>]*/?>` "![$2]($1)" $content -}}
-{{- $content = replaceRE `<img[^>]*alt="([^"]*)"[^>]*src="([^"]*)"[^>]*/?>` "![$1]($2)" $content -}}
-{{- $content = replaceRE `<img[^>]*/?>` "" $content -}}
-{{- /* Phase 6: Convert heading tags to markdown headings */ -}}
-{{- $content = replaceRE `<h1[^>]*>([^<]*)</h1>` "\n# $1\n" $content -}}
-{{- $content = replaceRE `<h2[^>]*>([^<]*)</h2>` "\n## $1\n" $content -}}
-{{- $content = replaceRE `<h3[^>]*>([^<]*)</h3>` "\n### $1\n" $content -}}
-{{- $content = replaceRE `<h4[^>]*>([^<]*)</h4>` "\n#### $1\n" $content -}}
-{{- $content = replaceRE `<h5[^>]*>([^<]*)</h5>` "\n##### $1\n" $content -}}
-{{- $content = replaceRE `<h6[^>]*>([^<]*)</h6>` "\n###### $1\n" $content -}}
-{{- /* Strip any remaining HTML tags not yet handled */ -}}
-{{- $content = replaceRE `</?a[^>]*>` "" $content -}}
-{{- /* Strip lone +/- lines left from accordion toggle spans */ -}}
-{{- $content = replaceRE `(?m)^[+\-]\n` "" $content -}}
-{{- /* Strip auto-generated cobra footer */ -}}
-{{- $content = replaceRE `(?m)^###### Auto generated by spf13/cobra.*$` "" $content -}}
-{{- /* Phase 7: Group unwrapped choosable options into chooser blocks.
+{{- /* Phase 7: Group unwrapped choosable options into chooser blocks. Global and after the
+       rejoin: these <!-- … --> markers span fence boundaries and the (?s) patterns must see
+       the whole document. They operate only on comment markers, never on code text.
        Choosable shortcodes emit <!-- option-TYPE: label --> / <!-- /option-TYPE --> with the
        chooser type baked in. Choosables inside a chooser shortcode have their types stripped
        by the chooser template, so any typed option tags remaining here are standalone and
@@ -64,7 +82,8 @@
     {{- $content = replaceRE (printf `<!-- /option-%s -->` $type) "<!-- /option -->" $content -}}
   {{- end -}}
 {{- end -}}
-{{- /* Phase 8: Decode HTML entities and final cleanup */ -}}
+{{- /* Phase 8: Decode HTML entities and final cleanup. htmlUnescape stays global by design:
+       it decodes &lt;/&gt;/&amp; in BOTH prose and the (now span-free) code segments. */ -}}
 {{- $content = $content | htmlUnescape -}}
 {{- $content = replaceRE `\n{3,}` "\n\n" $content -}}
 {{- return $content -}}

--- a/scripts/content-review/check-rendered-markdown.py
+++ b/scripts/content-review/check-rendered-markdown.py
@@ -13,14 +13,18 @@ Legitimate shortcode-syntax *examples* (docs that teach Hugo) live in fenced
 code blocks or inline code spans; those are stripped before scanning so the
 signal stays clean. A delimiter outside code formatting is a real leak.
 
-Scope note — this catches DELIMITER leaks only. It does NOT catch content
-*mangling*, where a shortcode's markdown template silently drops or rewrites
-content (e.g. stripped `<artifactId>` tags in Java blocks, or `[ -f` collapsing
-to `[-f` in Bash blocks). Those are rendering-pipeline bugs for the templating
-owner — tracked separately, not rediscoverable by a delimiter grep.
+Scope note — the line-by-line scan catches DELIMITER leaks only. It does NOT
+discover content *mangling*, where the markdown pipeline silently drops or
+rewrites content (e.g. stripped `<artifactId>` tags in Java blocks, or `[ -f`
+collapsing to `[-f` in Bash blocks); those general bugs are the templating
+owner's. The SPECIFIC mangling bugs fixed in #19872 are locked in by a targeted
+`--assert-unmangled` regression guard (see `KNOWN_UNMANGLED`): it asserts that
+known-affected built pages still render their code verbatim, so the fix can't
+silently regress.
 
 Usage:
     check-rendered-markdown.py [--public public] [--strict]
+    check-rendered-markdown.py --assert-unmangled [--public public] [--strict]
     check-rendered-markdown.py --self-test
 
 `--strict` exits non-zero when any leak is found (for gating CI); the default is
@@ -33,6 +37,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 # An opening (`{{<`, `{{%`) or closing (`>}}`, `%}}`) Hugo shortcode delimiter.
@@ -42,6 +47,19 @@ DELIM_RE = re.compile(r"\{\{[<%]|[>%]\}\}")
 FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 # An inline code span: `…`. Stripped so documented syntax doesn't false-positive.
 INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+# Targeted regression guard for the code-block mangling fixed in #19872. The
+# markdown pipeline (layouts/partials/docs/markdown-pipeline.md) used to run
+# prose-only regexes over fenced code, deleting `<artifactId>`-style tags and
+# collapsing `[ -f` to `[-f`. Each entry maps a built page (path under `public/`)
+# to substrings that MUST appear verbatim in its rendered `.md`. Checked by
+# `--assert-unmangled`, so the fix can't silently regress.
+KNOWN_UNMANGLED: dict[str, list[str]] = {
+    "docs/iac/concepts/components/index.md": ["<artifactId>my-component</artifactId>"],
+    "docs/iac/cli/command-line-completion/index.md": ["[ -f /etc/bash_completion ]"],
+    "docs/iac/guides/testing/unit/index.md": ["</artifactId>"],
+    "docs/iac/get-started/terraform/terraform-modules/index.md": ["</artifactId>"],
+}
 
 
 def scan_text(text: str) -> list[tuple[int, str]]:
@@ -72,10 +90,32 @@ def scan_tree(public: Path) -> dict[str, list[tuple[int, str]]]:
     return found
 
 
+def assert_unmangled(public: Path) -> list[str]:
+    """Return failures for known-fixed pages whose un-mangled code is missing.
+
+    A failure means the markdown pipeline mangled a code block again (or the page
+    moved). Empty list means every `KNOWN_UNMANGLED` page rendered its code verbatim.
+    """
+    failures: list[str] = []
+    for rel, needles in KNOWN_UNMANGLED.items():
+        page = public / rel
+        if not page.is_file():
+            failures.append(f"{rel}: built page not found")
+            continue
+        text = page.read_text(errors="replace")
+        for needle in needles:
+            if needle not in text:
+                failures.append(f"{rel}: expected un-mangled code not found: {needle!r}")
+    return failures
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument("--public", default="public", help="built-site root (default: public)")
-    ap.add_argument("--strict", action="store_true", help="exit non-zero if any leak is found")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit non-zero if any leak or mangling regression is found")
+    ap.add_argument("--assert-unmangled", action="store_true",
+                    help="also verify the #19872 code-mangling fix on known-affected pages")
     ap.add_argument("--self-test", action="store_true", help="run offline scan-logic checks")
     args = ap.parse_args()
 
@@ -88,18 +128,31 @@ def main() -> int:
               file=sys.stderr)
         return 2
 
+    # Delimiter-leak scan (advisory unless --strict).
     found = scan_tree(root)
-    total = sum(len(h) for h in found.values())
-    if not found:
+    if found:
+        total = sum(len(h) for h in found.values())
+        for rel, hits in found.items():
+            for line_no, line in hits:
+                print(f"{rel}:{line_no}: {line}")
+        print(f"\ncheck-rendered-markdown: {total} leak(s) across {len(found)} page(s)",
+              file=sys.stderr)
+    else:
         print(f"check-rendered-markdown: scanned {root}/ — no leaked shortcode delimiters")
-        return 0
 
-    for rel, hits in found.items():
-        for line_no, line in hits:
-            print(f"{rel}:{line_no}: {line}")
-    print(f"\ncheck-rendered-markdown: {total} leak(s) across {len(found)} page(s)",
-          file=sys.stderr)
-    return 1 if args.strict else 0
+    # Known-mangling regression guard (opt-in; advisory unless --strict).
+    mangled: list[str] = []
+    if args.assert_unmangled:
+        mangled = assert_unmangled(root)
+        if mangled:
+            for failure in mangled:
+                print(f"check-rendered-markdown: MANGLED: {failure}", file=sys.stderr)
+            print(f"\ncheck-rendered-markdown: {len(mangled)} code-mangling regression(s)",
+                  file=sys.stderr)
+        else:
+            print(f"check-rendered-markdown: {len(KNOWN_UNMANGLED)} known-mangling page(s) render code verbatim")
+
+    return 1 if (found or mangled) and args.strict else 0
 
 
 def self_test() -> int:
@@ -132,6 +185,25 @@ def self_test() -> int:
     mixed = scan_text("```\n{{< safe >}}\n```\n\nBut {{< leaked >}} here.\n")
     check("fence then a real leak: only the leak counts",
           len(mixed) == 1 and mixed[0][0] == 5)
+
+    # #19872 regression guard: assert_unmangled exercised against a throwaway tree.
+    with tempfile.TemporaryDirectory() as tmp:
+        public = Path(tmp)
+        rel, needles = next(iter(KNOWN_UNMANGLED.items()))
+        page = public / rel
+        page.parent.mkdir(parents=True, exist_ok=True)
+
+        page.write_text(f"prefix {needles[0]} suffix\n")
+        good = assert_unmangled(public)
+        check("assert_unmangled passes a page with the un-mangled marker",
+              not any(rel in f and "expected" in f for f in good))
+        check("assert_unmangled flags the other pages as not found",
+              any("not found" in f for f in good))
+
+        page.write_text("mangled output with the marker removed\n")
+        bad = assert_unmangled(public)
+        check("assert_unmangled flags a page whose marker was mangled away",
+              any(rel in f and "expected" in f for f in bad))
 
     if failures:
         print(f"\n{len(failures)} failure(s)", file=sys.stderr)


### PR DESCRIPTION
## What

Fixes #19872 — the customer-facing markdown (`.md`) render of docs pages mangled content inside fenced code blocks. The HTML view was always correct; the bug was specific to the `.md` output pipeline (`layouts/partials/docs/markdown-pipeline.md`), which ran prose-targeting regexes over the entire document, **including inside code fences**.

## Root cause

Three prose-only `replaceRE` passes were corrupting code:

| Pass | Intended for | Collateral damage |
|------|--------------|-------------------|
| `</?a[^>]*>` | strip leftover `<a>` anchors | deleted **any** tag starting with `a` — `<artifactId>`/`</artifactId>` in Maven/Gradle XML (while `<groupId>`/`<version>` survived) |
| `\[\s+` → `[` | clean `[ text ](url)` link brackets | collapsed `[ -f` → `[-f` in Bash, and joined array literals (`[\n    {` → `[{`) |
| `<h1>…</h1>` → `# …` | HTML→markdown headings | turned `<h1>…</h1>` inside shell `echo` examples into a markdown heading |

## Fix

Make the prose-only transforms **fence-aware**, reusing the pipeline's existing split-on-`` ``` `` pattern: prose (even) segments get the full transform set; code (odd) segments get only Chroma `<span>` stripping, with HTML-entity decoding still applied globally at the end. The anchor regex is also tightened to `</?a(?:\s[^>]*)?>` (matches only real `<a>` tags) as defense-in-depth.

This is a single-source-of-truth change — both `layouts/docs/single.md` and `list.md` route through the partial — so it covers the whole docs `.md` corpus and neutralizes the entire class of "prose regex corrupts code," not just the two reported cases.

## Regression guard

Adds `--assert-unmangled` to `scripts/content-review/check-rendered-markdown.py` (the script whose docstring already named these bugs). It asserts known-affected built pages render their code verbatim, with offline `--self-test` cases. Intended for CI as `--assert-unmangled --strict`.

## Verification

Built the site before and after the change (Hugo 0.157.0) and diffed the affected pages. **Every** change is inside a code fence and restores correct source content, with **no** prose/heading/link/chooser-block changes:

- `components`: `my-component` / `awsx` → `<artifactId>…</artifactId>`
- `command-line-completion`: `[-f /etc/bash_completion ]` → `[ -f /etc/bash_completion ]`
- `unit`, `terraform-modules`: `<artifactId>` restored; array literals and an `echo "<h1>…</h1>"` example un-mangled

Checks run:
- `check-rendered-markdown.py --assert-unmangled --strict` → exit 0
- `check-rendered-markdown.py --self-test` → all pass
- `make lint` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vCD2921qr6i5oKqSm9z8N

---
_Generated by [Claude Code](https://claude.ai/code/session_011vCD2921qr6i5oKqSm9z8N)_