### PR TITLE
Rework feedback dialog flow and add dark-mode support

### DIFF
--- a/layouts/partials/docs/feedback.html
+++ b/layouts/partials/docs/feedback.html
@@ -1,45 +1,54 @@
-<div id="docsFeedbackContainer" class="hidden mt-4 border-t border-gray-200 text-xs text-gray-600">
+<div id="docsFeedbackContainer" class="hidden mt-4 border-t border-docs-border text-xs text-docs-fg-muted">
     <div id="feedbackButtons">
         <p class="my-4">Was this page helpful?</p>
         <div class="flex items-center">
-            <a id="docsFeedbackYes" data-track="feedback-yes" class="flex items-center cursor-pointer hover:text-gray-700">
+            <a id="docsFeedbackYes" data-track="feedback-yes" class="flex items-center cursor-pointer hover:text-docs-fg">
                 {{ partial "icon.html" (dict "name" "thumbs-up" "class" "mr-2") }}
                 <span> Yes </span>
             </a>
-            <a id="docsFeedbackNo" data-track="feedback-no" class="flex items-center cursor-pointer ml-4 hover:text-gray-700">
+            <a id="docsFeedbackNo" data-track="feedback-no" class="flex items-center cursor-pointer ml-4 hover:text-docs-fg">
                 {{ partial "icon.html" (dict "name" "thumbs-down" "class" "mr-2") }}
                 <span> No </span>
             </a>
         </div>
     </div>
-    <div id="feedbackThankYou" class="hidden">
-        {{ $problemTitle := printf "Issue with %s" .Permalink }}
-        {{ $improvementTitle := printf "Improvement for %s" .Permalink }}
-        <p>Thank you for your feedback!</p>
-        <p>If you have a question about how to use Pulumi, reach out in <a href="https://slack.pulumi.com/">Community Slack</a>.</p>
-        <p>
-            Open an issue on GitHub to
-            <a href="https://github.com/pulumi/docs/issues/new?title={{ $problemTitle }}">report a problem</a> or
-            <a href="https://github.com/pulumi/docs/issues/new?title={{ $improvementTitle }}">suggest an improvement</a>.
-        </p>
-    </div>
-    <div id="feedbackLongForm" class="hidden text-gray-700 text-sm">
+    <div id="feedbackLongForm" class="hidden text-docs-fg-muted text-sm">
         <div class="popup-overlay">
-            <div class="bg-white m-auto w-10/12 md:w-5/12 rounded overflow-hidden">
+            <div class="bg-docs-card m-auto w-10/12 md:w-5/12 rounded-lg overflow-hidden">
                 <div class="mx-5 pt-4 flex relative">
-                    <p class="inline-block m-0 text-3xl">Feedback</p>
+                    <h3 class="inline-block m-0">Feedback</h3>
                 </div>
-                <div class="p-5 pt-0">
+                <div id="feedbackForm" class="p-5 pt-0">
                     <p>Thank you for your feedback! If you would like to provide additional feedback, please let us know your thoughts below.</p>
