### PR TITLE
Auto-refresh stale reviews when the push only touches flagged lines (#20078 §3.7)

### DIFF
--- a/.claude/commands/docs-review/references/update.md
+++ b/.claude/commands/docs-review/references/update.md
@@ -32,6 +32,10 @@ gh pr view "$PR_NUMBER" --json title,body,isDraft,labels,files,headRefOid,headRe
 
 `last-reviewed-sha` reads the most recent SHA from the 📜 Review history section in the 1/M comment.
 
+### Automated invocation
+
+When `MENTION_AUTHOR` is `auto-refresh`, there is no human mention: the run was dispatched by the auto-refresh gate in claude-code-review.yml because a push touched only lines carried by 🚨 Outstanding findings (deterministically checked by `auto-refresh-gate.py`). Treat the run strictly as **Case 1 (fix-response)** scoped to the outstanding findings and the pushed lines: re-verify each outstanding finding against the new diff, move resolved ones to ✅ Resolved, and flag regressions the push introduced on those lines. Case 2 (dispute) never applies — there is no mention text to adjudicate — and do not re-extract claims or raise findings on content the push did not touch. `auto-refresh` is not a GitHub user; never render it as an `@`-mention.
+
 **Fallback rules when `last-reviewed-sha` is unusable:**
 
 - **Empty output** (history line missing, comment corrupted): fall back to a full `gh pr diff "$PR_NUMBER"` (no range). Treat the whole PR as new content; this is equivalent to starting over.

--- a/.claude/commands/docs-review/scripts/auto-refresh-gate.py
+++ b/.claude/commands/docs-review/scripts/auto-refresh-gate.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""auto-refresh-gate.py — deterministic gate for the stale-review auto-refresh.
+
+Decides whether a `synchronize` push qualifies for an automatic scoped review
+refresh (the `#update-review` path in claude-update.yml) without the author
+having to mention `@claude`. The qualifying shape is the "I fixed what you
+flagged" push: every hunk of the push diff lands on (or right next to) a line
+range carried by a 🚨 Outstanding finding in the pinned review, and the push
+is small. Everything else — new files, large diffs, hunks outside flagged
+ranges, unparsable inputs — leaves the PR in review:stale exactly as today.
+
+The model never decides whether to auto-fire; this script does. Fail-closed
+everywhere: any ambiguity means {"fire": false}.
+
+Inputs (all file paths):
+  --pinned-body  Output of `pinned-comment.sh fetch --pr N` (the full pinned
+                 review, possibly multiple pages separated by the
+                 PINNED-COMMENT-DELIMITER line).
+  --push-diff    Unified diff of `<last-reviewed-sha>...<head>` (GitHub
+                 compare API, diff media type). Three-dot compare equals the
+                 push delta on a normal push; after a force-push the
+                 merge-base drifts older, the diff inflates, and the gate
+                 fails closed — which is the wanted behavior.
+  --pr-files     JSON array of the PR's changed file paths
+                 (`gh pr view --json files --jq '[.files[].path]'`).
+
+Output: one JSON object on stdout — {"fire": bool, "reason": "<trace>"} —
+with exit 0. Exit 2 only on unusable invocations (missing file, undecodable
+input); callers must treat a non-zero exit as fire=false.
+
+Line-anchor caveat: `[L<a>-<b>]` bullet prefixes carry no file path, so on a
+multi-file PR the hunk match runs against the union of ranges across files. A
+cross-file coincidental overlap can fire a refresh that wasn't strictly
+warranted; the consequence is one budget-capped Sonnet fix-response run that
+re-verifies all outstanding findings — benign. The dangerous direction
+(firing on large rewrites) is blocked by MAX_CHANGED_LINES and the
+every-hunk-must-overlap rule.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+# Budget caps. A push bigger than this is not a "trivial delta" no matter
+# where its hunks land — the author should use the explicit refresh paths.
+MAX_CHANGED_LINES = 80
+# Findings anchor the flagged lines; authors legitimately touch the sentence
+# or list item around them. Overlap is tested with this many lines of slack
+# on each side of an anchor range.
+SLACK_LINES = 3
+
+# Page separator emitted by pinned-comment.sh fetch between N/M comments.
+PAGE_DELIMITER = "----- PINNED-COMMENT-DELIMITER -----"
+
+HERE = Path(__file__).resolve().parent
+
+# validate-pinned.py owns the pinned-comment grammar (bucket sections, bullet
+# prefixes). Import it rather than re-implementing; the filename is hyphenated
+# so this goes through importlib, same as test_splicer.py.
+_spec = importlib.util.spec_from_file_location(
+    "validate_pinned", HERE / "validate-pinned.py")
+validate_pinned = importlib.util.module_from_spec(_spec)
+# Register before exec: validate-pinned.py defines dataclasses, and the
+# dataclass machinery resolves the defining module through sys.modules.
+sys.modules["validate_pinned"] = validate_pinned
+_spec.loader.exec_module(validate_pinned)  # type: ignore[union-attr]
+
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(?:\d+)(?:,\d+)? @@")
+_RANGE_RE = re.compile(r"^L(\d+)(?:-(\d+))?$")
+
+
+def result(fire: bool, reason: str) -> int:
+    print(json.dumps({"fire": fire, "reason": reason}))
+    return 0
+
+
+def parse_anchor_ranges(pinned_body: str) -> list[tuple[int, int]] | None:
+    """Extract the [L<a>-<b>] ranges of every 🚨 Outstanding bullet.
+
+    Returns None when any Outstanding bullet lacks a parseable line-range
+    prefix (legacy formats) — that finding can't be located, so the caller
+    must fail closed. Returns [] when the bucket is empty or absent.
+    """
+    ranges: list[tuple[int, int]] = []
+    for page in pinned_body.split(PAGE_DELIMITER):
+        for bullet in validate_pinned.extract_bucket_bullets(page, "🚨 Outstanding"):
+            prefix = validate_pinned.extract_bullet_prefix(bullet)
+            if prefix is None:
+                return None
+            m = _RANGE_RE.match(prefix)
+            if m is None:
+                return None
+            start = int(m.group(1))
+            end = int(m.group(2)) if m.group(2) else start
+            ranges.append((min(start, end), max(start, end)))
+    return ranges
+
+
+def parse_push_diff(diff_text: str):
+    """Parse a unified diff into per-file old-side hunk ranges.
+
+    Returns (hunks, changed_lines, blocker) where hunks is
+    {file → [(old_start, old_end), ...]} keyed by new-side path,
+    changed_lines counts +/- body lines, and blocker is a reason string when
+    the diff contains something the gate must refuse (added/deleted/renamed/
+    binary files), else None.
+    """
+    hunks: dict[str, list[tuple[int, int]]] = {}
+    changed_lines = 0
+    blocker: str | None = None
+    current_file: str | None = None
+    old_is_devnull = False
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            current_file = None
+            old_is_devnull = False
+        elif line.startswith("rename from ") or line.startswith("rename to "):
+            blocker = "push renames a file"
+        elif line.startswith("Binary files ") or line.startswith("GIT binary patch"):
+            blocker = "push touches a binary file"
+        elif line.startswith("--- "):
+            old_is_devnull = line[4:].strip() == "/dev/null"
+        elif line.startswith("+++ "):
+            target = line[4:].strip()
+            if target == "/dev/null":
+                blocker = "push deletes a file"
+                current_file = None
+            elif old_is_devnull:
+                blocker = "push adds a new file"
+                current_file = None
+            else:
+                current_file = target[2:] if target.startswith("b/") else target
+        elif line.startswith("@@"):
+            m = _HUNK_RE.match(line)
+            if m is None or current_file is None:
+                continue
+            old_start = int(m.group(1))
+            old_count = int(m.group(2)) if m.group(2) is not None else 1
+            if old_count == 0:
+                # Pure insertion: git anchors it *after* old line N. Treat as
+                # adjacent to (N, N+1) so an insertion next to a flagged range
+                # still matches within slack.
+                span = (old_start, old_start + 1)
+            else:
+                span = (old_start, old_start + old_count - 1)
+            hunks.setdefault(current_file, []).append(span)
+        elif line.startswith("+") and not line.startswith("+++"):
+            changed_lines += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            changed_lines += 1
+
+    return hunks, changed_lines, blocker
+
+
+def overlaps(hunk: tuple[int, int], anchor: tuple[int, int]) -> bool:
+    return (hunk[0] <= anchor[1] + SLACK_LINES
+            and hunk[1] >= anchor[0] - SLACK_LINES)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pinned-body", required=True)
+    ap.add_argument("--push-diff", required=True)
+    ap.add_argument("--pr-files", required=True)
+    args = ap.parse_args()
+
+    try:
+        pinned_body = Path(args.pinned_body).read_text(encoding="utf-8")
+        diff_text = Path(args.push_diff).read_text(encoding="utf-8")
+        pr_files = json.loads(Path(args.pr_files).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        print(f"auto-refresh-gate: unusable input: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(pr_files, list) or not all(isinstance(p, str) for p in pr_files):
+        print("auto-refresh-gate: --pr-files must be a JSON array of paths",
+              file=sys.stderr)
+        return 2
+
+    if not pinned_body.strip():
+        return result(False, "no pinned review found")
+
+    anchors = parse_anchor_ranges(pinned_body)
+    if anchors is None:
+        return result(False, "an outstanding finding has no parseable [L...] anchor")
+    if not anchors:
+        return result(False, "no outstanding findings to refresh against")
+
+    if not diff_text.strip():
+        return result(False, "empty push diff")
+
+    hunks, changed_lines, blocker = parse_push_diff(diff_text)
+    if blocker is not None:
+        return result(False, blocker)
+    if not hunks:
+        return result(False, "no parseable hunks in push diff")
+    if changed_lines > MAX_CHANGED_LINES:
+        return result(
+            False,
+            f"push diff too large ({changed_lines} changed lines > {MAX_CHANGED_LINES})")
+
+    pr_file_set = set(pr_files)
+    for path, spans in hunks.items():
+        if path not in pr_file_set:
+            return result(False, f"push touches {path}, which is outside the PR's reviewed files")
+        for span in spans:
+            if not any(overlaps(span, anchor) for anchor in anchors):
+                return result(
+                    False,
+                    f"hunk {path}:{span[0]}-{span[1]} is outside outstanding finding lines")
+
+    n_hunks = sum(len(s) for s in hunks.values())
+    return result(
+        True,
+        f"{n_hunks} hunk(s) across {len(hunks)} file(s), {changed_lines} changed lines, "
+        f"all within outstanding finding lines (±{SLACK_LINES})")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/test_auto_refresh_gate.py
+++ b/.claude/commands/docs-review/scripts/test_auto_refresh_gate.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Unit tests for auto-refresh-gate.py.
+
+Self-contained — run with `python3 test_auto_refresh_gate.py` (no pytest dep).
+Imports the gate module directly and exercises the pure functions plus the
+CLI entry point end-to-end via temp files, mirroring test_splicer.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import traceback
+from contextlib import redirect_stdout
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+GATE_PATH = HERE / "auto-refresh-gate.py"
+
+_spec = importlib.util.spec_from_file_location("auto_refresh_gate", GATE_PATH)
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)  # type: ignore[union-attr]
+
+
+# ---- Fixtures ----------------------------------------------------------------
+
+
+def pinned_body(*outstanding_bullets: str) -> str:
+    bullets = "\n".join(outstanding_bullets)
+    return (
+        "<!-- CLAUDE_REVIEW 1/1 -->\n"
+        "## Docs review\n\n"
+        "### 🔍 Verification trail\n\n"
+        "- L42 \"claim\" → 🚨 contradicted evidence\n\n"
+        "### 🚨 Outstanding in this PR\n\n"
+        f"{bullets}\n\n"
+        "### ⚠️ Low-confidence\n\n"
+        "- **[L200]** something dubious\n\n"
+        "### 📜 Review history\n\n"
+        "- 2026-07-01T00:00:00Z — initial review (abc1234)\n"
+    )
+
+
+def make_diff(path: str, old_start: int, old_count: int, *,
+              added: int = 1, removed: int = 1, new_file: bool = False,
+              deleted: bool = False, rename: bool = False) -> str:
+    """Build a minimal single-hunk unified diff."""
+    old_path = "/dev/null" if new_file else f"a/{path}"
+    new_path = "/dev/null" if deleted else f"b/{path}"
+    lines = [f"diff --git a/{path} b/{path}"]
+    if rename:
+        lines += [f"rename from {path}", f"rename to {path}.moved"]
+    lines += [
+        f"--- {old_path}",
+        f"+++ {new_path}",
+        f"@@ -{old_start},{old_count} +{old_start},{old_count - removed + added} @@",
+    ]
+    lines += [f"-old line {i}" for i in range(removed)]
+    lines += [f"+new line {i}" for i in range(added)]
+    return "\n".join(lines) + "\n"
+
+
+def run_gate(body: str, diff: str, pr_files: list[str]) -> tuple[int, dict]:
+    """Invoke gate.main() through the CLI surface with temp files."""
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        (tdp / "body.md").write_text(body, encoding="utf-8")
+        (tdp / "push.diff").write_text(diff, encoding="utf-8")
+        (tdp / "files.json").write_text(json.dumps(pr_files), encoding="utf-8")
+        argv = sys.argv
+        sys.argv = ["auto-refresh-gate.py",
+                    "--pinned-body", str(tdp / "body.md"),
+                    "--push-diff", str(tdp / "push.diff"),
+                    "--pr-files", str(tdp / "files.json")]
+        out = io.StringIO()
+        try:
+            with redirect_stdout(out):
+                rc = gate.main()
+        finally:
+            sys.argv = argv
+    payload = json.loads(out.getvalue()) if out.getvalue().strip() else {}
+    return rc, payload
+
+
+FILE = "content/docs/iac/concepts/stacks.md"
+
+
+# ---- Tests -------------------------------------------------------------------
+
+
+def test_exact_overlap_fires():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    rc, res = run_gate(body, make_diff(FILE, 42, 3), [FILE])
+    assert rc == 0 and res["fire"] is True, res
+
+
+def test_single_line_anchor_fires():
+    body = pinned_body("- **[L42]** wrong default value")
+    rc, res = run_gate(body, make_diff(FILE, 42, 1), [FILE])
+    assert rc == 0 and res["fire"] is True, res
+
+
+def test_slack_boundary():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    # Hunk ends exactly SLACK_LINES above the anchor start: 37 >= 40 - 3.
+    rc, res = run_gate(body, make_diff(FILE, 37, 1), [FILE])
+    assert res["fire"] is True, res
+    # One line further out: 36 < 40 - 3 → no fire.
+    rc, res = run_gate(body, make_diff(FILE, 36, 1), [FILE])
+    assert res["fire"] is False, res
+
+
+def test_out_of_range_hunk_fails():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    rc, res = run_gate(body, make_diff(FILE, 300, 2), [FILE])
+    assert rc == 0 and res["fire"] is False, res
+    assert "outside outstanding finding lines" in res["reason"], res
+
+
+def test_pure_insertion_adjacent_to_anchor_fires():
+    body = pinned_body("- **[L40-50]** missing caveat")
+    diff = (
+        f"diff --git a/{FILE} b/{FILE}\n"
+        f"--- a/{FILE}\n"
+        f"+++ b/{FILE}\n"
+        "@@ -50,0 +51,2 @@\n"
+        "+a new caveat line\n"
+        "+another line\n"
+    )
+    rc, res = run_gate(body, diff, [FILE])
+    assert rc == 0 and res["fire"] is True, res
+
+
+def test_file_outside_pr_fails():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    rc, res = run_gate(body, make_diff(FILE, 42, 3), ["content/docs/other.md"])
+    assert res["fire"] is False and "outside the PR's reviewed files" in res["reason"], res
+
+
+def test_new_file_fails():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    rc, res = run_gate(body, make_diff(FILE, 42, 3, new_file=True), [FILE])
+    assert res["fire"] is False and res["reason"] == "push adds a new file", res
+
+
+def test_deleted_file_fails():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    rc, res = run_gate(body, make_diff(FILE, 42, 3, deleted=True), [FILE])
+    assert res["fire"] is False and res["reason"] == "push deletes a file", res
+
+
+def test_renamed_file_fails():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    rc, res = run_gate(body, make_diff(FILE, 42, 3, rename=True), [FILE])
+    assert res["fire"] is False and res["reason"] == "push renames a file", res
+
+
+def test_size_cap_fails():
+    body = pinned_body("- **[L1-500]** sprawling finding")
+    over = gate.MAX_CHANGED_LINES + 1
+    rc, res = run_gate(body, make_diff(FILE, 10, over, added=over, removed=over), [FILE])
+    assert res["fire"] is False and "too large" in res["reason"], res
+
+
+def test_empty_diff_fails():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    rc, res = run_gate(body, "", [FILE])
+    assert rc == 0 and res["fire"] is False and res["reason"] == "empty push diff", res
+
+
+def test_empty_pinned_body_fails():
+    rc, res = run_gate("", make_diff(FILE, 42, 3), [FILE])
+    assert rc == 0 and res["fire"] is False and res["reason"] == "no pinned review found", res
+
+
+def test_no_outstanding_bucket_fails():
+    body = pinned_body().replace("### 🚨 Outstanding in this PR\n\n\n\n", "")
+    rc, res = run_gate(body, make_diff(FILE, 42, 3), [FILE])
+    assert res["fire"] is False and "no outstanding findings" in res["reason"], res
+
+
+def test_unparsable_anchor_fails_closed():
+    # Legacy bullet format without the canonical [L...] prefix.
+    body = pinned_body("- **content/docs/foo.md L40-50** wrong default value")
+    rc, res = run_gate(body, make_diff(FILE, 42, 3), [FILE])
+    assert res["fire"] is False and "no parseable" in res["reason"], res
+
+
+def test_multi_page_outstanding_union():
+    page1 = pinned_body("- **[L40-50]** first finding")
+    page2 = (
+        "<!-- CLAUDE_REVIEW 2/2 -->\n"
+        "### 🚨 Outstanding in this PR\n\n"
+        "- **[L300-310]** overflow-page finding\n"
+    )
+    body = page1 + "\n----- PINNED-COMMENT-DELIMITER -----\n" + page2
+    rc, res = run_gate(body, make_diff(FILE, 305, 2), [FILE])
+    assert rc == 0 and res["fire"] is True, res
+
+
+def test_multi_hunk_one_outside_fails():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    diff = make_diff(FILE, 42, 3) + make_diff(FILE, 400, 2)
+    rc, res = run_gate(body, diff, [FILE])
+    assert res["fire"] is False and "outside outstanding finding lines" in res["reason"], res
+
+
+def test_binary_file_fails():
+    body = pinned_body("- **[L40-50]** wrong default value")
+    diff = (
+        "diff --git a/static/images/x.png b/static/images/x.png\n"
+        "Binary files a/static/images/x.png and b/static/images/x.png differ\n"
+    )
+    rc, res = run_gate(body, diff, ["static/images/x.png"])
+    assert res["fire"] is False and "binary" in res["reason"], res
+
+
+def test_missing_input_file_exits_2():
+    argv = sys.argv
+    sys.argv = ["auto-refresh-gate.py",
+                "--pinned-body", "/nonexistent/body.md",
+                "--push-diff", "/nonexistent/push.diff",
+                "--pr-files", "/nonexistent/files.json"]
+    try:
+        rc = gate.main()
+    finally:
+        sys.argv = argv
+    assert rc == 2, rc
+
+
+def test_malformed_pr_files_exits_2():
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        (tdp / "body.md").write_text(pinned_body("- **[L40-50]** x"), encoding="utf-8")
+        (tdp / "push.diff").write_text(make_diff(FILE, 42, 3), encoding="utf-8")
+        (tdp / "files.json").write_text('{"not": "a list"}', encoding="utf-8")
+        argv = sys.argv
+        sys.argv = ["auto-refresh-gate.py",
+                    "--pinned-body", str(tdp / "body.md"),
+                    "--push-diff", str(tdp / "push.diff"),
+                    "--pr-files", str(tdp / "files.json")]
+        try:
+            rc = gate.main()
+        finally:
+            sys.argv = argv
+    assert rc == 2, rc
+
+
+# ---- Runner ------------------------------------------------------------------
+
+
+def main() -> int:
+    tests = [(name, fn) for name, fn in sorted(globals().items())
+             if name.startswith("test_") and callable(fn)]
+    failures = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except Exception:
+            failures += 1
+            print(f"FAIL {name}")
+            traceback.print_exc()
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,7 +50,9 @@ on:
         default: ''
 
 jobs:
-  # synchronize → just mark the existing pinned review stale.
+  # synchronize → mark the existing pinned review stale, and record whether
+  # the prior state was outstanding-issues so the auto-refresh job below can
+  # decide whether the push is a candidate for a scoped automatic update.
   mark-stale:
     if: |
       github.event_name == 'pull_request' &&
@@ -61,8 +63,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    outputs:
+      was_outstanding: ${{ steps.transition.outputs.was_outstanding }}
     steps:
       - name: Mark previous Claude review as stale
+        id: transition
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
@@ -75,14 +80,119 @@ jobs:
           # are not transitioned: in-progress means a run is mid-flight,
           # error is a workflow failure (separate triage), and stale is
           # already terminal.
+          WAS_OUTSTANDING=false
           LABELS=$(gh pr view "$PR" --repo "${{ github.repository }}" --json labels --jq '[.labels[].name] | join(",")')
           if [[ ",$LABELS," == *",review:outstanding-issues,"* ]]; then
             gh pr edit "$PR" --repo "${{ github.repository }}" \
               --add-label "review:stale" --remove-label "review:outstanding-issues"
+            WAS_OUTSTANDING=true
           elif [[ ",$LABELS," == *",review:no-blockers,"* ]]; then
             gh pr edit "$PR" --repo "${{ github.repository }}" \
               --add-label "review:stale" --remove-label "review:no-blockers"
           fi
+          echo "was_outstanding=$WAS_OUTSTANDING" >> "$GITHUB_OUTPUT"
+
+  # Auto-refresh a just-staled review when the push delta is trivial — the
+  # "I fixed what you flagged" case. A deterministic gate
+  # (auto-refresh-gate.py) checks that every hunk of the push diff lands on
+  # (or within a few lines of) a 🚨 Outstanding finding's [L...] anchor and
+  # that the push is small; only then is claude-update.yml dispatched to run
+  # the scoped Sonnet fix-response pass. Anything the gate can't prove —
+  # large pushes, new files, hunks outside flagged lines, force-pushes,
+  # unparsable pinned comments — leaves the PR in review:stale exactly as
+  # before, with the documented explicit refresh paths
+  # (`@claude #update-review` / `#new-review` / draft→ready).
+  #
+  # Scope guards:
+  # - Only fires when mark-stale transitioned OFF review:outstanding-issues.
+  #   A stale no-blockers review has nothing to re-verify.
+  # - Same-repo head branches only. Fork PRs run pull_request with a
+  #   read-only token that can't dispatch workflows; they keep the manual
+  #   refresh flow.
+  # - Once per push comes free: one synchronize event per push, and
+  #   claude-update.yml's per-PR concurrency group (cancel-in-progress)
+  #   collapses stacked pushes onto the newest head.
+  auto-refresh:
+    needs: mark-stale
+    if: |
+      needs.mark-stale.outputs.was_outstanding == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write # gh workflow run claude-update.yml
+    steps:
+      # The gate scripts come from the BASE ref, never the PR head — the
+      # decision to spend model budget must not be steerable by the PR
+      # under review. Sparse checkout: this job only needs the scripts.
+      - name: Checkout gate scripts (base ref)
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 1
+          sparse-checkout: .claude/commands/docs-review/scripts
+
+      - name: Evaluate auto-refresh gate
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.after }}
+        run: |
+          SCRIPTS=.claude/commands/docs-review/scripts
+          no_fire() {
+            echo "fire=false" >> "$GITHUB_OUTPUT"
+            echo "auto-refresh gate: no fire — $1" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          bash "$SCRIPTS/pinned-comment.sh" fetch --pr "$PR" --repo "$REPO" \
+            > /tmp/pinned-body.md || true
+          [ -s /tmp/pinned-body.md ] || no_fire "no pinned review on PR #$PR"
+
+          LAST_SHA=$(bash "$SCRIPTS/pinned-comment.sh" last-reviewed-sha \
+            --pr "$PR" --repo "$REPO" 2>/dev/null || true)
+          [ -n "$LAST_SHA" ] || no_fire "no last-reviewed SHA in review history"
+
+          # Push delta via the compare API — no checkout depth games. The
+          # three-dot compare diffs merge-base..head: on a normal push the
+          # merge-base IS the last-reviewed SHA (exact push delta); after a
+          # force-push the merge-base drifts older, the diff inflates, and
+          # the gate fails closed downstream.
+          gh api -H "Accept: application/vnd.github.v3.diff" \
+            "repos/$REPO/compare/$LAST_SHA...$HEAD_SHA" > /tmp/push.diff \
+            || no_fire "compare $LAST_SHA...$HEAD_SHA failed (history rewritten?)"
+
+          gh pr view "$PR" --repo "$REPO" --json files \
+            --jq '[.files[].path]' > /tmp/pr-files.json \
+            || no_fire "could not list PR files"
+
+          RESULT=$(python3 "$SCRIPTS/auto-refresh-gate.py" \
+            --pinned-body /tmp/pinned-body.md \
+            --push-diff /tmp/push.diff \
+            --pr-files /tmp/pr-files.json) \
+            || no_fire "gate script error (fail closed)"
+
+          FIRE=$(echo "$RESULT" | jq -r '.fire')
+          REASON=$(echo "$RESULT" | jq -r '.reason')
+          echo "fire=$FIRE" >> "$GITHUB_OUTPUT"
+          echo "auto-refresh gate: fire=$FIRE — $REASON" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Dispatch with GITHUB_TOKEN — same pattern as claude-new.yml's
+      # dispatch of this workflow. The dispatched run's actor becomes
+      # github-actions[bot]; claude-update.yml opts in via allowed_bots.
+      - name: Dispatch scoped update review
+        if: steps.gate.outputs.fire == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run claude-update.yml \
+            --repo "${{ github.repository }}" \
+            -f pr_number="${{ github.event.pull_request.number }}" \
+            -f head_sha="${{ github.event.after }}" \
+            -f auto=true
 
   claude-review:
     # Fire only for workflow_run events from Claude Triage that were

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -6,6 +6,14 @@ name: Pre-merge Review (update-review)
 # refresh -- bare `@claude` mentions go to claude.yml (off-the-shelf tag
 # mode) and `@claude #new-review` goes to claude-new.yml (regenerate).
 # The compound-mention contract is documented inline in the prompt.
+#
+# A second entry point exists for the stale-review auto-refresh: the
+# auto-refresh job in claude-code-review.yml dispatches this workflow
+# (workflow_dispatch, auto=true) when a synchronize push passes the
+# deterministic auto-refresh-gate.py check — every hunk lands on a line
+# range carried by a 🚨 Outstanding finding and the push is small. The run
+# then follows update.md Case 1 (fix-response) with a synthesized mention
+# body; there is no human mention author.
 
 on:
   issue_comment:
@@ -16,6 +24,25 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  # Dispatched by claude-code-review.yml's auto-refresh job (auto=true).
+  # Humans with write access can also dispatch manually from the Actions
+  # UI as an alternative to commenting `@claude #update-review`.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose pinned review to refresh'
+        required: true
+        type: string
+      head_sha:
+        description: 'PR head SHA the dispatcher evaluated; the run no-ops if the PR head has moved past it (superseded by a newer push)'
+        required: false
+        type: string
+        default: ''
+      auto:
+        description: 'true when dispatched by the auto-refresh gate (attributes the run to auto-refresh instead of a human mention author)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   claude-update:
@@ -29,10 +56,18 @@ jobs:
     #      contains literal "@claude" instructions which would otherwise
     #      re-trigger on every review post.
     if: |
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(github.event.comment.body, '#update-review') && !contains(github.event.comment.body, '#new-review') && github.event.comment.user.login != 'claude[bot]') ||
+      ((github.event_name == 'workflow_dispatch') ||
+       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(github.event.comment.body, '#update-review') && !contains(github.event.comment.body, '#new-review') && github.event.comment.user.login != 'claude[bot]') ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(github.event.comment.body, '#update-review') && !contains(github.event.comment.body, '#new-review') && github.event.comment.user.login != 'claude[bot]') ||
        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(github.event.review.body, '#update-review') && !contains(github.event.review.body, '#new-review') && github.event.review.user.login != 'claude[bot]') ||
        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (contains(github.event.issue.body, '#update-review') || contains(github.event.issue.title, '#update-review')) && !contains(github.event.issue.body, '#new-review') && !contains(github.event.issue.title, '#new-review') && github.event.issue.user.login != 'claude[bot]'))
