### PR TITLE
Add author bylines to IaC comparison pages for entity-authority schema

### DIFF
--- a/content/docs/iac/comparisons/_index.md
+++ b/content/docs/iac/comparisons/_index.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi Compared to Alternatives"
+authors: ["joe-duffy"]
 meta_desc: Learn how Pulumi compares with alternative infrastructure as code solutions that may share overlapping capabilities.
 title: Comparisons
 h1: Compare Pulumi to other solutions

--- a/content/docs/iac/comparisons/arm-templates.md
+++ b/content/docs/iac/comparisons/arm-templates.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. ARM Templates"
+authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. ARM Templates: Pulumi is a multi-cloud IaC platform in general-purpose languages; ARM Templates and Bicep are Azure-only declarative templates."
 title: ARM Templates
 h1: Pulumi vs. ARM Templates

--- a/content/docs/iac/comparisons/aws-cdk.md
+++ b/content/docs/iac/comparisons/aws-cdk.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. AWS CDK"
+authors: ["joe-duffy"]
 meta_desc: "Compare Pulumi and AWS CDK: language support, multi-cloud coverage, state, secrets, policy, and migration paths. Neutral, side-by-side, with adoption guidance."
 title: AWS CDK
 h1: Pulumi vs. AWS CDK

--- a/content/docs/iac/comparisons/cdktf.md
+++ b/content/docs/iac/comparisons/cdktf.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. CDKTF"
+authors: ["joe-duffy"]
 meta_desc: "Compare Pulumi and CDK for Terraform (CDKTF, deprecated December 2025): language support, providers, state, secrets, and migration paths — side-by-side."
 title: CDKTF
 h1: Pulumi vs. CDKTF

--- a/content/docs/iac/comparisons/chef-puppet-etc.md
+++ b/content/docs/iac/comparisons/chef-puppet-etc.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Chef, Puppet, Ansible, and Salt"
+authors: ["joe-duffy"]
 meta_desc: Learn about the major differences between Pulumi and configuration management tools like Chef, Puppet, Ansible, Salt, and more.
 title: Chef & Puppet
 h1: Chef, Puppet, Ansible, & Salt vs Pulumi

--- a/content/docs/iac/comparisons/cloud-sdks.md
+++ b/content/docs/iac/comparisons/cloud-sdks.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Cloud SDKs (AWS Boto)"
+authors: ["joe-duffy"]
 meta_desc: Learn about the major differences between Pulumi and cloud SDKs like AWS Boto and more.
 title: Cloud SDKs
 h1: Pulumi vs. AWS Boto and Cloud SDKs

--- a/content/docs/iac/comparisons/cloudformation.md
+++ b/content/docs/iac/comparisons/cloudformation.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. AWS CloudFormation"
+authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. AWS CloudFormation: Pulumi is a multi-cloud IaC tool in general-purpose languages; CloudFormation is AWS-only with JSON/YAML templates."
 title: AWS CloudFormation
 h1: Pulumi vs. AWS CloudFormation

--- a/content/docs/iac/comparisons/crossplane.md
+++ b/content/docs/iac/comparisons/crossplane.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Crossplane"
+authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. Crossplane: Pulumi is a multi-language IaC platform; Crossplane is a Kubernetes-native control plane for managing cloud infrastructure."
 title: Crossplane
 h1: Pulumi vs. Crossplane

--- a/content/docs/iac/comparisons/custom.md
+++ b/content/docs/iac/comparisons/custom.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Custom IaC Solutions"
+authors: ["joe-duffy"]
 meta_desc: Learn about the major differences between Pulumi and custom infrastructure as code solutions.
 title: Custom Solutions
 h1: Pulumi vs custom infra-as-code solutions

--- a/content/docs/iac/comparisons/helm.md
+++ b/content/docs/iac/comparisons/helm.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Helm"
+authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. Helm: Pulumi is multi-cloud IaC in general-purpose languages; Helm is a Kubernetes-only package manager. Many teams use them together."
 title: Helm
 h1: Pulumi vs. Helm

--- a/content/docs/iac/comparisons/k8s-yaml-dsls.md
+++ b/content/docs/iac/comparisons/k8s-yaml-dsls.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Kubernetes YAML Manifests"
+authors: ["joe-duffy"]
 meta_desc: "How Pulumi compares to Kubernetes YAML Manifests: a multi-cloud IaC platform in general-purpose languages versus Kubernetes' native declarative config format."
 title: Kubernetes YAML Manifests
 h1: Pulumi vs. Kubernetes YAML Manifests

