### PR TITLE
Redirect and noindex the /gads/ section index

### DIFF
--- a/content/gads/_index.md
+++ b/content/gads/_index.md
@@ -1,0 +1,18 @@
+---
+# /gads/ is a container for paid-search landing pages, not a destination of its
+# own. Without this file Hugo auto-generated a section list page for it, which
+# rendered through _default/list.html (badly), was crawlable, and shipped in the
+# sitemap. See https://github.com/pulumi/docs/issues/20268.
+#
+# redirect_to sends it to the homepage: head.html emits a zero-delay meta
+# refresh, which scripts/translate-redirects.js turns into a real S3 301 keyed
+# to gads/index.html alone. The landing pages under /gads/* are separate files
+# and are unaffected.
+#
+# block_external_search_index adds a noindex tag and drops the page from the
+# sitemap and the on-site search index, so it stays out of search results even
+# before the 301 is applied.
+title: Google Ads landing pages
+block_external_search_index: true
+redirect_to: /
+---


### PR DESCRIPTION
Fixes #20268.

`/gads/` is a container for paid-search landing pages, not a destination of its own. Because there was no `_index.md`, Hugo auto-generated a section list page for it that rendered through `_default/list.html` (badly — see the screenshot in the issue), carried no `noindex`, and shipped in `sitemap.xml`.

## What this does

Adds `content/gads/_index.md` with two frontmatter flags:

- **`redirect_to: /`** — `layouts/partials/head.html` emits a zero-delay meta refresh, and `scripts/translate-redirects.js` (run during the deploy sync) scans the built HTML for exactly that tag and turns it into a real **S3 301** keyed to `gads/index.html`. So we get a proper 301 to the homepage rather than a soft meta-refresh.
- **`block_external_search_index: true`** — adds `<meta name="robots" content="noindex">` and drops the page from `sitemap.xml` and the Algolia on-site search index. This covers the "just make sure it's not indexed" requirement independently of the redirect.

## Subpages are unaffected

The 301 keys are per-object with no prefix matching (`make-s3-redirects.js` does a `PutObject` with `WebsiteRedirectLocation` at one exact key), and the landing pages under `/gads/*` are separate output files with no meta refresh of their own. Verified against a full `./scripts/build-site.sh`:

- `/gads/` now carries both `<meta http-equiv="refresh" content="0; url=/">` and `<meta name="robots" content="noindex">`.
- `/gads/` no longer appears in `public/sitemap.xml`.
- `translate-redirects.js` emits exactly **one** new entry: `gads/index.html|/`. (The two other `gads` entries in that file are pre-existing alias redirects, untouched.)
- The set of built pages under `public/gads/` is **identical** before and after (34 subpages); `/gads/terraform/` still renders its full content and has no redirect on it.

`make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)