### PR TITLE
Update Neo code reviews and GitHub App docs for the centralized settings screen

### DIFF
--- a/content/docs/ai/code-reviews/_index.md
+++ b/content/docs/ai/code-reviews/_index.md
@@ -16,10 +16,6 @@ menu:
         identifier: ai-code-reviews
 ---
 
-{{% notes type="info" %}}
-Neo code reviews are currently in public preview and will be generally available on July 1, 2026.
-{{% /notes %}}
-
 Neo code reviews analyze pull requests against what Pulumi Cloud knows about your running infrastructure and leave feedback in the pull request. They read the `pulumi preview` output and, when the GitHub App's [Code access for AI reviews](/docs/integrations/version-control/github-app/#integration-settings) setting is on (the default), the pull request's code changes. Neo comments inline on the specific lines that need attention and does not block the merge.
 
 ## Configuring reviews

--- a/content/docs/ai/code-reviews/_index.md
+++ b/content/docs/ai/code-reviews/_index.md
@@ -20,15 +20,23 @@ menu:
 Neo code reviews are currently in public preview and will be generally available on July 1, 2026.
 {{% /notes %}}
 
-Neo code reviews analyze pull requests against what Pulumi Cloud knows about your running infrastructure and leave feedback in the pull request. They read the `pulumi preview` output and comment inline on the specific lines that need attention. Neo does not block the merge.
+Neo code reviews analyze pull requests against what Pulumi Cloud knows about your running infrastructure and leave feedback in the pull request. They read the `pulumi preview` output and, when the GitHub App's [Code access for AI reviews](/docs/integrations/version-control/github-app/#integration-settings) setting is on (the default), the pull request's code changes. Neo comments inline on the specific lines that need attention and does not block the merge.
 
-## Automated reviews
+## Configuring reviews
 
-By default, Neo reviews every pull request automatically, skipping drafts and pull requests opened by bots.
+Configure how Neo reviews pull requests under **Settings** > **Neo settings** > **Code reviews**. You set organization-wide defaults, and where a repository needs different behavior you add a per-repository override and change the fields that should differ from those defaults.
+
+- **Enable code reviews.** Turn Neo code reviews on or off for the organization, or for a single repository in an override.
+- **Automatically review new pull requests.** Start a review as soon as a pull request is opened, reopened, or marked ready for review. Turn this off to keep reviews on demand.
+- **Review when a label is added.** Name one or more labels that trigger a review when they are applied to a pull request. This works independently of automatic review, so you can review only labeled pull requests.
+- **Ignore draft pull requests.** Skip pull requests that are still in draft. This is on by default, and a draft is reviewed once marked ready for review.
+- **Use Neo integrations.** Let Neo draw on your connected observability, incident, and issue-tracking tools for more context during a review.
+
+Neo reviews a pull request when opened, not on every push. After you push new commits, mention `@pulumi-neo` to request a fresh review. Pull requests opened by bots are skipped.
 
 ## Manual reviews
 
