### PR TITLE
SEO: definition + FAQ + how-to recap for seven-rules AI-native software factory post

### DIFF
--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -190,13 +190,8 @@ If you're where I was two years ago: don't ask how AI fits into what you already
 ## Frequently asked questions
 
 {{< details "What is a software factory?" >}}
-A software factory is a software operation run as a repeatable industrial process rather than a craft: work moves down an automated line instead of every feature being hand-built. In an AI-native software factory, autonomous agents write and ship most of the code, while engineers decide what gets built and talk to customers. The team handles what the agents can't. The factory keeps producing whether the engineers are at their desks or not.
+A software factory runs software delivery as a repeatable industrial process instead of hand-crafting each feature, the way a physical factory turns out products on a line. The idea predates AI. An AI-native software factory is the version where agents do most of the building and the engineers steer.
 {{< /details >}}
-
-{{< details "What is an AI software factory?" >}}
-An AI software factory, or AI-native software factory, is a software factory where AI agents do most of the building. Instead of enhancing a traditional workflow with AI tools, the whole delivery line is redesigned around what agents can do: agents write and check the code through an automated loop, and engineers focus on defining the work and deciding what to build. At Compostable AI, five engineers run one across nineteen clients.
-{{< /details >}}
-
 {{< details "How is a software factory different from traditional software development?" >}}
 Traditional development treats code as a craft, each function written and reviewed by hand. A software factory treats software delivery as an industrial process: agents handle the writing and checking through an automated, converging loop, and the expensive human hours move to defining the work and deciding what to build. The goal is to minimize human hours per unit of value shipped.
 {{< /details >}}

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -44,6 +44,10 @@ But two years into the agentic AI revolution, I realised software is going to lo
 
 I joined Compostable AI soon after it was founded 2.5 years ago, and I built the engineering org AI-native from day one. The technology has come a long way since then, and so has my understanding of what AI-native actually means. Here are seven rules I keep coming back to.
 
+{{< notes type="info" size="large" >}}
+**An AI-native software factory** is a software operation where autonomous agents write, review, and ship most of the code, while the engineering team's job shifts to defining the work, talking to customers, and deciding what gets built — rather than writing it by hand. The rules below are how we keep that factory producing reliably.
+{{< /notes >}}
+
 ## 1. Transform, don't enhance
 
 <img src="rule-1-chrysalis.png" alt="" class="float-right w-32 ml-4 mb-2 mt-1 rounded-lg sm:w-40 sm:ml-6 lg:w-44">
@@ -173,11 +177,33 @@ And the part that matters most: the factory keeps running, testing, and deployin
 A factory scattered across laptops can't be improved as a system. Cloud keeps it in one shape, 24/7, and lets the team iterate together.
 {{< /notes >}}
 
+## How to build an AI-native software factory
+
+Put together, the seven rules are a practical path to building an AI-native software factory: transform the workflow rather than bolt AI onto it, remove problems instead of engineering around them, pick tools your agents can drive, split work across specialized agents, measure human hours per unit of value, design for convergence over one-shot correctness, and run the factory in the cloud so it operates 24/7. None of it is a template — it's the practice of applying each rule where the new economics actually change what's hard.
+
 ## Closing thought
 
 I've shipped more code in the last two years than I did in the fifteen before that. Most of it in languages I couldn't write by hand. And that's after a stretch in leadership where I wrote almost none.
 
 If you're where I was two years ago: don't ask how AI fits into what you already do. The factory is built one rule at a time, and it's not a template — it's the practice of finding where you're taking advantage of the new economics and where you're not, where your practices still need an update. The leverage is in finding these places and improving them.
