### PR TITLE
Stop the docs .md pipeline eating &lt;project&gt;-style placeholders in prose

### DIFF
--- a/layouts/partials/docs/markdown-pipeline.md
+++ b/layouts/partials/docs/markdown-pipeline.md
@@ -24,9 +24,12 @@
 {{- range $i, $seg := $segments -}}
   {{- if eq (mod $i 2) 0 -}}
     {{- /* ---- PROSE branch ---- */ -}}
-    {{- /* Phase 2: Strip block-level and decorative tags in consolidated passes */ -}}
-    {{- $seg = replaceRE `</?(?:span|label|div|p|blockquote|ol|ul|li|pre|section|table|thead|tbody|tr|td|th|dl|dt|dd|details|summary)[^>]*>` "" $seg -}}
-    {{- $seg = replaceRE `(?:<i[^>]*></i>|<input[^>]*>)` "" $seg -}}
+    {{- /* Phase 2: Strip block-level and decorative tags. The `(?:\s[^>]*)?` (not a bare
+           `[^>]*`) requires the element name to be followed by `>` or whitespace, so real tags
+           strip but look-alike placeholders survive — e.g. `<project>` is not a `<p>` tag and
+           `<table-name>` is not a `<table>`. Mirrors the anchor-strip tightening in Phase 6. */ -}}
+    {{- $seg = replaceRE `</?(?:span|label|div|p|blockquote|ol|ul|li|pre|section|table|thead|tbody|tr|td|th|dl|dt|dd|details|summary)(?:\s[^>]*)?>` "" $seg -}}
+    {{- $seg = replaceRE `(?:<i(?:\s[^>]*)?></i>|<input(?:\s[^>]*)?>)` "" $seg -}}
     {{- $seg = replaceRE `<!--\s*markdownlint[^>]*-->` "" $seg -}}
     {{- /* Phase 3: Strip deep leading whitespace left by HTML tag removal. Prose only;
            code indentation lives in the odd segments and is preserved. */ -}}

--- a/scripts/content-review/check-rendered-markdown.py
+++ b/scripts/content-review/check-rendered-markdown.py
@@ -48,17 +48,20 @@ FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 # An inline code span: `…`. Stripped so documented syntax doesn't false-positive.
 INLINE_CODE_RE = re.compile(r"`[^`]*`")
 
-# Targeted regression guard for the code-block mangling fixed in #19872. The
-# markdown pipeline (layouts/partials/docs/markdown-pipeline.md) used to run
-# prose-only regexes over fenced code, deleting `<artifactId>`-style tags and
-# collapsing `[ -f` to `[-f`. Each entry maps a built page (path under `public/`)
+# Targeted regression guard for the code-mangling fixed under #19872. The markdown
+# pipeline (layouts/partials/docs/markdown-pipeline.md) ran prose-targeting regexes
+# too greedily: they deleted `<artifactId>`-style tags inside fenced code and
+# `<project>`-style placeholders inside prose inline-code (any `<a…>`/`<p…>`/… token),
+# and collapsed `[ -f` to `[-f`. Each entry maps a built page (path under `public/`)
 # to substrings that MUST appear verbatim in its rendered `.md`. Checked by
-# `--assert-unmangled`, so the fix can't silently regress.
+# `--assert-unmangled`, so the fixes can't silently regress.
 KNOWN_UNMANGLED: dict[str, list[str]] = {
     "docs/iac/concepts/components/index.md": ["<artifactId>my-component</artifactId>"],
     "docs/iac/cli/command-line-completion/index.md": ["[ -f /etc/bash_completion ]"],
     "docs/iac/guides/testing/unit/index.md": ["</artifactId>"],
     "docs/iac/get-started/terraform/terraform-modules/index.md": ["</artifactId>"],
+    # Phase 2 follow-up: `<project>` (a `<p…>` token) was eaten from a prose inline-code span.
+    "docs/administration/access-identity/oidc-issuers/gitlab/index.md": ["<namespace>/<project>"],
 }
 
 


### PR DESCRIPTION
## What

Follow-up to #19888 (refs #19872). The markdown (`.md`) export pipeline's **Phase 2** block-tag strip was deleting `<…>` placeholders from **prose inline-code** — e.g. `Pulumi.<project-name>.yaml` rendered as `Pulumi..yaml`, and `project_path:<namespace>/<project>` as `project_path:<namespace>/`.

## Root cause

Same class of bug as the anchor-strip fixed in #19888, just a different regex. Phase 2 stripped tags with a greedy alternation:

```
</?(?:span|label|div|p|…|summary)[^>]*>
```

Because each element name is followed by a bare `[^>]*`, it matched **any tag whose name merely starts with a listed element**. The `p` prefix is the worst offender — it ate the most common docs placeholders: `<project>`, `<package-name>`, `<path>`, `<prompt>`, `<password>`, `<provider…>` (and via other prefixes, `<link>`/`<library>`, `<track>`, …).

#19888 already made the pipeline fence-aware, so **fenced code was protected**; this was the remaining damage, confined to **prose inline-code spans**. Confirmed live: `docs/administration/access-identity/oidc-issuers/gitlab` rendered `project_path:<namespace>/:…`.

## Fix

Tighten the Phase 2 regexes to require the element name be followed by `>` or whitespace (`(?:\s[^>]*)?`), exactly mirroring the Phase 6 anchor-strip tightening (`</?a(?:\s[^>]*)?>`):

```
</?(?:span|…|summary)(?:\s[^>]*)?>          # main pass
(?:<i(?:\s[^>]*)?></i>|<input(?:\s[^>]*)?>)  # decorative pass
```

Real tags still strip (`<div>`, `<div class="x">`, `</p>`, `<td colspan="2">`, `<input type="checkbox">`); look-alike placeholders survive (`<project>`, `<table-name>`). No legitimate strip is lost — real elements only ever appear as `<name>`, `<name …attrs>`, or `</name>`, all still matched.

The GitLab OIDC page is added to the `--assert-unmangled` guard in `scripts/content-review/check-rendered-markdown.py`.

**Deliberately out of scope** (kept minimal): the `<h1>`–`<h6>`/`<code>`/`<img>` passes share the `name[^>]*>` shape but require a closing-tag/attr structure placeholders don't have, and show no evidence of damage — left as-is.

## Verification

Built the whole docs corpus before and after the change (Hugo 0.157.0) and diffed all **820** pages:

- **760 identical, 60 changed — every change is a pure `<…>` placeholder restoration** (proved by stripping all angle tokens and confirming the remaining prose text is byte-identical on all 60).
- **0 pages shrank · 0 raw block-tag leaks** (`<p>` 43→43, `<li>` 6→6 — real tags still stripped) **· 0 unbalanced fences.**
- Restorations include `<project>` 12→65, `<provider>` 1→13, `<package-name>` 0→10, `<prompt>` 0→4.
- `check-rendered-markdown.py --assert-unmangled --strict` → exit 0 (5/5 guard pages, incl. new GitLab row); `--self-test` → all pass.
- `prettier --check` clean on changed files; markdown linter 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vCD2921qr6i5oKqSm9z8N

---
_Generated by [Claude Code](https://claude.ai/code/session_011vCD2921qr6i5oKqSm9z8N)_