### PR TITLE
Close superseded CLI regen PRs so they can't go stale-conflicted

### DIFF
--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -8,6 +8,13 @@ env:
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 name: Update latest-dev-version
+
+# Serialize runs: dev builds can dispatch minutes apart, and a queue of pending
+# runs collapses to the newest one, which carries the newest version anyway.
+concurrency:
+  group: pulumi-cli-dev-version
+  cancel-in-progress: false
+
 on:
   repository_dispatch:
     types:
@@ -57,6 +64,26 @@ jobs:
         uses: pulumi/esc-action@v3
       - name: checkout docs repo
         uses: actions/checkout@v7
+      # A still-open dev-version PR is superseded by this run's newer build. Left
+      # alone it goes permanently conflicted the moment this run's PR merges (both
+      # rewrite the same line of static/latest-dev-version), so close it up front.
+      # Best-effort: a failed close only leaves a conflicted PR for the next run
+      # to close; it must not block publishing the new version.
+      - name: Close superseded dev-version PRs
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          DEV_VERSION: ${{ github.event.inputs.dev_version || github.event.client_payload.dev_version }}
+        run: |
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --author pulumi-bot --label automation/pulumi-cli-docs --state open \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("Regen dev version")) | .number') \
+            || { echo "::warning::Failed to list open dev-version PRs; skipping supersede step."; exit 0; }
+          for pr in $prs; do
+            gh pr close "$pr" --repo "$GITHUB_REPOSITORY" --delete-branch \
+              --comment "Superseded by dev build \`$DEV_VERSION\` ($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID); closing so it can't go stale-conflicted." \
+              || echo "::warning::Failed to close superseded PR #$pr; the next dev-version run will retry."
+          done
       - name: Update latest version
         run: |
           echo -n "${{ github.event.inputs.dev_version || github.event.client_payload.dev_version }}" > ./static/latest-dev-version

--- a/.github/workflows/pulumi-cli-dev-version.yml
+++ b/.github/workflows/pulumi-cli-dev-version.yml
@@ -54,6 +54,32 @@ jobs:
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+      # A still-open older dev-version PR is superseded by the PR this run just
+      # opened. Left alone it goes permanently conflicted the moment the newer PR
+      # merges (both rewrite the same line of static/latest-dev-version), so close
+      # it. Runs only after the successor PR exists, so a failed run never leaves
+      # us with no open dev-version PR. If the predecessor auto-merges in the
+      # brief window before this step closes it, this run's PR goes conflicted
+      # instead — and the next run's sweep closes it. Best-effort: a failed
+      # list/close only leaves a conflicted PR for the next run to clean up.
+      - name: Close superseded dev-version PRs
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          DEV_VERSION: ${{ github.event.inputs.dev_version || github.event.client_payload.dev_version }}
+          NEW_PR: ${{ steps.create-pr.outputs.pr_number }}
+        run: |
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --author pulumi-bot --label automation/pulumi-cli-docs --state open \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("Regen dev version")) | .number') \
+            || { echo "::warning::Failed to list open dev-version PRs; skipping supersede step."; exit 0; }
+          for pr in $prs; do
+            [ "$pr" = "$NEW_PR" ] && continue
+            gh pr close "$pr" --repo "$GITHUB_REPOSITORY" --delete-branch \
+              --comment "Superseded by dev build \`$DEV_VERSION\` (#$NEW_PR, $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID); closing so it can't go stale-conflicted." \
+              || echo "::warning::Failed to close superseded PR #$pr; the next dev-version run will retry."
+          done
   update-latest-dev-version:
     runs-on: ubuntu-latest
     outputs:
@@ -64,26 +90,6 @@ jobs:
         uses: pulumi/esc-action@v3
       - name: checkout docs repo
         uses: actions/checkout@v7