+
+## Frequently asked questions
+
+{{< details "What is an AI-native software factory?" >}}
+An AI-native software factory is a software operation where autonomous agents write, review, and ship most of the code, while engineers define the work, talk to customers, and decide what gets built. The team handles what the agents can't; the factory keeps producing whether the engineers are at their desks or not.
+{{< /details >}}
+
+{{< details "How is a software factory different from traditional software development?" >}}
+Traditional development treats code as a craft — each function written and reviewed by hand. A software factory treats software delivery as an industrial process: agents handle the writing and checking through an automated, converging loop, and the expensive human hours move to defining the work and deciding what to build. The goal is to minimize human hours per unit of value shipped.
+{{< /details >}}
+
+{{< details "How do you keep AI agents from breaking things across customers?" >}}
+Rather than build a shared multi-tenant sandbox, Compostable AI removes the problem: every client gets two dedicated AWS accounts — one for production and a "digital twin" staging account. Agents iterate on staging until the work checks out, and only then does it ship to production. Infrastructure-as-code tools like AWS Control Tower and Pulumi make running that account fleet tractable for a small team.
+{{< /details >}}
+
+{{< details "What tools does an AI-native software factory need?" >}}
+Tools your agents can actually drive — anything with a robust API and a clean CLI, rather than click-ops around a web UI. Compostable AI expresses infrastructure as type-safe TypeScript with [Pulumi](/), pairs it with [Pulumi Neo](/product/neo/) for domain-specific infrastructure skills, and uses [Pulumi ESC](/docs/pulumi-cloud/esc/) for configuration. If part of your stack still requires a human to click through a UI, your agents stop there.
+{{< /details >}}
 
 ---
 

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -179,7 +179,7 @@ A factory scattered across laptops can't be improved as a system. Cloud keeps it
 
 ## How to build an AI-native software factory
 
-There's no single blueprint for how to build a software factory, but these seven rules are a practical path — the software factory model we run at Compostable AI. As a concrete software factory example, that means: transform the workflow rather than bolt AI onto it, remove problems instead of engineering around them, pick tools your agents can drive, split work across specialized agents, measure human hours per unit of value, design for convergence over one-shot correctness, and run the factory in the cloud so it operates 24/7. None of it is a template — it's the practice of applying each rule where the new economics actually change what's hard.
+There's no single blueprint for how to build a software factory, but these seven rules are the software factory model we run at Compostable AI: transform the workflow rather than bolt AI onto it, remove problems instead of engineering around them, pick tools your agents can drive, split work across specialized agents, measure human hours per unit of value, design for convergence over one-shot correctness, and run the factory in the cloud so it operates 24/7.
 
 ## Closing thought
 
@@ -190,23 +190,23 @@ If you're where I was two years ago: don't ask how AI fits into what you already
 ## Frequently asked questions
 
 {{< details "What is a software factory?" >}}
-A software factory is a software operation run as a repeatable industrial process rather than a craft: work moves down an automated line instead of every feature being hand-built. In an AI-native software factory, autonomous agents write, review, and ship most of the code, while engineers define the work, talk to customers, and decide what gets built. The team handles what the agents can't; the factory keeps producing whether the engineers are at their desks or not.
+A software factory is a software operation run as a repeatable industrial process rather than a craft: work moves down an automated line instead of every feature being hand-built. In an AI-native software factory, autonomous agents write and ship most of the code, while engineers decide what gets built and talk to customers. The team handles what the agents can't. The factory keeps producing whether the engineers are at their desks or not.
 {{< /details >}}
 
 {{< details "What is an AI software factory?" >}}
-An AI software factory (or AI-native software factory) is a software factory where AI agents do most of the building. Instead of enhancing a traditional workflow with AI tools, the whole delivery line is redesigned around what agents can do: agents write, review, and check the code through an automated loop, and engineers focus on defining the work and deciding what to build. At Compostable AI, five engineers run one across nineteen clients.
+An AI software factory, or AI-native software factory, is a software factory where AI agents do most of the building. Instead of enhancing a traditional workflow with AI tools, the whole delivery line is redesigned around what agents can do: agents write and check the code through an automated loop, and engineers focus on defining the work and deciding what to build. At Compostable AI, five engineers run one across nineteen clients.
 {{< /details >}}
 
 {{< details "How is a software factory different from traditional software development?" >}}