-                    <textarea
-                        id="feedbackAdditionalComments"
-                        rows="5"
-                        class="mb-3 w-full p-2 bg-white rounded border border-gray-500 outline-none"
-                        placeholder="Additional Comments"
-                    ></textarea>
-                    <input id="feedbackEmail" type="email" class="block mb-4 w-full p-2 rounded border border-gray-500 outline-none" placeholder="Email (optional)" />
-                    <a id="docsSubmitFeedback" class="btn btn-primary md:w-1/4 mb-3 block md:inline-block">Submit</a>
-                    <a id="docsCloseFeedbackLongForm" class="cursor-pointer md:inline-block md:w-1/4 text-center block">Close</a>
+                    <div class="mb-3">
+                        <textarea
+                            id="feedbackAdditionalComments"
+                            rows="5"
+                            class="w-full p-2 rounded border border-docs-border outline-none focus:ring-violet-primary focus:ring-2"
+                            placeholder="Additional Comments"
+                            required
+                        ></textarea>
+                        <p id="feedbackCommentsError" class="hidden mt-1 text-red-primary">Please add a comment before submitting.</p>
+                    </div>
+                    <input id="feedbackEmail" type="email" class="block mb-4 w-full p-2 rounded border border-docs-border outline-none focus:ring-violet-primary focus:ring-2" placeholder="Email (optional)" />
+                    <div class="flex gap-2 justify-between">
+                        <a id="docsSubmitFeedback" class="btn btn-primary">Submit</a>
+                        <a id="docsCloseFeedbackLongForm" class="btn btn-secondary">Close</a>
+                    </div>
+                </div>
+                <div id="feedbackSuccess" class="hidden p-5 pt-0">
+                    {{ $problemTitle := printf "Issue with %s" .Permalink }}
+                    {{ $improvementTitle := printf "Improvement for %s" .Permalink }}
+                    <p>Thank you for your feedback!</p>
+                    <p>If you have a question about how to use Pulumi, reach out in <a class="text-docs-link underline" href="https://slack.pulumi.com/">Community Slack</a>.</p>
+                    <p>
+                        Open an issue on GitHub to
+                        <a class="text-docs-link underline" href="https://github.com/pulumi/docs/issues/new?title={{ $problemTitle }}">report a problem</a> or
+                        <a class="text-docs-link underline" href="https://github.com/pulumi/docs/issues/new?title={{ $improvementTitle }}">suggest an improvement</a>.
+                    </p>
+                    <div class="flex justify-end mt-4">
+                        <a id="docsDoneFeedback" class="btn btn-primary">Done</a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/layouts/partials/docs/table-of-contents.html
+++ b/layouts/partials/docs/table-of-contents.html
@@ -60,7 +60,7 @@
         <li>
             <a
                 data-track="request-change"
-                class="text-gray-600 hover:text-gray-700 text-xs"
+                class="text-docs-fg-muted hover:text-docs-fg text-xs no-underline"
                 href="{{ $.Site.Params.contentRepositoryURL }}/issues/new?body=File: [content/{{ .File.Path }}]({{ $.Page.Permalink }})"
                 target="_blank"
             >

--- a/layouts/partials/docs/table-of-contents.html
+++ b/layouts/partials/docs/table-of-contents.html
@@ -64,7 +64,7 @@
                 href="{{ $.Site.Params.contentRepositoryURL }}/issues/new?body=File: [content/{{ .File.Path }}]({{ $.Page.Permalink }})"
                 target="_blank"
             >
-                {{ partial "icon.html" (dict "name" "check-square" "class" "mr-2") }}Request a Change
+                {{ partial "icon.html" (dict "name" "check-square" "class" "mr-2") }}Report an Issue
             </a>
         </li>
     {{ end }}

--- a/layouts/partials/tutorials/feedback.html
+++ b/layouts/partials/tutorials/feedback.html
@@ -12,34 +12,43 @@
             </a>
         </div>
     </div>
-    <div id="feedbackThankYou" class="hidden">
-        {{ $problemTitle := printf "Issue with %s" .Permalink }}
-        {{ $improvementTitle := printf "Improvement for %s" .Permalink }}
-        <p>Thank you for your feedback!</p>
-        <p>If you have a question about how to use Pulumi, reach out in <a href="https://slack.pulumi.com/">Community Slack</a>.</p>
-        <p>
-            Open an issue on GitHub to
-            <a href="https://github.com/pulumi/docs/issues/new?title={{ $problemTitle }}">report a problem</a> or
-            <a href="https://github.com/pulumi/docs/issues/new?title={{ $improvementTitle }}">suggest an improvement</a>.
-        </p>
-    </div>
     <div id="feedbackLongForm" class="hidden text-gray-700 text-sm">
         <div class="popup-overlay">
-            <div class="bg-white m-auto w-10/12 md:w-5/12 rounded overflow-hidden">
+            <div class="bg-white m-auto w-10/12 md:w-5/12 rounded-lg overflow-hidden">
                 <div class="mx-5 pt-4 flex relative">
-                    <p class="inline-block m-0 text-3xl">Feedback</p>
+                    <h3 class="inline-block m-0">Feedback</h3>
                 </div>
