### PR TITLE
Add Floqer (RB2B) visitor identification, consent-gated, on high-intent pages

### DIFF
--- a/content/case-studies/_index.md
+++ b/content/case-studies/_index.md
@@ -1,4 +1,5 @@
 ---
+include_floqer: true
 title: Case Studies
 description: See how our customers are using Pulumi to solve complex, real-world infrastructure challenges at scale.
 meta_desc: |

--- a/content/case-studies/_index.md
+++ b/content/case-studies/_index.md
@@ -1,9 +1,9 @@
 ---
-include_floqer: true
 title: Case Studies
 description: See how our customers are using Pulumi to solve complex, real-world infrastructure challenges at scale.
 meta_desc: |
     See how our customers are using Pulumi to solve complex, real-world infrastructure challenges at scale.
+include_floqer: true
 
 aliases:
     - /case-studies/lykke/

--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -2,9 +2,9 @@
 title_tag: "Pulumi vs. Terraform"
 authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. Terraform: Pulumi uses general-purpose languages (Python, TypeScript, Go) across any cloud; Terraform uses HCL with HashiCorp's providers."
-include_floqer: true
 title: Terraform
 h1: Pulumi vs. Terraform
+include_floqer: true
 menu:
     iac:
         name: Terraform

--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -1,8 +1,8 @@
 ---
-include_floqer: true
 title_tag: "Pulumi vs. Terraform"
 authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. Terraform: Pulumi uses general-purpose languages (Python, TypeScript, Go) across any cloud; Terraform uses HCL with HashiCorp's providers."
+include_floqer: true
 title: Terraform
 h1: Pulumi vs. Terraform
 menu:

--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -1,4 +1,5 @@
 ---
+include_floqer: true
 title_tag: "Pulumi vs. Terraform"
 authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. Terraform: Pulumi uses general-purpose languages (Python, TypeScript, Go) across any cloud; Terraform uses HCL with HashiCorp's providers."

--- a/content/docs/iac/comparisons/terraform/opentofu.md
+++ b/content/docs/iac/comparisons/terraform/opentofu.md
@@ -1,4 +1,5 @@
 ---
+include_floqer: true
 title_tag: "OpenTofu vs. Terraform"
 authors: ["joe-duffy"]
 meta_desc: Compare and contrast OpenTofu and Terraform across key features. Learn how they differ and why many teams are migrating to Pulumi.

--- a/content/docs/iac/comparisons/terraform/opentofu.md
+++ b/content/docs/iac/comparisons/terraform/opentofu.md
@@ -2,9 +2,9 @@
 title_tag: "OpenTofu vs. Terraform"
 authors: ["joe-duffy"]
 meta_desc: Compare and contrast OpenTofu and Terraform across key features. Learn how they differ and why many teams are migrating to Pulumi.
-include_floqer: true
 title: OpenTofu vs. Terraform
 h1: OpenTofu vs. Terraform
+include_floqer: true
 menu:
     iac:
         name: OpenTofu vs. Terraform

--- a/content/docs/iac/comparisons/terraform/opentofu.md
+++ b/content/docs/iac/comparisons/terraform/opentofu.md
@@ -1,8 +1,8 @@
 ---
-include_floqer: true
 title_tag: "OpenTofu vs. Terraform"
 authors: ["joe-duffy"]
 meta_desc: Compare and contrast OpenTofu and Terraform across key features. Learn how they differ and why many teams are migrating to Pulumi.
+include_floqer: true
 title: OpenTofu vs. Terraform
 h1: OpenTofu vs. Terraform
 menu:

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -1,4 +1,5 @@
 ---
+include_floqer: true
 title: Pricing
 meta_desc: Pulumi IaC and Pulumi ESC are available in various editions and are free to individuals
 type: page

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -1,9 +1,9 @@
 ---
 title: Pricing
 meta_desc: Pulumi IaC and Pulumi ESC are available in various editions and are free to individuals
-include_floqer: true
 type: page
 layout: pricing
+include_floqer: true
 menu:
     header:
         weight: 2

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -1,7 +1,7 @@
 ---
-include_floqer: true
 title: Pricing
 meta_desc: Pulumi IaC and Pulumi ESC are available in various editions and are free to individuals
+include_floqer: true
 type: page
 layout: pricing
 menu:

--- a/content/product/_index.md
+++ b/content/product/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Unified Platform for Infrastructure Teams – Pulumi
 meta_desc: Build, deploy, and manage cloud infrastructure faster. Write code in any language, automate with AI, and enforce governance at scale.
-include_floqer: true
 meta_image: /images/product/overview/overview-meta.png
 type: page
 layout: product-page
