### PR TITLE
docs: Neo usage limits — org-limit emails only

### DIFF
--- a/content/docs/ai/usage-limits/_index.md
+++ b/content/docs/ai/usage-limits/_index.md
@@ -44,12 +44,12 @@ The **Manage token usage** panel lists each member with these columns:
 
 ## Email alerts
 
-Turn on **Enable email notifications** to be alerted by email as usage climbs toward a limit. Billing admins receive alerts for the organization limit; a member also receives alerts when their own per-member usage crosses a threshold.
+Turn on **Enable email notifications** to be alerted by email as usage climbs toward the organization limit. Billing managers and admins receive the alerts.
 
 Emails go out at these points:
 
 - **50%, 80%, and 95%.** Early warnings that give you time to raise the limit before Neo pauses.
-- **100%.** Neo has reached the limit and is now paused for the affected organization or member.
+- **100%.** Neo has reached the organization limit and is now paused for the organization.
 
 ## What happens when a limit is reached
 


### PR DESCRIPTION
We're removing limit notification emails when members cross a personal per-member limit threshold since they were added early (and erroneously)  and they have alternate ways to look at it (and it was causing emails that look like duplicates for small orgs). Org limits will still email the admin when thresholds are reached. Per-member *pausing* behavior is unchanged; this touches only the Email alerts section.