-      # A still-open dev-version PR is superseded by this run's newer build. Left
-      # alone it goes permanently conflicted the moment this run's PR merges (both
-      # rewrite the same line of static/latest-dev-version), so close it up front.
-      # Best-effort: a failed close only leaves a conflicted PR for the next run
-      # to close; it must not block publishing the new version.
-      - name: Close superseded dev-version PRs
-        env:
-          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-          DEV_VERSION: ${{ github.event.inputs.dev_version || github.event.client_payload.dev_version }}
-        run: |
-          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
-            --author pulumi-bot --label automation/pulumi-cli-docs --state open \
-            --json number,title \
-            --jq '.[] | select(.title | startswith("Regen dev version")) | .number') \
-            || { echo "::warning::Failed to list open dev-version PRs; skipping supersede step."; exit 0; }
-          for pr in $prs; do
-            gh pr close "$pr" --repo "$GITHUB_REPOSITORY" --delete-branch \
-              --comment "Superseded by dev build \`$DEV_VERSION\` ($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID); closing so it can't go stale-conflicted." \
-              || echo "::warning::Failed to close superseded PR #$pr; the next dev-version run will retry."
-          done
       - name: Update latest version
         run: |
           echo -n "${{ github.event.inputs.dev_version || github.event.client_payload.dev_version }}" > ./static/latest-dev-version

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -7,6 +7,13 @@ env:
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 name: Pulumi CLI docs
+
+# Serialize runs so two release regens can't open PRs that conflict on the
+# shared generated files (static/latest-version, data/versions.json, CLI pages).
+concurrency:
+  group: pulumi-cli-docs
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
@@ -76,6 +83,27 @@ jobs:
           version: ${{ env.PULUMI_VERSION }}
       - name: checkout docs repo
         uses: actions/checkout@v7
+      # A still-open CLI-docs PR is superseded by this run's newer release and
+      # would go permanently conflicted (both rewrite static/latest-version and
+      # data/versions.json) once this run's PR merges — close it up front.
+      # Best-effort: a failed close must not block regenerating the docs.
+      # Skipped for publish_only backfills, which open no PR and must not close
+      # a live one.
+      - name: Close superseded CLI-docs PRs
+        if: github.event.inputs.publish_only != 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+        run: |
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --author pulumi-bot --label automation/pulumi-cli-docs --state open \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("Generate Pulumi CLI docs")) | .number') \
+            || { echo "::warning::Failed to list open CLI-docs PRs; skipping supersede step."; exit 0; }
+          for pr in $prs; do
+            gh pr close "$pr" --repo "$GITHUB_REPOSITORY" --delete-branch \
+              --comment "Superseded by the regen for \`v$PULUMI_VERSION\` ($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID); closing so it can't go stale-conflicted." \
+              || echo "::warning::Failed to close superseded PR #$pr; the next CLI-docs run will retry."
+          done
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3
         with:

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -68,6 +68,31 @@ jobs:
         run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+      # A still-open older CLI-docs PR is superseded by the PR this run just
+      # opened and would go permanently conflicted (both rewrite
+      # static/latest-version and data/versions.json) the moment the newer PR
+      # merges — so close it. Runs only after the successor PR exists, so a
+      # failed run never leaves us with no open CLI-docs PR. Best-effort: a
+      # failed list/close only leaves a conflicted PR for the next run to clean
+      # up. (publish_only backfills never reach this job, so they can't close a
+      # live PR.)
+      - name: Close superseded CLI-docs PRs
+        if: steps.create-pr.outputs.pr_created == 'true' && github.event.inputs.skip_auto_merge != 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          NEW_PR: ${{ steps.create-pr.outputs.pr_number }}
+        run: |
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --author pulumi-bot --label automation/pulumi-cli-docs --state open \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("Generate Pulumi CLI docs")) | .number') \
+            || { echo "::warning::Failed to list open CLI-docs PRs; skipping supersede step."; exit 0; }
+          for pr in $prs; do
+            [ "$pr" = "$NEW_PR" ] && continue
+            gh pr close "$pr" --repo "$GITHUB_REPOSITORY" --delete-branch \
+              --comment "Superseded by the regen for \`v$PULUMI_VERSION\` (#$NEW_PR, $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID); closing so it can't go stale-conflicted." \
+              || echo "::warning::Failed to close superseded PR #$pr; the next CLI-docs run will retry."
+          done
   build-pulumi-cli-docs:
     runs-on: ubuntu-latest
     outputs:
