### PR TITLE
Add shared form styling system and normalize control chrome

### DIFF
--- a/layouts/partials/contact-us.html
+++ b/layouts/partials/contact-us.html
@@ -7,8 +7,8 @@
                         <div class="hs-form hs-form-fg-dark font-normal">
                             <pulumi-contact-us-form
                                 items="{{ .Params.form | jsonify }}"
-                                label-class="block mb-2 font-normal text-sm"
-                                select-class="w-full p-2 text-sm rounded-lg block text-gray-700 border border-gray-300 rounded bg-white focus:outline-none focus:ring focus:ring-violet-primary"
+                                label-class="block mb-2 font-normal text-sm text-gray-950"
+                                select-class="form-select form-select-lg"
                             ></pulumi-contact-us-form>
                         </div>
                     </div>

--- a/layouts/partials/docs/feedback.html
+++ b/layouts/partials/docs/feedback.html
@@ -24,13 +24,13 @@
                         <textarea
                             id="feedbackAdditionalComments"
                             rows="5"
-                            class="w-full p-2 rounded border border-docs-border outline-none focus:ring-violet-primary focus:ring-2"
+                            class="form-textarea"
                             placeholder="Additional Comments"
                             required
                         ></textarea>
                         <p id="feedbackCommentsError" class="hidden mt-1 text-red-primary">Please add a comment before submitting.</p>
                     </div>
-                    <input id="feedbackEmail" type="email" class="block mb-4 w-full p-2 rounded border border-docs-border outline-none focus:ring-violet-primary focus:ring-2" placeholder="Email (optional)" />
+                    <input id="feedbackEmail" type="email" class="form-input mb-4" placeholder="Email (optional)" />
                     <div class="flex gap-2 justify-between">
                         <a id="docsSubmitFeedback" class="btn btn-primary">Submit</a>
                         <a id="docsCloseFeedbackLongForm" class="btn btn-secondary">Close</a>

--- a/layouts/partials/tutorials/feedback.html
+++ b/layouts/partials/tutorials/feedback.html
@@ -24,13 +24,13 @@
                         <textarea
                             id="feedbackAdditionalComments"
                             rows="5"
-                            class="w-full p-2 bg-white rounded border border-gray-500 outline-none focus:ring-violet-primary focus:ring-2"
+                            class="form-textarea"
                             placeholder="Additional Comments"
                             required
                         ></textarea>
                         <p id="feedbackCommentsError" class="hidden mt-1 text-red-primary">Please add a comment before submitting.</p>
                     </div>
-                    <input id="feedbackEmail" type="email" class="block mb-4 w-full p-2 rounded border border-gray-500 outline-none focus:ring-violet-primary focus:ring-2" placeholder="Email (optional)" />
+                    <input id="feedbackEmail" type="email" class="form-input mb-4" placeholder="Email (optional)" />
                     <div class="flex gap-2 justify-between">
                         <a id="docsSubmitFeedback" class="btn btn-primary">Submit</a>
                         <a id="docsCloseFeedbackLongForm" class="btn btn-secondary">Close</a>

