### PR TITLE
docs(idp): add copyable Deploy with Pulumi button snippet

### DIFF
--- a/content/docs/idp/integrations/pulumi-button.md
+++ b/content/docs/idp/integrations/pulumi-button.md
@@ -26,6 +26,14 @@ For example, select the `Deploy` button to configure and create a new empty Java
 
 [![Deploy](/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/templates/javascript)
 
+Rather than right-clicking the button to recover its image URL, copy the Markdown snippet below and drop it straight into a README, gist, or blog post:
+
+```markdown
+[![Deploy](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/templates/javascript)
+```
+
+Swap the `template` query parameter for the URL of your own project template to point the button at your repository instead. See [Creating a Pulumi Button](#creating-a-pulumi-button) below for the full Markdown and HTML forms, plus the complete set of button image variants.
+
 To create a _Deploy with Pulumi_ button:
 
  1. Include optional template metadata in your `Pulumi.yaml`.
@@ -66,16 +74,18 @@ After you've verified your project template works as expected, you can add a but
 Here's an example in Markdown:
 
 ```markdown
-[![Deploy](/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/aws-js-s3-folder)
+[![Deploy](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/aws-js-s3-folder)
 ```
 
 Or, the equivalent HTML:
 
 ```html
 <a href="https://app.pulumi.com/new?template=https://github.com/pulumi/examples/aws-js-s3-folder">
-  <img src="/images/deploy-with-pulumi/dark.svg" alt="Deploy">
+  <img src="https://www.pulumi.com/images/deploy-with-pulumi/dark.svg" alt="Deploy">
 </a>
 ```
+
+Use the fully qualified image URL, as shown above, rather than a relative path — a relative path only resolves on pulumi.com and renders as a broken image once the snippet is pasted into a README hosted elsewhere.
 
 ### Button Image
 

--- a/content/docs/idp/integrations/pulumi-button.md
+++ b/content/docs/idp/integrations/pulumi-button.md
@@ -85,7 +85,7 @@ Or, the equivalent HTML:
 </a>
 ```
 
-Use the fully qualified image URL, as shown above, rather than a relative path — a relative path only resolves on pulumi.com and renders as a broken image once the snippet is pasted into a README hosted elsewhere.
+Use the fully qualified image URL rather than a relative path — a relative path only resolves on pulumi.com and renders as a broken image once the snippet is pasted into a README hosted elsewhere.
 
 ### Button Image
 


### PR DESCRIPTION
## What

Adds a ready-to-copy Markdown snippet directly beneath the intro "Deploy with Pulumi" button example, so a reader can grab the exact source for that button without right-clicking the rendered image to find its URL. It also fixes the existing "Creating a Pulumi Button" example snippets, which used relative image paths (`/images/deploy-with-pulumi/dark.svg`) that only resolve on pulumi.com — once copied into a README hosted elsewhere, the button image renders broken. Those snippets now use the fully qualified `https://www.pulumi.com/...` URL, matching the pattern already used correctly in the "Button Image" reference list further down the page.

## Why

Fixes #12057. The reporter noted that producing a button snippet required right-clicking the rendered button to recover its image URL and hand-crafting the Markdown link, a step that's easy to get wrong. This change surfaces the snippet directly, and closes a related gap where even the page's existing example snippets would have broken once copied outside pulumi.com.

## Verification

- Confirmed both the button SVG URL and the `app.pulumi.com/new?template=...` target URL return `200`.
- Verified the YAML front matter still parses and all fenced code blocks remain balanced.
- Reviewed the rendered diff for correctness; no other content on the page was touched.

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*