+    # One update per PR at a time; a newer trigger (another push through the
+    # auto-refresh gate, or a fresh #update-review mention) cancels the
+    # in-flight run — the newest head wins. Also the once-per-push dedup for
+    # the auto path: stacked synchronize events collapse here.
+    concurrency:
+      group: claude-update-${{ github.event.inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -62,6 +97,10 @@ jobs:
               PR="${{ github.event.pull_request.number }}"
               IS_PR="true"
               ;;
+            workflow_dispatch)
+              PR="${{ github.event.inputs.pr_number }}"
+              IS_PR="true"
+              ;;
             *)
               PR=""; IS_PR="false"
               ;;
@@ -70,17 +109,35 @@ jobs:
             SHA=$(gh pr view "$PR" --repo "${{ github.repository }}" --json headRefOid --jq .headRefOid)
             echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           fi
+          # Staleness guard for dispatched runs: the dispatcher pins the head
+          # SHA it evaluated. If the PR has moved on since (another push beat
+          # this run out of the queue), the whole run no-ops — the newer
+          # push's own gate evaluation owns the refresh. The concurrency
+          # group handles overlapping runs; this handles the
+          # already-finished-dispatching race.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+             && [ -n "${{ github.event.inputs.head_sha }}" ] \
+             && [ "$SHA" != "${{ github.event.inputs.head_sha }}" ]; then
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+            echo "PR #$PR head moved from ${{ github.event.inputs.head_sha }} to $SHA — superseded; no-op"
+          fi
 
       # ESC runs before checkout so the bot token can authenticate the
       # checkout — pushes made by claude-code-action later in the workflow
       # then go out as pulumi-bot rather than github-actions[bot],
       # which is what lets downstream workflows (build-and-deploy, social
       # review, etc.) fire on those commits.
