### PR TITLE
Add recent + upcoming talks to Adam Gordon Bell's speaker page

### DIFF
--- a/content/community/team/adam-gordon-bell.md
+++ b/content/community/team/adam-gordon-bell.md
@@ -9,6 +9,10 @@ aliases:
   - /adam
   - /community/community-engineering/adam-gordon-bell/
 talks:
+- event: "DevOpsDays Rockies 2026"
+  title: "When AI Agents Touch Real Infrastructure: War Stories"
+  url: "https://talks.devopsdays.org/dodroxrox26/"
+  date: 2026-09-22T09:00:00.000-06:00
 - event: "KCDC 2026"
   title: "Demystifying the Magic: Let's Build an Infrastructure-as-Code Tool from Scratch"
   url: "https://www.kcdc.info/"

--- a/content/community/team/adam-gordon-bell.md
+++ b/content/community/team/adam-gordon-bell.md
@@ -10,11 +10,11 @@ aliases:
   - /community/community-engineering/adam-gordon-bell/
 talks:
 - event: "DevOpsDays Rockies 2026"
-  title: "When AI Agents Touch Real Infrastructure: War Stories"
+  title: "When AI Agents Touch Real Infrastructure"
   url: "https://talks.devopsdays.org/dodroxrox26/"
   date: 2026-09-22T09:00:00.000-06:00
 - event: "KCDC 2026"
-  title: "Demystifying the Magic: Let's Build an Infrastructure-as-Code Tool from Scratch"
+  title: "Let's Build an Infrastructure-as-Code Tool from Scratch"
   url: "https://www.kcdc.info/"
   date: 2026-09-10T09:00:00.000-05:00
 - event: "Pinecone Meetup NYC: Scaling AI Infrastructure"

--- a/content/community/team/adam-gordon-bell.md
+++ b/content/community/team/adam-gordon-bell.md
@@ -9,6 +9,18 @@ aliases:
   - /adam
   - /community/community-engineering/adam-gordon-bell/
 talks:
+- event: "KCDC 2026"
+  title: "Demystifying the Magic: Let's Build an Infrastructure-as-Code Tool from Scratch"
+  url: "https://www.kcdc.info/"
+  date: 2026-09-10T09:00:00.000-05:00
+- event: "Pinecone Meetup NYC: Scaling AI Infrastructure"
+  title: "I Built an AI Running Coach (And Gave It Memory)"
+  url: "https://luma.com/pinecone-m9my"
+  date: 2026-06-18T17:00:00.000-04:00
+- event: "AICamp New York 2026"
+  title: "Workshop: Deploying AI Agents on AWS With Pulumi and Amazon Bedrock AgentCore"
+  url: "https://www.aicamp.ai/event/eventdetails/W2026061714"
+  date: 2026-06-17T17:30:00.000-04:00
 - event: "MLCon San Diego 2026"
   title: "Building Action-Taking AI Agents: Reliability Lessons from Real Systems"
   url: "https://mlconference.ai/"


### PR DESCRIPTION
Adds three entries to Adam's `talks:` list on his community team page (newest-first, same format as other speakers):

| Event | Title | Date | Link |
|---|---|---|---|
| KCDC 2026 (accepted, upcoming) | Demystifying the Magic: Let's Build an IaC Tool from Scratch | Sep 10 | https://www.kcdc.info/ |
| Pinecone Meetup NYC: Scaling AI Infrastructure | I Built an AI Running Coach (And Gave It Memory) | Jun 18 | https://luma.com/pinecone-m9my |
| AICamp New York 2026 | Workshop: Deploying AI Agents on AWS With Pulumi and Amazon Bedrock AgentCore | Jun 17 | https://www.aicamp.ai/event/eventdetails/W2026061714 |

The AICamp NY entry mirrors the same workshop on Engin Diri's page (co-taught). KCDC session time is a placeholder pending the published schedule.