-Traditional development treats code as a craft — each function written and reviewed by hand. A software factory treats software delivery as an industrial process: agents handle the writing and checking through an automated, converging loop, and the expensive human hours move to defining the work and deciding what to build. The goal is to minimize human hours per unit of value shipped.
+Traditional development treats code as a craft, each function written and reviewed by hand. A software factory treats software delivery as an industrial process: agents handle the writing and checking through an automated, converging loop, and the expensive human hours move to defining the work and deciding what to build. The goal is to minimize human hours per unit of value shipped.
 {{< /details >}}
 
 {{< details "How do you keep AI agents from breaking things across customers?" >}}
-Rather than build a shared multi-tenant sandbox, Compostable AI removes the problem: every client gets two dedicated AWS accounts — one for production and a "digital twin" staging account. Agents iterate on staging until the work checks out, and only then does it ship to production. Infrastructure-as-code tools like AWS Control Tower and Pulumi make running that account fleet tractable for a small team.
+Rather than build a shared multi-tenant sandbox, Compostable AI removes the problem: every client gets two dedicated AWS accounts, one for production and a "digital twin" staging account. Agents iterate on staging until the work checks out, and only then does it ship to production. Infrastructure-as-code tools like AWS Control Tower and Pulumi make running that account fleet tractable for a small team.
 {{< /details >}}
 
 {{< details "What tools does an AI-native software factory need?" >}}
-Tools your agents can actually drive — anything with a robust API and a clean CLI, rather than click-ops around a web UI. Compostable AI expresses infrastructure as type-safe TypeScript with [Pulumi](/), pairs it with [Pulumi Neo](/product/neo/) for domain-specific infrastructure skills, and uses [Pulumi ESC](/docs/pulumi-cloud/esc/) for configuration. If part of your stack still requires a human to click through a UI, your agents stop there.
+Tools your agents can actually drive, anything with a solid API and a clean CLI, rather than click-ops around a web UI. Compostable AI expresses infrastructure as type-safe TypeScript with [Pulumi](/), pairs it with [Pulumi Neo](/product/neo/) for domain-specific infrastructure skills, and uses [Pulumi ESC](/docs/pulumi-cloud/esc/) for configuration. If part of your stack still requires a human to click through a UI, your agents stop there.
 {{< /details >}}
 
 ---

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -45,7 +45,7 @@ But two years into the agentic AI revolution, I realised software is going to lo
 I joined Compostable AI soon after it was founded 2.5 years ago, and I built the engineering org AI-native from day one. The technology has come a long way since then, and so has my understanding of what AI-native actually means. Here are seven rules I keep coming back to.
 
 {{< notes type="info" size="large" >}}
-**An AI software factory**, also called an AI-native software factory, is a software operation where autonomous agents write and ship most of the code, while the engineering team's job shifts to deciding what gets built and talking to customers, not writing the code by hand. The rules below are how we keep it running.
+**An AI software factory**, also called an AI-native software factory, is a software operation where autonomous agents write and ship most of the code. The engineers stop writing it by hand and spend their time deciding what gets built and talking to customers. The rules below are how we keep it running.
 {{< /notes >}}
 
 ## 1. Transform, don't enhance

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -45,7 +45,7 @@ But two years into the agentic AI revolution, I realised software is going to lo
 I joined Compostable AI soon after it was founded 2.5 years ago, and I built the engineering org AI-native from day one. The technology has come a long way since then, and so has my understanding of what AI-native actually means. Here are seven rules I keep coming back to.
 
 {{< notes type="info" size="large" >}}
-**An AI software factory**, also called an AI-native software factory, is a software operation where autonomous agents write and ship most of the code. The engineers stop writing it by hand and spend their time deciding what gets built and talking to customers. The rules below are how we keep it running.
+**An AI software factory** is a software operation where autonomous agents write and ship most of the code. The engineers stop writing it by hand and spend their time deciding what gets built and talking to customers. The rules below are our rules for building and running an AI-native software factory.
 {{< /notes >}}
 
 ## 1. Transform, don't enhance

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -45,7 +45,7 @@ But two years into the agentic AI revolution, I realised software is going to lo
 I joined Compostable AI soon after it was founded 2.5 years ago, and I built the engineering org AI-native from day one. The technology has come a long way since then, and so has my understanding of what AI-native actually means. Here are seven rules I keep coming back to.
 
 {{< notes type="info" size="large" >}}
