### PR TITLE
Persist an entity-keyed claims index and re-verify volatile claims nightly

### DIFF
--- a/.claude/commands/docs-review/scripts/entity_key.py
+++ b/.claude/commands/docs-review/scripts/entity_key.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""entity_key.py — deterministic entity keying for extracted claims.
+
+Shared by `merge-claims.py` (stamps `entity_key` + `volatile` onto each merged
+claim) and `scripts/content-review/reverify-claims.py` (groups the persisted
+claims index by entity for nightly re-verification). One module so both sides
+derive identical keys.
+
+An entity key names the *subject* of a claim — the CLI flag, package, price,
+or API surface it asserts something about — normalized so two pages asserting
+facts about the same entity produce the same key. The claimed *value* (the
+version number, the price figure) is deliberately excluded: the key must stay
+stable when the value changes, or re-verification and contradiction detection
+can't join across pages and time.
+
+Key format: `<type>/<subject-slug>`, e.g.
+    version/pulumi-gcp
+    numerical/deployment-minutes-free-tier
+    api-surface/aws-s3-bucket-versioning
+    entity-spec/enterprise-plan-audit-logs
+
+Only the four concrete, entity-shaped types are keyed — `version`,
+`numerical`, `api-surface`, `entity-spec`. Everything else (behavior,
+positioning, quote, ...) gets `entity_key: None`: those claims still persist
+in the index but are invisible to entity-keyed consumers. A keyable claim
+whose subject doesn't normalize to at least one significant token also gets
+None — a missing key is always safe (the claim just isn't re-verified from
+the index), a wrong key is not.
+
+`volatile` marks the claim types worth cheap nightly re-verification straight
+from the index — assertions whose truth drifts with the outside world even
+when the page doesn't change: version pins, prices/rates/limits, and
+pricing/limit-flavored entity specs.
+
+No LLM involvement: derivation is pure text normalization, so keys are
+reproducible from the claim record alone. Run the smoke checks with
+`python3 entity_key.py --self-test`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+# Claim types that name a concrete entity we can key on. The soft/judgment
+# types (behavior, feature, positioning, comparison, quote, attribution,
+# temporal, cross-reference, url) are not keyed.
+KEYED_TYPES = {"version", "numerical", "api-surface", "entity-spec"}
+
+# Types whose truth drifts with the outside world; re-verified nightly from
+# the index. `entity-spec` is volatile only in its pricing/limit flavor —
+# "runners run in us-west-2" is stable, "feature Z is on the Enterprise plan"
+# is not.
+ALWAYS_VOLATILE_TYPES = {"version", "numerical"}
+PRICING_LIMIT_RE = re.compile(
+    r"\b(?:price|prices|pricing|priced|cost|costs|fee|fees|billed|billing|"
+    r"per[- ](?:month|year|hour|minute|user|seat|resource|credit)|"
+    r"tier|tiers|plan|plans|edition|editions|subscription|"
+    r"limit|limits|limited|quota|quotas|cap|capped|maximum|minimum|"
+    r"free|paid|enterprise|business[- ]critical)\b",
+    re.IGNORECASE,
+)
+
+MAX_SUBJECT_TOKENS = 5
+
+_STOPWORDS = {
+    "the", "a", "an", "of", "to", "in", "on", "is", "are", "be", "and", "or",
+    "for", "with", "that", "this", "it", "its", "by", "as", "at", "from",
+    "was", "were", "has", "have", "had", "will", "can", "but", "not", "all",
+    "any", "each", "per", "you", "your", "when", "which", "than", "then",
+    "there", "their", "these", "those", "into", "onto", "also", "only",
+    "more", "most", "least", "such", "may", "must", "should", "would",
+    "does", "do", "did", "no", "new", "now", "up", "down", "requires",
+    "required", "supports", "supported", "available", "takes", "take",
+    "uses", "used", "using", "default", "defaults", "currently", "since",
+    "version", "versions",  # "version" itself is the type, never the subject
+}
+
+# A version-like or purely numeric token is the claim's VALUE, not its
+# subject — excluded so the key survives a value change. `v3.230`, `3.252.0`,
+# `18+`, `40x`, `$75`, `99.9%`.
+_VALUE_TOKEN_RE = re.compile(
+    r"""^(?:
+        v?\d+(?:\.\d+)*(?:-[\w.]+)?   # 3.252.0, v8.2, 1.21-rc1
+        | \d+(?:\.\d+)?[x%+]?         # 40x, 99.9%, 18+
+        | \$\d+(?:\.\d+)?[km]?        # $75, $1.5k
+    )$""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_CODE_SPAN_RE = re.compile(r"`([^`\n]+)`")
+_WORD_RE = re.compile(r"[A-Za-z0-9$][\w.$+%-]*")
+
+
+def _slug_token(raw: str) -> str:
+    """Normalize one token into slug form: lowercase, inner punctuation → '-'."""
+    t = raw.lower().strip(".,;:!?'\"()[]{}")
+    t = re.sub(r"[^a-z0-9]+", "-", t).strip("-")
+    return t
+
+
+def _subject_tokens(text: str) -> list[str]:
+    """Ordered significant tokens of a claim's subject: stopwords, bare URLs,
+    and value-shaped tokens (numbers, versions, prices) removed."""
+    text = re.sub(r"https?://\S+", " ", text or "")
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in _WORD_RE.findall(text):
+        if _VALUE_TOKEN_RE.match(raw.strip(".,;:!?'\"()[]{}")):
+            continue
+        t = _slug_token(raw)
+        if not t or len(t) < 2 or t.isdigit() or t in _STOPWORDS or t in seen:
+            continue
+        seen.add(t)
+        out.append(t)
+        if len(out) >= MAX_SUBJECT_TOKENS:
+            break
+    return out
+
+
+def _code_subject(text: str) -> str | None:
+    """The first backticked identifier that isn't a value — the strongest
+    subject signal for api-surface claims (`--diff`, `aws.s3.Bucket`)."""
+    for m in _CODE_SPAN_RE.finditer(text or ""):
+        span = m.group(1).strip()
+        # A multi-word span is a phrase, not an identifier.
+        if not span or " " in span:
+            continue
+        if _VALUE_TOKEN_RE.match(span):
+            continue
+        t = _slug_token(span)
+        if t and t not in _STOPWORDS:
+            return t
+    return None
+
+
+def derive(claim: dict) -> tuple[str | None, bool]:
+    """(entity_key, volatile) for one claim record.
+
+    Reads `type`, `text`, and `source_hint`. Never raises: any shape it can't
+    key returns (None, volatile-by-type).
+    """
+    ctype = str(claim.get("type") or "")
+    text = str(claim.get("text") or "")
+    hint = str(claim.get("source_hint") or "")
+
+    volatile = ctype in ALWAYS_VOLATILE_TYPES or (
+        ctype == "entity-spec" and bool(PRICING_LIMIT_RE.search(text))
+    )
+
+    if ctype not in KEYED_TYPES:
+        return None, volatile
+
+    tokens: list[str] = []
+    if ctype == "api-surface":
+        code = _code_subject(text) or _code_subject(hint)
+        if code:
+            tokens = [code]
+    if not tokens and ctype == "version":
+        # The pinned package/product: prefer the extractor's source_hint
+        # ("pulumi-gcp"), fall back to the text's subject tokens.
+        tokens = _subject_tokens(hint)[:2] or _subject_tokens(text)[:2]
+    if not tokens:
+        tokens = _subject_tokens(text)
+        if not tokens:
+            tokens = _subject_tokens(hint)
+
+    if not tokens:
+        return None, volatile
+    return f"{ctype}/{'-'.join(tokens)}", volatile
+
+
+def stamp(claim: dict) -> dict:
+    """Mutate `claim` in place with `entity_key` and `volatile`; returns it."""
+    key, volatile = derive(claim)
+    claim["entity_key"] = key
+    claim["volatile"] = volatile
+    return claim
+
+
+# ---- self-test ---------------------------------------------------------------
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        if not cond:
+            failures.append(name)
+            print(f"FAIL: {name}", file=sys.stderr)
+        else:
+            print(f"ok: {name}")
+
+    # Version pin: keyed on the package, not the version number; volatile.
+    k, v = derive({"type": "version",
+                   "text": "`pulumi-gcp` v8.2.0 is the current provider release.",
+                   "source_hint": "pulumi-gcp"})
+    check("version keyed on package", k == "version/pulumi-gcp")
+    check("version is volatile", v is True)
+
+    # Same entity, different pinned value -> same key (value excluded).
+    k2, _ = derive({"type": "version",
+                    "text": "`pulumi-gcp` v9.0.1 is the current provider release.",
+                    "source_hint": "pulumi-gcp"})
+    check("version key stable across value change", k2 == k)
+
+    # Version with no hint falls back to text subject.
+    k, _ = derive({"type": "version", "text": "Requires Node.js 18+."})
+    check("version falls back to text subject", k == "version/node-js")
+
+    # Numerical: subject tokens only, figure stripped; volatile.
+    k, v = derive({"type": "numerical",
+                   "text": "The Free tier includes 3,000 deployment minutes."})
+    check("numerical keyed on subject", k is not None and k.startswith("numerical/"))
+    check("numerical key has no figure", k is not None and "3" not in k)
+    check("numerical is volatile", v is True)
+    k2, _ = derive({"type": "numerical",
+                    "text": "The Free tier includes 5,000 deployment minutes."})
+    check("numerical key stable across value change", k2 == k)
+
+    # api-surface: keyed on the backticked identifier.
+    k, v = derive({"type": "api-surface",
+                   "text": "The `aws.s3.Bucket` constructor takes a `versioning` argument.",
+                   "source_hint": "pulumi-aws"})
+    check("api-surface keyed on identifier", k == "api-surface/aws-s3-bucket")
+    check("api-surface is not volatile", v is False)
+
+    # entity-spec, pricing-flavored -> volatile; stable flavor -> not.
+    k, v = derive({"type": "entity-spec",
+                   "text": "Audit logs are available on the Enterprise plan."})
+    check("pricing entity-spec keyed", k is not None and k.startswith("entity-spec/"))
+    check("pricing entity-spec is volatile", v is True)
+    _, v = derive({"type": "entity-spec",
+                   "text": "Pulumi-hosted deployment runners run in AWS us-west-2."})
+    check("hosting entity-spec is not volatile", v is False)
+
+    # Non-keyed types: no key, not volatile.
+    k, v = derive({"type": "behavior",
+                   "text": "`pulumi up` deploys all resources in the stack."})
+    check("behavior not keyed", k is None)
+    check("behavior not volatile", v is False)
+
+    # Unkeyable subject -> None, never a junk key.
+    k, _ = derive({"type": "numerical", "text": "40x"})
+    check("value-only text yields no key", k is None)
+
+    # Missing/garbage fields never raise.
+    k, v = derive({})
+    check("empty claim yields (None, False)", k is None and v is False)
+
+    # stamp() mutates in place.
+    c = {"type": "version", "text": "requires Go 1.21", "source_hint": "go"}
+    stamp(c)
+    check("stamp sets both fields", c["entity_key"] == "version/go" and c["volatile"] is True)
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall entity_key self-tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        sys.exit(self_test())
+    print(__doc__.split("\n\n")[0], file=sys.stderr)
+    sys.exit(2)

--- a/.claude/commands/docs-review/scripts/merge-claims.py
+++ b/.claude/commands/docs-review/scripts/merge-claims.py
@@ -40,6 +40,8 @@ Output schema:
          "text": "...", "type": "...", "source_hint": "...",  # source_hint optional
          "confidence": "high"|"medium"|"low",
          "found_by": ["regex", "llm-atomic", "llm-holistic"],   # 1+ of these
+         "entity_key": "version/pulumi-gcp" | null,             # see entity_key.py
+         "volatile": true|false,                                # see entity_key.py
          "line_range_unverified": true},                        # present only when flagged
         ...
       ],
@@ -58,6 +60,14 @@ import re
 import sys
 import traceback
 from pathlib import Path
+
+# Entity keying (entity_key + volatile on each merged claim) feeds the
+# persistent claims index; a missing/broken module degrades to unkeyed claims
+# rather than failing the merge.
+try:
+    import entity_key as _entity_key
+except ImportError:
+    _entity_key = None
 
 SCHEMA_VERSION = 1
 TOKEN_OVERLAP_THRESHOLD = 0.34
@@ -354,6 +364,12 @@ def main() -> int:
             llm_count += 1
 
     merged = merge_claims(all_records)
+
+    if _entity_key is not None:
+        for c in merged:
+            _entity_key.stamp(c)
+    else:
+        errors.append("entity_key module unavailable; claims are unkeyed")
 
     meta = {"regex_claims": regex_count, "llm_claims": llm_count, "merged_claims": len(merged), **token_meta}
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/.claude/commands/docs-review/scripts/verify-claims.py
+++ b/.claude/commands/docs-review/scripts/verify-claims.py
@@ -60,6 +60,8 @@ Output schema:
       "verdicts": [
         {"claim_id": "c1", "file": "content/blog/foo.md", "line_range": "L42",
          "text": "...", "type": "...",
+         "entity_key": "version/pulumi-gcp",   # carried from the claim when keyed (see entity_key.py)
+         "volatile": true,                     # carried alongside entity_key
          "route": "pass0" | "pass1" | "pass2" | "pass3",
          "verdict": "verified" | "matches" | "not-a-claim" | "unverifiable" | "contradicted" | "mismatch",
          "confidence": "high" | "medium" | "low",
@@ -901,6 +903,18 @@ def main() -> int:
                 verdicts.append(rec)
                 if err:
                     errors.append(err)
+
+    # Carry each claim's entity keying (stamped by merge-claims.py) onto its
+    # verdict, so the persisted claims index (`record-claims.py`) reads
+    # `.verified-claims.json` alone. Verdict records are built in several
+    # paths (pass0 / model / dry-run / error), so stamp once here by claim_id
+    # instead of in each constructor.
+    by_id = {c.get("__id"): c for c in claims}
+    for v in verdicts:
+        c = by_id.get(v.get("claim_id"))
+        if c is not None and c.get("entity_key") is not None:
+            v["entity_key"] = c["entity_key"]
+            v["volatile"] = bool(c.get("volatile"))
 
     meta = dict(base_meta)
     meta["n_claims"] = len(claims)

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -46,6 +46,10 @@ Read `.content-review-queue.json` from the repo root (written by
 ```
 
 - `lane` — `priority` (scored pick) or `manual` (workflow_dispatch override).
+- `stale_claims` (when present) — count of this page's volatile claims the
+  nightly re-verification found contradicted (see §Claims index below). A
+  non-zero count is why the page jumped the queue: treat the ledger markers'
+  entity keys and evidence as priority findings to re-check first.
 - `no_retire` — when true, retirement must never be proposed for this page.
   This is the **hard veto** on retirement — honor it regardless of evidence.
 - If `articles` is empty or `halted` is set, do nothing (the workflow won't
@@ -356,3 +360,27 @@ The verdict sentinel (step 8), your working-tree edits, and the edited PR body
 draft are your only outputs. The workflow publishes the branch, records the
 ledger, and drives the docs review from them — there is no results file to
 write.
+
+## Claims index and stale-claim boosts
+
+Alongside the ledger record, the workflow persists the page's
+`.verified-claims.json` to a **claims index** — one snapshot object per page
+at `claims/<slug>.json` in the ledger bucket, written by
+`scripts/content-review/record-claims.py`. Each kept claim carries the
+`entity_key` / `volatile` fields stamped by the docs-review pipeline
+(`entity_key.py`), so downstream consumers can join claims across pages by
+the entity they assert something about.
+
+The nightly `claims-reverify.yml` workflow re-checks volatile entities
+(version pins, prices, limits) straight from this index
+(`scripts/content-review/reverify-claims.py`). When an entity re-verifies
+contradicted, every page asserting it gets a `stale_claims` marker in its
+ledger entry, and `select-articles.py` boosts those pages to the front of the
+next sweep — that is how a page can arrive in your queue the day after a
+release changed a fact it states.
+
+None of this is yours to write: this worker's whole-page runs are the index's
+**only** writer, and the workflow runs `record-claims.py` itself after your
+review. The markers clear automatically when your review's ledger and claims
+rewrites land. Do not create, edit, or upload `claims/` objects or
+`stale_claims` fields.

--- a/.github/workflows/claims-reverify.yml
+++ b/.github/workflows/claims-reverify.yml
@@ -1,0 +1,173 @@
+name: "Scheduled jobs: Re-verify volatile claims"
+
+# Nightly re-verification of VOLATILE claims (version pins, prices, limits)
+# straight from the S3 claims index that content-review-article.yml persists —
+# no page diff, no re-extraction, one cheap verifier call per entity
+# (pulumi/docs#20078 §4.1). Entities that re-verify contradicted get a
+# `stale_claims` marker written into their pages' ledger objects; the daily
+# content-review dispatcher's selector boosts marked pages to the front of
+# the queue, and the normal per-article worker fixes the page through the
+# existing PR machinery. This job never edits content and never opens PRs —
+# it only checks facts and marks pages as due.
+#
+# SINGLE SWITCH (default-on) — the CLAIMS_REVERIFY_COUNT repo variable is both
+# the on/off and the cadence knob (same pattern as CONTENT_REVIEW_COUNT):
+#   unset -> on, 25 entities/night (the default)
+#   '0'   -> off: the whole job is skipped (no runner, no spend)
+#   'N'   -> on, N entities/night
+# The sweep is a stateless day rotation over the volatile entity set, so all
+# of it is covered every ceil(N_entities/count) nights regardless of the knob.
+
+on:
+  schedule:
+    # Daily at 7:00AM UTC — hours before the 2:00PM content-review dispatcher,
+    # so tonight's stale markers are in the ledger before today's selection.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      count:
+        description: 'Number of volatile entities to re-verify'
+        required: false
+        default: '25'
+      dry_run:
+        description: 'No API calls, no marker uploads — plumbing check only'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  id-token: write # Required for ESC OIDC auth + AWS OIDC role
+
+jobs:
+  # Same fail-open holiday gate as review-existing-content.yml: variable
+  # unset, feed failure, or parse error all yield is_holiday=false.
+  holiday-check:
+    name: Company-holiday check
+    runs-on: ubuntu-latest
+    outputs:
+      is_holiday: ${{ steps.check.outputs.is_holiday }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: check
+        env:
+          ICS_URL: ${{ vars.BAMBOOHR_HOLIDAY_ICS_URL }}
+        run: |
+          if [ -z "$ICS_URL" ]; then
+            echo "BAMBOOHR_HOLIDAY_ICS_URL not set; not skipping for holidays"
+            echo "is_holiday=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if ! curl -fsSL --max-time 20 "$ICS_URL" -o holidays.ics; then
+            echo "::warning::holiday feed unavailable (404/fetch failure); failing open (re-verify will run)"
+            echo "is_holiday=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if python3 scripts/content-review/is-holiday.py --ics holidays.ics --tz America/Chicago; then
+            echo "is_holiday=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_holiday=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  reverify:
+    name: Re-verify volatile claims
+    needs: holiday-check
+    runs-on: ubuntu-latest
+    # PULUMI_STACK_NAME is an environment-scoped variable, so the job must
+    # select the environment to resolve the ledger bucket from stack outputs.
+    environment: production
+    # Hard cost ceiling: N short verifier calls fit well inside this.
+    timeout-minutes: 30
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (vars.CLAIMS_REVERIFY_COUNT != '0' && needs.holiday-check.outputs.is_holiday != 'true')
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v3
+      # Shallow checkout is fine: the verifier's read_file only needs the
+      # current tree, and this job reads no git history.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Both S3 prefixes (claims index + review ledger) live in the ledger
+      # bucket, resolved from our Pulumi stack output — never a hand-maintained
+      # variable. Every S3 step degrades gracefully: with no bucket the script
+      # sees an empty claims dir and exits with an empty report.
+      - name: Configure AWS credentials
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-session-name: claims-reverify
+          aws-region: us-west-2
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+      - name: Resolve ledger bucket
+        id: ledger-bucket
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName \
+            --stack "${{ vars.PULUMI_STACK_NAME }}" 2>/dev/null || true)
+          if [ -n "$BUCKET" ]; then
+            echo "ledger_uri=s3://$BUCKET/ledger/" >> "$GITHUB_OUTPUT"
+            echo "claims_uri=s3://$BUCKET/claims/" >> "$GITHUB_OUTPUT"
+          else
+            echo "ledger bucket output unavailable; nothing to re-verify"
+          fi
+
+      - name: Fetch claims index and review ledger from S3
+        if: steps.ledger-bucket.outputs.claims_uri != ''
+        continue-on-error: true
+        run: |
+          mkdir -p .claims-cache .ledger-cache
+          aws s3 sync "${{ steps.ledger-bucket.outputs.claims_uri }}" .claims-cache/ --quiet \
+            || echo "claims index unavailable; nothing to re-verify"
+          aws s3 sync "${{ steps.ledger-bucket.outputs.ledger_uri }}" .ledger-cache/ --quiet \
+            || echo "review ledger unavailable; markers will create minimal entries"
+          echo "claims snapshots: $(ls .claims-cache | wc -l), ledger entries: $(ls .ledger-cache | wc -l)"
+
+      # One verifier call per entity, deduped across pages. Stale verdicts are
+      # written back to the ledger as stale_claims markers (uploaded object by
+      # object). GH_TOKEN feeds the verifier's gh_query lane.
+      - name: Re-verify volatile entities
+        id: reverify
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONTENT_REVIEW_LEDGER_URI: ${{ steps.ledger-bucket.outputs.ledger_uri }}
+        run: |
+          ARGS=(--claims-dir .claims-cache --ledger-dir .ledger-cache
+                --count "${{ github.event.inputs.count || vars.CLAIMS_REVERIFY_COUNT || '25' }}"
+                --out .claims-reverify-report.json)
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          python3 scripts/content-review/reverify-claims.py "${ARGS[@]}"
+          echo "--- report ---"
+          cat .claims-reverify-report.json
+
+      # Counts only + a run link — the evidence lives in the report artifact
+      # and the ledger markers; the fix arrives as a normal content-review PR.
+      - name: Post stale summary to Slack
+        if: steps.reverify.outputs.has_stale == 'true'
+        env:
+          SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
+        run: |
+          TEXT=$(jq -r --arg run "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '
+            "Nightly claims re-verify: \(.meta.n_stale) of \(.meta.n_checked) checked volatile entities are stale. " +
+            "Affected pages are boosted into the next content-review sweep. <\($run)|Run log>"
+          ' .claims-reverify-report.json)
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data "$(jq -n --arg ch "#docs-ops" --arg txt "$TEXT" \
+              '{channel: $ch, text: $txt, unfurl_links: false}')"
+
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -567,6 +567,9 @@ jobs:
             --stack "${{ vars.PULUMI_STACK_NAME }}" 2>/dev/null || true)
           if [ -n "$BUCKET" ]; then
             echo "uri=s3://$BUCKET/ledger/" >> "$GITHUB_OUTPUT"
+            # The claims index shares the ledger bucket under its own prefix
+            # (one snapshot object per page; see record-claims.py).
+            echo "claims_uri=s3://$BUCKET/claims/" >> "$GITHUB_OUTPUT"
           else
             echo "ledger bucket output unavailable; ledger write will be skipped"
           fi
@@ -593,6 +596,30 @@ jobs:
             --queue .content-review-queue.json \
             --verdict .content-review-verdict.json \
             --claude-outcome "${{ needs.review.outputs.claude_outcome }}"
+
+      # Persist the page's verified claims to the claims index (same bucket,
+      # claims/ prefix) — the whole-page snapshot the nightly volatile
+      # re-verification (claims-reverify.yml) reads. This worker is the index's
+      # ONLY writer: its runs are whole-page, so overwriting <slug>.json is
+      # always correct; the pre-merge PR review is partial-page and must never
+      # write here. Inputs come from the pre-model guardrail snapshot (not the
+      # model-writable handoff artifact), so the index records exactly what
+      # the pre-steps verified. record-claims.py skips the upload when the
+      # verify pre-step degraded (empty verdicts + errors), preserving the
+      # previous snapshot.
+      - name: Record claims index
+        if: always() && steps.ledger-bucket.outputs.claims_uri != ''
+        continue-on-error: true
+        env:
+          CONTENT_REVIEW_CLAIMS_URI: ${{ steps.ledger-bucket.outputs.claims_uri }}
+        run: |
+          if [ ! -f .review-snapshot/.verified-claims.json ]; then
+            echo "no snapshotted verified-claims; skipping the claims index write"
+            exit 0
+          fi
+          python3 scripts/content-review/record-claims.py \
+            --queue .review-snapshot/.content-review-queue.json \
+            --verified .review-snapshot/.verified-claims.json
 
       # No explicit review dispatch: a content-review PR that passes re-lint is
       # promoted draft → ready in the step above, and that transition drives the

--- a/scripts/content-review/record-claims.py
+++ b/scripts/content-review/record-claims.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Record one content-review article's verified claims to the S3 claims index.
+
+The per-article worker (`.github/workflows/content-review-article.yml`) already
+runs the docs-review claim pipeline over a synthetic whole-file diff and then
+throws `.verified-claims.json` away. This script persists it instead: one JSON
+object per page at `<CONTENT_REVIEW_CLAIMS_URI>/<slug>.json` (the same bucket
+as the review ledger, under a `claims/` prefix), keyed by the entity keying
+`merge-claims.py` stamps via `entity_key.py`.
+
+The index is the foundation for event-driven freshness (pulumi/docs#20078
+§4.1): the nightly `reverify-claims.py` job re-checks volatile entities
+(versions, prices, limits) straight from the index — no re-extraction — and
+release-triggered / contradiction-detection consumers join pages on
+`entity_key`.
+
+Writer discipline: ONLY this per-article worker writes the claims index. Its
+runs are whole-page snapshots, so overwriting `<slug>.json` is always correct;
+the pre-merge PR review sees partial-page diffs and must never write here (a
+partial snapshot would silently shrink a page's claim set).
+
+Snapshot rules:
+  * Kept verdicts: verified | matches | contradicted | mismatch — the claims
+    that say something about the page. `not-a-claim` and `unverifiable` are
+    noise for index consumers and are dropped.
+  * A verified artifact that is absent, unparseable, or degraded (zero
+    verdicts WITH pipeline errors — e.g. the verifier never started) skips the
+    upload entirely, preserving the page's previous snapshot. Zero verdicts
+    with no errors is a genuinely claim-free page and uploads an empty
+    snapshot.
+  * Claims without an `entity_key` are persisted too — they're invisible to
+    entity-keyed consumers but keep the snapshot a faithful record of the page.
+
+Degrades gracefully like `record-review.py`: no CONTENT_REVIEW_CLAIMS_URI →
+local artifact only; a failed upload warns and never fails the run.
+
+Self-contained — run the smoke checks with `python3 record-claims.py --self-test`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+# Reuse slugify from select-articles.py (single source of truth), same
+# import-by-path pattern as record-review.py.
+_spec = importlib.util.spec_from_file_location(
+    "select_articles", HERE / "select-articles.py"
+)
+_select = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_select)
+slugify = _select.slugify
+
+SCHEMA_VERSION = 1
+KEPT_VERDICTS = {"verified", "matches", "contradicted", "mismatch"}
+
+# Verdict fields carried into the snapshot, in output order.
+CLAIM_FIELDS = [
+    "claim_id", "entity_key", "volatile", "type", "text", "line_range",
+    "verdict", "confidence", "evidence", "source",
+]
+
+
+def log(msg: str) -> None:
+    print(f"record-claims: {msg}", file=sys.stderr)
+
+
+def warn(msg: str) -> None:
+    print(f"::warning::record-claims: {msg}", file=sys.stderr)
+
+
+# ---- inputs -----------------------------------------------------------------
+
+
+def load_queue_article(queue_path: Path) -> dict:
+    data = json.loads(queue_path.read_text())
+    articles = data.get("articles") or []
+    if not articles:
+        raise SystemExit(f"record-claims: no articles in {queue_path}")
+    a = articles[0]
+    path = a["path"]
+    return {"path": path, "slug": a.get("slug") or slugify(path)}
+
+
+def load_verified(verified_path: Path) -> dict | None:
+    """The `.verified-claims.json` artifact, or None when absent/unparseable."""
+    if not verified_path.is_file():
+        return None
+    try:
+        doc = json.loads(verified_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        warn(f"verified-claims artifact unreadable ({e})")
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def head_commit(commit: str | None) -> str:
+    """The snapshot's provenance commit; `--commit` injects it for tests."""
+    if commit:
+        return commit
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        return ""
+    return out.stdout.strip() if out.returncode == 0 else ""
+
+
+# ---- snapshot ----------------------------------------------------------------
+
+
+def build_snapshot(article: dict, verified: dict, commit: str) -> dict:
+    """The canonical claims-index object for one page."""
+    kept = []
+    verdicts = [v for v in (verified.get("verdicts") or []) if isinstance(v, dict)]
+    for v in verdicts:
+        if v.get("verdict") not in KEPT_VERDICTS:
+            continue
+        entry = {k: v.get(k) for k in CLAIM_FIELDS if k in v}
+        entry.setdefault("entity_key", None)
+        entry.setdefault("volatile", False)
+        kept.append(entry)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "path": article["path"],
+        "slug": article["slug"],
+        "commit": commit,
+        "reviewed_at": datetime.now(timezone.utc).date().isoformat(),
+        "model": verified.get("model"),
+        "claims": kept,
+        "meta": {
+            "n_verdicts": len(verdicts),
+            "n_kept": len(kept),
+            "n_keyed": sum(1 for c in kept if c.get("entity_key")),
+            "n_volatile": sum(1 for c in kept if c.get("volatile")),
+        },
+    }
+
+
+def degraded(verified: dict | None) -> str | None:
+    """Why this artifact must not overwrite the page's previous snapshot, or
+    None when it's trustworthy. Zero verdicts + pipeline errors = the verifier
+    never really ran (missing API key, uncaught exception); an upload would
+    clobber a good snapshot with an empty one."""
+    if verified is None:
+        return "verified-claims artifact absent or unreadable"
+    if not (verified.get("verdicts") or []) and (verified.get("errors") or []):
+        return f"zero verdicts with pipeline errors: {'; '.join(str(e) for e in verified['errors'][:3])}"
+    return None
+
+
+# ---- outputs ----------------------------------------------------------------
+
+
+def upload(snapshot: dict, slug: str, uri: str) -> None:
+    key = f"{uri.rstrip('/')}/{slug}.json"
+    try:
+        subprocess.run(
+            ["aws", "s3", "cp", "-", key],
+            input=json.dumps(snapshot, indent=2) + "\n",
+            text=True, check=True,
+        )
+        log(f"uploaded claims snapshot to {key}")
+    except FileNotFoundError:
+        warn("aws CLI not available; claims snapshot not uploaded")
+    except subprocess.CalledProcessError as e:
+        warn(f"claims snapshot upload failed for {slug} ({e})")
+
+
+# ---- main -------------------------------------------------------------------
+
+
+def run(args) -> int:
+    article = load_queue_article(Path(args.queue))
+    verified = load_verified(Path(args.verified))
+
+    skip_reason = degraded(verified)
+    if skip_reason:
+        warn(f"{skip_reason}; keeping the page's previous snapshot (no upload)")
+        return 0
+
+    snapshot = build_snapshot(article, verified, head_commit(args.commit))
+    out_path = Path(args.out)
+    out_path.write_text(json.dumps(snapshot, indent=2) + "\n")
+    m = snapshot["meta"]
+    log(f"slug={article['slug']} kept={m['n_kept']}/{m['n_verdicts']} "
+        f"keyed={m['n_keyed']} volatile={m['n_volatile']} -> {out_path}")
+
+    uri = os.environ.get("CONTENT_REVIEW_CLAIMS_URI", "").strip()
+    if uri:
+        upload(snapshot, article["slug"], uri)
+    else:
+        warn("CONTENT_REVIEW_CLAIMS_URI unset; claims snapshot written locally only")
+    return 0
+
+
+def self_test() -> int:
+    import tempfile
+
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+            print(f"FAIL: {name}", file=sys.stderr)
+        else:
+            print(f"ok: {name}")
+
+    article = {"path": "content/docs/iac/concepts/stacks.md",
+               "slug": "docs-iac-concepts-stacks"}
+    verified = {
+        "schema_version": 1,
+        "model": "claude-sonnet-5",
+        "verdicts": [
+            {"claim_id": "c1", "type": "version", "text": "pulumi-gcp v8.2.0",
+             "line_range": "L10", "entity_key": "version/pulumi-gcp",
+             "volatile": True, "verdict": "verified", "confidence": "high",
+             "evidence": "release notes", "source": "gh release view",
+             "route": "pass1", "model_usage": {"turns": 2}},
+            {"claim_id": "c2", "type": "behavior", "text": "pulumi up deploys",
+             "line_range": "L20", "verdict": "verified", "confidence": "high",
+             "evidence": "docs", "source": "repo:content/docs/cli.md"},
+            {"claim_id": "c3", "type": "numerical", "text": ":latest tag",
+             "line_range": "L30", "verdict": "not-a-claim", "confidence": "high",
+             "evidence": "docker tag", "source": "pass0"},
+            {"claim_id": "c4", "type": "numerical", "text": "price is $75",
+             "line_range": "L40", "entity_key": "numerical/price",
+             "volatile": True, "verdict": "contradicted", "confidence": "high",
+             "evidence": "now $99", "source": "vendor page"},
+            {"claim_id": "c5", "type": "feature", "text": "supports X",
+             "line_range": "L50", "verdict": "unverifiable", "confidence": "low",
+             "evidence": "paywalled", "source": "n/a"},
+        ],
+        "errors": [],
+    }
+
+    snap = build_snapshot(article, verified, "abc1234")
+    check("keeps verified/contradicted, drops not-a-claim/unverifiable",
+          [c["claim_id"] for c in snap["claims"]] == ["c1", "c2", "c4"])
+    check("route/model_usage stripped from entries",
+          all("route" not in c and "model_usage" not in c for c in snap["claims"]))
+    check("unkeyed claim persists with null key",
+          snap["claims"][1]["entity_key"] is None and snap["claims"][1]["volatile"] is False)
+    check("meta counts", snap["meta"] == {"n_verdicts": 5, "n_kept": 3,
+                                          "n_keyed": 2, "n_volatile": 2})
+    check("provenance carried", snap["commit"] == "abc1234"
+          and snap["path"] == article["path"] and snap["slug"] == article["slug"]
+          and snap["model"] == "claude-sonnet-5" and bool(snap["reviewed_at"]))
+
+    # Degradation rules.
+    check("absent artifact -> skip", degraded(None) is not None)
+    check("zero verdicts + errors -> skip (degraded run)",
+          degraded({"verdicts": [], "errors": ["ANTHROPIC_API_KEY not set"]}) is not None)
+    check("zero verdicts, no errors -> genuine empty snapshot uploads",
+          degraded({"verdicts": [], "errors": []}) is None)
+    check("normal artifact -> no skip", degraded(verified) is None)
+
+    empty = build_snapshot(article, {"verdicts": [], "errors": []}, "")
+    check("claim-free page yields empty claims list", empty["claims"] == []
+          and empty["meta"]["n_kept"] == 0)
+
+    with tempfile.TemporaryDirectory() as d:
+        q = Path(d) / "queue.json"
+        q.write_text(json.dumps({"articles": [{"path": "content/docs/iac/concepts/stacks/_index.md"}]}))
+        a = load_queue_article(q)
+        check("queue slug falls back to slugify", a["slug"] == "docs-iac-concepts-stacks")
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall record-claims self-tests passed")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Record a page's verified claims to the S3 claims index.")
+    p.add_argument("--queue", help="single-article queue JSON (.content-review-queue.json)")
+    p.add_argument("--verified", default=".verified-claims.json",
+                   help="verified-claims artifact from the pre-compute step")
+    p.add_argument("--commit", help="inject the provenance commit (tests); default: git rev-parse HEAD")
+    p.add_argument("--out", default=".content-review-claims.json",
+                   help="local snapshot artifact path")
+    p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.queue:
+        p.error("--queue is required")
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/reverify-claims.py
+++ b/scripts/content-review/reverify-claims.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Nightly re-verification of volatile claims from the S3 claims index.
+
+Consumes the per-page claims snapshots `record-claims.py` persists (one JSON
+object per page under the ledger bucket's `claims/` prefix) and re-checks the
+*volatile* entities — version pins, prices, limits — straight from the index:
+no page diff, no re-extraction, one verifier call per entity. This is the
+event-driven-freshness consumer from pulumi/docs#20078 §4.1: a claim that
+drifted (the provider released v9, the price changed) is caught within a
+night instead of waiting for the page's next staleness-driven sweep.
+
+How a stale finding flows (no new human burden, no prose generation):
+  1. An entity re-verifies `contradicted`/`mismatch`.
+  2. Every page asserting that entity gets a `stale_claims` marker written
+     into its LEDGER object (`ledger/<slug>.json`) — evidence attached.
+  3. `select-articles.py` adds a large additive boost for marked pages, so
+     the next daily content-review sweep picks them up; the normal worker
+     re-reviews the page, fixes it through the existing PR machinery, and
+     its ledger/claims rewrites clear the marker automatically.
+
+Selection (deterministic, stateless): volatile keyed entities are deduped
+across pages (one verification per entity per night, fanned back out to all
+pages asserting it), entities already marked stale are skipped (they're
+waiting on a review, not on another check), the rest are sorted by entity
+key and swept in day-rotated chunks of `--count` — days-since-epoch modulo
+the chunk count picks tonight's chunk, so the whole volatile set is covered
+every ceil(N/count) nights with no persisted cursor.
+
+Verification reuses `verify-claims.py`'s per-claim machinery (routing +
+agent-loop verifier) by module import; each entity's freshest claim record is
+the input. `contradicted`/`mismatch` → stale; `verified`/`matches` → fresh;
+anything else (`unverifiable`, errors) → inconclusive, reported but never
+marked — a flaky check must not burn review-queue slots.
+
+Writes `.claims-reverify-report.json` (plus `n_checked`/`n_stale`/`has_stale`
+to $GITHUB_OUTPUT) and, when CONTENT_REVIEW_LEDGER_URI is set, uploads each
+marked ledger object. Degrades gracefully: no API key, no claims dir, or no
+volatile entities → empty report, exit 0.
+
+Usage:
+    reverify-claims.py --claims-dir .claims-cache --ledger-dir .ledger-cache \
+        --count 25 [--today YYYY-MM-DD] [--repo-root .] [--model <m>]
+        [--out .claims-reverify-report.json] [--dry-run]
+
+Self-contained smoke checks: `python3 reverify-claims.py --self-test`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parents[2]
+VERIFY_CLAIMS = HERE / ".claude/commands/docs-review/scripts/verify-claims.py"
+
+SCHEMA_VERSION = 1
+DEFAULT_COUNT = 25
+MAX_CONCURRENCY = 8
+STALE_VERDICTS = {"contradicted", "mismatch"}
+FRESH_VERDICTS = {"verified", "matches"}
+
+
+def log(msg: str) -> None:
+    print(f"reverify-claims: {msg}", file=sys.stderr)
+
+
+def warn(msg: str) -> None:
+    print(f"::warning::reverify-claims: {msg}", file=sys.stderr)
+
+
+def _load_verify_claims():
+    """Import verify-claims.py by path (hyphenated filename; main() is guarded,
+    so importing has no side effects). Same pattern record-review.py uses for
+    select-articles.py."""
+    spec = importlib.util.spec_from_file_location("verify_claims", VERIFY_CLAIMS)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---- index loading -----------------------------------------------------------
+
+
+def load_snapshots(claims_dir: Path) -> list[dict]:
+    """All parseable per-page claims snapshots under the synced claims/ prefix."""
+    out: list[dict] = []
+    if not claims_dir.is_dir():
+        return out
+    for f in sorted(claims_dir.glob("*.json")):
+        try:
+            snap = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            warn(f"unreadable claims snapshot {f}")
+            continue
+        if isinstance(snap, dict) and snap.get("path") and snap.get("slug"):
+            out.append(snap)
+    return out
+
+
+def volatile_entities(snapshots: list[dict]) -> dict[str, list[dict]]:
+    """{entity_key: [assertion, ...]} over every volatile keyed claim.
+
+    Each assertion carries the claim record plus its page provenance
+    (path/slug/reviewed_at), so a stale verdict can fan back out to every
+    page asserting the entity."""
+    entities: dict[str, list[dict]] = {}
+    for snap in snapshots:
+        for c in snap.get("claims") or []:
+            if not isinstance(c, dict) or not c.get("entity_key") or not c.get("volatile"):
+                continue
+            entities.setdefault(c["entity_key"], []).append({
+                "claim": c,
+                "path": snap["path"],
+                "slug": snap["slug"],
+                "reviewed_at": snap.get("reviewed_at") or "",
+            })
+    return entities
+
+
+def already_marked(key: str, assertions: list[dict], ledger: dict[str, dict]) -> bool:
+    """True when some page asserting this entity already carries its stale
+    marker — the entity is waiting on a review, not on another check."""
+    for a in assertions:
+        entry = ledger.get(a["path"]) or {}
+        for m in entry.get("stale_claims") or []:
+            if isinstance(m, dict) and m.get("entity_key") == key:
+                return True
+    return False
+
+
+def tonight_chunk(keys: list[str], count: int, today: date) -> list[str]:
+    """Day-rotated chunk of the sorted entity keys: full coverage every
+    ceil(N/count) nights, deterministic from the date alone."""
+    if not keys or count <= 0:
+        return []
+    n_chunks = -(-len(keys) // count)  # ceil
+    idx = today.toordinal() % n_chunks
+    return keys[idx * count:(idx + 1) * count]
+
+
+def representative(assertions: list[dict]) -> dict:
+    """The freshest assertion's claim record — the input to the verifier."""
+    return max(assertions, key=lambda a: a["reviewed_at"])["claim"]
+
+
+# ---- ledger markers ----------------------------------------------------------
+
+
+def load_ledger(ledger_dir: Path) -> dict[str, dict]:
+    entries: dict[str, dict] = {}
+    if not ledger_dir.is_dir():
+        return entries
+    for f in sorted(ledger_dir.glob("*.json")):
+        try:
+            entry = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(entry, dict) and entry.get("path"):
+            entry["_file"] = str(f)
+            entries[entry["path"]] = entry
+    return entries
+
+
+def apply_markers(ledger: dict[str, dict], stale: list[dict], today: date) -> dict[str, dict]:
+    """Fold stale entity verdicts into the affected pages' ledger entries.
+
+    Returns {slug: updated entry (without bookkeeping keys)} for every entry
+    that changed. Idempotent: a marker for an already-marked entity_key is
+    replaced, not duplicated. A page missing from the ledger (shouldn't
+    happen — the same worker run writes both objects) gets a minimal entry so
+    the selector can still see the marker."""
+    changed: dict[str, dict] = {}
+    for s in stale:
+        marker = {
+            "entity_key": s["entity_key"],
+            "verdict": s["verdict"],
+            "evidence": s.get("evidence") or "",
+            "source": s.get("source") or "",
+            "checked_at": today.isoformat(),
+        }
+        for page in s["pages"]:
+            entry = ledger.get(page["path"])
+            if entry is None:
+                warn(f"no ledger entry for {page['path']}; creating a minimal one")
+                entry = {"path": page["path"], "slug": page["slug"]}
+                ledger[page["path"]] = entry
+            markers = [m for m in (entry.get("stale_claims") or [])
+                       if isinstance(m, dict) and m.get("entity_key") != s["entity_key"]]
+            markers.append(marker)
+            entry["stale_claims"] = markers
+            slug = entry.get("slug") or page["slug"]
+            changed[slug] = {k: v for k, v in entry.items() if k != "_file"}
+    return changed
+
+
+def upload_entry(entry: dict, slug: str, uri: str) -> None:
+    import subprocess
+    key = f"{uri.rstrip('/')}/{slug}.json"
+    try:
+        subprocess.run(
+            ["aws", "s3", "cp", "-", key],
+            input=json.dumps(entry, indent=2) + "\n",
+            text=True, check=True,
+        )
+        log(f"uploaded stale-claims marker to {key}")
+    except FileNotFoundError:
+        warn("aws CLI not available; ledger markers not uploaded")
+    except subprocess.CalledProcessError as e:
+        warn(f"marker upload failed for {slug} ({e})")
+
+
+# ---- outputs -----------------------------------------------------------------
+
+
+def write_outputs(report: dict) -> None:
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if not gh_out:
+        return
+    with open(gh_out, "a") as fh:
+        fh.write(f"n_checked={report['meta']['n_checked']}\n")
+        fh.write(f"n_stale={report['meta']['n_stale']}\n")
+        fh.write(f"has_stale={'true' if report['meta']['n_stale'] else 'false'}\n")
+
+
+def finish(report: dict, out_path: Path) -> int:
+    out_path.write_text(json.dumps(report, indent=2) + "\n")
+    m = report["meta"]
+    log(f"checked={m['n_checked']} stale={m['n_stale']} fresh={m['n_fresh']} "
+        f"inconclusive={m['n_inconclusive']} (volatile entities={m['n_entities']}) -> {out_path}")
+    write_outputs(report)
+    return 0
+
+
+# ---- main --------------------------------------------------------------------
+
+
+def run(args) -> int:
+    today = None
+    if args.today:
+        today = datetime.strptime(args.today, "%Y-%m-%d").date()
+    today = today or datetime.now(timezone.utc).date()
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "checked_at": today.isoformat(),
+        "entities": [],
+        "meta": {"n_snapshots": 0, "n_entities": 0, "n_checked": 0,
+                 "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0},
+    }
+    out_path = Path(args.out)
+
+    snapshots = load_snapshots(Path(args.claims_dir))
+    report["meta"]["n_snapshots"] = len(snapshots)
+    if not snapshots:
+        log("no claims snapshots; nothing to re-verify")
+        return finish(report, out_path)
+
+    ledger = load_ledger(Path(args.ledger_dir))
+    entities = volatile_entities(snapshots)
+    report["meta"]["n_entities"] = len(entities)
+
+    unmarked = sorted(k for k, v in entities.items() if not already_marked(k, v, ledger))
+    keys = tonight_chunk(unmarked, args.count, today)
+    if not keys:
+        log("no volatile entities due tonight")
+        return finish(report, out_path)
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key and not args.dry_run:
+        warn("ANTHROPIC_API_KEY not set; re-verification skipped")
+        return finish(report, out_path)
+
+    vc = _load_verify_claims()
+    repo_root = Path(args.repo_root).resolve()
+
+    def check_entity(key: str) -> dict:
+        claim = dict(representative(entities[key]))
+        claim["__id"] = key
+        claim["__route"] = vc.route_claim(claim, {})
+        rec, err = vc.process_claim(api_key, claim, {}, args.model, repo_root, args.dry_run)
+        return {
+            "entity_key": key,
+            "verdict": rec.get("verdict"),
+            "confidence": rec.get("confidence"),
+            "evidence": rec.get("evidence"),
+            "source": rec.get("source"),
+            "route": rec.get("route"),
+            "error": err,
+            "pages": [{"path": a["path"], "slug": a["slug"]} for a in entities[key]],
+        }
+
+    with ThreadPoolExecutor(max_workers=min(MAX_CONCURRENCY, len(keys))) as pool:
+        results = list(pool.map(check_entity, keys))
+
+    stale = [r for r in results if r["verdict"] in STALE_VERDICTS]
+    fresh = [r for r in results if r["verdict"] in FRESH_VERDICTS]
+    report["entities"] = results
+    report["meta"]["n_checked"] = len(results)
+    report["meta"]["n_stale"] = len(stale)
+    report["meta"]["n_fresh"] = len(fresh)
+    report["meta"]["n_inconclusive"] = len(results) - len(stale) - len(fresh)
+
+    if stale:
+        changed = apply_markers(ledger, stale, today)
+        uri = os.environ.get("CONTENT_REVIEW_LEDGER_URI", "").strip()
+        for slug, entry in sorted(changed.items()):
+            local = Path(args.ledger_dir) / f"{slug}.json"
+            local.parent.mkdir(parents=True, exist_ok=True)
+            local.write_text(json.dumps(entry, indent=2) + "\n")
+            if uri and not args.dry_run:
+                upload_entry(entry, slug, uri)
+        if not uri:
+            warn("CONTENT_REVIEW_LEDGER_URI unset; markers written locally only")
+
+    return finish(report, out_path)
+
+
+# ---- self-test ---------------------------------------------------------------
+
+
+def self_test() -> int:
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+            print(f"FAIL: {name}", file=sys.stderr)
+        else:
+            print(f"ok: {name}")
+
+    def snap(slug, reviewed_at, *claims):
+        return {"schema_version": 1, "path": f"content/docs/{slug}.md",
+                "slug": f"docs-{slug}", "reviewed_at": reviewed_at,
+                "claims": list(claims)}
+
+    ver = {"entity_key": "version/pulumi-gcp", "volatile": True, "type": "version",
+           "text": "pulumi-gcp v8.2.0", "line_range": "L10", "verdict": "verified"}
+    price = {"entity_key": "numerical/team-plan-price", "volatile": True,
+             "type": "numerical", "text": "the Team plan costs $75", "line_range": "L5",
+             "verdict": "verified"}
+    stable = {"entity_key": "api-surface/versioning", "volatile": False,
+              "type": "api-surface", "text": "`versioning` argument", "line_range": "L7",
+              "verdict": "verified"}
+    unkeyed = {"entity_key": None, "volatile": True, "type": "numerical",
+               "text": "40x", "line_range": "L9", "verdict": "verified"}
+
+    snaps = [snap("a", "2026-07-01", ver, stable),
+             snap("b", "2026-07-05", dict(ver, text="pulumi-gcp v8.3.0"), price, unkeyed)]
+
+    ents = volatile_entities(snaps)
+    check("volatile keyed entities only",
+          set(ents) == {"version/pulumi-gcp", "numerical/team-plan-price"})
+    check("entity fans out across pages", len(ents["version/pulumi-gcp"]) == 2)
+    check("representative is the freshest assertion",
+          representative(ents["version/pulumi-gcp"])["text"] == "pulumi-gcp v8.3.0")
+
+    # Chunk rotation: deterministic, complete coverage across consecutive days.
+    keys = [f"k{i}" for i in range(5)]
+    d0 = date(2026, 7, 6)
+    chunks = [tonight_chunk(keys, 2, date.fromordinal(d0.toordinal() + i)) for i in range(3)]
+    check("chunks cover all keys over the rotation",
+          sorted(k for ch in chunks for k in ch) == sorted(keys))
+    check("same day -> same chunk", tonight_chunk(keys, 2, d0) == chunks[0])
+    check("count of zero -> empty chunk", tonight_chunk(keys, 0, d0) == [])
+    check("empty keys -> empty chunk", tonight_chunk([], 3, d0) == [])
+
+    # Markers: fan-out, idempotence, minimal entry for a ledger gap.
+    ledger = {"content/docs/a.md": {"path": "content/docs/a.md", "slug": "docs-a",
+                                    "status": "clean", "_file": "x"}}
+    stale = [{"entity_key": "version/pulumi-gcp", "verdict": "contradicted",
+              "evidence": "v9.0 released", "source": "gh release view",
+              "pages": [{"path": "content/docs/a.md", "slug": "docs-a"},
+                        {"path": "content/docs/b.md", "slug": "docs-b"}]}]
+    today = date(2026, 7, 9)
+    changed = apply_markers(ledger, stale, today)
+    check("marker fans out to both pages", set(changed) == {"docs-a", "docs-b"})
+    check("existing entry keeps its fields",
+          changed["docs-a"]["status"] == "clean" and "_file" not in changed["docs-a"])
+    check("marker shape", changed["docs-a"]["stale_claims"][0] == {
+        "entity_key": "version/pulumi-gcp", "verdict": "contradicted",
+        "evidence": "v9.0 released", "source": "gh release view",
+        "checked_at": "2026-07-09"})
+    check("minimal entry created for ledger gap",
+          changed["docs-b"]["path"] == "content/docs/b.md")
+
+    changed2 = apply_markers(ledger, stale, today)
+    check("re-marking is idempotent",
+          len(changed2["docs-a"]["stale_claims"]) == 1)
+
+    check("already_marked sees the marker",
+          already_marked("version/pulumi-gcp", ents["version/pulumi-gcp"], ledger))
+    check("already_marked ignores other entities",
+          not already_marked("numerical/team-plan-price",
+                             ents["numerical/team-plan-price"], ledger))
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall reverify-claims self-tests passed")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--claims-dir", default=".claims-cache",
+                   help="local sync of the claims/ prefix")
+    p.add_argument("--ledger-dir", default=".ledger-cache",
+                   help="local sync of the ledger/ prefix (markers are written here)")
+    p.add_argument("--count", type=int, default=DEFAULT_COUNT,
+                   help="entities to re-verify tonight (chunk size of the rotation)")
+    p.add_argument("--today", help="override today's date YYYY-MM-DD (testing)")
+    p.add_argument("--repo-root", default=str(HERE), help="repo root for the verifier's read_file")
+    p.add_argument("--model", default=None, help="verifier model (default: verify-claims.py's)")
+    p.add_argument("--out", default=".claims-reverify-report.json")
+    p.add_argument("--dry-run", action="store_true",
+                   help="no API calls, no uploads; placeholder verdicts (testing)")
+    p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if args.model is None:
+        args.model = _load_verify_claims().DEFAULT_MODEL
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -22,7 +22,7 @@ Selection algorithm (weighted fair queuing by staleness):
    reserved lane — staleness self-corrects starvation (the longer a page
    goes unreviewed the higher it climbs, so the whole corpus is swept):
 