+include_floqer: true
 
 aliases:
   - /product/pulumi-cloud/

--- a/content/product/_index.md
+++ b/content/product/_index.md
@@ -1,7 +1,7 @@
 ---
-include_floqer: true
 title: Unified Platform for Infrastructure Teams – Pulumi
 meta_desc: Build, deploy, and manage cloud infrastructure faster. Write code in any language, automate with AI, and enforce governance at scale.
+include_floqer: true
 meta_image: /images/product/overview/overview-meta.png
 type: page
 layout: product-page

--- a/content/product/_index.md
+++ b/content/product/_index.md
@@ -1,4 +1,5 @@
 ---
+include_floqer: true
 title: Unified Platform for Infrastructure Teams – Pulumi
 meta_desc: Build, deploy, and manage cloud infrastructure faster. Write code in any language, automate with AI, and enforce governance at scale.
 meta_image: /images/product/overview/overview-meta.png

--- a/content/product/infrastructure-as-code.md
+++ b/content/product/infrastructure-as-code.md
@@ -1,7 +1,7 @@
 ---
-include_floqer: true
 title: "Infrastructure as code in Any Language – Pulumi IaC"
 meta_desc: Write infrastructure code using TypeScript, Python, Go, .NET, Java, or YAML. Deploy to any cloud with built-in previews and testing.
+include_floqer: true
 meta_image: /images/product/infrastructure-as-code/iac-meta.png
 type: page
 layout: product-page

--- a/content/product/infrastructure-as-code.md
+++ b/content/product/infrastructure-as-code.md
@@ -1,4 +1,5 @@
 ---
+include_floqer: true
 title: "Infrastructure as code in Any Language – Pulumi IaC"
 meta_desc: Write infrastructure code using TypeScript, Python, Go, .NET, Java, or YAML. Deploy to any cloud with built-in previews and testing.
 meta_image: /images/product/infrastructure-as-code/iac-meta.png

--- a/content/product/infrastructure-as-code.md
+++ b/content/product/infrastructure-as-code.md
@@ -1,10 +1,10 @@
 ---
 title: "Infrastructure as code in Any Language – Pulumi IaC"
 meta_desc: Write infrastructure code using TypeScript, Python, Go, .NET, Java, or YAML. Deploy to any cloud with built-in previews and testing.
-include_floqer: true
 meta_image: /images/product/infrastructure-as-code/iac-meta.png
 type: page
 layout: product-page
+include_floqer: true
 aliases:
   - /product/iac
   - /product/pulumi-iac

--- a/content/product/neo.md
+++ b/content/product/neo.md
@@ -1,4 +1,5 @@
 ---
+include_floqer: true
 title: "Pulumi Neo - Your AI Infrastructure Agent"
 layout: product-page
 type: page

--- a/content/product/neo.md
+++ b/content/product/neo.md
@@ -15,8 +15,8 @@ aliases:
 
 meta_title: "Pulumi Neo - Your AI Platform Engineer"
 meta_desc: "Meet Neo, your AI platform engineer. Automate infrastructure provisioning, governance, and optimization with enterprise controls."
-include_floqer: true
 meta_image: /images/product/neo/neo-meta.png
+include_floqer: true
 
 sections:
   - type: hero

--- a/content/product/neo.md
+++ b/content/product/neo.md
@@ -1,5 +1,4 @@
 ---
-include_floqer: true
 title: "Pulumi Neo - Your AI Infrastructure Agent"
 layout: product-page
 type: page
@@ -16,6 +15,7 @@ aliases:
 
 meta_title: "Pulumi Neo - Your AI Platform Engineer"
 meta_desc: "Meet Neo, your AI platform engineer. Automate infrastructure provisioning, governance, and optimization with enterprise controls."
+include_floqer: true
 meta_image: /images/product/neo/neo-meta.png
 
 sections:

--- a/content/product/secrets-management.md
+++ b/content/product/secrets-management.md
@@ -1,10 +1,10 @@
 ---
 title: "Centralized Configuration & Secrets Management – Pulumi ESC"
 meta_desc: Centralize secrets and configurations with Pulumi ESC. Connect any vault, eliminate secrets sprawl, secure every environment.
-include_floqer: true
 meta_image: /images/product/secrets-management/esc-meta.png
 type: page
 layout: product-page
+include_floqer: true
 aliases:
   - /esc
   - /product/esc

--- a/content/product/secrets-management.md
+++ b/content/product/secrets-management.md
@@ -1,4 +1,5 @@
 ---
+include_floqer: true
 title: "Centralized Configuration & Secrets Management – Pulumi ESC"
 meta_desc: Centralize secrets and configurations with Pulumi ESC. Connect any vault, eliminate secrets sprawl, secure every environment.
 meta_image: /images/product/secrets-management/esc-meta.png

