### PR TITLE
Add CNS Munich 2026 talk to Engin Diri's speaker page

### DIFF
--- a/content/community/team/engin-diri.md
+++ b/content/community/team/engin-diri.md
@@ -9,6 +9,10 @@ aliases:
   - /engin
   - /community/community-engineering/engin-diri/
 talks:
+- event: "Cloud Native Summit Munich 2026"
+  title: "The Ralph Wiggum Loop: How Autonomous AI Loops Built My Serverless SaaS While I Slept"
+  url: "https://www.cnsmunich.com/schedule/"
+  date: 2026-06-30T14:20:00.000+02:00
 - event: "ilionx DevDays 2026"
   title: "Beyond pulumi up: A Tour of Pulumi Cloud and the Neo Agent"
   url: "https://www.ilionxdevdays.com/"


### PR DESCRIPTION
Adds Engin Diri's upcoming talk at **Cloud Native Summit Munich 2026** to his speaker page.

- **Event:** Cloud Native Summit Munich 2026 (June 29–30, 2026, smartvillage Bogenhausen)
- **Title:** "The Ralph Wiggum Loop: How Autonomous AI Loops Built My Serverless SaaS While I Slept"
- **When:** Tuesday, June 30, 2026, 14:20–14:50 CEST, Room Barcelona
- **Session:** Confirmed

Entry lands at the top of the newest-first `talks` list.
