### PR TITLE
Note edition availability across RBAC docs

### DIFF
--- a/content/docs/administration/access-identity/rbac/_index.md
+++ b/content/docs/administration/access-identity/rbac/_index.md
@@ -14,6 +14,10 @@ menu:
 
 Role-Based Access Control (RBAC) in Pulumi Cloud controls who can access which resources in your organization and what actions they can take. You compose access from reusable building blocks — scopes, permission sets, and roles — and assign it to users, teams, and machine tokens. [Organization-wide role settings](/docs/administration/access-identity/rbac/roles#organization-wide-role-settings) establish the baseline permissions that every member receives by default.
 
+{{% notes "info" %}}
+Pulumi Cloud's configurable RBAC features — custom roles, custom permission sets, teams, and tag-based (ABAC) rules — are only available in the Pulumi Enterprise or Business Critical editions. The built-in roles (Admin, Member, and Billing Manager) and [organization-wide role settings](/docs/administration/access-identity/rbac/roles#organization-wide-role-settings) are available in all editions, including Team. To learn more, see the [pricing page](/pricing/).
+{{% /notes %}}
+
 This model lets you:
 
 - Define precise access levels for each type of resource.

--- a/content/docs/administration/access-identity/rbac/entities.md
+++ b/content/docs/administration/access-identity/rbac/entities.md
@@ -16,6 +16,10 @@ An entity is a Pulumi object that can have [permission sets](/docs/administratio
 
 In Pulumi Cloud's authorization model, we use the term "entity" instead of "resource" to refer to such objects. This is because "resource" already has a specific meaning within Pulumi (referring to cloud infrastructure resources). We use the term "entity" to avoid confusion when discussing authorization.
 
+{{% notes "info" %}}
+Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enterprise or Business Critical editions. To learn more, see the [pricing page](/pricing/).
+{{% /notes %}}
+
 ## Entity types
 
 An entity type is a category of objects that can be protected by the RBAC system. Each entity type has its own set of associated permission sets and is managed independently.

--- a/content/docs/administration/access-identity/rbac/permission-sets.md
+++ b/content/docs/administration/access-identity/rbac/permission-sets.md
@@ -18,6 +18,10 @@ Permission sets in Pulumi Cloud are predefined bundles of [scopes](/docs/adminis
 
 Every permission set belongs to a specific [entity type](/docs/administration/access-identity/rbac/entities#entity-types) (stacks, environments, or insights accounts) and can only include scopes of that same type.
 
+{{% notes "info" %}}
+Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enterprise or Business Critical editions. To learn more, see the [pricing page](/pricing/).
+{{% /notes %}}
+
 ## Default permission sets
 
 Pulumi Cloud provides several default permission sets that you can use to quickly get started:
@@ -59,10 +63,7 @@ These permission sets bundle organization-level (global) scopes. Rather than gra
 
 ## Custom permission sets
 
-{{% notes "info" %}}
-Custom permission sets are only available to organizations using Pulumi Enterprise Edition and Pulumi Business Critical Edition.
-To learn more about editions visit the [pricing page](/pricing/).
-{{% /notes %}}
+### Creating custom permission sets
 
 To create a custom permission set, you must be an organization admin.
 

--- a/content/docs/administration/access-identity/rbac/roles.md
+++ b/content/docs/administration/access-identity/rbac/roles.md
@@ -105,7 +105,7 @@ This group includes a single capability toggle:
 ## Custom roles
 
 {{% notes "info" %}}
-Custom roles are only available to organizations using Pulumi Enterprise Edition and Pulumi Business Critical Edition. To learn more about editions, visit the [pricing page](/pricing/).
+Custom roles are only available in the Pulumi Enterprise or Business Critical editions. Pulumi Enterprise allows up to 25 custom roles; Pulumi Business Critical allows unlimited custom roles. To learn more, see the [pricing page](/pricing/).
 
 The baseline permissions for members who have not been given an explicit custom role are configured in [Organization-wide role settings](#organization-wide-role-settings).
 {{% /notes %}}

--- a/content/docs/administration/access-identity/rbac/scopes.md
+++ b/content/docs/administration/access-identity/rbac/scopes.md
@@ -16,6 +16,10 @@ aliases:
 
 Scopes are the most granular level of access control in Pulumi Cloud's RBAC system. Each scope represents a specific action that can be performed on a resource, such as reading stack configurations or updating environment settings. Scopes are the building blocks of [permission sets](/docs/administration/access-identity/rbac/permission-sets), which are then bundled into [roles](/docs/administration/access-identity/rbac/roles) to create comprehensive access control configurations.
 
+{{% notes "info" %}}
+Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enterprise or Business Critical editions. To learn more, see the [pricing page](/pricing/).
+{{% /notes %}}
+
 ## How Scopes Work
 
 Scopes follow a consistent naming pattern: `object:action`. For example:

--- a/content/docs/administration/access-identity/rbac/scopes/environments.md
+++ b/content/docs/administration/access-identity/rbac/scopes/environments.md
@@ -17,6 +17,10 @@ aliases:
 
 This document defines all the available [scopes](/docs/administration/access-identity/rbac/scopes/) in Pulumi Cloud assignable to specific environments or sets of environments.
 
+{{% notes "info" %}}
+Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enterprise or Business Critical editions. To learn more, see the [pricing page](/pricing/).
+{{% /notes %}}
+
 Note that creating, listing, or restoring environments are organization-level operations, and these scopes can be found in the [organization settings scopes](/docs/administration/access-identity/rbac/scopes/org-settings).
 
 ## Environments

--- a/content/docs/administration/access-identity/rbac/scopes/insights-accounts.md
+++ b/content/docs/administration/access-identity/rbac/scopes/insights-accounts.md
@@ -17,6 +17,10 @@ aliases:
 
 This document defines all the available [scopes](/docs/administration/access-identity/rbac/scopes/) in Pulumi Cloud assignable to specific insights accounts or sets of insights accounts.
 
+{{% notes "info" %}}
+Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enterprise or Business Critical editions. To learn more, see the [pricing page](/pricing/).
+{{% /notes %}}
+
 Note that creating, listing, or restoring insights accounts are organization-level operations, and these scopes can be found in the [organization settings scopes](/docs/administration/access-identity/rbac/scopes/org-settings).
 
 ## Insights Accounts

--- a/content/docs/administration/access-identity/rbac/scopes/org-settings.md
+++ b/content/docs/administration/access-identity/rbac/scopes/org-settings.md
@@ -17,6 +17,10 @@ aliases:
 
 This document defines all the available scopes in Pulumi Cloud, organized by [entity type](/docs/administration/access-identity/rbac/entities#entity-types) and group.
 
+{{% notes "info" %}}
+Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enterprise or Business Critical editions. To learn more, see the [pricing page](/pricing/).
+{{% /notes %}}
+
 ## Agent Pools
 
 | Value | Description |

--- a/content/docs/administration/access-identity/rbac/scopes/stacks.md
+++ b/content/docs/administration/access-identity/rbac/scopes/stacks.md
@@ -17,6 +17,10 @@ aliases:
 
 This document defines all the available [scopes](/docs/administration/access-identity/rbac/scopes/) in Pulumi Cloud assignable to specific stacks or sets of stacks.
 
+{{% notes "info" %}}
+Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enterprise or Business Critical editions. To learn more, see the [pricing page](/pricing/).
+{{% /notes %}}
+
 Note that creating, listing, or restoring stacks are organization-level operations, and these scopes can be found in the [organization settings scopes](/docs/administration/access-identity/rbac/scopes/org-settings).
 
 ## Stacks

--- a/content/docs/administration/access-identity/rbac/teams.md
+++ b/content/docs/administration/access-identity/rbac/teams.md
@@ -16,8 +16,7 @@ aliases:
 ---
 
 {{% notes "info" %}}
-Teams are only available to organizations using Pulumi Enterprise Edition and Pulumi Business Critical Edition.
-To learn more about editions visit the [pricing page](/pricing/).
+Teams are only available in the Pulumi Enterprise or Business Critical editions. To learn more, see the [pricing page](/pricing/).
 {{% /notes %}}
 
 The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users. When your organization has custom roles enabled, teams can also be assigned **roles** (in addition to stack-level permissions), so that members receive the union of the team's roles and their own user role.


### PR DESCRIPTION
Ensures every RBAC documentation page consistently notes which features are limited to specific editions, per #19932. Edition facts are sourced from the [pricing page](/pricing/).

## Changes
- Added/standardized "only available in the Pulumi Enterprise or Business Critical editions" notes across all RBAC pages (`_index`, `scopes` + subpages, `entities`, `permission-sets`, `roles`, `teams`).
- Recorded the custom-role limit in `roles.md`: Enterprise up to 25, Business Critical unlimited.
- Landing page clarifies built-in roles (Admin/Member/Billing Manager) and org-wide role settings remain available in all editions, including Team.
- Removed a now-redundant duplicate note in `permission-sets.md`.

Fixes #19932