+      # The three setup steps below skip on superseded dispatched runs
+      # (steps.head sets superseded=true when the PR head moved past the
+      # dispatcher's pinned SHA) — the run is a no-op, so don't pay for
+      # secrets, checkout, or toolchain install.
       - name: Fetch secrets from ESC
         id: esc-secrets
+        if: steps.head.outputs.superseded != 'true'
         uses: pulumi/esc-action@v3
 
       - name: Checkout repository
+        if: steps.head.outputs.superseded != 'true'
         uses: actions/checkout@v7
         with:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
@@ -90,13 +147,34 @@ jobs:
       # Install mise-managed tools (Vale, Node, etc.) so the prose-lint
       # step below has the pinned vale binary on PATH.
       - name: Install mise-managed tools
+        if: steps.head.outputs.superseded != 'true'
         uses: jdx/mise-action@v4
         with:
           cache: true
 
       - name: Check repository write access
         id: check-access
+        if: steps.head.outputs.superseded != 'true'
         run: |
+          # workflow_dispatch runs skip the collaborator-permission lookup:
+          # triggering a dispatch already requires write access (humans via
+          # the Actions UI) or comes from the auto-refresh gate in
+          # claude-code-review.yml, which only fires for same-repo branches
+          # (pushable only with write access). There is no mention author;
+          # auto-gated runs attribute to "auto-refresh", manual dispatches
+          # to the dispatching actor.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ github.event.inputs.auto }}" = "true" ]; then
+              AUTHOR="auto-refresh"
+            else
+              AUTHOR="${{ github.actor }}"
+            fi
+            echo "has_write_access=true" >> $GITHUB_OUTPUT
+            echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+            echo "✓ workflow_dispatch by $AUTHOR — write access implied by dispatch permissions"
+            exit 0
+          fi
+
           # Use the actual repository the workflow is running in, not a hardcoded
           # upstream name. The GITHUB_TOKEN is only scoped to this repo, so a
           # hardcoded owner/repo would always return "none" in fork-based testing
