### PR TITLE
Call out the Automation API reference on the concepts page

### DIFF
--- a/content/docs/iac/concepts/automation-api.md
+++ b/content/docs/iac/concepts/automation-api.md
@@ -83,7 +83,9 @@ The program's lifecycle must be fully contained within the function, callback, o
 
 Like the rest of Pulumi, Automation API is available in multiple languages, so you can build applications that use it in TypeScript/JavaScript, Python, Go, C#, and Java. Automation API also supports cross-language use, where it runs in a program written in a different language than the Pulumi programs it manages.
 
-|                                                        | Language                                                                | Status |
+Each language has its own Automation API reference documentation. Follow the link in the **API reference** column below to view the reference for your language.
+
+|                                                        | API reference                                                           | Status |
 | ------------------------------------------------------ | ----------------------------------------------------------------------- | ------ |
 | <img src="/logos/tech/logo-ts.png" class="h-10" />     | [TypeScript](/docs/reference/pkg/nodejs/pulumi/pulumi/automation/) | Stable |
 | <img src="/logos/tech/logo-js.png" class="h-10" />     | [JavaScript](/docs/reference/pkg/nodejs/pulumi/pulumi/automation/) | Stable |


### PR DESCRIPTION
## Summary

Makes the per-language Automation API **reference** links explicit on the Automation API concepts page (`/docs/iac/concepts/automation-api/`).

Previously the language names in the "Supported languages" table linked to the per-language API reference, but the column was labeled "Language" — so readers couldn't tell the links went to reference material. This is the exact UX complaint in #11645:

> In the Languages section, the language names link to the reference material, but that defies my expectation. I would have expected a link on TypeScript to go to the TypeScript homepage, and for there to be another column with a link to the reference material.

## Changes

- Relabel the table column from **Language** to **API reference**.
- Add a lead-in sentence pointing readers to that column for their language's reference docs.

Content-only change; link targets are unchanged.

Fixes #11645

🤖 Generated with [Claude Code](https://claude.com/claude-code)