### PR TITLE
Note that team tokens carry org-wide default permissions

### DIFF
--- a/content/docs/administration/access-identity/access-tokens.md
+++ b/content/docs/administration/access-identity/access-tokens.md
@@ -97,6 +97,10 @@ Team tokens are machine tokens scoped to the resources and permissions of a spec
 
 A team token's effective permissions are the union of all [roles assigned to that team](/docs/administration/access-identity/rbac/teams/), evaluated at the time of each request. If the team's role assignments change — for example, the team is granted access to a new set of stacks — the token's capabilities update automatically without any token recreation. This makes team tokens a good fit for long-lived automation where access needs may evolve over time.
 
+{{% notes type="info" %}}
+In addition to the team's role assignments, a team token also receives your organization's **default Member permissions** — the baseline access configured in [Organization-wide role settings](/docs/administration/access-identity/rbac/roles#organization-wide-role-settings). For example, if your organization's default stack access is set to **Read**, a team token can read every stack in the organization, not just the stacks the team has been granted. Keep this in mind when relying on a team token to scope automation to a single team's resources.
+{{% /notes %}}
+
 As with organization tokens, team token activity is recorded in audit logs with the token's name, keeping actions traceable without exposing individual users.
 
 ### Who can manage team tokens

--- a/content/docs/administration/access-identity/rbac/_index.md
+++ b/content/docs/administration/access-identity/rbac/_index.md
@@ -27,7 +27,7 @@ Roles apply to these kinds of principals in Pulumi Cloud:
 
 - **Users**: Each organization member has exactly one organization role (Admin, Member, Billing Manager, or a custom role).
 - **[Teams](/docs/administration/access-identity/rbac/teams/)**: A team can be granted access two ways — through **roles** and through **entity access** granted directly on specific stacks, environments, and Insights accounts (outside of any role). Members of a team receive the union of the team's roles, its direct entity access grants, and their own user role.
-- **[Team tokens](/docs/administration/access-identity/access-tokens/#team-access-tokens)**: Machine tokens that act on behalf of a team. A team token's permissions are the union of the roles assigned to its team — they are not assigned a role directly.
+- **[Team tokens](/docs/administration/access-identity/access-tokens/#team-access-tokens)**: Machine tokens that act on behalf of a team. A team token's permissions are the union of the roles assigned to its team — they are not assigned a role directly — and they also inherit the organization's default Member permissions configured in [Organization-wide role settings](/docs/administration/access-identity/rbac/roles#organization-wide-role-settings).
 - **[Organization access tokens](/docs/administration/access-identity/access-tokens/#creating-an-organization-access-token)**: Machine tokens that are assigned exactly one role defining the token's permissions across the organization.
 
 ## How permissions accumulate for users


### PR DESCRIPTION
## Description

Documents that **team tokens also carry the organization's default Member permissions** — the baseline access configured in [Organization-wide role settings](/docs/administration/access-identity/rbac/roles#organization-wide-role-settings) — on top of the roles assigned to their team.

Previously the docs described a team token's permissions only as *the union of the roles assigned to that team*, which could mislead a reader scoping automation to a single team's resources (e.g. a team token can read every stack in the org when the org default stack access is set to **Read**).

## Changes

- `content/docs/administration/access-identity/access-tokens.md` — add an `info` note to the "What team tokens can do" section with a concrete example.
- `content/docs/administration/access-identity/rbac/_index.md` — extend the "Team tokens" principal bullet in "Where roles apply" to stay consistent.

## Notes

- Content-only change; `make lint` passes.
- Standard `{{% notes %}}` callout, dark-mode safe.

Fixes #19942

🤖 Generated with [Claude Code](https://claude.com/claude-code)