### PR TITLE
blog(iac-tools): 2026 freshness refresh + conversion CTAs on #1 cited page

### DIFF
--- a/content/blog/infrastructure-as-code-tools/index.md
+++ b/content/blog/infrastructure-as-code-tools/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Most Effective Infrastructure as Code (IaC) Tools"
-date: 2025-06-26
+date: 2026-07-05
 draft: false
 meta_desc: "Complete guide to the most effective IaC tools. Compare Pulumi, Terraform, OpenTofu, AWS CDK, and more to find the perfect solution."
 authors:
@@ -17,13 +17,15 @@ tags:
 category: general
 ---
 
-Infrastructure as Code (IaC) has evolved beyond simple automation into a fundamental shift toward applying software engineering practices to infrastructure management. In 2025, leading organizations aren't just provisioning infrastructure—they're treating it as software, complete with testing, version control, code reviews, and continuous integration.
+Infrastructure as Code (IaC) has evolved beyond simple automation into a fundamental shift toward applying software engineering practices to infrastructure management. In 2026, leading organizations aren't just provisioning infrastructure—they're treating it as software, complete with testing, version control, code reviews, and continuous integration.
 
 <!--more-->
 
 As infrastructure complexity grows, teams increasingly seek approaches that provide the same developer productivity tools they use for application development. While template-based and domain-specific language approaches serve many use cases effectively, teams with complex requirements or programming backgrounds often find that general-purpose programming languages offer advantages in testing, abstraction, and collaboration.
 
 This comprehensive guide examines the most effective infrastructure as code tools available today, providing detailed analysis of core IaC platforms, complementary tools, and related technologies through the lens of software engineering best practices. Whether you're starting fresh with IaC or evaluating alternatives to overcome limitations in your current toolchain, we'll help you navigate this complex landscape and choose solutions that truly bring software engineering to infrastructure.
+
+Ready to try one of these approaches yourself? [Get started with Pulumi for free](/docs/install/) and provision your first resource in minutes, or [see Pulumi Neo in action](/product/neo/) to explore how an AI agent can manage infrastructure changes alongside your team.
 
 ## What is Infrastructure as Code?
 
@@ -63,7 +65,7 @@ The shift to IaC tools addresses fundamental challenges that manual infrastructu
 
 This guide covers the following infrastructure as code tools and platforms:
 
