### PR TITLE
Make versioned-docs backfills correct and quiet (Python version pin + notify guard)

### DIFF
--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -208,7 +208,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-cli-docs]

--- a/.github/workflows/pulumi-esc-sdk-dotnet-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-dotnet-docs.yml
@@ -215,7 +215,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-esc-sdk-dotnet-docs]

--- a/.github/workflows/pulumi-esc-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-python-docs.yml
@@ -195,7 +195,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-esc-sdk-python-docs]

--- a/.github/workflows/pulumi-esc-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-python-docs.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Generate Pulumi ESC SDK Python docs
         env:
           PACKAGE: pulumi_esc_sdk
+          VERSION: ${{ env.ESC_SDK_VERSION }}
         run: ./scripts/generate_python_docs.sh
       - name: git status
         run: git status && git diff

--- a/.github/workflows/pulumi-esc-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-typescript-docs.yml
@@ -217,7 +217,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-esc-sdk-typescript-docs]

--- a/.github/workflows/pulumi-policy-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-python-docs.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Generate Pulumi Policy SDK Python docs
         env:
           PACKAGE: pulumi_policy
+          VERSION: ${{ env.POLICY_SDK_VERSION }}
         run: ./scripts/generate_python_docs.sh
       - name: git status
         run: git status && git diff

--- a/.github/workflows/pulumi-policy-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-python-docs.yml
@@ -195,7 +195,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-policy-sdk-python-docs]

--- a/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
@@ -213,7 +213,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-policy-sdk-typescript-docs]

--- a/.github/workflows/pulumi-sdk-dotnet-docs.yml
+++ b/.github/workflows/pulumi-sdk-dotnet-docs.yml
@@ -215,7 +215,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-sdk-dotnet-docs]

--- a/.github/workflows/pulumi-sdk-java-docs.yml
+++ b/.github/workflows/pulumi-sdk-java-docs.yml
@@ -214,7 +214,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-sdk-java-docs]

--- a/.github/workflows/pulumi-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-sdk-python-docs.yml
@@ -195,7 +195,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-sdk-python-docs]

--- a/.github/workflows/pulumi-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-sdk-python-docs.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Generate Pulumi Python SDK docs
         env:
           PACKAGE: pulumi
+          VERSION: ${{ env.PULUMI_VERSION }}
         run: ./scripts/generate_python_docs.sh
       - name: git status
         run: git status && git diff

--- a/.github/workflows/pulumi-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-sdk-typescript-docs.yml
@@ -203,7 +203,7 @@ jobs:
             --site "${{ steps.vdocs.outputs.site }}" \
             "${EXTRA[@]}"
   notify:
-    if: failure()
+    if: failure() && github.event.inputs.publish_only != 'true'
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [pull-request, build-pulumi-sdk-typescript-docs]


### PR DESCRIPTION
Two backfill-hygiene fixes surfaced while backfilling the versioned SDK docs to production.

## 1. Pin the SDK version in the Python doc workflows

`pulumi-sdk-python-docs`, `pulumi-policy-sdk-python-docs`, and `pulumi-esc-sdk-python-docs` call `generate_python_docs.sh` without passing `VERSION`, so it `pip install --upgrade`s and documents the **latest** package regardless of the requested version. Harmless for normal releases (requested == latest), but it makes a backfill generate today's SDK for every historical version. Pass each tool's version env so the script pins `PACKAGE==VERSION` — matching how the TS/.NET/Java workflows already check out their source repo at the version tag.

## 2. Don't Slack-notify on backfill build failures

Every doc workflow's `notify` job posts a build-failure message to **docs-ops**. Backfilling an ancient release whose toolchain no longer builds (e.g. pre-1.0 Java SDKs under Gradle 9) is expected and skippable — not worth paging docs-ops. Gate `notify` on `publish_only != 'true'` across all 10 doc workflows so backfills stay quiet; real release failures still notify.

Unblocks the Python versioned-docs backfill and keeps future backfills quiet.