### PR TITLE
docs: how to change the company name shown on invoices

### DIFF
--- a/content/docs/administration/organizations-teams/organizations.md
+++ b/content/docs/administration/organizations-teams/organizations.md
@@ -104,7 +104,7 @@ If you need to delegate billing-only access to a team member without granting fu
 
 ## Changing the company name on invoices
 
-The company name that appears on Pulumi invoices is sourced from your organization's display name. To change it, update the display name and the change will be reflected on your next invoice. Updates take effect within a short time after saving.
+The company name that appears on Pulumi invoices is sourced from your organization's display name. To change it, update the display name. The updated name will appear on your next invoice, and updates take effect shortly after saving.
 
 To update your organization's display name:
 

--- a/content/docs/administration/organizations-teams/organizations.md
+++ b/content/docs/administration/organizations-teams/organizations.md
@@ -102,6 +102,19 @@ To update billing information:
 
 If you need to delegate billing-only access to a team member without granting full admin rights, see [Billing Managers](/docs/administration/organizations-teams/billing-managers/).
 
+## Changing the company name on invoices
+
+The company name that appears on Pulumi invoices is sourced from your organization's display name. To change it, update the display name and the change will be reflected on your next invoice. Updates take effect within a short time after saving.
+
+To update your organization's display name:
+
+1. Navigate to **Settings** > **General**.
+1. Update the **Display Name** field and save your changes.
+
+Updating the display name requires the `organization:billing` permission, which is granted to organization admins and Billing Managers.
+
+If you need a legal entity name on invoices that is different from your organization's product-facing display name, [contact support](/support/). Distinct legal billing names on invoices are a planned enhancement.
+
 ## Transferring stacks
 
 Stack admins can transfer individual stacks between personal accounts and organizations, or between organizations. Organization admins can transfer stacks in bulk.

--- a/content/docs/administration/organizations-teams/organizations.md
+++ b/content/docs/administration/organizations-teams/organizations.md
@@ -113,7 +113,7 @@ To update your organization's display name:
 
 Updating the display name requires the `organization:rename` permission, which is granted to organization admins.
 
-If you need a legal entity name on invoices that is different from your organization's product-facing display name, [contact support](/support/). Distinct legal billing names on invoices are a planned enhancement.
+If you need a legal entity name on invoices that is different from your organization's product-facing display name, [contact support](/support/).
 
 ## Transferring stacks
 

--- a/content/docs/administration/organizations-teams/organizations.md
+++ b/content/docs/administration/organizations-teams/organizations.md
@@ -111,7 +111,7 @@ To update your organization's display name:
 1. Navigate to **Settings** > **General**.
 1. Update the **Display Name** field and save your changes.
 
-Updating the display name requires the `organization:billing` permission, which is granted to organization admins and Billing Managers.
+Updating the display name requires the `organization:rename` permission, which is granted to organization admins.
 
 If you need a legal entity name on invoices that is different from your organization's product-facing display name, [contact support](/support/). Distinct legal billing names on invoices are a planned enhancement.
 


### PR DESCRIPTION
Customers regularly file support tickets asking how to change the company name shown on their Pulumi invoices. The name is sourced from their organization's display name (Settings > General > Display Name), and the sync to Stripe is automatic — but this is not documented anywhere, so users don't realize they can self-serve. Ops handles each ticket manually.

This adds a short "Changing the company name on invoices" section to the existing Pulumi Cloud Organizations page, placed directly after "Updating billing information" so it sits with related billing self-service content. 