### PR TITLE
Consolidate provider-building docs and correct SDK publishing guidance

### DIFF
--- a/content/docs/iac/concepts/packages/_index.md
+++ b/content/docs/iac/concepts/packages/_index.md
@@ -156,7 +156,7 @@ There are two common cases for authoring packages:
 If you are authoring a Pulumi component to be shared within your team or organization, you will need to decide whether to use local SDKs or publish SDKs. **Most component authors will want consumers to use local SDKs** for the following reasons:
 
 - Most component authors will want to use local SDKs because publishing SDKs requires significant overhead: your CI/CD process will need to generate SDKs for all Pulumi languages (or at least all the languages your package consumers will use) and you will need package feeds to host those published SDKs.
-- If you are authoring **components only** (not custom resources), you can write them in any Pulumi language. However, if you want to publish SDKs for your components, you'll need to use the [Pulumi Provider SDK](/docs/iac/guides/building-extending/providers/pulumi-provider-sdk/) (written in Go) to generate the schema that enables multi-language SDK generation. For components, this added complexity is usually not worth the effort compared to using local SDKs.
+- If you are authoring **components only** (not custom resources), you can write them in any Pulumi language and distribute them as a [source-based plugin package](/docs/iac/guides/building-extending/packages/source-based-plugin/). Pulumi introspects the package to generate a consumer-side SDK in any language, inferring the schema from your types automatically—you do **not** need the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/) to do this. By default consumers generate a local SDK at `pulumi package add` time, but you can also [pre-publish SDKs](/docs/iac/guides/building-extending/packages/source-based-plugin/#pre-publishing-language-sdks) to language registries (npm, PyPI, etc.) from any authoring language. Pre-publishing adds CI/CD and package-feed overhead, so for components it's usually not worth the effort compared to using local SDKs.
 
 For an example of building and publishing a component with local SDKs, see [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/).
 
@@ -164,7 +164,7 @@ For an example of building and publishing a component with local SDKs, see [Buil
 You can author a Pulumi package in any language, create a hand-authored schema, then generate and publish SDKs from that schema. However, this approach requires significant effort to manage at scale, as you'll need to maintain the schema manually and ensure it stays synchronized with your provider code.
 {{% /notes %}}
 
-However, using Pulumi Provider SDK and publishing SDKs might work better when:
+However, publishing SDKs—and, in some cases, compiling your component to a binary with the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/)—might work better when:
 
 - If the component is intended for internal use and your organization has security policies that restrict the ability of developers to install software on their devices (specifically, a required runtime for your package), writing your component in Go and publishing it as a binary with published SDKs hosted in an internal package feed will make it easier for consumers to use your package.
 - If you are intending to publish your component(s) in the Pulumi Registry for general public consumption, you should write your component in Go, and publish it as a binary with published SDKs hosted in the standard public package feeds (i.e., npm, PyPI, etc.). Note that the Pulumi Registry requires package contributors to generate SDKs in all languages Pulumi supports.
@@ -173,6 +173,6 @@ However, using Pulumi Provider SDK and publishing SDKs might work better when:
 
 ### Authoring a Pulumi provider
 
-If you are authoring a Pulumi provider that allows consumers to manage resources for a new cloud or SaaS provider, you should author your provider in Go using [Pulumi Provider SDK](/docs/iac/guides/building-extending/providers/pulumi-provider-sdk/).
+If you are authoring a Pulumi provider that allows consumers to manage resources for a new cloud or SaaS provider, you should author your provider in Go using the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/).
 
 For a guide to authoring your provider, see [Build a Provider](/docs/iac/guides/building-extending/providers/build-a-provider/). For a guide to publishing your provider in the Pulumi Registry, see [Publishing Pulumi Packages](/docs/iac/guides/building-extending/packages/publishing-packages/).

--- a/content/docs/iac/guides/building-extending/_index.md
+++ b/content/docs/iac/guides/building-extending/_index.md
@@ -47,7 +47,7 @@ Create custom providers to integrate new cloud platforms and services with Pulum
 
 **[Build a Provider](/docs/iac/guides/building-extending/providers/build-a-provider/)** - Step-by-step guide to building a Pulumi provider that enables infrastructure management for any API or service.
 
-**[Pulumi Provider SDK](/docs/iac/guides/building-extending/providers/pulumi-provider-sdk/)** - Reference documentation for the SDK used to build native Pulumi providers with full access to the resource model.
+**[Pulumi Go Provider SDK](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/)** - Reference documentation for the SDK used to build native Pulumi providers with full access to the resource model.
 
 **[Debugging Providers](/docs/iac/guides/building-extending/providers/debugging-providers/)** - Techniques and tools for troubleshooting provider development and diagnosing issues.
 

--- a/content/docs/iac/guides/building-extending/components/testing-components.md
+++ b/content/docs/iac/guides/building-extending/components/testing-components.md
@@ -161,4 +161,4 @@ This provides essential details for debugging interop issues and schema mismatch
 
 - [Build a Component](/docs/iac/using-pulumi/build-a-component/)
 - [Testing Pulumi Programs](/docs/iac/guides/testing/)
-- [Pulumi Provider SDK](/docs/iac/build-with-pulumi/pulumi-provider-sdk/)
+- [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/)

