### PR TITLE
Add guide: gating Pulumi Deployments with ESC open approvals

### DIFF
--- a/content/docs/deployments/guides/_index.md
+++ b/content/docs/deployments/guides/_index.md
@@ -13,6 +13,7 @@ menu:
 These guides walk through common Pulumi Deployments tasks. Each one is self-contained, so start with whichever matches what you are trying to do.
 
 - [Cloud Credentials](/docs/deployments/guides/cloud-credentials/): Supply the cloud credentials a deployment needs to manage your infrastructure.
+- [Requiring Approval Before a Deployment Runs](/docs/deployments/guides/gated-deployments/): Deployments has no native approval gate; this workaround requires reviewer sign-off using an ESC Open approval.
 - [Customer-Managed Workflow Runners](/docs/deployments/guides/customer-managed-workflow-runners/): Set up and scale self-hosted runner pools.
 - [Custom Images](/docs/deployments/guides/custom-images/): Customize the container image your deployments run in.
 - [Private Sources](/docs/deployments/guides/private-sources/): Give deployments access to private Git repositories and package feeds.

--- a/content/docs/deployments/guides/cloud-credentials.md
+++ b/content/docs/deployments/guides/cloud-credentials.md
@@ -53,3 +53,5 @@ After an OIDC Identity Provider has been configured:
 
 - If you are using Pulumi ESC, ensure that your Pulumi Deployments token has permissions to open any imported Pulumi ESC Environments. For more information, see [Deployment Permissions](/docs/deployments/operations/permissions/)
 - If you are using Pulumi Deployments OIDC, set up your [Deployment Settings](/docs/deployments/concepts/settings/) for your stack to use your OIDC configuration.
+
+Deployments has no native approval gate, but if you want to require reviewer sign-off before a deployment runs, you can work around this by gating the ESC environment that supplies its credentials. See [Requiring Approval Before a Deployment Runs](/docs/deployments/guides/gated-deployments/).

