### PR TITLE
Add shared badge system and normalize badge call sites

### DIFF
--- a/layouts/changelog/single.html
+++ b/layouts/changelog/single.html
@@ -21,7 +21,7 @@
     <article data-changelog-article>
         <p class="body-sm m-0 mb-3">
             <time class="text-gray-700" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2, 2006" }}</time>
-            {{ with .Params.tier }}<span class="inline-flex items-center align-middle ml-2 rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider leading-none">{{ . }}</span>{{ end }}
+            {{ with .Params.tier }}<span class="badge badge-secondary badge-sm ml-2">{{ . }}</span>{{ end }}
         </p>
         <h1 class="heading-2 font-display font-semibold text-service-black m-0 mb-4">{{ .Title }}</h1>
         <div class="text-base leading-relaxed">

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -26,10 +26,7 @@
                     <div class="flex items-center gap-3">
                         <h2 class="text-2xl font-semibold tracking-tight m-0">{{ $tier.title }}</h2>
                         {{ with $tier.badge }}
-                        <span
-                            class="inline-flex items-center rounded-full bg-violet-100 text-violet-primary px-2.5 py-0.5 text-xs font-mono uppercase tracking-wider"
-                            >{{ . }}</span
-                        >
+                        <span class="badge badge-brand">{{ . }}</span>
                         {{ end }}
                     </div>
                     <p class="mt-2 text-base text-gray-700 m-0 md:min-h-[3rem] block">{{ $tier.subtitle }}</p>

--- a/layouts/page/reinvent.html
+++ b/layouts/page/reinvent.html
@@ -187,7 +187,7 @@
             <!-- Meagan Cojocar -->
             <div class="bg-white rounded-lg shadow-lg pt-6 pr-6 relative overflow-hidden w-full xl:w-1/2 flex flex-col" style="border-top: 4px solid; border-color: #5a30c5;">
                 <div class="flex items-start justify-between mb-4 pl-6">
-                    <span class="bg-violet-100 text-violet-primary text-xs font-semibold px-3 py-1 rounded-full">ENGINEERING</span>
+                    <span class="badge badge-brand">ENGINEERING</span>
                 </div>
                 <h3 class="text-xl font-bold mb-0 text-left pl-6">Meagan Cojocar</h3>
                 <p class="text-gray-600 mb-4 text-left m-0 pl-6">Vice President and GM, IaC</p>
@@ -208,7 +208,7 @@
              <!-- Komal Ali -->
              <div class="bg-white rounded-lg shadow-lg pt-6 pr-6 relative overflow-hidden w-full xl:w-1/2 flex flex-col" style="border-top: 4px solid; border-color: #5a30c5;">
                  <div class="flex items-start justify-between mb-4 pl-6">
-                     <span class="bg-violet-100 text-violet-primary text-xs font-semibold px-3 py-1 rounded-full">ENGINEERING</span>
+                     <span class="badge badge-brand">ENGINEERING</span>
                  </div>
                  <h3 class="text-xl font-bold mb-0 text-left pl-6">Komal Ali</h3>
                  <p class="text-gray-600 mb-4 text-left m-0 pl-6">Director of Engineering, IaC and AI</p>
@@ -230,7 +230,7 @@
         <!-- Craig Dillon -->
         <div class="bg-white rounded-lg shadow-lg pt-6 pr-6 relative overflow-visible w-full flex flex-col" style="border-top: 4px solid; border-color: #5a30c5;">
             <div class="flex items-start justify-between mb-4 pl-6">
-                <span class="bg-violet-100 text-violet-primary text-xs font-semibold px-3 py-1 rounded-full">ENTERPRISE SERVICES</span>
+                <span class="badge badge-brand">ENTERPRISE SERVICES</span>
             </div>
             <h3 class="text-xl font-bold mb-0 text-left pl-6">Craig Dillon</h3>
             <p class="text-gray-600 mb-4 text-left m-0 pl-6">Head of Professional Services</p>
@@ -259,7 +259,7 @@
             <!-- Mitch Gerdisch -->
             <div class="bg-white rounded-lg shadow-lg pt-6 pr-6 relative overflow-hidden w-full xl:w-1/2 flex flex-col" style="border-top: 4px solid; border-color: #5a30c5;">
                 <div class="flex items-start justify-between mb-4 pl-6">
