### PR TITLE
Add deterministic snippet-parse sweep (issue #20078 §4.3, phase 1)

### DIFF
--- a/scripts/snippet-sweep/check-ts.mjs
+++ b/scripts/snippet-sweep/check-ts.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Batch TypeScript/JavaScript syntax checker for the snippet sweep.
+//
+// stdin:  JSON array of {id: number, lang: "typescript"|"javascript",
+//         content: string}
+// stdout: JSON array of {id, message, line_offset} — one entry per block
+//         that FAILS to parse; clean blocks are omitted.
+//
+// Syntax only: ts.transpileModule with reportDiagnostics surfaces parse
+// errors without type checking or module resolution, so import-less
+// fragments parse fine (top-level statements are legal in a module).
+//
+// Precision over recall, via a scaffold ladder mirroring the Go/Python
+// checkers. Documentation elisions (`...` as a value placeholder, `{ ... }`
+// object stubs, `/*...*/` as an expression) are neutralized first; then a
+// block that fails plain parsing is retried across elision substitutions
+// (`null` for statement positions, `...{}` spread for object/array/call
+// positions) and forms (.tsx for JSX samples, expression wrap for bare
+// object/config fragments, brace-balancing for pedagogically truncated
+// classes). A block flags only if EVERY combination fails; the plain
+// diagnostic is the one reported (closest to what the reader sees).
+
+import ts from "typescript";
+import { readFileSync } from "node:fs";
+
+const ELISION_LINE = /^(\s*)(\.{2,}|…)\s*$/;
+// `/*...*/` used as an expression placeholder normalizes to `...` so the
+// substitution variants below treat both spellings the same.
+const COMMENT_ELISION = /\/\*\s*\.{3}\s*\*\/(?=\s*[,)\]};]|\s*$)/gm;
+const INLINE_ELISION = /(?<![\w\])])(\.\.\.|…)(?=\s*[,)\]};]|\s*$)/gm;
+const OBJECT_STUB = /\{\s*(\.\.\.|…)\s*\}/g;
+
+function preprocess(content) {
+  return content
+    .split("\n")
+    .map((line) => line.replace(ELISION_LINE, "$1// ..."))
+    .join("\n")
+    .replace(OBJECT_STUB, "{}")
+    .replace(COMMENT_ELISION, "...");
+}
+
+function braceDeficit(content) {
+  let open = 0;
+  for (const ch of content) {
+    if (ch === "{") open += 1;
+    else if (ch === "}") open -= 1;
+  }
+  return open;
+}
+
+function firstDiagnostic(content, fileName, jsx) {
+  const compilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+  };
+  if (jsx) compilerOptions.jsx = ts.JsxEmit.Preserve;
+  const out = ts.transpileModule(content, {
+    fileName,
+    reportDiagnostics: true,
+    compilerOptions,
+  });
+  // Only diagnostics anchored to the source file are parse errors; unanchored
+  // ones are compiler-option noise and must not flag a snippet.
+  const diags = (out.diagnostics || []).filter(
+    (d) => d.category === ts.DiagnosticCategory.Error && d.file
+  );
+  if (diags.length === 0) return null;
+  const d = diags[0];
+  let line = 0;
+  if (d.file && typeof d.start === "number") {
+    line = d.file.getLineAndCharacterOfPosition(d.start).line;
+  }
+  const message = ts.flattenDiagnosticMessageText(d.messageText, " ");
+  return { message: `TS${d.code}: ${message}`, line_offset: line };
+}
+
+function check(block) {
+  const ext = block.lang === "typescript" ? "ts" : "js";
+  const base = preprocess(block.content);
+  const substitutions = [
+    base.replace(INLINE_ELISION, "null"),
+    base.replace(INLINE_ELISION, "...{}"),
+  ];
+
+  let plainError;
+  for (const src of substitutions) {
+    const forms = [
+      { text: src, file: `snippet.${ext}`, jsx: false },
+      { text: src, file: `snippet.${ext}x`, jsx: true },
+      { text: `const __snippet = {\n${src}\n};`, file: `snippet.${ext}`, jsx: false },
+      { text: `const __snippet = (\n${src}\n);`, file: `snippet.${ext}`, jsx: false },
+    ];
+    const deficit = braceDeficit(src);
+    if (deficit > 0) {
+      forms.push({
+        text: src + "\n" + "}".repeat(deficit),
+        file: `snippet.${ext}`,
+        jsx: false,
+      });
+    }
+    for (const form of forms) {
+      const err = firstDiagnostic(form.text, form.file, form.jsx);
+      if (err === null) return null;
+      if (plainError === undefined) plainError = err;
+    }
+  }
+  return plainError;
+}
+
+const blocks = JSON.parse(readFileSync(0, "utf8"));
+const failures = [];
+for (const block of blocks) {
+  const err = check(block);
+  if (err !== null) failures.push({ id: block.id, ...err });
+}
+process.stdout.write(JSON.stringify(failures));

