### PR TITLE
Declare tmp dependency in @pulumi/eks example programs

### DIFF
--- a/static/programs/aws-eks-cluster-default-typescript/package.json
+++ b/static/programs/aws-eks-cluster-default-typescript/package.json
@@ -6,6 +6,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/eks": "^2.0.0"
+        "@pulumi/eks": "^2.0.0",
+        "tmp": "^0.2.3"
     }
 }

--- a/static/programs/aws-eks-cluster-k8s-canary-typescript/package.json
+++ b/static/programs/aws-eks-cluster-k8s-canary-typescript/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/eks": "^2.0.0",
+        "tmp": "^0.2.3",
         "@pulumi/kubernetes": "^4.0.0"
     }
 }

--- a/static/programs/aws-eks-cluster-node-groups-typescript/package.json
+++ b/static/programs/aws-eks-cluster-node-groups-typescript/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^7.0.0",
-        "@pulumi/eks": "^2.0.0"
+        "@pulumi/eks": "^2.0.0",
+        "tmp": "^0.2.3"
     }
 }

--- a/static/programs/aws-eks-cluster-settings-typescript/package.json
+++ b/static/programs/aws-eks-cluster-settings-typescript/package.json
@@ -6,6 +6,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/eks": "^2.0.0"
+        "@pulumi/eks": "^2.0.0",
+        "tmp": "^0.2.3"
     }
 }

--- a/static/programs/aws-eks-cluster-typescript/package.json
+++ b/static/programs/aws-eks-cluster-typescript/package.json
@@ -8,6 +8,7 @@
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^7.0.0",
         "@pulumi/awsx": "^3.0.0",
-        "@pulumi/eks": "^2.0.0"
+        "@pulumi/eks": "^2.0.0",
+        "tmp": "^0.2.3"
     }
 }

--- a/static/programs/aws-eks-helm-wordpress-typescript/package.json
+++ b/static/programs/aws-eks-helm-wordpress-typescript/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/eks": "^2.0.0",
+        "tmp": "^0.2.3",
         "@pulumi/kubernetes": "^4.0.0"
     }
 }

--- a/static/programs/aws-eks-k8s-configgroup-transform-typescript/package.json
+++ b/static/programs/aws-eks-k8s-configgroup-transform-typescript/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/eks": "^2.0.0",
+        "tmp": "^0.2.3",
         "@pulumi/kubernetes": "^4.0.0"
     }
 }

--- a/static/programs/aws-eks-k8s-configgroup-typescript/package.json
+++ b/static/programs/aws-eks-k8s-configgroup-typescript/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/eks": "^2.0.0",
+        "tmp": "^0.2.3",
         "@pulumi/kubernetes": "^4.0.0"
     }
 }

--- a/static/programs/awsx-ecr-eks-deployment-service-typescript/package.json
+++ b/static/programs/awsx-ecr-eks-deployment-service-typescript/package.json
@@ -8,6 +8,7 @@
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/awsx": "^3.0.0",
         "@pulumi/eks": "^4.0.0",
+        "tmp": "^0.2.3",
         "@pulumi/kubernetes": "^4.0.0"
     }
 }

--- a/static/programs/tf-state-ref-typescript/package.json
+++ b/static/programs/tf-state-ref-typescript/package.json
@@ -7,6 +7,7 @@
     },
     "dependencies": {
         "@pulumi/eks": "^3.9.1",
+        "tmp": "^0.2.3",
         "@pulumi/pulumi": "^3.113.0",
         "@pulumi/terraform": "^6.0.1"
     }


### PR DESCRIPTION
### Proposed changes

`@pulumi/eks`'s compiled runtime calls `require("tmp")` (in `cluster.js` and `cmd/provider/cni.js`), but no published version of `@pulumi/eks` declares `tmp` in its own `dependencies`. It only ever resolved because `tmp` happened to be hoisted into `node_modules` by another package in the dependency tree. The `@pulumi/pulumi@3.250.0` release (2026-07-02) reshuffled the transitive tree so `tmp` no longer resolves, and every `@pulumi/eks` example program began failing at runtime in the nightly **Run Example Code Tests** workflow (`scheduled-test.yml`) with:

```
error: Running program '.../index.ts' failed with an unhandled exception:
Error: Cannot find module 'tmp'
```

The nightly ran green through 2026-07-01 and red on 2026-07-02.

This PR declares `tmp` (`^0.2.3`) explicitly in the `dependencies` of the 10 affected example programs, so resolution no longer depends on hoist luck. It deliberately does **not** change the `@pulumi/eks` or `@pulumi/pulumi` version pins — that is orthogonal, and the undeclared-dependency bug is not specific to a single eks version.

Affected programs (all under `static/programs/`):

1. `aws-eks-cluster-default-typescript`
1. `aws-eks-cluster-k8s-canary-typescript`
1. `aws-eks-cluster-node-groups-typescript`
1. `aws-eks-cluster-settings-typescript`
1. `aws-eks-cluster-typescript`
1. `aws-eks-helm-wordpress-typescript`
1. `aws-eks-k8s-configgroup-transform-typescript`
1. `aws-eks-k8s-configgroup-typescript`
1. `awsx-ecr-eks-deployment-service-typescript`
1. `tf-state-ref-typescript`

Verified locally: after `npm install` in an affected program, `require('tmp')` resolves (`tmp@0.2.7`), including when resolved from within the installed `@pulumi/eks` package directory — the exact context where `cluster.js` / `cni.js` do `require("tmp")`.

### Unreleased product version (optional)

N/A — this only touches example-program dependency declarations, not product docs.

### Related issues (optional)

The real fix belongs upstream: `@pulumi/eks` should declare its own `tmp` dependency. A follow-up issue against [`pulumi/pulumi-eks`](https://github.com/pulumi/pulumi-eks) is planned; this PR is a stopgap to get the nightly example tests green in the meantime.