-                    <span class="bg-violet-100 text-violet-primary text-xs font-semibold px-3 py-1 rounded-full">SOLUTIONS</span>
+                    <span class="badge badge-brand">SOLUTIONS</span>
                 </div>
                 <h3 class="text-xl font-bold mb-0 text-left pl-6">Mitch Gerdisch</h3>
                 <p class="text-gray-600 mb-4 text-left m-0 pl-6">Principal Solutions Architect</p>
@@ -280,7 +280,7 @@
             <!-- James Connell -->
             <div class="bg-white rounded-lg shadow-lg pt-6 pr-6 relative overflow-hidden w-full xl:w-1/2 flex flex-col" style="border-top: 4px solid; border-color: #5a30c5;">
                 <div class="flex items-start justify-between mb-4 pl-6">
-                    <span class="bg-violet-100 text-violet-primary text-xs font-semibold px-3 py-1 rounded-full">SOLUTIONS</span>
+                    <span class="badge badge-brand">SOLUTIONS</span>
                 </div>
                 <h3 class="text-xl font-bold mb-0 text-left pl-6 ">James Connell</h3>
                 <p class="text-gray-600 mb-4 text-left m-0 pl-6">Senior Solutions Architect</p>

--- a/layouts/partials/alert.html
+++ b/layouts/partials/alert.html
@@ -1,6 +1,5 @@
 {{ $text := "PulumiUP: A two-hour virtual event for cloud engineers. Save your spot!" }}
 {{ $url := relref . "/pulumi-up" }}
-{{ $color := "orange" }}
 
 
 <div class="mx-auto mb-12">
@@ -9,7 +8,7 @@
             href="{{ $url }}"
             class="block p-2 bg-violet-400 hover:bg-violet-300 transition-all items-center text-violet-100 leading-none rounded-full flex md:inline-flex "
         >
-            <span class="alert-chicklet flex rounded-full bg-{{ $color }}-700 border-4 border-{{ $color }}-600 uppercase text-white px-2 py-1 text-xs font-bold mr-2">New!</span>
+            <span class="alert-chicklet badge badge-warning mr-2">New!</span>
             <span class="alert-content text-left flex-auto text-white text-sm md:text-base leading-normal">
                 {{ $text | safeHTML }}
             </span>

--- a/layouts/partials/announcement-banner.html
+++ b/layouts/partials/announcement-banner.html
@@ -47,7 +47,7 @@
        data-announcement-id="{{ .id }}">
     <div class="flex flex-1 min-w-0 items-center gap-3">
       {{ if $href }}<a href="{{ $href }}" tabindex="-1" class="contents text-white group-hover:text-white/90 hover:no-underline">{{ end }}
-        {{ with .badge }}<span class="shrink-0 inline-flex items-center rounded-full bg-violet-300 text-violet-950 px-2 py-0.5 font-mono text-xs font-semibold uppercase tracking-wide">{{ . }}</span>{{ end }}
+        {{ with .badge }}<span class="badge badge-brand shrink-0">{{ . }}</span>{{ end }}
         {{ with .icon }}{{ partial "icon.html" (dict "name" . "class" "size-5 shrink-0 text-violet-300" "weight" "fill") }}{{ end }}
         <div class="min-w-0 overflow-hidden whitespace-nowrap" data-announcement-marquee>
           <span class="inline-block" data-announcement-content>

--- a/layouts/partials/badge.html
+++ b/layouts/partials/badge.html
@@ -1,0 +1,27 @@
+{{- /*
+    Shared badge/pill — mono uppercase overline text on a fully-rounded pill.
+    Emits the `.badge` classes defined in theme/src/scss/_badges.scss.
+
+    Params:
+      text    (required) label
+      variant default | brand | secondary | outline | success | warning
+              | destructive | info | dark  (default: brand)
+      size    "" (default h-5) | sm | lg
+      href    optional → renders a link (with hover/focus); `relative z-10` keeps it
+              clickable above a card's stretched title link
+      icon    optional raw SVG/HTML rendered before the text (safeHTML)
+      track   optional data-track value
+*/ -}}
+{{- $text := .text -}}
+{{- $variant := .variant | default "brand" -}}
+{{- $size := .size -}}
+{{- $href := .href -}}
+{{- $icon := .icon -}}
+{{- $track := .track -}}
+{{- $class := printf "badge badge-%s" $variant -}}
+{{- with $size }}{{ $class = printf "%s badge-%s" $class . }}{{ end -}}
+{{- if $href -}}
+<a href="{{ $href }}"{{ with $track }} data-track="{{ . }}"{{ end }} class="relative z-10 {{ $class }}">{{ with $icon }}{{ . | safeHTML }}{{ end }}{{ $text }}</a>
+{{- else -}}
+<span class="{{ $class }}">{{ with $icon }}{{ . | safeHTML }}{{ end }}{{ $text }}</span>
+{{- end -}}

