### PR TITLE
Document plugin auto-install behavior for Automation API

### DIFF
--- a/content/docs/iac/concepts/automation-api.md
+++ b/content/docs/iac/concepts/automation-api.md
@@ -79,6 +79,17 @@ Unlike traditional Pulumi programs, an inline program doesn't require a separate
 
 The program's lifecycle must be fully contained within the function, callback, or closure passed as the inline program. Performing actions outside the scope of the inline program function is unsafe and can lead to unpredictable behavior.
 
+## Plugins
+
+Pulumi providers are distributed as plugins that the engine loads at runtime, separately from the language SDK you import in your program. When you run the CLI, the engine automatically downloads any missing provider plugin before an operation. Automation API drives the same engine, so this behavior is identical: for providers published to the [Pulumi Registry](/registry/), you don't need to install plugins yourself---running `up`, `preview`, or `refresh` downloads them on demand, matching the SDK version your program references.
+
+A `Workspace` still exposes an explicit `installPlugin` method (`install_plugin`, `InstallPlugin`, `InstallPluginAsync`). You need it only in specific cases:
+
+- **Local or parameterized packages** that aren't published to the Registry---such as [`terraform-provider`](/registry/packages/terraform-provider/) or a custom provider---where the engine can't resolve the plugin automatically. See [Using local packages with Automation API](/docs/iac/guides/building-extending/automation-api/#using-local-packages-with-automation-api).
+- **Pinning a specific plugin version** independently of the SDK, or **pre-fetching** plugins ahead of an operation---for example in air-gapped environments or to avoid a download during a timed deployment.
+
+For background on plugins and the [`pulumi plugin`](/docs/iac/cli/commands/pulumi_plugin/) CLI commands that manage them, see [Pulumi packages](/docs/iac/concepts/packages/).
+
 ## Supported languages
 
 Like the rest of Pulumi, Automation API is available in multiple languages, so you can build applications that use it in TypeScript/JavaScript, Python, Go, C#, and Java. Automation API also supports cross-language use, where it runs in a program written in a different language than the Pulumi programs it manages.

--- a/content/docs/iac/guides/building-extending/automation-api.md
+++ b/content/docs/iac/guides/building-extending/automation-api.md
@@ -533,6 +533,8 @@ A `Stack` object operates within the context of a `Workspace`. A `Workspace` is 
 
 ## Configure your provider plugins
 
+Automation API drives the same engine as the CLI, so it downloads any missing provider plugin automatically before an operation---the explicit `installPlugin` call below isn't required for providers published to the [Pulumi Registry](/registry/). It's shown here to pin a specific plugin version; you also need it for [local or parameterized packages](/docs/iac/guides/building-extending/automation-api/#using-local-packages-with-automation-api). See [Plugins](/docs/iac/concepts/automation-api/#plugins) for details.
+
 The AWS plugin also needs configuration. You can provide that configuration just as you would with other Pulumi programs: either through [stack configuration](/docs/concepts/config/) or environment variables. In this tutorial, you'll use the `Stack` object to set the AWS region for the AWS provider plugin.
 
 {{< chooser language "typescript,python,go,csharp,java" >}}


### PR DESCRIPTION
## Summary

Resolves #11727, which asked for docs on managing Pulumi plugins with Automation API. The issue's 2021 premise — that "with the Automation API you are responsible for managing them" — is **outdated**: Automation API drives the same engine as the CLI, so registry provider plugins auto-install on `up`/`preview`/`refresh`. The existing docs' unconditional `installPlugin()` calls made manual management look mandatory when it isn't.

## Changes

- **`content/docs/iac/concepts/automation-api.md`** — new `## Plugins` section explaining plugin-vs-SDK, that registry plugins auto-install, and the narrow cases where `installPlugin` is still needed (local/parameterized packages, version pinning, pre-fetch/air-gapped).
- **`content/docs/iac/guides/building-extending/automation-api.md`** — clarifies "Configure your provider plugins" so the `installPlugin` call reads as optional for registry providers, with cross-links to the concept doc, the local-packages section, and the `pulumi plugin` CLI reference.

## Verification

Ran an inline TypeScript Automation API program (`random` provider) against an **isolated empty plugin cache** with **no `installPlugin` call**:

```
>>> NOT calling installPlugin — relying on engine auto-install
 +  pulumi:pulumi:Stack ... Downloading provider: random
 +  random:index:RandomPet my-pet created
>>> up succeeded. petName = funny-man
```

The engine auto-downloaded the plugin and the update succeeded. A control run with an explicit `installPlugin` also succeeded. Tested with pulumi CLI 3.248.0 / SDK 3.250.0, `@pulumi/random` 4.21.0.

## Follow-up (not in this PR)

The issue also requested a link **from** the `pulumi plugin` CLI pages back to Automation API. Those pages (`content/docs/iac/cli/commands/pulumi_plugin*.md`) are **auto-generated** from `pulumi/pulumi` source, so that direction needs an upstream change and can't land here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #11727