### PR TITLE
Document args.opts and the parent resource option in policy authoring

### DIFF
--- a/content/docs/insights/policy/policy-packs/authoring.md
+++ b/content/docs/insights/policy/policy-packs/authoring.md
@@ -640,6 +640,96 @@ When writing policies for dynamic providers:
 
 1. **Document your assumptions**: Clearly document which properties your policy uses to identify dynamic providers so that changes to the dynamic provider implementation don't inadvertently break policy enforcement.
 
+## Inspecting resource options
+
+Resource validation callbacks receive an `args.opts` object of type `PolicyResourceOptions`. It mirrors the [resource options](/docs/iac/concepts/options/) set on the resource under validation, letting policies make decisions based on how a resource is configured rather than only its properties. The available fields are:
+
+- `protect` — whether the resource is protected from deletion.
+- `ignoreChanges` (`ignore_changes` in Python) — properties whose changes the engine ignores.
+- `deleteBeforeReplace` (`delete_before_replace`) — whether the resource is deleted before its replacement is created.
+- `aliases` — additional URNs aliased to the resource.
+- `customTimeouts` (`custom_timeouts`) — custom create, update, and delete timeouts.
+- `additionalSecretOutputs` (`additional_secret_outputs`) — outputs always treated as secrets.
+- `parent` — the [URN](/docs/iac/concepts/resources/names/#urns) of the resource's [parent](/docs/iac/concepts/options/parent/). For a resource created directly at the stack root rather than as a child of another resource or component, this is the URN of the root stack resource (type `pulumi:pulumi:Stack`).
+
+### Example: Enforcing a resource's parent
+
+The `parent` option is useful for enforcing that certain resources are only created as children of the component that is supposed to manage them, rather than loose at the stack root or under the wrong parent. Because `parent` is the parent's URN, you can extract the parent's type token from it: a URN has the form `urn:pulumi:{stack}::{project}::{parentType}${resourceType}::{name}`, so the type is the third `::`-delimited segment, and the resource's own type is the token after the last `$`.
+
+The following example requires that every `aws:rds/instance:Instance` is a child of a `my:components:Database` component:
+
+{{< chooser language "typescript,python" >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+import * as aws from "@pulumi/aws";
+import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
+
+const requiredParentType = "my:components:Database";
+
+new PolicyPack("parent-policies", {
+    policies: [{
+        name: "rds-instance-parent",
+        description: "Requires RDS instances to be managed by a Database component.",
+        enforcementLevel: "mandatory",
+        validateResource: validateResourceOfType(aws.rds.Instance, (instance, args, reportViolation) => {
+            // args.opts.parent is the parent's URN; for a resource at the stack root it is the root stack's URN (type pulumi:pulumi:Stack).
+            const parentUrn = args.opts.parent;
+            const parentType = parentUrn?.split("::")[2]?.split("$").pop();
+            if (parentType !== requiredParentType) {
+                reportViolation(
+                    `RDS instances must be a child of a '${requiredParentType}' component.`);
+            }
+        }),
+    }],
+});
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```python
+from pulumi_policy import (
+    EnforcementLevel,
+    PolicyPack,
+    ReportViolation,
+    ResourceValidationArgs,
+    ResourceValidationPolicy,
+)
+
+REQUIRED_PARENT_TYPE = "my:components:Database"
+
+def rds_instance_parent(args: ResourceValidationArgs, report_violation: ReportViolation):
+    if args.resource_type == "aws:rds/instance:Instance":
+        # args.opts.parent is the parent's URN; for a resource at the stack root it is the root stack's URN (type pulumi:pulumi:Stack).
+        parent_urn = args.opts.parent
+        parent_type = parent_urn.split("::")[2].split("$")[-1] if parent_urn else None
+        if parent_type != REQUIRED_PARENT_TYPE:
+            report_violation(
+                f"RDS instances must be a child of a '{REQUIRED_PARENT_TYPE}' component.")
+
+PolicyPack(
+    "parent-policies",
+    policies=[
+        ResourceValidationPolicy(
+            name="rds-instance-parent",
+            description="Requires RDS instances to be managed by a Database component.",
+            enforcement_level=EnforcementLevel.MANDATORY,
+            validate=rds_instance_parent,
+        ),
+    ],
+)
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}
+
+{{% notes type="info" %}}
+`args.opts` is available on `ResourceValidationArgs` (resource validation policies), not on `StackValidationArgs`. To reason about parent-child relationships across the full resource graph, use a [stack validation policy](#stack-validation-policies) and inspect `args.resources`. See [resource options](/docs/iac/concepts/options/) for what each option means on the resource side.
+{{% /notes %}}
+
 ## Running policies locally
 
 Test your policy pack locally before publishing.


### PR DESCRIPTION
## Description

Documents the `args.opts` (`PolicyResourceOptions`) object available on CrossGuard resource validation callbacks, and the scenarios its `parent` field enables — specifically enforcing that a resource is only created as a child of the component that should manage it.

Previously, `args.opts` and its `parent` field existed only in the auto-generated SDK reference and were undocumented in prose anywhere under `content/docs/`.

## Changes

Adds one new `## Inspecting resource options` section to `content/docs/insights/policy/policy-packs/authoring.md` (placed after the dynamic-providers section):

- Intro prose documenting all seven `PolicyResourceOptions` fields (`protect`, `ignoreChanges`, `deleteBeforeReplace`, `aliases`, `customTimeouts`, `additionalSecretOutputs`, `parent`), verified against the `@pulumi/policy` SDK reference.
- A worked TypeScript + Python example (`### Example: Enforcing a resource's parent`) that reads `args.opts.parent` (the parent's URN) and reports a violation unless an RDS instance is a child of a specific component type. TypeScript uses the typed `validateResourceOfType` helper (no manual type check); Python uses the `args.resource_type ==` guard.
- An info callout clarifying `opts` is on `ResourceValidationArgs` (resource validation), not stack validation, and pointing to the resource-options concept docs.

## Verification

- `make lint` passes.
- Built locally with `make serve`; the page renders at HTTP 200, the TS/Python chooser toggles correctly, and all internal links (`/docs/iac/concepts/options/`, `/docs/iac/concepts/options/parent/`, `#urns`, `#stack-validation-policies`) resolve.
- URN-parsing snippet hand-verified against the canonical URN format.

Fixes #14473

🤖 Generated with [Claude Code](https://claude.com/claude-code)