### PR TITLE
Fix bare .btn styling on stepper next-step links

### DIFF
--- a/layouts/shortcodes/get-started-stepper.html
+++ b/layouts/shortcodes/get-started-stepper.html
@@ -45,6 +45,6 @@
         {{ if isset $next.Params "stepper_link" }}
             {{ $linkTitle = $next.Params.stepper_link }}
         {{ end }}
-        <a data-track="next-step" class="btn" href="{{ $next.RelPermalink }}">{{ $linkTitle }} &rarr;</a>
+        <a data-track="next-step" class="btn btn-primary" href="{{ $next.RelPermalink }}">{{ $linkTitle }} &rarr;</a>
     {{ end }}
 </div>

--- a/layouts/shortcodes/tutorials/stepper.html
+++ b/layouts/shortcodes/tutorials/stepper.html
@@ -28,8 +28,8 @@
     {{ end }}
     {{ if ne $step $last }}
         {{ $next := index $pages (add $step 1) }}
-        <a data-track="next-step" class="btn w-full md:w-auto" href="{{ $next.RelPermalink }}"><span class="hidden md:inline">Next: </span>{{ $next.LinkTitle }} &rarr;</a>
+        <a data-track="next-step" class="btn btn-primary w-full md:w-auto" href="{{ $next.RelPermalink }}"><span class="hidden md:inline">Next: </span>{{ $next.LinkTitle }} &rarr;</a>
     {{ else }}
-        <a data-track="next-step" class="btn w-full md:w-auto" href="{{ .Page.Parent.RelPermalink }}"><span class="hidden md:inline">Back to </span>{{ .Page.Parent.Title }} &rarr;</a>
+        <a data-track="next-step" class="btn btn-primary w-full md:w-auto" href="{{ .Page.Parent.RelPermalink }}"><span class="hidden md:inline">Back to </span>{{ .Page.Parent.Title }} &rarr;</a>
     {{ end }}
 </div>


### PR DESCRIPTION
### Proposed changes

The "Next step" links in the get-started and tutorial stepper shortcodes carried a bare `.btn` class with no variant, leaving them unstyled. This adds `btn-primary` so they render as the primary forward action, pairing with the existing `btn-outline` "Previous" buttons. These were the only bare `.btn` instances in the codebase.