### PR TITLE
blog(why-switch-to-pulumi): refresh AI section for Pulumi Neo

### DIFF
--- a/content/blog/why-switch-to-pulumi/index.md
+++ b/content/blog/why-switch-to-pulumi/index.md
@@ -327,10 +327,10 @@ scalability, and collaboration.
     Cloud. Because that infrastructure is defined in Python, TypeScript, Go, C#, or
     Java rather than a bespoke configuration language, Neo can read, reason about,
     test, and ship it the same way an AI coding agent already handles the rest of
-    your codebase. Terraform, on the other hand, is defined in HCL, a proprietary
-    domain-specific language that AI agents can generate and reason about less
-    reliably than a general-purpose programming language, which is exactly the gap
-    that leads teams to switch.
+    your codebase. Terraform, by contrast, is defined in HCL, a domain-specific
+    configuration language that AI agents can generate and reason about less
+    reliably than a general-purpose programming language — one more reason
+    teams switch.
 
 - **Greater Scalability.** Pulumi embraces software engineering as a
     way to solve and manage the exponentially increasing complexity of

--- a/content/blog/why-switch-to-pulumi/index.md
+++ b/content/blog/why-switch-to-pulumi/index.md
@@ -1,7 +1,8 @@
 ---
 title: "Why Switch to Pulumi for Infrastructure as Code?"
 date: 2024-07-23T19:47:50-07:00
-meta_desc: "Pulumi: the top choice for infrastructure as code. Boost productivity, scale infinitely, and leverage AI to revolutionize infrastructure management."
+updated: 2026-07-05
+meta_desc: "Pulumi: the top choice for infrastructure as code. Boost productivity, scale infinitely, and use Pulumi Neo to automate infrastructure management with AI."
 authors:
     - aaron-kao
 tags:
@@ -14,10 +15,6 @@ social:
     twitter: Why should you switch to Pulumi? This blog post runs through all the reasons by use case, by alternatives, and by benefits.
     linkedin:
 ---
-
-{{< notes type="info" >}}
-Note: This post discusses Pulumi Copilot, which Pulumi Neo has replaced. [Learn about Neo →](/docs/ai/)
-{{< /notes >}}
 
 The cloud promised to revolutionize your business.
 
@@ -59,7 +56,7 @@ infrastructure, development, and security teams.
 infrastructure as code by empowering you with the familiar
 languages and tools you love for application development. While modern
 programming languages have evolved to provide powerful features like AI
-copilots, Intellisense, linting tools, testing frameworks, and CICD
+coding agents, Intellisense, linting tools, testing frameworks, and CICD
 pipelines, infrastructure management has lagged behind, relying on rigid
 scripting languages and error-prone manual processes. Pulumi bridges
 this gap by allowing you to use industry-standard programming
@@ -70,7 +67,7 @@ behind with your IaC tooling.
 
 **Powering the Next Wave.** Pulumi is at the forefront of the industry.
 It helps you embrace the latest practices (e.g., Platform Engineering, GitOps) and
-builds the latest technologies (e.g., AI Copilots) into the core user
+builds the latest technologies (e.g., AI agents like Pulumi Neo) into the core user
 experience. It also helps you build and manage new technology
 paradigms (e.g., AI workloads, LLMs, internal developer platforms).
 
@@ -87,12 +84,12 @@ software engineering to manage infrastructure of this
 modern and immense scale.
 
 **AI-Powered.** Pulumi builds AI into the core infrastructure management
-experience. Pulumi combines the power of large language models with
-semantic understanding of the cloud to unlock greater insights and
-controls over managing cloud infrastructure. Pulumi leverages the
-familiar GPT experience you know, love, and use daily, so
-you can find and take action on any resource in your cloud
-environments.
+experience through Pulumi Neo, an agentic infrastructure engineer that
+understands the real state of your cloud environments and works inside
+your existing workflows. Neo runs multi-step tasks, generates previews
+for approval, and opens pull requests for the changes it proposes, so
+you stay in the loop while it does the legwork of finding and acting on
+any resource in your infrastructure.
 
 ### Ok, but why does this matter enough for me to switch?
 
@@ -121,7 +118,7 @@ infrastructure.\
 provides stability and choice.*
 
 **Increased Productivity.** You expect your tools
-and workflows to keep up with the industry: AI copilots, Intellisense,
+and workflows to keep up with the industry: AI coding agents, Intellisense,
 linting tools, testing frameworks, and CICD pipelines. But most of these
 innovations are just for building applications and services and not for
 infrastructure, configurations, policies, and secrets. Existing
@@ -320,18 +317,20 @@ scalability, and collaboration.
 - **Increased Productivity.** As discussed at the beginning,
     Pulumi's promise is to build in all the
     latest advancements in both the developer and operations experience.
