### PR TITLE
Add classic pagination on deep blog listing pages

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -26,6 +26,8 @@
             </div>
         {{ end }}
 
+        {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
+
         <div data-post-list class="flex flex-col">
             {{ range $paginator.Pages }}{{ partial "blog/card/list-row.html" (dict "page" .) }}{{ end }}
         </div>

--- a/layouts/partials/blog/paginator.html
+++ b/layouts/partials/blog/paginator.html
@@ -1,17 +1,35 @@
 {{- /*
     Blog paginator — custom markup over .Paginator (Previous / windowed numbers /
-    Next). Replaces _internal/pagination.html. `data-next-url` on the <nav> is the
-    hook the infinite-scroll JS reads to fetch the next page; the numbered links
-    are the no-JS / crawler fallback (JS hides the nav once it upgrades). Call
-    with the page context after .Paginate has run.
+    Next). Replaces _internal/pagination.html.
+
+    Both forms render a "Page N of total" label (left) and the pager controls
+    (right) inside a justify-between wrapper.
+
+    Two call forms:
+      Bottom (default): {{ partial "blog/paginator.html" . }} — passes the page.
+        The wrapper carries the `data-paginator` / `data-next-url` hook the
+        infinite-scroll JS reads and hides (as a unit) once it upgrades; the
+        numbered links are the no-JS / crawler fallback.
+      Top (deep pages only): {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
+        A visible-only copy shown above the list on /page/N/ (N >= 2) landings,
+        where the JS disables infinite scroll and classic pagination takes over.
+        Omits the JS hook (no data-paginator / data-next-url) so it never competes
+        with the bottom pager's querySelector, and renders nothing on page 1.
+
+    Call after .Paginate has run.
 */ -}}
-{{- $p := .Paginator -}}
-{{- if gt $p.TotalPages 1 -}}
+{{- $ctx := . -}}
+{{- $top := false -}}
+{{- if reflect.IsMap . -}}{{ $ctx = .context }}{{ $top = eq .position "top" }}{{- end -}}
+{{- $p := $ctx.Paginator -}}
+{{- if and (gt $p.TotalPages 1) (or (not $top) (gt $p.PageNumber 1)) -}}
 {{- $cur := $p.PageNumber -}}
 {{- $total := $p.TotalPages -}}
 {{- $start := cond (gt (sub $cur 2) 1) (sub $cur 2) 1 -}}
 {{- $end := cond (lt (add $cur 2) $total) (add $cur 2) $total -}}
-<nav data-paginator aria-label="Blog pagination" class="mt-12 flex flex-wrap items-center justify-center gap-2"{{ with $p.Next }} data-next-url="{{ .URL }}"{{ end }}>
+<div{{ if not $top }} data-paginator{{ end }} class="flex flex-wrap items-center justify-between gap-4{{ if $top }} mb-8{{ else }} mt-12{{ end }}"{{ if not $top }}{{ with $p.Next }} data-next-url="{{ .URL }}"{{ end }}{{ end }}>
+    <p class="m-0! font-overline-sm text-gray-700">Page {{ $cur }} of {{ $total }}</p>
+    <nav aria-label="Blog pagination{{ if $top }} (top){{ end }}" class="flex flex-wrap items-center justify-end gap-2">
     {{- with $p.Prev }}<a href="{{ .URL }}" rel="prev" data-track="paginator-prev" class="btn btn-sm btn-outline">Previous</a>{{ end }}
     {{- if gt $start 1 }}
         <a href="{{ (index $p.Pagers 0).URL }}" data-track="paginator-1" class="btn btn-icon-sm btn-ghost">1</a>
@@ -27,5 +45,6 @@
         <a href="{{ (index $p.Pagers (sub $total 1)).URL }}" data-track="paginator-{{ $total }}" class="btn btn-icon-sm btn-ghost">{{ $total }}</a>
     {{- end }}
     {{- with $p.Next }}<a href="{{ .URL }}" rel="next" data-track="paginator-next" class="btn btn-sm btn-outline">Next</a>{{ end }}
-</nav>
+    </nav>
+</div>
 {{- end -}}

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -20,6 +20,7 @@
 
         {{ $posts := where .Data.Pages "Section" "blog" }}
         {{ $paginator := .Paginate $posts.ByDate.Reverse }}
+        {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
         <div data-post-list class="flex flex-col">
             {{ range $paginator.Pages }}{{ partial "blog/card/list-row.html" (dict "page" .) }}{{ end }}
         </div>

--- a/layouts/taxonomy/category.html
+++ b/layouts/taxonomy/category.html
@@ -13,6 +13,7 @@
     <div class="container mx-auto px-4 py-8 lg:py-12">
         {{ $posts := (where .Data.Pages "Section" "blog").ByDate.Reverse }}
         {{ $paginator := .Paginate $posts }}
+        {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
         {{ partial "blog/interleaved-list.html" (dict "paginator" $paginator "pages" $posts) }}
         {{ partial "blog/paginator.html" . }}
     </div>

--- a/layouts/taxonomy/series.html
+++ b/layouts/taxonomy/series.html
@@ -17,6 +17,7 @@
         <div class="container mx-auto px-4 py-8 lg:py-12">
             {{ $posts := (where .Data.Pages "Section" "blog").ByDate.Reverse }}
             {{ $paginator := .Paginate $posts }}
+            {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
             {{ partial "blog/interleaved-list.html" (dict "paginator" $paginator "pages" $posts) }}
             {{ partial "blog/paginator.html" . }}
         </div>

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -7,6 +7,7 @@
     <div class="container mx-auto px-4 py-8 lg:py-12">
         {{ $posts := (where .Data.Pages "Section" "blog").ByDate.Reverse }}
         {{ $paginator := .Paginate $posts }}
+        {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
         {{ partial "blog/interleaved-list.html" (dict "paginator" $paginator "pages" $posts) }}
         {{ partial "blog/paginator.html" . }}
     </div>

--- a/layouts/taxonomy/taxonomy.html
+++ b/layouts/taxonomy/taxonomy.html
@@ -6,6 +6,7 @@
 
     <div class="container mx-auto px-4 py-8 lg:py-12">
         {{ $paginator := .Paginate .Data.Pages.ByDate.Reverse }}
+        {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
         <div data-post-list class="flex flex-col">
             {{ range $paginator.Pages }}{{ partial "blog/card/list-row.html" (dict "page" .) }}{{ end }}
         </div>

--- a/theme/src/ts/blog-list.ts
+++ b/theme/src/ts/blog-list.ts
@@ -8,7 +8,7 @@
 //   [data-post-row]            one post row (also present in the rows fragment)
 //   [data-post-grid]           (term pages) the medium-card grid above the list
 //   [data-post-card]           one grid card
-//   [data-paginator]           the numbered pager; data-next-url = next page URL
+//   [data-paginator]           the pager wrapper (label + nav); data-next-url = next page URL
 //   [data-blog-filter]         the homepage filter bar
 //   [data-blog-filter] a[data-category]  a filter pill ("" = All), .is-active
 
@@ -18,6 +18,14 @@ const REVEAL_STEP = 10; // rows revealed per step when a category filter is acti
 document.addEventListener("DOMContentLoaded", () => {
     const list = document.querySelector<HTMLElement>("[data-post-list]");
     if (!list) {
+        return;
+    }
+
+    // Deep /page/N/ landings render classic pagination (server-rendered top +
+    // bottom pagers). Skip the infinite-scroll / load-more enhancement so those
+    // pagers stay visible and paging is done via normal navigation. Page 1 (no
+    // /page/N/ segment) keeps the enhancement.
+    if (/\/page\/\d+\/$/.test(location.pathname)) {
         return;
     }
 
@@ -73,18 +81,41 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Keep the address bar in sync with the page currently at the top of the
     // viewport (replaceState, so Back doesn't step through every loaded page).
-    const markerObserver = new IntersectionObserver(
-        entries => {
-            for (const e of entries) {
-                if (e.isIntersecting) {
-                    const url = (e.target as HTMLElement).dataset.pageUrl;
-                    if (url) {
-                        history.replaceState(null, "", url);
-                    }
-                }
+    // Driven by a scroll listener, NOT a thin-band IntersectionObserver: a normal
+    // wheel scroll can jump a 0-height boundary marker clean over a narrow band, so
+    // it never reports as intersecting and the URL would stall. Instead, on each
+    // scroll we take the LAST boundary marker that has passed the top of the
+    // viewport — monotonic, so it can never be skipped. Markers ([data-page-url])
+    // sit in page order in the list.
+    const TOP_THRESHOLD = 120; // a boundary counts as "passed" at/above this y
+    let syncScheduled = false;
+    function syncUrl(): void {
+        syncScheduled = false;
+        if (mode !== "paginate") {
+            return; // filtered/reveal mode owns the URL (a real category term page)
+        }
+        const markers = list.querySelectorAll<HTMLElement>("[data-page-url]");
+        let url = basePath;
+        for (let i = 0; i < markers.length; i++) {
+            if (markers[i].getBoundingClientRect().top <= TOP_THRESHOLD) {
+                url = markers[i].dataset.pageUrl || url;
+            } else {
+                break;
+            }
+        }
+        if (new URL(url, location.origin).pathname !== location.pathname) {
+            history.replaceState(null, "", url);
+        }
+    }
+    window.addEventListener(
+        "scroll",
+        () => {
+            if (!syncScheduled) {
+                syncScheduled = true;
+                requestAnimationFrame(syncUrl);
             }
         },
-        { rootMargin: "0px 0px -80% 0px" },
+        { passive: true },
     );
 
     function done(): boolean {
@@ -114,13 +145,12 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
                 const doc = new DOMParser().parseFromString(text, "text/html");
 
-                // Boundary marker for URL sync.
+                // Boundary marker (read by syncUrl on scroll) for URL sync.
                 const marker = document.createElement("div");
                 marker.dataset.pageUrl = url;
                 marker.style.height = "0";
                 marker.setAttribute("aria-hidden", "true");
                 list.appendChild(marker);
-                markerObserver.observe(marker);
 
                 // A term page's grid run can span pager pages: fetched grid
                 // cards continue the existing [data-post-grid] (the split point


### PR DESCRIPTION
Was easy to get lost when you refreshed the page and landed directly on a paginated page, this adds traditional pagination for those and fixes some jankiness with the infinite scroll url updating.

<img width="1532" height="303" alt="Screenshot 2026-07-13 at 9 35 25 AM" src="https://github.com/user-attachments/assets/f70b2960-5e5f-4d51-a818-8b69a8690fa0" />


---

### Proposed changes

Landing directly on a deep blog listing page (e.g. `/blog/category/general/page/4/`) previously hid the only paginator and just kept infinite-scrolling forward, leaving no way to navigate pages. Now deep `/page/N/` pages (category, tag, series, author, and the `/blog/` homepage) render a numbered pager with a "Page N of total" label at the **top and bottom** and disable infinite scroll, so paging is done via normal navigation; page 1 keeps the infinite-scroll + load-more experience unchanged. This PR also fixes the address-bar page sync, which a normal-speed scroll could skip (stalling the URL) — the thin-band `IntersectionObserver` is replaced with a scroll-driven check that tracks the last passed page boundary. All changes are in the blog listing templates, the shared `paginator.html` partial, and `blog-list.ts`.