### PR TITLE
content-review: add auto-merge notice to the PR body

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -223,6 +223,9 @@ review (a clean lint means it flows through the normal pipeline; a trivial fix i
 short-circuited there). A lint failure leaves the PR a draft with a comment for a
 human; humans merge. The sections (each is checked for):
 
+- **Auto-merge notice** (top `> [!IMPORTANT]` block): the re-lint gate arms
+  GitHub auto-merge on the PR, so the body flags that approving merges it.
+  **Leave verbatim** — do not move, reword, or remove it.
 - **Why this page**: composed from the selection queue (lane, tier, traffic
   figure + period, last reviewed). **Leave verbatim** — do not re-narrate it.
 - **Fixes applied**: pre-stubbed one row per high-confidence finding. Keep a row

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -281,6 +281,8 @@ jobs:
                and promotes the PR to ready only if lint passes — that ready
                transition is what triggers triage and the docs review. Do NOT
                write the body from scratch. EDIT the draft:
+               - The top `> [!IMPORTANT]` auto-merge notice is verbatim — leave
+                 it exactly as composed; do not move, reword, or remove it.
                - "Why this page" is rendered from the selection queue — leave it
                  verbatim, its facts are authoritative.
                - "Fixes applied" is pre-stubbed with one row per high-confidence

--- a/scripts/content-review/compose-pr-body.py
+++ b/scripts/content-review/compose-pr-body.py
@@ -14,6 +14,8 @@ fix rows it actually applied (filling the correction), moves the rest to
 
 What the composer renders (facts — never the model's to invent):
 
+  * A top `> [!IMPORTANT]` auto-merge notice — every fix PR is armed for
+    auto-merge by the re-lint gate, so the body flags that approving merges it.
   * "Why this page" — verbatim from the selection queue (via render-provenance).
   * "Fixes applied" / "Findings not applied" — one stub per pre-found finding
     from `.verified-claims.json` (contradicted/mismatch/unverifiable claims),
@@ -67,6 +69,18 @@ _rg = importlib.util.module_from_spec(_spec_g)
 _spec_g.loader.exec_module(_rg)
 
 LINT_PLACEHOLDER = "<!-- LINT-RESULT -->"
+
+# Rendered at the top of every fix PR so a reviewer can't miss that approving
+# the PR merges it. The re-lint gate arms GitHub auto-merge (squash) once the
+# PR is promoted to ready; `master` requires an approval + the build check, so
+# the PR merges the moment those are satisfied.
+AUTOMERGE_NOTICE = (
+    "> [!IMPORTANT]\n"
+    "> **This PR is set to auto-merge (squash).** Once it has an approving review "
+    "and the required build check passes, GitHub will merge it automatically — "
+    "**approving this PR will merge it.** To prevent that, disable auto-merge "
+    "(or convert the PR back to a draft) before approving."
+)
 
 # Vale categories whose fix has exactly one correct form and preserves meaning —
 # safe to pre-bucket as a fix candidate. Everything else (passive voice,
@@ -336,6 +350,8 @@ def compose(queue: dict, verified, vale, readthrough, frontmatter, gates=None) -
     inv = artifact_inventory(verified, vale, readthrough, frontmatter)
 
     return "\n".join([
+        AUTOMERGE_NOTICE,
+        "",
         _rp.render(queue).rstrip(),
         "",
         render_fixes(findings).rstrip(),

--- a/scripts/content-review/test_compose_pr_body.py
+++ b/scripts/content-review/test_compose_pr_body.py
@@ -75,6 +75,11 @@ for sec in ["Why this page", "Fixes applied", "Findings not applied",
             "Screenshot check", "Rendered content", "Verification"]:
     check(f"section present: {sec}", f"## {sec}" in out)
 
+# Auto-merge notice is a prominent IMPORTANT alert at the very top.
+check("auto-merge notice present", "> [!IMPORTANT]" in out and "auto-merge" in out.lower())
+check("auto-merge notice is at the top", out.lstrip().startswith("> [!IMPORTANT]"))
+check("auto-merge notice warns approving merges", "approving this pr will merge it" in out.lower())
+
 # Provenance composed (real visits, not narrated).
 check("provenance shows real visits", "384 monthly visits" in out)
 


### PR DESCRIPTION
Follow-up to #19887 (which armed auto-merge): make the body say so. This commit was accidentally pushed to #19887's branch *after* it merged, so it never landed — re-landing it here off current master.

The composed PR body now leads with a `> [!IMPORTANT]` callout stating the PR is set to auto-merge and that **approving merges it** (and how to stop that). The prompt + SKILL instruct the model to leave the notice verbatim; a test asserts it's present at the top.

Drafted by Claude; reviewed by Cam.