-                <div class="p-5 pt-0">
+                <div id="feedbackForm" class="p-5 pt-0">
                     <p>Thank you for your feedback! If you would like to provide additional feedback, please let us know your thoughts below.</p>
-                    <textarea
-                        id="feedbackAdditionalComments"
-                        rows="5"
-                        class="mb-3 w-full p-2 bg-white rounded border border-gray-500 outline-none"
-                        placeholder="Additional Comments"
-                    ></textarea>
-                    <input id="feedbackEmail" type="email" class="block mb-4 w-full p-2 rounded border border-gray-500 outline-none" placeholder="Email (optional)" />
-                    <a id="docsSubmitFeedback" class="btn btn-primary md:w-1/4 mb-3 block md:inline-block">Submit</a>
-                    <a id="docsCloseFeedbackLongForm" class="cursor-pointer md:inline-block md:w-1/4 text-center block">Close</a>
+                    <div class="mb-3">
+                        <textarea
+                            id="feedbackAdditionalComments"
+                            rows="5"
+                            class="w-full p-2 bg-white rounded border border-gray-500 outline-none focus:ring-violet-primary focus:ring-2"
+                            placeholder="Additional Comments"
+                            required
+                        ></textarea>
+                        <p id="feedbackCommentsError" class="hidden mt-1 text-red-primary">Please add a comment before submitting.</p>
+                    </div>
+                    <input id="feedbackEmail" type="email" class="block mb-4 w-full p-2 rounded border border-gray-500 outline-none focus:ring-violet-primary focus:ring-2" placeholder="Email (optional)" />
+                    <div class="flex gap-2 justify-between">
+                        <a id="docsSubmitFeedback" class="btn btn-primary">Submit</a>
+                        <a id="docsCloseFeedbackLongForm" class="btn btn-secondary">Close</a>
+                    </div>
+                </div>
+                <div id="feedbackSuccess" class="hidden p-5 pt-0">
+                    {{ $problemTitle := printf "Issue with %s" .Permalink }}
+                    {{ $improvementTitle := printf "Improvement for %s" .Permalink }}
+                    <p>Thank you for your feedback!</p>
+                    <p>If you have a question about how to use Pulumi, reach out in <a class="text-violet-primary underline" href="https://slack.pulumi.com/">Community Slack</a>.</p>
+                    <p>
+                        Open an issue on GitHub to
+                        <a class="text-violet-primary underline" href="https://github.com/pulumi/docs/issues/new?title={{ $problemTitle }}">report a problem</a> or
+                        <a class="text-violet-primary underline" href="https://github.com/pulumi/docs/issues/new?title={{ $improvementTitle }}">suggest an improvement</a>.
+                    </p>
+                    <div class="flex justify-end mt-4">
+                        <a id="docsDoneFeedback" class="btn btn-primary">Done</a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/theme/src/scss/_theme.scss
+++ b/theme/src/scss/_theme.scss
@@ -137,6 +137,21 @@
   --color-green-accent: #21c45d;
   --color-green-primary: #1c7d41;
 
+  /* Docs semantic tokens — registered here only so Tailwind v4 generates the
+     `*-docs-*` color utilities (e.g. bg-docs-bg, text-docs-fg, border-docs-border).
+     The light/dark values live on the --docs-* tokens in docs/_docs-theme.scss and
+     are re-declared on body.section-docs so these aliases flip per theme; the :root
+     values here are inert (only docs pages use these utilities). */
+  --color-docs-bg: var(--docs-bg);
+  --color-docs-bg-alt: var(--docs-bg-alt);
+  --color-docs-surface: var(--docs-surface);
+  --color-docs-fg: var(--docs-fg);
+  --color-docs-fg-muted: var(--docs-fg-muted);
+  --color-docs-border: var(--docs-border);
+  --color-docs-card: var(--docs-card);
+  --color-docs-card-border: var(--docs-card-border);
+  --color-docs-link: var(--docs-link);
+
   --font-display: Inter, ui-sans-serif, system-ui, sans-serif;
   --font-body: Inter, ui-sans-serif, system-ui, sans-serif;
   --font-mono: "Monaspace Neon Var", ui-monospace, SFMono-Regular, monospace;