--- a/content/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk.md
+++ b/content/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk.md
@@ -25,6 +25,14 @@ aliases:
 
 The library uses Go reflection to derive the package's [schema](/docs/iac/guides/building-extending/packages/schema/) from your Go types, so multi-language SDKs can be generated without hand-authoring a JSON schema. Pulumi uses pulumi-go-provider internally for several of its own packages, including [`pulumi-command`](/registry/packages/command/).
 
+Compared to implementing the provider gRPC interface directly, pulumi-go-provider offers:
+
+- **Minimal code**: you define resources, functions, and components as Go structs and methods, and the library handles the RPC plumbing and generates the schema for multi-language SDKs.
+- **A built-in testing framework**: the `integration` package exercises providers in-process, without the Pulumi engine.
+- **Middleware**: layers that handle token dispatch, schema generation, and cancellation propagation.
+
+For a complete step-by-step walkthrough that builds a provider from scratch, see [Build a Provider](/docs/iac/guides/building-extending/providers/build-a-provider/).
+
 Useful links:
 
 - **Repository**: [pulumi/pulumi-go-provider](https://github.com/pulumi/pulumi-go-provider/) on GitHub
@@ -84,6 +92,8 @@ func (HelloWorld) Create(
 ```
 
 Sensible defaults are provided for any lifecycle method you don't implement. Because the example above doesn't implement `Diff` or `Update`, any input change replaces the resource. `Check` and `Read` confirm that inputs deserialize into `HelloWorldArgs`. `Delete` is a no-op.
+
+For a full walkthrough that implements every CRUD lifecycle method (`Create`, `Read`, `Update`, `Delete`, `Check`, and `Diff`), see [Build a Provider](/docs/iac/guides/building-extending/providers/build-a-provider/).
 
 ## Functions
 

--- a/content/docs/iac/guides/building-extending/providers/build-a-provider.md
+++ b/content/docs/iac/guides/building-extending/providers/build-a-provider.md
@@ -69,11 +69,7 @@ Pulumi providers can be written in any language that supports gRPC, and used in 
 
 We recommend using the Pulumi Go Provider SDK for Go providers, as it handles protocol complexity and generates schemas automatically. For other languages, or when you need full control over your schema and data structure mappings, use the [direct implementation](/docs/iac/guides/building-extending/providers/implementers/) approach.
 
-Some advantages of using the Pulumi Provider SDK:
-
-- **Minimal Code Required**: You define your resource types and implementation using Go structs and methods, and the SDK handles the rest (RPC, auto-generated schema for multi-language support, etc).
-- **Includes a Testing Framework**: Testing custom providers is made much easier with the SDK's built-in testing framework.
-- **Middleware Support**: Enhances providers with layers like dispatch logic, schema generation, and cancellation propagation.
+This guide focuses on building a custom resource. For the library's full capabilities—including [functions](/docs/iac/concepts/functions/) and [components](/docs/iac/concepts/components/), the built-in testing framework, and its internal architecture—see the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/) overview.
 
 ## Example: Build a custom `file` provider
 

--- a/content/docs/iac/guides/building-extending/providers/provider-configuration.md
+++ b/content/docs/iac/guides/building-extending/providers/provider-configuration.md
@@ -12,7 +12,7 @@ menu:
 
 A Pulumi provider can declare its own configuration keys, which users set via `pulumi config`, [Pulumi ESC](/docs/esc/) environments, or environment variables. Declaring configuration in the provider schema (rather than reading it ad hoc inside resource methods) gives you typed access in every language SDK, automatic secret handling, and automatic fallback to environment variables.
 
-This guide uses the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/providers/sdks/pulumi-go-provider-sdk/). For the underlying schema fields, see the [package schema reference](/docs/iac/guides/building-extending/packages/schema/#default).
+This guide uses the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/). For the underlying schema fields, see the [package schema reference](/docs/iac/guides/building-extending/packages/schema/#default).
 
 ## Declaring a config type
 

--- a/content/docs/idp/guides/publishing-from-github-actions.md
+++ b/content/docs/idp/guides/publishing-from-github-actions.md
@@ -107,7 +107,7 @@ clean:
 
 ### Unit Tests
 
-Write unit tests that validate your component's logic without creating cloud resources by using the `integration` library from the [Pulumi Provider SDK](/docs/iac/guides/building-extending/providers/pulumi-provider-sdk/). Here we can set up a mock provider server to catch calls for resource creation and return mock resources back.
+Write unit tests that validate your component's logic without creating cloud resources by using the `integration` library from the [Pulumi Go Provider SDK](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/). Here we can set up a mock provider server to catch calls for resource creation and return mock resources back.
 
 ```go
 // ./main_test.go


### PR DESCRIPTION
Consolidates the two overlapping provider/SDK docs pages and corrects a factual error about publishing SDKs. Fixes #18558.

## Changes
- **Build a Provider** → now purely the hands-on tutorial; dropped the duplicated SDK value-prop, added a pointer to the SDK overview.
- **Pulumi Go Provider SDK** → now the library reference; absorbed the value-prop, added the missing back-link to the tutorial and a pointer to the full CRUD walkthrough.
- Corrected `concepts/packages/` which wrongly implied the Go Provider SDK is required to publish component SDKs — source-based plugins can pre-publish SDKs in any language.
- Repointed 6 stale inbound links to the SDK page's canonical `packages/` path.