-    When you write Pulumi code, you now have AI copilots that can pair program with you,
+    When you write Pulumi code, you now have AI coding agents that can pair program with you,
     IDEs that have autocompletion and Intellisense squiggles, powerful libraries of low
     level and abstract functions, testing frameworks, code review tools, automated release controls via CICD pipelines, and great software packaging tools. When it
-    comes to managing infrastructure with Pulumi, you also have Pulumi Copilot which combines
-    the best generative AI models available in the industry today with
-    access to your data and actions within Pulumi
-    Cloud. Pulumi Copilot incorporates the context of where you are
-    in the Pulumi Cloud console to easily answer questions about "this
-    stack" or "the latest update" as well as automating cloud tasks.
-    Terraform, on the other hand, has built a proprietary
-    ecosystem that doesn't tap into the latest advancements of how code
-    is written or how infrastructure is managed.
+    comes to managing infrastructure with Pulumi, you also have Pulumi Neo, an agentic
+    infrastructure engineer that works inside your existing workflow: it proposes
+    changes, runs previews, responds to failures, and opens pull requests in tight
+    feedback loops, grounded in the real state of your infrastructure in Pulumi
+    Cloud. Because that infrastructure is defined in Python, TypeScript, Go, C#, or
+    Java rather than a bespoke configuration language, Neo can read, reason about,
+    test, and ship it the same way an AI coding agent already handles the rest of
+    your codebase. Terraform, on the other hand, is defined in HCL, a proprietary
+    domain-specific language that AI agents can generate and reason about less
+    reliably than a general-purpose programming language, which is exactly the gap
+    that leads teams to switch.
 
 - **Greater Scalability.** Pulumi embraces software engineering as a
     way to solve and manage the exponentially increasing complexity of


### PR DESCRIPTION
## What changed

Refreshes `content/blog/why-switch-to-pulumi/index.md` to remove retired **Pulumi Copilot** product references (Copilot has been replaced by **Pulumi Neo**) and rewrite the AI-assistance passages around Neo's actual agentic workflow.

Specifically:

- Removed the top-of-post "this post discusses Pulumi Copilot" caveat note — no longer needed once the body itself is accurate.
- Rewrote the "Increased Productivity" bullet under "Why Pulumi vs. Terraform?" to describe Pulumi Neo (proposes changes, runs previews, responds to failures, opens pull requests, grounded in the real state of your infrastructure in Pulumi Cloud) instead of the retired Copilot product.
- Rewrote the "AI-Powered" paragraph to describe Neo's agentic capabilities instead of a dated "familiar GPT experience" framing.
- Modernized generic "AI copilots" references to "AI coding agents" in three other spots, since Copilot is a specific (retired) Pulumi product name and "AI copilots" reads as a reference to it.
- Reinforced the core positioning angle: because Pulumi infrastructure is defined in real general-purpose languages (Python, TypeScript, Go, C#, Java) rather than a proprietary DSL, AI agents can read, reason about, test, and ship it the same way they already handle the rest of a codebase — this is presented as a fair comparison (Terraform's HCL is described as "harder for agents to reason about reliably," not "lacks testing," since `terraform test` has existed since Terraform 1.6).
- Marked the post `updated: 2026-07-05` per the existing site convention (original `date` frontmatter preserved; `updated` field added, matching precedent in other refreshed posts such as `content/blog/drift-detection/index.md`).
- Lightly refreshed `meta_desc` to mention Pulumi Neo instead of generic "AI."

## Why

Part of an ongoing SEO/AEO content-freshness pass: this post is a bottom-of-funnel comparison piece that AI answer engines and search crawlers actively cite when users ask about switching from Terraform. Leaving a retired product name (Pulumi Copilot) in a heavily-trafficked comparison post erodes both user trust and LLM citation accuracy. Rewriting the AI section around Neo's real, current capabilities keeps the post's strongest argument — "Pulumi speaks real code, which is exactly what makes it AI-agent-ready" — accurate and current for 2026.

## Notes for reviewers

- Byline is unchanged (`aaron-kao`) — no `pulumi-content-team` (or similar) author key exists in `data/team/team/`, and inventing one would break the Hugo author lookup, so the original author was kept rather than substituting an unverified byline.
- No new numeric proof points were added to this post; the existing claims were left as-is except for the Copilot/Neo swap, to minimize fact-check surface area.
- Terraform testing comparison was deliberately kept fair — the old copy implied Terraform lacks testing tooling, which is no longer true (`terraform test` / `.tftest.hcl` since Terraform 1.6). The new copy frames the gap as HCL being harder for AI agents to reason about, not an testing-capability gap.

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*
