### PR TITLE
Restore redirects for 18 /docs URLs still 404ing after the IA restructure

### DIFF
--- a/content/docs/administration/_index.md
+++ b/content/docs/administration/_index.md
@@ -15,6 +15,7 @@ aliases:
   - /docs/administration/
   - /docs/pulumi-cloud/
   - /docs/pulumi-cloud/admin/
+  - /docs/intro/console/
 
 link_buttons:
   primary:

--- a/content/docs/administration/access-identity/oidc-issuers/github.md
+++ b/content/docs/administration/access-identity/oidc-issuers/github.md
@@ -13,6 +13,7 @@ aliases:
 - /docs/administration/access-identity/oidc-client/github/
 - /docs/pulumi-cloud/oidc/client/github/
 - /docs/pulumi-cloud/access-management/oidc-client/github/
+- /docs/pulumi-cloud/access-management/oidc/client/github/
 ---
 
 This document outlines the steps required to configure Pulumi Cloud to accept GitHub id_tokens and exchange them for Pulumi access tokens. Three token types are supported — [organization](#organization-tokens), [team](#team-tokens), and [personal](#personal-tokens) — subject to your [Pulumi edition](/docs/administration/access-identity/oidc-issuers/#token-types-by-edition).

--- a/content/docs/deployments/concepts/_index.md
+++ b/content/docs/deployments/concepts/_index.md
@@ -19,6 +19,7 @@ aliases:
 - /docs/pulumi-cloud/deployments/platform/
 - /docs/pulumi-cloud/deployments/using/
 - /docs/pulumi-cloud/deployments/using-deployments/
+- /docs/deployments/deployments/using/
 - /docs/deployments/deployments/reference/
 - /docs/pulumi-cloud/deployments/reference/
 - /docs/platform/deployments/reference/

--- a/content/docs/iac/cli/commands/pulumi_cloud_api.md
+++ b/content/docs/iac/cli/commands/pulumi_cloud_api.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/iac/cli/commands/pulumi_api/
+---

--- a/content/docs/iac/cli/commands/pulumi_cloud_api_describe.md
+++ b/content/docs/iac/cli/commands/pulumi_cloud_api_describe.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/iac/cli/commands/pulumi_api_describe/
+---

--- a/content/docs/iac/cli/commands/pulumi_cloud_api_list.md
+++ b/content/docs/iac/cli/commands/pulumi_cloud_api_list.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/iac/cli/commands/pulumi_api_list/
+---

--- a/content/docs/iac/concepts/resources/options/retainOnDelete.md
+++ b/content/docs/iac/concepts/resources/options/retainOnDelete.md
@@ -11,6 +11,7 @@ menu:
 aliases:
   - /docs/intro/concepts/resources/options/retainondelete/
   - /docs/concepts/options/retainondelete/
+  - /docs/iac/concepts/options/retainondelete/
   - /docs/iac/concepts/options/retainOnDelete/
 ---
 

--- a/content/docs/iac/concepts/stacks.md
+++ b/content/docs/iac/concepts/stacks.md
@@ -11,6 +11,7 @@ menu:
     concepts:
         weight: 2
 aliases:
+- /docs/iac/concepts/stacks/stackreference/
 - /docs/reference/stack/
 - /docs/tour/programs-exports/
 - /docs/intro/concepts/stack/

--- a/content/docs/iac/get-started/aws/create-project.md
+++ b/content/docs/iac/get-started/aws/create-project.md
@@ -11,6 +11,7 @@ menu:
         weight: 4
 
 aliases:
+    - /docs/get-started/aws/review-project/
     - /docs/iac/get-started/aws/b/create-project/
     - /docs/quickstart/aws/create-project/
     - /docs/clouds/aws/get-started/create-project/

--- a/content/docs/iac/get-started/azure/begin.md
+++ b/content/docs/iac/get-started/azure/begin.md
@@ -12,6 +12,7 @@ menu:
         parent: azure-get-started
         weight: 2
 aliases:
+    - /docs/get-started/azure/begin/
     - /docs/quickstart/azure/begin/
     - /docs/quickstart/azure/install-pulumi/
     - /docs/quickstart/azure/install-language-runtime/

--- a/content/docs/iac/get-started/azure/create-project.md
+++ b/content/docs/iac/get-started/azure/create-project.md
@@ -11,6 +11,7 @@ menu:
         parent: azure-get-started
         weight: 4
 aliases:
+    - /docs/get-started/azure/create-project/
     - /docs/quickstart/azure/create-project/
     - /docs/clouds/azure/get-started/create-project/
     - /docs/quickstart/azure/review-project/

--- a/content/docs/iac/get-started/kubernetes/modify-program.md
+++ b/content/docs/iac/get-started/kubernetes/modify-program.md
@@ -12,6 +12,7 @@ menu:
         weight: 6
 
 aliases:
+    - /docs/get-started/kubernetes/modify-program/
     - /docs/quickstart/kubernetes/modify-program/
     - /docs/quickstart/kubernetes/deploy-changes/
 ---

--- a/content/docs/iac/guides/building-extending/components/build-a-component.md
+++ b/content/docs/iac/guides/building-extending/components/build-a-component.md
@@ -9,6 +9,7 @@ menu:
         parent: iac-guides-components
         weight: 10
 aliases:
+- /docs/reference/component-tutorial/
 - /docs/iac/using-pulumi/build-a-component/
 - /docs/iac/using-pulumi/extending-pulumi/build-a-component/
 ---

--- a/content/docs/iac/guides/migration/_index.md
+++ b/content/docs/iac/guides/migration/_index.md
@@ -10,6 +10,7 @@ menu:
         weight: 50
         identifier: iac-guides-migration
 aliases:
+    - /docs/guides/adopting/
     - /docs/iac/adopting-pulumi/
     - /docs/iac/adopting-pulumi/migrating-to-pulumi/
     - /docs/using-pulumi/adopting-pulumi/

--- a/content/docs/iac/operations/continuous-delivery/_index.md
+++ b/content/docs/iac/operations/continuous-delivery/_index.md
@@ -17,6 +17,7 @@ aliases:
 - /docs/guides/continuous-delivery/
 - /docs/using-pulumi/continuous-delivery/
 - /docs/iac/packages-and-automation/continuous-delivery/
+- /docs/iac/guides/continuous-delivery/add-support-for-cicd-systems/
 - /docs/iac/operations/continuous-delivery/add-support-for-cicd-systems/
 - /docs/iac/using-pulumi/continuous-delivery/add-support-for-cicd-systems/
 - /docs/reference/cd-supporting-new-ci/

--- a/content/docs/iac/operations/troubleshooting/_index.md
+++ b/content/docs/iac/operations/troubleshooting/_index.md
@@ -22,6 +22,7 @@ aliases:
   - /docs/troubleshooting/
   - /docs/troubleshooting/overview/
   - /docs/iac/support/
+  - /docs/iac/support/troubleshooting/
   - /docs/iac/troubleshooting/
 
 sections:

--- a/content/docs/insights/policy/_index.md
+++ b/content/docs/insights/policy/_index.md
@@ -18,6 +18,7 @@ aliases:
 - /docs/iac/crossguard/
 - /docs/insights/policy-as-code/
 - /docs/insights/policy/core-concepts/
+- /docs/iac/crossguard/core-concepts/
 - /docs/iac/packages-and-automation/crossguard/core-concepts/
 - /docs/iac/using-pulumi/crossguard/core-concepts/
 ---

--- a/content/docs/insights/policy/policy-packs/pre-built-packs.md
+++ b/content/docs/insights/policy/policy-packs/pre-built-packs.md
@@ -8,6 +8,7 @@ menu:
     parent: policy-packs
     weight: 10
 aliases:
+  - /docs/insights/policy/pre-built-packs/
   - /docs/insights/policy/policy-as-code/pre-built-packs/
   - /docs/pulumi-cloud/insights/pre-built-packs/
   - /docs/iac/crossguard/pre-built-packs/

--- a/content/docs/integrations/clouds/aws/cloudfx/_index.md
+++ b/content/docs/integrations/clouds/aws/cloudfx/_index.md
@@ -1,5 +1,6 @@
 ---
-redirect_to: /docs/iac/get-started/
+redirect_to: /docs/integrations/clouds/aws/
 aliases:
+- /docs/clouds/aws/cloudfx/
 - /docs/iac/clouds/aws/cloudfx/
 ---

--- a/content/tutorials/_index.md
+++ b/content/tutorials/_index.md
@@ -4,6 +4,7 @@ linktitle: Tutorials
 meta_desc: Hands-on guides to help you get the most out of Pulumi.
 aliases:
     - /learn
+    - /docs/reference/tutorials/
 ---
 
 Hands-on guides to help you get the most out of Pulumi.


### PR DESCRIPTION
Fixes #20242.

Restores redirects for the 18 `/docs` paths in the issue. 17 are missing `aliases:` entries; one turned out to be a different bug entirely (below). Also adds `redirect_to:` stubs for the renamed `pulumi cloud api *` CLI commands.

## The retainOnDelete one wasn't a missing redirect — it was a casing bug

`/docs/iac/concepts/options/retainondelete/` already **had** an alias. It was spelled in camelCase:

```yaml
aliases:
  - /docs/iac/concepts/options/retainOnDelete/
```

Hugo lowercases page URLs derived from filenames, but writes aliases **verbatim**. So the build emitted the alias only at the camelCase key, while the lowercase URL — the one the world actually links to, and the one Hugo itself would have served back when the page lived there — had nothing behind it. S3 and CloudFront are case-sensitive, so it 404'd.

This survived because **macOS hides it**: APFS is case-insensitive, so the lowercase path resolves fine on a developer's machine and breaks only in production.

It was the *only* uppercase alias in the entire content tree (I swept all of `content/` to confirm), and it had the highest crawler-404 count in the issue by a wide margin — 91, roughly 3x the next path. That fits: crawlers were hitting the lowercase form and getting told the page was dead.

Both spellings are now aliased, so the camelCase URL that exists in production today keeps working rather than becoming a new 404.

## Redirect chain fixed

The cloudfx stub pointed at `/docs/iac/get-started/`, which has no `_index.md` — it is *itself* only an alias. That made it a three-hop client-side chain. Retargeted to `/docs/integrations/clouds/aws/`, a real page and a more useful destination for cloudfx traffic than the get-started hub.

## Scope note

The issue names `pulumi_cloud_api_describe`. The entire `pulumi cloud api` group was renamed to top-level `pulumi api`, so I also stubbed its two siblings (`pulumi_cloud_api`, `pulumi_cloud_api_list`), which 404 identically. These use `redirect_to:` frontmatter rather than `aliases:` because `content/docs/iac/cli/commands/` is regenerated from the CLI and the regen workflow deletes every page that lacks a `redirect_to:` — the same pattern as the existing `pulumi_history.md` stub.

## Judgment calls

Two paths are genuinely dead 2018-era pages with no true successor; destinations chosen with @jkodroff:

- `/docs/reference/tutorials/` (a tutorial hub) → `/tutorials/`
- `/docs/reference/component-tutorial/` (subclassing `ComponentResource`) → the `build-a-component` guide

## Verification

Built the site and resolved each path against the emitted output. The check compares path segments as exact strings against directory listings rather than using a filesystem existence test — on APFS, `test -e` answers the case question *wrong*, which is what let the original bug ship. All 20 paths emit a redirect to the intended destination.

`make lint` clean (1807 files, 0 errors).

## Not addressed: `/docs/robots.txt`

The issue's closing note suggests a `410` would quiet the ~688 crawler 404s. It wouldn't, so I left it alone.

RFC 9309 §2.3.1.4 names 404 and 410 together as "Unavailable" and prescribes *identical* crawler behavior for both. A crawler fetching robots.txt cannot act on the difference, and it re-fetches on its own cache TTL regardless. The 404-vs-410 distinction people have in mind is about *content indexing*, which doesn't apply — robots.txt is a directive fetch, not an indexable page.

The requests themselves are non-compliant: robots.txt is only defined at the root of an origin, so `/docs/robots.txt` is crawlers naively resolving the filename relative to the directory they're in. Suggest filtering it from the 404 reporting query as known noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)