@@ -161,6 +239,10 @@ jobs:
               PR_NUMBER="${{ github.event.issue.number }}"
               IS_PR="false"
               ;;
+            workflow_dispatch)
+              PR_NUMBER="${{ github.event.inputs.pr_number }}"
+              IS_PR="true"
+              ;;
           esac
 
           HAS_PINNED="false"
@@ -204,6 +286,9 @@ jobs:
       # scraping the event payload at runtime. Env vars carry the body
       # safely (no direct interpolation into shell -- bodies can contain
       # arbitrary text including shell metacharacters).
+      # workflow_dispatch has no triggering comment; the body is a fixed
+      # synthesized instruction scoping the run to update.md Case 1
+      # (fix-response) over the existing outstanding findings.
       - name: Save mention body
         id: mention
         if: steps.check-access.outputs.has_write_access == 'true'
@@ -222,6 +307,9 @@ jobs:
               ;;
             issues)
               BODY="$ISSUE_BODY"
+              ;;
+            workflow_dispatch)
+              BODY="Automated refresh (no human mention): the latest push was gated as touching only lines carried by outstanding findings. Treat this as update.md Case 1 (fix-response): re-verify each 🚨 Outstanding finding against the new diff, move resolved ones to ✅ Resolved with the commit SHA, and check the pushed lines for new problems. Do not re-extract claims or raise findings on content the push did not touch. There is no dispute to adjudicate."
               ;;
             *)
               BODY=""
