### PR TITLE
Fix confirmed drift and dead code in the review automation (#20078 §3.3)

### DIFF
--- a/.claude/commands/docs-review/references/infra.md
+++ b/.claude/commands/docs-review/references/infra.md
@@ -78,6 +78,8 @@ If the PR changes any of the above without updating `BUILD-AND-DEPLOY.md` — or
 
 When the diff touches `scripts/`, `Makefile`, or build/serve config, grep `BUILD-AND-DEPLOY.md` for the affected script/flag/env-var names *even when the diff doesn't touch the doc*. That's where the contradiction case hides.
 
+The same rule covers the review automation's own meta-docs. When the diff touches the review pipeline — `.github/workflows/claude-*.yml`, `content-review-article.yml`, `review-existing-content.yml`, `check-links.yml`, or the review skills under `.claude/commands/` — grep `CONTRIBUTING.md` and `AGENTS.md` for claims about the changed surface (model pins, trigger events, labels, thresholds, hashtag commands) *even when the diff doesn't touch those docs*. A model bump or trigger change that leaves the contributor-facing description asserting the old behavior is the same contradiction case: 🚨 when a doc claim is concretely contradicted by the diff.
+
 For the canonical risk catalog, consult `BUILD-AND-DEPLOY.md` §Infrastructure Change Review; for the runtime/build/dev split, §Dependency risk tiers.
 
 ## Do not flag

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -399,8 +399,8 @@ jobs:
       # staleness clock; a failed run or a stranded branch is "incomplete" and
       # stays due (retried next sweep up to the attempt cap). record-review.py
       # builds the canonical record, derives the PR facts from `gh`, stamps
-      # reviewed_at, increments attempts, uploads, and emits the dispatch signal.
-      # One article per run ⇒ one object, so writes never collide.
+      # reviewed_at, increments attempts, and uploads. One article per run ⇒
+      # one object, so writes never collide.
       - name: Record review ledger
         id: record
         if: always() && steps.ledger-bucket.outputs.uri != ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The repository runs a tiered review pipeline on every PR. AI-assisted contributo
 Transitioning to **Ready for review** triggers:
 
 1. A re-triage to refresh labels (domain, trivial / frontmatter-only short-circuits, prose-flagged signal if applicable).
-1. The full Claude review (currently `claude-opus-4-7`), composed per touched domain. Findings post to a single pinned comment at the top of the PR — overflow is appended as additional pinned comments tagged `<!-- CLAUDE_REVIEW N/M -->`.
+1. The full Claude review (currently `claude-opus-4-8`), composed per touched domain. Findings post to a single pinned comment at the top of the PR — overflow is appended as additional pinned comments tagged `<!-- CLAUDE_REVIEW N/M -->`.
 
 Mark the PR ready when you're done iterating, not when you start. Each ready-transition produces one full review run; thrashing through draft → ready → draft burns review budget and produces stale pinned comments.
 

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -33,9 +33,8 @@ Canonical record (every field always present):
 
 The record is written locally (audit artifact) and, when CONTENT_REVIEW_LEDGER_URI
 is set, uploaded to <uri>/<slug>.json with reviewed_at stamped to today (UTC).
-A `dispatch` / `pr_number` / `head_sha` signal is emitted to $GITHUB_OUTPUT for
-the workflow's review-dispatch step. Degrades gracefully: a missing bucket URI
-skips the upload (the page reappears next cycle) rather than failing the run.
+Degrades gracefully: a missing bucket URI skips the upload (the page reappears
+next cycle) rather than failing the run.
 
 Self-contained — run the smoke checks with `python3 record-review.py --self-test`.
 """
@@ -318,7 +317,7 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
     return rec
 
 
-# ---- outputs ----------------------------------------------------------------
+# ---- output -----------------------------------------------------------------
 
 
 def upload(record: dict, slug: str, uri: str) -> None:
@@ -335,23 +334,6 @@ def upload(record: dict, slug: str, uri: str) -> None:
         warn("aws CLI not available; ledger record not uploaded")
     except subprocess.CalledProcessError as e:
         warn(f"ledger upload failed for {slug} ({e})")
-
-
-def emit_outputs(record: dict) -> None:
-    """Write dispatch/pr_number/head_sha to $GITHUB_OUTPUT (or stdout)."""
-    dispatch = "true" if record["status"] == "reviewed" else "false"
-    lines = [
-        f"dispatch={dispatch}",
-        f"pr_number={record['pr_number']}",
-        f"head_sha={record['head_sha']}",
-        f"status={record['status']}",
-    ]
-    out_path = os.environ.get("GITHUB_OUTPUT")
-    if out_path:
-        with open(out_path, "a") as f:
-            f.write("\n".join(lines) + "\n")
-    for line in lines:
-        print(line)
 
 
 # ---- main -------------------------------------------------------------------
@@ -410,7 +392,6 @@ def run(args) -> int:
     else:
         warn("CONTENT_REVIEW_LEDGER_URI unset; ledger record written locally only")
 
-    emit_outputs(record)
     return 0
 
 


### PR DESCRIPTION
### Proposed changes

Implements §3.3 of the docs-review-automation evaluation (#20078): fix the two confirmed pieces of drift/dead code, and extend the infra review's doc-drift check so the pipeline guards its own meta-docs.

1. **`CONTRIBUTING.md`** — the review-model claim said `claude-opus-4-7`; the workflow (`claude-code-review.yml`) has pinned `claude-opus-4-8`. Doc now matches the workflow.
1. **`scripts/content-review/record-review.py`** — removed the dead `emit_outputs()` signal (`dispatch`/`pr_number`/`head_sha` to `$GITHUB_OUTPUT`). It fed a review-dispatch step the worker workflow no longer has (promotion rides the draft→ready transition), and nothing references `steps.record.outputs.*`. The `pr_number`/`head_sha` fields remain on the ledger record itself. Updated the module docstring and the workflow step comment (`content-review-article.yml`) that still described the signal. All `--self-test` smoke checks pass unchanged.
1. **`.claude/commands/docs-review/references/infra.md`** — §Documentation drift now mirrors its `BUILD-AND-DEPLOY.md` rule for the review pipeline's own meta-docs: when a PR touches the review workflows or skills, grep `CONTRIBUTING.md`/`AGENTS.md` for contradicted claims about models, triggers, labels, and thresholds even when those docs aren't in the diff — exactly how item 1 drifted.

Two notes for the issue, out of scope here:

- `check-links.yml` still pins `claude-opus-4-7` while both review workflows use `4-8` — a real workflow pin (possibly intentional cost tiering), needs a maintainer decision rather than a doc fix.
- §3.3's sub-claim that the emitted signal "tests a status value (`"reviewed"`) outside the recorder's current status vocabulary" is inaccurate — `reviewed` is a canonical ledger status (`record-review.py` docstring and `build_record`, exercised by the self-tests). The removal is justified by the unconsumed output alone.

Verification: `python3 scripts/content-review/record-review.py --self-test` passes; `make lint` passes (1781 files, 0 errors; Prettier clean); no dangling `emit_outputs`/`review-dispatch`/`dispatch=` references remain.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Part of #20078 (§3.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhnUeqDsHbqLiyGQD9eAoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhnUeqDsHbqLiyGQD9eAoD)_