### PR TITLE
Add reader signals (GSC, feedback, real 404s) to content-review selection

### DIFF
--- a/.claude/commands/fix-broken-links/SKILL.md
+++ b/.claude/commands/fix-broken-links/SKILL.md
@@ -15,17 +15,40 @@ Read `.broken-links.json` from the repo root. Shape:
 ```json
 {
   "generated": "2026-06-02T15:00:00.000Z",
-  "internal": [{ "source": "...", "destination": "...", "reason": "HTTP_404" }],
+  "internal": [
+    { "source": "...", "destination": "...", "reason": "HTTP_404", "hits": 210 },
+    { "source": "(server logs)", "destination": "...", "reason": "REAL_404", "hits": 94 }
+  ],
   "external": [{ "source": "...", "destination": "...", "reason": "HTTP_404" }]
 }
 ```
 
 - `source` — the live page the broken link was found **on**.
 - `destination` — the URL that failed.
-- `reason` — BLC reason code (`HTTP_404`, `HTTP_410`, `ERRNO_ENOTFOUND`, …).
+- `reason` — BLC reason code (`HTTP_404`, `HTTP_410`, `ERRNO_ENOTFOUND`, …), or
+  `REAL_404` for entries merged from server logs (below).
 - `internal` — `destination` is on `pulumi.com`; `external` — third-party.
+- `hits` — optional: real 404 requests on that destination from server logs
+  over the export window (merged in by
+  `scripts/link-checker/merge-404-signal.py`). The list is sorted by `hits`
+  descending — **work highest-hits first**; entries without `hits` follow.
 
 If both lists are empty, do nothing (the workflow won't invoke you in that case, but be defensive).
+
+### Real-404 signal (`reason: "REAL_404"`)
+
+These entries come from **server logs**, not the crawler: URLs readers actually
+requested that returned 404 — external referrers, bookmarks, stale search
+results. That means:
+
+- `source` is `(server logs)` — there is no on-site page to edit; the fix is
+  almost always a **Hugo alias** or **S3 redirect** to the obvious successor
+  page, or the nearest section index when none exists.
+- Verify the URL still 404s before fixing (the export is up to a week old; it
+  may have been fixed since).
+- Residual noise the export's bot filter missed (crawler probes, exploit
+  scans) goes under **False positives / not actioned** — never give junk paths
+  a redirect.
 
 ## Verify each link before fixing it
 

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -31,6 +31,12 @@ Read `.content-review-queue.json` from the repo root (written by
   "count": 3,
   "halted": null,
   "traffic": { "available": true, "period": "2026-05", "pages_matched": 731 },
+  "reader_signals": {
+    "available": true,
+    "gsc": { "available": true, "period": {"start": "2026-03-14", "end": "2026-06-11"},
+             "pages_matched": 612, "median_ctr": 0.031, "max_impressions": 88012 },
+    "feedback": { "available": true, "pages_matched": 214 }
+  },
   "articles": [
     { "path": "content/docs/iac/concepts/stacks/_index.md",
       "url": "/docs/iac/concepts/stacks/",
@@ -39,6 +45,11 @@ Read `.content-review-queue.json` from the repo root (written by
       "tier": 1,
       "no_retire": true,
       "monthly_visits": 12345,
+      "signals": {
+        "gsc": { "impressions": 15234, "ctr": 0.0205, "opportunity": 0.41,
+                 "multiplier": 1.1025, "low_ctr_flag": true },
+        "feedback": { "yes": 4, "no": 9, "neg_rate": 0.6923, "multiplier": 1.27 }
+      },
       "last_reviewed": null,
       "score": 0.91 }
   ]
@@ -52,6 +63,11 @@ Read `.content-review-queue.json` from the repo root (written by
   entity keys and evidence as priority findings to re-check first.
 - `no_retire` — when true, retirement must never be proposed for this page.
   This is the **hard veto** on retirement — honor it regardless of evidence.
+- `reader_signals` / `signals` — Search Console and feedback-widget figures
+  from the optional reader-signals export; `null` when the export wasn't
+  available for the run (a signal-blind run says so, it never fabricates).
+  These fed the selection score and the composed "Why this page" block — they
+  are selection facts, not review instructions.
 - If `articles` is empty or `halted` is set, do nothing (the workflow won't
   invoke you in that case, but be defensive).
 - `traffic.available: false` is not your problem to fix: the dispatcher's
@@ -191,6 +207,12 @@ Editing guardrails:
   (`layouts/shortcodes/`, `layouts/partials/`, `data/`); a retirement may
   touch `content/`, `scripts/redirects/`, and `data/docs_menu_sections.yml`.
   Any other changed path makes the gate reject the whole review.
+- A `low_ctr_flag` on the queue entry's `signals.gsc` block is **FLAG-ONLY**:
+  never rewrite `title` or `meta_desc` in response to it. The composer has
+  already pre-stubbed a "Search opportunity" row under Findings not applied —
+  keep it (you may add one line of observation, e.g. what the title fails to
+  say); a human runs `/seo-analyze` on it. Meta rewrites are the canonical
+  slop risk this restriction exists for.
 - Ordered lists keep their `1.` numbering; files end with a newline; H1 Title
   Case, H2+ sentence case (see `STYLE-GUIDE.md` — but don't re-case headings
   that aren't otherwise wrong).
@@ -271,7 +293,9 @@ with a comment for a human; humans merge. The sections (each is checked for):
   GitHub auto-merge on the PR, so the body flags that approving merges it.
   **Leave verbatim** — do not move, reword, or remove it.
 - **Why this page**: composed from the selection queue (lane, tier, traffic
-  figure + period, last reviewed). **Leave verbatim** — do not re-narrate it.
+  figure + period, Search/Reader-feedback figures when the reader-signals
+  export was available, last reviewed). **Leave verbatim** — do not
+  re-narrate it.
 - **Fixes applied**: pre-stubbed one row per high-confidence finding. Keep a row
   only for a fix you actually applied (fill its Correction); move the rest down.
 - **Findings not applied**: pre-stubbed with the lower-confidence findings, plus
@@ -366,7 +390,9 @@ the bar, with the full reasoning documented in the PR.
 - **Evidence required (two-sided):** the page appears in the traffic report
   with near-zero views (absence from the report is NOT evidence — the page
   may be new or alias-attributed), **and** GSC impressions/clicks are low
-  over its window when that data is present; **or** the page is demonstrably
+  over its window when that data is present — read them from the queue
+  entry's `signals.gsc` block (a `signals: null` run has no GSC evidence, so
+  this leg cannot be satisfied); **or** the page is demonstrably
   redundant with a named page (cite `.cross-sibling-discovery.json`). Check
   the page's age in git — never propose retiring a page younger than a year.
 - **Retire = redirect, never 404.** The PR must redirect the page to its

--- a/.claude/commands/review-existing-content/references/pr-body-template.md
+++ b/.claude/commands/review-existing-content/references/pr-body-template.md
@@ -13,8 +13,9 @@ The sections, and what's yours vs. the composer's:
 ## Why this page
 
 Rendered by the composer from the selection queue (lane, strategic tier, traffic
-figure + report period, last-reviewed). **Leave verbatim** — its figures are
-authoritative; do not re-narrate it.
+figure + report period, last-reviewed; plus **Search** and **Reader feedback**
+lines when the reader-signals export was available for the run). **Leave
+verbatim** — its figures are authoritative; do not re-narrate it.
 
 ## Fixes applied
 
@@ -31,7 +32,9 @@ PR should exist.
 
 Pre-stubbed with the lower-confidence findings; add any row you moved down from
 *Fixes applied*. One line of reasoning each (why it's judgment-level, not a
-high-confidence fix).
+high-confidence fix). When selection flagged the page `low_ctr_flag`, the
+composer pre-stubs a flag-only **Search opportunity** row here with its reason
+already filled — keep it; never rewrite `title`/`meta_desc` in response.
 
 For the judgment-level items above, run `/glow-up <path>`.
 

--- a/.claude/commands/review-existing-content/references/strategic-tiers.yaml
+++ b/.claude/commands/review-existing-content/references/strategic-tiers.yaml
@@ -17,12 +17,14 @@
 #               regardless of evidence. This is the PRIMARY retirement
 #               guardrail (retirement is no longer gated to a lane). Tier 1
 #               implies no_retire; set it explicitly on lower tiers that are
-#               SEO-critical or contractually required. Once GSC data is
-#               flowing, high-impression entries can be regenerated from
-#               thresholds; hand-curated entries stay.
-#               The veto is CODE-ENFORCED: the per-article worker fails any
-#               content-review/retire-<slug> branch whose page matches a
-#               no_retire (or tier-1/tier-0) prefix, via
+#               SEO-critical or contractually required. GSC data now flows via
+#               the reader-signals export (select-articles.py --signals-file;
+#               per-page impressions/CTR ride each queue entry's signals.gsc
+#               block) — regenerating high-impression entries from thresholds
+#               remains a follow-up; hand-curated entries stay.
+#               The veto is CODE-ENFORCED: the publish job rejects a
+#               retirement verdict whose page matches a no_retire (or
+#               tier-1/tier-0) prefix, via
 #               scripts/content-review/check-retire-veto.py — the model's
 #               reading of the skill is the instruction, this file is the
 #               guarantee.

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -44,11 +44,59 @@ jobs:
         with:
           hugo-version: '0.157.0'
           extended: true