@@ -292,6 +380,13 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Use bot token so pushes trigger downstream workflows (e.g., social review)
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          # The auto-refresh gate in claude-code-review.yml dispatches this
+          # workflow with GITHUB_TOKEN, which makes the run's actor
+          # github-actions[bot] (type=Bot) — rejected by
+          # claude-code-action@v1 by default. Same allowance
+          # claude-code-review.yml makes for its bot-dispatched #new-review
+          # path.
+          allowed_bots: 'github-actions[bot]'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -364,15 +459,26 @@ jobs:
           COMMENT_ID="${{ steps.progress.outputs.comment_id }}"
           OUTCOME="${{ steps.claude.outcome }}"
           AUTHOR="${{ steps.check-access.outputs.author }}"
+          # Auto-gated runs have no human requester: "auto-refresh" is not a
+          # GitHub user, so never render it as an @-mention (it would ping an
+          # unrelated account of that name). Plain wording instead.
           if [ "$OUTCOME" = "success" ]; then
             gh api -X DELETE "repos/$REPO/issues/comments/$COMMENT_ID" >/dev/null 2>&1 || true
-            BODY=$(printf '<!-- CLAUDE_PROGRESS -->\n%s' "🤖 Review updated on @${AUTHOR}'s request.")
+            if [ "$AUTHOR" = "auto-refresh" ]; then
+              BODY=$(printf '<!-- CLAUDE_PROGRESS -->\n%s' "🤖 Review auto-refreshed — the latest push only touched lines with outstanding findings.")
+            else
+              BODY=$(printf '<!-- CLAUDE_PROGRESS -->\n%s' "🤖 Review updated on @${AUTHOR}'s request.")
+            fi
             gh api "repos/$REPO/issues/$PR/comments" -f body="$BODY" >/dev/null || true
           elif [ "$OUTCOME" = "cancelled" ] || [ "$OUTCOME" = "skipped" ]; then
             gh api -X DELETE "repos/$REPO/issues/comments/$COMMENT_ID" >/dev/null 2>&1 || true
           else
             gh api -X DELETE "repos/$REPO/issues/comments/$COMMENT_ID" >/dev/null 2>&1 || true