--- a/content/docs/iac/comparisons/opentofu.md
+++ b/content/docs/iac/comparisons/opentofu.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. OpenTofu"
+authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. OpenTofu: Pulumi is a multi-cloud IaC platform in general-purpose languages; OpenTofu is a Linux Foundation Terraform fork that uses HCL."
 title: OpenTofu
 h1: Pulumi vs. OpenTofu

--- a/content/docs/iac/comparisons/serverless.md
+++ b/content/docs/iac/comparisons/serverless.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Serverless Framework"
+authors: ["joe-duffy"]
 meta_desc: "Compare Pulumi and the Serverless Framework: a multi-cloud IaC platform in general-purpose languages versus an AWS-focused tool for deploying Lambda apps."
 title: Serverless Framework
 h1: Pulumi vs. Serverless Framework

--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Terraform"
+authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. Terraform: Pulumi uses general-purpose languages (Python, TypeScript, Go) across any cloud; Terraform uses HCL with HashiCorp's providers."
 title: Terraform
 h1: Pulumi vs. Terraform

--- a/content/docs/iac/comparisons/terraform/opentofu.md
+++ b/content/docs/iac/comparisons/terraform/opentofu.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "OpenTofu vs. Terraform"
+authors: ["joe-duffy"]
 meta_desc: Compare and contrast OpenTofu and Terraform across key features. Learn how they differ and why many teams are migrating to Pulumi.
 title: OpenTofu vs. Terraform
 h1: OpenTofu vs. Terraform

--- a/content/docs/iac/comparisons/terraform/terminology.md
+++ b/content/docs/iac/comparisons/terraform/terminology.md
@@ -1,5 +1,6 @@
 ---
 title_tag: "Pulumi vs. Terraform: Terminology and Commands"
+authors: ["joe-duffy"]
 meta_desc: Many of the terms you may know from working with Terraform have direct equivalents in Pulumi. Here is a list of common terms and how they relate to Pulumi.
 title: Pulumi equivalents
 h1: Pulumi terms & command equivalents


### PR DESCRIPTION
## What

Adds `authors: ["joe-duffy"]` frontmatter to all 16 pages under `content/docs/iac/comparisons/` (Pulumi vs. Terraform, AWS CDK, CDKTF, CloudFormation, Crossplane, Helm, ARM Templates, Chef/Puppet/config-management, cloud SDKs, serverless, k8s YAML DSLs, and the comparisons landing page).

## Why

None of these pages had an `authors` field, so the existing schema partial (`layouts/partials/schema/collectors/article-entity.html`) fell back to attributing authorship to the generic Pulumi Organization entity instead of a named Person. Per Pulumi's GEO/AEO strategy, named author entities with `sameAs` social-profile links raise LLM/AI-system trust signals, and comparison pages are exactly the content type answer engines cite most when responding to evaluative queries like "Pulumi vs. Terraform" or "Terraform alternatives" — Tier 1/2 keywords with the strongest LLM-citation opportunity.

This is a content-only change. No template edits were required: `layouts/partials/schema/utils/author-entities.html` already builds a full `Person` entity (jobTitle, worksFor, `sameAs` from social profiles, canonical `/authors/<slug>/` URL) from any slug present in `data/team/team/*.toml`. This mechanism is already live and working for `/what-is/` pages with declared authors — this PR just extends the same data-driven pattern to the comparisons section, which was the highest-leverage un-covered page type for entity authority given its OpenAI/LLM citation volume.

I picked `joe-duffy` (Pulumi co-founder/CEO) as author of record for this batch since these are foundational, technical/architectural comparison pages. Confirmed the slug resolves via `data/team/team/joe-duffy.toml` (github, linkedin, x social profiles present, so `sameAs` will populate correctly).

## Validation

- Confirmed via `layouts/partials/schema/collectors/main-entity.html` that `.Type "docs"` routes through `article-entity.html`, which calls `author-entities.html` against `.Params.authors` — the exact mechanism this PR feeds.
- Parsed all 16 edited files' YAML frontmatter with `PyYAML` to confirm valid syntax and the correct `authors: ["joe-duffy"]` value landed on every file.
- Diffed each file to confirm only the intended single line was added, with no stray indentation or formatting damage.
- Did not run a full local Hugo build — the site's asset pipeline (icon sprites, CSS, OpenAPI spec fetch) requires `make ensure`/npm steps beyond this session's scope; CI (`pull-request.yml` / `build-and-deploy.yml`) will do the authoritative build and link checks.

## Scope note

This is a **technical SEO / schema** change (entity authority for AEO), not new content authoring — it fits my daily technical-SEO-only mandate. No prose, positioning, or comparison-page copy was touched.

---
🧠 *This PR was created by [workprentice](https://github.com/workprentice) on behalf of @joeduffy.*