+      # The reader-signals export (see review-existing-content.yml) carries a
+      # `not_found` section: real 404 hits from server logs — URLs readers
+      # actually request that no crawl of our own pages can see (external
+      # referrers, bookmarks, stale search results). Resolve + fetch it the
+      # same way that workflow does, then merge it into .broken-links.json so
+      # the fix-broken-links triage works both lists at once, highest-traffic
+      # first. Every step degrades gracefully: until the export ships
+      # (pulumi/docs#20078 item 4.5), the merge is a logged no-op and this
+      # workflow behaves exactly as before.
+      - name: Configure AWS credentials
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-session-name: check-links
+          aws-region: us-west-2
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+      - name: Resolve reader-signals URI
+        id: signals-uri
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          URI=$(pulumi stack output docsReaderSignalsLatestS3Uri \
+            --stack pulumi/dwh-workflows-orchestrate-airflow/production 2>/dev/null || true)
+          if [ -n "$URI" ]; then
+            echo "resolved reader-signals export URI: $URI"
+            echo "uri=$URI" >> "$GITHUB_OUTPUT"
+          else
+            echo "reader-signals export not yet published; link check proceeds without the real-404 signal"
+          fi
+      - name: Fetch reader-signals snapshot from S3
+        if: steps.signals-uri.outputs.uri != ''
+        continue-on-error: true
+        run: |
+          if aws s3 cp "${{ steps.signals-uri.outputs.uri }}" .reader-signals.json --quiet; then
+            echo "fetched reader-signals snapshot: $(wc -c < .reader-signals.json) bytes"
+          else
+            echo "reader-signals snapshot unavailable; link check proceeds without it"
+          fi
       # No SLACK_ACCESS_TOKEN in env: the checker no longer posts to Slack. It
       # writes its results to .broken-links.json, and Slack posting (the PR
       # link) happens at the end of this workflow instead.
       - name: Run make check_links
         run: make check_links
+      # Deterministic enrichment (never model-run): annotate crawler entries
+      # with real reader 404 traffic and append high-hit server-log 404s the
+      # crawler can't see. Runs before the broken-count gate below, so a day
+      # with zero crawler breakage but real 404 traffic still triggers triage.
+      - name: Merge real-404 signal
+        continue-on-error: true
+        run: python3 scripts/link-checker/merge-404-signal.py
       # Branch the rest of the workflow on whether anything is actually broken.
       # On a clean run the Claude and Slack steps below are skipped entirely, so
       # quiet days cost no API spend and post nothing.

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -60,7 +60,11 @@ jobs:
           role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
           role-session-name: check-links
           aws-region: us-west-2
+      # continue-on-error like the rest of this block: the CLI exists here only
+      # for the optional enrichment, and a failed install must not take down
+      # the core daily link check.
       - name: Install Pulumi CLI
+        continue-on-error: true
         uses: pulumi/actions@v7
       - name: Resolve reader-signals URI
         id: signals-uri

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -6,7 +6,10 @@ name: "Scheduled jobs: Review existing content (dispatcher)"
 # picks the day's articles by weighted fair queuing — score = importance
 # (strategic tier x traffic) x staleness (days since the page's effective last
 # review) — and this workflow then fans out one
-# content-review-article.yml run per selected article. Each worker reviews
+# content-review-article.yml run per selected article. The importance term is
+# strategic tier x traffic, nudged by bounded boost-only reader signals (Search
+# Console impressions/CTR, feedback-widget votes) when their export exists.
+# Each worker reviews
 # exactly one article and, if it finds a fix, opens a draft PR; the re-lint
 # gate promotes it to ready (firing the normal triage -> review chain) and
 # arms GitHub auto-merge. master requires an approving review + the build
@@ -248,6 +251,37 @@ jobs:
             echo "traffic snapshot unavailable; selection proceeds without it"
           fi
 
+      # The reader-signals export (Search Console impressions/CTR, docs
+      # feedback-widget vote counts, real-404 hits per URL) follows the exact
+      # same pattern as the traffic snapshot above: produced weekly by the data
+      # team, latest-object URI published on their Airflow stack. Until that
+      # export ships, this resolve logs the skip and selection scores exactly
+      # as before — the consumer side here is inert-but-ready by design
+      # (pulumi/docs#20078 item 4.5).
+      - name: Resolve reader-signals URI
+        id: signals-uri
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          URI=$(pulumi stack output docsReaderSignalsLatestS3Uri \
+            --stack pulumi/dwh-workflows-orchestrate-airflow/production 2>/dev/null || true)
+          if [ -n "$URI" ]; then
+            echo "resolved reader-signals export URI: $URI"
+            echo "uri=$URI" >> "$GITHUB_OUTPUT"
+          else
+            echo "reader-signals export not yet published; selection proceeds without reader signals"
+          fi
+      - name: Fetch reader-signals snapshot from S3
+        if: steps.signals-uri.outputs.uri != ''
+        continue-on-error: true
+        run: |
+          if aws s3 cp "${{ steps.signals-uri.outputs.uri }}" .reader-signals.json --quiet; then
+            echo "fetched reader-signals snapshot: $(wc -c < .reader-signals.json) bytes"
+          else
+            echo "reader-signals snapshot unavailable; selection proceeds without it"
+          fi
+
       # The review ledger (one JSON object per page, key = slug) lives in S3, not
       # the repo — so the daily bookkeeping never round-trips through a PR. Sync
       # it down to a local cache that select-articles.py reads via --ledger-dir.
@@ -279,6 +313,9 @@ jobs:
           if [ -f .traffic-snapshot ]; then
             ARGS+=(--traffic-file .traffic-snapshot)
           fi
+          if [ -f .reader-signals.json ]; then
+            ARGS+=(--signals-file .reader-signals.json)
+          fi
           if [ -n "${{ github.event.inputs.paths }}" ]; then
             ARGS+=(--paths "${{ github.event.inputs.paths }}")
           fi
@@ -303,12 +340,14 @@ jobs:
           # pre-merge review uses. `path`/`lane` are still passed for the
           # concurrency group and the --paths fallback.
           TRAFFIC=$(jq -c '.traffic' .content-review-queue.json)
+          SIGNALS=$(jq -c '.reader_signals // null' .content-review-queue.json)
           GEN=$(jq -r '.generated' .content-review-queue.json)
           jq -c '.articles[]' .content-review-queue.json | while read -r a; do
             P=$(echo "$a" | jq -r '.path')
             L=$(echo "$a" | jq -r '.lane')
-            Q=$(jq -nc --argjson art "$a" --argjson traffic "$TRAFFIC" --arg gen "$GEN" \
-              '{generated: $gen, count: 1, traffic: $traffic, articles: [$art]}')
+            Q=$(jq -nc --argjson art "$a" --argjson traffic "$TRAFFIC" \
+              --argjson signals "$SIGNALS" --arg gen "$GEN" \
+              '{generated: $gen, count: 1, traffic: $traffic, reader_signals: $signals, articles: [$art]}')
             echo "dispatching worker for $P (lane=$L)"
             gh workflow run content-review-article.yml \
               --repo "${{ github.repository }}" \

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -1296,6 +1296,9 @@ The repository uses 24 GitHub Actions workflows organized into categories. All w
 - Run `make check_links`
 - Crawl production site (<www.pulumi.com>)
 - Check all links (internal and external)
+- Merge real-404 server-log hits from the reader-signals export into
+  `.broken-links.json` (`scripts/link-checker/merge-404-signal.py`; no-op
+  until the data-team export exists)
 - Report broken links
 
 **Output:** Slack notification with broken link report
