### PR TITLE
Document GitHub App installation linking and recovery

### DIFF
--- a/content/docs/ai/code-reviews/_index.md
+++ b/content/docs/ai/code-reviews/_index.md
@@ -46,3 +46,7 @@ Neo code reviews run on GitHub.com. GitHub Enterprise Server is not supported. C
 ## Permissions
 
 Neo code reviews run with the same governance as any other [Neo task](/docs/ai/tasks/), including the [role-based access control](/docs/administration/access-identity/rbac/), guardrails, and audit logging your organization has configured. To turn them off, disable Neo code reviews in your [GitHub App integration settings](/docs/integrations/version-control/github-app/).
+
+## Troubleshooting
+
+If Neo isn't reviewing pull requests in a repository, confirm that the Pulumi GitHub App installation covering that repository is linked to your Pulumi organization. Installations created directly from the GitHub Marketplace can exist without a linked organization, and Neo skips reviews on their pull requests. When this happens, the Pulumi preview comment on the pull request includes a note with a link to finish connecting the installation. See [Link an existing installation](/docs/integrations/version-control/github-app/#link-an-existing-installation).

--- a/content/docs/integrations/version-control/github-app.md
+++ b/content/docs/integrations/version-control/github-app.md
@@ -39,6 +39,16 @@ To install the GitHub app, you must have admin permissions in **both** the targe
 1. Navigate to **Management** > **Version control**.
 1. Select **Add account** and choose **GitHub**, then follow the prompts.
 
+### Install from the GitHub Marketplace
+
+You can also start the installation from GitHub instead of Pulumi Cloud, either by installing the app from the GitHub Marketplace or by approving an installation request from a non-admin member of your GitHub organization. After the installation completes, GitHub redirects you to Pulumi Cloud, where you choose the Pulumi organization to link the installation to. If Pulumi can't verify that you control the installation, you're prompted to connect your GitHub account first. For installations on a GitHub organization account, you must be an admin of that GitHub organization, not just a member, because linking gives the Pulumi organization access to the repositories the installation covers.
+
+### Link an existing installation
+
+If the app is already installed in GitHub but not connected to your Pulumi organization, the **Management** > **Version control** page lists installations you can link, each with a **Link** action. The **Add account** > **GitHub** wizard offers the same **Link existing install** option when Pulumi finds one. As with Marketplace installs, you may be prompted to connect your GitHub account so Pulumi can verify that you control the installation.
+
+An installation can be linked to one Pulumi organization this way. If it's already linked to a different Pulumi organization, linking fails; see [Multiple GitHub organizations](#multiple-github-organizations) for sharing a GitHub organization across Pulumi organizations.
+
 ### Multiple GitHub organizations
 
 Multiple GitHub organizations can be connected to a single Pulumi organization. You can add each one via **Management** > **Version control** > **Add account**.
@@ -199,8 +209,9 @@ Uninstalling the GitHub app will delete any push-to-deploy and review stack conf
 
 If you previously installed the GitHub app but Pulumi Cloud does not show it as connected to your desired organization, try the following:
 
-1. Ensure you're a GitHub admin of the GitHub organization where you're installing the app.
-1. Uninstall the app and re-install it following the steps above. See [Uninstallation](#uninstallation) for both methods.
+1. Navigate to **Management** > **Version control** and check whether the installation is listed as available to link, then select **Link**. See [Link an existing installation](#link-an-existing-installation).
+1. Ensure you're a GitHub admin of the GitHub organization where the app is installed.
+1. If the installation still doesn't appear, uninstall the app and re-install it following the steps above. See [Uninstallation](#uninstallation) for both methods.
 
 ### PR comments not appearing
 


### PR DESCRIPTION
## Summary

Documents the recovery and prevention flows for unlinked GitHub App installations shipped in pulumi/pulumi-service#45717:

- **`content/docs/integrations/version-control/github-app.md`**
  - New **Install from the GitHub Marketplace** section: installs started from GitHub (Marketplace or an admin approving a member's request) now redirect to Pulumi Cloud to choose the organization to link, may prompt for a GitHub account connection, and require GitHub org admin (not member) since linking grants repo access.
  - New **Link an existing installation** section: the Version control page surfaces claimable installations with a **Link** action, and the Add account wizard offers **Link existing install**; an installation already linked to a different Pulumi organization can't be re-claimed.
  - Troubleshooting "App not appearing as installed": the Link flow is now the first remedy; uninstall/reinstall drops to last resort.
- **`content/docs/ai/code-reviews/_index.md`**
  - New **Troubleshooting** section: unlinked installations cause Neo to skip reviews, and the Pulumi preview comment links to the claim page.

All behavior and UI-copy claims were verified against the pulumi-service PR source (button labels "Link" and "Link existing install" are verbatim from the component templates).

## ⚠️ Do not merge yet

The documented UI is gated behind the `unlinked-github-app-recovery` feature flag, which is **default-off and not yet enabled** (the service PR's rollout checklist is still open). Keep this draft until the flag is enabled in production, then mark ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)