--- a/layouts/partials/blog/badge.html
+++ b/layouts/partials/blog/badge.html
@@ -1,32 +1,17 @@
 {{- /*
-    Generic blog badge/pill — mono uppercase (Monaspace, 12px, 0.6px tracking).
-    Variants (from Figma):
-      outline    (default) white bg + gray-200 border — categories, "Part N"
-      secondary  gray-50 bg, no border — tags
-      dark       service-black bg + gray-800 border, white text — on violet-950
+    Blog badge/pill — thin wrapper over the shared `partials/badge.html`. Kept so the
+    ~8 blog callers (category/tag/series badges, card partials) need no changes. The
+    variant names map 1:1 onto the shared system; `outline` is the default.
+
     Params:
       text    (required) label
-      variant outline | secondary | dark
-      href    optional → renders a link (with hover); `relative z-10` keeps it
-              clickable above a card's stretched title link
+      variant outline (default) | secondary | dark
+      href    optional → renders a link
       track   optional data-track value
 */ -}}
-{{- $text := .text -}}
 {{- $variant := .variant | default "outline" -}}
-{{- $href := .href -}}
-{{- $track := .track -}}
-{{- $base := "inline-flex items-center justify-center px-2 py-0.5 rounded-lg font-overline-sm whitespace-nowrap" -}}
-{{- $skin := "bg-white border border-gray-200 text-service-black" -}}
-{{- $hover := "hover:border-violet-primary hover:text-violet-primary" -}}
-{{- if eq $variant "secondary" -}}
-    {{- $skin = "bg-gray-50 text-service-black" -}}
-    {{- $hover = "hover:bg-gray-100 hover:text-violet-primary" -}}
-{{- else if eq $variant "dark" -}}
-    {{- $skin = "bg-service-black border border-gray-800 text-white" -}}
-    {{- $hover = "hover:border-violet-300 hover:text-white" -}}
-{{- end -}}
-{{- if $href -}}
-<a href="{{ $href }}"{{ with $track }} data-track="{{ . }}"{{ end }} class="relative z-10 {{ $base }} {{ $skin }} transition-colors {{ $hover }}">{{ $text }}</a>
-{{- else -}}
-<span class="{{ $base }} {{ $skin }}">{{ $text }}</span>
-{{- end -}}
+{{- partial "badge.html" (dict
+    "text" .text
+    "variant" $variant
+    "href" .href
+    "track" .track) -}}

--- a/layouts/partials/blog/series-fan.html
+++ b/layouts/partials/blog/series-fan.html
@@ -8,6 +8,6 @@
 */ -}}
 {{- $count := .count -}}
 <div class="relative isolate flex items-center">
-    <span class="relative inline-flex h-7 items-center whitespace-nowrap rounded-lg border border-gray-200 bg-white px-2 font-overline-sm text-service-black" style="z-index: {{ add $count 1 }}">{{ $count }} part series</span>
-    {{- if gt $count 1 }}{{ range $i := (seq (sub $count 1)) }}<span aria-hidden="true" class="relative -ml-[56px] h-7 w-16 shrink-0 rounded-lg border border-gray-200 bg-white" style="z-index: {{ sub $count $i }}"></span>{{ end }}{{ end -}}
+    <span class="badge badge-outline relative" style="z-index: {{ add $count 1 }}">{{ $count }} part series</span>
+    {{- if gt $count 1 }}{{ range $i := (seq (sub $count 1)) }}<span aria-hidden="true" class="relative -ml-[56px] h-5 w-16 shrink-0 rounded-full border border-gray-200 bg-white" style="z-index: {{ sub $count $i }}"></span>{{ end }}{{ end -}}
 </div>

--- a/layouts/partials/releases/card-text-block.html
+++ b/layouts/partials/releases/card-text-block.html
@@ -32,7 +32,7 @@
     </div>
     {{ end }}
     {{ with $title }}
