### PR TITLE
Versioned docs backfill: drain-wait race fix + faster stagger; mark rollout done

### DIFF
--- a/scripts/versioned-docs/README.md
+++ b/scripts/versioned-docs/README.md
@@ -94,18 +94,30 @@ live page. Old toolchains that fail to build are skipped, not fixed (they just n
 Edit `static/js/versioned-docs.js` / `.css` and redeploy the site. **Never move** the
 `/js/versioned-docs.js` URL — archived pages reference it forever.
 
-## Production setup checklist (not yet done)
-1. `pulumi up` `infrastructure/versioned-docs/production` (creates the prod bucket + role). This
+## Production setup — DONE (2026-07-01)
+
+Rolled out to `www.pulumi.com` (CloudFront `E3PRSXO1BZJEEY`, bucket
+`pulumi-docs-versioned-production`). The steps below are kept as the record / re-run reference.
+
+1. ✅ `pulumi up` `infrastructure/versioned-docs/production` (creates the prod bucket + role). This
    is the switch: once its outputs exist, release workflows resolve them and start archiving —
    there is no separate enable flag.
-2. Set `www.pulumi.com:versionedDocsStack: "pulumi/pulumi-docs-versioned/production"` in
+2. ✅ Set `www.pulumi.com:versionedDocsStack: "pulumi/pulumi-docs-versioned/production"` in
    `infrastructure/Pulumi.www-production.yaml` (a StackReference to the stack from step 1, so it
    must come second), then let a normal site deploy's `pulumi up www-production` add the origin +
    `/docs/versioned/*` behavior and serve `/js/versioned-docs.js` + `/css/versioned-docs-archive.css`.
-3. Backfill the historical catalog (dispatch the workflows with `target_env=production`,
-   `publish_only=true`, staggered, then `rebuild-manifest.sh`).
-4. Verify: archives serve `max-age=31536000, immutable`, the manifest `max-age=300`, and the
-   existing `/docs/*` + dotnet routes still resolve.
+   (Pre-merge, `pulumi preview www-production` confirmed the change was additive: +1 origin, +1
+   behavior, +2 policies, in-place distribution update, no deletes.)
+3. ✅ Backfill the historical catalog via `backfill.sh` (see §Backfill). Final catalog: 10 tools,
+   ~430 versions. Floors: the pulumi/pulumi trio (pulumi-cli/nodejs/python) at `v3.150.0`; small
+   SDKs all-in (ancient pre-1.0 java/policy/esc + oldest dotnet fail-skip on toolchain age).
+4. ✅ Verified: archives serve `max-age=31536000, immutable`, the manifest `max-age=300`, existing
+   `/docs/*` + dotnet routes still resolve, and every archive is version-faithful (QA-swept).
+
+**Gotcha learned during rollout:** the three Python doc workflows must pass `VERSION` to
+`generate_python_docs.sh` (fixed in PR #20010) or a backfill documents the *latest* package for
+every historical version. The TypeScript/.NET/Java workflows are fine — they check out their
+source repo at the version tag.
 
 ## Tool ids
 `pulumi-cli`, `nodejs`, `nodejs-policy`, `nodejs-esc-sdk`, `python`, `python-policy`,

--- a/scripts/versioned-docs/backfill.sh
+++ b/scripts/versioned-docs/backfill.sh
@@ -29,7 +29,7 @@
 #   --tools "a b c"              subset of tool ids (default: all 10)
 #   --ref REF                    git ref to dispatch workflows from (default: current branch)
 #   --latest TOOL=vX.Y.Z         override the "latest" (live) version for a tool's manifest (repeatable)
-#   --stagger SECONDS            delay between dispatches (default 30)
+#   --stagger SECONDS            delay between dispatches (default 10)
 #   --wait-timeout SECONDS       max time to wait for archives to land (default 3600)
 #   --skip-existing / --no-skip-existing  skip versions already in the target bucket (default: skip)
 #   --dry-run                    print the plan; dispatch/reconcile nothing
@@ -72,7 +72,7 @@ declare -A REPO=(
 )
 
 ENV=""; SOURCE_BASE="https://www.pulumi-test.io"; TOOLS=""; REF=""
-STAGGER=30; WAIT_TIMEOUT=3600; SKIP_EXISTING=true
+STAGGER=10; WAIT_TIMEOUT=3600; SKIP_EXISTING=true
 VERSIONS_FROM="tags"; MIN_VERSION=""; MAX_MINORS=""
 DRY_RUN=false; DISPATCH=true; RECONCILE=true; YES=false
 declare -A LATEST_OVERRIDE=()
@@ -203,6 +203,7 @@ archive_exists() { aws s3api head-object --bucket "$BUCKET" --key "docs/versione
 # 4. Dispatch phase.
 declare -A EXPECT   # "tool/version" -> 1 for everything we expect to land
 if [[ "$DISPATCH" == "true" ]]; then
+  DISPATCH_START_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"   # marks our runs for the drain-wait below
   log "Dispatching workflows (stagger ${STAGGER}s, skip-existing=$SKIP_EXISTING)…"
   for tool in $TOOLS; do
     for v in ${ARCHIVES[$tool]}; do
@@ -231,6 +232,29 @@ if [[ "$DISPATCH" == "true" ]]; then
     [[ "$missing" -eq 0 ]] && { log "  all ${#EXPECT[@]} archives present."; break; }
     [[ "$(date +%s)" -ge "$deadline" ]] && { warn "timeout with $missing not yet landed (may be build failures — skipped, not fixed):$miss_list"; break; }
     log "  $missing/${#EXPECT[@]} still pending; re-checking in 30s…"
+    sleep 30
+  done
+
+  # 5b. Wait for the dispatched workflow RUNS to reach a terminal state before reconciling.
+  # publish-version.sh writes versions.json as its LAST step, but the archive index.html polled
+  # above is synced BEFORE that write — so reconciling the moment archives appear can be clobbered
+  # by a trailing manifest write (observed once: the latest->liveRoot pointer got dropped). Waiting
+  # for the runs to finish makes rebuild-manifest the guaranteed last writer. No live-site impact:
+  # this only defers the single final manifest reconcile.
+  log "Waiting for dispatched workflow runs to finish before reconcile…"
+  declare -A WF_SEEN=(); for tool in $TOOLS; do WF_SEEN["${WORKFLOW[$tool]}"]=1; done
+  drain_deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+  while :; do
+    active=0
+    for wf in "${!WF_SEEN[@]}"; do
+      n=$(gh run list --workflow "$wf" --limit 300 --json status,createdAt \
+            --jq "[.[] | select(.createdAt >= \"$DISPATCH_START_ISO\" and .status != \"completed\")] | length" \
+            2>/dev/null || echo 0)
+      active=$((active + n))
+    done
+    [[ "$active" -eq 0 ]] && { log "  all dispatched runs terminal."; break; }
+    [[ "$(date +%s)" -ge "$drain_deadline" ]] && { warn "timeout with $active run(s) still active; reconciling anyway (re-run --reconcile-only once they finish if the manifest looks short)."; break; }
+    log "  $active dispatched run(s) still active; re-checking in 30s…"
     sleep 30
   done
 fi


### PR DESCRIPTION
Post-rollout follow-up for the versioned SDK/CLI docs backfill driver (`scripts/versioned-docs/backfill.sh`). Both changes were made and battle-tested during the 2026-07-01 production backfill; this lands them on master.

## 1. Wait for dispatched runs to finish before reconciling

`publish-version.sh` writes `versions.json` as its **last** step, but the backfill's wait phase only polled each archive's `index.html` (synced earlier). So the end-of-run `rebuild-manifest` could be **clobbered by a trailing manifest write**, dropping the `latest→liveRoot` pointer (observed once in prod). Add a **drain-wait**: after archives land, wait for the dispatched workflow runs to reach a terminal state, so `rebuild-manifest` is the guaranteed last writer. No live-site impact — it only defers the single final reconcile.

## 2. Faster dispatch stagger (30s → 10s)

At ~100+ dispatches, 30s of stagger added over an hour of pure dispatch delay. 10s is ample against GitHub API pacing; no build-correctness change.

## 3. README: mark production setup done

Flip the "Production setup checklist" to done and record the outcome (dist `E3PRSXO1BZJEEY`, bucket `pulumi-docs-versioned-production`, ~430 versions across 10 tools, floors) plus the Python-workflow version-pin gotcha (fixed separately in #20010).