@@ -2436,7 +2439,10 @@ ONLY_TEST="aws-s3-bucket-typescript" ./scripts/programs/test.sh
 make check_links
 ```
 
-**CI Execution:** Daily at 3 PM UTC via `check-links.yml`
+**CI Execution:** Daily at 3 PM UTC via `check-links.yml`. In CI the results
+are enriched with real-404 server-log hits from the reader-signals export
+(`scripts/link-checker/merge-404-signal.py`) before triage, so the highest
+reader-impact breakage is fixed first.
 
 **Output:** Report posted to Slack
 

--- a/scripts/content-review/compose-pr-body.py
+++ b/scripts/content-review/compose-pr-body.py
@@ -114,6 +114,13 @@ def _truncate(s: str, n: int = 160) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+def _fmt_int(n) -> str:
+    try:
+        return f"{int(n):,}"
+    except (TypeError, ValueError):
+        return str(n)
+
+
 def collect(verified, vale, readthrough, frontmatter) -> tuple[list[dict], list[str]]:
     findings: list[dict] = []
     errors: list[str] = []
@@ -231,8 +238,10 @@ def render_deferrals(findings: list[dict], path: str) -> str:
         "     high-confidence fix). Add any rows you moved down from above. -->\n\n"
     )
     if deferrals:
+        # A finding may carry a pre-composed `reason` (deterministic deferrals,
+        # e.g. the flag-only Search Console row); otherwise the model fills it.
         body = "".join(
-            f"- **{f['label']}** — <TODO: why judgment-level>"
+            f"- **{f['label']}** — {f.get('reason') or '<TODO: why judgment-level>'}"
             + (f" _(context: {f['detail']})_" if f["detail"] else "")
             + "\n"
             for f in deferrals
@@ -344,9 +353,37 @@ def artifact_inventory(verified, vale, readthrough, frontmatter) -> dict:
     return inv
 
 
+def low_ctr_finding(queue: dict) -> dict | None:
+    """The flag-only Search Console deferral, when selection flagged the page.
+
+    Always `fix: False`: a low CTR is a signal for a human to look at the
+    title/meta_desc (via /seo-analyze), never something the worker rewrites —
+    meta rewrites are the canonical slop risk this pipeline is built to avoid.
+    """
+    a = (queue.get("articles") or [{}])[0]
+    g = (a.get("signals") or {}).get("gsc") or {}
+    if not g.get("low_ctr_flag"):
+        return None
+    median = ((queue.get("reader_signals") or {}).get("gsc") or {}).get("median_ctr")
+    detail = f"{_fmt_int(g.get('impressions'))} impressions at {g.get('ctr', 0) * 100:.2f}% CTR"
+    if median:
+        detail += f" vs. corpus median {median * 100:.2f}%"
+    return {
+        "label": "Search opportunity: high impressions with below-median CTR — "
+                 "the title/meta_desc may under-sell this page in search",
+        "source": "Search Console (reader-signals export)",
+        "detail": detail,
+        "reason": "flag-only by design — title/meta_desc rewrites are a human call (`/seo-analyze`)",
+        "fix": False,
+    }
+
+
 def compose(queue: dict, verified, vale, readthrough, frontmatter, gates=None) -> str:
     path = ((queue.get("articles") or [{}])[0]).get("path", "")
     findings, errors = collect(verified, vale, readthrough, frontmatter)
+    lcf = low_ctr_finding(queue)
+    if lcf:
+        findings.append(lcf)
     inv = artifact_inventory(verified, vale, readthrough, frontmatter)
 
     return "\n".join([

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -31,7 +31,8 @@ genuinely "incomplete" and stays due for retry.
 Canonical record (every field always present):
   { path, slug, lane, status, pr, pr_number, head_sha, fixes,
     skipped_findings, retirement, note, attempts, clarity_flag,
-    tier, score, monthly_visits, traffic_available, reviewed_at }
+    tier, score, monthly_visits, traffic_available, signals,
+    signals_available, reviewed_at }
 
 The record is written locally (audit artifact) and, when CONTENT_REVIEW_LEDGER_URI
 is set, uploaded to <uri>/<slug>.json with reviewed_at stamped to today (UTC).
@@ -125,6 +126,10 @@ def load_queue_article(queue_path: Path) -> dict:
         "score": a.get("score"),
         "monthly_visits": _maybe_int(a.get("monthly_visits")),
         "traffic_available": bool(traffic.get("available")),
+        # Reader signals (GSC/feedback figures + multipliers + low_ctr_flag),
+        # verbatim from the queue entry; null on a signal-blind run.
+        "signals": a.get("signals"),
+        "signals_available": bool((data.get("reader_signals") or {}).get("available")),
     }
 
 
@@ -276,6 +281,8 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         "score": article.get("score"),
         "monthly_visits": article.get("monthly_visits"),
         "traffic_available": bool(article.get("traffic_available")),
+        "signals": article.get("signals"),
+        "signals_available": bool(article.get("signals_available")),
         "reviewed_at": datetime.now(timezone.utc).date().isoformat(),
     }
 
@@ -412,8 +419,14 @@ def self_test() -> int:
     with tempfile.TemporaryDirectory() as d:
         d = Path(d)
         queue = d / "queue.json"
+        signals_block = {
+            "gsc": {"impressions": 15234, "ctr": 0.0205, "opportunity": 0.41,
+                    "multiplier": 1.1025, "low_ctr_flag": True},
+            "feedback": {"yes": 4, "no": 9, "neg_rate": 0.6923, "multiplier": 1.27},
+        }
         queue.write_text(json.dumps({
             "traffic": {"available": True},
+            "reader_signals": {"available": True},
             "articles": [{
                 "path": "content/docs/iac/concepts/converters.md",
                 "slug": "docs-iac-concepts-converters",
@@ -421,12 +434,31 @@ def self_test() -> int:
                 "tier": 2,
                 "score": 137.5,
                 "monthly_visits": 842,
+                "signals": signals_block,
             }]
         }))
         article = load_queue_article(queue)
         check("queue article carries the selection signal",
               article["tier"] == 2 and article["score"] == 137.5
               and article["monthly_visits"] == 842 and article["traffic_available"] is True)
+        check("queue article carries reader signals verbatim",
+              article["signals"] == signals_block and article["signals_available"] is True)
+
+        # A signal-blind queue (no reader_signals block, e.g. a --paths manual
+        # dispatch or a pre-export run) records null/false, never fabricates.
+        blind = d / "queue-blind.json"
+        blind.write_text(json.dumps({
+            "traffic": {"available": True},
+            "articles": [{"path": "content/docs/iac/concepts/converters.md",
+                          "slug": "docs-iac-concepts-converters"}]
+        }))
+        blind_article = load_queue_article(blind)
+        check("signal-blind queue -> signals null, signals_available False",
+              blind_article["signals"] is None
+              and blind_article["signals_available"] is False)
+        blind_rec = build_record(blind_article, None, None, blind_article["slug"])
+        check("signal-blind record persists null/false",
+              blind_rec["signals"] is None and blind_rec["signals_available"] is False)
 
         # No verdict, no signal -> incomplete (the conservative default).
         rec = build_record(article, None, None, article["slug"])
@@ -455,11 +487,13 @@ def self_test() -> int:
             "path", "slug", "lane", "status", "pr", "pr_number", "head_sha",
             "fixes", "skipped_findings", "retirement", "note", "attempts",
             "clarity_flag", "tier", "score", "monthly_visits",
-            "traffic_available", "reviewed_at"})
+            "traffic_available", "signals", "signals_available", "reviewed_at"})
         check("no-verdict clarity_flag defaults False", rec["clarity_flag"] is False)
         check("selection signal persisted on the record",
               rec["tier"] == 2 and rec["score"] == 137.5
               and rec["monthly_visits"] == 842 and rec["traffic_available"] is True)
+        check("reader signals persisted on the record verbatim",
+              rec["signals"] == signals_block and rec["signals_available"] is True)
 
         # Repeated incomplete accrues against the prior count the selector carried.
         retried = {**article, "attempts": 2}

--- a/scripts/content-review/render-provenance.py
+++ b/scripts/content-review/render-provenance.py
@@ -10,10 +10,10 @@ queue entry instead (the same split the pre-merge review uses via
 `compose-review.py`): code emits the facts, the model only writes judgment.
 
 Input is the single-article queue the dispatcher handed the worker
-(`.content-review-queue.json`): a `traffic` meta block plus one `articles[0]`
-entry carrying `monthly_visits`, `tier`, `no_retire`, `last_reviewed`,
-`attempts`, and `score`. Output is the exact `## Why this page` Markdown the
-worker pastes verbatim into the PR body.
+(`.content-review-queue.json`): `traffic` and `reader_signals` meta blocks plus
+one `articles[0]` entry carrying `monthly_visits`, `signals`, `tier`,
+`no_retire`, `last_reviewed`, `attempts`, and `score`. Output is the exact
+`## Why this page` Markdown the worker pastes verbatim into the PR body.
 
 Usage:
     render-provenance.py --queue .content-review-queue.json --out .provenance.md
@@ -44,6 +44,45 @@ def _period_str(traffic: dict) -> str | None:
             return f"{start} to {end}"
         return start or end
     return period or traffic.get("generated")