-       score = importance * staleness
+       score = importance * staleness + stale_claim_boost
 
    importance = tier_w * (0.5 + 0.5*traffic_n)   with a traffic snapshot
               = tier_w                            tier-only when absent
@@ -37,6 +37,12 @@ Selection algorithm (weighted fair queuing by staleness):
                 git creation date: a brand-new page sorts to the back, an
                 ancient never-reviewed page to the front. A human (non-bot)
                 edit fully resets the clock.
+
+   stale_claim_boost = STALE_CLAIM_BOOST when the page's ledger entry has a
+                non-empty `stale_claims` list (written by the nightly
+                reverify-claims.py when a volatile claim the page asserts
+                re-verified contradicted); 0 otherwise. Marked pages jump the
+                queue; the marker clears when the review rewrites the entry.
 
    Ties break on path ascending, so runs are reproducible.
 
@@ -88,6 +94,15 @@ MAX_OPEN_PRS = 9
 ATTEMPT_CAP = 3
 
 TIER_WEIGHTS = {1: 1.0, 2: 0.6, 3: 0.3}
+
+# Additive boost for a page whose ledger entry carries a non-empty
+# `stale_claims` marker (a volatile claim it asserts re-verified contradicted
+# — see reverify-claims.py). Sized to outrank a top-importance page that has
+# gone unreviewed for a year (1.0 * 365), so a known-stale fact beats any
+# ordinary staleness — while an ancient never-reviewed page can still win, so
+# the sweep is never fully starved. The marker vanishes when the page's next
+# review rewrites its ledger entry, so the boost self-clears.
+STALE_CLAIM_BOOST = 400.0
 
 # Statuses a ledger entry can carry (set by record-review.py). Any status other
 # than "incomplete" is a completed review whose date advances the clock; legacy
