### PR TITLE
Document Neo as an Agent Skills client on the Agent Skills page

### DIFF
--- a/content/docs/ai/skills/index.md
+++ b/content/docs/ai/skills/index.md
@@ -2,7 +2,7 @@
 title: Agent Skills
 title_tag: Pulumi Agent Skills
 h1: Pulumi Agent Skills
-meta_desc: Learn how Pulumi Agent Skills teach AI coding assistants like Claude Code and Cursor to work with Pulumi, and how Pulumi Neo runs them built in.
+meta_desc: Learn how Pulumi Agent Skills teach Claude Code, Cursor, GitHub Copilot, and JetBrains Junie to work with Pulumi. Neo ships with them built in.
 menu:
     ai:
         name: Agent Skills
@@ -28,9 +28,9 @@ Agent Skills are reusable knowledge packages that teach AI coding assistants dom
 
 ## Agent Skills in Neo
 
-Neo is an Agent Skills client. It ships with the Pulumi Agent Skills catalog built in (the same skills published in [pulumi/agent-skills](https://github.com/pulumi/agent-skills)), plus a few Neo-specific skills for Pulumi Cloud workflows.
+Neo is an Agent Skills client. It ships with the Pulumi Agent Skills catalog built in (the same skills published in [pulumi/agent-skills](https://github.com/pulumi/agent-skills)).
 
-Neo follows the [agentskills.io](https://agentskills.io) standard: it reads each skill's `SKILL.md` and shows the model a catalog of skill names and descriptions. When a skill matches the task, Neo loads its full instructions and bundled files. This happens automatically on every request, so you don't need to name a skill to use it, and skills stay loaded through long tasks.
+Neo follows the [agentskills.io](https://agentskills.io) standard: it discovers each skill's `SKILL.md` and loads relevant skills automatically when a task calls for them, so you never need to name a skill yourself.
 
 There is nothing to install or configure. The catalog updates with each Neo release. To add or improve a skill, contribute to the [agent-skills repository](https://github.com/pulumi/agent-skills/blob/main/CONTRIBUTING.md); accepted skills work in Neo and in every other assistant that supports the standard.
 

--- a/content/docs/ai/skills/index.md
+++ b/content/docs/ai/skills/index.md
@@ -2,7 +2,7 @@
 title: Agent Skills
 title_tag: Pulumi Agent Skills
 h1: Pulumi Agent Skills
-meta_desc: Learn how to use Pulumi Agent Skills to teach AI coding assistants like Claude Code, Cursor, GitHub Copilot, and JetBrains Junie how to work with Pulumi.
+meta_desc: Learn how Pulumi Agent Skills teach AI coding assistants like Claude Code and Cursor to work with Pulumi, and how Pulumi Neo runs them built in.
 menu:
     ai:
         name: Agent Skills
@@ -18,12 +18,21 @@ Pulumi Agent Skills are knowledge packages that teach AI coding assistants domai
 
 Agent Skills are reusable knowledge packages that teach AI coding assistants domain-specific workflows. They follow the [agentskills.io](https://agentskills.io) open standard and work with:
 
+- [Pulumi Neo](/docs/ai/) (built in, no installation needed)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
 - [OpenAI Codex](https://openai.com/api/)
 - [Cursor](https://cursor.sh)
 - [GitHub Copilot](https://docs.github.com/en/copilot)
 - [Google Gemini](https://geminicli.com/)
 - [JetBrains Junie](https://www.jetbrains.com/junie/)
+
+## Agent Skills in Neo
+
+Neo is an Agent Skills client. It ships with the Pulumi Agent Skills catalog built in (the same skills published in [pulumi/agent-skills](https://github.com/pulumi/agent-skills)), plus a few Neo-specific skills for Pulumi Cloud workflows.
+
+Neo follows the [agentskills.io](https://agentskills.io) standard: it reads each skill's `SKILL.md` and shows the model a catalog of skill names and descriptions. When a skill matches the task, Neo loads its full instructions and bundled files. This happens automatically on every request, so you don't need to name a skill to use it, and skills stay loaded through long tasks.
+
+There is nothing to install or configure. The catalog updates with each Neo release. To add or improve a skill, contribute to the [agent-skills repository](https://github.com/pulumi/agent-skills/blob/main/CONTRIBUTING.md); accepted skills work in Neo and in every other assistant that supports the standard.
 
 ## Available Skills
 

--- a/content/docs/ai/skills/index.md
+++ b/content/docs/ai/skills/index.md
@@ -26,13 +26,13 @@ Agent Skills are reusable knowledge packages that teach AI coding assistants dom
 - [Google Gemini](https://geminicli.com/)
 - [JetBrains Junie](https://www.jetbrains.com/junie/)
 
-## Agent Skills in Neo
+## How Neo uses Agent Skills
 
 Neo is an Agent Skills client. It ships with the Pulumi Agent Skills catalog built in (the same skills published in [pulumi/agent-skills](https://github.com/pulumi/agent-skills)).
 
 Neo follows the [agentskills.io](https://agentskills.io) standard: it discovers each skill's `SKILL.md` and loads relevant skills automatically when a task calls for them, so you never need to name a skill yourself.
 
-There is nothing to install or configure. The catalog updates with each Neo release. To add or improve a skill, contribute to the [agent-skills repository](https://github.com/pulumi/agent-skills/blob/main/CONTRIBUTING.md); accepted skills work in Neo and in every other assistant that supports the standard.
+You don't need to install or configure anything. The catalog updates with each Neo release. To add or improve a skill, contribute to the [agent-skills repository](https://github.com/pulumi/agent-skills/blob/main/CONTRIBUTING.md); accepted skills work in Neo and in every other assistant that supports the standard.
 
 ## Available Skills
 


### PR DESCRIPTION
### Proposed changes

The Agent Skills page currently presents Pulumi Agent Skills as something for third-party coding assistants only (Claude Code, Cursor, Copilot, etc.). Neo itself discovers and executes these skills — it ships with the pulumi/agent-skills catalog built in, loads each skill's SKILL.md per the agentskills.io standard, and applies relevant skills automatically per request — but the docs never say so.

This PR:

- Adds an "Agent Skills in Neo" section explaining that Neo is an Agent Skills client, how skills are discovered/activated, and that the catalog updates with each Neo release (nothing to install)
- Adds Pulumi Neo to the "work with:" client list (marked built in)
- Updates the meta description to mention Neo

This also unblocks listing Neo on the agentskills.io Client Showcase, which requires a public docs page demonstrating the Skills implementation (their maintainers reject products without one — see agentskills/agentskills CONTRIBUTING.md "Ecosystem Listings & Logo Requests").

### Related issues (optional)

n/a