+
+
+def _signal_lines(queue: dict, a: dict) -> list[str]:
+    """Search + Reader-feedback lines, present only when the reader-signals
+    export was available for the run (absent export -> no lines, matching the
+    pre-signals PR body byte-for-byte)."""
+    meta = queue.get("reader_signals") or {}
+    if not meta.get("available"):
+        return []
+    signals = a.get("signals") or {}
+    lines = []
+
+    gsc_meta = meta.get("gsc") or {}
+    if gsc_meta.get("available"):
+        g = signals.get("gsc")
+        if g:
+            parts = [f"{_fmt_int(g['impressions'])} impressions", f"{g['ctr'] * 100:.2f}% CTR"]
+            median = gsc_meta.get("median_ctr")
+            if median:
+                parts.append(f"corpus median {median * 100:.2f}%")
+            period = _period_str(gsc_meta)
+            if period:
+                parts.append(f"period {period}")
+            flag_s = " — **low-CTR flag**" if g.get("low_ctr_flag") else ""
+            lines.append(f"- **Search:** {', '.join(parts)}{flag_s}")
+        else:
+            lines.append("- **Search:** no Search Console data for this page")
+
+    fb_meta = meta.get("feedback") or {}
+    if fb_meta.get("available"):
+        f = signals.get("feedback")
+        if f:
+            total = f["yes"] + f["no"]
+            neg = f" ({f['no'] / total:.0%} negative)" if total else ""
+            lines.append(f"- **Reader feedback:** {f['yes']} yes / {f['no']} no{neg}")
+        else:
+            lines.append("- **Reader feedback:** none recorded")
+
+    return lines
 
 
 def render(queue: dict) -> str:
@@ -94,12 +133,15 @@ def render(queue: dict) -> str:
 
     page_line = f"`{path}`" + (f" → [{url}]({url})" if url else "")
 