--- a/scripts/snippet-sweep/checkers.py
+++ b/scripts/snippet-sweep/checkers.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Per-language parse checkers for the snippet sweep.
+
+Design contract (precision over recall — "zero-slop"): a checker returns
+
+    None                          — block parses cleanly
+    SKIP                          — block cannot be checked with near-
+                                    certainty; counted, never flagged
+    {"message": str,
+     "line_offset": int}          — parse error; line_offset is 0-based
+                                    within the block content, so the
+                                    reported source line is
+                                    block["start_line"] + line_offset
+
+Only languages in CHECKERS are checked at all; everything else (bash
+transcripts, HCL, C#/Java until v2, untagged blocks) is out of scope by
+construction, not skipped-and-counted.
+
+The TypeScript/JavaScript checker shells out once per corpus to
+`check-ts.mjs` (see `check_ts_batch`), not per block. Go shells out to
+`gofmt -e` per candidate with a scaffold ladder. Python/YAML/JSON are
+stdlib/PyYAML in-process.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+CHECK_TS = HERE / "check-ts.mjs"
+
+SKIP = "skip"
+
+# A line of nothing but dots (`...`, `....`) is a documentation elision,
+# not code. Replaced with a per-language comment (indent preserved) before
+# parsing.
+ELLIPSIS_LINE_RE = re.compile(r"^(\s*)(\.{2,}|…)\s*$")
+
+# Inline elision used as an expression placeholder — `prop: ...`, `f(...)`,
+# `[...]` at end of list. The lookbehind spares Go variadics (`args...`)
+# and TS spreads (`...args` has an identifier after, so the lookahead
+# already excludes it). re.M so `$` means end-of-line (`const x = ...`).
+INLINE_ELISION_RE = re.compile(
+    r"(?<![\w\])])(\.\.\.|…)(?=\s*[,)\]};]|\s*$)", re.M
+)
+
+# Python fragments that open mid-construct can never parse standalone.
+PY_CONTINUATION_RE = re.compile(
+    r"^\s*(else\b|elif\b|except\b|finally\b|case\b)"
+)
+
+# Blocks composed by Hugo at render time ({{< example-program-snippet >}}
+# inside a fence), containing hyphenated angle placeholders
+# (`<backend-url>`, `<your-org>` — hyphens keep this away from real
+# generics, since identifiers can't contain `-`), or containing
+# elision-bracketed prose (`... a cluster's output property ...`) are
+# pseudo-code by design — uncheckable.
+_UNCHECKABLE_RES = (
+    re.compile(r"\{\{[<%]"),
+    re.compile(r"<[a-z0-9]+(?:-[a-z0-9]+)+>"),
+    re.compile(r"\.\.\. [A-Za-z][^.\n]* \.\.\."),
+)
+
+
+def pre_skip(content: str) -> bool:
+    """True when a block is uncheckable regardless of language."""
+    return any(r.search(content) for r in _UNCHECKABLE_RES)
+
+
+def _replace_elision_lines(content: str, comment: str) -> str:
+    return "\n".join(
+        ELLIPSIS_LINE_RE.sub(rf"\g<1>{comment}", line)
+        for line in content.split("\n")
+    )
+
+
+def _strip_elisions(content: str, comment: str, placeholder: str) -> str:
+    """Neutralize doc elisions: dot-only lines become a comment, inline
+    `...` placeholders become a parseable expression."""
+    return INLINE_ELISION_RE.sub(
+        placeholder, _replace_elision_lines(content, comment)
+    )
+
+
+# ---- Python -----------------------------------------------------------------
+
+
+def check_python(content: str):
+    stripped = content.strip()
+    if not stripped:
+        return SKIP
+    first = stripped.split("\n", 1)[0]
+    # Interactive-session transcripts (>>> prompts) aren't parseable modules.
+    if first.lstrip().startswith(">>>"):
+        return SKIP
+    if PY_CONTINUATION_RE.match(first):
+        return SKIP
+    src = textwrap.dedent(content)
+    # `...` is a legal expression, but dot-lines like `....` aren't, and a
+    # trailing `, ...` elision after a keyword argument parses as a
+    # positional-after-keyword error — drop it.
+    src = _replace_elision_lines(src, "...")
+    src = re.sub(r",[ \t]*(\.\.\.|…)(?=\s*\))", "", src)
+    # Scaffold ladder, mirroring the Go checker. Doc fragments routinely
+    # (2) elide a def/class body with only a comment, (3) elide trailing
+    # keyword arguments with a `...` line inside a call, or (4) show a bare
+    # signature with no body. Flag only if every form fails; report the
+    # as-is error.
+    scaffolds = [
+        src,
+        re.sub(r"^(\s*)#.*$", r"\g<1>...", src, flags=re.M),
+        "\n".join(
+            line for line in src.split("\n")
+            if not re.match(r"^\s*(\.\.\.|…)\s*$", line)
+        ),
+        src.rstrip() + (" ..." if src.rstrip().endswith(":") else ": ..."),
+    ]
+    first_error = None
+    for candidate in scaffolds:
+        try:
+            ast.parse(candidate)
+            return None
+        except SyntaxError as e:
+            if first_error is None:
+                first_error = {
+                    "message": f"python: {e.msg}",
+                    "line_offset": max((e.lineno or 1) - 1, 0),
+                }
+    return first_error
+
+
+# ---- YAML -------------------------------------------------------------------
+
+
+class _PermissiveLoader(yaml.SafeLoader):
+    """SafeLoader that accepts unknown tags (!Ref, !!custom, ...).
+
+    Docs YAML routinely carries CloudFormation and other domain tags; the
+    sweep checks well-formedness, not schema, so every tag constructs to
+    None instead of erroring.
+    """
+
+
+_PermissiveLoader.add_multi_constructor("", lambda loader, suffix, node: None)
+
+
+def check_yaml(content: str):
+    if not content.strip():
+        return SKIP
+    # Hugo/Helm templating renders before the YAML is ever parsed for real;
+    # the raw text is not valid YAML by design.
+    if "{{" in content:
+        return SKIP
+    try:
+        list(yaml.load_all(_replace_elision_lines(content, "# ..."),
+                           Loader=_PermissiveLoader))
+    except yaml.YAMLError as e:
+        line = getattr(getattr(e, "problem_mark", None), "line", 0)
+        msg = getattr(e, "problem", None) or str(e).split("\n")[0]
+        return {"message": f"yaml: {msg}", "line_offset": line}
+    return None
+
+
+# ---- JSON -------------------------------------------------------------------
+
+
+def check_json(content: str):
+    if not content.strip():
+        return SKIP
+    # Commented or elided JSON is legal *as documentation*; only clean-looking
+    # blocks are held to strict JSON. `\s//` catches both full-line and
+    # trailing annotations (`"value": 21600 // seconds`) without skipping
+    # every block that merely contains a URL ("https://...").
+    if "..." in content or "…" in content:
+        return SKIP
+    if re.search(r"(?:^|\s)//|/\*", content, re.M):
+        return SKIP
+    try:
+        json.loads(content)
+    except json.JSONDecodeError as e:
+        # Keyed fragments of a larger object (`"key": {...}`) are common in
+        # schema docs; retry wrapped in braces and flag only if both fail.
+        try:
+            json.loads("{%s}" % content)
+        except json.JSONDecodeError:
+            return {"message": f"json: {e.msg}", "line_offset": e.lineno - 1}
+    return None
+
+
+# ---- Go ---------------------------------------------------------------------
+
+
+def _gofmt(src: str):
+    """Run `gofmt -e` on src; return None if clean, else (message, line)."""
+    proc = subprocess.run(
+        ["gofmt", "-e"],
+        input=src,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return None
+    first = (proc.stderr.strip() or "syntax error").split("\n")[0]
+    # gofmt errors look like `<standard input>:3:5: message`.
+    m = re.match(r"^<standard input>:(\d+):(?:\d+:)?\s*(.*)$", first)
+    if m:
+        return m.group(2), int(m.group(1)) - 1
+    return first, 0
+
+
+GO_IMPORT_RE = re.compile(
+    r"\A((?:\s*(?://.*)?\n)*(?:import\s+(?:\([^)]*\)|\"[^\"]*\"|\w+\s+\"[^\"]*\")\s*\n)+)",
+)
+
+
+def check_go(content: str):
+    if not content.strip():
+        return SKIP
+    # go.mod files are conventionally fenced as ```go but aren't Go source.
+    first = next(
+        (l for l in content.split("\n") if l.strip() and not l.strip().startswith("//")),
+        "",
+    )
+    if first.startswith("module "):
+        return SKIP
+    src = _strip_elisions(content, "// ...", "nil")
+    # Scaffold ladder: a snippet may be a full file, a file body missing its
+    # package clause, a bare statement fragment, a pedagogical mix of an
+    # import block followed by statement code (imports hoisted, rest
+    # wrapped), or a func-literal/value fragment lifted from a larger
+    # expression (`var _ =`, trailing comma stripped). Flag only if *every*
+    # form fails; report the as-is error (closest to what the reader sees).
+    scaffolds = [
+        (src, 0),
+        (f"package main\n{src}", 1),
+        ("package main\nfunc _() {\n" + src + "\n}", 2),
+        ("package main\nvar _ = " + src.rstrip().rstrip(","), 1),
+    ]
+    m = GO_IMPORT_RE.match(src)
+    if m:
+        imports, rest = m.group(1), src[m.end():]
+        scaffolds.append(
+            (f"package main\n{imports}func _() {{\n{rest}\n}}", None)
+        )
+    first_error = None
+    for candidate, prefix_lines in scaffolds:
+        result = _gofmt(candidate)
+        if result is None:
+            return None
+        if first_error is None:
+            msg, line = result
+            first_error = {
+                "message": f"go: {msg}",
+                "line_offset": max(line - prefix_lines, 0),
+            }
+    return first_error
+
+
+# ---- TypeScript / JavaScript (batch) -----------------------------------------
+
+
+# A full-line comment naming a config file marks a multi-file teaching
+# block (`// package.json` followed by JSON, then application code) —
+# not a single parseable unit.
+TS_FILENAME_COMMENT_RE = re.compile(
+    r"^\s*//\s*[\w@./-]*\.(json|jsonc|yaml|yml|toml|txt)\s*$", re.M
+)
+
+
+def check_ts_batch(blocks: list[dict]) -> dict[int, dict | str | None]:
+    """Check all TS/JS blocks in one Node process.
+
+    `blocks` items need `lang` and `content`; the return maps each input
+    index to None (clean), SKIP (uncheckable), or an error dict. Elision
+    handling and the scaffold ladder live in check-ts.mjs.
+
+    Raises RuntimeError if the Node helper itself fails (infra error, not
+    a finding).
+    """
+    if not blocks:
+        return {}
+    results: dict[int, dict | str | None] = {}
+    payload = []
+    for i, b in enumerate(blocks):
+        if TS_FILENAME_COMMENT_RE.search(b["content"]):
+            results[i] = SKIP
+            continue
+        results[i] = None
+        payload.append({"id": i, "lang": b["lang"], "content": b["content"]})
+    if not payload:
+        return results
+    proc = subprocess.run(
+        ["node", str(CHECK_TS)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"check-ts.mjs failed (exit {proc.returncode}): {proc.stderr.strip()}"
+        )
+    for item in json.loads(proc.stdout):
+        results[item["id"]] = {
+            "message": f"{blocks[item['id']]['lang']}: {item['message']}",
+            "line_offset": item["line_offset"],
+        }
+    return results
+
+
+# Languages checked in-process, one block at a time. TS/JS run through
+# check_ts_batch instead (see sweep.py).
+CHECKERS = {
+    "python": check_python,
+    "yaml": check_yaml,
+    "json": check_json,
+    "go": check_go,
+}
+
+TS_LANGS = {"typescript", "javascript"}

--- a/scripts/snippet-sweep/extract.py
+++ b/scripts/snippet-sweep/extract.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Extract fenced code blocks from Hugo markdown content.
+
+Pure, importable module: no I/O beyond reading the file handed to it, no
+side effects. The sweep orchestrator (`sweep.py`) feeds each block to the
+per-language checkers in `checkers.py`.
+
+Fence handling follows CommonMark:
+
+- An opening fence is 3+ backticks or tildes, indented at most 3 spaces,
+  optionally followed by an info string (no backticks allowed in a
+  backtick fence's info string).
+- The block closes only on a fence of the *same character* with *at least
+  the opening length* and nothing but whitespace after it. This makes
+  nested fences safe (a four-backtick block quoting a three-backtick
+  example stays one block).
+- An unclosed fence runs to end of file.
+
+The leading `---` frontmatter block is skipped. Hugo shortcode wrapper
+lines outside fences ({{% choosable %}}, {{< chooser >}}) are ordinary
+non-fence text and need no special handling; shortcode text *inside* a
+fence is literal block content and is left to the checkers' skip rules.
+
+Each block is reported as a dict:
+
+    {"path": str, "block_index": int, "lang": str,
+     "start_line": int, "end_line": int, "content": str}
+
+`start_line` is the 1-based line number of the first *content* line (the
+line after the opening fence); `end_line` is the last content line.
+`block_index` is the 0-based index among all fenced blocks in the file.
+`lang` is the first info-string token, lowercased, with common aliases
+normalized (`ts` -> `typescript`, `py` -> `python`, ...). Blocks with no
+info string get `lang == ""`.
+"""
+
+from __future__ import annotations
+
+import re
+
+FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})[ \t]*(.*)$")
+
+LANG_ALIASES = {
+    "ts": "typescript",
+    "js": "javascript",
+    "py": "python",
+    "yml": "yaml",
+    "golang": "go",
+    "sh": "bash",
+    "shell": "bash",
+    "cs": "csharp",
+}
+
+
+def normalize_lang(info: str) -> str:
+    """First info-string token, lowercased, aliases resolved.
+
+    Hugo allows attribute blocks in the info string (```typescript
+    {hl_lines=[3]}); the token ends at whitespace or `{`.
+    """
+    token = re.split(r"[\s{]", info.strip(), maxsplit=1)[0].lower()
+    return LANG_ALIASES.get(token, token)
+
+
+def extract_blocks(text: str, path: str) -> list[dict]:
+    """Return all fenced code blocks in `text` (see module docstring)."""
+    lines = text.split("\n")
+    # A file ending in a newline yields a phantom empty final element; drop
+    # it so an unclosed fence at EOF doesn't grow a trailing blank line.
+    if lines and lines[-1] == "":
+        lines.pop()
+    blocks: list[dict] = []
+    i = 0
+    n = len(lines)
+
+    # Skip frontmatter line-wise so downstream line numbers stay correct.
+    if lines and lines[0].strip() == "---":
+        j = 1
+        while j < n and lines[j].strip() != "---":
+            j += 1
+        if j < n:
+            i = j + 1
+
+    block_index = 0
+    while i < n:
+        m = FENCE_OPEN_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        fence = m.group(1)
+        fence_char, fence_len = fence[0], len(fence)
+        info = m.group(2)
+        # CommonMark: a backtick fence's info string cannot contain backticks
+        # (that's inline code, not a fence).
+        if fence_char == "`" and "`" in info:
+            i += 1
+            continue
+        close_re = re.compile(
+            r"^ {0,3}%s{%d,}[ \t]*$" % (re.escape(fence_char), fence_len)
+        )
+        start = i + 1
+        j = start
+        while j < n and not close_re.match(lines[j]):
+            j += 1
+        content_lines = lines[start:j]
+        blocks.append(
+            {
+                "path": path,
+                "block_index": block_index,
+                "lang": normalize_lang(info),
+                "start_line": start + 1,  # 1-based; == fence line + 1
+                "end_line": j,  # 1-based last content line
+                "content": "\n".join(content_lines),
+            }
+        )
+        block_index += 1
+        i = j + 1
+
+    return blocks

--- a/scripts/snippet-sweep/ignore.txt
+++ b/scripts/snippet-sweep/ignore.txt
@@ -1,0 +1,18 @@
+# Snippet-sweep false-positive suppressions.
+#
+# A block listed here is counted as `suppressed` and never flagged. Two
+# line formats (comments with `#`; blank lines ignored):
+#
+#   <content-path><TAB><hash12>   suppress one block. hash12 is the value
+#                                 from the finding's `hash` field (sha256
+#                                 of the block content with trailing
+#                                 whitespace and outer blank lines
+#                                 stripped) — editing the block changes
+#                                 the hash and re-exposes it.
+#   <regex over content-path>     suppress every block on matching pages.
+#
+# Keep a trailing comment on every entry saying WHY it is suppressed.
+# `sweep.py --explain-ignores` lists entries that no longer match, for
+# periodic cleanup.
+
+content/docs/iac/concepts/inputs-outputs/apply.md	94c1851bbc13	# intentional mix of import block, func decl, and "inside a program" statements — not one parseable unit

--- a/scripts/snippet-sweep/package-lock.json
+++ b/scripts/snippet-sweep/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "snippet-sweep",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "snippet-sweep",
+      "dependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/scripts/snippet-sweep/package.json
+++ b/scripts/snippet-sweep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "snippet-sweep",
+  "private": true,
+  "description": "Deterministic snippet-parse sweep (see sweep.py); typescript is pinned to mirror the repo root",
+  "dependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/scripts/snippet-sweep/sweep.py
+++ b/scripts/snippet-sweep/sweep.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Nightly deterministic snippet-parse sweep (issue #20078 §4.3).
+
+Extracts every inline fenced code block on tier-1/2 pages under
+`content/docs/` and runs a per-language *parse floor* — no execution, no
+AI model. Findings are written as a signal file consumed by the content
+review selector (`scripts/content-review/select-articles.py
+--signal-file`) as queue-priority boosts; the sweep itself never opens
+PRs or notifies on findings.
+
+Precision over recall: a block that can't be checked with near-certainty
+is skipped, not flagged (see `checkers.py`), and residual false positives
+are suppressed via `ignore.txt` (path + content-hash entries that
+auto-expire when the block changes).
+
+Usage:
+    sweep.py [--tiers <yaml>] [--max-tier 2] [--out .snippet-sweep.json]
+             [--paths content/docs/a.md,content/docs/b.md] [--all-tiers]
+             [--dry-run] [--explain-ignores] [--root <repo>]
+
+Exit code is 0 even when findings exist — findings are a signal, not a
+failure. Non-zero (2) means the sweep itself broke (missing toolchain,
+unreadable tiers file): the workflow must fail loudly rather than upload
+a garbage signal.
+
+Signal schema (`.snippet-sweep.json`):
+
+    {"schema_version": 1, "tool_version": "...", "generated": "<ISO>",
+     "tier_scope": [1, 2],
+     "stats": {"pages_scanned": N, "blocks_checked": N,
+               "blocks_skipped": N, "suppressed": N},
+     "pages": {"content/docs/...md": {"errors": N, "samples": [
+        {"lang": ..., "line": ..., "block_index": ..., "check": "syntax",
+         "message": ..., "hash": ...}]}}}
+
+`samples` is capped at MAX_SAMPLES per page; `hash` is the suppression
+key, copy-pasteable into `ignore.txt`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+DEFAULT_IGNORE = HERE / "ignore.txt"
+CONTENT_DIR = "content/docs"
+
+SCHEMA_VERSION = 1
+TOOL_VERSION = "1.0"
+MAX_SAMPLES = 5
+
+sys.path.insert(0, str(HERE))
+from checkers import CHECKERS, SKIP, TS_LANGS, check_ts_batch, pre_skip  # noqa: E402
+from extract import extract_blocks  # noqa: E402
+
+
+def load_selector():
+    """Import load_tiers/tier_for/is_draft from select-articles.py.
+
+    Reused, not copied, so the sweep can never drift from the selector's
+    longest-prefix tier semantics (the hyphenated filename rules out a
+    normal import).
+    """
+    path = REPO_ROOT / "scripts/content-review/select-articles.py"
+    spec = importlib.util.spec_from_file_location("select_articles", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---- Suppressions -------------------------------------------------------------
+
+
+def block_hash(content: str) -> str:
+    """sha256[:12] of whitespace-normalized block content.
+
+    Trailing whitespace per line and leading/trailing blank lines are
+    stripped, so cosmetic edits don't rotate the hash — but any content
+    edit re-exposes a suppressed block (suppressions can't silently rot
+    into blanket immunity).
+    """
+    lines = [line.rstrip() for line in content.split("\n")]
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    normalized = "\n".join(lines)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+
+
+def load_ignores(ignore_file: Path) -> tuple[list[tuple[str, str]], list[re.Pattern]]:
+    """Parse ignore.txt into (path, hash) pairs and path regexes.
+
+    Line formats (comments with `#`, inline or full-line):
+        <content-path><TAB><hash12>    suppress one block
+        <regex over content-path>      suppress a whole page/subtree
+    """
+    pairs: list[tuple[str, str]] = []
+    patterns: list[re.Pattern] = []
+    if not ignore_file.exists():
+        return pairs, patterns
+    for raw in ignore_file.read_text().split("\n"):
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if "\t" in line:
+            path, block = line.split("\t", 1)
+            pairs.append((path.strip(), block.strip()))
+        else:
+            patterns.append(re.compile(line.strip()))
+    return pairs, patterns
+
+
+# ---- Sweep --------------------------------------------------------------------
+
+
+def checkable(block: dict) -> bool:
+    return block["lang"] in CHECKERS or block["lang"] in TS_LANGS
+
+
+def sweep(pages: list[str], root: Path, ignore_file: Path) -> dict:
+    """Run the sweep over `pages` (repo-relative paths); return the signal."""
+    pairs, patterns = load_ignores(ignore_file)
+    used_ignores: set = set()
+
+    stats = {"pages_scanned": 0, "blocks_checked": 0, "blocks_skipped": 0,
+             "suppressed": 0}
+    findings: dict[str, list[dict]] = {}
+    ts_pending: list[tuple[str, dict]] = []  # (path, block) for the batch
+
+    def suppressed(path: str, content: str) -> bool:
+        for pat in patterns:
+            if pat.search(path):
+                used_ignores.add(pat.pattern)
+                return True
+        h = block_hash(content)
+        if (path, h) in pairs:
+            used_ignores.add((path, h))
+            return True
+        return False
+
+    def record(path: str, block: dict, error: dict) -> None:
+        findings.setdefault(path, []).append(
+            {
+                "lang": block["lang"],
+                "line": block["start_line"] + error["line_offset"],
+                "block_index": block["block_index"],
+                "check": "syntax",
+                "message": error["message"],
+                "hash": block_hash(block["content"]),
+            }
+        )
+
+    for path in pages:
+        stats["pages_scanned"] += 1
+        try:
+            text = (root / path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for block in extract_blocks(text, path):
+            if not checkable(block):
+                continue
+            if pre_skip(block["content"]):
+                stats["blocks_skipped"] += 1
+                continue
+            if suppressed(path, block["content"]):
+                stats["suppressed"] += 1
+                continue
+            if block["lang"] in TS_LANGS:
+                ts_pending.append((path, block))
+                continue
+            result = CHECKERS[block["lang"]](block["content"])
+            if result == SKIP:
+                stats["blocks_skipped"] += 1
+                continue
+            stats["blocks_checked"] += 1
+            if result is not None:
+                record(path, block, result)
+
+    ts_results = check_ts_batch([b for _, b in ts_pending])
+    for i, (path, block) in enumerate(ts_pending):
+        result = ts_results.get(i)
+        if result == SKIP:
+            stats["blocks_skipped"] += 1
+            continue
+        stats["blocks_checked"] += 1
+        if result is not None:
+            record(path, block, result)
+
+    signal_pages = {
+        path: {"errors": len(samples), "samples": samples[:MAX_SAMPLES]}
+        for path, samples in sorted(findings.items())
+    }
+    unused = [
+        entry for entry in ([p.pattern for p in patterns] + pairs)
+        if entry not in used_ignores
+    ]
+    return {"stats": stats, "pages": signal_pages, "unused_ignores": unused}
+
+
+# ---- CLI ----------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--tiers", type=Path, default=None,
+                   help="strategic-tiers.yaml (default: the selector's)")
+    p.add_argument("--max-tier", type=int, default=2)
+    p.add_argument("--all-tiers", action="store_true",
+                   help="scan every non-tier-0 page (local audits)")
+    p.add_argument("--out", type=Path, default=Path(".snippet-sweep.json"))
+    p.add_argument("--paths", help="comma-separated content paths (subset run)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="print findings as a table; write nothing")
+    p.add_argument("--explain-ignores", action="store_true",
+                   help="list ignore.txt entries that no longer match anything")
+    p.add_argument("--ignore-file", type=Path, default=DEFAULT_IGNORE)
+    p.add_argument("--root", type=Path, default=REPO_ROOT,
+                   help="repo root override (tests)")
+    args = p.parse_args()
+
+    selector = load_selector()
+    tiers_file = args.tiers or (
+        args.root / ".claude/commands/review-existing-content/references/strategic-tiers.yaml"
+    )
+    try:
+        rules = selector.load_tiers(tiers_file)
+    except OSError as e:
+        print(f"error: cannot read tiers file: {e}", file=sys.stderr)
+        return 2
+
+    for tool, langs in (("node", "TypeScript/JavaScript"), ("gofmt", "Go")):
+        if shutil.which(tool) is None:
+            print(f"error: `{tool}` not found — required for {langs} checks",
+                  file=sys.stderr)
+            return 2
+
+    if args.paths:
+        pages = [s.strip() for s in args.paths.split(",") if s.strip()]
+    else:
+        pages = sorted(
+            str(f.relative_to(args.root))
+            for f in (args.root / CONTENT_DIR).rglob("*.md")
+        )
+
+    scoped: list[str] = []
+    tier_scope = list(range(1, args.max_tier + 1))
+    for path in pages:
+        tier, _ = selector.tier_for(path, rules)
+        if tier == 0:
+            continue
+        if not args.all_tiers and tier > args.max_tier:
+            continue
+        if selector.is_draft(args.root / path):
+            continue
+        scoped.append(path)
+
+    result = sweep(scoped, args.root, args.ignore_file)
+
+    if args.explain_ignores:
+        if result["unused_ignores"]:
+            print("ignore.txt entries that no longer match anything:")
+            for entry in result["unused_ignores"]:
+                print(f"  {entry}")
+        else:
+            print("all ignore.txt entries are live")
+        return 0
+
+    if args.dry_run:
+        total = sum(pg["errors"] for pg in result["pages"].values())
+        print(f"{result['stats']} | findings: {total}")
+        for path, page in result["pages"].items():
+            for s in page["samples"]:
+                print(f"{path}:{s['line']}\t{s['lang']}\t{s['hash']}\t{s['message']}")
+        return 0
+
+    signal = {
+        "schema_version": SCHEMA_VERSION,
+        "tool_version": TOOL_VERSION,
+        "generated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "tier_scope": tier_scope if not args.all_tiers else "all",
+        "stats": result["stats"],
+        "pages": result["pages"],
+    }
+    args.out.write_text(json.dumps(signal, indent=2) + "\n")
+    total = sum(pg["errors"] for pg in result["pages"].values())
+    print(f"wrote {args.out}: {total} finding(s) across "
+          f"{len(result['pages'])} page(s); stats={result['stats']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/snippet-sweep/test_checkers.py
+++ b/scripts/snippet-sweep/test_checkers.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Tests for checkers.py — golden both ways per language.
+
+Seeded errors MUST flag; documentation fragments MUST NOT. Every "must
+not flag" case here is a false-positive class found during the initial
+full-corpus audit — keep them passing or the sweep starts producing slop.
+
+Self-contained — run with `python3 test_checkers.py` (no pytest dep;
+requires `node` and `gofmt` on PATH, same as the sweep itself).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from checkers import (
+    SKIP,
+    check_go,
+    check_json,
+    check_python,
+    check_ts_batch,
+    check_yaml,
+    pre_skip,
+)
+
+_failures: list[str] = []
+_passes = 0
+
+
+def check(cond: bool, msg: str) -> None:
+    global _passes
+    if cond:
+        _passes += 1
+    else:
+        _failures.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def ts(content: str, lang: str = "typescript"):
+    return check_ts_batch([{"lang": lang, "content": content}])[0]
+
+
+print("== pre_skip (uncheckable regardless of language)")
+check(pre_skip('{{< example-program-snippet path="x" >}}'), "hugo shortcode <")
+check(pre_skip("{{% choosable %}}"), "hugo shortcode %")
+check(pre_skip("url: <backend-url>"), "hyphenated placeholder")
+check(pre_skip("export const k = ... a cluster's output property ...;"),
+      "elision-bracketed prose")
+check(not pre_skip("const x: Array<string> = [];"), "generics don't skip")
+check(not pre_skip("f(args...)"), "variadic doesn't skip")
+
+print("== python")
+check(check_python("bucket = s3.Bucket('b')") is None, "clean fragment")
+check(check_python("    return x") is None, "indented body dedents")
+check(check_python("else:\n    pass") == SKIP, "continuation keyword skips")
+check(check_python(">>> import pulumi") == SKIP, "REPL transcript skips")
+check(check_python("f(x=1, ...)") is None, "trailing elision after kwarg")
+check(check_python("f(\n    x=1,\n    ...\n)") is None,
+      "elision line inside call")
+check(check_python("def f(args):\n    # ...\n\ng(f)") is None,
+      "comment-only def body")
+check(check_python("class C(Base):\n    # TODO one\n    # TODO two") is None,
+      "comment-only class body")
+check(check_python("def f(self,\n      x: int = 1) -> str") is None,
+      "signature-only fragment")
+check(check_python("....\nx = 1") is None, "dot-elision line")
+check(check_python("web = Webhook('x',\n    active: True,\n)") is not None,
+      "colon-for-equals kwargs flags")
+check(check_python("f(a=1\n  b=2)") is not None, "missing comma flags")
+check(check_python("x = (1") is not None, "unclosed paren flags")
+
+print("== yaml")
+check(check_yaml("a: 1\nb:\n  - c\n---\nd: 2") is None, "multi-doc")
+check(check_yaml("Value: !Ref Foo\nB: !!custom x") is None, "unknown tags")
+check(check_yaml("a: {{ .Values.x }}") == SKIP, "templating skips")
+check(check_yaml("....\nbackend:\n  url: https://x") is None,
+      "dot-elision line")
+check(check_yaml("key: [${interp.id}]") is not None,
+      "unquoted interpolation in flow sequence flags")
+check(check_yaml("a: b\n c: d") is not None, "bad indent flags")
+
+print("== json")
+check(check_json('{"a": [1, 2], "b": null}') is None, "clean object")
+check(check_json('"key": {"a": 1}') is None, "keyed fragment wraps")
+check(check_json('{\n  // comment\n  "a": 1\n}') == SKIP, "line comment skips")
+check(check_json('{"v": 21600 // seconds\n}') == SKIP,
+      "trailing comment skips")
+check(check_json('{"a": "https://x//y"}') is None, "URL // does not skip")
+check(check_json('{"a": 1,}') is not None, "trailing comma flags")
+check(check_json('{"a" 1}') is not None, "missing colon flags")
+
+print("== go")
+check(check_go(
+    "package main\nimport \"fmt\"\nfunc main() { fmt.Println(1) }"
+) is None, "full program")
+check(check_go("func f() int {\n\treturn 1\n}") is None, "package-less decl")
+check(check_go('x := cfg.Require("k")\nfmt.Println(x)') is None,
+      "statement fragment")
+check(check_go(
+    'import (\n    "fmt"\n)\n\nx := 1\nfmt.Println(x)'
+) is None, "imports hoisted over statements")
+check(check_go(
+    "func(_ ctx.Context, a *T) *R {\n\treturn nil\n},"
+) is None, "func-literal fragment with trailing comma")
+check(check_go("module example.com/x\n\ngo 1.24") == SKIP, "go.mod skips")
+check(check_go("f(a, b...)") is None, "variadic untouched")
+check(check_go("x := f(\n\ta,\n)") is None, "trailing comma call")
+check(check_go("m := Map{ /*...*/ }") is None, "comment elision in braces")
+check(check_go(
+    "func main() {\n\tRun(func() error {\n\t\treturn nil\n\t}\n}"
+) is not None, "missing close paren flags")
+check(check_go("const t = `abc\n") is not None,
+      "unterminated raw string flags")
+
+print("== typescript / javascript")
+check(ts('import * as aws from "@pulumi/aws";\nconst b = new aws.s3.Bucket("b");') is None,
+      "import fragment")
+check(ts("prop: value,\nother: 3,") is None, "object-property fragment")
+check(ts("const el = <div a={1}>hi</div>;") is None, "JSX retries as tsx")
+check(ts("const secret = ...\nconst x = 1;") is None, "statement elision")
+check(ts('new R("n", { ... }, { parent: this });') is None, "object stub")
+check(ts("new C(this, 'c', {\n  ..., // trimmed\n  a: 1,\n});") is None,
+      "object spread elision")
+check(ts('const o = { a: /*...*/ };') is None, "comment elision value")
+check(ts('{\n  "compilerOptions": {\n    // ...\n    "baseUrl": "."\n  }\n}') is None,
+      "JSONC config wraps as expression")
+check(ts("class C {\n  readonly x: Output<string>;") is None,
+      "brace-deficit class fragment")
+check(ts("// package.json\n{\n}\nimport x from 'y';") == SKIP,
+      "multi-file teaching block skips")
+check(ts('f("h", new CB("f", {\n  cb: () => {},\n});') is not None,
+      "missing close paren flags")
+check(ts("const o = { foo() {} bar() {} };") is not None,
+      "missing comma between methods flags")
+check(ts("export = async () => {\n}", lang="javascript") is not None,
+      "TS-only syntax in javascript flags")
+check(ts("export docsBucketName = x.name;") is not None,
+      "export without declaration flags")
+
+print("== batch mapping")
+res = check_ts_batch([
+    {"lang": "typescript", "content": "const a = 1;"},
+    {"lang": "typescript", "content": "// tsconfig.json\n{}"},
+    {"lang": "typescript", "content": "const b = ((;"},
+])
+check(res[0] is None and res[1] == SKIP and res[2] is not None,
+      "indices survive skip interleaving")
+
+if _failures:
+    print(f"\n{len(_failures)} failure(s), {_passes} passed", file=sys.stderr)
+    sys.exit(1)
+print(f"\nall {_passes} checks passed")

--- a/scripts/snippet-sweep/test_extract.py
+++ b/scripts/snippet-sweep/test_extract.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Tests for extract.py.
+
+Self-contained — run with `python3 test_extract.py` (no pytest dep).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from extract import extract_blocks, normalize_lang
+
+_failures: list[str] = []
+_passes = 0
+
+
+def check(cond: bool, msg: str) -> None:
+    global _passes
+    if cond:
+        _passes += 1
+    else:
+        _failures.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def blocks_of(text: str):
+    return extract_blocks(text, "test.md")
+
+
+print("== language normalization")
+check(normalize_lang("typescript {hl_lines=[3]}") == "typescript",
+      "info-string attributes stripped")
+check(normalize_lang("ts") == "typescript", "ts alias")
+check(normalize_lang("py") == "python", "py alias")
+check(normalize_lang("yml") == "yaml", "yml alias")
+check(normalize_lang("Golang") == "go", "case-insensitive alias")
+check(normalize_lang("") == "", "no info string -> empty lang")
+
+print("== plain fences")
+bs = blocks_of("a\n\n```python\nx = 1\n```\n\nb\n")
+check(len(bs) == 1, "one block")
+check(bs[0]["lang"] == "python", "lang parsed")
+check(bs[0]["start_line"] == 4 and bs[0]["end_line"] == 4, "line numbers")
+check(bs[0]["content"] == "x = 1", "content")
+check(bs[0]["block_index"] == 0, "index")
+
+print("== tilde fences")
+bs = blocks_of("~~~go\nfmt.Println()\n~~~\n")
+check(len(bs) == 1 and bs[0]["lang"] == "go", "tilde fence extracted")
+
+print("== nested fences (CommonMark length rule)")
+bs = blocks_of("````\n```typescript\ninner\n```\n````\n")
+check(len(bs) == 1, "outer four-backtick block is one block")
+check("```typescript" in bs[0]["content"], "inner fence is literal content")
+check(bs[0]["lang"] == "", "outer block has no lang")
+
+print("== longer closing fence closes")
+bs = blocks_of("```python\nx = 1\n`````\nprose\n")
+check(len(bs) == 1 and bs[0]["content"] == "x = 1", "close on longer fence")
+
+print("== mismatched fence char does not close")
+bs = blocks_of("```python\nx = 1\n~~~\ny = 2\n```\n")
+check(len(bs) == 1 and "~~~" in bs[0]["content"], "tildes inside backtick block")
+
+print("== unclosed fence runs to EOF")
+bs = blocks_of("```python\nx = 1\ny = 2\n")
+check(len(bs) == 1 and bs[0]["content"] == "x = 1\ny = 2", "unclosed at EOF")
+
+print("== backtick info string with backtick is not a fence")
+bs = blocks_of("``` `not a fence`\ntext\n")
+check(len(bs) == 0, "inline-code lookalike skipped")
+
+print("== indentation")
+bs = blocks_of("   ```python\nx = 1\n   ```\n")
+check(len(bs) == 1, "three-space indented fence opens")
+bs = blocks_of("    ```python\nnot a fence\n    ```\n")
+check(len(bs) == 0, "four-space indent is an indented code block, not a fence")
+
+print("== frontmatter skipped")
+md = "---\ntitle: T\ndraft: false\n---\n\n```yaml\na: 1\n```\n"
+bs = blocks_of(md)
+check(len(bs) == 1, "frontmatter --- lines don't confuse the extractor")
+check(bs[0]["start_line"] == 7, "line numbers account for frontmatter")
+
+print("== choosable-wrapped blocks")
+md = (
+    "---\ntitle: T\n---\n\n"
+    '{{< chooser language "typescript,python" >}}\n'
+    "{{% choosable language typescript %}}\n\n"
+    "```typescript\nconst a = 1;\n```\n\n"
+    "{{% /choosable %}}\n"
+    "{{% choosable language python %}}\n\n"
+    "```python\na = 1\n```\n\n"
+    "{{% /choosable %}}\n"
+    "{{< /chooser >}}\n"
+)
+bs = blocks_of(md)
+check(len(bs) == 2, "both choosable blocks extracted")
+check([b["lang"] for b in bs] == ["typescript", "python"], "langs in order")
+check([b["block_index"] for b in bs] == [0, 1], "indices sequential")
+
+if _failures:
+    print(f"\n{len(_failures)} failure(s), {_passes} passed", file=sys.stderr)
+    sys.exit(1)
+print(f"\nall {_passes} checks passed")

--- a/scripts/snippet-sweep/test_sweep.py
+++ b/scripts/snippet-sweep/test_sweep.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Integration tests for sweep.py.
+
+Self-contained — run with `python3 test_sweep.py`. Builds a throwaway
+content/docs tree with a fixture tiers file, shells out to sweep.py with
+`--root`, and asserts on the signal JSON: tier filtering, draft skip,
+suppression by content hash, pre-skip rules, and the schema contract the
+selector's `--signal-file` loader will depend on.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "sweep.py"
+
+_failures: list[str] = []
+_passes = 0
+
+
+def check(cond: bool, msg: str) -> None:
+    global _passes
+    if cond:
+        _passes += 1
+    else:
+        _failures.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+BROKEN_PY = "---\ntitle: T\n---\n\n```python\nx = (1\n```\n"
+CLEAN_TS = '---\ntitle: T\n---\n\n```typescript\nconst a = 1;\n```\n'
+DRAFT_BROKEN = "---\ntitle: T\ndraft: true\n---\n\n```python\nx = (1\n```\n"
+SHORTCODE = (
+    "---\ntitle: T\n---\n\n```python\n"
+    '{{< example-program-snippet path="x" >}}\n```\n'
+)
+
+TIERS = """\
+tiers:
+  - prefix: content/docs/generated/
+    tier: 0
+  - prefix: content/docs/concepts/
+    tier: 1
+  - prefix: content/docs/other/
+    tier: 3
+"""
+
+
+def run(root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root),
+         "--tiers", str(root / "tiers.yaml"), *args],
+        capture_output=True, text=True, cwd=root,
+    )
+
+
+with tempfile.TemporaryDirectory() as td:
+    root = Path(td)
+    (root / "tiers.yaml").write_text(TIERS)
+    docs = root / "content/docs"
+    for rel, body in {
+        "concepts/broken.md": BROKEN_PY,
+        "concepts/clean.md": CLEAN_TS,
+        "concepts/draft.md": DRAFT_BROKEN,
+        "concepts/shortcode.md": SHORTCODE,
+        "generated/broken.md": BROKEN_PY,
+        "other/broken.md": BROKEN_PY,
+    }.items():
+        p = docs / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    # sweep.py resolves the selector from the real repo, not --root, so no
+    # scripts/ tree is needed in the fixture.
+
+    print("== default scope (tier 1-2)")
+    out = root / "signal.json"
+    proc = run(root, "--out", str(out), "--ignore-file", str(root / "no-ignores.txt"))
+    check(proc.returncode == 0, f"exit 0 with findings: {proc.stderr}")
+    signal = json.loads(out.read_text())
+    check(signal["schema_version"] == 1, "schema_version")
+    check(signal["tier_scope"] == [1, 2], "tier_scope")
+    check("content/docs/generated/broken.md" not in signal["pages"],
+          "tier-0 page excluded")
+    check("content/docs/other/broken.md" not in signal["pages"],
+          "tier-3 page excluded by default")
+    check("content/docs/concepts/draft.md" not in signal["pages"],
+          "draft page excluded")
+    check(list(signal["pages"]) == ["content/docs/concepts/broken.md"],
+          f"exactly the broken tier-1 page flags: {list(signal['pages'])}")
+    page = signal["pages"]["content/docs/concepts/broken.md"]
+    sample = page["samples"][0]
+    check(page["errors"] == 1, "error count")
+    check(sample["lang"] == "python" and sample["check"] == "syntax",
+          "sample lang/check")
+    check(sample["line"] == 6, f"sample line is source-anchored: {sample['line']}")
+    check(len(sample["hash"]) == 12, "sample carries suppression hash")
+    check(signal["stats"]["blocks_skipped"] >= 1, "shortcode block counted as skipped")
+    check("generated" in signal, "generated timestamp present")
+
+    print("== --all-tiers")
+    proc = run(root, "--out", str(out), "--all-tiers",
+               "--ignore-file", str(root / "no-ignores.txt"))
+    signal = json.loads(out.read_text())
+    check("content/docs/other/broken.md" in signal["pages"],
+          "tier-3 page included with --all-tiers")
+    check("content/docs/generated/broken.md" not in signal["pages"],
+          "tier-0 still excluded with --all-tiers")
+
+    print("== suppression by content hash")
+    h = sample["hash"]
+    ignores = root / "ignores.txt"
+    ignores.write_text(
+        f"# test\ncontent/docs/concepts/broken.md\t{h}   # fixture\n"
+    )
+    proc = run(root, "--out", str(out), "--ignore-file", str(ignores))
+    signal = json.loads(out.read_text())
+    check(signal["pages"] == {}, "hash suppression removes the finding")
+    check(signal["stats"]["suppressed"] == 1, "suppressed counted")
+
+    print("== suppression expires on edit")
+    (docs / "concepts/broken.md").write_text(
+        "---\ntitle: T\n---\n\n```python\nx = (1  # edited\n```\n"
+    )
+    proc = run(root, "--out", str(out), "--ignore-file", str(ignores))
+    signal = json.loads(out.read_text())
+    check("content/docs/concepts/broken.md" in signal["pages"],
+          "edited block re-exposed")
+
+    print("== path-regex suppression + --explain-ignores")
+    ignores.write_text("content/docs/concepts/.*   # whole subtree\n"
+                       f"content/docs/concepts/broken.md\t{h}   # now dead\n")
+    proc = run(root, "--out", str(out), "--ignore-file", str(ignores))
+    signal = json.loads(out.read_text())
+    check(signal["pages"] == {}, "regex suppression")
+    proc = run(root, "--explain-ignores", "--ignore-file", str(ignores))
+    check("broken.md" in proc.stdout and h in proc.stdout,
+          f"--explain-ignores lists the dead hash entry: {proc.stdout!r}")
+
+    print("== --paths subset")
+    proc = run(root, "--out", str(out), "--paths",
+               "content/docs/concepts/clean.md",
+               "--ignore-file", str(root / "no-ignores.txt"))
+    signal = json.loads(out.read_text())
+    check(signal["pages"] == {} and signal["stats"]["pages_scanned"] == 1,
+          "subset run scans only the named page")
+
+    print("== infra error exits non-zero")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root),
+         "--tiers", str(root / "missing.yaml")],
+        capture_output=True, text=True,
+    )
+    check(proc.returncode == 2, "unreadable tiers file -> exit 2")
+
+if _failures:
+    print(f"\n{len(_failures)} failure(s), {_passes} passed", file=sys.stderr)
+    sys.exit(1)
+print(f"\nall {_passes} checks passed")


### PR DESCRIPTION
### Proposed changes

Phase 1 of #20078 §4.3: a **deterministic corpus-wide snippet-parse sweep** — a parse floor over inline code blocks in `content/docs/`, with no execution and no AI model. Today, `static/programs/` is CI-tested and PR review checks inline snippets only in touched files; the rest of the corpus is never checked.

This PR lands the tooling under `scripts/snippet-sweep/`:

- **`extract.py`** — CommonMark-correct fenced-block extractor (nested fences, tilde fences, info-string attributes, frontmatter, language aliases), transparent to `{{% choosable %}}`/`{{< chooser >}}` wrappers.
- **`checkers.py` + `check-ts.mjs`** — per-language syntax checkers for **python, typescript, javascript, go, yaml, json** (`ast.parse`, `ts.transpileModule` syntactic diagnostics, `gofmt -e`, `yaml.safe_load_all` with permissive tags, `json.loads`). C#/Java are deferred to v2 (need heavy scaffolding for acceptable precision); bash/HCL are out of scope by design.
- **`sweep.py`** — CLI orchestrator; reuses `load_tiers`/`tier_for`/`is_draft` from `scripts/content-review/select-articles.py` (imported, not copied, so tier semantics can't drift). Scans tier-1/2 pages by default; emits a versioned signal JSON for the phase-3 selector boost. Exit 0 with findings (findings are a signal, not a failure); exit 2 only when the sweep itself breaks.
- **`ignore.txt`** — false-positive suppressions keyed by path + content hash, so suppressions auto-expire when a block is edited. `--explain-ignores` lists dead entries.

**Design center is precision over recall ("zero-slop")**: blocks that can't be checked with near-certainty are skipped, not flagged — Hugo-composed snippets, hyphenated `<placeholder>` tokens, prose elisions, REPL transcripts, go.mod-as-`go`, multi-file teaching blocks, templated YAML, commented JSON. Documentation elisions (`...` lines/placeholders, `{ ... }` stubs, comment-only bodies, signature-only defs) are neutralized via per-language scaffold ladders that flag only when *every* form fails.

**Full-corpus audit (the phase-1 zero-slop gate)**: 578 pages scanned, 1,403 blocks checked, 119 skipped as uncheckable, **24 findings — every one manually adjudicated as a genuine syntax error** readers would copy (missing parens/commas in Go examples, Python kwargs written with `:` instead of `=`, unescaped nested quotes, `export =` in a `javascript` fence, unquoted `${}` interpolation in a YAML flow sequence, leftover `\{` template escapes, etc.). The one intentional pseudo-code block found is the first `ignore.txt` entry. The sweep runs in ~4s and is deterministic across runs.

Tests: three self-contained suites (`python3 test_*.py`, repo convention) — extractor golden tests, per-language golden-both-ways checker tests (every FP class from the audit is a regression case), and CLI integration tests (tier filtering, draft skip, suppression expiry, exit codes).

**Not in this PR** (phased rollout per the issue): phase 2 adds the nightly workflow uploading the signal to S3; phase 3 wires `select-articles.py --signal-file` with an additive staleness-equivalent boost, provenance line, and ledger field. The 24 real findings above should be fixed by the normal content-review pipeline once the boost lands (or cherry-picked into a docs-fix PR sooner if wanted).

Defaults taken without a maintainer prompt (flagging per plan): v1 language set as above, tier-1/2 scope, phased landing. Happy to adjust.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Part of #20078 (§4.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdehavB4SnPVHA1nA5MjJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdehavB4SnPVHA1nA5MjJK)_