### PR TITLE
Hide docs sidebar toggle on desktop widths

### DIFF
--- a/theme/src/scss/docs/_docs-main.scss
+++ b/theme/src/scss/docs/_docs-main.scss
@@ -231,6 +231,15 @@ body.section-registry {
             }
         }
 
+        // Once the sidebar becomes a persistent desktop sidebar (>1024px, matching
+        // the JS that strips the collapse state classes), the toggle tab is inert —
+        // hide it so it doesn't linger on narrow desktop widths.
+        @media (min-width: 1025px) {
+            .docs-nav-toggle {
+                display: none;
+            }
+        }
+
         .docs-main-nav-wrapper {
             position: relative;
             display: flex;
@@ -271,10 +280,6 @@ body.section-registry {
             display: flex;
             position: relative;
             top: 0;
-
-            .docs-nav-toggle {
-                display: none;
-            }
 
             + div.docs-main-content-wrapper {
                 margin-left: 0;


### PR DESCRIPTION
## What

The left-nav show/hide toggle tab (`.docs-nav-toggle`) is a mobile/tablet control, but it lingered as an inert "box" pinned to the left edge on narrow desktop windows:

<img width="270" height="233" alt="image" src="https://github.com/user-attachments/assets/aa32c59c-6e26-4ed3-b955-772f296a840b" />

## Why

The sidebar becomes a persistent 240px desktop sidebar at **≥1024px** (and the JS strips the toggle's collapse state above 1024px, so the toggle does nothing there), but the tab itself wasn't hidden until **≥1297px**. That left a dead zone of **1025–1296px** where both the full sidebar and the useless toggle showed.

## Fix

Hide `.docs-nav-toggle` at ≥1025px — matching where the sidebar goes persistent — and drop the now-redundant hide from the old 1297px block. Mobile/tablet behavior (≤1024px) is unchanged; dark mode is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)