--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -27,6 +27,22 @@ body.section-docs {
     --docs-card-border: var(--color-gray-200);
     --docs-ring: var(--color-violet-700);
 
+    // Re-expose the semantic tokens under Tailwind's --color-* namespace so the
+    // generated utilities (bg-docs-bg, text-docs-fg, border-docs-border, …) resolve
+    // and flip with the theme. This MUST live here, not just in @theme: a --color-*
+    // alias declared only at :root substitutes --docs-* against the (undefined) root
+    // value and never flips. Declared on this element it substitutes the live --docs-*
+    // above — which the dark rule below re-points — so the utilities track both modes.
+    --color-docs-bg: var(--docs-bg);
+    --color-docs-bg-alt: var(--docs-bg-alt);
+    --color-docs-surface: var(--docs-surface);
+    --color-docs-fg: var(--docs-fg);
+    --color-docs-fg-muted: var(--docs-fg-muted);
+    --color-docs-border: var(--docs-border);
+    --color-docs-card: var(--docs-card);
+    --color-docs-card-border: var(--docs-card-border);
+    --color-docs-link: var(--docs-link);
+
     background-color: var(--docs-bg);
     color: var(--docs-fg);
 }
@@ -355,19 +371,41 @@ html[data-theme="dark"] body.section-docs {
         a:hover {
             color: var(--docs-fg);
         }
+    }
 
-        #feedbackLongForm {
-            color: var(--docs-fg-muted);
+    // The feedback dialog is reparented to <body> while open (so its fixed overlay
+    // escapes the sidebar), so it must be matched on its own — not nested under
+    // #docsFeedbackContainer, which it leaves once opened.
+    #feedbackLongForm {
+        color: var(--docs-fg-muted);
 
-            .popup-overlay > div {
-                background-color: var(--docs-card);
-            }
+        .popup-overlay > div {
+            background-color: var(--docs-card);
+        }
 
-            textarea,
-            input {
-                background-color: var(--docs-surface);
-                border-color: var(--docs-border);
-                color: var(--docs-fg);
+        textarea,
+        input {
+            background-color: var(--docs-surface);
+            border-color: var(--docs-border);
+            color: var(--docs-fg);
+        }
+
+        // The required-comment error state is red. Light mode gets this from the
+        // text-red-primary / border-red-primary / focus:ring-red-primary utilities, but
+        // here those lose to the unlayered `p { color }` and `* { border-color }` rules
+        // above, so the red has to be re-asserted at id specificity. Dark uses the
+        // lighter red-300 (#ff9fa4) so it stays legible on the dark card; red-700 reads
+        // as near-black. The ring is scoped to the error class so the default focus
+        // stays violet.
+        #feedbackCommentsError {
+            color: var(--color-red-300);
+        }
+
+        #feedbackAdditionalComments.border-red-primary {
+            border-color: var(--color-red-300);
+
+            &:focus {
+                --tw-ring-color: var(--color-red-300);
             }
         }
     }

