### PR TITLE
Add Pulumi.FutureTense and Pulumi.NarrativeWe Vale rules

### DIFF
--- a/.claude/commands/docs-review/scripts/vale-deterministic-fixes.yaml
+++ b/.claude/commands/docs-review/scripts/vale-deterministic-fixes.yaml
@@ -36,5 +36,7 @@ deterministic_fix:
 #   Pulumi.HeadingSentenceCase    - auto-lowercasing risks mangling proper nouns outside the exceptions list.
 #   Pulumi.CommandBackticks       - false-positive-prone (phrase may already sit in a heading, link, or code).
 #   Pulumi.PoliciesSingular       - needs verb conjugation (are->is), not a fixed swap.
+#   Pulumi.FutureTense            - present-tense rewrite needs verb conjugation (will pause -> pauses), not a fixed swap.
+#   Pulumi.NarrativeWe            - imperative rewrite is editorial (let's create -> create), not a swap.
 #   Pulumi.HedgeThenPivot / SetPieceTransitions / ListicleH2Headings /
 #   Pulumi.EmDashDensity / Pulumi.Repetition - AI-prose heuristics; inherently judgment/rewrite.

--- a/.claude/commands/docs-review/scripts/vale-findings-filter.py
+++ b/.claude/commands/docs-review/scripts/vale-findings-filter.py
@@ -109,6 +109,8 @@ RULE_CATEGORIES: dict[str, str] = {
     "Pulumi.CommandBackticks": "unbacked CLI command",
     "Pulumi.HeadingSentenceCase": "heading capitalization",
     "Pulumi.Repetition": "repeated word",
+    "Pulumi.FutureTense": "future tense",
+    "Pulumi.NarrativeWe": "narrative voice",
     "Google.Acronyms": "acronym",
     "Google.Contractions": "contractions",
     "Google.Ellipses": "punctuation",

--- a/.vale.ini
+++ b/.vale.ini
@@ -21,8 +21,8 @@ TokenIgnores = ({{[%<].*?[%>]}}), \
 # Disable Google rules that conflict with Pulumi house style.
 Google.Headings = NO        # Replaced by Pulumi.HeadingSentenceCase, which scopes to H2+ only (Pulumi uses Title Case for the H1/page title). Nothing else enforced H2 case — markdownlint has no sentence-case rule.
 Google.WordList = NO        # Google product-name overrides don't match Pulumi terminology.
-Google.We = NO              # Documentation style allows first-person plural.
-Google.Will = NO            # Too noisy on declarative technical prose.
+Google.We = NO              # Blanket first-person flagger; replaced by Pulumi.NarrativeWe, which targets only narrative-walkthrough constructions (let's / we'll / now we ...), not every 'we'.
+Google.Will = NO            # Too noisy on declarative technical prose (flags every 'will'); replaced by Pulumi.FutureTense, which anchors on product subjects.
 Google.Parens = NO          # Vague rule ("use parens judiciously"); not actionable.
 Google.EmDash = NO          # Noisy on existing technical prose; false-positive rate exceeds signal.
 Google.Colons = NO          # Flags all ': A' but Google's guide permits capital after a colon when a complete sentence follows ("Note: This operation...").
@@ -36,7 +36,14 @@ write-good.E-Prime = NO     # Banning all forms of "to be" is impractical for te
 # Per-path overrides. Vale merges sections; more-specific wins on conflicts.
 [content/blog/**/*.md]
 Google.FirstPerson = NO     # Blog posts are written in author voice; 'I'/'my'/'me' are the medium.
+Pulumi.FutureTense = NO     # Blog voice is exempt from the docs present-tense norm; announcements legitimately describe upcoming behavior.
+Pulumi.NarrativeWe = NO     # Blog voice is exempt; narrative first-person plural is the medium.
+
+[content/{what-is,learn}/**/*.md]
+Pulumi.NarrativeWe = NO     # Narrative-voice norm is scoped to docs and tutorials per the writing-style audit; explainer voice is out of scope.
 
 [content/docs/iac/cli/commands/**/*.md]
 Pulumi.HeadingSentenceCase = NO  # Generated from `pulumi gen-docs`; the cobra `### SEE ALSO` headings are fixed boilerplate, not hand-authored prose.
 Pulumi.CrossReferenceHeadings = NO  # Same generated pages; the cobra `SEE ALSO` blocks are tooling output, not hand-authored cross-references.
+Pulumi.FutureTense = NO     # Generated from `pulumi gen-docs`; tense fixes belong upstream in pulumi/pulumi.
+Pulumi.NarrativeWe = NO     # Same generated pages; not hand-authored prose.

--- a/styles/Pulumi/FutureTense.yml
+++ b/styles/Pulumi/FutureTense.yml
@@ -1,0 +1,31 @@
+# Flags future tense used for product behavior ("Neo will pause", "the CLI
+# will prompt") where the Google style guide -- and STYLE-GUIDE.md §Grammar
+# and punctuation -- call for present tense ("Neo pauses", "the CLI prompts").
+#
+# Deliberately NOT a blanket 'will' flagger: Google.Will (disabled in
+# .vale.ini) flags every 'will' and was too noisy on declarative technical
+# prose. This rule anchors on a product subject instead:
+#   - token 1: proper-noun products (Neo, Pulumi + optional product suffix,
+#     ESC, CrossGuard). Case-sensitive, so Title-Case headings self-exclude.
+#   - token 2: 'the/this <product-noun> will', with a corpus-frequency-curated
+#     noun list. 'tutorial', 'reader', 'value', 'output', 'file' are excluded
+#     on purpose -- future tense there is usually preview semantics, not drift.
+# 'will not' / "won't" (both apostrophe forms) are included: "Pulumi will not
+# share your data" is still a behavior statement. The trailing (?: \w+)? pulls
+# the following verb into the match so the message reads "Pulumi will remove",
+# not a bare "Pulumi will".
+#
+# No passive-future token ("will be created"): corpus sampling showed those
+# hits are dominated by legitimate preview/plan semantics ("resources that
+# will be created"), so flagging them would sink precision.
+#
+# Second-person futures ("you will need an AWS account") never match -- there
+# is no second-person subject in either token.
+extends: existence
+message: "Future tense ('%s') -- prefer present tense for product behavior: 'Neo pauses', not 'Neo will pause' (STYLE-GUIDE.md §Grammar and punctuation)."
+link: "https://developers.google.com/style/tense"
+level: warning
+ignorecase: false
+tokens:
+  - '(?:Neo|Pulumi(?: Cloud| ESC| IaC| AI| Deployments| Insights| Copilot| CrossGuard)?|ESC|CrossGuard) (?:will(?: not)?|won[''’]t)(?: \w+)?'
+  - '[Tt]h(?:e|is) (?:following )?(?:Pulumi )?(?:CLI|engine|provider|operator|agent|service|command|program|polic(?:y|ies)|stack|resource|deployment|update|preview|operation|process|console|backend|component|environment|plugin|webhook|token|API|SDK)(?:e?s)? (?:will(?: not)?|won[''’]t)(?: \w+)?'

--- a/styles/Pulumi/NarrativeWe.yml
+++ b/styles/Pulumi/NarrativeWe.yml
@@ -1,0 +1,37 @@
+# Flags narrative walkthrough voice ("Let's create a bucket", "now we'll
+# deploy") where docs voice calls for imperative second person ("Create a
+# bucket") -- STYLE-GUIDE.md §Grammar and punctuation, and the brand
+# writing-style guide's point-of-view rule.
+#
+# Deliberately NOT a blanket first-person flagger: Google.We (disabled in
+# .vale.ini) flags every 'we'/'us'/'our'/"let's". A voice-norm audit found
+# ~93% of first-person drift in docs is this narrative-walkthrough shape, so
+# the rule targets only those constructions and never matches bare 'we',
+# 'us', 'our', 'we recommend', or 'contact us'. 'let us' carries a negative
+# lookahead so "let us know" (community-feedback idiom) stays clean; the
+# lookahead compiles via Vale's regexp2 fallback (RE2-pure alternative if it
+# ever errors: 'let us [a-jl-z]\w*').
+#
+# Both apostrophe forms are matched -- the ['’] character class covers
+# straight and curly apostrophes (both appear in the corpus).
+#
+# Scope: docs + tutorials only. Blog, what-is/learn, and generated CLI pages
+# are opted out per-path in .vale.ini -- narrative voice is the medium in
+# blog posts and out of scope for explainers.
+extends: existence
+message: "Narrative walkthrough voice ('%s') -- prefer imperative second person: 'Create a bucket', not 'Let's create a bucket' (STYLE-GUIDE.md §Grammar and punctuation)."
+link: "https://brand.pulumi.com/voice/writing-style/"
+level: warning
+ignorecase: true
+tokens:
+  - "let['’]s"
+  - 'let us (?!know\b)\w+'
+  - "we['’]ll"
+  - "we will"
+  - "we['’]re going to"
+  - "we are going to"
+  - "we can now"
+  - "we['’]ve now"
+  - "we have now"
+  - "now,? we"
+  - "next,? we"


### PR DESCRIPTION
### Proposed changes

A writing-style health audit of `content/docs/**` (549 hand-authored pages) found **future tense for product behavior** ("Neo will pause" vs "Neo pauses") is the one style norm with real drift (~40% of pages, worst in `support/`, `ai/`, `iac/`), and **narrative walkthrough voice** ("now we'll create…", "let's…") a smaller second — ~93% of first-person drift is walkthrough voice, only ~7% is "we recommend". The companion PR #20201 surfaces both norms in `STYLE-GUIDE.md` §Grammar and punctuation; this PR adds the Vale enforcement layer.

**Two targeted rules instead of the blanket Google flaggers** (`Google.Will` / `Google.We` stay disabled; their `.vale.ini` rationale comments now say why):

- **`Pulumi.FutureTense`** anchors on a product subject — `Neo`/`Pulumi`(+product)/`ESC`/`CrossGuard`, or `the/this` + a corpus-curated product noun — followed by `will`/`will not`/`won't` (both apostrophe forms). "You will need an AWS account" never matches. Deliberately no passive-future token: corpus sampling shows "will be created" hits are dominated by legitimate preview/plan semantics.
- **`Pulumi.NarrativeWe`** catches only walkthrough constructions (`let's`, `we'll`, `we will`, `we're going to`, `now we`, `next, we`, …) and never bare `we`/`us`/`our`/`we recommend`/`contact us`; "let us know" is exempted via lookahead.

**Scoping** (per-path in `.vale.ini`):

| Rule | docs | tutorials | what-is / learn | blog | generated CLI pages |
|---|---|---|---|---|---|
| `Pulumi.FutureTense` | ✅ | ✅ | ✅ | ❌ (announcements legitimately describe upcoming behavior) | ❌ (fix upstream in pulumi/pulumi) |
| `Pulumi.NarrativeWe` | ✅ | ✅ | ❌ | ❌ (narrative voice is the medium; 1,800+ existing uses) | ❌ |

Both rules are `warning`-level advisory nags — `make lint-prose` still always exits 0, and the PR review pipeline's caps (10 findings/file, 50/PR, PR-added lines only) bound the volume. They're **flag-only**: added to the "deliberately NOT listed" ledger in `vale-deterministic-fixes.yaml`, since tense/person rewrites need verb conjugation (same rationale as `Pulumi.PoliciesSingular`). Whole-file sweeps (`review-existing-content`) will surface the ~430 existing corpus hits gradually as pages cycle through review — that's the intended remediation channel for the backlog.

**Verification** (vale 3.14.2):

- Fixture matrix across all five path scopes: all 16 should-flag lines fire (including curly-apostrophe forms); zero false flags on "You will need…", "We recommend…", "Contact us", "let us know", inline-code and fenced-code trigger phrases; per-path disables confirmed for blog, what-is (brace-glob section), and generated CLI pages.
- Corpus precision: 20 random hits sampled per rule — FutureTense 20/20 valid, NarrativeWe 19/20 (the one residual: "we'll be in touch" in the support FAQ, where "we" genuinely is Pulumi). Totals: 216 hits / 119 files (FutureTense), 216 / 79 (NarrativeWe).
- Pipeline smoke: `vale-findings-filter.py` emits `category: "future tense"` / `deterministic_fix: false`; `make lint` passes.

Known cosmetic overlaps: "Let's dive in" also hits `SetPieceTransitions`; passive spans may co-flag with `Google.Passive`. Both advisory.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Companion to #20201 (style-guide wording; the §Grammar and punctuation heading the rule messages cite already exists on master, so nothing dangles regardless of merge order). Prompted by the s224 docs voice-norm audit / writing-style health report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APgibYxksnSbE2fNLJnRXC

---
_Generated by [Claude Code](https://claude.ai/code/session_01APgibYxksnSbE2fNLJnRXC)_