### PR TITLE
docs: correct and expand Deployments dependency caching

### DIFF
--- a/content/blog/announcing-dependency-caching-deployments/index.md
+++ b/content/blog/announcing-dependency-caching-deployments/index.md
@@ -20,7 +20,7 @@ When using Pulumi Deployments, installing dependencies can be a time-consuming p
 
 ## How dependency caching works
 
-Pulumi Deployments now can automatically cache dependencies for [popular package managers](/docs/pulumi-cloud/deployments/faq/#dependency-caching), such as npm, pip, and go modules. When a deployment is triggered, Pulumi will:
+Pulumi Deployments now can automatically cache dependencies for [popular package managers](/docs/deployments/concepts/settings/#dependency-caching), such as npm, pip, and go modules. When a deployment is triggered, Pulumi will:
 
 1.	Check for an existing cache of your dependencies.
 2.	If a cache already exists, Pulumi will reuse those dependencies, bypassing the need to install them from scratch.
@@ -75,9 +75,9 @@ const settings = new service.DeploymentSettings("deployment_settings", {
 
 ### Using the REST API
 
-You can also enable dependency caching using the Pulumi REST API. See the [API documentation](/docs/pulumi-cloud/deployments/api/#cache-options) for more information.
+You can also enable dependency caching using the Pulumi REST API. See the [dependency caching documentation](/docs/deployments/concepts/settings/#dependency-caching) for more information.
 
-For more information on how dependency caching works with Pulumi Cloud Deployments and the list of supported package managers, check out the [FAQ](/docs/pulumi-cloud/deployments/faq/#dependency-caching) on dependency caching.
+For more information on how dependency caching works with Pulumi Cloud Deployments and the list of supported package managers, check out the [dependency caching documentation](/docs/deployments/concepts/settings/#dependency-caching).
 
 ## What’s next?
 

--- a/content/docs/deployments/concepts/customer-managed-runners.md
+++ b/content/docs/deployments/concepts/customer-managed-runners.md
@@ -90,6 +90,12 @@ Regardless of the deploy target, each agent process runs **one deployment at a t
 | **Scaling** | Run more agent processes (for example, more hosts or systemd units) | Run more agent replicas, or use `single_run` with a `Job`/`CronJob` for ephemeral per-job runners |
 | **Best fit** | A single VM or host where you want the simplest setup | An existing Kubernetes environment that should schedule and bound runner resources |
 
+## Dependency caching
+
+Pulumi's [dependency caching](/docs/deployments/concepts/settings/#dependency-caching) is not available on customer-managed runner pools. If a stack is assigned to a customer-managed pool, the setting has no effect.
+
+Because you control the runner environment and image, you can manage caching yourself — for example, by persisting package manager caches and the Pulumi plugin directory (`~/.pulumi/plugins`) across jobs, or by pre-baking them into your runner image.
+
 ## Providing cloud credentials to workflow runners
 
 {{% notes type="info" %}}

--- a/content/docs/deployments/concepts/pulumi-managed-runners.md
+++ b/content/docs/deployments/concepts/pulumi-managed-runners.md
@@ -38,3 +38,5 @@ Deployments run on single-use virtual machines; compute and storage are never sh
 ## Dependency caching
 
 When using Pulumi-managed runners, you can speed up deployments with [dependency caching](/docs/deployments/concepts/settings/#dependency-caching), which stores your downloaded dependencies between runs.
+
+Dependency caching is specific to Pulumi-managed runners. If you run a [customer-managed runner pool](/docs/deployments/concepts/customer-managed-runners/#dependency-caching), you manage caching yourself.

--- a/content/docs/deployments/concepts/settings.md
+++ b/content/docs/deployments/concepts/settings.md
@@ -16,7 +16,7 @@ menu:
 
 Deployment settings refer to the full set of configuration required to run a Pulumi Deployment, defined on a per-stack basis. These settings can be managed through the Pulumi Cloud UI, via the REST API, or defined as code with the Pulumi Cloud provider.
 
-## Creating Deployment Settings
+## Creating deployment settings
 
 You can create and manage deployment settings in several ways:
 
@@ -28,7 +28,7 @@ From the Pulumi Cloud console, a stack's deployment settings can be accessed via
 
 Alternatively, a stack's deployment settings may be defined and subsequently modified using the REST API. For more information, see [Patch Settings](/docs/reference/cloud-rest-api/deployments/#patch-settings) in the [Pulumi Deployments REST API docs](/docs/reference/cloud-rest-api/deployments).
 
-### Defined as Code with the Pulumi Cloud provider
+### Defined as code with the Pulumi Cloud provider
 
 Finally, a stack's deployment settings may be defined as a resource within the stack itself using the Pulumi Cloud provider. This lets you securely store your settings in source control alongside your code. For more information, see the [`pulumiservice.DeploymentSettings`](https://www.pulumi.com/registry/packages/pulumiservice/api-docs/deploymentsettings/) resource docs in the [Pulumi Registry](/registry).
 
@@ -71,7 +71,7 @@ The **No code** source lets you base a stack's deployment on a [Pulumi template]
 
 Select **None** when the deployment has no source to fetch — typically because the Pulumi program is already present in a [custom executor image](#custom-executor-images).
 
-## Path Filtering
+## Path filtering
 
 When using a [VCS integration](/docs/integrations/version-control/) and push-to-deploy, you may want a deployment to trigger only when a push changes files you care about. You can do this with path filters. This is especially useful for monorepos, where a single repository holds multiple Pulumi programs and you want each stack to deploy only when its own files change.
 
@@ -113,7 +113,7 @@ foo/bar/**
 a change to `foo/bar/main.ts` does **not** trigger a deployment — it matches the `!foo/**` exclude filter, and the `foo/bar/**` include filter cannot override that. To deploy on changes under `foo/bar/` while ignoring the rest of `foo/`, exclude only the specific subdirectories you want to skip (for example `!foo/baz/**`) rather than excluding all of `foo/`.
 {{% /notes %}}
 
-## Tag Filtering
+## Tag filtering
 
 When using a [VCS integration](/docs/integrations/version-control/) and push-to-deploy, you can trigger a deployment when a git tag is pushed instead of (or in addition to) a branch push. This is useful for release-based workflows where you deploy only when you cut a release — for example, pushing a `v1.2.0` tag — rather than on every commit. Tag triggers are supported across all version control integrations (GitHub, GitLab, Bitbucket, Azure DevOps, and Custom VCS).
 
@@ -155,7 +155,7 @@ When a tag push triggers a deployment, Pulumi sets the `PULUMI_CI_TAG_NAME` envi
 GitLab integrations created before this feature did not subscribe to tag push events. To use tag triggers with one, enable **Tag push events** on the existing GitLab group webhook — there's no need to re-create the integration. See the [GitLab integration docs](/docs/integrations/version-control/gitlab/#push-to-deploy) for details. This caveat applies only to GitLab; other providers require no action.
 {{% /notes %}}
 
-## Deployment Runner Pools
+## Deployment runner pools
 
 When using Pulumi Deployments, you have options for where your workflows run:
 
@@ -182,7 +182,7 @@ Organization roles are managed through the Roles section. For more information o
 
 For a full explanation of how a deployment's permissions are determined, the default permissions for each trigger, and how to grant additional access, see [Permissions](/docs/deployments/operations/permissions/).
 
-## Pre-Run Commands
+## Pre-run commands
 
 Pre-run commands allow you to execute arbitrary shell commands before the deployment process starts. This is useful for environment setup, authentication with private package repositories, or other preparatory work. Note that each line of your pre-run command runs in a separate shell.
 
@@ -203,13 +203,13 @@ pulumi env run my-aws-env -- aws s3 ls
 This executes the `aws s3 ls` command with credentials from your `my-aws-env` ESC environment. See the [Pulumi CLI documentation](/docs/iac/cli/commands/pulumi_env/) for more details.
 {{% /notes %}}
 
-## Skipping Automatic Dependency Installation
+## Skipping automatic dependency installation
 
 By default, the deployment executor will attempt to install dependencies for your project by using the default dependency manager for the language (i.e. `npm` for nodejs or `virtualenv` for python). However, there may be scenarios where you may want to have more control over the dependency installation step (e.g. you are using `yarn` and/or a different version of `node` than the one that is installed by default).
 
 This is enabled by skipping the default dependency installation step (under Advanced Settings in the UI), and setting a few pre-run commands and environment variables.
 
-## Skipping Intermediate Deployments
+## Skipping intermediate deployments
 
 By default, when multiple deployments are queued for a stack, Pulumi runs them sequentially until the backlog is cleared. For a stack that receives many pushes in quick succession — for example, a busy shared stack where pull requests merge frequently — this means every intermediate commit gets its own deployment, even though only the final state matters.
 
@@ -227,7 +227,7 @@ Keep these trade-offs in mind:
 - **You lose the per-commit deployment record.** Skipped commits do not get their own deployment, so you won't have an individual update history or preview for each intermediate change.
 - **The deployment in progress is not interrupted.** Skipping consolidates the *queued* backlog; it does not cancel a deployment that is already running. Stopping a running deployment requires explicitly [cancelling it](/docs/reference/cloud-rest-api/deployments/), which is a dangerous operation that can leave the stack in an inconsistent state.
 
-## Custom Executor Images
+## Custom executor images
 
 By default, deployments run inside the [`pulumi/pulumi`](https://hub.docker.com/r/pulumi/pulumi) image, which includes the `pulumi` CLI and [LTS versions](https://github.com/pulumi/pulumi-docker-containers/blob/main/README.md#version-policy) of all supported language runtimes. You can override this from the **Custom Executor Image** field in your stack's deployment settings, either to pin a specific Pulumi CLI version or to use your own image with additional tools.
 
@@ -241,31 +241,104 @@ Pulumi Deployments supports OIDC for authenticating with cloud providers. This e
 
 For details on supported clouds see [OIDC Setup for Pulumi Deployments](/docs/deployments/guides/oidc/).
 
-## Dependency Caching
+## Dependency caching
 
-When using Pulumi-managed agents, you can speed up deployments using dependency caching.
+When using Pulumi-managed workflow runners, you can speed up deployments with dependency caching.
+
+The mechanism is straightforward. On the first deployment, the runner detects your downloaded dependencies using lock files, archives them, and stores the archive in blob storage. On later deployments, the runner pulls that archive down and unpacks it, saving the time it would otherwise spend downloading the same dependencies. When your dependencies change, the runner invalidates the old cache and creates a new one.
 
 {{% notes type="info" %}}
-If you have configured the stack to use a [Customer-managed agent](/docs/deployments/concepts/customer-managed-runners/) runner pool this option is unavailable. Running a customer-managed agent pool gives you full control over the lifetime of the agent and its caching.
+Dependency caching is unavailable on stacks that use a [customer-managed runner pool](/docs/deployments/concepts/customer-managed-runners/#dependency-caching), because you already control the lifetime and contents of those runners.
 {{% /notes %}}
 
-The caching method is simple: during the first deployment, the deployment agent will automatically detect downloaded dependencies using lock files, zip them up and store the archive in blob storage. During all subsequent deployments, agents will pull such an archive down and unpack it, saving time it would normally take to download those dependencies. When your dependencies change, deployment agents will automatically invalidate the old cache and create a new one.
+### Enabling dependency caching
 
-Caches are shared on the project level, so all stacks within a project can share the same cache. However, caches are fully isolated and never shared between customers.
+Dependency caching is off by default. You can enable it per stack:
 
-Dependency caching is supported for the following runtimes:
+- **Pulumi Cloud**: on the stack's **Settings** → **Deploy** page, turn on **Enable dependency caching**.
+- **Deployment settings**: set `cacheOptions.enable` to `true`.
+- **REST API**: set the same `cacheOptions.enable` field on the stack's [deployment settings](/docs/reference/cloud-rest-api/deployments/).
 
-- `.NET` - no special configuration required
-- `Python` - ensure that you have either `requirements.txt` (pip) or `uv.lock` (uv) in the root of your source code. If both files are present, caching is skipped. Note: Poetry is not supported — if you use Poetry, you can export a `requirements.txt` with `poetry export -f requirements.txt --output requirements.txt` to enable caching.
-- `Go` - ensure that you have `go.mod` and `go.sum` in the root of your source code.
-- `NodeJS` - `npm`, `yarn`, and `pnpm` are supported.
-  - For `npm`, ensure that you have `package-lock.json` in the root of your source code.
-  - For `yarn`, ensure that you have `yarn.lock` in the root of your source code.
-  - For `pnpm`, ensure that you have `pnpm-lock.yaml` in the root of your source code.
+Dependency caching is not available on stacks backed by Terraform state.
 
-To confirm dependency caching is working and/or to troubleshoot, check out logs of your deployments, specifically the `Restore Cache` and `Save Cache` steps.
+Because caching is a per-stack setting but the cache itself is shared across the project, stacks in the same project can have it enabled and disabled independently:
 
-## Environment Variables
+- A stack with caching **disabled** runs no cache steps at all. It neither reads from nor writes to the project's cache, so it can't benefit from it and can't disturb it.
+- A stack with caching **enabled** reads and writes the shared project cache, keyed by the contents of its lock files.
+- Two caching-enabled stacks with identical lock files share the same cache entries and warm the cache for each other.
+- Disabling caching on a stack does not delete anything. [Clearing the cache](#clearing-the-cache) is a separate, project-wide action.
+
+### What gets cached
+
+In addition to the dependencies below, every cache entry includes the downloaded Pulumi plugins (`~/.pulumi/plugins`) and policy packs (`~/.pulumi/policies`). Language SDKs are not handled specially — they are cached as part of your normal package manager dependencies.
+
+| Runtime | Detected using | Cached directories |
+|---------|----------------|--------------------|
+| Python (pip) | `requirements.txt` | The `venv` directory beside it, and `~/.cache/pip` |
+| Python (uv) | `uv.lock` | The uv cache directory |
+| Python (Poetry) | `poetry.lock` | The in-project `.venv` directory, and Poetry's cache directory |
+| Node.js (npm) | `package-lock.json` | `node_modules` and the npm cache |
+| Node.js (Yarn) | `yarn.lock` | `node_modules` and the Yarn cache |
+| Node.js (pnpm) | `pnpm-lock.yaml` | The pnpm store (not `node_modules`) |
+| .NET | `packages.lock.json`, or `.csproj`, `.fsproj`, and `.vbproj` files | `~/.nuget/packages` |
+| Go | `go.sum`, falling back to `go.mod` | The module cache and the build cache |
+
+Lock files are located by searching the deployment's working directory and then each of its parent directories, so a lock file at the root of a monorepo works even when `Pulumi.yaml` lives in a subdirectory. The .NET runtime is the exception: it searches only the working directory and below.
+
+A few constraints are worth knowing before you turn caching on:
+
+- **Java and YAML are not supported.** Only Python, Node.js, .NET, and Go have caching support. Enabling the setting on a Java or YAML stack is harmless but has no effect — the cache steps run, log `Skipping caching step: unsupported runtime`, and nothing is cached, including plugins.
+- **Python projects must have exactly one lock file.** If more than one of `requirements.txt`, `uv.lock`, and `poetry.lock` is present, Pulumi can't tell which package manager you intend to use and skips caching entirely — including plugins. Poetry is supported natively, so do not export a `requirements.txt` alongside your `poetry.lock`.
+- **For pip, the virtual environment must be named `venv`.** A virtual environment named `.venv` or `env` is not cached.
+- **For Node.js**, a `packageManager` field in `package.json` determines the package manager. Without that field, Pulumi infers it from the lock file, and multiple lock files cause caching to be skipped.
+- **Custom executor images must include your package manager.** Pulumi asks the package manager (`npm`, `yarn`, `pnpm`, `uv`, or `poetry`) where its cache lives, so the binary has to be on the `PATH`. If it isn't, caching is skipped. See [Deployment execution environment](/docs/deployments/guides/custom-images/).
+- **Overriding `PULUMI_HOME` disables plugin caching.** The plugin and policy paths are fixed at `~/.pulumi`, so if you point `PULUMI_HOME` elsewhere with a custom environment variable, those directories are not cached. Your language dependencies are still cached.
+
+### Verifying and troubleshooting
+
+To confirm caching is working, open a deployment's logs and read the **Restore cache** and **Save cache** steps. Neither step prints the words "hit" or "miss," so look for these lines instead.
+
+In the **Restore cache** step:
+
+| Log line | What it means |
+|----------|---------------|
+| `Detected project runtime: python` | Pulumi identified the runtime. |
+| `Calculated cache entry with key pip-<hash>...` | Pulumi computed the cache key from your lock file. |
+| `Decompressing and extracting cache...` followed by `Cache restored successfully` | **Cache hit.** Dependencies were restored. |
+| `No cache to restore, skipping...` | **Cache miss.** Either this is the first deployment, or your lock file changed. |
+| `Skipping caching step: <reason>` | **Nothing was cached.** The reason explains why — usually an unsupported runtime or a missing or ambiguous lock file. |
+
+In the **Save cache** step:
+
+| Log line | What it means |
+|----------|---------------|
+| `Got cache entry key <key>..., capturing paths: [...]` | The directories about to be archived. |
+| `Compressed file "<key>.tar.zst", size: ...` followed by `Uploaded ... successfully` | A new cache entry was written. |
+| `Key "<key>" already cached, skipping...` | Your dependencies were unchanged, so nothing was re-uploaded. This is the normal steady state. |
+| `Warning: cache entry ... exceeded size limit ..., skipping...` | The archive was larger than the size limit and was not saved. |
+| `Directory "<path>" not found, skipping...` | An expected directory didn't exist and was left out of the archive. |
+
+If a deployment isn't getting faster, the most common cause is a `Skipping caching step` line in the **Restore cache** step. Read the reason it gives.
+
+### Clearing the cache
+
+Pulumi invalidates the cache automatically whenever your lock files change, so clearing it by hand is rarely necessary. If you need to force a cold rebuild, you can:
+
+- **Pulumi Cloud**: use the **Clear cache** action on the stack's **Deployments** page.
+- **REST API**: send `DELETE /api/stacks/{organization}/{project}/{stack}/deployments/cache`.
+
+Both clear the cache for the **entire project**, not just the selected stack. Every stack in the project will rebuild its cache on its next deployment.
+
+### Limits and constraints
+
+- Caches are shared at the project level, so all stacks within a project can share the same cache. Caches are fully isolated and never shared between organizations.
+- Cache archives are limited to 5 GB compressed. A larger archive is skipped with a warning rather than failing the deployment.
+- **A cache failure never fails a deployment.** Every problem with caching is a warning and a skip, which is why an unexpectedly slow deployment is worth checking against the log lines above.
+- Cache keys are matched exactly. Unlike some CI systems, there is no partial or fallback key match, so any change to a lock file produces a completely cold cache.
+- Caches that go unread for roughly a month are evicted. A cache in regular use stays warm.
+- The **Save cache** step does not run when a `destroy` operation is configured to delete the stack afterward.
+
+## Environment variables
 
 By default, there are a set of environment variables set by the process automatically:
 


### PR DESCRIPTION
Answers open questions from #docs about Deployments dependency caching, all verified against `pulumi-service` rather than taken on trust.

The headline fix is a correctness one: our docs told Poetry users to export a `requirements.txt`. The Python cacher requires *exactly one* of `requirements.txt` / `uv.lock` / `poetry.lock`, so following that advice left users with two lock files and **no caching at all — including plugins**. Poetry has been natively supported since pulumi/pulumi-service#45258, so the workaround is removed.

## Changes

- **settings.md** — rewrote `Dependency caching` into subsections: enabling it (never documented anywhere but the 2024 launch blog), what actually gets cached per runtime, the log lines that indicate a hit / miss / skip, clearing the cache, and limits.
- Stated plainly that **Java and YAML are unsupported** (previously left to inference) and that a cache failure never fails a deployment — which is why silently-not-caching is easy to miss.
- Documented the `PULUMI_HOME` limitation (pulumi/pulumi-service#45972).
- **customer-managed-runners.md** — new section noting caching is unavailable there, and that you manage it yourself.
- **pulumi-managed-runners.md** — cross-link to the above.
- **Blog** — repointed 3 dead `/docs/pulumi-cloud/deployments/...` links.
- Page headings moved to sentence case per AGENTS.md. **Anchors verified unchanged** by diffing rendered IDs against master — `#dependency-caching` is deep-linked from the runners page and the launch blog.

## Reviewer note

Cache eviction is documented as "roughly a month" of no reads. That comes from infra config (`cacheEvictionDaysToExpire`, default 30), not a product-level guarantee — happy to soften if we'd rather not commit to a number publicly.