--- a/theme/src/ts/docs-feedback.ts
+++ b/theme/src/ts/docs-feedback.ts
@@ -6,19 +6,12 @@ document.addEventListener("DOMContentLoaded", function () {
         container.classList.remove("hidden");
     }
 
-    ["docsFeedbackYes", "docsFeedbackNo"].forEach(function (key) {
-        var answer = key === "docsFeedbackYes" ? "Yes" : "No";
-        var btn = document.getElementById(key);
-        if (btn) {
-            btn.addEventListener("click", function () {
-                var longForm = document.getElementById("feedbackLongForm");
-                if (longForm) {
-                    longForm.classList.remove("hidden");
-                }
-                showAdditionalCommentSection(answer);
-            });
-        }
-    });
+    var longForm = document.getElementById("feedbackLongForm");
+    // While open, the dialog is reparented to <body> so its fixed overlay escapes
+    // any transformed/clipping ancestor in the sidebar. Remember where it lives so
+    // closing can put it back.
+    var longFormHome = longForm?.parentElement;
+    var currentAnswer = "";
 
     function sendFeedbackToSegment(answer, comments, email) {
         var trackingObj = {
@@ -37,54 +30,104 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     }
 
-    function showAdditionalCommentSection(answer) {
-        var feedbackLongForm = document.getElementById("feedbackLongForm");
-        var feedbackLongFormParent = feedbackLongForm?.parentElement;
-        if (feedbackLongForm) {
-            document.body.appendChild(feedbackLongForm);
-        }
-
-        var submitBtn = document.getElementById("docsSubmitFeedback");
-        if (submitBtn) {
-            submitBtn.addEventListener("click", function () {
-                var comments = (document.getElementById("feedbackAdditionalComments") as HTMLTextAreaElement)?.value?.trim() || "";
-                var email = (document.getElementById("feedbackEmail") as HTMLInputElement)?.value?.trim() || "";
-
-                sendFeedbackToSegment(answer, comments, email);
-
-                (document.getElementById("feedbackAdditionalComments") as HTMLTextAreaElement).value = "";
-                (document.getElementById("feedbackEmail") as HTMLInputElement).value = "";
-
-                document.getElementById("feedbackButtons")?.classList.add("hidden");
-                document.getElementById("feedbackLongForm")?.classList.add("hidden");
-                document.getElementById("feedbackThankYou")?.classList.remove("hidden");
-            });
-        }
-
-        var closeBtn = document.getElementById("docsCloseFeedbackLongForm");
-        if (closeBtn) {
-            closeBtn.addEventListener("click", function () {
-                sendFeedbackToSegment(answer, "", "");
-
-                (document.getElementById("feedbackAdditionalComments") as HTMLTextAreaElement).value = "";
-                (document.getElementById("feedbackEmail") as HTMLInputElement).value = "";
-
-                document.getElementById("feedbackButtons")?.classList.add("hidden");
-                document.getElementById("feedbackLongForm")?.classList.add("hidden");
-                document.getElementById("feedbackThankYou")?.classList.remove("hidden");
-
-                if (feedbackLongFormParent && feedbackLongForm) {
-                    feedbackLongFormParent.appendChild(feedbackLongForm);
-                }
-            });
-        }
-
-        window.addEventListener("beforeunload", function () {
-            var longForm = document.getElementById("feedbackLongForm");
-            var feedbackSent = longForm?.classList.contains("hidden");
-            if (!feedbackSent) {
-                sendFeedbackToSegment(answer, "", "");
-            }
-        });
+    function showSuccess(success) {
+        document.getElementById("feedbackForm")?.classList.toggle("hidden", success);
+        document.getElementById("feedbackSuccess")?.classList.toggle("hidden", !success);
     }
+
+    // Toggle the required-comment error state: show/hide the message, red border, and
+    // a red focus ring (swapped in for the default violet only while in the error state).
+    function setCommentError(hasError) {
+        var field = document.getElementById("feedbackAdditionalComments");
+        document.getElementById("feedbackCommentsError")?.classList.toggle("hidden", !hasError);
+        field?.classList.toggle("border-red-primary", hasError);
+        field?.classList.toggle("focus:ring-red-primary", hasError);
+        field?.classList.toggle("focus:ring-violet-primary", !hasError);
+    }
+
+    function openDialog(answer) {
+        if (!longForm) {
+            return;
+        }
+        currentAnswer = answer;
+        showSuccess(false);
+        longForm.classList.remove("hidden");
+        document.body.appendChild(longForm);
+        document.getElementById("feedbackAdditionalComments")?.focus();
+    }
+
+    function closeDialog() {
+        if (!longForm) {
+            return;
+        }
+        longForm.classList.add("hidden");
+        if (longFormHome) {
+            longFormHome.appendChild(longForm);
+        }
+        // Reset for the next time the dialog is opened.
+        var comments = document.getElementById("feedbackAdditionalComments") as HTMLTextAreaElement;
+        var email = document.getElementById("feedbackEmail") as HTMLInputElement;
+        if (comments) {
+            comments.value = "";
+        }
+        if (email) {
+            email.value = "";
+        }
+        setCommentError(false);
+        showSuccess(false);
+    }
+
+    ["docsFeedbackYes", "docsFeedbackNo"].forEach(function (key) {
+        var answer = key === "docsFeedbackYes" ? "Yes" : "No";
+        var btn = document.getElementById(key);
+        if (btn) {
+            btn.addEventListener("click", function () {
+                openDialog(answer);
+            });
+        }
+    });
+
+    // Submit: a comment is required. If it's empty, surface the error and stop;
+    // otherwise record the feedback and show the thank-you message in the dialog.
+    document.getElementById("docsSubmitFeedback")?.addEventListener("click", function () {
+        var commentsField = document.getElementById("feedbackAdditionalComments") as HTMLTextAreaElement;
+        var comments = commentsField?.value?.trim() || "";
+        var email = (document.getElementById("feedbackEmail") as HTMLInputElement)?.value?.trim() || "";
+
+        if (!comments) {
+            setCommentError(true);
+            commentsField?.focus();
+            return;
+        }
+
+        sendFeedbackToSegment(currentAnswer, comments, email);
+        showSuccess(true);
+    });
+
+    // Clear the required-comment error as soon as the user starts typing.
+    document.getElementById("feedbackAdditionalComments")?.addEventListener("input", function () {
+        setCommentError(false);
+    });
+
+    // Close (cancel): record the yes/no vote, then return the widget to its
+    // original state without showing the thank-you message.
+    document.getElementById("docsCloseFeedbackLongForm")?.addEventListener("click", function () {
+        sendFeedbackToSegment(currentAnswer, "", "");
+        closeDialog();
+    });
+
+    // Done: dismiss the post-submit thank-you message.
+    document.getElementById("docsDoneFeedback")?.addEventListener("click", function () {
+        closeDialog();
+    });
+
+    // If the dialog is still on the form (not yet submitted) when the user
+    // navigates away, record the vote so it isn't lost.
+    window.addEventListener("beforeunload", function () {
+        var dialogOpen = longForm && !longForm.classList.contains("hidden");
+        var onForm = !document.getElementById("feedbackForm")?.classList.contains("hidden");
+        if (dialogOpen && onForm && currentAnswer) {
+            sendFeedbackToSegment(currentAnswer, "", "");
+        }
+    });
 });


### PR DESCRIPTION
Fixes the layout issues with the feedback dialog and moves the success message into the dialog. Also fixes dark mode rendering.

---

Fixes #19794, #19795

## What changed

- **Fix the cancel/close bug:** the feedback dialog now reliably returns to its original DOM location and resets its state when closed, so reopening it works correctly (previously canceling left the widget in a broken state).
- **Restructure the dialog flow:** the post-submit "thank you" message is now a panel *inside* the dialog (`#feedbackSuccess`) with a **Done** button, replacing the separate `#feedbackThankYou` block. Submit, Close, and Done now have clearly separated handlers.
- **Require a comment on submit:** the Additional Comments field is now `required`; submitting empty surfaces an inline error message, a red border, and a red focus ring. The error clears as soon as the user starts typing.
- **Reparent-aware lifecycle:** the dialog is moved to `<body>` while open (so its fixed overlay escapes any clipping/transformed sidebar ancestor) and returned to its home element on close. The `beforeunload` vote-recording was updated to match the new open/closed detection.
- **Dark-mode support (docs):**
  - Repainted the docs feedback partial and table-of-contents "request a change" link with semantic `--docs-*` tokens (`text-docs-fg`, `border-docs-border`, `bg-docs-card`, `text-docs-link`, etc.) so they flip with the theme.
  - Registered `--color-docs-*` aliases in `_theme.scss` (so Tailwind v4 generates the `*-docs-*` utilities) and re-declared them on `body.section-docs` in `_docs-theme.scss` so they resolve and flip correctly.
  - Moved the `#feedbackLongForm` dark rules out from under `#docsFeedbackContainer` (the dialog leaves that container when reparented to `<body>`) and added a legible dark treatment for the required-comment error state (`red-300`).
- **UI polish:** dialog heading changed from a styled `<p>` to an `<h3>`, buttons use `btn-primary`/`btn-secondary` in a flex row, and inputs gain a focus ring.

Applied to both the docs (`layouts/partials/docs/feedback.html`) and tutorials (`layouts/partials/tutorials/feedback.html`) feedback partials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)