### PR TITLE
Show blog post publish date in search results

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -7,6 +7,10 @@
     {{- end -}}
 
     {{- if ne $page.File nil -}}
+        {{- $date := "" -}}
+        {{- if and (eq $page.Section "blog") (not $page.Date.IsZero) -}}
+            {{- $date = $page.Date.Format "Jan 2, 2006" -}}
+        {{- end -}}
         {{-
             $index = $index | append (
                 dict
@@ -16,6 +20,7 @@
                     "href" $page.RelPermalink
                     "params" $page.Params
                     "kind" $page.Kind
+                    "date" $date
                     "ancestors" (after 1 $ancestors)
             )
         -}}

--- a/scripts/search/page.js
+++ b/scripts/search/page.js
@@ -122,6 +122,7 @@ module.exports = {
                     description: item.params.meta_desc,
                     href: item.href,
                     authors: item.params.authors,
+                    date: item.date || undefined,
                     tags: item.params.tags,
                     rank: this.getRank(item),
                     boosted: this.isBoosted(item),

--- a/theme/src/scss/_algolia.scss
+++ b/theme/src/scss/_algolia.scss
@@ -160,7 +160,7 @@
             }
 
             .date {
-                @apply text-gray-600 -mt-2 mb-3;
+                @apply text-gray-600 -mt-1 mb-3;
                 font-size: 0.6875rem;
             }
         }

--- a/theme/src/scss/_algolia.scss
+++ b/theme/src/scss/_algolia.scss
@@ -159,9 +159,11 @@
                 @apply text-xs text-gray-800 leading-relaxed;
             }
 
-            // The blog post publish date.
+            // The blog post publish date. It sits just under the title (which supplies the small
+            // gap above), with a larger gap below so it reads as part of the title, not the summary.
             .date {
-                @apply text-xs text-gray-600 mt-1;
+                @apply text-gray-600 -mt-2 mb-3;
+                font-size: 0.6875rem; // 11px — a touch smaller than the description
             }
         }
     }

--- a/theme/src/scss/_algolia.scss
+++ b/theme/src/scss/_algolia.scss
@@ -159,11 +159,9 @@
                 @apply text-xs text-gray-800 leading-relaxed;
             }
 
-            // The blog post publish date. It sits just under the title (which supplies the small
-            // gap above), with a larger gap below so it reads as part of the title, not the summary.
             .date {
                 @apply text-gray-600 -mt-2 mb-3;
-                font-size: 0.6875rem; // 11px — a touch smaller than the description
+                font-size: 0.6875rem;
             }
         }
     }

--- a/theme/src/scss/_algolia.scss
+++ b/theme/src/scss/_algolia.scss
@@ -158,6 +158,11 @@
             .description {
                 @apply text-xs text-gray-800 leading-relaxed;
             }
+
+            // The blog post publish date.
+            .date {
+                @apply text-xs text-gray-600 mt-1;
+            }
         }
     }
 

--- a/theme/src/ts/algolia/autocomplete.ts
+++ b/theme/src/ts/algolia/autocomplete.ts
@@ -243,12 +243,12 @@ function initAutocomplete(el: HTMLElement) {
                                             ${ labelForTag(item.section) }
                                         </span>
                                     </div>
-                                    <div class="description">
-                                        ${ item.description !== "" && components.Highlight({ hit: item, attribute: "description" }) }
-                                    </div>
                                     ${ item.date
                                         ? html`<div class="date">${ item.date }</div>`
                                         : "" }
+                                    <div class="description">
+                                        ${ item.description !== "" && components.Highlight({ hit: item, attribute: "description" }) }
+                                    </div>
                                 </div>
                             </a>
                         </div>

--- a/theme/src/ts/algolia/autocomplete.ts
+++ b/theme/src/ts/algolia/autocomplete.ts
@@ -9,6 +9,7 @@ interface SearchResultHit {
     ancestors?: string[];
     h1?: string;
     title: string;
+    date?: string;
 }
 
 // CSS selector of the element to convert into an autocomplete control.
@@ -245,6 +246,9 @@ function initAutocomplete(el: HTMLElement) {
                                     <div class="description">
                                         ${ item.description !== "" && components.Highlight({ hit: item, attribute: "description" }) }
                                     </div>
+                                    ${ item.date
+                                        ? html`<div class="date">${ item.date }</div>`
+                                        : "" }
                                 </div>
                             </a>
                         </div>


### PR DESCRIPTION
## What

Adds the blog post publish date to blog results in the search dialog, as requested by folks searching the blog who wanted a date on each result.

Fixes #13801.

Flying a _little_ bit blind here until the `date` field gets added to Algolia (which'll happen on release), but this should look like this once deployed:

<img width="710" height="203" alt="image" src="https://github.com/user-attachments/assets/36eda26b-f121-4e56-ad8e-249822f0c9a8" />

## How

Threads the date through all four layers of the search pipeline, scoped to **blog** hits only (docs/registry/etc. records are unchanged):

- **`layouts/index.json`** — Hugo's search-index JSON now emits a formatted `date` (`Jan 2, 2006`, matching the blog UI) for blog pages that have a non-zero date.
- **`scripts/search/page.js`** — carries `date` onto each Algolia record (`undefined` for non-blog records, keeping them clean).
- **`theme/src/ts/algolia/autocomplete.ts`** — renders the date under the description when a hit has one.
- **`theme/src/scss/_algolia.scss`** — styles it as small muted text. Uses literal Tailwind gray classes that the docs dark-mode block auto-remaps, so it reads correctly in both themes.

## Notes

- The dates appear in the live dialog only **after the Algolia index is regenerated**, which happens in the normal build/deploy pipeline (Hugo produces `public/index.json`, then records are re-uploaded). Existing records won't have the field until then.
- `date` is a display-only attribute — deliberately not added to searchable attributes.
- Verified the theme webpack build compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)