### PR TITLE
Fix versioned-docs dropdown, unpin prod deploy, fix TS SDK docs build

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -89,13 +89,8 @@ jobs:
           sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
           rm /tmp/vale.tar.gz
 
-      # Pinned to 3.248.0 to work around a bug in 3.249.0 that breaks the
-      # production deploy. Remove this pin (letting the action install the
-      # latest CLI, its default) once 3.250.0 is released.
       - name: Install Pulumi CLI
         uses: pulumi/actions@v7
-        with:
-          pulumi-version: 3.248.0
 
       # Restore previously generated OpenGraph cards so the build-time generator
       # only re-renders pages that changed (manifest content-hash skip). The

--- a/.github/workflows/pulumi-sdk-typescript-docs.yml
+++ b/.github/workflows/pulumi-sdk-typescript-docs.yml
@@ -109,7 +109,7 @@ jobs:
       - run: make ensure
         working-directory: docs
       - name: run yarn install in nodejs sdk
-        run: yarn install && yarn run tsc
+        run: npm ci && yarn run tsc
         working-directory: pulumi/sdk/nodejs
       - name: run typedoc
         run: PKGS=pulumi NOBUILD=true ./scripts/run_typedoc.sh

--- a/scripts/versioned-docs/rebuild-manifest.sh
+++ b/scripts/versioned-docs/rebuild-manifest.sh
@@ -9,10 +9,15 @@
 # by semver (not date), no per-version release-date lookup is needed.
 #
 # It lists every docs/versioned/<tool>/v*/ archive prefix and writes a semver-sorted manifest.
-# The live "latest" version (--latest-version) is emitted as a single entry pointing at the
-# liveRoot with latest:true (and excluded from the archive list if it was also archived).
-# Existing per-version dates are preserved when present; otherwise left empty (unused — the
-# UI sorts and labels by version, not date).
+# EVERY version — including the live "latest" (--latest-version) — is emitted pointing at its
+# own immutable /vX/ archive path; the entry matching --latest-version just carries latest:true.
+# The loader (versioned-docs.js baseFor) routes the latest entry to the liveRoot for freshness
+# and every other entry to its archive path, so a version keeps a real archive to fall back to
+# the moment it stops being latest (otherwise the demoted entry would alias the now-newer live
+# docs — the dropdown-serves-wrong-version bug). If the latest version has no archive in the
+# bucket yet, it is still emitted as a liveRoot/latest:true fallback so the selector never loses
+# its live option. Existing per-version dates are preserved when present; otherwise left empty
+# (unused — the UI sorts and labels by version, not date).
 #
 # Usage:
 #   rebuild-manifest.sh --tool pulumi-cli --bucket pulumi-docs-versioned-testing \
@@ -61,9 +66,9 @@ versions_json="$(printf '%s\n' "${ARCHIVES[@]}" | jq -R 'select(length>0)' | jq 
   --arg latest "$LATEST_VERSION" --arg liveRoot "$LIVE_ROOT" --arg vroot "$VERSIONED_ROOT" \
   --argjson existing "$existing" '
   ( ($existing.versions // []) | map({ (.version): (.date // "") }) | add // {} ) as $dates
-  | ( map(select(. != $latest))
-      | map({ version: ., date: ($dates[.] // ""), path: ($vroot + . + "/"), latest: false }) )
-    + [ { version: $latest, date: ($dates[$latest] // ""), path: $liveRoot, latest: true } ]
+  | ( map({ version: ., date: ($dates[.] // ""), path: ($vroot + . + "/"), latest: (. == $latest) }) ) as $entries
+  | ( if ($entries | any(.version == $latest)) then $entries
+      else $entries + [ { version: $latest, date: ($dates[$latest] // ""), path: $liveRoot, latest: true } ] end )
   | sort_by(.version | ltrimstr("v") | (try (split(".") | map(tonumber)) catch [.])) | reverse
 ')"
 


### PR DESCRIPTION
Three fixes tied to the 3.250.0 release.

## 1. TypeScript SDK docs build (was failing every run)
`@opentelemetry/api@1.9.1` ships `.d.ts` using TS-4.5 inline `type` export modifiers (`export { X, type Y }`). The nodejs SDK pins `typescript@3.8.3`, which cannot parse that → `TS1005: ',' expected`. The SDK ships a `package-lock.json` pinning the good `1.9.0`, but the step ran `yarn install`, which ignores the npm lockfile and floats to `1.9.1`. Switched to `npm ci` so the lockfile is honored.

## 2. Unpin the production deploy
Removes the temporary `pulumi-version: 3.248.0` pin in `build-and-deploy.yml` (added in #20035 to work around a `3.249.0` `pulumi preview` hang). The pin comment said to remove it once `3.250.0` shipped — it has.

## 3. Versioned-docs dropdown served the wrong version
Selecting a demoted version (e.g. `3.249.0`) in the version dropdown served the newer live content (`3.250.0`). Root cause: `rebuild-manifest.sh` pointed the current-latest entry at the liveRoot and excluded it from the archive list, so when a new release demoted it, the entry still aliased the (now newer) live docs and no real archive existed. The manifest now homes **every** version — including the current latest — at its own immutable `/vX/` archive path, flagging latest by version match. The client loader already routes the `latest` entry to the liveRoot for freshness, so each version keeps a real archive to fall back to the moment it stops being latest. Falls back to a liveRoot latest entry when the latest has no archive yet.

A follow-up supervised production pass will backfill the missing per-tool archives so the already-demoted versions (`3.249.0` on CLI + Python, plus the latent case on the other tools) resolve to real content.

## Test plan
- [ ] `pulumi-sdk-typescript-docs` workflow_dispatch → green
- [ ] First production `build-and-deploy` after merge → preview/up step completes (no 3.249.0-style hang)
- [ ] After the archive backfill: `/docs/versioned/pulumi-cli/versions.json` entries point at `/vX/` paths; `HEAD /docs/versioned/pulumi-cli/v3.249.0/` → 200 immutable; dropdown lands on real per-version content