### PR TITLE
docs: link to the brand guidelines in style guide

### DIFF
--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -179,11 +179,12 @@ Both syntaxes work for plain text content, but use percent signs for shortcodes 
 ## Grammar and punctuation
 
 - Use the Oxford (serial) comma: "build, deploy, and manage," not "build, deploy and manage."
+- Use present tense for how the product behaves: "Neo pauses when the limit is reached," not "Neo will pause." Reserve the future tense for events that genuinely happen later.
 - Contractions are fine — preferred, even — in docs. They read more naturally.
 - Put commas and periods outside closing quotation marks unless they belong to the quoted text — e.g., write `"us-west-2"`, with the comma outside.
 - Em-dashes are fine when you write them yourself, but revise away the em-dashes, three-item series, and filler phrasings that LLMs tend to emit — they read as unedited machine output.
 
-For dates, times, numbers, point of view (*you* vs. *we*), and anything else this guide doesn't specify, defer to the brand `writing-style` guidelines.
+For dates, times, numbers, and anything else this guide doesn't specify, defer to the brand [writing-style guide](https://brand.pulumi.com/voice/writing-style/). On **point of view** — the most-missed rule — it uses the second person (*you*), not the first-person plural (*we*): in docs, "we aren't doing anything — the reader is." Reserve *we* for blog and community content.
 
 ---
 


### PR DESCRIPTION
Two small changes to the writing-style guidance, to make them clearer to Claude:
* Add a link to the brand writing-style guide so people can quickly reach it
* Highlight the present-tense guidance from Google's Doc Style Guide since it isn't being followed very frequently (40% of current doc pages use future tense for present-tense product behavior). The other major bits of the Style Guide are pretty well followed (imperative voice for steps and mechanism-first openings all around 90%)
STYLE-GUIDE.md , just a link and a copied statement from the Google Doc Style Guidelines that prompted by auditing how consistently our docs actually follow it. Both **surface** existing conventions rather than invent new ones.

No new rules here, happy to change whatever, just want it easier for people (and Claudes) to find and follow the key guidelines.