### PR TITLE
Fix changelog videos not playing in the modal on Safari/iOS

### DIFF
--- a/theme/src/ts/releases.ts
+++ b/theme/src/ts/releases.ts
@@ -63,6 +63,17 @@ document.addEventListener("DOMContentLoaded", () => {
     function openModal(article: Element, trigger: HTMLElement | null): void {
         content.innerHTML = "";
         content.appendChild(article.cloneNode(true));
+        // WebKit (Safari + iOS) doesn't re-run the media resource selection
+        // algorithm for a <video> cloned out of a detached DOMParser document,
+        // so it never loads its <source>, shows no first frame, and never arms
+        // autoplay. Chrome/Firefox do. Force a fresh load, then kick off
+        // autoplay ourselves for the videos that ask for it.
+        content.querySelectorAll<HTMLVideoElement>("video").forEach(video => {
+            video.load();
+            if (video.autoplay) {
+                video.play().catch(() => { /* autoplay may be blocked (e.g. iOS Low Power Mode); the first frame still shows */ });
+            }
+        });
         modal.classList.remove("hidden");
         modal.scrollTop = 0;
         document.body.style.overflow = "hidden";


### PR DESCRIPTION
Embedded changelog videos rendered blank (no first frame, no autoplay) inside the `/releases/` overlay on Safari and iOS, while working in Chrome and Firefox. This change forces each injected video to `load()` and (if it opts into autoplay) `play()` once it's in the live DOM, which is a no-op in the browsers that already worked.

### Before

<img width="801" height="728" alt="image" src="https://github.com/user-attachments/assets/7e24472f-4735-4550-ac04-d2d01888f366" />

### After

<img width="802" height="653" alt="image" src="https://github.com/user-attachments/assets/0088463e-c036-4a12-929e-9c3a5992ee5b" />