-### 10 Most Used IaC Tools in 2025
+### 10 Most Used IaC Tools in 2026
 
 1. **[Pulumi IaC](#1-pulumi)** - Modern IaC with general-purpose programming languages
 2. **[Terraform](#2-terraform)** - BSL-licensed IaC from HashiCorp that uses the HCL domain-specific language
@@ -639,7 +641,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
 License: Proprietary (Google Service)  
 Best For: Google Cloud Platform deployments using Terraform
 
-Google Cloud Infrastructure Manager automates the deployment and management of Google Cloud infrastructure resources using Terraform configurations, representing Google's modern approach to infrastructure as code. Infrastructure Manager replaces Google Cloud Deployment Manager, which will reach end of support on December 31, 2025.
+Google Cloud Infrastructure Manager automates the deployment and management of Google Cloud infrastructure resources using Terraform configurations, representing Google's modern approach to infrastructure as code. Infrastructure Manager replaces Google Cloud Deployment Manager, which reached end of support on December 31, 2025.
 
 Key Features:
 
@@ -1230,7 +1232,7 @@ For AWS-only deployments: CloudFormation provides the deepest native AWS service
 
 For Terraform ecosystem users: OpenTofu provides open-source licensing with Terraform compatibility, while Terraform offers extensive community resources and established workflows.
 
-### Is Terraform still worth learning in 2025?
+### Is Terraform still worth learning in 2026?
 
 Terraform remains a valuable skill and viable choice for many scenarios, though teams should consider their specific needs and long-term goals:
 
@@ -1364,7 +1366,7 @@ The key is choosing tools that provide comprehensive migration support and incre
 
 ## Conclusion: The Evolution of Infrastructure as Code
 
-The infrastructure as code landscape in 2025 reflects a maturing field where different approaches serve different organizational needs and team preferences. The evolution from manual processes to automated infrastructure has branched into multiple viable paths, each with distinct advantages.
+The infrastructure as code landscape in 2026 reflects a maturing field where different approaches serve different organizational needs and team preferences. The evolution from manual processes to automated infrastructure has branched into multiple viable paths, each with distinct advantages.
 
 The Spectrum of Approaches:
 
@@ -1388,4 +1390,4 @@ The Future of Infrastructure:
 
 The industry continues evolving toward treating infrastructure as software, but this transformation takes many forms. Organizations exploring [serverless architectures](/serverless/) and container strategies particularly benefit from programmable infrastructure approaches. Whether through enhanced DSLs, visual design tools, programming languages, or hybrid approaches, the goal remains consistent: enabling teams to manage infrastructure with the same reliability, collaboration, and velocity they expect from modern software development.
 
-For teams ready to embrace programming language-based infrastructure as code, [Get started with Pulumi](/docs/get-started/) to experience how familiar languages and software engineering practices can transform infrastructure management with comprehensive testing, powerful abstractions, and seamless multi-cloud support.
+For teams ready to embrace programming language-based infrastructure as code, [get started with Pulumi for free](/docs/install/) to experience how familiar languages and software engineering practices can transform infrastructure management with comprehensive testing, powerful abstractions, and seamless multi-cloud support. Want to see where infrastructure is headed next? [Explore Pulumi Neo](/product/neo/), the AI agent that proposes changes, runs previews, and opens PRs alongside your team.


### PR DESCRIPTION
## Summary

Quick-win optimization on `/blog/infrastructure-as-code-tools/` — our #1 most-cited page in Profound's IaC category tracking (259 citations, 1.72% citation share trailing 30d) but a page that drove 279 GA sessions and **zero conversions** over the trailing 28 days.

## What changed

1. **2026 freshness refresh** (surgical, not a rewrite): bumped the `date` front-matter field and every in-body "in 2025" / "2025" reference (intro, "10 Most Used IaC Tools" heading, Terraform FAQ heading, conclusion) to 2026. Also corrected the Google Cloud Deployment Manager EOL sentence to past tense, since that end-of-support date (Dec 31, 2025) has now passed.
2. **Conversion CTAs**: added one CTA right after the intro (before it disappears below the fold) and one at the close of the post, both linking to our two highest-converting destinations per GA (`/docs/install/` at 5.71% and `/product/neo/` at 3.20%), replacing the lower-converting `/docs/get-started/` link that was there before.
3. **Canonical diagnosis (no code change needed)**: I went looking for a canonical bug per the card title, but found none. The page has no `canonical_url` front-matter override, so it falls through to the site-wide self-referential default in `layouts/partials/head.html` — which is correct and already live. Per `BLOGGING.md`, `canonical_url` is intentionally reserved for blog posts that announce a docs-documented feature (where the docs page should win); this is an evergreen listicle, so a self-canonical is the right call, not a bug to fix.

## Related finding (not fixed in this PR — flagging for a follow-up)

This post and `/what-is/top-iac-tools/` (our #2 most-cited page, 102 citations) cover near-identical ground — "best/top IaC tools" — and could be cannibalizing each other's ranking and diluting which one LLMs/Google treat as canonical for the query. I did not force a cross-canonical here since that risks deindexing our #1 cited asset without clearer evidence Google has already collapsed the two. Recommend a separate content-strategy pass to differentiate intent (e.g., this post stays the deep buyer's-guide, the `what-is` page becomes a tighter definitional/FAQ page) rather than solving it via canonical tags.

## Testing

Manual review of the diff; sparse checkout of this repo doesn't include the full Hugo toolchain so `make lint`/`make build` weren't run locally — happy to have CI confirm.

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*