@@ -377,9 +392,11 @@ def score_page(
     last_review: date | None,
     today: date,
     have_traffic: bool,
+    stale_claims: bool = False,
 ) -> float:
     staleness = max((today - last_review).days, 0) if last_review else 0
-    return round(importance(tier, visits, max_visits, median_visits, have_traffic) * staleness, 4)
+    boost = STALE_CLAIM_BOOST if stale_claims else 0.0
+    return round(importance(tier, visits, max_visits, median_visits, have_traffic) * staleness + boost, 4)
 
 
 # ---- Subcommands ---------------------------------------------------------------
@@ -508,6 +525,7 @@ def main() -> int:
             "monthly_visits": traffic.get(path),
             "last_reviewed": entry.get("reviewed_at"),
             "attempts": int(entry.get("attempts", 0)),
+            "stale_claims": len(entry.get("stale_claims") or []),
             "score": score,
         }
 
@@ -574,6 +592,7 @@ def main() -> int:
                     effective_last_review(path, ledger.get(path), newest_non_bot, created),
                     today,
                     have_traffic,
+                    stale_claims=bool((ledger.get(path) or {}).get("stale_claims")),
                 ),
                 path,
             )


### PR DESCRIPTION
### Proposed changes

Implements §4.1 of #20078 (the "persist the claims index" lever): every content review already extracts, classifies, and verifies factual claims, then throws the result away. This PR persists them per page, keyed by entity, and puts the index to work for event-driven freshness — scoped to the **foundation + nightly volatile re-verification**; release-triggered re-verification and corpus-wide contradiction detection consume the same index/markers and are specified in the issue as follow-ups.

