### PR TITLE
Generate meta images for changelog pages

### DIFF
--- a/scripts/generate-meta-images.mjs
+++ b/scripts/generate-meta-images.mjs
@@ -159,6 +159,20 @@ const SECTIONS = [
     valid: (f) => !!f.title,
   },
   {
+    // Changelog entries (content/releases/changelog/<slug>.md) get the dark
+    // docs "info" card with a "Releases" badge. Scoped to the changelog subtree
+    // only — the /releases landing page is intentionally excluded (it gets a
+    // custom meta_image later). The changelog _index has build.render=never (no
+    // list page renders), so its card would never be referenced; skip it.
+    name: "releases/changelog",
+    template: "info",
+    recursive: true,
+    sampleGroupBy: () => "changelog",
+    skip: (fm) => fm.build && fm.build.render === "never",
+    fields: (fm) => ({ sectionLabel: "Releases", subSectionLabel: "", title: clean(fm.title), description: clean(fm.meta_desc) }),
+    valid: (f) => !!f.title,
+  },
+  {
     // Event / workshop cards (content/events/<slug>/index.md leaf bundles).
     // Individual events → the events card in two sizes (landscape OG meta image
     // + square second og:image). The /events/ index page → a plain title card,


### PR DESCRIPTION
Adds a section config to `scripts/generate-meta-images.mjs` that renders the dark docs-style "info" card for each changelog entry with a RELEASES badge.

<img width="662" height="355" alt="image" src="https://github.com/user-attachments/assets/0f70eacf-5fad-40bd-b9b5-f85526efbb5e" />
