### PR TITLE
Performance: remove dead GitHub buttons.js, hero fetchpriority, header-nav cache TTL, swiper reflow fix

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -1028,6 +1028,12 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         },
         {
             ...baseCacheBehavior,
+            pathPattern: "/js/header-nav.*.js",
+            cachePolicyId: oneYearCachePolicy.id,
+            responseHeadersPolicyId: ImmutableCachePolicy.id,
+        },
+        {
+            ...baseCacheBehavior,
             pathPattern: "/js/algolia.*.js",
             cachePolicyId: oneYearCachePolicy.id,
             responseHeadersPolicyId: ImmutableCachePolicy.id,

--- a/layouts/partials/fingerprinted-img.html
+++ b/layouts/partials/fingerprinted-img.html
@@ -38,8 +38,8 @@
     {{ end }}
     {{ end }}
     {{ $img = $img | fingerprint }}
-<img {{ with $.class }}class="{{ . }}"{{ end }} src="{{ $img.RelPermalink }}" alt="{{ $.alt }}" {{ with $.width }}width="{{ . }}"{{ end }} {{ with $.height }}height="{{ . }}"{{ end }} {{ with $.style }}style="{{ . }}"{{ end }} {{ if $srcset }}srcset="{{ delimit $srcset ", " }}" sizes="(max-width: 768px) 100vw, {{ $maxWidth }}px"{{ end }} loading="{{ $.loading | default "lazy" }}" decoding="async"{{ with $.ariaHidden }} aria-hidden="{{ . }}"{{ end }} />
+<img {{ with $.class }}class="{{ . }}"{{ end }} src="{{ $img.RelPermalink }}" alt="{{ $.alt }}" {{ with $.width }}width="{{ . }}"{{ end }} {{ with $.height }}height="{{ . }}"{{ end }} {{ with $.style }}style="{{ . }}"{{ end }} {{ if $srcset }}srcset="{{ delimit $srcset ", " }}" sizes="(max-width: 768px) 100vw, {{ $maxWidth }}px"{{ end }} loading="{{ $.loading | default "lazy" }}"{{ with $.fetchpriority }} fetchpriority="{{ . }}"{{ end }} decoding="async"{{ with $.ariaHidden }} aria-hidden="{{ . }}"{{ end }} />
 {{ else }}
     {{ $img = $img | fingerprint }}
-<img {{ with .class }}class="{{ . }}"{{ end }} src="{{ $img.RelPermalink }}" alt="{{ .alt }}" {{ with .width }}width="{{ . }}"{{ end }} {{ with .height }}height="{{ . }}"{{ end }} {{ with .style }}style="{{ . }}"{{ end }} loading="{{ .loading | default "lazy" }}" decoding="async"{{ with .ariaHidden }} aria-hidden="{{ . }}"{{ end }} />
+<img {{ with .class }}class="{{ . }}"{{ end }} src="{{ $img.RelPermalink }}" alt="{{ .alt }}" {{ with .width }}width="{{ . }}"{{ end }} {{ with .height }}height="{{ . }}"{{ end }} {{ with .style }}style="{{ . }}"{{ end }} loading="{{ .loading | default "lazy" }}"{{ with .fetchpriority }} fetchpriority="{{ . }}"{{ end }} decoding="async"{{ with .ariaHidden }} aria-hidden="{{ . }}"{{ end }} />
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -273,14 +273,6 @@
     <link rel="alternate" type="application/rss+xml" href="{{ "/blog/rss.xml" | absURL }}" title="Pulumi Blog" />
 
 
-    <script>
-        window.addEventListener('load', function() {
-            var s = document.createElement('script');
-            s.src = 'https://buttons.github.io/buttons.js';
-            document.body.appendChild(s);
-        });
-    </script>
-
     <!--Segment tracking-->
     <script>
         // Do not load Segment for these user agents.

--- a/layouts/partials/template-partials/template-hero.html
+++ b/layouts/partials/template-partials/template-hero.html
@@ -171,7 +171,7 @@
                     {{ partial "template-partials/template-code-snippets.html" (dict "code_snippets" $codeSnippets "title" $codeTitle) }}
                 </div>
                 {{ if $overlayImage }}
-                {{ partial "fingerprinted-img.html" (dict "src" $overlayImage "alt" $overlayAlt "class" "hero-code-overlay" "loading" "eager" "ariaHidden" "true") }}
+                {{ partial "fingerprinted-img.html" (dict "src" $overlayImage "alt" $overlayAlt "class" "hero-code-overlay" "loading" "eager" "fetchpriority" "high" "ariaHidden" "true") }}
                 {{ end }}
             </div>
             {{ else }}
@@ -192,7 +192,7 @@
         </div>
         {{ else if $image }}
         <div class="xl:w-1/2 w-full">
-            {{ partial "fingerprinted-img.html" (dict "src" $image "alt" $imageAlt "class" "w-full h-auto" "loading" "eager" "style" ($imageStyle | safeCSS)) }}
+            {{ partial "fingerprinted-img.html" (dict "src" $image "alt" $imageAlt "class" "w-full h-auto" "loading" "eager" "fetchpriority" "high" "style" ($imageStyle | safeCSS)) }}
         </div>
         {{ end }}
     </div>
@@ -245,7 +245,7 @@
                     {{ partial "template-partials/template-code-snippets.html" (dict "code_snippets" $codeSnippets "title" $codeTitle) }}
                 </div>
                 {{ if $overlayImage }}
-                {{ partial "fingerprinted-img.html" (dict "src" $overlayImage "alt" $overlayAlt "class" "hero-code-overlay" "loading" "eager" "ariaHidden" "true") }}
+                {{ partial "fingerprinted-img.html" (dict "src" $overlayImage "alt" $overlayAlt "class" "hero-code-overlay" "loading" "eager" "fetchpriority" "high" "ariaHidden" "true") }}
                 {{ end }}
             </div>
         </div>
@@ -261,7 +261,7 @@
         </div>
         {{ else if $image }}
         <div class="product-hero-visual flex justify-center">
-            {{ partial "fingerprinted-img.html" (dict "src" $image "alt" $imageAlt "class" "w-full h-auto rounded-lg" "loading" "eager" "style" ($imageStyle | safeCSS) "maxWidth" 1500 "quality" 95) }}
+            {{ partial "fingerprinted-img.html" (dict "src" $image "alt" $imageAlt "class" "w-full h-auto rounded-lg" "loading" "eager" "fetchpriority" "high" "style" ($imageStyle | safeCSS) "maxWidth" 1500 "quality" 95) }}
         </div>
         {{ end }}
     </div>

--- a/theme/src/scss/_header.scss
+++ b/theme/src/scss/_header.scss
@@ -4,11 +4,6 @@ pulumi-user-toggle:not(.hydrated) [slot="signed-in"] {
     display: none;
 }
 
-// Hide the raw "Star" anchor before buttons.github.io replaces it with an iframe.
-.github-widget > a.github-button {
-    visibility: hidden;
-}
-
 .top-nav-bar {
     @apply text-sm;
 

--- a/theme/stencil/src/components/swiper/swiper.tsx
+++ b/theme/stencil/src/components/swiper/swiper.tsx
@@ -43,6 +43,10 @@ export class Swiper {
 
     private wrapper: HTMLElement;
     private container: HTMLElement;
+    // Container width is measured once (and on resize) rather than read from
+    // offsetWidth at each use — interleaving those reads with the slide-width
+    // writes below forces synchronous layout on every call.
+    private containerWidth = 0;
     private currentIndex = 0;
     private slideCount = 0;
     private cloneCount = 0;
@@ -62,6 +66,7 @@ export class Swiper {
 
         if (this.slideCount === 0) return;
 
+        this.measureContainer();
         this.applySlideWidths();
 
         if (this.loop && this.slideCount > this.slides) {
@@ -86,6 +91,7 @@ export class Swiper {
         this.container.addEventListener("pointerdown", this.onPointerDown);
 
         this.resizeObserver = new ResizeObserver(() => {
+            this.measureContainer();
             this.applySlideWidths();
             this.isTransitioning = false;
             this.jumpTo(this.currentIndex);
@@ -112,10 +118,13 @@ export class Swiper {
         document.removeEventListener("pointerup", this.onPointerUp);
     }
 
+    private measureContainer() {
+        this.containerWidth = this.container.offsetWidth;
+    }
+
     private applySlideWidths() {
         const allSlides = Array.from(this.wrapper.querySelectorAll(":scope > .swiper-slide")) as HTMLElement[];
-        const containerWidth = this.container.offsetWidth;
-        const slideWidth = (containerWidth - this.spaceBetween * (this.slides - 1)) / this.slides;
+        const slideWidth = (this.containerWidth - this.spaceBetween * (this.slides - 1)) / this.slides;
         for (const slide of allSlides) {
             slide.style.width = `${slideWidth}px`;
             slide.style.marginRight = `${this.spaceBetween}px`;
@@ -123,16 +132,14 @@ export class Swiper {
     }
 
     private getStep(): number {
-        const containerWidth = this.container.offsetWidth;
-        return (containerWidth - this.spaceBetween * (this.slides - 1)) / this.slides + this.spaceBetween;
+        return (this.containerWidth - this.spaceBetween * (this.slides - 1)) / this.slides + this.spaceBetween;
     }
 
     private translateForIndex(index: number): number {
         const step = this.getStep();
         let tx = -(index + this.cloneCount) * step;
         if (this.centeredSlides && this.slides > 1) {
-            const containerWidth = this.container.offsetWidth;
-            tx += (containerWidth - (step - this.spaceBetween)) / 2;
+            tx += (this.containerWidth - (step - this.spaceBetween)) / 2;
         }
         return tx;
     }
@@ -226,12 +233,11 @@ export class Swiper {
         const step = this.getStep();
         const totalSlides = this.slideCount + 2 * this.cloneCount;
         const totalWidth = totalSlides * step - this.spaceBetween;
-        const containerWidth = this.container.offsetWidth;
         const offset = this.centeredSlides && this.slides > 1
-            ? (containerWidth - (step - this.spaceBetween)) / 2
+            ? (this.containerWidth - (step - this.spaceBetween)) / 2
             : 0;
         const maxTx = offset;
-        const minTx = Math.min(offset, containerWidth - totalWidth + offset);
+        const minTx = Math.min(offset, this.containerWidth - totalWidth + offset);
         return Math.max(minTx, Math.min(maxTx, tx));
     }
 


### PR DESCRIPTION
Looking into how to possibly slim down the third-party scripts, but have a few fixes for the codebase here. The good news is real users are getting a good experience overall - our visitors are likely on higher-end phones and are not affected nearly as much.

<img width="984" height="545" alt="Screenshot 2026-07-08 at 3 16 25 PM" src="https://github.com/user-attachments/assets/44e8bd6d-1238-4c4c-97f2-f51422ab45b3" />

---

## Context

PageSpeed Insights mobile for `www.pulumi.com` scores 47 in the lab (field CrUX data passes Core Web Vitals). The dominant cost is third-party marketing JS (HubSpot, Intercom, GTM — loaded as Segment destinations, tracked separately), but the lab trace also flagged several repo-controlled issues, fixed here.

## Changes

- **Remove `buttons.github.io/buttons.js`** — loaded on every page via `head.html`, but nothing on the site renders a `.github-button` element anymore; the star buttons are first-party (`github-star-button.html` with build-time counts from `scripts/fetch-github-stars.js`). Also removes the leftover `.github-widget` rule in `_header.scss`. Saves a third-party request + connection per page.
- **`fetchpriority=high` on hero images** — the homepage LCP element (`img.hero-code-overlay`) had no priority hint, the only failing item on Lighthouse's LCP request-discovery audit. `fingerprinted-img.html` gains a `fetchpriority` param, set on the four `loading="eager"` hero images in `template-hero.html`.
- **CloudFront: immutable caching for `/js/header-nav.*.js`** — the one fingerprinted bundle missing from the immutable path patterns in `infrastructure/index.ts`, so it shipped with `max-age=60` and revalidated on every visit (flagged by the cache-lifetimes audit). Infra change deploys via the usual infrastructure pipeline, not the site deploy.
- **Swiper forced-reflow fix** — `pulumi-swiper` (Stencil) re-read `container.offsetWidth` between slide-width writes, clone insertion, and translate updates; Lighthouse attributed 118 ms of forced reflow to it on the throttled homepage trace. Width is now measured once, cached, and refreshed in the existing `ResizeObserver`.

## Verification

- `npx stencil build` compiles clean (pre-existing package.json warnings only).
- `npx tsc --noEmit` passes in `infrastructure/`.
- `make lint` passes.

## Not in this PR (follow-ups from the audit)

- Third-party JS diet: Intercom facade/scoping, double gtag containers, LinkedIn Insight loading both old+new tags, HubSpot analytics cost — these are Segment/marketing-workspace config, not repo code.
- Optional: longer TTL for non-fingerprinted `/images/*`; vendoring anchor.js off cdnjs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)