### PR TITLE
updated css for registration forms to resize and reposition captcha icon

### DIFF
--- a/theme/src/scss/_hubspot.scss
+++ b/theme/src/scss/_hubspot.scss
@@ -177,6 +177,25 @@
     }
 }
 
+// adjusting the recaptcha position for the event registration form
+.event-single-registration .hs-form {
+    position: relative;
+    padding-bottom: 3.5rem;
+
+    .hs-recaptcha {
+        @apply m-0;
+
+        position: absolute;
+        bottom: 0;
+        right: 0;
+    }
+}
+
+.grecaptcha-badge {
+    transform: scale(0.6);
+    transform-origin: bottom right;
+}
+
 .waitlist-form {
     .hs-field-desc {
         @apply opacity-75 text-xs font-normal my-1;


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Tip: open this PR as a **draft** while you iterate. Automated review
    fires when you mark it ready for review — drafting first keeps the
    review fresh and avoids comment noise.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Updated hubspot scss to resize and relocate the reCAPTCHA icon on the registration forms for workshops. Can test going to the events page and clicking on one. http://www-testing-pulumi-docs-origin-pr-20005-e5fb79ba.s3-website.us-west-2.amazonaws.com/events/autonomous-agents-need-guardrails-openclaw/

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A