**Entity keying** (`.claude/commands/docs-review/scripts/entity_key.py`, new)
- Deterministic `entity_key` (`<type>/<subject-slug>`, e.g. `version/pulumi-gcp`) + `volatile` flag for `version` / `numerical` / `api-surface` / `entity-spec` claims. The claimed *value* is excluded from the key, so it stays stable when the fact changes. No LLM involved; unkeyable claims get `null` (safe: invisible to consumers, never wrong).
- `merge-claims.py` stamps both fields on merged claims; `verify-claims.py` carries them onto verdicts so `.verified-claims.json` is self-contained.

**Claims index writer** (`scripts/content-review/record-claims.py`, new)
- One snapshot object per page at `claims/<slug>.json` in the existing content-review ledger bucket (no new infrastructure). Keeps `verified|matches|contradicted|mismatch` verdicts; drops noise. A degraded verify run (zero verdicts + pipeline errors) skips the upload so it never clobbers a good snapshot.
- Wired into `content-review-article.yml` as an `if: always()` / `continue-on-error` step. The whole-page per-article worker is the index's **only** writer — the partial-page pre-merge review never writes (a partial snapshot would silently shrink a page's claim set).

**Nightly volatile re-verify** (`scripts/content-review/reverify-claims.py` + `.github/workflows/claims-reverify.yml`, new)
- Re-checks volatile entities (version pins, prices, limits) straight from the index via the existing `verify-claims.py` machinery — no re-extraction, one verifier call per entity deduped across pages.
- Selection is a **stateless day-rotated sweep** (sorted entity keys, chunk = days-since-epoch mod chunk-count): full coverage every ⌈N/count⌉ nights with no persisted cursor. (The plan said "oldest-verified first"; without persisted check-state that re-checks the same entities every night, so the rotation replaces it.) Entities already marked stale are skipped — they're waiting on a review, not another check.
- `CLAIMS_REVERIFY_COUNT` repo var is the single on/off + cadence knob (`CONTENT_REVIEW_COUNT` pattern); fail-open holiday gate; ESC + AWS OIDC + stack-output bucket resolution; counts-only Slack summary to #docs-ops.
- Contradicted entities write a `stale_claims` marker (entity key, verdict, evidence, `checked_at`) into every affected page's ledger entry. Inconclusive verdicts (`unverifiable`, errors) are reported but never marked.

**Selection boost** (`scripts/content-review/select-articles.py`)
- `score = importance × staleness + STALE_CLAIM_BOOST` (400, sized to outrank a tier-1 page unreviewed for a year) for pages with a non-empty `stale_claims` marker, so known-stale facts jump the next daily sweep and flow through the existing review/PR machinery — no new human burden, no prose generation. Markers self-clear when the page's next review rewrites its ledger entry.
- `review-existing-content/SKILL.md` documents the loop and the writer discipline.

Verification: self-tests in each new script (`--self-test`) plus `record-review.py`'s all pass; fixture runs exercised merge → verify → snapshot → re-verify (incl. day-rotation determinism and marker idempotence) and the selection boost against the real corpus (marked page scored 401 vs 1 unmarked); `make lint` passes. Post-merge: dispatch `content-review-article.yml` on one page and confirm `claims/<slug>.json` lands, then dispatch `claims-reverify.yml` with a small count.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Part of #20078 (§4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qL256vna5F3JN8bUPr26D

---
_Generated by [Claude Code](https://claude.ai/code/session_015qL256vna5F3JN8bUPr26D)_