-**An AI software factory** — also called an AI-native software factory — is a software operation where autonomous agents write, review, and ship most of the code, while the engineering team's job shifts to defining the work, talking to customers, and deciding what gets built — rather than writing it by hand. The rules below are how we keep that factory producing reliably.
+**An AI software factory**, also called an AI-native software factory, is a software operation where autonomous agents write and ship most of the code, while the engineering team's job shifts to deciding what gets built and talking to customers, not writing the code by hand. The rules below are how we keep it running.
 {{< /notes >}}
 
 ## 1. Transform, don't enhance

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -45,7 +45,7 @@ But two years into the agentic AI revolution, I realised software is going to lo
 I joined Compostable AI soon after it was founded 2.5 years ago, and I built the engineering org AI-native from day one. The technology has come a long way since then, and so has my understanding of what AI-native actually means. Here are seven rules I keep coming back to.
 
 {{< notes type="info" size="large" >}}
-**An AI-native software factory** — also called an AI software factory — is a software operation where autonomous agents write, review, and ship most of the code, while the engineering team's job shifts to defining the work, talking to customers, and deciding what gets built — rather than writing it by hand. The rules below are how we keep that factory producing reliably.
+**An AI software factory** — also called an AI-native software factory — is a software operation where autonomous agents write, review, and ship most of the code, while the engineering team's job shifts to defining the work, talking to customers, and deciding what gets built — rather than writing it by hand. The rules below are how we keep that factory producing reliably.
 {{< /notes >}}
 
 ## 1. Transform, don't enhance
@@ -191,6 +191,10 @@ If you're where I was two years ago: don't ask how AI fits into what you already
 
 {{< details "What is a software factory?" >}}
 A software factory is a software operation run as a repeatable industrial process rather than a craft: work moves down an automated line instead of every feature being hand-built. In an AI-native software factory, autonomous agents write, review, and ship most of the code, while engineers define the work, talk to customers, and decide what gets built. The team handles what the agents can't; the factory keeps producing whether the engineers are at their desks or not.
+{{< /details >}}
+
+{{< details "What is an AI software factory?" >}}
+An AI software factory (or AI-native software factory) is a software factory where AI agents do most of the building. Instead of enhancing a traditional workflow with AI tools, the whole delivery line is redesigned around what agents can do: agents write, review, and check the code through an automated loop, and engineers focus on defining the work and deciding what to build. At Compostable AI, five engineers run one across nineteen clients.
 {{< /details >}}
 
 {{< details "How is a software factory different from traditional software development?" >}}

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -169,7 +169,7 @@ Even a converged factory has to live somewhere. Try running a fully automated fa
 
 Cloud also kills configuration drift across a dozen developer machines. The same prompts run against different model versions, and env vars sit half-set on half the laptops. The thing you're trying to optimize lives in different states across the team. Cloud isn't just where the factory runs; it's the only place a team can iterate on it together. Keep everything in one place — AWS, Pulumi Cloud, GitHub. The specific stack matters less than the principle of one place.
 
-And the part that matters most: the factory keeps running, testing, and deploying long after we've closed our laptops and gone to sleep.
+And the part that matters most: the factory keeps running, testing, and deploying long after we've closed our laptops and gone to sleep — the [dark factory](/blog/dark-factory-pattern-pulumi-autonomous-iac/) pattern, where the line keeps producing with the lights off.
 
 {{< notes type="tip" size="large" >}}
 **Build the factory somewhere you can work on it — not just somewhere it can run.**
@@ -211,4 +211,4 @@ Tools your agents can actually drive — anything with a robust API and a clean 
 
 ---
 
