### PR TITLE
Show full changelog content in the releases RSS feed

### DIFF
--- a/layouts/releases/rss.xml
+++ b/layouts/releases/rss.xml
@@ -5,9 +5,11 @@
     Driven by this section's pages (.RegularPagesRecursive — see
     content/releases/_index.md), emitted newest-first by date and mirroring
     the JSON feed: one <item> per release page and per changelog item, linking
-    to the page's own URL. Descriptions come from short_description (releases)
-    or meta_desc (changelog items). Modeled on layouts/blog/rss.xml and
-    layouts/events/rss.xml.
+    to the page's own URL. <description> carries the page's full rendered body
+    — the field readers universally display as the article (matching
+    layouts/blog/rss.xml) — falling back to the short summary
+    (short_description for releases, meta_desc for changelog items) when a page
+    has no body. Modeled on layouts/blog/rss.xml and layouts/events/rss.xml.
 */ -}}
 <rss version="2.0">
     <channel>
@@ -21,9 +23,11 @@
                 <link>{{ .Permalink }}</link>
                 <guid>{{ .Permalink }}</guid>
                 <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-                {{ with or .Params.short_description .Params.meta_desc }}
+                {{ with .Content }}
+                <description>{{ . | html }}</description>
+                {{ else }}{{ with or .Params.short_description .Params.meta_desc }}
                 <description>{{ . | markdownify | plainify | htmlUnescape | chomp | replaceRE "\\s+" " " }}</description>
-                {{ end }}
+                {{ end }}{{ end }}
             </item>
         {{ end }}
     </channel>


### PR DESCRIPTION
The releases RSS feed currently puts only the meta description in the `<description>` field, so RSS readers showed a one-line summary instead of the changelog content. This change renders each release/changelog page's full HTML body into the `<description>` field so readers display the full article.

<img width="1239" height="943" alt="image" src="https://github.com/user-attachments/assets/4d3f6e97-4dfa-421d-9cbf-e11f37226da9" />
