### PR TITLE
Add ilionx DevDays 2026 talk to Engin Diri team page

### DIFF
--- a/content/community/team/engin-diri.md
+++ b/content/community/team/engin-diri.md
@@ -9,6 +9,10 @@ aliases:
   - /engin
   - /community/community-engineering/engin-diri/
 talks:
+- event: "ilionx DevDays 2026"
+  title: "Beyond pulumi up: A Tour of Pulumi Cloud and the Neo Agent"
+  url: "https://www.ilionxdevdays.com/"
+  date: 2026-06-26T15:20:00.000+02:00
 - event: "AICamp New York 2026"
   title: "Workshop: Deploying AI Agents on AWS With Pulumi and Amazon Bedrock AgentCore"
   url: "https://www.aicamp.ai/event/eventdetails/W2026061714"


### PR DESCRIPTION
## Description

Adds Engin Diri's most recent talk to his community engineering team page.

**Talk:** Beyond pulumi up: A Tour of Pulumi Cloud and the Neo Agent
**Event:** ilionx DevDays 2026 — Van Der Valk Arnhem, Netherlands
**Date:** Friday, June 26, 2026, 15:20 CET

Entry is placed at the top of the `talks` list to keep the descending-date ordering.

## Checklist

- [x] Frontmatter-only change to `content/community/team/engin-diri.md`