--- a/theme/src/scss/_blog.scss
+++ b/theme/src/scss/_blog.scss
@@ -63,9 +63,12 @@
     @apply justify-center;
 
     input:not(.hs-button) {
-        // Match the adjacent submit (.btn-lg): h-10 + rounded-lg. Overrides the
-        // base .newsletter py-3, which otherwise renders the input a touch tall.
-        @apply h-10 rounded-lg py-0 border-gray-300 bg-white text-service-black;
+        // This single-field newsletter form has no <fieldset>, so the normalized
+        // `.hs-form fieldset input` base never reaches it — set chrome in full here.
+        // h-10 + rounded-lg matches the adjacent submit (.btn-lg). Vertical padding
+        // comes from the .newsletter base py-3 in _hubspot.scss (same specificity,
+        // later import — it wins the tie); h-10 pins the height regardless.
+        @apply h-10 rounded-lg border-gray-300 bg-white text-service-black;
 
         &:focus {
             @apply border-violet-primary outline-none ring-2 ring-violet-primary/30;
@@ -83,6 +86,10 @@
     @apply relative;
 
     input:not(.hs-button) {
+        // No <fieldset> in this newsletter form, so set chrome in full here (the
+        // bg-white also masks the footer's global dark newsletter-inline palette).
+        // z-10 on focus lifts the input above the seam so its full (focused) border
+        // renders over the adjacent button.
         @apply relative h-9 w-44 rounded-l-lg rounded-r-none! border-gray-300 bg-white py-1.75 text-sm text-service-black;
 
         &:focus {

--- a/theme/src/scss/_event-list.scss
+++ b/theme/src/scss/_event-list.scss
@@ -52,23 +52,31 @@
                 @apply text-base;
             }
 
+            // Small-select chrome (mirrors form-select-sm in _forms.scss). The caret
+            // lives in the component's shadow DOM (filter-select-option-group.tsx);
+            // the pr-7 gutter leaves room for it. This block out-specifies the shared
+            // components/_filter-select.scss rule, so keep the two visually in sync.
             .toggle {
-                @apply pl-2 pr-5 py-1 rounded bg-white border border-gray-300 transition-all whitespace-nowrap;
+                @apply flex items-center h-8 pl-2 pr-7 bg-white border border-gray-300 transition-all whitespace-nowrap cursor-pointer;
                 width: auto;
+                border-radius: $form-radius;
+                box-shadow: $form-select-shadow;
 
                 @include screen-lg {
-                    @apply pr-6;
+                    @apply pr-8;
                 }
 
                 &:hover {
-                    @apply text-black;
-                    background-color: #e8e8ec;
+                    @apply border-gray-500 bg-gray-100;
                 }
             }
 
+            // Panel matches the main-nav dropdown (.card + shadow): gray-200 border,
+            // rounded-lg, Tailwind `shadow`.
             .options {
-                @apply absolute bg-white py-2 pl-1 pr-4 rounded shadow mt-1 border border-gray-300 leading-loose z-50;
+                @apply absolute bg-white py-2 pl-1 pr-4 shadow mt-1 border border-gray-200 leading-loose z-50;
                 max-width: calc(100vw - 2rem);
+                border-radius: $form-radius;
 
                 @include screen-lg {
                     @apply pr-8;
@@ -76,16 +84,10 @@
                 }
             }
 
-            &:hover,
-            &[expanded] {
-                &::part(toggle) {
-                    @apply text-black;
-                }
-
-                .toggle {
-                    @apply text-black;
-                    background-color: #e8e8ec;
-                }
+            // Open state — violet-800 focus-ring treatment shared with form controls.
+            &[expanded] .toggle {
+                @apply border-violet-800;
+                box-shadow: $form-focus-ring, $form-select-shadow;
             }
         }
     }

--- a/theme/src/scss/_footer.scss
+++ b/theme/src/scss/_footer.scss
@@ -40,13 +40,18 @@
         @apply ml-0!;
     }
 
-    input {
+    // Dark re-skin + joined-left layout. This single-field newsletter form has no
+    // <fieldset>, so the normalized `.hs-form fieldset input` base never reaches it —
+    // the control chrome (border, height, radius) is set in full here.
+    input:not(.hs-button) {
         @apply bg-black text-white border border-gray-800 rounded-l-lg rounded-r-none! h-10 py-0;
 
         &::placeholder { @apply text-gray-500; }
+    }
 
-        &.hs-button {
-            @apply leading-none bg-violet-primary text-white rounded-l-none! rounded-r-lg! h-10 px-2! py-0 ml-0;
-        }
+    input.hs-button {
+        // 1px violet-primary border so the button's edges line up with the input's
+        // border in the joined control (.btn ships a transparent border otherwise).
+        @apply leading-none bg-violet-primary text-white border-violet-primary rounded-l-none! rounded-r-lg! h-10 px-2! py-0 ml-0;
     }
 }

--- a/theme/src/scss/_forms.scss
+++ b/theme/src/scss/_forms.scss
@@ -1,0 +1,193 @@
+// Form system — inputs, textareas, selects, checkboxes, radios, and labels.
+//
+// Compose with:  class="form-input form-input-lg"  (default size baked into the
+// base class; add a size modifier only to override — same convention as .btn/.badge).
+//
+// Controls:  form-input | form-textarea | form-select | form-checkbox | form-radio
+// Sizes:     (default) | -sm | -lg | -xl
+// Meta:      form-label | form-help | form-error
+//
+// HEIGHT CONTRACT: control heights mirror the .btn size scale (_button.scss) so a
+// form control and a same-size button line up:
+//     -sm = h-8   (default) = h-9   -lg = h-10   -xl = h-12
+//
+// Colors come from the Pulumi brand tokens: bg white, text gray-950, border
+// gray-300, placeholder gray-500, focus border+ring violet-800, disabled opacity-50.
+//
+// This partial is imported FIRST inside main.scss's @layer components block so the
+// later form-consuming partials (_hubspot.scss, _blog.scss, _footer.scss) can
+// @include its mixins — Sass resolves imports sequentially.
+
+// Single radius knob — retune every control at once. Buttons don't vary radius by
+// size, so neither do inputs. Plain border-radius (not @apply) so the CSS var flows.
+$form-radius: var(--radius-lg);
+
+// Inset depth shadows layered on top of the border (brand tokens shadow.input /
+// shadow.select). Inputs get a top inner shadow; selects a bottom inner shadow.
+// The resting shadow is exposed as the --form-resting-shadow custom property so a
+// dark context can suppress it without restating the focus stack below. To
+// suppress, set it to the no-op shadow `0 0 #0000` — NOT `none`: `none` is
+// invalid inside a shadow list, so `box-shadow: $form-focus-ring, none` gets
+// discarded at computed-value time and the focus ring vanishes with it.
+$form-input-shadow: inset 0 2px 4px 0 rgb(0 0 0 / 0.12);
+$form-select-shadow: inset 0 -2px 4px 0 rgb(0 0 0 / 0.08);
+
+// Focus adds a 2px violet-800 inset ring ON TOP of the resting shadow, and the
+// border also goes violet-800 — the two merge into one clean ~3px edge.
+$form-focus-ring: inset 0 0 0 2px var(--color-violet-800);
+$form-invalid-ring: inset 0 0 0 2px var(--color-red-600);
+
+// Caret chevron drawn as a background SVG (class-wide fix for flush carets). The
+// gray-500 (#9997a0) stroke matches placeholder text; the light variant (gray-300
+// #cbcace) is for dark surfaces. NOTE: this same SVG is duplicated verbatim in the
+// filter-select Stencil component (shadow DOM can't read this Sass var) —
+// theme/stencil/src/components/filter-select/filter-select-option-group.tsx. Keep
+// them in sync.
+$form-caret-svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%239997a0' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E";
+$form-caret-svg-light: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%23cbcace' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E";
+
+// Custom check/dot marks for the shadcn-style checkbox/radio (white on violet).
+$form-check-svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m3.5 8 3 3 6-6.5'/%3E%3C/svg%3E";
+$form-radio-svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3' fill='%23fff'/%3E%3C/svg%3E";
+
+// ---------------------------------------------------------------------------
+// Mixins — consumed here and by _hubspot.scss / _blog.scss / _footer.scss.
+// ---------------------------------------------------------------------------
+
+// Base chrome shared by inputs, textareas, and selects. 16px text on mobile
+// (text-base) prevents iOS zoom-on-focus; md:text-sm matches .btn on desktop.
+@mixin form-control-base {
+    @apply block w-full min-w-0 appearance-none border border-gray-300 bg-white text-gray-950
+           transition-all outline-none placeholder:text-gray-500
+           disabled:pointer-events-none disabled:opacity-50 disabled:bg-gray-100
+           h-9 px-2.5 py-1.75 text-base md:text-sm;
+
+    border-radius: $form-radius;
+    --form-resting-shadow: #{$form-input-shadow};
+    box-shadow: var(--form-resting-shadow, none);
+
+    &:focus,
+    &:focus-visible {
+        @apply border-violet-800;
+        box-shadow: $form-focus-ring, var(--form-resting-shadow, none);
+    }
+
+    // Invalid state — aria-invalid (hand-authored) and HubSpot's .error class.
+    &[aria-invalid="true"],
+    &.error {
+        @apply border-red-600;
+
+        &:focus,
+        &:focus-visible {
+            @apply border-red-600;
+            box-shadow: $form-invalid-ring, var(--form-resting-shadow, none);
+        }
+    }
+}
+
+// Size mixins — heights mirror the .btn scale (see contract above).
+@mixin form-control-sm { @apply h-8 px-2 py-1.5 text-sm; }
+@mixin form-control-lg { @apply h-10 px-3 py-2; }
+@mixin form-control-xl { @apply h-12 px-3 py-2.5; }
+
+// Textarea additions — grow vertically instead of a fixed height.
+@mixin form-textarea-chrome { @apply h-auto min-h-16 py-2; }
+
+// Select-specific chrome: bottom inner shadow, pointer cursor, room for the caret,
+// and the chevron background. Include AFTER a size mixin so the pr-8 wins over the
+// size's horizontal padding.
+@mixin form-select-chrome {
+    @apply cursor-pointer pr-8;
+
+    --form-resting-shadow: #{$form-select-shadow};
+    background-image: url("#{$form-caret-svg}");
+    background-repeat: no-repeat;
+    background-position: right 0.625rem center;
+    background-size: 1rem;
+
+    // Native multi-selects and sized listboxes have no single caret and grow.
+    &[multiple],
+    &[size]:not([size="1"]) {
+        @apply h-auto pr-2.5;
+        background-image: none;
+    }
+}
+
+// Shadcn-style checkbox/radio base. No inner depth shadow on check controls.
+@mixin form-check-base {
+    // p-0 + box-border keep it a 1rem SQUARE even when a wider control padding
+    // (e.g. HubSpot's fieldset input chrome) would otherwise inflate the box.
+    @apply appearance-none size-4 shrink-0 p-0 box-border border border-gray-300 bg-white align-middle
+           cursor-pointer transition-all outline-none bg-center bg-no-repeat
+           checked:bg-violet-primary checked:border-violet-primary
+           focus-visible:border-violet-primary focus-visible:ring-3 focus-visible:ring-violet-primary/50
+           disabled:pointer-events-none disabled:opacity-50;
+
+    background-size: 0.75rem;
+    // No inner depth shadow on check controls. Also resets the input inset shadow
+    // when this mixin is layered onto a HubSpot `.hs-form fieldset input`.
+    box-shadow: none;
+}
+
+// ---------------------------------------------------------------------------
+// Classes.
+// ---------------------------------------------------------------------------
+
+.form-input { @include form-control-base; }
+
+.form-textarea {
+    @include form-control-base;
+    @include form-textarea-chrome;
+}
+
+.form-select {
+    @include form-control-base;
+    @include form-select-chrome;
+
+    // Light caret + no inner shadow, for dark surfaces (footer, dark panels).
+    &.form-select-inverse {
+        --form-resting-shadow: 0 0 #0000;
+        background-image: url("#{$form-caret-svg-light}");
+    }
+}
+
+// Size modifiers. Selects re-assert their caret gutter after the size padding.
+.form-input-sm,
+.form-textarea-sm { @include form-control-sm; }
+.form-input-lg,
+.form-textarea-lg { @include form-control-lg; }
+.form-input-xl,
+.form-textarea-xl { @include form-control-xl; }
+
+.form-select-sm {
+    @include form-control-sm;
+    @apply pr-7;
+    background-position: right 0.5rem center;
+}
+.form-select-lg {
+    @include form-control-lg;
+    @apply pr-8;
+}
+.form-select-xl {
+    @include form-control-xl;
+    @apply pr-8;
+}
+
+.form-checkbox {
+    @include form-check-base;
+
+    border-radius: 4px;
+
+    &:checked { background-image: url("#{$form-check-svg}"); }
+}
+
+.form-radio {
+    @include form-check-base;
+    @apply rounded-full;
+
+    &:checked { background-image: url("#{$form-radio-svg}"); }
+}
+
+.form-label { @apply block text-sm mb-1 text-gray-950; }
+.form-help  { @apply block text-xs text-gray-500 mt-1; }
+.form-error { @apply block text-xs text-red-600 mt-1; }

--- a/theme/src/scss/_hubspot.scss
+++ b/theme/src/scss/_hubspot.scss
@@ -3,7 +3,7 @@
 }
 
 .hs-form {
-    @apply text-sm;
+    @apply text-sm relative;
 
     &.hs-demo-form {
         max-width: 500px;
@@ -13,26 +13,33 @@
     fieldset {
         @apply block !max-w-none;
 
+        // HubSpot injects `margin-right: 8px` on every `.input` wrapper (all
+        // form-columns-* variants), which — with our full-width input — overflows
+        // the column. Zero it everywhere (our !important beats HubSpot's
+        // non-important rule); the two-column gutter is supplied instead by padding
+        // on the first field div below.
+        .input {
+            margin-right: 0 !important;
+        }
+
         &:not(.form-columns-1)>.field:first-child {
-            @apply pr-2;
+            @apply pr-4;
         }
 
         label {
-            @apply block mt-3 mb-1 font-normal;
+            @apply block mt-5 mb-1 font-normal;
         }
 
-        .hs-input {
-            @apply block text-gray-700;
+        // Force full width to beat HubSpot's inline width, but NOT on checkboxes/
+        // radios — those are sized by the custom check control below (1rem square).
+        // This exclusion is what stops the consent checkboxes rendering stretched.
+        .hs-input:not([type="checkbox"]):not([type="radio"]) {
+            @apply block;
             width: 100% !important;
         }
 
-        .legal-consent-container .hs-form-booleancheckbox-display .hs-input {
-            width: auto !important;
-            margin-top: 4px;
-        }
-
         .hs-form-required {
-            @apply ml-1 text-red-500;
+            @apply ml-1 text-red-600;
         }
 
         .hs-richtext p {
@@ -43,23 +50,50 @@
             }
         }
 
+        // Normalized control chrome (see _forms.scss). HubSpot forms stay at lg.
+        // NOTE: this base rule is deliberately kept at the SAME low specificity
+        // (0,1,2) as the pre-normalization `input, textarea, select` rule so the
+        // downstream dark/compact overrides (_footer, _blog) — which were written
+        // to beat that selector — keep winning. Do NOT rewrite it with `:not()`
+        // type guards; those inflate specificity and swallow those overrides. The
+        // submit button lives OUTSIDE the fieldsets, so it isn't matched here.
         input,
         textarea,
         select {
-            @apply border border-gray-300 rounded-lg p-2 bg-white;
-
-            &:focus {
-                @apply outline-none ring ring-violet-primary;
-            }
+            @include form-control-base;
+            @include form-control-lg;
         }
 
-        // Text-like inputs only: checkboxes/radios (consent fields, .hs-form-radio)
-        // must keep their natural height.
-        input:not([type="submit"]):not([type="checkbox"]):not([type="radio"]),
+        textarea {
+            @include form-textarea-chrome;
+        }
+
         select {
-            @apply h-10;
+            @include form-select-chrome;
+            @apply pr-8;
         }
+    }
 
+    // Custom shadcn-style check controls. Placed at .hs-form level (NOT inside
+    // fieldset) so it also reaches the legal-consent subscription checkboxes, which
+    // HubSpot renders in .legal-consent-container OUTSIDE the fieldsets. Comes after
+    // the fieldset `.hs-input { width:100% !important }` rule in source order, so at
+    // the same specificity the !important 1rem size wins and the box stays square.
+    input[type="checkbox"],
+    input[type="radio"] {
+        @include form-check-base;
+        width: 1rem !important;
+        height: 1rem !important;
+    }
+
+    input[type="checkbox"] {
+        border-radius: 4px;
+        &:checked { background-image: url("#{$form-check-svg}"); }
+    }
+
+    input[type="radio"] {
+        @apply rounded-full;
+        &:checked { background-image: url("#{$form-radio-svg}"); }
     }
 
     input[type="submit"] {
@@ -69,7 +103,7 @@
     }
 
     .hs-error-msgs {
-        @apply list-none mt-2 p-0 text-red-500 text-xs;
+        @apply list-none mt-2 p-0 text-red-600 text-xs;
 
         label {
             @apply mb-0;
@@ -90,8 +124,17 @@
 
     &-fg-dark {
         @apply text-gray-700;
+
+        // Labels stay dark (matches non-fg-dark forms, whose labels inherit the
+        // gray-950 page text); the gray-700 above is for body/legal copy only.
+        label {
+            @apply text-gray-950;
+        }
     }
 
+    // Newsletter — a single-field form with NO <fieldset>, so the normalized
+    // `.hs-form fieldset input` base never reaches its input. Control chrome is set
+    // here in full; the inline dark/compact variants (_footer, _blog) override it.
     &.newsletter {
         @apply flex items-start;
 
@@ -107,18 +150,20 @@
             }
         }
 
-        input {
+        // No bg / border-color here on purpose: this base imports AFTER _footer and
+        // _blog, so at equal specificity it would win ties. Leaving palette unset lets
+        // the inline dark (_footer) and light (_blog) variants own it; the plain
+        // newsletter falls back to the browser-default white input.
+        input:not(.hs-button) {
             @apply block py-3 px-4 rounded-lg border;
+
+            // Resting inner shadow, matching the .form-input system. Set only here
+            // (no variant sets box-shadow), so every newsletter input — plain, blog
+            // header, blog-post — inherits it; on the footer's black it's invisible.
+            box-shadow: $form-input-shadow;
 
             @include screen-md {
                 @apply w-56;
-            }
-
-            &.hs-button {
-                @extend .btn;
-                @extend .btn-primary;
-                @extend .btn-lg;
-                @apply w-auto ml-2;
             }
 
             &:focus {
@@ -126,31 +171,37 @@
             }
         }
 
-        &.newsletter-dark-border input {
+        input.hs-button {
+            @extend .btn;
+            @extend .btn-primary;
+            @extend .btn-lg;
+            @apply w-auto ml-2;
+        }
+
+        &.newsletter-dark-border input:not(.hs-button) {
             @apply border-gray-800;
         }
 
-        &.newsletter-wide input {
+        &.newsletter-wide input:not(.hs-button) {
             @apply w-full;
 
             @include screen-lg {
                 width: 24rem;
             }
-
-            &[type="submit"] {
-                @apply w-auto;
-            }
         }
     }
 
     .hs-recaptcha {
-        @apply mb-5;
+        @apply  absolute right-2 bottom-1;
     }
 
     .legal-consent-container {
         @apply my-4;
         ul {
             @apply list-none pl-0;
+        }
+        .hs-form-booleancheckbox-display > span {
+            @apply ml-0!;
         }
     }
 
@@ -162,39 +213,27 @@
         cursor: pointer;
     }
 
-    .hs-form-booleancheckbox-display .hs-input {
-        @apply inline-block mr-3;
+    // Lay the checkbox beside its (possibly multi-line) consent text and align the
+    // 1rem box with the first line — replaces the old top-margin nudge that
+    // misaligned it. `gap` supplies the spacing (was mr-3 on the input).
+    .hs-form-booleancheckbox-display {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.5rem;
 
-        width: auto !important;
-        margin-top: 4px;
+        .hs-input {
+            margin-top: 0.125rem;
+        }
     }
 
     .hs-form-radio {
         @apply list-none;
 
         .hs-form-radio-display {
-            @apply inline-flex;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
         }
-
-        .hs-input {
-            @apply mr-3;
-
-            width: fit-content !important;
-        }
-    }
-}
-
-// adjusting the recaptcha position for the event registration form
-.event-single-registration .hs-form {
-    position: relative;
-    padding-bottom: 3.5rem;
-
-    .hs-recaptcha {
-        @apply m-0;
-
-        position: absolute;
-        bottom: 0;
-        right: 0;
     }
 }
 
@@ -229,20 +268,4 @@
     .input {
         @apply mt-1;
     }
-
-    input,
-    textarea,
-    select {
-        @apply border border-gray-300 rounded-lg p-2 bg-white;
-
-        &:focus {
-            @apply outline-none ring ring-violet-primary;
-        }
-    }
-
-    input:not([type="submit"]):not([type="checkbox"]):not([type="radio"]),
-    select {
-        @apply h-10;
-    }
-
 }

--- a/theme/src/scss/components/_filter-select.scss
+++ b/theme/src/scss/components/_filter-select.scss
@@ -2,35 +2,41 @@ pulumi-filter-select {
     pulumi-filter-select-option-group {
         @apply font-display text-base;
 
+        // Slotted light-DOM toggle, styled as a small select (mirrors form-select-sm
+        // in _forms.scss). The caret itself lives in the component's shadow DOM —
+        // see theme/stencil/src/components/filter-select/filter-select-option-group.tsx.
         .toggle {
-            @apply pl-2 pr-6 py-1 rounded bg-white border-2 border-gray-900 transition-all;
+            @apply flex items-center h-8 pl-2 pr-7 text-sm bg-white border border-gray-300 transition-all cursor-pointer;
+
+            border-radius: $form-radius;
+            box-shadow: $form-select-shadow;
 
             @include screen-md {
                 @apply w-48;
             }
 
             &:hover {
-                @apply bg-gray-900 text-white;
+                @apply border-gray-500 bg-gray-100;
             }
         }
 
+        // Panel matches the main-nav dropdown (.card + shadow): gray-200 border,
+        // rounded-lg, Tailwind `shadow`.
         .options {
-            @apply bg-white py-2 pl-1 pr-4 rounded border border-gray-900 shadow mt-1 leading-loose z-50;
+            @apply bg-white py-2 pl-1 pr-4 border border-gray-200 shadow mt-1 leading-loose z-50;
+
+            border-radius: $form-radius;
 
             @include screen-md {
                 @apply pr-8;
             }
         }
 
-        &:hover,
-        &[expanded] {
-            &::part(toggle) {
-                @apply text-white;
-            }
+        // Open state — the violet-800 focus-ring treatment shared with form controls.
+        &[expanded] .toggle {
+            @apply border-violet-800;
 
-            .toggle {
-                @apply bg-gray-900 text-white;
-            }
+            box-shadow: $form-focus-ring, $form-select-shadow;
         }
     }
 }

--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -959,6 +959,44 @@ body[data-theme="dark"] {
 }
 
 // ---------------------------------------------------------------------------
+// Form controls (_forms.scss). The .form-* classes are painted with @apply
+// utilities (bg-white, text-gray-950, border-gray-300, the inset shadow), which
+// the docs dark remap can't reach — so re-skin them here to the docs tokens.
+// Currently the only docs form controls are the feedback-widget textarea + email
+// input (layouts/partials/docs/feedback.html). Unlayered → wins over the layered
+// @apply base regardless of specificity.
+// ---------------------------------------------------------------------------
+html[data-theme="dark"] body.section-docs {
+    .form-input,
+    .form-textarea,
+    .form-select {
+        background-color: var(--docs-card);
+        color: var(--docs-fg);
+        border-color: var(--docs-border);
+        // Black inner shadow is invisible/wrong on the dark surface. No-op shadow,
+        // NOT `none` — `none` inside the focus shadow list below would invalidate
+        // the whole declaration and drop the ring (see _forms.scss).
+        --form-resting-shadow: 0 0 #0000;
+
+        &::placeholder {
+            color: var(--docs-fg-muted);
+        }
+
+        // Lighter (violet-300) focus ring for contrast on the dark surface.
+        &:focus,
+        &:focus-visible {
+            border-color: var(--docs-ring);
+            box-shadow: inset 0 0 0 2px var(--docs-ring), var(--form-resting-shadow, none);
+        }
+    }
+
+    // Light caret for the dark surface. Duplicated from $form-caret-svg-light.
+    .form-select {
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%23cbcace' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Sidebar theme toggle — pinned to the bottom of the docs nav. Three icon
 // buttons (sun / moon / monitor); the active one reflects data-theme-pref.
 // ---------------------------------------------------------------------------

--- a/theme/src/scss/main.scss
+++ b/theme/src/scss/main.scss
@@ -132,6 +132,8 @@ $sitenav-offset: calc($sitenav-height + 16px);
 }
 
 @layer components {
+    // Imported FIRST: later partials (_hubspot, _blog, _footer) @include its mixins.
+    @import "forms";
     @import "about";
     @import "accordion";
     @import "algolia";
@@ -375,9 +377,6 @@ $sitenav-offset: calc($sitenav-height + 16px);
         }
     }
 
-    section.newsletter-input pulumi-hubspot-form input.hs-input {
-        @apply rounded-lg;
-    }
 }
 
 @import "consent-banner";

--- a/theme/src/scss/marketing/_pulumi-deployments.scss
+++ b/theme/src/scss/marketing/_pulumi-deployments.scss
@@ -1,6 +1,5 @@
 div.pulumi-deployments {
-    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
-    --tw-shadow: 0 10px 15px -3pxrgba(0,0,0,.1),0 4px 6px -2pxrgba(0,0,0,.05)
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
     padding: 2.5rem;
     background-color: #fff;
     border: 1px solid #e5e5df;
@@ -32,19 +31,8 @@ div.pulumi-deployments {
         opacity: .5;
     }
 
-    input:not([type="submit"]):not([type="checkbox"]),
-    textarea {
-        background-color: #fff;
-        border-color: #e5e5df;
-        border-radius: 0.25rem;
-        border-width: 1px;
-        padding: 0.5rem;
-        margin: 0.5rem 0 16px 0;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-
+    // Control chrome comes from the normalized base in _forms.scss/_hubspot.scss;
+    // only the deployments-specific margins remain here.
     input[type="submit"] {
         margin-top: 8px;
     }

--- a/theme/stencil/src/components/filter-select/filter-select-option-group.tsx
+++ b/theme/stencil/src/components/filter-select/filter-select-option-group.tsx
@@ -43,16 +43,26 @@ import { Component, h, Element, Prop, Method, Listen } from "@stencil/core";
             pointer-events: auto;
         }
 
+        /* SVG chevron caret, sitting in the toggle's pr-7 gutter. This data-URI is
+           duplicated from $form-caret-svg in theme/src/scss/_forms.scss (shadow DOM
+           can't read the SCSS var) — keep the two in sync. */
         .toggle slot::after {
             position: absolute;
-            right: 0.5em;
+            right: 0.625rem;
             top: 50%;
+            width: 1rem;
+            height: 1rem;
+            content: "";
             transform: translateY(-50%);
-            content: "▾";
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%239997a0' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: 1rem;
+            transition: transform 100ms;
         }
 
         :host([expanded]) .toggle slot::after {
-            transform: rotate(180deg) translateY(50%);
+            transform: translateY(-50%) rotate(180deg);
         }
     `,
 })

--- a/theme/stencil/src/components/filter-select/filter-select-option.tsx
+++ b/theme/stencil/src/components/filter-select/filter-select-option.tsx
@@ -10,11 +10,46 @@ export interface Filter {
     shadow: true,
     styles: `
         label {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
             white-space: nowrap;
+            font-size: 0.8125rem;
+            line-height: 1.4;
+            cursor: pointer;
         }
 
-        input {
-            margin-right: 0.5em;
+        /* Shadcn-style custom checkbox — mirrors .form-checkbox in _forms.scss.
+           CSS custom properties inherit through the shadow boundary, so the brand
+           tokens resolve here; the white check data-URI is duplicated from
+           $form-check-svg (shadow DOM can't read the SCSS var). */
+        input[type="checkbox"] {
+            appearance: none;
+            -webkit-appearance: none;
+            margin: 0;
+            width: 1rem;
+            height: 1rem;
+            flex-shrink: 0;
+            border: 1px solid var(--color-gray-300, #cbcace);
+            border-radius: 4px;
+            background-color: #fff;
+            background-position: center;
+            background-repeat: no-repeat;
+            background-size: 0.75rem;
+            cursor: pointer;
+            transition: all 100ms;
+        }
+
+        input[type="checkbox"]:checked {
+            background-color: var(--color-violet-primary, #5a30c5);
+            border-color: var(--color-violet-primary, #5a30c5);
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m3.5 8 3 3 6-6.5'/%3E%3C/svg%3E");
+        }
+
+        input[type="checkbox"]:focus-visible {
+            outline: none;
+            border-color: var(--color-violet-primary, #5a30c5);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-violet-primary, #5a30c5) 50%, transparent);
         }
     `,
 })


### PR DESCRIPTION
Normalizes and updates all forms styles to (mostly) match the console.

<img width="790" height="1218" alt="Screenshot 2026-07-14 at 2 32 31 PM" src="https://github.com/user-attachments/assets/5314e24b-43ca-4390-98f8-4f3558f3b106" />

<img width="774" height="351" alt="Screenshot 2026-07-14 at 2 32 42 PM" src="https://github.com/user-attachments/assets/0e6ba62d-0060-4620-bc06-2f39e607baf4" />



### Proposed changes

Adds `theme/src/scss/_forms.scss`, a single source of truth for form control chrome — `.form-*` classes and reusable mixins for inputs, textareas, selects, checkboxes, and radios, built on Pulumi brand tokens with a size scale that mirrors the `.btn` heights. All the site's form surfaces (HubSpot forms, the docs/tutorials feedback widgets, contact-us, the footer and blog newsletters, the deployments marketing form, and the `pulumi-filter-select` Stencil component) are rewired to consume this shared base instead of hand-rolled utility soup, and the docs form controls get a dark-mode re-skin via the `--docs-*` tokens.