-    <h3 class="heading-2 font-display font-semibold tracking-tighter text-service-black m-0 leading-[1.1]">{{ . }}{{ with $tier }}<span class="inline-flex items-center align-middle ml-2 rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider leading-none transition-colors group-hover/linked:bg-violet-100 group-hover/linked:text-violet-primary">{{ . }}</span>{{ end }}</h3>
+    <h3 class="heading-2 font-display font-semibold tracking-tighter text-service-black m-0 leading-[1.1]">{{ . }}{{ with $tier }}<span class="badge badge-secondary badge-sm ml-2 group-hover/linked:bg-violet-100 group-hover/linked:text-violet-primary">{{ . }}</span>{{ end }}</h3>
     {{ end }}
     {{ with $description }}
     <div class="body-base text-service-black leading-6">

--- a/layouts/partials/releases/changelog-item.html
+++ b/layouts/partials/releases/changelog-item.html
@@ -18,7 +18,7 @@
     <a href="{{ $page.RelPermalink }}" data-changelog-link class="group/item flex items-center gap-2 py-4 no-underline hover:no-underline mb-0 text-service-black hover:text-violet-primary transition-colors">
         <span class="flex items-center gap-1 sm:gap-2 flex-wrap">
             <span class="heading-4 mb-0">{{ $page.Title }}</span>
-            {{ with $page.Params.tier }}<span class="whitespace-nowrap items-center align-middle rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider leading-none">{{ . }}</span>{{ end }}
+            {{ with $page.Params.tier }}<span class="badge badge-secondary badge-sm">{{ . }}</span>{{ end }}
         </span>
         <time datetime="{{ $page.Date.Format "2006-01-02" }}" class="body-sm ml-auto shrink-0 whitespace-nowrap text-gray-700">{{ $page.Date.Format "Jan 2" }}</time>
     </a>

--- a/layouts/partials/releases/release-item.html
+++ b/layouts/partials/releases/release-item.html
@@ -37,10 +37,7 @@
     <div class="flex flex-col lg:flex-row items-center">
         <div class="pb-0 xl:pl-52 flex-1 min-w-0 flex flex-col gap-5 px-8 py-10 md:px-12 md:py-14 lg:px-16 lg:py-16">
             {{ with $overline }}
-            <span
-                class="inline-flex items-center self-start rounded-full bg-violet-100 text-violet-primary px-4 py-2 text-xs font-mono uppercase tracking-wider"
-                >{{ . }}</span
-            >
+            <span class="badge badge-brand badge-lg self-start">{{ . }}</span>
             {{ end }}
             {{ with $heading }}
             <h2 class="heading-xl font-display font-semibold tracking-tighter text-service-black m-0 leading-[1.1]">{{ . }}</h2>

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -10,7 +10,7 @@
                 <div class="flex flex-col gap-2">
                     <h2 class="heading-1 m-0!">{{ .name }}</h2>
                     <div class="flex flex-wrap items-center gap-2">
-                        {{ if eq .status "guest" }}<span class="inline-flex items-center rounded-lg bg-violet-100 px-2 py-0.5 font-overline-sm text-violet-primary">Guest</span>{{ end }}
+                        {{ if eq .status "guest" }}<span class="badge badge-brand">Guest</span>{{ end }}
                         {{ with .title }}<span class="font-overline-sm">{{ . }}</span>{{ end }}
                     </div>
                     {{ with .social }}{{ partial "widgets/social-icons.html" (dict "social" .) }}{{ end }}

