### PR TITLE
Fix chooser Preview badge sizing and styling

### DIFF
--- a/theme/src/scss/_badges.scss
+++ b/theme/src/scss/_badges.scss
@@ -1,5 +1,5 @@
 .badge {
-    @apply align-middle rounded rounded-lg uppercase px-2 py-1 text-xs font-bold;
+    @apply align-middle rounded rounded-lg uppercase px-2 py-0 text-xs font-normal font-mono;
 
     &.badge-preview {
         @apply bg-orange-200 text-orange-600;


### PR DESCRIPTION
### Proposed changes

The **PREVIEW** badge in the language chooser toolbar was taller than the tab row (inflating the toolbar height), was bold, and used the default sans font. This updates the base `.badge` `@apply` in `theme/src/scss/_badges.scss`: `py-1` → `py-0` so the badge no longer stretches the toolbar height, `font-bold` → `font-normal` for regular-weight text, and adds `font-mono` to render in Monaspace Neon, matching the Pulumi brand's use of Monaspace for labels/overlines. The `.badge` / `.badge-preview` classes are used only for the chooser Preview badge, so the base-class change is safe to apply globally.