### PR TITLE
docs(iac): add proof points and answer-first intro to Terraform comparison

### DIFF
--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -153,7 +153,7 @@ Yes. [Pulumi Cloud as a Terraform state backend](/docs/iac/get-started/terraform
 
 ## Next steps
 
-- [Get started with Pulumi](/docs/iac/get-started/)
-- [Pulumi terms and command equivalents for Terraform users](/docs/iac/comparisons/terraform/terminology/)
-- [Pulumi vs. OpenTofu](/docs/iac/comparisons/opentofu/)
-- [OpenTofu vs. Terraform](/docs/iac/comparisons/terraform/opentofu/)
+* [Get started with Pulumi](/docs/iac/get-started/)
+* [Pulumi terms and command equivalents for Terraform users](/docs/iac/comparisons/terraform/terminology/)
+* [Pulumi vs. OpenTofu](/docs/iac/comparisons/opentofu/)
+* [OpenTofu vs. Terraform](/docs/iac/comparisons/terraform/opentofu/)

--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -20,9 +20,9 @@ aliases:
 - /docs/iac/concepts/vs/terraform/
 ---
 
-Pulumi and [HashiCorp Terraform](https://developer.hashicorp.com/terraform) are both declarative infrastructure as code tools with overlapping capabilities and several meaningful differences. Pulumi lets you define infrastructure in general-purpose languages (Python, TypeScript, JavaScript, Go, .NET, Java, or YAML) and supports any cloud or SaaS provider through the [Pulumi Registry](/registry/); Terraform uses [HashiCorp Configuration Language (HCL)](https://developer.hashicorp.com/terraform/language) with HashiCorp's provider ecosystem.
+Pulumi and Terraform are both infrastructure as code tools for provisioning and managing cloud resources declaratively. The core difference: Pulumi uses general-purpose languages (Python, TypeScript, Go, .NET, Java, or YAML) across any cloud or SaaS provider, while [HashiCorp Terraform](https://developer.hashicorp.com/terraform) uses its own domain-specific language, [HCL](https://developer.hashicorp.com/terraform/language), with HashiCorp's provider ecosystem.
 
-This page covers what each tool is, a feature-by-feature comparison, the most important differences in detail, and the available paths for adopting Pulumi alongside or instead of Terraform.
+This page covers what each tool is, a feature-by-feature comparison, real-world results from teams that have adopted Pulumi, the most important differences in detail, and the available paths for adopting Pulumi alongside or instead of Terraform.
 
 ## What is Pulumi?
 
@@ -51,6 +51,14 @@ Terraform is an infrastructure as code tool created by HashiCorp (acquired by IB
 | Policy as code | [Pulumi Policies](/docs/insights/policy/) — open source, with rules written in Python, TypeScript, or Open Policy Agent Rego; Pulumi Cloud commercial plans add centralized policy management plus [Pulumi-maintained policy packs](/docs/insights/policy/policy-packs/pre-built-packs/) for compliance frameworks like CIS, HITRUST, NIST, and PCI DSS | [Sentinel](https://developer.hashicorp.com/sentinel) (proprietary, HCP Terraform / Enterprise only) and Open Policy Agent |
 | Open source | Yes — [Apache License 2.0](https://github.com/pulumi/pulumi/blob/master/LICENSE) | No — [Business Source License 1.1](https://github.com/hashicorp/terraform/blob/main/LICENSE) |
 | Commercial option | [Pulumi Cloud](/docs/iac/guides/basics/pulumi-cloud-vs-oss/) | HCP Terraform / Terraform Enterprise |
+
+## Real-world results
+
+These figures come from Pulumi's own published customer case studies, not independent third-party benchmarks. Terraform has a comparably large base of production users, and its longer incumbency in the IaC market means a larger catalog of community modules and provider maturity exists today than for any single alternative, Pulumi included.
+
+* **[Starburst](/case-studies/starburst/)** replaced Terraform with Pulumi for its multi-region Kubernetes deployments and cut deployment time from two weeks to about three hours — a 112x improvement — by replacing hand-maintained HCL glue scripts with [Automation API](/docs/iac/concepts/automation-api/)-driven orchestration written in Java.
+* **[Wiz](/case-studies/wiz/)** uses Pulumi's Automation API to manage over one million cloud resources across thousands of Kubernetes clusters worldwide, handling hundreds of thousands of infrastructure updates daily.
+* **[BMW](/case-studies/bmw/)**'s Software Factory manages 20,000+ cloud resources with Python-based infrastructure code integrated into its existing CI/CD workflows.
 
 ## Key differences
 


### PR DESCRIPTION
## Summary

Refreshes the Pulumi vs. Terraform comparison page (`/docs/iac/comparisons/terraform/`) with a stronger, answer-first intro and a new "Real-world results" section citing published customer proof points. Part of the recurring technical/on-page SEO optimization pass — this is a refresh of existing content, not new authoring.

## Changes

- **Answer-first intro**: rewrote the opening paragraph to lead with a direct definition of what each tool is in the first ~49 words (was previously a single dense sentence that buried the core distinction). This follows the GEO/AEO best practice of front-loading the direct answer so LLM answer engines can extract and cite it cleanly.
- **New "Real-world results" section** (placed right after the feature comparison table, before "Key differences"): three proof points pulled from Pulumi's own published case studies —
  - [Starburst](https://www.pulumi.com/case-studies/starburst/): 112x faster deployments (two weeks → ~3 hours) after replacing Terraform/HCL glue scripts with Pulumi's Automation API.
  - [Wiz](https://www.pulumi.com/case-studies/wiz/): 1M+ cloud resources managed across thousands of Kubernetes clusters, hundreds of thousands of infra updates daily.
  - [BMW](https://www.pulumi.com/case-studies/bmw/): 20,000+ cloud resources managed with Python-based IaC.
- **Fairness caveat**: added a sentence up front noting these are Pulumi's own published figures (not independent benchmarks) and that Terraform has a comparably large production install base and a longer-established module/provider ecosystem. Keeping the page fair and non-one-sided is deliberate — LLM answer engines are less likely to cite comparison content that reads as pure marketing.

## Verification

- All three stats checked against the live, current Pulumi case-study pages at time of writing (not secondary blog mentions), matching the wording used in each case study verbatim where practical.
- Word count on the new intro's first two sentences: 49 words (within the 40–60 word answer-first target).
- No changes to frontmatter, aliases, or existing FAQ section — this is a targeted content refresh only.

## Byline

Pulumi Content Team

---
🧠 *This PR was created by [workprentice](https://github.com/workprentice) on behalf of @joeduffy.*
