### PR TITLE
Explain how the GitHub App provides GITHUB_TOKEN to deployments

### DIFF
--- a/content/docs/deployments/concepts/settings.md
+++ b/content/docs/deployments/concepts/settings.md
@@ -269,7 +269,7 @@ To confirm dependency caching is working and/or to troubleshoot, check out logs 
 
 By default, there are a set of environment variables set by the process automatically:
 
-- `GITHUB_TOKEN`: Personal Access Token configured when the source is GitHub (unless there is a token configured by the custom environment variables)
+- `GITHUB_TOKEN`: A GitHub access token, set automatically when the deployment's source is a GitHub repository. When the source is connected through the [Pulumi GitHub App](/docs/integrations/version-control/github-app/#github-token-in-deployments), this is a short-lived app installation token scoped to your whole GitHub App installation, not just the source repository; when you configure the source with your own personal access token, that token is used instead. Not set if you provide your own `GITHUB_TOKEN` through custom environment variables. See [GitHub token in deployments](/docs/integrations/version-control/github-app/#github-token-in-deployments) for scope and security details.
 - `PULUMI_ACCESS_TOKEN`: A temporary token with read-write access only to the stack being deployed.
 - `PULUMI_DEPLOY_OIDC_CONFIG`: OIDC configuration provided for the cloud integrations
 - `PULUMI_CI_SYSTEM`: "Pulumi Deployments"

--- a/content/docs/deployments/guides/private-sources.md
+++ b/content/docs/deployments/guides/private-sources.md
@@ -39,6 +39,10 @@ When your program depends on code in another private Git repository — for exam
 
 Because the `insteadOf` rule applies to all of GitHub, a single key with access to every required repository covers multiple private dependencies at once — there is no per-repository configuration to repeat.
 
+{{% notes type="info" %}}
+If the private dependency lives in a repository that your [Pulumi GitHub App](/docs/integrations/version-control/github-app/#github-token-in-deployments) installation can already reach, you may not need an SSH key at all. Deployments from a GitHub-App-connected source automatically receive a `GITHUB_TOKEN` that can clone those repositories; configure Git to authenticate over HTTPS with it instead — for example, `git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"` in your pre-run commands. Use the SSH-key approach above when the dependency is on another host or in a repository outside the app's access.
+{{% /notes %}}
+
 ## Private package feeds
 
 If your dependencies come from a private package registry rather than a Git repository, authenticate to that registry instead of configuring SSH. Provide the registry token as a secret environment variable, then write the appropriate per-language configuration in the **Pre-run commands**:

--- a/content/docs/integrations/version-control/github-app.md
+++ b/content/docs/integrations/version-control/github-app.md
@@ -164,6 +164,18 @@ You can also deploy on git tag pushes — for example, on every `v*` release tag
 
 [Review stacks](/docs/deployments/concepts/review-stacks/) are dedicated cloud environments that get created automatically every time a pull request is opened, powered by Pulumi Deployments. Open a pull request, and Pulumi Deployments will stand up a stack with your changes and add a PR comment with the outputs from your deployment. Merge the PR and Pulumi Deployments will destroy the stack and free up the associated resources.
 
+### GitHub token in deployments
+
+When [Pulumi Deployments](/docs/deployments/) runs a deployment whose source repository is connected through the GitHub app, Pulumi automatically injects a `GITHUB_TOKEN` environment variable into the deployment. Your Pulumi program and [pre-run commands](/docs/deployments/concepts/settings/#pre-run-commands) can use it to authenticate to GitHub — for example, to install a private module or clone another repository — without configuring a token yourself. This is why deploying from a GitHub-connected repository "just works" for GitHub-hosted dependencies.
+
+The value is a short-lived GitHub App installation access token: it is valid for about an hour and re-minted for each deployment. If you instead configured the source with your own personal access token, that token is promoted to `GITHUB_TOKEN` as-is.
+
+{{% notes type="warning" %}}
+The token is **not** limited to the source repository. It carries the full scope of the Pulumi GitHub App installation: every repository you granted the app, with the same permissions the app holds — which include write access to repository contents. In practice a deployment can therefore read from and write to any repository the installation can reach, so treat `GITHUB_TOKEN` as a broadly privileged credential. If you need a narrower credential, set your own `GITHUB_TOKEN` (or another token) through [custom environment variables](/docs/deployments/concepts/settings/#environment-variables); an explicit value always overrides the one Pulumi provides.
+{{% /notes %}}
+
+On GitHub Enterprise Server, Pulumi additionally sets `GH_HOST`, `GITHUB_ENTERPRISE_TOKEN`, and `GH_ENTERPRISE_TOKEN` so the [`gh` CLI](https://cli.github.com/) and other tooling authenticate against your server.
+
 ## CI integration
 
 The GitHub app only requires that your code is hosted on GitHub and that you use pull requests to manage changes. It does not require GitHub Actions — any CI/CD system works, including GitHub Actions, CircleCI, Jenkins, Pulumi Deployments, or any other system.


### PR DESCRIPTION
Explains how the Pulumi GitHub App interacts with Deployments for GitHub tokens, resolving the docs gap in #15597.

## Changes
- **github-app.md**: new "GitHub token in deployments" section — the app auto-injects `GITHUB_TOKEN`, it's a short-lived installation access token scoped to the *whole* app installation (all granted repos, including contents write) rather than just the source repo, refreshed per run, and overridable via custom env vars.
- **settings.md**: corrected the imprecise "Personal Access Token" wording for the auto-set `GITHUB_TOKEN` env var; linked to the new section for scope/security details.
- **private-sources.md**: note that the auto-provided `GITHUB_TOKEN` can clone app-reachable private repos over HTTPS, as an alternative to the SSH-key setup.

Scope and token-type behavior were verified against the pulumi-service source (empty `InstallationTokenOptions{}` → no scope narrowing; app manifest declares `contents: write` among other permissions).

Fixes #15597