### PR TITLE
Add small AI-inaccuracy disclaimer to Neo Slack integration page

### DIFF
--- a/content/docs/ai/integrations/slack/_index.md
+++ b/content/docs/ai/integrations/slack/_index.md
@@ -47,3 +47,5 @@ Tasks started from Slack run with the [RBAC permissions](/docs/administration/ac
 
 - Starting a conversation with Neo in a direct message isn't supported.
 - One task per thread.
+
+<p style="font-size: 0.8rem; color: var(--docs-fg-muted); margin-top: 2rem;"><em>Neo is powered by AI, and AI-generated content can be inaccurate. Review Neo's responses and actions before relying on them.</em></p>

--- a/content/docs/ai/integrations/slack/_index.md
+++ b/content/docs/ai/integrations/slack/_index.md
@@ -48,4 +48,4 @@ Tasks started from Slack run with the [RBAC permissions](/docs/administration/ac
 - Starting a conversation with Neo in a direct message isn't supported.
 - One task per thread.
 
-<p style="font-size: 0.8rem; color: var(--docs-fg-muted); margin-top: 2rem;"><em>Neo is powered by AI, and AI-generated content can be inaccurate. Review Neo's responses and actions before relying on them.</em></p>
+<p style="font-size: 0.8rem; color: var(--docs-fg-muted); margin-top: 2rem;"><em>Neo is powered by AI, and AI-generated content can be inaccurate.</em></p>

--- a/content/docs/ai/integrations/slack/_index.md
+++ b/content/docs/ai/integrations/slack/_index.md
@@ -48,4 +48,4 @@ Tasks started from Slack run with the [RBAC permissions](/docs/administration/ac
 - Starting a conversation with Neo in a direct message isn't supported.
 - One task per thread.
 
-<p style="font-size: 0.8rem; color: var(--docs-fg-muted); margin-top: 2rem;"><em>Neo is powered by AI, and AI-generated content can be inaccurate.</em></p>
+<p style="font-size: 0.8rem; color: var(--docs-fg-muted); margin-top: 2rem;"><em>Neo is powered by AI, and AI-generated content can be inaccurate. Review carefully before acting on the response.</em></p>


### PR DESCRIPTION
## What

Adds a small, muted disclaimer at the bottom of the Neo Slack integration page (`/docs/ai/integrations/slack/`) noting that AI-generated content can be inaccurate.

## Why

It's a requirement for the Slack marketplace.

## Notes

- The disclaimer is intentionally small (`0.8rem`) and muted, placed at the very bottom below the Limitations section.
- Uses the `--docs-fg-muted` semantic token so it stays legible in both light and dark mode (per AGENTS.md dark-mode guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)