### PR TITLE
Fix stale navigation and grammar in Insights Before You Begin

### DIFF
--- a/content/docs/insights/discovery/get-started/begin.md
+++ b/content/docs/insights/discovery/get-started/begin.md
@@ -16,7 +16,7 @@ aliases:
 
 ## Before you begin
 
-First, let's run through a few prerequisites and quick steps to ensure you ready to create your first Account Discovery scan.
+Before setting up your first Account Discovery scan, confirm the following prerequisites are in place.
 
 - Ensure you’re an admin of your Pulumi organization.
 - Verify you have permissions to create credentials in the provider account you want to scan.
@@ -32,9 +32,13 @@ Pulumi Insights Account Discovery requires read-only access to your cloud accoun
 Account Discovery leverages Pulumi ESC to securely manage the credentials required to discover and read infrastructure resources, aligning with enterprise best practices for managing application secrets.
 {{% /notes %}}
 
-To create an environment, [sign into the Pulumi cloud](https://app.pulumi.com/signin) console and navigate to **Pulumi ESC** and select **Environments** in the left-hand menu.
+To create an environment:
 
-Next, click **Create Environment** and enter a name for the project and environment, such as `insights-discovery-project` and `insights-environment` and then click **Create**.
+1. Open [Pulumi Cloud](https://app.pulumi.com/signin) and select **Environments** in the left navigation.
+1. Select **+ Create Environment**, then choose **New Environment**.
+1. For **Project name**, enter a name such as `insights-discovery`.
+1. For **Environment name**, enter a name such as `insights-env`.
+1. Select **Create Environment**.
 
 Leave the default environment definition for now, and you will return to finish configuring ESC after you create the required credentials.
 

--- a/content/docs/insights/discovery/get-started/begin.md
+++ b/content/docs/insights/discovery/get-started/begin.md
@@ -37,7 +37,7 @@ To create an environment:
 1. Open [Pulumi Cloud](https://app.pulumi.com/signin) and select **Environments** in the left navigation.
 1. Select **+ Create Environment**, then choose **New Environment**.
 1. For **Project name**, enter a name such as `insights-discovery`.
-1. For **Environment name**, enter a name such as `insights-env`.
+1. For **Environment name**, enter a name such as `insights-discovery-env`.
 1. Select **Create Environment**.
 
 Leave the default environment definition for now, and you will return to finish configuring ESC after you create the required credentials.


### PR DESCRIPTION
This PR fixes #16415, in which the "Before You Begin" page for Pulumi Insights Account Discovery was reported as difficult to follow.

## Changes

**Grammar fix:** The opening sentence contained a grammatical error ("ensure you ready to create") that made it awkward to read. The sentence is now rewritten for clarity.

**Stale navigation language:** The page instructed users to "navigate to Pulumi ESC and select Environments in the left-hand menu," which no longer matches the current Pulumi Cloud UI. This has been updated to "select **Environments** in the left navigation," consistent with the current ESC get-started documentation.

**Updated Create Environment steps:** The previous instructions described the environment creation flow with a single sentence referencing a UI dialog that no longer exists in that form. The steps now reflect the current Pulumi Cloud UI: open Pulumi Cloud, select **+ Create Environment**, choose **New Environment**, enter a project name and environment name, and select **Create Environment**. This mirrors the flow described in the ESC get-started documentation.

**Consistent example names:** The example project and environment names (`insights-discovery` and `insights-env`) now align with the naming used in the subsequent "Create Accounts" step in this get-started sequence, making it easier to follow across pages.

## Testing

The updated navigation language was cross-referenced against the current ESC get-started page (`content/docs/esc/get-started/_index.md`) and the Insights visual-import and policy pages to confirm it matches the terminology used in recently updated content. No auto-generated content was modified.

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*
