### PR TITLE
Recommend skip-intermediate deployments for high-volume stacks

### DIFF
--- a/content/docs/deployments/concepts/settings.md
+++ b/content/docs/deployments/concepts/settings.md
@@ -211,7 +211,21 @@ This is enabled by skipping the default dependency installation step (under Adva
 
 ## Skipping Intermediate Deployments
 
-By default, when multiple deployments are pushed, they will be executed sequentially until the backlog is completed. In some cases, you may wish to only execute the most recent deployment since the changes are accumulative. By enabling the `Skip intermediate deployments` setting, Pulumi will skip all intermediary deployments of the same type and will execute only the latest.
+By default, when multiple deployments are queued for a stack, Pulumi runs them sequentially until the backlog is cleared. For a stack that receives many pushes in quick succession — for example, a busy shared stack where pull requests merge frequently — this means every intermediate commit gets its own deployment, even though only the final state matters.
+
+{{% notes type="info" %}}
+For high-volume stacks, Pulumi recommends enabling **Skip intermediate deployments** to batch the backlog into a single run. This is the supported best practice for collapsing a queue of rapid-fire deployments; you should not need ad-hoc workarounds such as manually cancelling in-progress deployments.
+{{% /notes %}}
+
+With **Skip intermediate deployments** enabled, whenever a deployment finishes Pulumi skips every queued deployment of the same type except the most recent one, so the stack jumps straight to the latest desired state instead of replaying every commit in between. Because the changes are cumulative, the end result is the same, and you save the deployment minutes and wall-clock time the skipped runs would have consumed.
+
+Enable it from your stack's deployment settings in the Pulumi Cloud UI, or set [`operationContext.options.skipIntermediateDeployments`](/registry/packages/pulumiservice/api-docs/deploymentsettings/) to `true` on the `pulumiservice.DeploymentSettings` resource.
+
+Keep these trade-offs in mind:
+
+- **Only deployments of the same type are consolidated.** Skipping applies per operation type (`update`, `preview`, `destroy`, and so on), so a queued `destroy` is never skipped in favor of an `update`.
+- **You lose the per-commit deployment record.** Skipped commits do not get their own deployment, so you won't have an individual update history or preview for each intermediate change.
+- **The deployment in progress is not interrupted.** Skipping consolidates the *queued* backlog; it does not cancel a deployment that is already running. Stopping a running deployment requires explicitly [cancelling it](/docs/reference/cloud-rest-api/deployments/), which is a dangerous operation that can leave the stack in an inconsistent state.
 
 ## Custom Executor Images
 


### PR DESCRIPTION
Documents the supported best practice for stacks that receive many pushes in quick succession, addressing #19553. Expands the "Skipping Intermediate Deployments" section to lead with the recommendation and explain the setting's behavior and trade-offs.

Research finding: "preempt" and "cancel intermediate" are not real Pulumi Deployments settings (confirmed against the pulumiservice provider schema, REST API, and UI), so they are deliberately not documented as such — "Skip intermediate deployments" is the only real batching control.

## Changes
- Lead with an info callout recommending **Skip intermediate deployments** for high-volume stacks
- Explain what it does, the UI location, and the `operationContext.options.skipIntermediateDeployments` IaC field
- Document trade-offs: same-type-only consolidation, no per-commit deployment record, in-progress run not interrupted (manual cancel only)

Fixes #19553