-            BODY=$(printf '<!-- CLAUDE_PROGRESS -->\n%s' "🤖 @${AUTHOR} — review errored. Mention @claude #update-review again to retry.")
+            if [ "$AUTHOR" = "auto-refresh" ]; then
+              BODY=$(printf '<!-- CLAUDE_PROGRESS -->\n%s' "🤖 Automatic review refresh errored; the review is still marked stale. Mention @claude #update-review to refresh it.")
+            else
+              BODY=$(printf '<!-- CLAUDE_PROGRESS -->\n%s' "🤖 @${AUTHOR} — review errored. Mention @claude #update-review again to retry.")
+            fi
             gh api "repos/$REPO/issues/$PR/comments" -f body="$BODY" >/dev/null || true
           fi
           if [ "$OUTCOME" = "success" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,6 @@ Before starting any documentation task, check `.claude/commands/` for a relevant
 
 ## PR Lifecycle for AI-Assisted Contributions
 
-Open as draft, mark ready when done. Each ready-transition fires one full review; thrashing draft → ready → draft burns budget. Leave AI authoring trailers in commits (`Co-Authored-By: Claude ...`) — stripping them is bad form and changes nothing about which review runs. Don't delete `<!-- CLAUDE_REVIEW N/M -->` comments — the re-entrant pipeline edits them in place. To refresh a stale review, mention `@claude #update-review` (fix-response / dispute / re-verify) or transition through draft and back to ready. Bare `@claude` (no hashtag) is for ad-hoc help,
+Open as draft, mark ready when done. Each ready-transition fires one full review; thrashing draft → ready → draft burns budget. Leave AI authoring trailers in commits (`Co-Authored-By: Claude ...`) — stripping them is bad form and changes nothing about which review runs. Don't delete `<!-- CLAUDE_REVIEW N/M -->` comments — the re-entrant pipeline edits them in place. A small push that only touches lines carrying outstanding findings refreshes the stale review automatically; otherwise, mention `@claude #update-review` (fix-response / dispute / re-verify) or transition through draft and back to ready. Bare `@claude` (no hashtag) is for ad-hoc help,
 
 For the full mechanics — refresh-pattern details, short-circuit thresholds, classifier internals — see `CONTRIBUTING.md` §AI-assisted contributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Open new PRs as **drafts** while you iterate. Automated review (style, accuracy,
 
 While you're iterating, consider running `/docs-review` locally — it runs the same style/accuracy pipeline as the automated bot, but stays in your conversation and never posts to GitHub. Catching findings here is cheaper than catching them after the pinned review fires.
 
-When you're ready, use the **Ready for review** button on the PR page. Triage runs again to refresh labels, then the full review fires once and pins its findings to a single comment at the top of the PR. New commits afterward will mark the review **stale** but won't auto-rerun — mention `@claude #update-review` in a comment to refresh, or transition through draft and back to ready.
+When you're ready, use the **Ready for review** button on the PR page. Triage runs again to refresh labels, then the full review fires once and pins its findings to a single comment at the top of the PR. New commits afterward mark the review **stale**. A small push that only touches the lines the review flagged refreshes the review automatically; anything larger won't auto-rerun — mention `@claude #update-review` in a comment to refresh, or transition through draft and back to ready.
 
 If your change is genuinely trivial (a typo, a one-line fix), opening directly as ready is fine — the pipeline will short-circuit on the `review:trivial` label.
 
@@ -33,7 +33,7 @@ If the PR was AI-drafted, leave the AI authoring trailers in commit messages (`C
 
 ### After review — three paths to refresh
 
-A pinned review goes **stale** when you push new commits after it ran. Stale reviews don't auto-rerun. Three ways to refresh:
+A pinned review goes **stale** when you push new commits after it ran. One case refreshes itself: when the review had outstanding findings and your push is small (≤80 changed lines) and touches only the flagged lines — the "I fixed what you flagged" push — a deterministic gate auto-fires the scoped `#update-review` path with no mention needed. Everything else stays stale until you refresh explicitly. Three ways:
 
 1. **`@claude` mention** — hashtag-driven routing. The re-entrant pipeline branches on what you put after `@claude`:
     - **`@claude #update-review`** — refresh the pinned review against the current PR head. Runs `claude-sonnet-5`. Three patterns the update path understands, all of which can appear in the same mention (the pipeline addresses any embedded asks inline before re-rendering the review):


### PR DESCRIPTION
### Proposed changes

Implements §3.7 of the docs-review automation evaluation (#20078): on `synchronize`, when a push looks like the common "I fixed what you flagged" case, the pipeline now auto-fires the scoped Sonnet `#update-review` path instead of leaving the PR in `review:stale` until the author remembers to mention `@claude`.

**The gate is deterministic — the model never decides whether to auto-fire:**

- **`.claude/commands/docs-review/scripts/auto-refresh-gate.py`** (new): parses the pinned review's 🚨 Outstanding `[L…]` anchors (reusing `validate-pinned.py`'s parsers) and the push diff, and fires only when **all** of the following hold:
  - every hunk's old-side range lands within ±3 lines of an outstanding finding's range;
  - the push is ≤80 changed lines;
  - no files are added, deleted, or renamed, and every touched file is already in the PR's diff.
  - Everything ambiguous — force-pushes, unparsable pinned comments, empty diffs, gate errors — fails closed to today's behavior (stale label, manual refresh).
- **`claude-code-review.yml`**: `mark-stale` now records whether it transitioned off `review:outstanding-issues`; a new `auto-refresh` job (same-repo branches only) runs the gate from the **base ref** (the budget decision isn't steerable by the PR under review), computes the push delta via the compare API (`last-reviewed-sha...head` — inflates on force-push, failing the gate), and dispatches `claude-update.yml` when the gate passes.
- **`claude-update.yml`**: new `workflow_dispatch` entrypoint (`pr_number`, `head_sha`, `auto`), a per-PR concurrency group (`cancel-in-progress` — newest head wins, once-per-push dedup), a head-SHA staleness guard that no-ops superseded runs before checkout, a synthesized Case 1 (fix-response) mention body for auto runs, `allowed_bots: github-actions[bot]` for the bot-dispatched actor, and auto-attributed progress/terminal comments (no `@auto-refresh` mention — that's not a real user).
- **`update.md`**: documents the automated invocation (strictly Case 1, scoped to outstanding findings and pushed lines; disputes never apply).
- **`CONTRIBUTING.md` / `AGENTS.md`**: the stale-review contract now describes the auto-refresh carve-out.

Tests: `test_auto_refresh_gate.py` (19 cases — overlap/slack boundaries, size cap, new/deleted/renamed/binary files, multi-page pinned comments, fail-closed paths), self-contained per the existing convention. `make lint` passes.

Known limitation (documented in the gate's docstring): `[L…]` anchors carry no file path, so on multi-file PRs the hunk match runs against the union of ranges. A coincidental cross-file overlap can fire an unnecessary refresh — the consequence is one budget-capped Sonnet run that re-verifies all outstanding findings, which is benign. Exact file-qualified anchors (persisting `.verified-claims.json` as an artifact) are noted as optional later hardening.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Part of #20078 (§3.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139uwXEGvRMpgtC5bdhM9Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_0139uwXEGvRMpgtC5bdhM9Vz)_