+    signal_lines = "".join(line + "\n" for line in _signal_lines(queue, a))
+
     return (
         "## Why this page\n\n"
         f"- **Page:** {page_line}\n"
         f"- **Lane:** {lane}\n"
         f"- **Strategic tier:** {tier_line}\n"
         f"- **Traffic:** {traffic_line}\n"
+        f"{signal_lines}"
         f"- **Last reviewed:** {reviewed_line}\n"
         f"- **Selection score:** {score_line}\n"
         "\n_This section is composed deterministically from the selection queue;"

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -24,11 +24,31 @@ Selection algorithm (weighted fair queuing by staleness):
 
        score = importance * staleness + stale_claim_boost
 
-   importance = tier_w * (0.5 + 0.5*traffic_n)   with a traffic snapshot
-              = tier_w                            tier-only when absent
+   importance = tier_w * (0.5 + 0.5*traffic_n) * gsc_m * feedback_m
+              = tier_w * gsc_m * feedback_m     tier-only when no traffic
    tier_w     = {1: 1.0, 2: 0.6, 3: 0.3}
    traffic_n  = log1p(visits) / log1p(max_visits); pages missing from the
                 report impute the median
+   gsc_m      = 1 + 0.25 * impressions_n * ctr_gap, in [1.0, 1.25]: the
+                Search Console "opportunity" boost — only pages searchers
+                see a lot (high impressions) but rarely click (CTR below
+                the corpus median) boost
+   feedback_m = 1 + 0.30 * neg_rate * min(1, votes/10), in [1.0, 1.30]:
+                the feedback-widget boost — "No, this page didn't help"
+                votes raise priority, damped below 10 total votes so a
+                couple of noisy votes can't max it out
+
+   The two reader-signal terms come from the optional reader-signals
+   export (--signals-file) and are boost-only with a floor of exactly
+   1.0: a page missing from the export (or under the noise thresholds,
+   or the export not existing at all) scores precisely what it would
+   have scored before these terms existed, and no page ever ranks lower
+   because of them. High CTR / positive feedback never suppress — a
+   well-titled page can still be factually stale, and that page is
+   exactly what the review is for. Unlike the traffic term (an always-on
+   scaler where absent pages impute the median so they aren't punished),
+   these are pure boosts, so neutral 1.0 — not the median — is the
+   no-penalty imputation.
    staleness  = (today - effective_last_review).days, floored at 0
    effective_last_review = max(bot_reviewed_at, last_non-bot_commit_date)
                 where bot_reviewed_at counts only for a *completed* review
@@ -48,8 +68,8 @@ Selection algorithm (weighted fair queuing by staleness):
 
 Usage:
     select-articles.py --count 3 --out .content-review-queue.json
-        [--traffic-file .traffic-snapshot] [--tiers <yaml>]
-        [--ledger-dir scripts/content-review/ledger]
+        [--traffic-file .traffic-snapshot] [--signals-file .reader-signals.json]
+        [--tiers <yaml>] [--ledger-dir scripts/content-review/ledger]
         [--paths content/docs/a.md,content/docs/b/_index.md]
         [--no-gh] [--today YYYY-MM-DD] [--dry-run]
     select-articles.py --stats   # ledger outcome report (merged/closed/open)
@@ -103,6 +123,21 @@ TIER_WEIGHTS = {1: 1.0, 2: 0.6, 3: 0.3}
 # the sweep is never fully starved. The marker vanishes when the page's next
 # review rewrites its ledger entry, so the boost self-clears.
 STALE_CLAIM_BOOST = 400.0
+
+# Reader-signal boost tuning. Both multipliers floor at exactly 1.0 (see the
+# module docstring); the caps keep the maximum combined boost (~1.63x) well
+# under the tier spread (3.3x), so signals reorder comparably stale same-tier
+# peers without overriding tiering or staleness.
+GSC_MIN_IMPRESSIONS = 200  # below this, CTR is noise -> neutral
+GSC_BOOST_MAX = 0.25  # gsc multiplier in [1.0, 1.25]
+FEEDBACK_MIN_TOTAL = 3  # fewer votes than this -> neutral
+FEEDBACK_SATURATION = 10  # votes at which neg_rate gets full weight
+FEEDBACK_BOOST_MAX = 0.30  # feedback multiplier in [1.0, 1.30]
+# The flag-only "title/meta_desc may under-sell this page in search" signal.
+# Deliberately stricter than the boost thresholds: the flag surfaces in the
+# review PR for a human, so it fires only on unambiguous cases.
+LOW_CTR_FLAG_MIN_IMPRESSIONS = 1000
+LOW_CTR_FLAG_RATIO = 0.5  # flag when ctr <= 0.5 * corpus median CTR
 
 # Statuses a ledger entry can carry (set by record-review.py). Any status other
 # than "incomplete" is a completed review whose date advances the clock; legacy
@@ -224,6 +259,107 @@ def load_traffic(traffic_file: Path | None, known_paths: set[str]) -> tuple[dict
 
     meta["pages_matched"] = len(pages)
     return pages, meta
+
+
+def load_reader_signals(
+    signals_file: Path | None, known_paths: set[str]
+) -> tuple[dict[str, dict], dict[str, dict], dict]:
+    """Parse the S3 reader-signals snapshot into per-content-path signal maps.
+
+    The snapshot is a single JSON object with independently optional sections
+    (see the data-export contract in the review-existing-content skill docs):
+
+        {"version": 1, "generated": ..., "signals": {
+            "gsc":      {"source", "period", "pages": {url: {impressions, clicks, position}}},
+            "feedback": {"source", "period", "pages": {url: {yes, no}}}}}
+
+    Returns (gsc, feedback, meta). A missing/unreadable/malformed file — or a
+    missing section — degrades that signal to unavailable, mirroring
+    load_traffic: selection then scores exactly as if the signal never existed.
+    """
+    meta = {
+        "gsc": {"available": False, "source": None, "period": None,
+                "pages_matched": 0, "median_ctr": None, "max_impressions": None},
+        "feedback": {"available": False, "source": None, "period": None,
+                     "pages_matched": 0},
+    }
+    gsc: dict[str, dict] = {}
+    feedback: dict[str, dict] = {}
+    if signals_file is None or not signals_file.is_file():
+        return gsc, feedback, meta
+    try:
+        data = json.loads(signals_file.read_text(errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return gsc, feedback, meta
+    if not isinstance(data, dict):
+        return gsc, feedback, meta
+    sections = data.get("signals")
+    if not isinstance(sections, dict):
+        return gsc, feedback, meta
+
+    def _int(v) -> int:
+        try:
+            return max(int(float(v)), 0)
+        except (TypeError, ValueError):
+            return 0
+
+    gsc_section = sections.get("gsc")
+    if isinstance(gsc_section, dict) and isinstance(gsc_section.get("pages"), dict):
+        for url_path, row in gsc_section["pages"].items():
+            if not isinstance(row, dict):
+                continue
+            cp = content_path_for_url(str(url_path), known_paths)
+            if not cp:
+                continue
+            impressions = _int(row.get("impressions"))
+            clicks = _int(row.get("clicks"))
+            entry = {
+                "impressions": impressions,
+                "clicks": clicks,
+                "ctr": round(clicks / impressions, 6) if impressions else 0.0,
+                "position": row.get("position"),
+            }
+            # A URL and its aliases may both appear; like the traffic snapshot,
+            # keep the row with the larger figure rather than double-counting.
+            prev = gsc.get(cp)
+            if prev is None or entry["impressions"] > prev["impressions"]:
+                gsc[cp] = entry
+        if gsc:
+            # Corpus stats over pages with meaningful volume only, so the
+            # long tail of near-zero-impression rows can't drag the median.
+            eligible = [e for e in gsc.values() if e["impressions"] >= GSC_MIN_IMPRESSIONS]
+            ctrs = sorted(e["ctr"] for e in eligible)
+            meta["gsc"] = {
+                "available": True,
+                "source": gsc_section.get("source"),
+                "period": gsc_section.get("period"),
+                "pages_matched": len(gsc),
+                "median_ctr": ctrs[len(ctrs) // 2] if ctrs else None,
+                "max_impressions": max((e["impressions"] for e in eligible), default=None),
+            }
+
+    fb_section = sections.get("feedback")
+    if isinstance(fb_section, dict) and isinstance(fb_section.get("pages"), dict):
+        for url_path, row in fb_section["pages"].items():
+            if not isinstance(row, dict):
+                continue
+            cp = content_path_for_url(str(url_path), known_paths)
+            if not cp:
+                continue
+            # Unlike pageviews, alias rows here are distinct vote events, not
+            # the same measurement counted twice — so aliases sum.
+            entry = feedback.setdefault(cp, {"yes": 0, "no": 0})
+            entry["yes"] += _int(row.get("yes"))
+            entry["no"] += _int(row.get("no"))
+        if feedback:
+            meta["feedback"] = {
+                "available": True,
+                "source": fb_section.get("source"),
+                "period": fb_section.get("period"),
+                "pages_matched": len(feedback),
+            }
+
+    return gsc, feedback, meta
 
 
 def load_ledger(ledger_dir: Path) -> dict[str, dict]:
@@ -368,20 +504,60 @@ def effective_last_review(
     return _ts_to_day(created.get(path))
 
 
+def gsc_multiplier(
+    entry: dict | None, max_impressions: int | None, median_ctr: float | None
+) -> tuple[float, float, bool]:
+    """(multiplier in [1, 1+GSC_BOOST_MAX], opportunity in [0, 1], low_ctr_flag).
+
+    Opportunity is impressions_n * ctr_gap: only the high-impressions AND
+    below-median-CTR quadrant boosts. Pages absent from the export or under
+    GSC_MIN_IMPRESSIONS are neutral (see the module docstring on imputation).
+    """
+    if (
+        not entry
+        or entry["impressions"] < GSC_MIN_IMPRESSIONS
+        or not max_impressions
+        or not median_ctr
+    ):
+        return 1.0, 0.0, False
+    impressions_n = math.log1p(entry["impressions"]) / math.log1p(max_impressions)
+    ctr_gap = min(max(median_ctr - entry["ctr"], 0.0) / median_ctr, 1.0)
+    opportunity = min(impressions_n * ctr_gap, 1.0)
+    flag = (
+        entry["impressions"] >= LOW_CTR_FLAG_MIN_IMPRESSIONS
+        and entry["ctr"] <= LOW_CTR_FLAG_RATIO * median_ctr
+    )
+    return 1.0 + GSC_BOOST_MAX * opportunity, round(opportunity, 4), flag
+
+
+def feedback_multiplier(entry: dict | None) -> tuple[float, float | None]:
+    """(multiplier in [1, 1+FEEDBACK_BOOST_MAX], neg_rate or None when too few votes)."""
+    if not entry:
+        return 1.0, None
+    total = entry["yes"] + entry["no"]
+    if total < FEEDBACK_MIN_TOTAL:
+        return 1.0, None
+    neg_rate = entry["no"] / total
+    weight = min(1.0, total / FEEDBACK_SATURATION)
+    return 1.0 + FEEDBACK_BOOST_MAX * neg_rate * weight, round(neg_rate, 4)
+
+
 def importance(
     tier: int,
     visits: int | None,
     max_visits: int,
     median_visits: int,
     have_traffic: bool,
+    gsc_m: float = 1.0,
+    feedback_m: float = 1.0,
 ) -> float:
     """Strategic weight, modulated by traffic when a snapshot is available."""
     tier_w = TIER_WEIGHTS.get(tier, TIER_WEIGHTS[3])
     if have_traffic and max_visits > 0:
         v = visits if visits is not None else median_visits
         traffic_n = math.log1p(v) / math.log1p(max_visits)
-        return tier_w * (0.5 + 0.5 * traffic_n)
-    return tier_w
+        return tier_w * (0.5 + 0.5 * traffic_n) * gsc_m * feedback_m
+    return tier_w * gsc_m * feedback_m
 
 
 def score_page(
@@ -393,10 +569,17 @@ def score_page(
     today: date,
     have_traffic: bool,
     stale_claims: bool = False,
+    gsc_m: float = 1.0,
+    feedback_m: float = 1.0,
 ) -> float:
     staleness = max((today - last_review).days, 0) if last_review else 0
     boost = STALE_CLAIM_BOOST if stale_claims else 0.0
-    return round(importance(tier, visits, max_visits, median_visits, have_traffic) * staleness + boost, 4)
+    return round(
+        importance(tier, visits, max_visits, median_visits, have_traffic, gsc_m, feedback_m)
+        * staleness
+        + boost,
+        4,
+    )
 
 
 # ---- Subcommands ---------------------------------------------------------------
@@ -465,6 +648,7 @@ def main() -> int:
     p.add_argument("--count", type=int, default=3)
     p.add_argument("--out", help="Queue JSON output path")
     p.add_argument("--traffic-file", help="S3-fetched traffic snapshot (CSV or JSON)")
+    p.add_argument("--signals-file", help="S3-fetched reader-signals snapshot (JSON)")
     p.add_argument("--tiers", default=str(DEFAULT_TIERS))
     p.add_argument("--ledger-dir", default=str(DEFAULT_LEDGER_DIR))
     p.add_argument("--repo-root", default=str(REPO_ROOT), help=argparse.SUPPRESS)
@@ -504,13 +688,46 @@ def main() -> int:
     max_visits = visits_known[-1] if visits_known else 0
     median_visits = visits_known[len(visits_known) // 2] if visits_known else 0
 
+    gsc, feedback, signals_meta = load_reader_signals(
+        Path(args.signals_file) if args.signals_file else None, known
+    )
+    signals_available = signals_meta["gsc"]["available"] or signals_meta["feedback"]["available"]
+
     queue: dict = {
         "generated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "count": 0,
         "halted": None,
         "traffic": {**traffic_meta, "available": have_traffic},
+        "reader_signals": {"available": signals_available, **signals_meta},
         "articles": [],
     }
+
+    def signal_terms(path: str) -> tuple[float, float, dict | None]:
+        """(gsc_m, feedback_m, per-article signals block) — one source for
+        both scoring and the queue entry, so they can't diverge."""
+        if not signals_available:
+            return 1.0, 1.0, None
+        gsc_entry = gsc.get(path)
+        fb_entry = feedback.get(path)
+        gsc_m, opportunity, low_ctr_flag = gsc_multiplier(
+            gsc_entry, signals_meta["gsc"]["max_impressions"], signals_meta["gsc"]["median_ctr"]
+        )
+        fb_m, neg_rate = feedback_multiplier(fb_entry)
+        return gsc_m, fb_m, {
+            "gsc": {
+                "impressions": gsc_entry["impressions"],
+                "ctr": gsc_entry["ctr"],
+                "opportunity": opportunity,
+                "multiplier": round(gsc_m, 4),
+                "low_ctr_flag": low_ctr_flag,
+            } if gsc_entry else None,
+            "feedback": {
+                "yes": fb_entry["yes"],
+                "no": fb_entry["no"],
+                "neg_rate": neg_rate,
+                "multiplier": round(fb_m, 4),
+            } if fb_entry else None,
+        }
 
     def article(path: str, lane: str, score: float | None) -> dict:
         tier, no_retire = tier_for(path, tier_rules)
@@ -523,6 +740,7 @@ def main() -> int:
             "tier": tier,
             "no_retire": no_retire,
             "monthly_visits": traffic.get(path),
+            "signals": signal_terms(path)[2],
             "last_reviewed": entry.get("reviewed_at"),
             "attempts": int(entry.get("attempts", 0)),
             "stale_claims": len(entry.get("stale_claims") or []),
@@ -581,23 +799,26 @@ def main() -> int:
             file=sys.stderr,
         )
 
+    def scored_entry(path: str) -> tuple[float, str]:
+        gsc_m, fb_m, _ = signal_terms(path)
+        return (
+            score_page(
+                tier_for(path, tier_rules)[0],
+                traffic.get(path),
+                max_visits,
+                median_visits,
+                effective_last_review(path, ledger.get(path), newest_non_bot, created),
+                today,
+                have_traffic,
+                stale_claims=bool((ledger.get(path) or {}).get("stale_claims")),
+                gsc_m=gsc_m,
+                feedback_m=fb_m,
+            ),
+            path,
+        )
+
     scored = sorted(
-        (
-            (
-                score_page(
-                    tier_for(path, tier_rules)[0],
-                    traffic.get(path),
-                    max_visits,
-                    median_visits,
-                    effective_last_review(path, ledger.get(path), newest_non_bot, created),
-                    today,
-                    have_traffic,
-                    stale_claims=bool((ledger.get(path) or {}).get("stale_claims")),
-                ),
-                path,
-            )
-            for path in candidates
-        ),
+        (scored_entry(path) for path in candidates),
         key=lambda t: (-t[0], t[1]),
     )
 

--- a/scripts/content-review/test_compose_pr_body.py
+++ b/scripts/content-review/test_compose_pr_body.py
@@ -161,6 +161,49 @@ nogate = c.compose(QUEUE, None, None, None, None, None)
 check("no gate -> screenshot TODO", "<TODO" in _between(nogate, "## Screenshot check", "## Rendered content"))
 check("no gate -> rendered TODO", "<TODO" in _between(nogate, "## Rendered content", "## Verification"))
 
+
+# ---- flag-only low-CTR pathway ------------------------------------------------
+#
+# A low_ctr_flag on the queue entry pre-stubs exactly one "Search opportunity"
+# deferral (fix: False, reason pre-composed) — never a fix row.
+
+FLAGGED_QUEUE = {
+    "traffic": {"available": True, "period": "2026-06"},
+    "reader_signals": {
+        "available": True,
+        "gsc": {"available": True, "median_ctr": 0.031, "max_impressions": 88012},
+        "feedback": {"available": True},
+    },
+    "articles": [{
+        **QUEUE["articles"][0],
+        "signals": {
+            "gsc": {"impressions": 15234, "ctr": 0.0205, "opportunity": 0.41,
+                    "multiplier": 1.1025, "low_ctr_flag": True},
+            "feedback": {"yes": 4, "no": 9, "neg_rate": 0.6923, "multiplier": 1.27},
+        },
+    }],
+}
+flagged = c.compose(FLAGGED_QUEUE, None, None, None, None)
+flag_fixes = _between(flagged, "## Fixes applied", "## Findings not applied")
+flag_defer = _between(flagged, "## Findings not applied", "## Screenshot check")
+check("low-CTR flag -> exactly one Search opportunity deferral",
+      flag_defer.count("Search opportunity") == 1)
+check("low-CTR deferral never lands as a fix row", "Search opportunity" not in flag_fixes)
+check("low-CTR deferral carries the figures",
+      "15,234 impressions at 2.05% CTR vs. corpus median 3.10%" in flag_defer)
+check("low-CTR deferral reason pre-composed (no TODO)",
+      "flag-only by design" in flag_defer and "/seo-analyze" in flag_defer)
+check("provenance carries the Search line", "**Search:** 15,234 impressions" in flagged)
+
+# No flag (or no signals at all) -> no Search opportunity row anywhere.
+check("unflagged queue has no Search opportunity row", "Search opportunity" not in out)
+unflagged = c.compose({**FLAGGED_QUEUE, "articles": [{
+    **FLAGGED_QUEUE["articles"][0],
+    "signals": {"gsc": {"impressions": 15234, "ctr": 0.05, "opportunity": 0.0,
+                        "multiplier": 1.0, "low_ctr_flag": False}, "feedback": None},
+}]}, None, None, None, None)
+check("healthy-CTR queue has no Search opportunity row", "Search opportunity" not in unflagged)
+
 if failures:
     print(f"\n{len(failures)} failure(s)", file=sys.stderr)
     sys.exit(1)

--- a/scripts/content-review/test_render_provenance.py
+++ b/scripts/content-review/test_render_provenance.py
@@ -79,6 +79,67 @@ check("snapshot-unavailable stated plainly", "snapshot unavailable this run" in 
 check("last_reviewed date rendered when present", "2026-05-01 (`attempts: 1`)" in out2)
 check("missing score degrades gracefully", "n/a (explicit dispatch)" in out2)
 
+# No reader_signals block (pre-export runs) -> body identical to before the
+# feature existed: no Search / Reader feedback lines at all.
+check("no reader_signals -> no Search line", "**Search:**" not in out)
+check("no reader_signals -> no feedback line", "**Reader feedback:**" not in out)
+
+# Reader signals available + page has figures -> Search and feedback lines.
+q_signals = {
+    "traffic": {"available": False},
+    "reader_signals": {
+        "available": True,
+        "gsc": {"available": True, "source": "google-search-console",
+                "period": {"start": "2026-03-14", "end": "2026-06-11"},
+                "pages_matched": 612, "median_ctr": 0.031, "max_impressions": 88012},
+        "feedback": {"available": True, "pages_matched": 214},
+    },
+    "articles": [_entry(signals={
+        "gsc": {"impressions": 15234, "ctr": 0.0205, "opportunity": 0.41,
+                "multiplier": 1.1025, "low_ctr_flag": True},
+        "feedback": {"yes": 4, "no": 9, "neg_rate": 0.6923, "multiplier": 1.27},
+    })],
+}
+out3 = rp.render(q_signals)
+check("Search line renders impressions + CTR",
+      "**Search:** 15,234 impressions, 2.05% CTR" in out3)
+check("Search line includes the corpus median", "corpus median 3.10%" in out3)
+check("Search line includes the period", "period 2026-03-14 to 2026-06-11" in out3)
+check("low-CTR flag surfaces", "**low-CTR flag**" in out3)
+check("feedback line renders votes + negativity",
+      "**Reader feedback:** 4 yes / 9 no (69% negative)" in out3)
+
+# Signals export available but this page has no rows -> distinct wording, no numbers.
+q_signals_absent = {
+    "traffic": {"available": False},
+    "reader_signals": {
+        "available": True,
+        "gsc": {"available": True, "median_ctr": 0.031},
+        "feedback": {"available": True},
+    },
+    "articles": [_entry(signals={"gsc": None, "feedback": None})],
+}
+out4 = rp.render(q_signals_absent)
+check("page absent from GSC reads distinctly", "no Search Console data for this page" in out4)
+check("page absent from feedback reads distinctly", "**Reader feedback:** none recorded" in out4)
+check("no flag when no data", "low-CTR flag" not in out4)
+
+# Unflagged page renders the Search line without the flag suffix.
+q_no_flag = {
+    "traffic": {"available": False},
+    "reader_signals": {"available": True,
+                       "gsc": {"available": True, "median_ctr": 0.031},
+                       "feedback": {"available": False}},
+    "articles": [_entry(signals={
+        "gsc": {"impressions": 2000, "ctr": 0.05, "opportunity": 0.0,
+                "multiplier": 1.0, "low_ctr_flag": False}})],
+}
+out5 = rp.render(q_no_flag)
+check("healthy page has Search line but no flag",
+      "**Search:** 2,000 impressions" in out5 and "low-CTR flag" not in out5)
+check("feedback section absent when that signal is unavailable",
+      "**Reader feedback:**" not in out5)
+
 if failures:
     print(f"\n{len(failures)} failure(s)", file=sys.stderr)
     sys.exit(1)

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -212,6 +212,86 @@ def main() -> int:
         qc = run_select(repo, tiers, empty, "--count", "20", "--traffic-file", str(csvf))
         check(qc["traffic"]["pages_matched"] == 1, "CSV snapshot parsed")
 
+        print("reader signals: exact degradation — no file, and all-neutral signals, score identically")
+        check(full["reader_signals"]["available"] is False, "no signals file -> unavailable")
+        check(all(a["signals"] is None for a in full["articles"]),
+              "no signals file -> per-article signals null")
+        neutral = tmp / "signals-neutral.json"
+        # Identical CTRs (gap 0 vs the median) and all-positive votes: every
+        # multiplier is exactly 1.0, so scores must equal the signal-blind run's.
+        neutral.write_text(json.dumps({"version": 1, "signals": {
+            "gsc": {"source": "gsc", "pages": {
+                "/docs/misc/one/": {"impressions": 5000, "clicks": 500},
+                "/docs/misc/two/": {"impressions": 5000, "clicks": 500}}},
+            "feedback": {"source": "segment", "pages": {
+                "/docs/misc/one/": {"yes": 10, "no": 0}}},
+        }}))
+        qn = run_select(repo, tiers, empty, "--count", "20", "--signals-file", str(neutral))
+        check(qn["reader_signals"]["available"] is True, "neutral signals file still marked available")
+        check(scores(qn) == s, "all-neutral signals -> scores byte-identical to the signal-blind run")
+
+        print("reader signals: GSC opportunity boost (high impressions AND low CTR only)")
+        gscf = tmp / "signals-gsc.json"
+        gscf.write_text(json.dumps({"version": 1, "signals": {"gsc": {
+            "source": "gsc", "period": {"start": "2026-03-14", "end": "2026-06-11"},
+            "pages": {
+                "/docs/misc/one/": {"impressions": 50000, "clicks": 250},
+                "/docs/misc/two/": {"impressions": 50000, "clicks": 5000},
+                "/docs/misc/protected/keep/": {"impressions": 100, "clicks": 1},
+            }}}}))
+        qg = run_select(repo, tiers, empty, "--count", "20", "--signals-file", str(gscf))
+        sg = scores(qg)
+        arts = {a["path"]: a for a in qg["articles"]}
+        check(sg[ONE] > sg[TWO], "low-CTR page outranks its equally stale high-CTR sibling")
+        one_gsc = arts[ONE]["signals"]["gsc"]
+        check(1.0 < one_gsc["multiplier"] <= 1.25, f"gsc multiplier bounded (got {one_gsc['multiplier']})")
+        check(one_gsc["low_ctr_flag"] is True, "low-CTR flag set on the flagged page")
+        check(arts[TWO]["signals"]["gsc"]["multiplier"] == 1.0, "at/above-median CTR stays neutral")
+        check(arts[TWO]["signals"]["gsc"]["low_ctr_flag"] is False, "healthy CTR not flagged")
+        keep_gsc = arts[KEEP]["signals"]["gsc"]
+        check(keep_gsc["multiplier"] == 1.0 and keep_gsc["low_ctr_flag"] is False,
+              "under-threshold impressions stay neutral and unflagged")
+        check(sg[TWO] == s[TWO], "boost-only: unboosted pages score exactly as before")
+        check(qg["reader_signals"]["gsc"]["available"] is True, "gsc meta available")
+        check(qg["reader_signals"]["feedback"]["available"] is False,
+              "gsc-only file leaves feedback unavailable")
+        check(qg["reader_signals"]["gsc"]["pages_matched"] == 3, "gsc pages matched")
+        check(qg["reader_signals"]["gsc"]["median_ctr"] is not None, "corpus median recorded")
+
+        print("reader signals: feedback boost (negative votes, damped below saturation)")
+        fbf = tmp / "signals-fb.json"
+        fbf.write_text(json.dumps({"version": 1, "signals": {"feedback": {
+            "source": "segment", "pages": {
+                "/docs/misc/one/": {"yes": 1, "no": 9},
+                "/docs/misc/two/": {"yes": 9, "no": 1},
+                "/docs/misc/protected/keep/": {"yes": 1, "no": 1},
+            }}}}))
+        qf = run_select(repo, tiers, empty, "--count", "20", "--signals-file", str(fbf))
+        sf = scores(qf)
+        artsf = {a["path"]: a for a in qf["articles"]}
+        check(sf[ONE] > sf[TWO], "negatively-voted page outranks its positively-voted sibling")
+        one_fb = artsf[ONE]["signals"]["feedback"]
+        check(1.0 < one_fb["multiplier"] <= 1.30, f"feedback multiplier bounded (got {one_fb['multiplier']})")
+        check(one_fb["neg_rate"] == 0.9, "neg_rate recorded")
+        check(artsf[KEEP]["signals"]["feedback"]["multiplier"] == 1.0,
+              "below-minimum vote count stays neutral")
+
+        print("reader signals: malformed file degrades to exactly the signal-blind run")
+        garbage = tmp / "signals-garbage.json"
+        garbage.write_text("not json {{{")
+        qb = run_select(repo, tiers, empty, "--count", "20", "--signals-file", str(garbage))
+        check(qb["reader_signals"]["available"] is False, "garbage file -> unavailable")
+        check(scores(qb) == s, "garbage file -> scores identical to no file")
+
+        print("reader signals: determinism with signals present")
+        qg2 = run_select(repo, tiers, empty, "--count", "20", "--signals-file", str(gscf))
+        check(scores(qg2) == sg, "signal-boosted selection is deterministic")
+
+        print("reader signals: --paths entries carry the signals block")
+        qp = run_select(repo, tiers, empty, "--paths", ONE, "--signals-file", str(gscf))
+        check(qp["articles"][0]["signals"]["gsc"]["low_ctr_flag"] is True,
+              "manual dispatch still carries the flag")
+
         print("incomplete review keeps a page due (its reviewed_at is ignored)")
         led_inc = tmp / "ledger-incomplete"
         write_ledger(led_inc, OVERVIEW, "2026-06-11", status="incomplete", attempts=1)

--- a/scripts/link-checker/merge-404-signal.py
+++ b/scripts/link-checker/merge-404-signal.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Merge the reader-signals real-404 export into the link checker's results.
+
+Deterministic workflow step (never model-run) that runs between
+`make check_links` and the check-links workflow's broken-count gate. The
+crawler finds links that are broken *on our own pages*; the reader-signals
+export's `not_found` section (server-log 404 hits) finds URLs readers actually
+request that don't exist — external referrers, bookmarks, stale search results
+— which no crawl of our own pages can see. Merging the two lets the existing
+fix-broken-links triage work both lists at once, highest-traffic first.
+
+What it does to `.broken-links.json` (in place):
+
+1. Annotates existing `internal` entries whose destination path appears in
+   `not_found` with `"hits": N` (real reader traffic on that breakage).
+2. Appends one entry per `not_found` path with hits >= MIN_HITS that no
+   crawler entry already covers: `{"source": "(server logs)", "destination":
+   "https://www.pulumi.com<path>", "reason": "REAL_404", "hits": N}` — capped
+   at MAX_APPENDED per run so one bad export can't flood the triage.
+3. Sorts `internal` by hits descending (entries without hits keep their
+   relative order at the end), so triage works high-traffic-first.
+
+No HTTP probing happens here: the fix-broken-links skill re-verifies every
+entry before touching anything, which also guards against a stale export.
+
+Degrades to a no-op (exit 0, file untouched) when the signals file is missing,
+unreadable, or has no `not_found` section — the pre-export steady state.
+
+Usage:
+    merge-404-signal.py [--signals .reader-signals.json] [--broken .broken-links.json]
+    merge-404-signal.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+SITE = "https://www.pulumi.com"
+MIN_HITS = 50  # server-log 404s below this are long-tail noise; skip
+MAX_APPENDED = 25  # flood guard: one bad export can't swamp the triage
+
+
+def log(msg: str) -> None:
+    print(f"merge-404-signal: {msg}", file=sys.stderr)
+
+
+def norm_path(url_or_path: str) -> str:
+    """Normalize a URL or path to a bare site-relative path with trailing slash."""
+    s = (url_or_path or "").strip()
+    if "://" in s:
+        s = urlparse(s).path
+    s = s.split("#", 1)[0].split("?", 1)[0]
+    if not s.startswith("/"):
+        s = "/" + s
+    # Normalize to trailing slash except for file-like paths (e.g. /foo.html).
+    if not s.endswith("/") and not re.search(r"\.[A-Za-z0-9]{1,5}$", s):
+        s += "/"
+    return s
+
+
+def load_not_found(signals_file: Path) -> dict[str, int]:
+    """{normalized path: hits} from the export, or {} when absent/malformed."""
+    if not signals_file.is_file():
+        return {}
+    try:
+        data = json.loads(signals_file.read_text(errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    section = (data.get("signals") or {}).get("not_found")
+    if not isinstance(section, dict) or not isinstance(section.get("paths"), dict):
+        return {}
+    out: dict[str, int] = {}
+    for path, row in section["paths"].items():
+        try:
+            hits = int(float((row or {}).get("hits", 0)))
+        except (TypeError, ValueError, AttributeError):
+            continue
+        if hits > 0:
+            p = norm_path(str(path))
+            out[p] = max(out.get(p, 0), hits)
+    return out
+
+
+def merge(broken: dict, not_found: dict[str, int]) -> tuple[dict, int, int]:
+    """Return (merged results, annotated count, appended count)."""
+    internal = broken.get("internal")
+    if not isinstance(internal, list):
+        internal = []
+        broken["internal"] = internal
+
+    covered: set[str] = set()
+    annotated = 0
+    for entry in internal:
+        if not isinstance(entry, dict):
+            continue
+        dest = norm_path(str(entry.get("destination", "")))
+        covered.add(dest)
+        if dest in not_found:
+            entry["hits"] = not_found[dest]
+            annotated += 1
+
+    appendable = sorted(
+        ((hits, path) for path, hits in not_found.items()
+         if hits >= MIN_HITS and path not in covered),
+        key=lambda t: (-t[0], t[1]),
+    )
+    dropped = max(len(appendable) - MAX_APPENDED, 0)
+    for hits, path in appendable[:MAX_APPENDED]:
+        internal.append({
+            "source": "(server logs)",
+            "destination": f"{SITE}{path}",
+            "reason": "REAL_404",
+            "hits": hits,
+        })
+    if dropped:
+        log(f"appended cap reached: dropped {dropped} lower-traffic real-404 path(s) "
+            f"(they'll resurface next run if still 404ing)")
+
+    # Highest reader impact first; unhit crawler entries keep their relative
+    # order at the end (sorted() is stable).
+    internal.sort(key=lambda e: -(e.get("hits") or 0) if isinstance(e, dict) else 0)
+
+    return broken, annotated, len(appendable[:MAX_APPENDED])
+
+
+def run(signals_path: Path, broken_path: Path) -> int:
+    not_found = load_not_found(signals_path)
+    if not not_found:
+        log(f"no usable not_found section in {signals_path}; leaving {broken_path} untouched")
+        return 0
+    if not broken_path.is_file():
+        log(f"{broken_path} not found; leaving it untouched (nothing to merge into)")
+        return 0
+    try:
+        broken = json.loads(broken_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        log(f"{broken_path} unreadable ({e}); leaving it untouched")
+        return 0
+    if not isinstance(broken, dict):
+        log(f"{broken_path} has an unexpected shape; leaving it untouched")
+        return 0
+
+    merged, annotated, appended = merge(broken, not_found)
+    broken_path.write_text(json.dumps(merged, indent=2) + "\n")
+    log(f"annotated {annotated} crawler entr(ies) with hits, appended {appended} "
+        f"REAL_404 entr(ies) from {len(not_found)} server-log path(s)")
+    return 0
+
+
+def self_test() -> int:
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+            print(f"FAIL: {name}", file=sys.stderr)
+        else:
+            print(f"ok: {name}")
+
+    check("norm_path strips origin and adds slash",
+          norm_path("https://www.pulumi.com/docs/old") == "/docs/old/")
+    check("norm_path keeps file-like paths slashless",
+          norm_path("/docs/foo.html") == "/docs/foo.html")
+    check("norm_path drops fragment and query",
+          norm_path("/docs/a/?x=1#frag") == "/docs/a/")
+
+    nf = {"/docs/gone/": 210, "/docs/tail/": 3, "/docs/covered/": 90}
+    broken = {
+        "generated": "2026-07-09T15:00:00Z",
+        "internal": [
+            {"source": "https://www.pulumi.com/docs/x/",
+             "destination": "https://www.pulumi.com/docs/covered/", "reason": "HTTP_404"},
+            {"source": "https://www.pulumi.com/docs/y/",
+             "destination": "https://www.pulumi.com/docs/unrelated/", "reason": "HTTP_404"},
+        ],
+        "external": [],
+    }
+    merged, annotated, appended = merge(json.loads(json.dumps(broken)), nf)
+    internal = merged["internal"]
+    check("crawler entry covered by logs gets hits", annotated == 1
+          and any(e.get("hits") == 90 and "covered" in e["destination"] for e in internal))
+    check("high-traffic uncovered path appended as REAL_404", appended == 1
+          and any(e.get("reason") == "REAL_404" and e.get("hits") == 210 for e in internal))
+    check("below-MIN_HITS path not appended",
+          not any("tail" in e.get("destination", "") for e in internal))
+    check("sorted by hits desc", [e.get("hits") for e in internal] == [210, 90, None])
+    check("external untouched", merged["external"] == [])
+
+    # Cap: MAX_APPENDED+10 eligible paths -> exactly MAX_APPENDED appended.
+    many = {f"/docs/gone-{i:03d}/": 1000 + i for i in range(MAX_APPENDED + 10)}
+    merged, _, appended = merge({"internal": [], "external": []}, many)
+    check("appended list capped", appended == MAX_APPENDED
+          and len(merged["internal"]) == MAX_APPENDED)
+    check("cap keeps the highest-hit paths",
+          merged["internal"][0]["hits"] == 1000 + MAX_APPENDED + 9)
+
+    # Alias/dup handling inside not_found (same path twice via norm) keeps max.
+    check("not_found normalizes and keeps max", load_not_found_from(
+        {"signals": {"not_found": {"paths": {
+            "/docs/a": {"hits": 5}, "/docs/a/": {"hits": 9}}}}}) == {"/docs/a/": 9})
+
+    # Degradation shapes.
+    check("missing not_found section -> {}", load_not_found_from({"signals": {}}) == {})
+    check("garbage rows skipped", load_not_found_from(
+        {"signals": {"not_found": {"paths": {"/x/": "nope", "/y/": {"hits": "abc"},
+                                             "/z/": {"hits": 60}}}}}) == {"/z/": 60})
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall merge-404-signal self-tests passed")
+    return 0
+
+
+def load_not_found_from(obj: dict) -> dict[str, int]:
+    """Self-test helper: run load_not_found against an in-memory object."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(obj, f)
+        name = f.name
+    try:
+        return load_not_found(Path(name))
+    finally:
+        Path(name).unlink()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--signals", default=".reader-signals.json")
+    p.add_argument("--broken", default=".broken-links.json")
+    p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
+    args = p.parse_args()
+    if args.self_test:
+        return self_test()
+    return run(Path(args.signals), Path(args.broken))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Proposed changes

Implements #20078 item **4.5 "Real reader signals into selection"**: the daily content-review selection weighed pages by pageviews alone. This PR wires three reader signals into the pipeline — Search Console impressions/CTR, docs feedback-widget votes, and real-404 server-log hits — deterministically and at zero model cost.

**Everything here is inert-but-ready**: both workflows resolve a new `docsReaderSignalsLatestS3Uri` output on the data team's Airflow stack (mirroring the `docsTrafficPageviewsLatestS3Uri` pageviews pattern). Until that export ships, every step logs a skip and behavior is byte-identical to today — verified by an exact-degradation regression test.

**Selection** (`scripts/content-review/select-articles.py`):

- New `--signals-file` loader for the combined reader-signals snapshot (independently optional `gsc` / `feedback` sections).
- Two bounded, **boost-only** multipliers on the importance term:
  - `gsc_m ∈ [1.0, 1.25]` — boosts only the high-impressions AND below-median-CTR quadrant (`1 + 0.25 · impressions_n · ctr_gap`).
  - `feedback_m ∈ [1.0, 1.30]` — negative-vote rate, damped below 10 total votes (`1 + 0.30 · neg_rate · min(1, votes/10)`).
  - Both floor at exactly 1.0: a missing export/section/page scores precisely the pre-signal value, and no page ever ranks lower. High CTR / positive feedback never suppress — a well-titled page can still be factually stale.
- Queue JSON gains a `reader_signals` meta block and a per-article `signals` block (figures, multipliers, `low_ctr_flag`) for auditability.

**Flag-only low-CTR pathway** (per the issue: meta rewrites are slop-prone):

- Selection stamps `low_ctr_flag` (impressions ≥ 1000 and CTR ≤ 0.5× corpus median).
- `compose-pr-body.py` pre-stubs a "Search opportunity" row under *Findings not applied* with its reason pre-composed (`fix: False` — it can never become a fix row).
- The `review-existing-content` skill now forbids `title`/`meta_desc` rewrites in response; a human runs `/seo-analyze`.
- `render-provenance.py` adds **Search** and **Reader feedback** lines to the composed "Why this page" block.

**Ledger** (`record-review.py`): persists `signals` / `signals_available` per review, so the versioned S3 ledger remains a complete why-it-was-picked record.

**404 → redirect triage** (`check-links.yml` + new `scripts/link-checker/merge-404-signal.py`): merges the export's `not_found` section (real 404 hits from server logs — URLs no crawl of our own pages can see) into `.broken-links.json` before the broken-count gate: annotates crawler entries with `hits`, appends high-hit `REAL_404` entries (≥ 50 hits, capped at 25/run), and sorts by hits so the fix-broken-links triage works highest-reader-impact first. The skill gains a matching "Real-404 signal" section (verify-before-fix; junk paths never get a redirect).

**Verification**

- `test_select_articles.py` 74/74 (exact-degradation floor, GSC/feedback boosts + bounds, flag thresholds, partial/garbage files, determinism, `--paths` carry-through).
- `test_render_provenance.py`, `test_compose_pr_body.py`, `record-review.py --self-test`, `merge-404-signal.py --self-test` all pass; `make lint` clean.
- End-to-end locally: selection with a synthetic snapshot → provenance → composed PR body, confirming the boost math, the low-CTR deferral stub, and the no-signals byte-identical fallback.

**Follow-up (not in this repo):** file the pulumi/data export request. Proposed issue text:

> **Title:** Docs reader-signals export (GSC + feedback widget + real 404s) for content-review selection
>
> **What:** A weekly per-URL snapshot combining three reader signals for `www.pulumi.com/docs/`, landed in S3 by Airflow and exposed via a `docsReaderSignalsLatestS3Uri` output on `pulumi/dwh-workflows-orchestrate-airflow/production` — the same pattern as `docsTrafficPageviewsLatestS3Uri` (pulumi/data#865).
>
> **Why:** pulumi/docs#20078 item 4.5. The consumer side is already merged in pulumi/docs and degrades gracefully until this exists — no coordination needed on ship day.
>
> **Contract:** one JSON object `{"version": 1, "generated": ..., "signals": {gsc, feedback, not_found}}`, keyed by root-relative URL paths with trailing slash; any section may be absent (consumers treat absence as "unavailable"):
> - `gsc`: per-page `{impressions, clicks, position}` over the trailing 90 days (GSC Search Analytics API, page dimension, `www.pulumi.com` property), `/docs/` pages only. CTR is consumer-derived from the raw counts.
> - `feedback`: per-page `{yes, no}` counts of the Segment `docs-feedback` event (`properties.url` = page path, `properties.answer` = Yes/No) over the trailing 180 days. **Counts only — the event's `comments`/`email` properties must not be exported (PII).**
> - `not_found`: top ≤ 500 404'd paths by `{hits}` over the trailing 30 days from CDN/access logs, bot and asset-probe filtered, excluding paths that already redirect.

### Related issues (optional)

Part of #20078 (item 4.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkYo21MH4Ay8v5Ch4jW4Bx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkYo21MH4Ay8v5Ch4jW4Bx)_