### PR TITLE
Refresh workshop confirmation page formatting

### DIFF
--- a/content/confirmation/workshop.md
+++ b/content/confirmation/workshop.md
@@ -4,7 +4,8 @@ meta_desc: This page provides confirmation after registering for a Pulumi worksh
 type: page
 layout: confirmation
 
-confirmation_text: Thank you for signing up for a Pulumi workshop! You'll receive a confirmation email shortly. While you're here, see how easy it is to get started using Pulumi below.
+confirmation_heading: Thank you for signing up for a Pulumi workshop!
+confirmation_text: You'll receive a confirmation email shortly. While you're here, see how easy it is to <a class="text-violet-primary underline" href="https://www.pulumi.com/docs/get-started/">get started with Pulumi</a>.
 
 block_external_search_index: true
 ---

--- a/content/confirmation/workshop.md
+++ b/content/confirmation/workshop.md
@@ -5,7 +5,7 @@ type: page
 layout: confirmation
 
 confirmation_heading: Thank you for signing up for a Pulumi workshop!
-confirmation_text: You'll receive a confirmation email shortly. While you're here, see how easy it is to <a class="text-violet-primary underline" href="https://www.pulumi.com/docs/get-started/">get started with Pulumi</a>.
+confirmation_text: You'll receive a confirmation email shortly. While you're here, see how easy it is to <a class="text-violet-primary underline" href="https://app.pulumi.com/signup">get started with Pulumi</a>.
 
 block_external_search_index: true
 ---

--- a/layouts/page/confirmation.html
+++ b/layouts/page/confirmation.html
@@ -1,6 +1,14 @@
 {{ define "hero" }}
-    <header class="container mx-auto text-center py-24">
-        <h4>{{ .Params.confirmation_text }}</h4>
+    <header class="container mx-auto max-w-3xl px-4 pt-24 pb-16">
+        <div class="card text-center p-10">
+            <span class="inline-flex text-violet-primary mb-6">
+                {{ partial "icon.html" (dict "name" "check-circle" "weight" "duotone" "size" "72") }}
+            </span>
+            {{ with .Params.confirmation_heading }}
+                <h1 class="mb-6">{{ . }}</h1>
+            {{ end }}
+            <p class="text-gray-700 text-xl mb-0">{{ .Params.confirmation_text | safeHTML }}</p>
+        </div>
     </header>
 {{ end }}
 


### PR DESCRIPTION
Wrap the confirmation message in a card with a success icon, split the message into a heading and supporting text, and link "get started with Pulumi" from the body copy.

### Proposed changes

Updated the workshop confirmation thank you page. Currently we are directing to a hubspot Pulumi insider subscription form. I am proposing we direct to a thank you confirmation page which currently exists, but needed some formatting updates.

### Unreleased product version (optional)
N/A

### Related issues (optional)
N/A