-You can scope Neo to review only when someone mentions `@pulumi-neo`, instead of automatically. Mention it in a pull request description, a review comment (top-level or inline), or an issue, and Neo replies in the same thread. Ask it to walk through what a change does, including resources that change in stacks the pull request does not modify directly.
+Mention `@pulumi-neo` in a pull request description, a review comment (top-level or inline), or an issue, and Neo replies in the same thread. Manual review is always available regardless of the automatic and label settings; use it to request a re-review after pushing new commits. Ask Neo to walk through what a change does, including resources that change in stacks the pull request does not modify directly.
 
 Neo matches your GitHub identity to your Pulumi user. If you signed in to Pulumi with GitHub, that link already exists; otherwise, [link a GitHub identity to your Pulumi account](/docs/administration/organizations-teams/accounts/#adding-new-identities).
 
@@ -40,9 +48,9 @@ Neo code reviews run on GitHub.com. GitHub Enterprise Server is not supported. C
 
 1. Enable [Pulumi Neo](/docs/ai/get-started/#enabling-and-disabling-neo) for your organization.
 1. Install the [Pulumi GitHub App](/docs/integrations/version-control/github-app/) on the repositories you want Neo to analyze.
-1. Confirm Neo code reviews are enabled in your [GitHub App integration settings](/docs/integrations/version-control/github-app/). They're on by default.
+1. Confirm Neo code reviews are enabled under **Settings** > **Neo settings** > **Code reviews**. They're on by default.
 1. Grant Pulumi access to your GitHub account by completing the [individual OAuth flow](/docs/integrations/version-control/github-app/#individual-user-setup) under **Management** > **Version control**.
 
 ## Permissions
 
-Neo code reviews run with the same governance as any other [Neo task](/docs/ai/tasks/), including the [role-based access control](/docs/administration/access-identity/rbac/), guardrails, and audit logging your organization has configured. To turn them off, disable Neo code reviews in your [GitHub App integration settings](/docs/integrations/version-control/github-app/).
+Neo code reviews run with the same governance as any other [Neo task](/docs/ai/tasks/), including the [role-based access control](/docs/administration/access-identity/rbac/), guardrails, and audit logging your organization has configured. To turn them off, or to change how they run, open **Settings** > **Neo settings** > **Code reviews**.

--- a/content/docs/integrations/version-control/github-app.md
+++ b/content/docs/integrations/version-control/github-app.md
@@ -128,11 +128,14 @@ After installing the app, you can configure pull request behavior. Toggle these 
 | Setting | Default | Description |
 |---|---|---|
 | Pull request comments | Enabled | Post deployment status and resource changes as comments on GitHub pull requests |
+| Draft pull request comments | Enabled | Post pull request comments while a pull request is still in draft. When disabled, the comment is held until the pull request is marked ready for review |
 | Neo code reviews | Enabled | Include Neo's AI-generated review of infrastructure changes in pull request comments (requires [Pulumi Neo](/docs/ai/get-started/#enabling-and-disabling-neo) to be enabled for your organization) |
 | Code access for AI reviews | Enabled | Let Neo read pull request code diffs when generating reviews instead of relying on Pulumi engine output alone |
 | Detailed diff for pull request comments | Enabled | Show property-level before/after diffs for changed resources in pull request comments |
 
-Changes save automatically. Neo code reviews and detailed diff require pull request comments to be enabled, and code access for AI reviews requires Neo code reviews. Code access for AI reviews is specific to the GitHub app and appears once the capability is enabled for your organization.
+Changes save automatically. Draft pull request comments, Neo code reviews, and detailed diff require pull request comments to be enabled, and code access for AI reviews requires Neo code reviews. Code access for AI reviews is specific to the GitHub app and appears once the capability is enabled for your organization.
+
+Organizations with [Neo code reviews](/docs/ai/code-reviews/) enabled manage them from **Settings** > **Neo settings** > **Code reviews**, where you set review behavior per organization and per repository. The **Neo code reviews** toggle above does not appear for those organizations; the other settings, including **Pull request comments**, **Code access for AI reviews**, and **Detailed diff for pull request comments**, continue to apply.
 
 To remove an integration, see [Uninstallation](#uninstallation).
 


### PR DESCRIPTION
## What this does

Updates Pulumi Cloud docs to match the shipped Neo code reviews work: the agentic pull-request review path, its centralized settings screen, and the related GitHub App settings.

### Neo code reviews page (`content/docs/ai/code-reviews/_index.md`)
- New **Configuring reviews** section covering the org-level settings screen (**Settings > Neo settings > Code reviews**): enable, automatic-on-open, label triggers, ignore draft pull requests, use Neo integrations, and per-repository overrides.
- Documents that reviews run when a pull request is opened, not on every push, and reframes manual `@pulumi-neo` review as always available and the way to request a re-review.
- **Setup** and **Permissions** now point at the centralized settings screen instead of the GitHub App integration toggle.
- Intro clarified: reviews read the `pulumi preview` output and, when **Code access for AI reviews** is on (the default), the pull request's code changes.

### GitHub App page (`content/docs/integrations/version-control/github-app.md`)
- New **Draft pull request comments** setting row, folded into the dependency note.
- New paragraph pointing organizations on Neo code reviews to the centralized settings screen, noting the per-install Neo toggle is hidden for them.