### PR TITLE
docs-review: don't publish truncated review bodies from the validator-fix splice lane

### DIFF
--- a/.claude/commands/docs-review/scripts/test_validator_fix.py
+++ b/.claude/commands/docs-review/scripts/test_validator_fix.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Unit tests for validator-fix.py.
+
+Self-contained — run with `python3 test_validator_fix.py` (no pytest dep).
+Imports the module directly and exercises `extract_splice_output()`, the
+guard that decides whether a Messages API response can be trusted as a
+full-body echo. Regression tests for pulumi/docs#20135, where a
+`stop_reason == "max_tokens"` truncation passed the old emptiness-only
+check and the amputated review body got published.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MODULE_PATH = HERE / "validator-fix.py"
+
+_spec = importlib.util.spec_from_file_location("validator_fix", MODULE_PATH)
+validator_fix = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(validator_fix)  # type: ignore[union-attr]
+
+extract_splice_output = validator_fix.extract_splice_output
+
+BODY = "### 🔍 Verification trail\n\n" + "\n".join(
+    f"- L{n} in `file.md` \"claim text {n}\" → ✅ verified" for n in range(40)
+)
+
+
+def _payload(text: str, stop_reason: str = "end_turn") -> dict:
+    return {
+        "content": [{"type": "text", "text": text}],
+        "stop_reason": stop_reason,
+    }
+
+
+def test_full_echo_passes() -> None:
+    out = extract_splice_output(_payload(BODY), len(BODY))
+    assert out == BODY, "verbatim full-length echo must be accepted"
+
+
+def test_max_tokens_rejected_even_with_content() -> None:
+    truncated = BODY[: len(BODY) // 2]
+    out = extract_splice_output(_payload(truncated, stop_reason="max_tokens"), len(BODY))
+    assert out is None, "max_tokens response must be discarded regardless of content"
+
+
+def test_max_tokens_rejected_even_at_full_length() -> None:
+    # Belt and suspenders: stop_reason wins even if the length looks fine.
+    out = extract_splice_output(_payload(BODY, stop_reason="max_tokens"), len(BODY))
+    assert out is None, "max_tokens response must be discarded even at full length"
+
+
+def test_empty_content_rejected() -> None:
+    out = extract_splice_output(_payload(""), len(BODY))
+    assert out is None, "empty content must be discarded"
+
+
+def test_missing_content_rejected() -> None:
+    out = extract_splice_output({"stop_reason": "end_turn"}, len(BODY))
+    assert out is None, "missing content block must be discarded"
+
+
+def test_shrunken_echo_rejected() -> None:
+    shrunk = BODY[: int(len(BODY) * 0.5)]
+    out = extract_splice_output(_payload(shrunk), len(BODY))
+    assert out is None, "echo far below the shrink floor must be discarded"
+
+
+def test_lightly_edited_echo_passes() -> None:
+    edited = BODY[: int(len(BODY) * 0.95)]
+    out = extract_splice_output(_payload(edited), len(BODY))
+    assert out == edited, "echo within the shrink floor must be accepted"
+
+
+def test_code_fence_stripped_before_length_check() -> None:
+    fenced = "```markdown\n" + BODY + "\n```"
+    out = extract_splice_output(_payload(fenced), len(BODY))
+    assert out == BODY, "fence wrapper must be stripped and the body accepted"
+
+
+TESTS = [
+    test_full_echo_passes,
+    test_max_tokens_rejected_even_with_content,
+    test_max_tokens_rejected_even_at_full_length,
+    test_empty_content_rejected,
+    test_missing_content_rejected,
+    test_shrunken_echo_rejected,
+    test_lightly_edited_echo_passes,
+    test_code_fence_stripped_before_length_check,
+]
+
+
+def main() -> int:
+    failures: list[tuple[str, str]] = []
+    for t in TESTS:
+        name = t.__name__
+        try:
+            t()
+            print(f"  ok  {name}")
+        except AssertionError as e:
+            failures.append((name, str(e) or "assertion failed"))
+            print(f"  FAIL {name}: {e}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  ERROR {name}:\n{traceback.format_exc()}")
+    print()
+    if failures:
+        print(f"{len(failures)}/{len(TESTS)} tests failed")
+        return 1
+    print(f"{len(TESTS)}/{len(TESTS)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/validator-fix.py
+++ b/.claude/commands/docs-review/scripts/validator-fix.py
@@ -83,10 +83,19 @@ MAX_RETRIES = 3  # API-level retries on 429 / 5xx / transient network
 # Maximum response tokens. The whole review body is echoed back verbatim, so
 # this must exceed the body's token count or the splice truncates. A ~60K-char
 # body is ~12K output tokens on Sonnet 4.6; Sonnet 5's ~30%-heavier tokenizer
-# pushes the same body to ~15-16K, which left almost no headroom under the old
-# 16K cap — so the cap is now 24K (still a single non-streamed response well
-# under SPLICE_TIMEOUT_S). Goes in the messages.create `max_tokens` field.
-MAX_OUTPUT_TOKENS = 24000
+# pushes the same body to ~15-16K. The 24K cap sized from that (~3.85 chars/
+# token) still truncated a trail-heavy body on pulumi/docs#20135: the 🔍 trail's
+# emoji/URL/citation density runs ~2.6 chars/token, so a ~70K-char body blew
+# past 24K and the amputated echo got posted. Cap is now 32K, and
+# extract_splice_output() rejects `stop_reason == "max_tokens"` outright so a
+# cap overrun defers to soft-floor (intact body) instead of publishing a
+# truncated one. Goes in the messages.create `max_tokens` field.
+MAX_OUTPUT_TOKENS = 32000
+# Minimum acceptable output/input length ratio for the body echo. Surgical
+# splices edit lines in place (reword a parenthetical, move a bullet) — they
+# never remove more than a few lines — so an echo materially shorter than the
+# input means the model dropped content even if stop_reason looks clean.
+SHRINK_FLOOR = 0.9
 # Maximum number of surgical violations to fold into a single batched Haiku
 # call. Pre-v16 was N sequential calls (each one rewrites the whole ~50KB
 # body — ~12K output tokens × ~250 tok/s = ~50s/call); a hot review with 30
@@ -432,7 +441,55 @@ def build_batched_prompt(violations: list[dict], body: str) -> str:
     )
 
 
-def dispatch_splice(prompt: str, api_key: str) -> str | None:
+def extract_splice_output(payload: dict, input_body_len: int) -> str | None:
+    """Extract the edited body from a Messages API response payload, or None
+    if the response cannot be trusted as a full-body echo.
+
+    Rejects (returns None, caller defers to soft-floor with the intact body):
+    - `stop_reason == "max_tokens"` — the echo hit the output cap and is
+      truncated mid-word. This is exactly what mangled pulumi/docs#20135:
+      the truncated body is non-empty, so an emptiness check alone lets it
+      through, Step D then sees 15 structural violations (amputated H3
+      sections), and the soft-floor path publishes the stump.
+    - Output shorter than SHRINK_FLOOR of the input body — surgical splices
+      edit lines in place; any wholesale shrink means content was lost.
+    """
+    stop_reason = payload.get("stop_reason")
+    if stop_reason == "max_tokens":
+        print(
+            "validator-fix.py: splice response hit max_tokens "
+            f"(cap {MAX_OUTPUT_TOKENS}) — body echo is truncated; discarding",
+            file=sys.stderr,
+        )
+        return None
+    content = payload.get("content") or []
+    text_parts = [c.get("text", "") for c in content if isinstance(c, dict) and c.get("type") == "text"]
+    output = "".join(text_parts).strip()
+    if not output:
+        print(
+            f"validator-fix.py: splice model returned empty content "
+            f"(stop_reason={stop_reason!r})",
+            file=sys.stderr,
+        )
+        return None
+    # Defensive: strip code fences if the model wrapped the output despite
+    # the system prompt's instruction.
+    if output.startswith("```"):
+        lines = output.splitlines()
+        if lines[0].startswith("```") and lines[-1].startswith("```"):
+            output = "\n".join(lines[1:-1])
+    if len(output) < SHRINK_FLOOR * input_body_len:
+        print(
+            f"validator-fix.py: splice output is {len(output)} chars vs "
+            f"{input_body_len} input (< {SHRINK_FLOOR:.0%} floor) — "
+            f"body echo lost content (stop_reason={stop_reason!r}); discarding",
+            file=sys.stderr,
+        )
+        return None
+    return output
+
+
+def dispatch_splice(prompt: str, api_key: str, input_body_len: int) -> str | None:
     """Run one splice call (Sonnet 5) via the Anthropic Messages API.
     Returns the edited body or None on error.
 
@@ -506,23 +563,7 @@ def dispatch_splice(prompt: str, api_key: str) -> str | None:
 
     # Successful 2xx → extract the assistant text content. The response shape:
     #   {"content": [{"type":"text","text":"<edited body>"}, ...], ...}
-    content = payload.get("content") or []
-    text_parts = [c.get("text", "") for c in content if isinstance(c, dict) and c.get("type") == "text"]
-    output = "".join(text_parts).strip()
-    if not output:
-        print(
-            f"validator-fix.py: splice model returned empty content "
-            f"(stop_reason={payload.get('stop_reason')!r})",
-            file=sys.stderr,
-        )
-        return None
-    # Defensive: strip code fences if Haiku wrapped the output despite
-    # the system prompt's instruction.
-    if output.startswith("```"):
-        lines = output.splitlines()
-        if lines[0].startswith("```") and lines[-1].startswith("```"):
-            output = "\n".join(lines[1:-1])
-    return output
+    return extract_splice_output(payload, input_body_len)
 
 
 def main() -> int:
@@ -599,7 +640,7 @@ def main() -> int:
     for rule_id in rule_order:
         rule_violations = by_rule[rule_id]
         prompt = build_batched_prompt(rule_violations, body)
-        edited = dispatch_splice(prompt, api_key)
+        edited = dispatch_splice(prompt, api_key, len(body))
         if edited is None:
             print(
                 f"validator-fix.py: splice dispatch failed for rule "


### PR DESCRIPTION
## Why

The pinned review on #20135 kept posting cut off mid-word (`CLAUDE_REVIEW 2/2` ended partway through a verification-trail entry). Root cause, confirmed from run [29058382560](https://github.com/pulumi/docs/actions/runs/29058382560): `validator-fix.py` echoes the entire review body through one Messages API call, and on a trail-heavy body (~2.6 chars/token — denser than the ~3.85 the 24K cap was sized for) the echo hit `max_tokens` and came back truncated. The truncated body is non-empty, so the emptiness-only check accepted it and wrote it over `.review-draft.md`. Step D re-validation then reported 15 structural violations (amputated H3 sections), which routed to `--soft-floor` and published the stump. Deterministic, so every `#new-review` truncated at the same spot.

## What

- New `extract_splice_output()` guard in `validator-fix.py`: discards responses with `stop_reason == "max_tokens"`, and any echo shorter than 90% of the input body (`SHRINK_FLOOR`). Both paths defer to soft-floor with the **intact** body — a review with a few cosmetic violations beats one missing its 🚨 Outstanding section.
- `MAX_OUTPUT_TOKENS` raised 24K → 32K so bodies like #20135's can actually complete the splice.
- `test_validator_fix.py`: self-contained unit tests for the guard (same conventions as `test_splicer.py`), 8/8 passing.

## Testing

- `python3 test_validator_fix.py` — 8/8 pass; `python3 test_splicer.py` still 25/25.
- After merge, a fresh `@claude #new-review` on #20135 should post the complete review.