### PR TITLE
Lazy-import cairosvg so logo-free feature templates render without libcairo

### DIFF
--- a/.claude/commands/blog-feature-image/scripts/compose_meta_image.py
+++ b/.claude/commands/blog-feature-image/scripts/compose_meta_image.py
@@ -66,9 +66,6 @@ def _ensure_cairo():
     os.execv(sys.executable, [sys.executable, *sys.argv])
 
 
-_ensure_cairo()
-
-import cairosvg
 import numpy as np
 import yaml
 from PIL import Image
@@ -91,6 +88,12 @@ def find_template(catalog: dict, filename: str) -> dict | None:
 
 def svg_to_png(svg_path: str, width: int, height: int) -> Image.Image:
     """Rasterize an SVG file to a PIL Image fitting within width x height."""
+    # cairosvg (and its native libcairo) is only needed to rasterize SVGs, so
+    # import it lazily here — logo-free templates never load libcairo. The cairo
+    # locator must run before the import (it may re-exec to fix the dylib path).
+    _ensure_cairo()
+    import cairosvg
+
     svg_path = str(svg_path)
     try:
         png_data = cairosvg.svg2png(url=svg_path, output_width=width)


### PR DESCRIPTION
## Problem

`compose_meta_image.py` imports `cairosvg` at module top level, so **every** invocation requires the native `libcairo` system library — even the logo-free feature templates (neo, platform, rocket, shield, lightbulb), which never rasterize an SVG. On a machine without `libcairo` those templates fail with `no library called "cairo" was found`, despite needing nothing cairo provides.

## Change

Move the `cairosvg` import — and the `_ensure_cairo()` locator that must run before it — out of module scope and into `svg_to_png()`, the only function that rasterizes SVGs. Logo-free templates now import the module and render without ever touching `cairosvg`/`libcairo`. Logo/icon templates hit the same locate → import → rasterize path as before, just deferred to first SVG render — behavior unchanged.

## Verification

- Logo-free `feature-neo.png` renders with **no cairo installed** (`ctypes.util.find_library("cairo")` → `None`): produces a 1884×1256 PNG, no error.
- Output is **byte-identical** (SHA-256 match) to the committed `content/blog/neo-usage-limits/feature.png`.
- Logo/icon path unchanged by inspection — `svg_to_png` still runs `_ensure_cairo()` → `import cairosvg` → `cairosvg.svg2png(...)` with the existing `rsvg-convert` fallback. Not run end-to-end here (no libcairo on this machine, which is the point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)