-*Watch the [original Pulumi webinar](https://www.youtube.com/watch?v=oHNdlWlsR-w). Learn more about [Compostable AI](https://compostable.ai/) and [Pulumi Neo](/product/neo/).*
+*Watch the [original Pulumi webinar](https://www.youtube.com/watch?v=oHNdlWlsR-w). Read the [Compostable AI case study](/case-studies/compostable-ai/), and learn more about [Compostable AI](https://compostable.ai/) and [Pulumi Neo](/product/neo/).*

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -189,8 +189,8 @@ If you're where I was two years ago: don't ask how AI fits into what you already
 
 ## Frequently asked questions
 
-{{< details "What is an AI-native software factory?" >}}
-An AI-native software factory is a software operation where autonomous agents write, review, and ship most of the code, while engineers define the work, talk to customers, and decide what gets built. The team handles what the agents can't; the factory keeps producing whether the engineers are at their desks or not.
+{{< details "What is a software factory?" >}}
+A software factory is a software operation run as a repeatable industrial process rather than a craft: work moves down an automated line instead of every feature being hand-built. In an AI-native software factory, autonomous agents write, review, and ship most of the code, while engineers define the work, talk to customers, and decide what gets built. The team handles what the agents can't; the factory keeps producing whether the engineers are at their desks or not.
 {{< /details >}}
 
 {{< details "How is a software factory different from traditional software development?" >}}

--- a/content/blog/seven-rules-ai-native-software-factory/index.md
+++ b/content/blog/seven-rules-ai-native-software-factory/index.md
@@ -45,7 +45,7 @@ But two years into the agentic AI revolution, I realised software is going to lo
 I joined Compostable AI soon after it was founded 2.5 years ago, and I built the engineering org AI-native from day one. The technology has come a long way since then, and so has my understanding of what AI-native actually means. Here are seven rules I keep coming back to.
 
 {{< notes type="info" size="large" >}}
-**An AI-native software factory** is a software operation where autonomous agents write, review, and ship most of the code, while the engineering team's job shifts to defining the work, talking to customers, and deciding what gets built — rather than writing it by hand. The rules below are how we keep that factory producing reliably.
+**An AI-native software factory** — also called an AI software factory — is a software operation where autonomous agents write, review, and ship most of the code, while the engineering team's job shifts to defining the work, talking to customers, and deciding what gets built — rather than writing it by hand. The rules below are how we keep that factory producing reliably.
 {{< /notes >}}
 
 ## 1. Transform, don't enhance
@@ -179,7 +179,7 @@ A factory scattered across laptops can't be improved as a system. Cloud keeps it
 
 ## How to build an AI-native software factory
 
-Put together, the seven rules are a practical path to building an AI-native software factory: transform the workflow rather than bolt AI onto it, remove problems instead of engineering around them, pick tools your agents can drive, split work across specialized agents, measure human hours per unit of value, design for convergence over one-shot correctness, and run the factory in the cloud so it operates 24/7. None of it is a template — it's the practice of applying each rule where the new economics actually change what's hard.
+There's no single blueprint for how to build a software factory, but these seven rules are a practical path — the software factory model we run at Compostable AI. As a concrete software factory example, that means: transform the workflow rather than bolt AI onto it, remove problems instead of engineering around them, pick tools your agents can drive, split work across specialized agents, measure human hours per unit of value, design for convergence over one-shot correctness, and run the factory in the cloud so it operates 24/7. None of it is a template — it's the practice of applying each rule where the new economics actually change what's hard.
 
 ## Closing thought
 


### PR DESCRIPTION
## What

A post-ship **SEO optimization** pass on the already-published [Seven Rules for Building an AI-Native Software Factory](https://www.pulumi.com/blog/seven-rules-ai-native-software-factory/) post. 

## Why

GSC data shows the post already ranks for the **"software factory" query cluster** but at **position ~15–18**.

## Changes (all additive)

1. **Definition callout** (`notes type="info"`) after the intro — a quotable, standalone definition of "AI-native software factory" for SEO/AEO extraction.
2. **`## How to build an AI-native software factory`** recap H2 before the closing — a search-intent heading that reinforces a term the post already ranks ~pos 5 for. Summarizes the seven rules.
3. **`## Frequently asked questions`** — a 4-item collapsible FAQ (`details` shortcode) that stays visually tidy and carries definitional query intent in the question text.

