### PR TITLE
Stop Vale rule from steering content to the deprecated "Pulumi Service" name

### DIFF
--- a/styles/Pulumi/Nomenclature.yml
+++ b/styles/Pulumi/Nomenclature.yml
@@ -27,7 +27,7 @@ swap:
   '\bPulumi Cli\b': Pulumi CLI
   '\bpulumi sdk\b': Pulumi SDK
   '\bPulumi Sdk\b': Pulumi SDK
-  '\bpulumi service\b': Pulumi Service
-  '\bPulumi service\b': Pulumi Service
+  '\bpulumi service\b': Pulumi Cloud
+  '\bPulumi service\b': Pulumi Cloud
   '\bPulumi Cloud Console\b': Pulumi Cloud console
   '\bPulumi Console\b': Pulumi Cloud console


### PR DESCRIPTION
### Proposed changes

The Vale nomenclature rule in `styles/Pulumi/Nomenclature.yml` was force-correcting `pulumi service` / `Pulumi service` to **`Pulumi Service`** — the pre-2022 name for what is now **Pulumi Cloud**. This is wrong on two counts:

- It steers writers toward a **retired brand name**. The hosted backend (and its provider) were renamed to Pulumi Cloud in 2022; our own content notes this, e.g. "the Pulumi Cloud provider (formerly known as the Pulumi Service provider)" in `content/blog/iac-best-practices-implementing-rbac-and-security/index.md`.
- It **contradicts the style guide it cites.** The rule's message points at `STYLE-GUIDE.md` §Product Names, which lists **Pulumi Cloud** as canonical and never mentions "Pulumi Service."

This rule (added recently) is what drove an automated content review to "correct" prose toward the deprecated name in #19963.

This change redirects the two malformed-casing patterns to **`Pulumi Cloud`** instead. The patterns only match the lowercase `service` forms, so the ~589 existing capitalized "Pulumi Service" occurrences across the repo are **untouched** (no mass rewrite) — only genuinely wrong casing now resolves, and it resolves to the current name.

A broader, opt-in migration of existing "Pulumi Service" → "Pulumi Cloud" is possible as a follow-up but is intentionally out of scope here (it would touch historical blog content and compound names like "Pulumi Service Provider").

### Unreleased product version (optional)

N/A

### Related issues (optional)

Surfaced by the automated content review in #19963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gt82g237JbWtb31bvTPUGP)_