### PR TITLE
Add HSTS preload/includeSubDomains and a Permissions-Policy header

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -635,7 +635,9 @@ const baseSecurityHeadersConfig = {
 // they're disabled outright rather than allowlisted.
 const permissionsPolicyHeaderItem = {
     header: "Permissions-Policy",
-    value: "geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()",
+    // interest-cohort=() is the FLoC opt-out, retained for older browsers/scanners that still
+    // check for it even though FLoC itself was discontinued in favor of the Topics API.
+    value: "geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=(), browsing-topics=()",
     override: false,
 };
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -617,6 +617,8 @@ const baseSecurityHeadersConfig = {
     },
     strictTransportSecurity: {
         accessControlMaxAgeSec: 31536000,
+        includeSubdomains: true,
+        preload: true,
         override: false,
     },
     xssProtection: {
@@ -626,6 +628,17 @@ const baseSecurityHeadersConfig = {
     }
 };
 
+// CloudFront's securityHeadersConfig schema has no native Permissions-Policy support, so it's
+// added as a plain custom header instead. This site's own code has no use for any of these
+// features (verified: no geolocation/camera/microphone/payment/usb API usage, and the embedded
+// YouTube/Google Maps iframes don't request any of them via their `allow` attribute), so
+// they're disabled outright rather than allowlisted.
+const permissionsPolicyHeaderItem = {
+    header: "Permissions-Policy",
+    value: "geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()",
+    override: false,
+};
+
 // Fingerprinted/hashed assets get immutable browser caching (1 year).
 // This is separate from CloudFront edge TTLs (defaultTtl/maxTtl) which only
 // control CDN-level caching. Without this policy, browsers see no Cache-Control
@@ -633,7 +646,7 @@ const baseSecurityHeadersConfig = {
 const BrandLogoCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('brand-logo-cache-headers', {
     securityHeadersConfig: baseSecurityHeadersConfig,
     customHeadersConfig: {
-        items: [{
+        items: [permissionsPolicyHeaderItem, {
             header: "Cache-Control",
             value: "public, max-age=1800",
             override: true,
@@ -644,7 +657,7 @@ const BrandLogoCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('brand-log
 const DefaultCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('default-cache-headers', {
     securityHeadersConfig: baseSecurityHeadersConfig,
     customHeadersConfig: {
-        items: [{
+        items: [permissionsPolicyHeaderItem, {
             header: "Cache-Control",
             value: "max-age=60, stale-while-revalidate=300",
             override: true,
@@ -655,7 +668,7 @@ const DefaultCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('default-cac
 const OneHourCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('one-hour-cache-headers', {
     securityHeadersConfig: baseSecurityHeadersConfig,
     customHeadersConfig: {
-        items: [{
+        items: [permissionsPolicyHeaderItem, {
             header: "Cache-Control",
             value: "public, max-age=3600",
             override: true,
@@ -666,7 +679,7 @@ const OneHourCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('one-hour-ca
 const ImmutableCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('immutable-cache-headers', {
     securityHeadersConfig: baseSecurityHeadersConfig,
     customHeadersConfig: {
-        items: [{
+        items: [permissionsPolicyHeaderItem, {
             header: "Cache-Control",
             value: "public, max-age=31536000, immutable",
             override: true,
@@ -679,7 +692,7 @@ const ImmutableCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('immutable
 const DocsResponseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy('docs-response-headers', {
     securityHeadersConfig: baseSecurityHeadersConfig,
     customHeadersConfig: {
-        items: [{
+        items: [permissionsPolicyHeaderItem, {
             header: "Vary",
             value: "Accept",
             override: false,

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -708,6 +708,9 @@ const DocsResponseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy('docs
 // each archived object's own Cache-Control (immutable 1y / manifest 5min) reach the browser.
 const VersionedDocsResponseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy('versioned-docs-response-headers', {
     securityHeadersConfig: baseSecurityHeadersConfig,
+    customHeadersConfig: {
+        items: [permissionsPolicyHeaderItem],
+    },
 });
 
 // baseCacheBehavior holds the fields shared by every behavior. TTLs and


### PR DESCRIPTION
## Summary
- www.pulumi.com's `Strict-Transport-Security` header set `max-age=31536000` but was missing `includeSubDomains`/`preload` — flagged in a prior vulnerability report against pulumi.com's HSTS config.
- No `Permissions-Policy` header was set anywhere on this site. CloudFront's `securityHeadersConfig` schema has no native support for this header, so it's added via `customHeadersConfig` on each of the six `ResponseHeadersPolicy` resources instead (including `VersionedDocsResponseHeadersPolicy`, for `/docs/versioned/*`), matching the same approach taken for api.pulumi.com/app.pulumi.com in pulumi/pulumi-service.
- Disables geolocation, camera, microphone, payment, usb, interest-cohort (FLoC), and browsing-topics (Topics API, FLoC's successor) outright — confirmed via a repo-wide search that no first-party code (layouts/, content/, assets/, theme/, cypress/) uses any of these APIs, and that the embedded YouTube/Google Maps iframes don't request them via `allow=`.
- Content-Security-Policy is intentionally left unchanged — the existing `frame-ancestors` policy is out of scope here; a fuller CSP is a separate, larger effort.

## Test plan
- [ ] Confirm the CI-provided test/preview stack serves `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` and a `Permissions-Policy` header on a docs page response
- [ ] Spot-check a page with an embedded YouTube video and the events page with a Google Maps embed to confirm both still render/play normally
- [ ] Confirm `tsc --noEmit` and `yarn lint` show no new errors introduced by this change (pre-existing tslint debt in this file is unrelated and unaffected — verified error count is unchanged before/after)
