### PR TITLE
Add pre-merge review outcome telemetry (issue #20078 §3.2)

### DIFF
--- a/.claude/commands/docs-review/SKILL.md
+++ b/.claude/commands/docs-review/SKILL.md
@@ -51,3 +51,14 @@ gh pr diff {{arg}}
 ```
 
 Format for terminal display. Include the scope in the summary, and offer to broaden if useful.
+
+## Outcome telemetry (quarterly review)
+
+Every closed PR's pinned review encodes what happened to its findings (✅ Resolved = fixed, `concede:` = conceded, `🛡️ Disputed … model held` = disputed, still-🚨-at-merge = ignored). `scripts/scrape-review-outcomes.py` derives per-finding outcomes from that structure; the weekly digest (`scripts/weekly-digest/digest.py`) aggregates the trailing week automatically. Quarterly, run the long-window tuning report:
+
+```bash
+uv run .claude/commands/docs-review/scripts/scrape-review-outcomes.py \
+    --closed-since <quarter-start> --stats
+```
+
+What to do with the numbers: verdict categories with high **concede** or **ignored-at-merge** rates are candidates for demoting from the always-🚨 carve-out list (or pruning entirely — edit `docs-review:references:output-format` §Bucket rules in a PR); recurring prose findings with high **fix** rates are candidates for promotion into Vale rules so they're caught pre-review. High `unconfirmed_at_merge` counts mean reviews are routinely stale at merge — evidence for auto-refreshing on trivial deltas. Telemetry informs the tuning; humans make the edits.

--- a/.claude/commands/docs-review/references/output-format.md
+++ b/.claude/commands/docs-review/references/output-format.md
@@ -337,7 +337,7 @@ Computation rules live in `docs-review:references:blog` §Priority 2.5.
 
     Bold every numeral in the summary (the total and each kind count) so they read at a glance even on a narrow screen. Order kinds by count descending; ties alphabetical. Render the breakdown even on single-finding files (the format is uniform across the review).
 - **💡 Pre-existing** is opt-in per domain (see each domain file). When emitted, cap at 15 per file. Render under a `<details>` block when the count would push the comment past 25k characters.
-- **✅ Resolved** lists findings from the previous review that no longer appear.
+- **✅ Resolved** lists findings from the previous review that no longer appear. Annotate conceded findings with `concede: <reason>` (per `docs-review:references:update` Case 2) — the outcome telemetry (`scrape-review-outcomes.py`) distinguishes fixed from conceded by that exact token, and the `outcome-annotation-shape` validator rule flags freelanced variants. The same applies to the held-dispute annotation `🛡️ **Disputed by <author> on YYYY-MM-DD, model held.**` in 🚨/⚠️.
 - **📜 Review history** is append-only across re-runs. Initial entry is the first line.
 
 Per-finding rendering (suggestion blocks, quote-and-rewrite mandate, fix prose) is governed by `docs-review:references:shared-criteria`.

--- a/.claude/commands/docs-review/references/update.md
+++ b/.claude/commands/docs-review/references/update.md
@@ -103,6 +103,8 @@ The author or another reviewer pushed back on a previous finding *without* a fix
    - The Outstanding count does not change.
 4. **Do not** reword the same finding hoping it lands better. The original wording is in the comment; either change your mind or explain why you didn't.
 
+**The annotation shapes are machine-scraped.** `scrape-review-outcomes.py` derives the weekly outcome telemetry (fixed / conceded / disputed counts) from the exact `concede: <reason>` and `🛡️ **Disputed by <author> on YYYY-MM-DD, model held.**` forms above — a freelanced variant ("author disputed this", "conceding the point") silently drops the finding out of those counts, and the validator's `outcome-annotation-shape` rule flags it.
+
 **Failure-mode examples:**
 
 > Author (write access) mentions Claude saying: "I built this — the project intentionally uses pattern X because of Y."

--- a/.claude/commands/docs-review/scripts/scrape-review-outcomes.py
+++ b/.claude/commands/docs-review/scripts/scrape-review-outcomes.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Scrape pre-merge review outcomes from pinned review comments.
+
+Closes the feedback loop described in issue #20078 §3.2: the pipeline records
+what it *spends* but not what *happens* to its findings. This script derives
+per-finding outcomes (fixed / conceded / ignored / disputed) from the pinned
+`<!-- CLAUDE_REVIEW N/M -->` comment sequence that the review workflows leave
+on every reviewed PR. The comment is frozen once the PR closes, so it IS the
+outcome ledger — no new state store, no model calls, no self-report.
+
+Outcome taxonomy (terminal, per finding):
+  * fixed                   — bullet in ✅ Resolved without a concede annotation
+  * conceded                — ✅ Resolved bullet carrying `concede:`
+  * ignored_outstanding     — still in 🚨 Outstanding when the PR merged
+  * ignored_low_confidence  — still in ⚠️ Low-confidence when the PR merged
+  * unconfirmed_at_merge    — still in 🚨/⚠️ at merge, but the review was stale
+                              (last 📜 history SHA is not the merge head), so
+                              "ignored" can't be honestly claimed
+  * abandoned               — PR closed without merging (excluded from rates)
+
+Orthogonal event flag: a finding is *disputed* when it carries a
+`🛡️ **Disputed by <author> on YYYY-MM-DD, model held.**` line (adjudication
+"held") or was conceded via a `concede:` annotation (adjudication "conceded").
+
+Style findings (`[style]` bullets under `#### Style findings`) are counted
+separately and never outcome-classified — they are regenerated fresh on every
+re-review and never move to ✅ Resolved, so per-finding tracking would lie.
+
+This is a telemetry READER, never a gate: unparseable or legacy comment
+formats degrade to `parse_confidence: "low"` (counts-only) or
+`status: "no_review_data"`, and the aggregate reports how often that happened
+so silent degradation stays visible.
+
+Usage:
+  scrape-review-outcomes.py --pr 20123 [--repo owner/repo]
+      One PR -> one outcome record (JSON to stdout).
+  scrape-review-outcomes.py --closed-since 2026-07-02 [--repo owner/repo]
+      All review-labeled PRs closed since the date -> per-PR records +
+      window aggregate (JSON to stdout). This is what digest.py calls.
+  scrape-review-outcomes.py --closed-since 2026-04-01 --stats
+      Same scrape, rendered as a markdown tuning report (per-verdict-category
+      fix/concede/ignore/dispute rates) for the quarterly outcome review.
+  scrape-review-outcomes.py --self-test
+      Run embedded smoke checks (no network).
+
+Parsing reuses validate-pinned.py's body helpers (find_section,
+extract_bucket_bullets, extract_count_table_row, extract_trail_records,
+extract_bullet_prefix) so the comment-format contract has exactly one parser.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+# Single source of truth for pinned-body parsing. validate-pinned.py's name is
+# hyphenated, so import by path; its main() is __main__-guarded, so importing
+# has no side effects (same pattern as scripts/content-review/record-review.py
+# importing select-articles.py).
+_spec = importlib.util.spec_from_file_location("validate_pinned", HERE / "validate-pinned.py")
+_vp = importlib.util.module_from_spec(_spec)
+# Register before exec: validate-pinned.py defines dataclasses, and the
+# dataclass machinery resolves the defining module through sys.modules.
+sys.modules["validate_pinned"] = _vp
+_spec.loader.exec_module(_vp)
+
+DEFAULT_REPO = "pulumi/docs"
+MARKER_RE = re.compile(r"^<!-- CLAUDE_REVIEW (\d+)/(\d+) -->")
+# Canonical annotation shapes are owned by validate-pinned.py (schema v18's
+# `outcome-annotation-shape` rule enforces them going forward); this reader
+# additionally accepts a looser legacy dispute form, since old pinned comments
+# predate the rule and a telemetry reader must never gate.
+DISPUTED_RE = _vp.DISPUTED_ANNOTATION_RE
+DISPUTED_LEGACY_RE = re.compile(r"🛡️?\s*\*{0,2}Disputed by\s+@?(\S+?)\s+on\s+(\d{4}-\d{2}-\d{2})")
+CONCEDE_RE = _vp.CONCEDE_ANNOTATION_RE
+STYLE_BULLET_RE = re.compile(r"^\s*-\s+\*\*line \d+:?\*\*|\[style\]")
+# SHA-ish tokens in 📜 history lines. Not anchored to a whole parenthetical:
+# the fix-response line renders `(2 new commits, d0c76f0)` (update.md Case 1),
+# so the SHA shares its parens with prose. Requiring at least one a-f letter
+# keeps pure-digit runs (issue numbers, dates) from matching.
+HISTORY_SHA_RE = re.compile(r"\b(?=[0-9a-f]*[a-f])[0-9a-f]{7,40}\b")
+# Column-0 finding-paragraph start, mirroring extract_bucket_bullets.
+FINDING_START_RE = re.compile(r"^(?:- )?\*\*\S")
+# Branch prefixes of the repo's own automation; their PRs' review outcomes are
+# reported separately from human-authored PRs.
+BOT_BRANCH_PREFIXES = ("content-review/", "fix-broken-links")
+BOT_LOGINS = {"pulumi-bot", "dependabot[bot]", "github-actions[bot]"}
+OUTCOME_KEYS = (
+    "fixed",
+    "conceded",
+    "ignored_outstanding",
+    "ignored_low_confidence",
+    "unconfirmed_at_merge",
+    "abandoned",
+)
+
+
+def log(msg: str) -> None:
+    print(f"scrape-review-outcomes: {msg}", file=sys.stderr)
+
+
+# ---- gh access ---------------------------------------------------------------
+
+
+def run_gh(args: list[str]) -> str:
+    """Run a gh command; return stdout, or "" on failure (logged to stderr)."""
+    try:
+        proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+        return proc.stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        detail = exc.stderr.strip() if hasattr(exc, "stderr") and exc.stderr else str(exc)
+        log(f"warning: gh {' '.join(args[:4])}... failed: {detail}")
+        return ""
+
+
+def fetch_pr_meta(repo: str, pr: int) -> dict | None:
+    out = run_gh(
+        [
+            "pr", "view", str(pr), "--repo", repo,
+            "--json",
+            "number,title,url,state,mergedAt,closedAt,headRefOid,headRefName,author,labels",
+        ]
+    )
+    if not out.strip():
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        log(f"warning: could not parse pr view JSON for #{pr}")
+        return None
+
+
+def fetch_pinned_bodies(repo: str, pr: int) -> list[str]:
+    """Return the bodies of every CLAUDE_REVIEW N/M comment, ordered by N.
+
+    Mirrors pinned-comment.sh list_pinned_comments/fetch, but keeps the
+    filtering in Python (jq compact output = one JSON object per line).
+    """
+    out = run_gh(
+        [
+            "api", "--paginate", f"repos/{repo}/issues/{pr}/comments",
+            "--jq", '.[] | {id: .id, body: .body} | @json',
+        ]
+    )
+    tagged = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            # --jq '@json' double-encodes: each output line is a JSON string
+            # containing a JSON object.
+            obj = json.loads(json.loads(line))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        body = obj.get("body") or ""
+        m = MARKER_RE.match(body.split("\n", 1)[0])
+        if m:
+            tagged.append((int(m.group(1)), body))
+    tagged.sort(key=lambda t: t[0])
+    return [body for _, body in tagged]
+
+
+def list_closed_prs(repo: str, since: str) -> list[dict]:
+    """Closed PRs since `since` (YYYY-MM-DD) that carry any review:* label."""
+    out = run_gh(
+        [
+            "pr", "list", "--repo", repo, "--state", "closed", "--limit", "300",
+            "--search", f"closed:>={since}",
+            "--json", "number,labels,closedAt",
+        ]
+    )
+    try:
+        raw = json.loads(out) if out.strip() else []
+    except json.JSONDecodeError:
+        log("warning: could not parse pr list JSON")
+        return []
+    return [
+        pr for pr in raw
+        if any(lbl.get("name", "").startswith("review:") for lbl in pr.get("labels", []))
+    ]
+
+
+# ---- body parsing --------------------------------------------------------------
+
+
+def first_line(paragraph: str, limit: int = 200) -> str:
+    text = paragraph.strip().splitlines()[0] if paragraph.strip() else ""
+    return text[:limit]
+
+
+def extract_finding_paragraphs(body: str, heading_substring: str) -> list[str]:
+    """Group a bucket section into per-finding paragraphs.
+
+    A paragraph starts at a column-0 `**`-prefixed line (the same shape
+    extract_bucket_bullets counts) and runs until the next one or the section
+    end, so annotation lines rendered under the finding (🛡️ Disputed,
+    concede reasons, suggestion blocks) stay attached to their finding.
+    """
+    span = _vp.find_section(body, heading_substring)
+    if span is None:
+        return []
+    start, end = span
+    lines = body.splitlines()[start + 1 : end]
+    paragraphs: list[str] = []
+    current: list[str] = []
+    for line in lines:
+        if FINDING_START_RE.match(line):
+            if current:
+                paragraphs.append("\n".join(current))
+            current = [line]
+        elif current:
+            current.append(line)
+    if current:
+        paragraphs.append("\n".join(current))
+    return paragraphs
+
+
+def build_verdict_index(body: str) -> dict[str, str]:
+    """Map every L-anchor in the 🔍 trail to its canonical verdict word."""
+    index: dict[str, str] = {}
+    for rec in _vp.extract_trail_records(body):
+        word = rec.get("verdict_word")
+        if not word:
+            continue
+        for ref in rec.get("line_refs", []):
+            index.setdefault(ref, word)
+    return index
+
+
+def verdict_for(paragraph: str, verdict_index: dict[str, str]) -> str | None:
+    prefix = _vp.extract_bullet_prefix(paragraph.splitlines()[0])
+    if prefix and prefix in verdict_index:
+        return verdict_index[prefix]
+    if prefix:
+        # Fall back to matching on the start line number (a bucket range can
+        # differ slightly from the trail's collapsed refs).
+        start = prefix.split("-")[0]
+        for ref, word in verdict_index.items():
+            if ref.split("-")[0] == start:
+                return word
+    return None
+
+
+def parse_history(body: str) -> dict:
+    text = _vp.section_text(body, "📜 Review history")
+    entries = [ln for ln in text.splitlines() if ln.strip().startswith("- ")]
+    shas = HISTORY_SHA_RE.findall(text)
+    return {"entries": len(entries), "last_sha": shas[-1] if shas else None}
+
+
+def classify_finding(paragraph: str, bucket: str, merged: bool, review_current: bool) -> dict:
+    is_style = bool(STYLE_BULLET_RE.search(paragraph.splitlines()[0]))
+    disputed = DISPUTED_RE.search(paragraph) or DISPUTED_LEGACY_RE.search(paragraph)
+    conceded = bool(CONCEDE_RE.search(paragraph))
+    if bucket == "resolved":
+        outcome = "conceded" if conceded else "fixed"
+    elif not merged:
+        outcome = "abandoned"
+    elif not review_current:
+        outcome = "unconfirmed_at_merge"
+    elif bucket == "outstanding":
+        outcome = "ignored_outstanding"
+    else:
+        outcome = "ignored_low_confidence"
+    record = {
+        "bucket": bucket,
+        "style": is_style,
+        "text": first_line(paragraph),
+        "outcome": outcome,
+    }
+    if disputed:
+        record["disputed"] = {
+            "by": disputed.group(1).rstrip(",.*"),
+            "on": disputed.group(2),
+            "adjudication": "conceded" if bucket == "resolved" else "held",
+        }
+    elif bucket == "resolved" and conceded:
+        record["disputed"] = {"by": None, "on": None, "adjudication": "conceded"}
+    return record
+
+
+def scrape_body(body: str, merged: bool, head_sha: str | None) -> dict:
+    """Parse one concatenated pinned-comment body into an outcome record core."""
+    counts = _vp.extract_count_table_row(body)
+    history = parse_history(body)
+    review_current = True
+    if merged and head_sha and history["last_sha"]:
+        review_current = head_sha.startswith(history["last_sha"])
+    verdict_index = build_verdict_index(body)
+
+    buckets = {
+        "outstanding": "🚨 Outstanding",
+        "low_confidence": "⚠️ Low-confidence",
+        "resolved": "✅ Resolved",
+    }
+    findings: list[dict] = []
+    style_count = 0
+    for bucket, heading in buckets.items():
+        for paragraph in extract_finding_paragraphs(body, heading):
+            record = classify_finding(paragraph, bucket, merged, review_current)
+            if record["style"]:
+                style_count += 1
+                continue
+            word = verdict_for(paragraph, verdict_index)
+            if word:
+                record["verdict"] = word
+            findings.append(record)
+
+    outcome_counts = {k: 0 for k in OUTCOME_KEYS}
+    for f in findings:
+        outcome_counts[f["outcome"]] += 1
+    disputes = [
+        {**f["disputed"], "finding": f["text"]} for f in findings if f.get("disputed")
+    ]
+
+    parsed_anything = counts is not None or findings or history["entries"]
+    return {
+        "counts_table": counts,
+        "findings": findings,
+        "style_findings": style_count,
+        "outcomes": outcome_counts,
+        "disputes": disputes,
+        "review_events": history["entries"],
+        "review_current_at_merge": review_current,
+        "pre_existing": len(extract_finding_paragraphs(body, "💡 Pre-existing")),
+        "parse_confidence": "high" if counts is not None else ("low" if parsed_anything else "none"),
+    }
+
+
+# ---- per-PR record --------------------------------------------------------------
+
+
+def author_kind(meta: dict) -> str:
+    login = ((meta.get("author") or {}).get("login") or "").lower()
+    branch = meta.get("headRefName") or ""
+    if login in BOT_LOGINS or login.endswith("[bot]"):
+        return "bot"
+    if any(branch.startswith(p) for p in BOT_BRANCH_PREFIXES):
+        return "bot"
+    return "human"
+
+
+def scrape_pr(repo: str, pr: int) -> dict:
+    meta = fetch_pr_meta(repo, pr)
+    if meta is None:
+        return {"pr": pr, "status": "pr_unavailable"}
+    merged = bool(meta.get("mergedAt"))
+    record = {
+        "pr": pr,
+        "title": meta.get("title"),
+        "url": meta.get("url"),
+        "merged": merged,
+        "closed_at": meta.get("mergedAt") or meta.get("closedAt"),
+        "author_kind": author_kind(meta),
+    }
+    bodies = fetch_pinned_bodies(repo, pr)
+    if not bodies:
+        # Short-circuited (review:trivial etc.), comment deleted, or never
+        # reviewed. Counted, never rated.
+        record["status"] = "no_review_data"
+        return record
+    body = "\n".join(bodies)
+    record.update(scrape_body(body, merged, meta.get("headRefOid")))
+    record["status"] = "scraped"
+    record["comment_count"] = len(bodies)
+    return record
+
+
+# ---- aggregation --------------------------------------------------------------
+
+
+def empty_outcomes() -> dict:
+    return {k: 0 for k in OUTCOME_KEYS}
+
+
+def aggregate(records: list[dict]) -> dict:
+    agg = {
+        "prs_scraped": 0,
+        "prs_no_review_data": 0,
+        "prs_parse_low": 0,
+        "outcomes": {"human": empty_outcomes(), "bot": empty_outcomes()},
+        "style_findings": 0,
+        "disputes": [],
+        "merged_with_outstanding": [],
+        "by_verdict": {},
+    }
+    for rec in records:
+        if rec.get("status") != "scraped":
+            agg["prs_no_review_data"] += 1
+            continue
+        agg["prs_scraped"] += 1
+        if rec.get("parse_confidence") != "high":
+            agg["prs_parse_low"] += 1
+        kind = rec.get("author_kind", "human")
+        for key, n in rec.get("outcomes", {}).items():
+            agg["outcomes"][kind][key] += n
+        agg["style_findings"] += rec.get("style_findings", 0)
+        for dispute in rec.get("disputes", []):
+            agg["disputes"].append({"pr": rec["pr"], **dispute})
+        outstanding = [
+            f["text"] for f in rec.get("findings", [])
+            if f["outcome"] == "ignored_outstanding"
+        ]
+        if outstanding:
+            agg["merged_with_outstanding"].append(
+                {"pr": rec["pr"], "title": rec.get("title"), "url": rec.get("url"), "findings": outstanding}
+            )
+        for f in rec.get("findings", []):
+            word = f.get("verdict")
+            if not word:
+                continue
+            per = agg["by_verdict"].setdefault(word, empty_outcomes())
+            per[f["outcome"]] += 1
+    return agg
+
+
+def render_stats(agg: dict, since: str) -> str:
+    """Markdown tuning report for the quarterly outcome review."""
+
+    def rate(n: int, d: int) -> str:
+        return f"{100 * n / d:.0f}%" if d else "–"
+
+    lines = [
+        f"# Review outcome stats since {since}",
+        "",
+        f"PRs with scraped reviews: **{agg['prs_scraped']}** "
+        f"(+{agg['prs_no_review_data']} with no review data, "
+        f"{agg['prs_parse_low']} parsed at low confidence)",
+        "",
+        "| Author | Fixed | Conceded | Ignored 🚨 | Ignored ⚠️ | Unconfirmed | Abandoned |",
+        "| :--- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for kind in ("human", "bot"):
+        o = agg["outcomes"][kind]
+        lines.append(
+            f"| {kind} | {o['fixed']} | {o['conceded']} | {o['ignored_outstanding']} "
+            f"| {o['ignored_low_confidence']} | {o['unconfirmed_at_merge']} | {o['abandoned']} |"
+        )
+    lines += [
+        "",
+        "## Per verdict category",
+        "",
+        "High concede/ignore rates mark carve-outs to demote or prune;",
+        "high fix rates on recurring findings mark Vale-promotion candidates.",
+        "",
+        "| Verdict | Total | Fix rate | Concede rate | Ignored-at-merge rate |",
+        "| :--- | ---: | ---: | ---: | ---: |",
+    ]
+    for word in sorted(agg["by_verdict"]):
+        o = agg["by_verdict"][word]
+        total = sum(o.values())
+        ignored = o["ignored_outstanding"] + o["ignored_low_confidence"]
+        lines.append(
+            f"| {word} | {total} | {rate(o['fixed'], total)} "
+            f"| {rate(o['conceded'], total)} | {rate(ignored, total)} |"
+        )
+    if agg["merged_with_outstanding"]:
+        lines += ["", "## Merged over 🚨 Outstanding findings", ""]
+        for item in agg["merged_with_outstanding"]:
+            lines.append(f"- #{item['pr']} {item['title']}")
+            for text in item["findings"]:
+                lines.append(f"  - {text}")
+    if agg["disputes"]:
+        lines += ["", "## Disputes", ""]
+        for d in agg["disputes"]:
+            who = f"@{d['by']}" if d.get("by") else "author"
+            lines.append(f"- #{d['pr']} {who} → **{d['adjudication']}** — {d['finding']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---- self-test --------------------------------------------------------------
+
+FIXTURE = """\
+<!-- CLAUDE_REVIEW 1/1 -->
+## Pre-merge Review — Last updated 2026-07-01T00:00:00Z
+
+| 🚨 Outstanding | ⚠️ Low-confidence | 💡 Pre-existing | ✅ Resolved |
+| :---: | :---: | :---: | :---: |
+| **1** | **2** | **0** | **2** |
+
+### 🔍 Verification trail
+
+<details>
+<summary><strong>3</strong> claims extracted · <strong>1</strong> verified · <strong>1</strong> unverifiable · <strong>1</strong> contradicted</summary>
+
+- L10 "the flag defaults to true" → ❌ contradicted (docs say false)
+- L20 "supports 3 clouds" → 🤷 unverifiable (no citation)
+- L30 "released in v3.0" → ✅ verified (changelog)
+</details>
+
+### 🚨 Outstanding in this PR
+
+*These must be resolved or refuted before merging.*
+
+- **[L10]** The flag default is wrong.
+  🛡️ **Disputed by alice on 2026-06-30, model held.** Docs contradict.
+
+### ⚠️ Low-confidence
+
+*Review each and resolve as appropriate — these don't block the PR.*
+
+- **[L20]** Please cite a source for the cloud count.
+
+#### Style findings
+
+- **line 42:** [style] _substitution_ — Use 'select' instead of 'click'.
+
+### ✅ Resolved since last review
+
+- **[L30]** Version claim corrected. (resolved in abc1234)
+
+- **[L44]** concede: author confirms intentional pattern.
+
+### 📜 Review history
+
+- 2026-06-29T00:00:00Z — initial review (abc1234)
+- 2026-07-01T00:00:00Z — re-reviewed after fix push (deadbee)
+"""
+
+
+def self_test() -> int:
+    failures = []
+
+    def check(name: str, cond: bool) -> None:
+        (print(f"  ok  {name}") if cond else failures.append(name))
+        if not cond:
+            print(f"  FAIL {name}")
+
+    merged_head = "deadbee0000000000000000000000000000000ff"
+    rec = scrape_body(FIXTURE, merged=True, head_sha=merged_head)
+    check("parse_confidence high", rec["parse_confidence"] == "high")
+    check("counts table parsed", rec["counts_table"] == {"outstanding": 1, "low_confidence": 2, "pre_existing": 0, "resolved": 2})
+    check("one ignored_outstanding", rec["outcomes"]["ignored_outstanding"] == 1)
+    check("one ignored_low_confidence", rec["outcomes"]["ignored_low_confidence"] == 1)
+    check("one fixed", rec["outcomes"]["fixed"] == 1)
+    check("one conceded", rec["outcomes"]["conceded"] == 1)
+    check("style counted separately", rec["style_findings"] == 1)
+    check("two disputes", len(rec["disputes"]) == 2)
+    held = [d for d in rec["disputes"] if d["adjudication"] == "held"]
+    check("held dispute names disputer", held and held[0]["by"] == "alice")
+    check("verdict joined from trail", any(f.get("verdict") == "contradicted" for f in rec["findings"]))
+    check("review current at merge", rec["review_current_at_merge"] is True)
+
+    stale = scrape_body(FIXTURE, merged=True, head_sha="0123456789abcdef0123456789abcdef01234567")
+    check("stale review -> unconfirmed", stale["outcomes"]["unconfirmed_at_merge"] == 2)
+    check("stale review -> no ignored", stale["outcomes"]["ignored_outstanding"] == 0)
+
+    closed = scrape_body(FIXTURE, merged=False, head_sha=None)
+    check("unmerged -> abandoned", closed["outcomes"]["abandoned"] == 2)
+    check("resolved still fixed on unmerged", closed["outcomes"]["fixed"] == 1)
+
+    empty = scrape_body("no review here", merged=True, head_sha=None)
+    check("garbage -> parse none", empty["parse_confidence"] == "none")
+
+    agg = aggregate([
+        {"status": "scraped", "pr": 1, "author_kind": "human", "parse_confidence": "high",
+         **{k: rec[k] for k in ("outcomes", "style_findings", "disputes", "findings")}},
+        {"status": "no_review_data", "pr": 2},
+    ])
+    check("aggregate scraped count", agg["prs_scraped"] == 1)
+    check("aggregate no-data count", agg["prs_no_review_data"] == 1)
+    check("aggregate human fixed", agg["outcomes"]["human"]["fixed"] == 1)
+    check("merged_with_outstanding listed", len(agg["merged_with_outstanding"]) == 1)
+    check("by_verdict contradicted", "contradicted" in agg["by_verdict"])
+    check("stats renders", "Per verdict category" in render_stats(agg, "2026-01-01"))
+
+    if failures:
+        print(f"{len(failures)} self-test failure(s)")
+        return 1
+    print("self-test passed")
+    return 0
+
+
+# ---- main --------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default=DEFAULT_REPO)
+    ap.add_argument("--pr", type=int, help="scrape a single PR")
+    ap.add_argument("--closed-since", help="scrape review-labeled PRs closed since YYYY-MM-DD")
+    ap.add_argument("--stats", action="store_true", help="render a markdown tuning report instead of JSON")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if args.pr:
+        json.dump(scrape_pr(args.repo, args.pr), sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 0
+    if args.closed_since:
+        try:
+            datetime.strptime(args.closed_since, "%Y-%m-%d")
+        except ValueError:
+            ap.error("--closed-since must be YYYY-MM-DD")
+        candidates = list_closed_prs(args.repo, args.closed_since)
+        log(f"{len(candidates)} review-labeled PRs closed since {args.closed_since}")
+        records = [scrape_pr(args.repo, pr["number"]) for pr in candidates]
+        agg = aggregate(records)
+        if args.stats:
+            sys.stdout.write(render_stats(agg, args.closed_since))
+            return 0
+        json.dump(
+            {
+                "since": args.closed_since,
+                "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "aggregate": agg,
+                "prs": records,
+            },
+            sys.stdout, indent=2, ensure_ascii=False,
+        )
+        sys.stdout.write("\n")
+        return 0
+    ap.error("one of --pr, --closed-since, --self-test is required")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/test_scrape_review_outcomes.py
+++ b/.claude/commands/docs-review/scripts/test_scrape_review_outcomes.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Unit tests for scrape-review-outcomes.py.
+
+Self-contained — run with `python3 test_scrape_review_outcomes.py` (no pytest
+dep). Imports the scraper module directly and exercises the body parsing,
+classification, and aggregation paths without shelling out to gh; the gh
+paths are covered by monkeypatching the module's run_gh.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+_spec = importlib.util.spec_from_file_location(
+    "scrape_review_outcomes", HERE / "scrape-review-outcomes.py"
+)
+sro = importlib.util.module_from_spec(_spec)
+sys.modules["scrape_review_outcomes"] = sro
+_spec.loader.exec_module(sro)  # type: ignore[union-attr]
+
+MERGE_HEAD = "deadbee0000000000000000000000000000000ff"
+
+
+def body_with(
+    outstanding: str = "",
+    low_confidence: str = "",
+    resolved: str = "",
+    trail: str = "",
+    history: str = "- 2026-07-01T00:00:00Z — initial review (deadbee)",
+    counts: tuple[int, int, int, int] = (0, 0, 0, 0),
+) -> str:
+    return f"""\
+<!-- CLAUDE_REVIEW 1/1 -->
+## Pre-merge Review — Last updated 2026-07-01T00:00:00Z
+
+| 🚨 Outstanding | ⚠️ Low-confidence | 💡 Pre-existing | ✅ Resolved |
+| :---: | :---: | :---: | :---: |
+| **{counts[0]}** | **{counts[1]}** | **{counts[2]}** | **{counts[3]}** |
+
+### 🔍 Verification trail
+
+{trail or '_No verifiable claims extracted from this diff._'}
+
+### 🚨 Outstanding in this PR
+
+{outstanding or '_None._'}
+
+### ⚠️ Low-confidence
+
+{low_confidence or '_None._'}
+
+### ✅ Resolved since last review
+
+{resolved or '_None._'}
+
+### 📜 Review history
+
+{history}
+"""
+
+
+# ---- tests -------------------------------------------------------------------
+
+
+def test_fixed_vs_conceded():
+    body = body_with(
+        resolved=(
+            "- **[L10]** Version corrected. (resolved in abc1234)\n"
+            "\n"
+            "- **[L20]** concede: author confirms intentional pattern.\n"
+        ),
+        counts=(0, 0, 0, 2),
+    )
+    rec = sro.scrape_body(body, merged=True, head_sha=MERGE_HEAD)
+    assert rec["outcomes"]["fixed"] == 1, rec["outcomes"]
+    assert rec["outcomes"]["conceded"] == 1, rec["outcomes"]
+    concessions = [d for d in rec["disputes"] if d["adjudication"] == "conceded"]
+    assert len(concessions) == 1
+
+
+def test_disputed_held_and_merged_over_outstanding():
+    body = body_with(
+        outstanding=(
+            "*These must be resolved or refuted before merging.*\n"
+            "\n"
+            "- **[L10]** The flag default is wrong.\n"
+            "  🛡️ **Disputed by alice on 2026-06-30, model held.** Docs contradict.\n"
+        ),
+        trail='- L10 "flag default" → ❌ contradicted (docs say false)',
+        counts=(1, 0, 0, 0),
+    )
+    rec = sro.scrape_body(body, merged=True, head_sha=MERGE_HEAD)
+    assert rec["outcomes"]["ignored_outstanding"] == 1, rec["outcomes"]
+    held = [d for d in rec["disputes"] if d["adjudication"] == "held"]
+    assert held and held[0]["by"] == "alice" and held[0]["on"] == "2026-06-30"
+    # The trail verdict word rides along for per-category stats.
+    assert rec["findings"][0]["verdict"] == "contradicted"
+
+
+def test_closed_unmerged_is_abandoned():
+    body = body_with(
+        outstanding="- **[L10]** Broken instruction.\n",
+        counts=(1, 0, 0, 0),
+    )
+    rec = sro.scrape_body(body, merged=False, head_sha=None)
+    assert rec["outcomes"]["abandoned"] == 1
+    assert rec["outcomes"]["ignored_outstanding"] == 0
+
+
+def test_stale_review_at_merge():
+    body = body_with(
+        outstanding="- **[L10]** Broken instruction.\n",
+        low_confidence="- **[L20]** Please cite a source.\n",
+        history="- 2026-07-01T00:00:00Z — initial review (0123abc)",
+        counts=(1, 1, 0, 0),
+    )
+    rec = sro.scrape_body(body, merged=True, head_sha=MERGE_HEAD)
+    assert rec["review_current_at_merge"] is False
+    assert rec["outcomes"]["unconfirmed_at_merge"] == 2
+    assert rec["outcomes"]["ignored_outstanding"] == 0
+    assert rec["outcomes"]["ignored_low_confidence"] == 0
+
+
+def test_style_findings_counted_not_classified():
+    body = body_with(
+        low_confidence=(
+            "- **[L20]** Please cite a source.\n"
+            "\n"
+            "#### Style findings\n"
+            "\n"
+            "*Found by pattern-based linting; Findings may be false positives.*\n"
+            "\n"
+            "- **line 42:** [style] _substitution_ — Use 'select' instead of 'click'.\n"
+            "- **line 87:** [style] _passive voice_ — Use active voice.\n"
+        ),
+        counts=(0, 3, 0, 0),
+    )
+    rec = sro.scrape_body(body, merged=True, head_sha=MERGE_HEAD)
+    assert rec["style_findings"] == 2
+    assert rec["outcomes"]["ignored_low_confidence"] == 1
+
+
+def test_multi_comment_overflow():
+    # ✅ Resolved spills into a 2/2 comment; scrape over the joined bodies.
+    first = body_with(
+        outstanding="- **[L10]** Broken instruction.\n",
+        counts=(1, 0, 0, 1),
+    )
+    # The overflow page carries the spilled section only (no table, no history).
+    second = (
+        "<!-- CLAUDE_REVIEW 2/2 -->\n"
+        "### ✅ Resolved since last review\n"
+        "\n"
+        "- **[L30]** Version corrected. (resolved in abc1234)\n"
+    )
+    # find_section returns the FIRST matching heading, so drop the 1/1 page's
+    # empty ✅ section the way the real overflow splitter does: page 1 ends at 📜.
+    first = first.replace(
+        "### ✅ Resolved since last review\n\n_None._\n\n", ""
+    )
+    rec = sro.scrape_body(first + "\n" + second, merged=True, head_sha=MERGE_HEAD)
+    assert rec["outcomes"]["fixed"] == 1, rec["outcomes"]
+    assert rec["outcomes"]["ignored_outstanding"] == 1
+
+
+def test_legacy_unparseable_degrades():
+    legacy = (
+        "<!-- CLAUDE_REVIEW 1/1 -->\n"
+        "Thanks! I reviewed this PR and found two issues, listed below.\n\n"
+        "1. The link is broken.\n2. The version is wrong.\n"
+    )
+    rec = sro.scrape_body(legacy, merged=True, head_sha=None)
+    assert rec["parse_confidence"] == "none"
+    assert sum(rec["outcomes"].values()) == 0
+
+    # History but no count table -> "low": partial signal, counted not rated.
+    partial = "### 📜 Review history\n\n- 2026-07-01 — initial review (abc1234)\n"
+    rec = sro.scrape_body(partial, merged=True, head_sha=None)
+    assert rec["parse_confidence"] == "low"
+
+
+def test_fetch_pinned_bodies_filters_and_orders():
+    def fake_run_gh(args):
+        rows = [
+            {"id": 3, "body": "<!-- CLAUDE_REVIEW 2/2 -->\nsecond"},
+            {"id": 1, "body": "just a human comment"},
+            {"id": 2, "body": "<!-- CLAUDE_REVIEW 1/2 -->\nfirst"},
+            {"id": 4, "body": "<!-- CLAUDE_PROGRESS -->\nprogress note"},
+        ]
+        return "\n".join(json.dumps(json.dumps(r)) for r in rows) + "\n"
+
+    original = sro.run_gh
+    sro.run_gh = fake_run_gh
+    try:
+        bodies = sro.fetch_pinned_bodies("pulumi/docs", 1)
+    finally:
+        sro.run_gh = original
+    assert len(bodies) == 2
+    assert bodies[0].endswith("first") and bodies[1].endswith("second")
+
+
+def test_scrape_pr_no_review_data():
+    def fake_meta(repo, pr):
+        return {
+            "number": pr, "title": "t", "url": "u", "state": "MERGED",
+            "mergedAt": "2026-07-01T00:00:00Z", "closedAt": None,
+            "headRefOid": MERGE_HEAD, "headRefName": "feature",
+            "author": {"login": "alice"}, "labels": [],
+        }
+
+    originals = (sro.fetch_pr_meta, sro.fetch_pinned_bodies)
+    sro.fetch_pr_meta = fake_meta
+    sro.fetch_pinned_bodies = lambda repo, pr: []
+    try:
+        rec = sro.scrape_pr("pulumi/docs", 42)
+    finally:
+        sro.fetch_pr_meta, sro.fetch_pinned_bodies = originals
+    assert rec["status"] == "no_review_data"
+    assert rec["author_kind"] == "human"
+
+
+def test_author_kind_bot_detection():
+    assert sro.author_kind({"author": {"login": "pulumi-bot"}, "headRefName": "x"}) == "bot"
+    assert sro.author_kind({"author": {"login": "octo[bot]"}, "headRefName": "x"}) == "bot"
+    assert sro.author_kind({"author": {"login": "alice"}, "headRefName": "content-review/foo"}) == "bot"
+    assert sro.author_kind({"author": {"login": "alice"}, "headRefName": "fix-typo"}) == "human"
+
+
+def test_aggregate_and_stats_render():
+    body = body_with(
+        outstanding=(
+            "- **[L10]** The flag default is wrong.\n"
+            "  🛡️ **Disputed by alice on 2026-06-30, model held.**\n"
+        ),
+        resolved="- **[L30]** concede: author is right.\n",
+        trail=(
+            '- L10 "flag" → ❌ contradicted (docs)\n'
+            '- L30 "claim" → 🤷 unverifiable (no source)'
+        ),
+        counts=(1, 0, 0, 1),
+    )
+    scraped = sro.scrape_body(body, merged=True, head_sha=MERGE_HEAD)
+    records = [
+        {"status": "scraped", "pr": 7, "title": "T", "url": "u",
+         "author_kind": "human", "parse_confidence": "high", **scraped},
+        {"status": "no_review_data", "pr": 8},
+    ]
+    agg = sro.aggregate(records)
+    assert agg["prs_scraped"] == 1 and agg["prs_no_review_data"] == 1
+    assert agg["outcomes"]["human"]["ignored_outstanding"] == 1
+    assert agg["outcomes"]["human"]["conceded"] == 1
+    assert agg["merged_with_outstanding"][0]["pr"] == 7
+    assert {d["adjudication"] for d in agg["disputes"]} == {"held", "conceded"}
+    assert agg["by_verdict"]["contradicted"]["ignored_outstanding"] == 1
+
+    report = sro.render_stats(agg, "2026-04-01")
+    assert "Merged over 🚨 Outstanding findings" in report
+    assert "| contradicted |" in report
+    assert "@alice" in report
+
+
+def test_real_pinned_review_pr20079():
+    """Regression fixture captured from pulumi/docs#20079's actual pinned review."""
+    body = (HERE / "testdata" / "pr20079-pinned-review.md").read_text()
+    # #20079 merged at head d0c76f0…; the last 📜 history SHA matches it.
+    rec = sro.scrape_body(body, merged=True, head_sha="d0c76f07aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    assert rec["parse_confidence"] == "high"
+    assert rec["counts_table"] == {"outstanding": 0, "low_confidence": 0, "pre_existing": 1, "resolved": 2}
+    assert rec["review_current_at_merge"] is True
+    assert rec["outcomes"]["fixed"] == 2, rec["outcomes"]
+    assert rec["outcomes"]["conceded"] == 0
+    assert sum(rec["outcomes"].values()) == 2
+    assert rec["pre_existing"] == 1
+    assert rec["review_events"] == 2
+    assert rec["disputes"] == []
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failures = 0
+    for test in tests:
+        try:
+            test()
+            print(f"  ok  {test.__name__}")
+        except Exception:
+            failures += 1
+            print(f"  FAIL {test.__name__}")
+            traceback.print_exc()
+    print(f"{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/testdata/pr20079-pinned-review.md
+++ b/.claude/commands/docs-review/scripts/testdata/pr20079-pinned-review.md
@@ -1,0 +1,84 @@
+<!-- CLAUDE_REVIEW 1/1 -->
+## Pre-merge Review — Last updated 2026-07-07T16:27:09Z
+
+> [!TIP]
+> **Summary:** This PR rebalances Pulumi's AI documentation and marketing copy so it presents the full spectrum of AI agents — third-party coding agents (Claude Code, Codex, Cursor, GitHub Copilot) working through Agent Skills and the MCP server, alongside Pulumi Neo — rather than framing Neo as the only path. (Fixture note: captured from pulumi/docs#20079's pinned review for scrape-review-outcomes.py regression tests; the verification-trail evidence text is truncated to a representative subset — the bucket sections, count table, and history are verbatim.)
+>
+> **Review confidence:**
+>
+> | Dimension | Level | Notes |
+> | :--- | :---: | :--- |
+> | mechanics | HIGH | Content-only PR; full Hugo build runs in the deploy job. One pre-existing alias collision noted under 💡. |
+> | facts | HIGH | Both prior facts findings (the `--json` overclaim and an unattributed "Many teams" claim) resolved by the two follow-up commits. |
+> | cross-sibling consistency | HIGH | Read all four `organizations-teams` siblings; the added "See also" links introduce no inconsistency. |
+
+<details>
+<summary>Investigation log</summary>
+
+- **Cross-sibling reads:** 4 of 4 siblings
+- **External claim verification:** 69 of 74 claims verified (2 unverifiable, 1 contradicted) · 4 specialists (numerical, cross-reference, capability, framing); 0 cross-specialist corroborations · routed: 0 inline, 69 Pass 1, 0 Pass 2, 5 Pass 3 (verified 4, contradicted 0, unverifiable 1).
+- **Cited-claim spot-checks:** not run (no cited claims)
+- **Frontmatter sweep:** ran on body + meta_desc
+- **Temporal-trigger sweep:** ran (recency words present in diff; spot-check in-review)
+- **Code execution:** not run (no `static/programs/` change)
+- **Code-examples checks:** not run (no fenced code blocks in content files)
+- **Editorial-balance pass:** not run (not under content/blog/)
+
+</details>
+
+| 🚨 Outstanding | ⚠️ Low-confidence | 💡 Pre-existing | ✅ Resolved |
+| :---: | :---: | :---: | :---: |
+| **0** | **0** | **1** | **2** |
+
+### 🔍 Verification trail
+
+<details>
+<summary><strong>75 claims extracted</strong> · <strong>69</strong> verified · <strong>2</strong> unverifiable · <strong>1</strong> contradicted</summary>
+
+- L97 in `AGENTS.md` "Pulumi supports the full spectrum of AI agents…" → ➖ not-a-claim (evidence: internal editorial/positioning guidance, not a falsifiable factual assertion; source: AGENTS.md L97 (self-referential authoring guideline))
+- L99 in `AGENTS.md` "- **Docs** (`content/docs/`, `content/what-is/`, `content/tutorials/`): community-centric and balanced…" → ✅ verified (evidence: Confirmed via GitHub API that content/docs/ai/skills/index.md exists; source: gh api repos/pulumi/docs/contents/content/docs/ai/skills)
+- L30 in `content/docs/ai/_index.md` "`pulumi do` performs one-shot resource operations." → ✅ verified (evidence: the docs page for `pulumi do` documents direct resource operations; source: repo:content/docs/iac/cli/direct-resource-operations.md)
+- L36 in `content/product/neo.md` "Neo is the industry's first AI agent built from the ground up…" → 🤷 unverifiable (evidence: Pulumi's own marketing superlative; no third-party authoritative source; source: gh search code --owner pulumi "industry's first AI agent")
+- L205 in `content/docs/ai/skills/index.md` "A page titled 'What is agentic infrastructure?'… exists at /what-is/what-is-agentic-infrast…" → ❌ contradicted (evidence: file listing missed the page; source: gh api repos/pulumi/docs/contents/content/what-is)
+- L61 in `content/what-is/what-is-agentic-infrastructure.md` "Many teams use Pulumi Neo for scheduled, longer-horizon infrastructure work…" → 🤷 unverifiable (evidence: unattributed "many teams" usage-pattern claim with no survey/data backing; source: content/docs/ai/skills/index.md)
+- L171 in `content/what-is/what-is-agentic-infrastructure.md` "Pulumi Neo accepts natural-language tasks, reasons over your actual infrastructure state graph…" → 🤝 matches (evidence: the same file's workflow walkthrough describes this; source: repo:content/what-is/what-is-agentic-infrastructure.md)
+- L55 in `content/what-is/what-is-agentic-infrastructure.md` "The Pulumi CLI can parse structured `--json` output." → ✅ verified (evidence: `46c4df5`/`d0c76f0` dropped the "from every command" quantifier; source: repo:content/docs/iac/cli/commands/pulumi_new.md; repo:content/docs/ai/_index.md L30)
+- L1 in `content/docs/_index.md` "frontmatter alias `/docs/reference/` collides with `content/docs/reference/_index.md`" → 🚩 flagged (frontmatter: alias-collision)
+
+</details>
+
+### 🚨 Outstanding in this PR
+
+_No outstanding findings in this PR._
+
+### ⚠️ Low-confidence
+
+_No low-confidence findings._
+
+### 📋 Triaged verifier findings
+
+<details>
+<summary><em>I double-checked these and realized they weren't real findings — click to expand</em></summary>
+
+- **[L205]** `content/docs/ai/skills/index.md` — link to `/what-is/what-is-agentic-infrastructure/` flagged as ❌ contradicted (target page reportedly not found). **Spurious:** the page exists — `content/what-is/what-is-agentic-infrastructure.md` is present in the repo (this PR edits it) and resolves to `/what-is/what-is-agentic-infrastructure/`, confirmed by the frontmatter sweep. The verification step's file listing simply missed it.
+
+</details>
+
+### 💡 Pre-existing issues in touched files (optional)
+
+- **[L1]** `content/docs/_index.md` — **Pre-existing:** the frontmatter alias `/docs/reference/` collides with the live page at `content/docs/reference/_index.md` (the real page wins, so the alias is inert). This PR only reorders the section cards and doesn't touch the `aliases` list, so the collision predates it. Worth removing the dead alias in a follow-up, but not this PR's concern.
+
+### ✅ Resolved since last review
+
+- **[L30]** `content/docs/ai/_index.md` / **[L55]** `content/what-is/what-is-agentic-infrastructure.md` — *"…and parse structured `--json` output from every command."* — ✅ resolved: `46c4df5` first scoped the claim to "the commands that emit it," then `d0c76f0` dropped the quantifier entirely rather than hedge it, landing on "parse structured `--json` output" — no more unqualified "every command" for `pulumi new` and other scaffolding commands to contradict.
+
+- **[L61]** `content/what-is/what-is-agentic-infrastructure.md` — *"Many teams use Pulumi Neo for scheduled, longer-horizon infrastructure work and their everyday coding agent for interactive development."* — ✅ resolved: `46c4df5` softened the unattributed "Many teams" adoption claim to "Teams often," removing the implication of measured usage data.
+
+### 📜 Review history
+
+- 2026-07-03T18:55:41Z — Balanced AI-positioning rebalance; flagged one `--json`-from-every-command overclaim, triaged a spurious "page not found" flag and a pre-existing alias collision (f87819a)
+- 2026-07-07T16:27:09Z — Re-reviewed after fix push (2 new commits, d0c76f0); both facts findings resolved, 0 outstanding remain
+
+---
+Need a re-review? Want to dispute a finding? Mention `@claude` and include `#update-review`.  
+(For ad-hoc questions or fixes, just `@claude` — no hashtag.)

--- a/.claude/commands/docs-review/scripts/validate-pinned.py
+++ b/.claude/commands/docs-review/scripts/validate-pinned.py
@@ -19,7 +19,17 @@ Exit codes:
   1  violations (fix-me marker written)
   2  usage / config error
 
-Schema version: 16 (v15→v16 adds the `flagged` (🚩) detector verdict to
+Schema version: 18 (v17→v18 adds the `outcome-annotation-shape` rule: the
+  re-entrant outcome annotations — `🛡️ **Disputed by <author> on YYYY-MM-DD,
+  model held.**` under a held finding and `concede: <reason>` on a ✅ Resolved
+  bullet — are now machine-scraped by scrape-review-outcomes.py for the
+  weekly outcome telemetry (issue #20078 §3.2), so a freelanced shape
+  ("author disputed this", "conceding the point") silently drops out of the
+  fixed/conceded/disputed counts. The rule fires only when a bucket paragraph
+  *looks* like it carries one of these annotations but doesn't parse; the
+  canonical regexes live here (DISPUTED_ANNOTATION_RE / CONCEDE_ANNOTATION_RE)
+  and the scraper imports them, so there is exactly one definition.
+  v15→v16 adds the `flagged` (🚩) detector verdict to
   `TRAIL_VERDICT_WORDS` / `EXPECTED_TRAIL_EMOJI` / `OUTSTANDING_VERDICT_WORDS` /
   `OUTSTANDING_TRAIL_EMOJIS` / the trail-line emoji alternation. `flagged` is
   the honest verdict for `route: "preflight"` detector findings (Hugo build,
@@ -110,7 +120,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-SCHEMA_VERSION = 17
+SCHEMA_VERSION = 18
 
 DEFAULT_OUTPUT_JSON = "/tmp/validate-pinned.fix-me.json"
 DEFAULT_OUTPUT_MARKDOWN = "/tmp/validate-pinned.fix-me.md"
@@ -186,6 +196,21 @@ LEGACY_TRAIL_EMOJIS = {"✅", "⚠️", "🚨"}
 # verdict word (used as a fallback when the verdict word isn't one of the
 # canonical TRAIL_VERDICT_WORDS).
 OUTSTANDING_TRAIL_EMOJIS = {"🚨", "❌", "⚔️", "🚩"}
+
+# Schema v18: canonical shapes of the re-entrant outcome annotations
+# (`docs-review:references:update` Case 1/2). scrape-review-outcomes.py keys
+# the weekly fixed/conceded/disputed telemetry on these exact shapes and
+# imports these constants — change them only together with that scraper and
+# update.md. The *_HINT_RE forms are the loose triggers the
+# `outcome-annotation-shape` rule uses to spot a paragraph that is trying to
+# carry the annotation but won't parse.
+# Capture groups (author, date) are for the scraper; this rule only searches.
+DISPUTED_ANNOTATION_RE = re.compile(
+    r"🛡️\s*\*\*Disputed by @?(\S+) on (\d{4}-\d{2}-\d{2}), model held\.\*\*"
+)
+DISPUTED_HINT_RE = re.compile(r"🛡|Disputed by\b", re.IGNORECASE)
+CONCEDE_ANNOTATION_RE = re.compile(r"\bconcede[:d]", re.IGNORECASE)
+CONCEDE_HINT_RE = re.compile(r"\bconce(?:de|des|ded|ding|ssion)\b", re.IGNORECASE)
 
 # Dispatch-metadata format on the External claim verification line
 # (output-format.md L122). Two segments are required, matched independently:
@@ -2201,6 +2226,76 @@ def check_no_todo_tokens(ctx: Context) -> list[Violation]:
     return violations
 
 
+def _finding_paragraphs(ctx: Context, heading_substring: str) -> list[tuple[int, str]]:
+    """Group a bucket section into (start_line_1indexed, paragraph) pairs.
+
+    A paragraph starts at a column-0 `**`-prefixed line (the same shape
+    extract_bucket_bullets counts) and runs to the next one or the section
+    end, so annotation lines rendered under a finding (🛡️ Disputed, concede
+    reasons) stay attached to it.
+    """
+    span = find_section(ctx.body, heading_substring)
+    if span is None:
+        return []
+    start, end = span
+    finding_re = re.compile(r"^(?:- )?\*\*\S")
+    paragraphs: list[tuple[int, str]] = []
+    current_start = None
+    current: list[str] = []
+    for i in range(start + 1, end):
+        line = ctx.body_lines[i]
+        if finding_re.match(line):
+            if current:
+                paragraphs.append((current_start + 1, "\n".join(current)))
+            current_start = i
+            current = [line]
+        elif current:
+            current.append(line)
+    if current:
+        paragraphs.append((current_start + 1, "\n".join(current)))
+    return paragraphs
+
+
+def check_outcome_annotation_shapes(ctx: Context) -> list[Violation]:
+    """Schema v18: outcome annotations must render in their canonical shapes.
+
+    scrape-review-outcomes.py derives the weekly fixed/conceded/disputed
+    telemetry (issue #20078 §3.2) from the `🛡️ **Disputed by <author> on
+    YYYY-MM-DD, model held.**` line and the `concede: <reason>` annotation
+    that `docs-review:references:update` Cases 1/2 prescribe. A freelanced
+    shape ("author disputed this", "conceding the point") silently drops the
+    finding out of those counts. Fires only when a paragraph *looks* like it
+    carries the annotation (loose *_HINT_RE match) but the canonical regex
+    doesn't parse it — plain findings never trip it.
+    """
+    violations: list[Violation] = []
+    for heading in ("🚨 Outstanding", "⚠️ Low-confidence"):
+        for line_no, paragraph in _finding_paragraphs(ctx, heading):
+            if DISPUTED_HINT_RE.search(paragraph) and not DISPUTED_ANNOTATION_RE.search(paragraph):
+                violations.append(Violation(
+                    rule_id="outcome-annotation-shape",
+                    line_ref=f"<body line {line_no}>",
+                    expected="held-dispute annotation rendered as `🛡️ **Disputed by <author> on YYYY-MM-DD, model held.**`",
+                    actual=f"paragraph mentions a dispute but the canonical annotation doesn't parse: {paragraph.strip().splitlines()[0][:120]}",
+                    hint="Render the dispute annotation exactly as `docs-review:references:update` Case 2 "
+                         "prescribes — `🛡️ **Disputed by <author> on YYYY-MM-DD, model held.**` on its own "
+                         "line directly under the finding text. The weekly outcome telemetry "
+                         "(scrape-review-outcomes.py) parses this exact shape.",
+                ))
+    for line_no, paragraph in _finding_paragraphs(ctx, "✅ Resolved"):
+        if CONCEDE_HINT_RE.search(paragraph) and not CONCEDE_ANNOTATION_RE.search(paragraph):
+            violations.append(Violation(
+                rule_id="outcome-annotation-shape",
+                line_ref=f"<body line {line_no}>",
+                expected="concession annotated as `concede: <reason>` on the ✅ Resolved bullet",
+                actual=f"bullet mentions a concession but carries no `concede:` annotation: {paragraph.strip().splitlines()[0][:120]}",
+                hint="Annotate conceded findings as `concede: <reason>` per `docs-review:references:update` "
+                     "Case 2 — the weekly outcome telemetry (scrape-review-outcomes.py) distinguishes "
+                     "fixed from conceded findings by this token.",
+            ))
+    return violations
+
+
 # ---- Rule registry ---------------------------------------------------------
 
 RULES = [
@@ -2359,6 +2454,12 @@ RULES = [
         "desc": "Schema v10: no `<TODO: …>` (or bare `<TODO>`) placeholder from compose-review.py's draft survives to the published body.",
         "hint": "Replace every `<TODO: …>` (summary paragraph, confidence levels, fix prose, cross-sibling count, review-history summary, Tier-2 editorial balance) with actual content. The composer's self-check passes `--skip-rule no-todo-tokens`; the publish path does not.",
         "check": check_no_todo_tokens,
+    },
+    {
+        "id": "outcome-annotation-shape",
+        "desc": "Schema v18: re-entrant outcome annotations render in their canonical, machine-scraped shapes — `🛡️ **Disputed by <author> on YYYY-MM-DD, model held.**` under a held finding; `concede: <reason>` on a conceded ✅ Resolved bullet. Fires only when a paragraph looks like it carries the annotation but the canonical form doesn't parse.",
+        "hint": "Render dispute/concession annotations exactly per `docs-review:references:update` Case 2: `🛡️ **Disputed by <author> on YYYY-MM-DD, model held.**` on its own line under the held finding, `concede: <reason>` on the conceded ✅ Resolved bullet. scrape-review-outcomes.py keys the weekly outcome telemetry on these shapes.",
+        "check": check_outcome_annotation_shapes,
     },
     {
         "id": "no-placeholder-empty-form",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Rare. Use when the pinned-review state is corrupted (the 1/M comment was manuall
 
 The `<!-- CLAUDE_REVIEW N/M -->` comments are managed by the pipeline. Don't delete them — the re-entrant skill expects to find and edit them in place. If you accidentally delete the 1/M summary, the next run posts fresh at the bottom of the timeline; recoverable but ugly.
 
+The pinned comment is also the pipeline's outcome ledger: after a PR closes, a weekly scrape derives what happened to each finding (fixed, conceded, disputed, or merged over) and aggregates it into the Monday `#docs-ops` digest, which is how the review's severity rules get tuned over time.
+
 ### Trivial and frontmatter-only short-circuits
 
 Two label-driven short-circuits skip the full Claude review (linters still run):

--- a/scripts/weekly-digest/digest.py
+++ b/scripts/weekly-digest/digest.py
@@ -17,11 +17,16 @@ import json
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 REPO = "pulumi/docs"
 BOT_LOGINS = {"pulumi-bot", "dependabot[bot]"}
 WINDOW_DAYS = 7
 NOW = datetime.now(timezone.utc)
+OUTCOME_SCRAPER = (
+    Path(__file__).resolve().parents[2]
+    / ".claude/commands/docs-review/scripts/scrape-review-outcomes.py"
+)
 
 
 def run_gh(args):
@@ -181,6 +186,32 @@ def shape_ci_health(raw):
     }
 
 
+def collect_review_outcomes(since):
+    """Pre-merge review outcome telemetry for PRs closed in the window.
+
+    Delegates to scrape-review-outcomes.py (issue #20078 §3.2), which derives
+    per-finding outcomes from each closed PR's pinned review comments. Only
+    the window aggregate rides into the digest — per-PR finding lists stay in
+    the scraper. Degrades to {"available": False} on any failure so a scraper
+    or gh outage mutes this section without killing the digest; the aggregate
+    itself carries `prs_no_review_data` / `prs_parse_low` so partial
+    degradation is visible rather than silent.
+    """
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(OUTCOME_SCRAPER), "--closed-since", since, "--repo", REPO],
+            capture_output=True, text=True, check=True,
+        )
+        aggregate = json.loads(proc.stdout).get("aggregate")
+    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        sys.stderr.write(f"warning: review-outcome scrape failed: {str(detail).strip()[:500]}\n")
+        return {"available": False}
+    if not isinstance(aggregate, dict):
+        return {"available": False}
+    return {"available": True, "since": since, **aggregate}
+
+
 def search_count(qualifier):
     """Exact issue count via the search API's total_count (REST, not GraphQL)."""
     out = run_gh(
@@ -232,11 +263,13 @@ def main():
             ]
         )
     )
+    review_outcomes = collect_review_outcomes(cutoff)
     digest = {
         "window_days": WINDOW_DAYS,
         "prs": prs,
         "issues": issues,
         "ci_health": ci_health,
+        "review_outcomes": review_outcomes,
     }
     json.dump(digest, sys.stdout, indent=2)
     sys.stdout.write("\n")

--- a/scripts/weekly-digest/synthesis-prompt.md
+++ b/scripts/weekly-digest/synthesis-prompt.md
@@ -25,6 +25,13 @@ HARD RULE FIRST: any draft PR (`isDraft == true`) goes straight to bucket 5 (In 
 Then:
 
 - Exclude bot PRs (`is_bot == true`, i.e. pulumi-bot / dependabot) from all of the narrative above. Mention them as a bare trailing count.
+- Review outcomes -- a short block (3-5 lines max) from `review_outcomes`, which aggregates what happened to pre-merge review findings on PRs closed in the window. Rules:
+  - If `review_outcomes.available == false`, emit exactly one line saying outcome telemetry was unavailable this week (this is a loud degradation signal, never omit it).
+  - Otherwise lead with the human-PR outcome counts from `review_outcomes.outcomes.human` in one line: fixed / conceded / ignored (sum `ignored_outstanding` + `ignored_low_confidence`) / unconfirmed-at-merge. Mention the bot split only if nonzero, as a bare trailing count.
+  - If `merged_with_outstanding` is non-empty, list each PR on its own line (number + one clause naming the finding) -- this is the highest-signal item in the block: someone merged over a merge-gate finding.
+  - If `disputes` is non-empty, one line per dispute: PR number, disputer, and whether the model held or conceded.
+  - If `prs_no_review_data` or `prs_parse_low` is high relative to `prs_scraped`, add one line noting the telemetry gap.
+  - On a quiet week (no scraped PRs), collapse the whole block to a single line ("No reviewed PRs closed this week") -- never drop the block entirely.
 - End with ONE line of CI health derived from `ci_health` (status plus success rate / failure count if useful). `ci_health` is computed over the last 24 hours, so describe the window that way -- do NOT call it "last N runs".
 
 ## Message 2 -- backlog_digest


### PR DESCRIPTION
### Proposed changes

Implements §3.2 of the docs-review automation evaluation (#20078): close the feedback loop on pre-merge findings. The pipeline records what it *spends* but not what *happens* to its findings — nothing tracks how many 🚨/⚠️ findings authors fix, dispute, concede, or ignore, so the severity rules are tuned by doctrine rather than data.

The key insight: the pinned review comment is already the outcome ledger. The re-entrant protocol leaves a machine-parseable terminal state on every reviewed PR (✅ Resolved = fixed, `concede:` = conceded, `🛡️ Disputed … model held` = disputed, still-🚨-at-merge = ignored), and the comment is frozen once the PR closes. No new state store, no model calls.

- **`scrape-review-outcomes.py`** (new, in `.claude/commands/docs-review/scripts/`) — derives per-finding outcomes from a closed PR's pinned comments, reusing `validate-pinned.py`'s parsing helpers. Per-finding attribution: severity tier, trail verdict word (enables per-carve-out-category concede/ignore rates), human vs. bot PR, dispute adjudication. Findings still open when the review was stale at merge classify as `unconfirmed_at_merge`, not `ignored`. Tolerant reader, never a gate: legacy formats degrade to counts-only with `parse_confidence` recorded. Modes: `--pr`, `--closed-since`, `--stats` (markdown tuning report), `--self-test`.
- **Weekly digest** — `digest.py` gains a `review_outcomes` section (7-day aggregate, human/bot split, PRs merged over 🚨 findings, disputes) and `synthesis-prompt.md` renders it as a short block in the Monday #docs-ops PR digest, with an explicit line when telemetry is degraded or unavailable.
- **Validator v18** — new `outcome-annotation-shape` rule: the dispute/concede annotations are now a machine-scraped contract, so a freelanced variant ("author disputed this", "conceding the point") is flagged. Fires only when a paragraph looks like it carries the annotation but the canonical form doesn't parse. The canonical regexes live in the validator; the scraper imports them.
- **Docs** — SKILL.md documents the quarterly outcome review (high concede/ignore rates → demote/prune carve-outs; high fix rates on recurring prose findings → Vale-promotion candidates per #20078 §4.2); `update.md`/`output-format.md` note the machine-scraped shapes; CONTRIBUTING.md gets one sentence on the ledger role.

Deliberate non-goals: no auto-editing of severity rules from telemetry (humans tune; the system reports), no new S3 state/workflows/credentials, no per-author scoreboards, no new human obligations.

**Verification:** scraper self-test (22 checks) and 12 unit tests pass, including a real-data regression fixture captured from #20079's actual pinned review — which surfaced and fixed a SHA-extraction gap on fix-push history lines (`(2 new commits, d0c76f0)`). All four existing script test suites pass; validator registers the new rule at schema v18; `make lint` passes (1781 files, 0 errors; Prettier clean); digest smoke-tested end-to-end with a stubbed `gh`.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Implements §3.2 of #20078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ABidEJ1sg7K75bXxViutp

---
_Generated by [Claude Code](https://claude.ai/code/session_018ABidEJ1sg7K75bXxViutp)_