### PR TITLE
Add LOPUG 2026 talk to Engin Diri's speaker page

### DIFF
--- a/content/community/team/engin-diri.md
+++ b/content/community/team/engin-diri.md
@@ -9,6 +9,10 @@ aliases:
   - /engin
   - /community/community-engineering/engin-diri/
 talks:
+- event: "London Platform User Group (LOPUG)"
+  title: "Stop Wasting GPUs: How We Built a Golden Path for GPU Sharing on Kubernetes"
+  url: "https://www.meetup.com/london-platform-user-group-lopug/events/313277993/"
+  date: 2026-07-08T18:30:00.000+01:00
 - event: "Cloud Native Summit Munich 2026"
   title: "The Ralph Wiggum Loop: How Autonomous AI Loops Built My Serverless SaaS While I Slept"
   url: "https://www.cnsmunich.com/schedule/"


### PR DESCRIPTION
Adds my upcoming talk at the **London Platform User Group (LOPUG)** to my speaker page.

- **Talk:** Stop Wasting GPUs: How We Built a Golden Path for GPU Sharing on Kubernetes
- **Event:** London Platform User Group (LOPUG)
- **When/where:** Wednesday, July 8, 2026, 6:30 PM BST — Telephone House, Shoreditch, London
- **Link:** https://www.meetup.com/london-platform-user-group-lopug/events/313277993/

Single 4-line addition to the `talks` list in `content/community/team/engin-diri.md`, placed at the top to preserve the list's reverse-chronological order.