### PR TITLE
Extend FAQPage schema to docs comparison pages (Terraform, OpenTofu, AWS CDK, Crossplane)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -37,8 +37,10 @@ By default (or when `schema_type: auto`), the system automatically determines th
 - type: blog → BlogPosting
 - type: tutorials → HowTo
 - type: webinars → Event
-- type: docs → TechArticle
-- type: what-is → FAQPage (if questions found) or TechArticle (if no questions)
+- type: docs → TechArticle, plus a supplemental FAQPage entity in the same @graph
+  if the page has a "Frequently asked questions" section (H3s ending in `?`)
+- type: what-is → FAQPage (if questions found) or TechArticle (if no questions),
+  plus the same supplemental FAQPage behavior as type: docs
 ```
 
 ### 2. URL Pattern Detection

--- a/layouts/partials/schema/graph-builder.html
+++ b/layouts/partials/schema/graph-builder.html
@@ -38,10 +38,17 @@
   {{ end }}
 {{ end }}
 
-{{/* What-is pages get Article as their main entity; if the page also has an FAQ
-     section, expose it as a FAQPage entity in the same graph under its own @id. */}}
+{{/* What-is and docs pages get Article/TechArticle as their main entity; if the page
+     also has a "Frequently asked questions"-style Q&A section, expose it as a
+     FAQPage entity in the same graph under its own @id. Pages that are themselves
+     the dedicated FAQ page (title/URL contains "faq") are excluded here because
+     main-entity.html already returns FAQPage as their *main* entity, so adding it
+     again here would duplicate it in the @graph. faq-entity.html safely returns an
+     empty dict when no question-shaped headers are found, so this is a no-op for
+     the many docs pages that have no FAQ section. */}}
 {{ $faqPage := dict }}
-{{ if and (eq .Type "what-is") .IsPage }}
+{{ $isDedicatedFaqPage := or (strings.Contains (lower .RelPermalink) "/faq") (strings.Contains (lower .Title) "faq") (strings.Contains (lower .Title) "frequently asked") }}
+{{ if and .IsPage (or (eq .Type "what-is") (eq .Type "docs")) (not $isDedicatedFaqPage) }}
   {{ $faqPage = partial "schema/collectors/faq-entity.html" . }}
   {{ if and $faqPage (ne $faqPage (dict)) }}
     {{ $faqPage = merge $faqPage (dict "@id" "#faq") }}


### PR DESCRIPTION
## What

Extends the site's existing FAQPage schema auto-detection so `type: docs` pages get the same supplemental FAQPage entity that `type: what-is` pages already receive when they have a "Frequently asked questions" section.

## Why

`layouts/partials/schema/graph-builder.html` only called the FAQ collector partial (`faq-entity.html`) for `what-is` pages. But `faq-entity.html` itself is generic — it just scans any page's raw markdown for a `## Frequently asked questions` block with `### ...?` sub-headings and returns an empty dict if none are found. That meant every `docs`-type page with a real, already-written FAQ section was silently missing FAQPage structured data, including the four IaC comparison pages:

- `/docs/iac/comparisons/terraform/` — 7 fully-written Q&As, zero schema
- `/docs/iac/comparisons/opentofu/`
- `/docs/iac/comparisons/aws-cdk/`
- `/docs/iac/comparisons/crossplane/`

These comparison pages are Pulumi's top citation-share content in our AI answer-engine tracking (Terraform comparison alone: 48 citations in the last 28 days, more than any other single docs page) and "pulumi vs terraform" is a Tier 1 SEO/AEO keyword (~720 searches/mo). FAQPage schema is the single highest-leverage structured-data type for both Google rich results and LLM citation probability, per our AEO guidelines — so this class of page not having it at all was the biggest gap I could find today.

## How

One condition in `graph-builder.html`: the FAQ supplement now fires for `what-is` OR `docs` type pages, guarded to skip pages whose title/URL already mark them as the dedicated FAQ page (those get `FAQPage` as their *main* entity already via `main-entity.html`, so re-adding it here would duplicate the entity in the `@graph`). No changes to the parsing logic itself — `faq-entity.html`'s existing, already-safe "return empty dict if no questions found" behavior means this is a no-op for the many `docs` pages that don't have a Q&A section.

`SCHEMA.md` updated to document the new behavior.

## Verification

- Traced `faq-entity.html`'s question-detection logic against the live content of `content/docs/iac/comparisons/terraform/_index.md`: its `## Frequently asked questions` heading followed by 7 `### ...?` sub-headings satisfies the existing (unchanged) H3-ends-in-`?` detection rule, so all 7 will be picked up.
- Confirmed no collision with the dedicated `/docs/iac/faq/` page, which is explicitly excluded by the new guard.
- Hugo isn't available in this sandbox to run a full local build, so I did a manual line-by-line trace of the template logic and the target page's markdown instead; happy to have a maintainer run `hugo server` to double check before merge, or I can iterate further if CI surfaces anything.

---

🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*