--- a/content/docs/deployments/guides/gated-deployments.md
+++ b/content/docs/deployments/guides/gated-deployments.md
@@ -1,0 +1,99 @@
+---
+title_tag: Requiring Approval Before a Pulumi Deployment Runs
+meta_desc: Pulumi Deployments has no native approval gate. Work around it by requiring reviewer sign-off via an ESC Open approval on the credential environment.
+title: Requiring Deployment Approval
+h1: Requiring Approval Before a Deployment Runs
+menu:
+  deployments:
+    name: Requiring Approval
+    parent: deployments-guides
+    weight: 15
+    identifier: deployments-guides-gated-deployments
+aliases: []
+---
+
+Pulumi Deployments does not currently support gated deployments: there is no built-in, deployment-level approval step that requires a reviewer to sign off before a deployment runs. This guide describes a **workaround** that achieves a similar outcome by gating the *credentials* a deployment needs rather than the deployment itself.
+
+The workaround is to put an [Open approval](/docs/esc/concepts/approvals/#open-approvals) ruleset on the environment that supplies the deployment's cloud credentials through [Pulumi ESC](/docs/esc/). A deployment must *open* that ESC environment to obtain its credentials, and an Open approval ruleset blocks any attempt to open the environment until a reviewer has approved an access grant. With the ruleset in place, the deployment cannot obtain credentials — and therefore cannot run — until someone approves.
+
+{{% notes type="warning" %}}
+This is a workaround, not a native approval gate, and it behaves differently from one in ways you should understand before adopting it:
+
+- **It gates credential access, not the deployment.** The approval mechanism has no awareness that a deployment exists; the deployment simply fails when it can't get credentials.
+- **An ungated run fails — it does not wait.** Without an active grant, the deployment reports an error rather than sitting in a "pending approval" state. See [Run the deployment](#run-the-deployment).
+- **You approve *before* triggering**, within a time-bounded grant window — the reverse of a typical trigger-then-approve gate.
+- **It fits user-initiated deployments best.** Git-push and pull-request deployments need extra setup and can't be gated as cleanly. See the note under [Request and approve access](#request-and-approve-access).
+
+If a native deployment approval gate would serve you better, let us know in [pulumi/pulumi-cloud-requests](https://github.com/pulumi/pulumi-cloud-requests/issues).
+{{% /notes %}}
+
+{{% notes type="info" %}}
+Open approvals in Pulumi ESC are available for organizations using the Enterprise and Business Critical editions. Learn more about editions on the [pricing page](/pricing/).
+{{% /notes %}}
+
+## Prerequisites
+
+1. An ESC environment that already supplies your deployment's cloud credentials. If you haven't set this up yet, see [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/guides/cloud-credentials/).
+1. A deployment whose Pulumi access token has `OPEN` access to that environment (and to any environments it imports transitively). See [Deployment Permissions](/docs/deployments/operations/permissions/#minimum-required-token-permissions).
+1. One or more reviewers who will approve access requests.
+
+## How gating works
+
+Because the gate lives on the credential environment rather than on the deployment, the "approval" is really an approval to open that environment. A deployment on its own would open the credential environment automatically and run without interruption. Adding an Open approval ruleset inserts a required approval before the environment can be opened:
+
+```mermaid
+sequenceDiagram
+    participant R as Requester
+    participant Rev as Reviewer
+    participant ESC as ESC environment
+    participant D as Deployment
+    R->>ESC: Submit open request (reason, duration)
+    Rev->>ESC: Approve and apply → access grant activated
+    R->>D: Trigger deployment (within grant window)
+    D->>ESC: Open environment for credentials
+    ESC-->>D: Credentials returned (grant is active)
+    Note over D: Deployment runs
+```
+
+Without an active access grant, the deployment's attempt to open the environment is denied and the deployment fails. This is what turns the ESC Open approval into a gate on the deployment.
+
+## Add an Open approval ruleset to the credential environment
+
+Configure the ruleset on the environment your deployment opens for credentials:
+
+1. Navigate to the environment in the Pulumi Cloud console.
+1. Open **Settings → Approval Rulesets** and select **Create Ruleset**.
+1. Select **Open** for the **Action**.
+1. Specify the approvers (teams, users, or permissions), the required number of approvals, and whether self-approval is allowed.
+1. Enable the ruleset.
+
+For full details on ruleset options, see [Configuring open approvals](/docs/esc/concepts/approvals/#configuring-open-approvals). Once the ruleset is enabled, any attempt to open the environment without an active access grant — including from a deployment — is denied.
+
+## Request and approve access
+
+Before the deployment can run, an approved access grant must be **active** on the environment for the identity the deployment will run as (see the note under [Run the deployment](#run-the-deployment)).
+
+1. **Submit an open request** for the environment, stating why access is needed and for how long. In the Pulumi Cloud console, open the environment, select **Request Open Access**, and fill in the **Description**, **Access duration**, and **Grant expiration**.
+1. **A reviewer approves the request.** Submitted requests appear in the **Approvals** tab. A reviewer selects **Review changes** and approves.
+1. **Apply the request to activate the grant.** Once the required number of approvals is met, select **Apply changes**. Approval alone does not grant access — the request must be applied, which activates the access grant.
+
+Two time-based controls bound the grant: **Grant expiration** is how long you have to activate the grant after it's approved, and **Access duration** is how long the grant stays valid after the environment is first opened. See [Understanding duration and expiration](/docs/esc/concepts/approvals/#understanding-duration-and-expiration) for details. Trigger the deployment while the grant is active.
+
+{{% notes type="warning" %}}
+An access grant is tied to the identity that opens the environment, and a deployment opens the environment as the identity that started the run:
+
+- **User-initiated** deployments — the console **Deploy** button, the REST API, or `pulumi deployment run` — run with the initiating user's permissions and use that user's grant. Obtain the grant as that user, then trigger the deployment within the grant window. This is the scenario open-approval gating fits best.
+- **Git-push and pull-request** deployments run under an ephemeral stack token that has no way to hold a pre-approved grant, so open approvals can't gate them directly. To gate an automated deployment, configure it with a dedicated [`PULUMI_ACCESS_TOKEN`](/docs/deployments/operations/permissions/#granting-additional-permissions) principal whose access you approve ahead of each run.
+{{% /notes %}}
+
+## Run the deployment
+
+With an approved grant active for the identity the deployment runs as, trigger the deployment (the Pulumi Cloud console **Deploy** button, the REST API, or `pulumi deployment run`). The deployment opens the credential environment, obtains credentials, and runs.
+
+Without an active grant, the deployment does **not** wait for approval — it fails as soon as it tries to open the environment, reporting that approval is required. Obtain the grant first, then run the deployment within its access window.
+
+## Next steps
+
+- [Supplying Cloud Credentials to Pulumi Deployments](/docs/deployments/guides/cloud-credentials/)
+- [Deployment Permissions](/docs/deployments/operations/permissions/)
+- [Approvals in Pulumi ESC](/docs/esc/concepts/approvals/)

--- a/content/docs/deployments/operations/permissions.md
+++ b/content/docs/deployments/operations/permissions.md
@@ -72,6 +72,8 @@ This approach offers several advantages:
 
 For more information on setting up ESC environments, see the [ESC documentation](/docs/esc/).
 
+Deployments has no native approval gate, but to require reviewer sign-off before a deployment runs you can work around this by adding an ESC Open approval ruleset to the environment that supplies its credentials. See [Requiring Approval Before a Deployment Runs](/docs/deployments/guides/gated-deployments/).
+
 You can use ESC with pre-run commands in Deployments by prefixing each command with `pulumi env run`. For example:
 
 ```bash

--- a/content/docs/esc/concepts/approvals.md
+++ b/content/docs/esc/concepts/approvals.md
@@ -115,6 +115,10 @@ If the ruleset requires re-approval when changes are modified, any edits to an a
 
 Open approvals extend Pulumi ESC's approval system to control when environments can be opened (activated). While update approvals govern configuration changes, open approvals enable just-in-time (JIT) access patterns by requiring review and sign-off before users can access an environment's secrets and credentials. Open approvals are useful when you want to grant temporary, auditable access to sensitive environments.
 
+{{% notes type="info" %}}
+Because a Pulumi Deployment opens an ESC environment to obtain its cloud credentials, an Open approval ruleset on that environment gates the deployment: it can't run until a reviewer approves access. Deployments has no native approval gate, so this is a supported workaround. See [Requiring Approval Before a Deployment Runs](/docs/deployments/guides/gated-deployments/) for a step-by-step walkthrough.
+{{% /notes %}}
+
 ### How open approvals work
 
 Open approvals add an additional gate on top of standard permission checks. Users must have `open` permission on an environment and an active access grant to open it.


### PR DESCRIPTION
## What

Adds a step-by-step guide, **Gating Deployments with ESC Approvals**, documenting the supported way to require reviewer sign-off before a Pulumi Deployment runs: place an ESC Open approval ruleset on the environment that supplies the deployment's cloud credentials. Because a deployment must *open* that environment to obtain credentials, the ruleset gates the run. Cross-linked from the ESC Approvals, Cloud Credentials, and Deployment Permissions pages.

Closes #19557

## Verified end-to-end

Against a Business Critical org, using a throwaway env + stack + deployment:

- A gated environment denies `open` without an active, approved **and applied** access grant (`403 … opens must be approved`).
- A Pulumi Deployment opens that environment as the identity that **initiated the run**. With an active grant it succeeds; without one it **fails** — it does not pause and wait.
- Open-approval gating fits **user-initiated** deployments (console **Deploy** / REST API / `pulumi deployment run`). **Git-push/PR** deployments run under an ephemeral stack token that can't hold a pre-approved grant, so they need a dedicated `PULUMI_ACCESS_TOKEN` principal — the guide documents this nuance.

## Related

While verifying, found and filed a CLI bug: `pulumi env open-request` creates the request as an unsubmitted draft, so it can never be approved — pulumi/esc#668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
