### PR TITLE
let the esc-action install pulumi

### DIFF
--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -66,18 +66,16 @@ jobs:
     outputs:
       has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@v3
       - name: set the pulumi version
         run: |
           echo "PULUMI_VERSION=${{ github.event.inputs.version || github.event.client_payload.ref }}" >> $GITHUB_ENV
+      - name: Fetch secrets from ESC and install the Pulumi CLI
+        id: esc-secrets
+        uses: pulumi/esc-action@v3
+        with:
+          version: ${{ env.PULUMI_VERSION }}
       - name: checkout docs repo
         uses: actions/checkout@v7
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
-        with:
-          pulumi-version: ${{ env.PULUMI_VERSION }}
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3
         with:

--- a/.github/workflows/pulumi-esc-sdk-dotnet-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-dotnet-docs.yml
@@ -152,8 +152,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:

--- a/.github/workflows/pulumi-esc-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-python-docs.yml
@@ -133,8 +133,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:

--- a/.github/workflows/pulumi-esc-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-esc-sdk-typescript-docs.yml
@@ -154,8 +154,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:

--- a/.github/workflows/pulumi-policy-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-python-docs.yml
@@ -133,8 +133,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:

--- a/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-policy-sdk-typescript-docs.yml
@@ -150,8 +150,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:

--- a/.github/workflows/pulumi-sdk-dotnet-docs.yml
+++ b/.github/workflows/pulumi-sdk-dotnet-docs.yml
@@ -152,8 +152,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:

--- a/.github/workflows/pulumi-sdk-java-docs.yml
+++ b/.github/workflows/pulumi-sdk-java-docs.yml
@@ -151,8 +151,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:

--- a/.github/workflows/pulumi-sdk-python-docs.yml
+++ b/.github/workflows/pulumi-sdk-python-docs.yml
@@ -133,8 +133,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:

--- a/.github/workflows/pulumi-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-sdk-typescript-docs.yml
@@ -140,8 +140,6 @@ jobs:
       # exists - the resolve step reads the bucket/role/distribution from stack outputs and
       # every step below no-ops while they are absent. Runs after commit, continue-on-error,
       # so a publish hiccup never blocks the docs PR.
-      - name: Install Pulumi CLI (for the stack-output lookup below)
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Resolve versioned-docs publish target
         id: vdocs
         env:


### PR DESCRIPTION
We bumped the esc-action to v3 in
https://github.com/pulumi/docs/pull/19988.  That major release started installing the pulumi CLI in `~/.pulumi/bin`, rather than in `~/.pulumi/esc/bin`.  This interferes with
`action-install-pulumi-cli`.

There's no real reason to use `action-install-pulumi-cli` anyway, because it's outdated, and has been subsumed.  So just let the `esc-action` install pulumi and we're good.
