### PR TITLE
Document experimental features policy

### DIFF
--- a/content/docs/iac/cli/environment-variables.md
+++ b/content/docs/iac/cli/environment-variables.md
@@ -375,7 +375,7 @@ aliases:
     </dt>
     <dd>
         <p>
-            Enables experimental options and commands.
+            Enables experimental options and commands. See <a href="/docs/support/faq/infrastructure/#what-does-experimental-mean">What does "experimental" mean?</a> for what to expect.
         </p>
         <pre><code class="text-xs">PULUMI_EXPERIMENTAL=true</code></pre>
     </dd>

--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -154,9 +154,9 @@ Keys that include an explicit namespace other than the project name (such as `aw
 
 ## Generate an update plan
 
-{{% notes type="warning" %}}
-[Update plans](/docs/concepts/plans/) are currently in experimental preview and will only show up in `--help` if the environment variable `PULUMI_EXPERIMENTAL` is set to `true`.
-{{% /notes %}}
+{{% experimental-feature %}}
+[Update plans](/docs/concepts/plans/) only show up in `--help` when the environment variable `PULUMI_EXPERIMENTAL` is set to `true`.
+{{% /experimental-feature %}}
 
 To preview an update of the currently selected stack and save that plan run `pulumi preview --save-plan=plan.json`. The operation uses the latest [configuration values](/docs/concepts/config/) for the active stack.
 

--- a/content/docs/iac/operations/stack-management/update-plans.md
+++ b/content/docs/iac/operations/stack-management/update-plans.md
@@ -70,6 +70,8 @@ they're used).
 
 ## Format
 
+{{< experimental-feature />}}
+
 The format of update plans is currently experimental and subject to change. The most up to date description of
 the format is the [code](https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/plan.go).
 

--- a/content/docs/support/faq/infrastructure.md
+++ b/content/docs/support/faq/infrastructure.md
@@ -6,7 +6,7 @@ h1: Infrastructure as Code FAQ
 menu:
     support:
         parent: support-faq
-        name: Infrastructure FAQ
+        name: IaC FAQ
         weight: 1
         identifier: support-faq-infrastructure
 aliases:
@@ -83,6 +83,12 @@ Pulumi is a declarative tool that uses imperative languages to define your end s
 ### How will Pulumi make me more productive?
 
 Pulumi uses strongly typed languages with programming languages that support [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense) and the [Language Server Protocol](https://en.wikipedia.org/wiki/Language_Server_Protocol) which means when you are defining Pulumi programs, you rarely need to leave your IDE.
+
+## Experimental features
+
+### What does "experimental" mean?
+
+Some Pulumi functionality is released as _experimental_. Experimental features are always opt-in: you enable them explicitly with a flag, command, or environment variable (such as `PULUMI_EXPERIMENTAL=true`). They are not necessarily supported, and they can change or be removed at any time without a deprecation cycle, so you should not rely on them for production workflows. When an experimental feature proves valuable, Pulumi invests in stabilizing it and promoting it to general availability, but until then its behavior can't be relied on.
 
 ## Provider Version Support
 

--- a/layouts/shortcodes/experimental-feature.html
+++ b/layouts/shortcodes/experimental-feature.html
@@ -1,0 +1,13 @@
+{{- $text := "This is an **experimental feature**. Experimental features are opt-in (enabled with a flag, command, or environment variable), may change or be removed at any time, and are not necessarily supported. See [What does \"experimental\" mean?](/docs/support/faq/infrastructure/#what-does-experimental-mean) for details." -}}
+<div class="note note-warning">
+    <div class="icon-and-line">
+        {{ partial "icon.html" (dict "name" "warning" "weight" "fill") }}
+        <div class="line"></div>
+    </div>
+    <div class="content">
+        {{ $text | markdownify }}
+        {{- with .Inner }}
+        {{ . | markdownify }}
+        {{- end }}
+    </div>
+</div>

--- a/layouts/shortcodes/experimental-feature.markdown.md
+++ b/layouts/shortcodes/experimental-feature.markdown.md
@@ -1,0 +1,4 @@
+{{- $text := "This is an **experimental feature**. Experimental features are opt-in (enabled with a flag, command, or environment variable), may change or be removed at any time, and are not necessarily supported. See What does \"experimental\" mean? (/docs/support/faq/infrastructure/#what-does-experimental-mean) for details." -}}
+{{- $inner := trim (printf "%s" .Inner) " \t\n\r" -}}
+
+> **Warning:** {{ $text }}{{ with $inner }} {{ . }}{{ end }}


### PR DESCRIPTION
Documents Pulumi's official stance on experimental features and adds a reusable warning shortcode so the notice renders consistently across the site.

## Changes
- Add a "What does 'experimental' mean?" answer to the IaC FAQ (and rename its nav label to "IaC FAQ")
- Add an `experimental-feature` shortcode (warning-style note, HTML + markdown output) linking to the FAQ answer
- Retrofit existing experimental mentions in stacks, update-plans, and the `PULUMI_EXPERIMENTAL` CLI env-var entry to use the shortcode / FAQ link

Fixes #11649