### PR TITLE
ci: pin production deploy to Pulumi CLI 3.248.0

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -89,8 +89,13 @@ jobs:
           sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
           rm /tmp/vale.tar.gz
 
+      # Pinned to 3.248.0 to work around a bug in 3.249.0 that breaks the
+      # production deploy. Remove this pin (letting the action install the
+      # latest CLI, its default) once 3.250.0 is released.
       - name: Install Pulumi CLI
         uses: pulumi/actions@v7
+        with:
+          pulumi-version: 3.248.0
 
       # Restore previously generated OpenGraph cards so the build-time generator
       # only re-renders pages that changed (manifest content-hash skip). The


### PR DESCRIPTION
### Proposed changes

Pins the production **Build and deploy** workflow (`.github/workflows/build-and-deploy.yml`) to Pulumi CLI **3.248.0** to work around a bug in **3.249.0** that breaks the deploy.

Previously the `Install Pulumi CLI` step used `pulumi/actions@v7` with no `pulumi-version` input, so it always installed the **latest** release. This adds an explicit pin:

```yaml
- name: Install Pulumi CLI
  uses: pulumi/actions@v7
  with:
    pulumi-version: 3.248.0
```

An inline comment documents that this is a temporary workaround to be removed once **3.250.0** ships, at which point the step reverts to installing the latest CLI (the action's default).

Scope note: this pins **production only**, as requested. The same unpinned `pulumi/actions@v7` pattern is also present in the testing deploy (`testing-build-and-deploy.yml`) and PR-preview deploy (`pull-request.yml`) workflows; those are intentionally left unchanged here.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e721ScxsJj8eTG8MRPzZv

---
_Generated by [Claude Code](https://claude.ai/code/session_017e721ScxsJj8eTG8MRPzZv)_