### PR TITLE
Promote /docs-review as a pre-flight step for authors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,9 @@
 
     Tip: open this PR as a **draft** while you iterate. Automated review
     fires when you mark it ready for review — drafting first keeps the
-    review fresh and avoids comment noise.
+    review fresh and avoids comment noise. While iterating, you can also
+    run /docs-review locally to catch findings before they cost review
+    budget.
 
     Help us merge your changes more quickly by adding more details such
     as labels, milestones, and reviewers.-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Open new PRs as **drafts** while you iterate. Automated review (style, accuracy,
 - Lets you push iteratively without spamming the PR with new comments each time.
 - Means the eventual review reflects your finished thinking, not a half-finished commit.
 
+While you're iterating, consider running `/docs-review` locally — it runs the same style/accuracy pipeline as the automated bot, but stays in your conversation and never posts to GitHub. Catching findings here is cheaper than catching them after the pinned review fires.
+
 When you're ready, use the **Ready for review** button on the PR page. Triage runs again to refresh labels, then the full review fires once and pins its findings to a single comment at the top of the PR. New commits afterward will mark the review **stale** but won't auto-rerun — mention `@claude #update-review` in a comment to refresh, or transition through draft and back to ready.
 
 If your change is genuinely trivial (a typo, a one-line fix), opening directly as ready is fine — the pipeline will short-circuit on the `review:trivial` label.


### PR DESCRIPTION
### Proposed changes

Implements item 4.7 ("Promote author-time review") from the docs-review automation evaluation in #20078.

The interactive `/docs-review` skill (`.claude/commands/docs-review/SKILL.md`) already runs the same style/accuracy/fact-check pipeline as the automated pre-merge bot, but stays entirely in-conversation and never posts to GitHub or triggers CI spend. It was effectively undiscoverable from the contributor-facing docs — the only existing mentions were implementation-detail cross-references, never a "run this before marking ready" recommendation.

This PR adds a short callout in two places, nudging authors to run `/docs-review` while iterating in draft, before findings cost review budget or reviewer attention:

- `CONTRIBUTING.md` — added a sentence in the `## Draft-first pull requests` section.
- `.github/PULL_REQUEST_TEMPLATE.md` — extended the existing draft-first tip comment.

No changes to the automated pipeline, workflows, or skill internals — this is purely a discoverability/documentation change.

### Related issues (optional)

Addresses item 4.7 of #20078.


---
_Generated by [Claude Code](https://claude.ai/code/session_012sv9H9n7eTYEHNerQkfztH)_