--- a/content/product/secrets-management.md
+++ b/content/product/secrets-management.md
@@ -1,7 +1,7 @@
 ---
-include_floqer: true
 title: "Centralized Configuration & Secrets Management – Pulumi ESC"
 meta_desc: Centralize secrets and configurations with Pulumi ESC. Connect any vault, eliminate secrets sprawl, secure every environment.
+include_floqer: true
 meta_image: /images/product/secrets-management/esc-meta.png
 type: page
 layout: product-page

--- a/layouts/partials/floqer.html
+++ b/layouts/partials/floqer.html
@@ -1,0 +1,26 @@
+{{- /*
+  Floqer (RB2B) visitor identification — https://floqer.com
+  Consent-gated: loads only after the site's consent-managed Segment analytics is
+  ready (window.analytics.ready). The consent manager (theme/src/ts/consent-manager)
+  only initializes analytics once the visitor's Marketing & Analytics consent is
+  satisfied — EU visitors must opt in via the banner; non-EU load by default. This is
+  fail-closed: if consent-managed analytics never loads, Floqer never loads.
+  Scoped per page via the `include_floqer: true` front-matter flag (wired in head.html),
+  and production-only. Loads the exact Floqer contact-tracker tag unchanged.
+*/ -}}
+<script>
+    (function () {
+        function loadFloqer() {
+            var s = document.createElement("script");
+            s.type = "text/javascript";
+            s.async = true;
+            s.src = "https://workers.floqer.com/signals/contact-tracker?sid=2fcba3d4-92cc-4be2-b102-6e0cbce15b38&ref=" + encodeURIComponent(window.location.href);
+            var f = document.getElementsByTagName("script")[0];
+            f.parentNode.insertBefore(s, f);
+        }
+        if (window.analytics && typeof window.analytics.ready === "function") {
+            // ready() fires only after the consent-managed analytics loads.
+            window.analytics.ready(loadFloqer);
+        }
+    })();
+</script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -407,6 +407,11 @@
             });
         </script>
 
+        <!-- Floqer (RB2B) visitor identification — Marketing & Analytics consent-gated (see partials/floqer.html). Page-scoped via `include_floqer` front matter. -->
+        {{ if .Params.include_floqer }}
+        {{ partial "floqer.html" . }}
+        {{ end }}
+
     {{- end }}
 
     <!-- Apply anchor links to headings in the docs, blog and taxonomy pages. -->


### PR DESCRIPTION
## What

Adds the **Floqer (RB2B) visitor-identification** tag to 8 high-intent pages, **consent-gated** and **production-only**.

Floqer de-anonymizes individual site visitors, so it's deliberately gated on the site's existing **Marketing & Analytics** consent rather than loading for everyone.

## Pages (via `include_floqer: true` front matter)

- `/pricing`
- `/product`
- `/product/neo`
- `/product/infrastructure-as-code`
- `/product/secrets-management`
- `/docs/iac/comparisons/terraform`
- `/docs/iac/comparisons/terraform/opentofu`
- `/case-studies`

## How it works

- New partial **`layouts/partials/floqer.html`** holds the vendor tag (unchanged: `workers.floqer.com/signals/contact-tracker?sid=…`).
- Wired into **`head.html`** inside the existing `production` block, right after Common Room:
  `{{ if .Params.include_floqer }}{{ partial "floqer.html" . }}{{ end }}`
- **Consent gate:** the tag only loads inside `window.analytics.ready(...)`. That callback fires **only after the consent-managed Segment analytics initializes** — which `theme/src/ts/consent-manager` does only once the visitor's consent is satisfied (EU visitors must opt in via the banner; non-EU load by default). **Fail-closed:** if consent-managed analytics never loads, Floqer never loads.

## Reviewer notes / open questions

1. **Gate granularity.** `analytics.ready` fires whenever the consent-managed analytics loads (i.e. the visitor consented to *any* destination). It is **not** strictly limited to the *Marketing and Analytics* category — a visitor who consents to Advertising only would also get Floqer. If you want it limited to the Marketing & Analytics category specifically, that needs a small hook in `consent-manager` (e.g. emit a category-consent signal Floqer can subscribe to). Happy to follow up if preferred.
2. **Consistency with Common Room.** Common Room (a similar visitor-ID tool) currently loads **ungated** in production. Floqer is intentionally stricter here (consent-gated) per requirement — flagging in case you want to reconcile the two.
3. **Prod-only** — won't appear in preview/dev builds; verify on production (or a prod-env build) on the 8 pages, with consent granted.

Requested by GTM / marketing ops. Vendor `sid` is Floqer's account key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