@@ -83,27 +108,6 @@ jobs:
           version: ${{ env.PULUMI_VERSION }}
       - name: checkout docs repo
         uses: actions/checkout@v7
-      # A still-open CLI-docs PR is superseded by this run's newer release and
-      # would go permanently conflicted (both rewrite static/latest-version and
-      # data/versions.json) once this run's PR merges — close it up front.
-      # Best-effort: a failed close must not block regenerating the docs.
-      # Skipped for publish_only backfills, which open no PR and must not close
-      # a live one.
-      - name: Close superseded CLI-docs PRs
-        if: github.event.inputs.publish_only != 'true'
-        env:
-          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-        run: |
-          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
-            --author pulumi-bot --label automation/pulumi-cli-docs --state open \
-            --json number,title \
-            --jq '.[] | select(.title | startswith("Generate Pulumi CLI docs")) | .number') \
-            || { echo "::warning::Failed to list open CLI-docs PRs; skipping supersede step."; exit 0; }
-          for pr in $prs; do
-            gh pr close "$pr" --repo "$GITHUB_REPOSITORY" --delete-branch \
-              --comment "Superseded by the regen for \`v$PULUMI_VERSION\` ($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID); closing so it can't go stale-conflicted." \
-              || echo "::warning::Failed to close superseded PR #$pr; the next CLI-docs run will retry."
-          done
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3
         with:


### PR DESCRIPTION
### Proposed changes

A few times a day, an automated "Regen dev version pulumi@…" PR ends up permanently conflicted and never auto-merges (e.g. #20185, #20094). Root cause: each `pulumi-cli-dev-version` dispatch opens a fresh PR off master rewriting the same one-line `static/latest-dev-version` file, and auto-merge takes ~15 minutes of CI. A dev build arriving inside that window branches without the in-flight PR's change, so the moment the earlier PR merges, the later one goes `dirty` forever — auto-merge stalls silently, later builds merge around it, and the orphan lingers until someone closes it by hand.

Since each new dispatch carries a strictly newer build, a still-open regen PR is superseded by definition. This PR fixes the mechanics at the source in both regen workflows (`pulumi-cli-dev-version.yml` and the release-driven `pulumi-cli-docs.yml`):

1. **Close superseded predecessors once the successor PR exists**: after each run opens its own PR (and arms auto-merge), it closes still-open predecessors with an explanatory comment + branch deletion. Ordering matters: closing only after a successful open means a failed run never leaves us with zero open regen PRs, and a no-change dispatch touches nothing. If a predecessor auto-merges in the brief window before it's closed, this run's PR goes conflicted instead — and the next run's sweep closes it, so nothing lingers. Scoped by title prefix (`Regen dev version` / `Generate Pulumi CLI docs`) since both workflows share the `automation/pulumi-cli-docs` label and must not close each other's PRs, and the run's own PR number is excluded. Best-effort: a failed list/close only leaves a conflicted PR for the next run to clean up.
1. **Serialize dispatches** with a per-workflow `concurrency` group (`cancel-in-progress: false`); a collapsed pending queue keeps the newest run, which carries the newest version anyway.
1. The supersede steps are skipped for `skip_auto_merge` test runs, and `publish_only` backfills never reach the pull-request job, so neither can close a live PR.

Verified: both workflows parse as YAML, and the `jq` title-prefix filters were dry-run against captured `gh pr list`-shaped JSON (each selects exactly its own workflow's PRs). Behavior changes only take effect once this merges to master, since `repository_dispatch` runs use the workflow file on the default branch.

### Unreleased product version (optional)

N/A

### Related issues (optional)

Supersedes the manual cleanup of conflicted automation PRs such as #20185.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEPa2ZyGq8T1Dc7SNvbRFM)_