--- a/theme/src/scss/_algolia.scss
+++ b/theme/src/scss/_algolia.scss
@@ -83,7 +83,10 @@
 
                 // The result-count badge.
                 .count {
-                    @apply ml-2 text-xs flex items-center rounded bg-violet-100/60 text-gray-700 px-1.5 py-0.5;
+                    @extend .badge;
+                    @extend .badge-secondary;
+                    @extend .badge-sm;
+                    @apply ml-2;
 
                     // When the item count is zero, don't show a background.
                     &.count-0 {

--- a/theme/src/scss/_badges.scss
+++ b/theme/src/scss/_badges.scss
@@ -1,10 +1,92 @@
-.badge {
-    @apply align-middle rounded rounded-lg uppercase px-2 py-0 text-xs font-normal font-mono;
+// Shared badge system — a small, fully-rounded pill with mono all-caps overline
+// text, modeled on the design-system `cva` badge (variant + size axes) and mapped
+// onto this repo's @pulumi/design-tokens palette (`{color}-muted` bg + `{color}-primary`
+// text for the soft variants). Render as `class="badge badge-<variant> [badge-<size>]"`
+// (or via `layouts/partials/badge.html`), or compose in SCSS with
+// `@extend .badge; @extend .badge-<variant>;`.
+//
+// Variants live as top-level classes (not nested `&.badge-*`) so `@extend` consumers
+// (chooser preview pill, docs nav count, Algolia count, event-card tag) can pull in a
+// single variant. `ghost`/`link` from the cva source are omitted — no consumers yet.
 
-    &.badge-preview {
-        @apply bg-orange-200 text-orange-600;
+.badge {
+    @apply inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1
+        overflow-hidden rounded-full border border-transparent px-2 py-0.5
+        align-middle font-mono text-xs uppercase tracking-wide whitespace-nowrap
+        transition-colors;
+
+    // Optional leading/trailing icon (parity with cva `[&>svg]:size-3`).
+    & > svg {
+        @apply size-3 pointer-events-none;
     }
-    &.badge-required {
-        @apply border border-red-200 text-red-600;
+}
+
+// --- Variants -----------------------------------------------------------------
+.badge-default {
+    @apply bg-violet-primary text-white;
+}
+.badge-brand {
+    @apply bg-violet-muted text-violet-primary;
+}
+.badge-secondary {
+    @apply bg-gray-100 text-gray-primary;
+}
+.badge-outline {
+    @apply bg-white border-gray-200 text-service-black;
+}
+.badge-success {
+    @apply bg-green-muted text-green-primary;
+}
+.badge-warning {
+    @apply bg-orange-muted text-orange-primary;
+}
+.badge-destructive {
+    @apply bg-red-muted text-red-primary;
+}
+.badge-info {
+    @apply bg-blue-muted text-blue-primary;
+}
+.badge-dark {
+    @apply bg-service-black border-gray-800 text-white;
+}
+
+// Back-compat aliases — the chooser (`_chooser.scss` @extend) and hand-authored
+// content (`saml/sso.md`) reference these names directly, so they must persist.
+.badge-preview {
+    @extend .badge-warning; // "PREVIEW" / "BETA" status
+}
+.badge-required {
+    @extend .badge-destructive; // "REQUIRED"
+}
+
+// --- Sizes (base = default: h-5 / text-xs) ------------------------------------
+.badge-sm {
+    @apply h-4 px-1.5 text-xxs;
+}
+.badge-lg {
+    @apply h-6 px-3 text-sm;
+}
+
+// --- Link affordances ---------------------------------------------------------
+a.badge {
+    @apply cursor-pointer;
+
+    &:focus-visible {
+        @apply outline-none ring-2 ring-violet-300;
     }
+}
+a.badge-default:hover {
+    @apply bg-violet-600;
+}
+a.badge-brand:hover {
+    @apply bg-violet-200;
+}
+a.badge-secondary:hover {
+    @apply bg-violet-100 text-violet-primary;
+}
+a.badge-outline:hover {
+    @apply border-violet-primary text-violet-primary;
+}
+a.badge-dark:hover {
+    @apply border-violet-300;
 }

--- a/theme/src/scss/_marketing.scss
+++ b/theme/src/scss/_marketing.scss
@@ -18,6 +18,10 @@
 
 // v4 layer placement: custom styles must be in @layer so Tailwind utilities can override them.
 @layer components {
+    // Shared badge/pill system — also used on marketing-bundle pages (blog cards,
+    // pricing, reinvent, releases). Ships in main.scss too; both bundles need it.
+    @import "badges";
+
     body {
         @apply overflow-x-hidden;
 

--- a/theme/src/scss/_templates.scss
+++ b/theme/src/scss/_templates.scss
@@ -664,7 +664,8 @@
     }
 
     .event-card-tag {
-        @apply inline-block font-body text-gray-700 rounded-md text-[0.7rem] py-0.5 px-2 bg-violet-50 border border-violet-200;
+        @extend .badge;
+        @extend .badge-secondary;
     }
 
     .event-card-cta {

--- a/theme/src/scss/_theme.scss
+++ b/theme/src/scss/_theme.scss
@@ -26,6 +26,7 @@
     --color-docs-link: var(--docs-link);
 
     /* Site-specific overrides */
+    --text-xxs: 0.625rem; /* 10px — badge `sm` size (tier pills) */
     --breakpoint-xl: 1270px;
     --breakpoint-nav-desktop: 1345px;
     --background-image-lines-top-right: url("/images/bg-lines-top-right-1.svg");

--- a/theme/src/scss/components/_chooser.scss
+++ b/theme/src/scss/components/_chooser.scss
@@ -54,6 +54,7 @@ pulumi-chooser {
                 @apply ml-1;
                 @extend .badge;
                 @extend .badge-preview;
+                @extend .badge-sm; // keep the tab-row height compact
             }
         }
     }
@@ -133,6 +134,7 @@ pulumi-chooser {
                             @apply ml-1;
                             @extend .badge;
                             @extend .badge-preview;
+                            @extend .badge-sm; // keep the toolbar height compact
                         }
                     }
                 }

--- a/theme/src/scss/docs/_docs-main.scss
+++ b/theme/src/scss/docs/_docs-main.scss
@@ -184,10 +184,9 @@ body.section-registry {
                 gap: 4px;
 
                 span.count-badge {
-                    font-size: 11px;
-                    padding: 0px 4px;
-                    border: 1px solid var(--color-violet-primary);
-                    border-radius: 6px;
+                    @extend .badge;
+                    @extend .badge-secondary;
+                    @extend .badge-sm;
                 }
             }
 

--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -507,18 +507,48 @@ html[data-theme="dark"] body.section-docs {
         border-bottom-color: var(--docs-link);
     }
 
-    // --- Badges (also render via chooser preview pills) ---------------------
+    // --- Badges -------------------------------------------------------------
+    // Soft variants are `{color}-muted` bg + `{color}-primary` text in light mode;
+    // dark flips them to a deep `{color}-950` fill + light `{color}-300` text.
     // The chooser pill is a bare `li > span` that gets its skin from
     // `@extend .badge-preview` (no literal class), so it needs naming here too.
+    .badge-warning,
     .badge-preview,
     pulumi-chooser > ul li > span {
         background-color: var(--color-orange-950);
         color: var(--color-orange-300);
     }
 
+    .badge-destructive,
     .badge-required {
-        border-color: var(--color-red-800);
+        background-color: var(--color-red-950);
         color: var(--color-red-300);
+    }
+
+    .badge-brand {
+        background-color: var(--color-violet-950);
+        color: var(--color-violet-300);
+    }
+
+    .badge-secondary {
+        background-color: var(--color-gray-800);
+        color: var(--color-gray-300);
+    }
+
+    .badge-success {
+        background-color: var(--color-green-950);
+        color: var(--color-green-300);
+    }
+
+    .badge-info {
+        background-color: var(--color-blue-950);
+        color: var(--color-blue-300);
+    }
+
+    .badge-outline {
+        background-color: transparent;
+        border-color: var(--docs-border);
+        color: var(--docs-fg);
     }
 
     // --- Resource-links (right-rail, docs-only) -----------------------------


### PR DESCRIPTION

Just some badge clean up.

<img width="873" height="1046" alt="Screenshot 2026-07-14 at 8 43 40 AM" src="https://github.com/user-attachments/assets/44b772b1-b134-4b86-8995-d376cf4255fa" />

### Proposed changes

Consolidates the scattered badge/pill implementations into one shared system in `theme/src/scss/_badges.scss`, modeled on the design-system `cva` badge (variant + size axes) and mapped onto the `@pulumi/design-tokens` palette — fully-rounded pills with mono all-caps overline text, with variants (`default`/`brand`/`secondary`/`outline`/`success`/`warning`/`destructive`/`info`/`dark`), `sm`/`lg` sizes, and back-compat aliases (`badge-preview` → warning, `badge-required` → destructive). Adds a generalized `layouts/partials/badge.html` and repoints every call site (blog category/tag/series, releases/changelog tier pills, pricing/reinvent/announcement/release eyebrows, alert chicklet, author "Guest", series-fan, event-card tag, docs nav + Algolia counts, chooser preview pill) at the shared classes. The chooser preview pill and count badges use the compact `badge-sm` size and the event-card tag uses the neutral secondary variant to avoid disrupting their layouts. Also adds a `--text-xxs` token and dark-mode overrides for the docs-reachable variants.